### PR TITLE
Reuse PMDASMClassLoader instance across all compilation units analyzed.

### DIFF
--- a/pmd/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -134,7 +134,7 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
 	}
 
 	public ClassTypeResolver(ClassLoader classLoader) {
-		pmdClassLoader = new PMDASMClassLoader(classLoader);
+		pmdClassLoader = PMDASMClassLoader.getInstance(classLoader);
 	}
 
 	// FUTURE ASTCompilationUnit should not be a TypeNode.  Clean this up accordingly.

--- a/pmd/src/test/java/net/sourceforge/pmd/typeresolution/PMDASMClassLoaderTest.java
+++ b/pmd/src/test/java/net/sourceforge/pmd/typeresolution/PMDASMClassLoaderTest.java
@@ -17,7 +17,7 @@ public class PMDASMClassLoaderTest {
     
     @Before
     public void setUp() throws Exception {
-        cl = new PMDASMClassLoader(getClass().getClassLoader());
+        cl = PMDASMClassLoader.getInstance(getClass().getClassLoader());
     }
 
     /**
@@ -78,7 +78,7 @@ public class PMDASMClassLoaderTest {
     @Test
     public void testCachingOfNotFoundClasses() throws Exception {
 	MockedClassLoader mockedClassloader = new MockedClassLoader();
-	PMDASMClassLoader cl = new PMDASMClassLoader(mockedClassloader);
+	PMDASMClassLoader cl = PMDASMClassLoader.getInstance(mockedClassloader);
 	String notExistingClassname = "that.clazz.doesnot.Exist";
 	try {
 	    cl.loadClass(notExistingClassname);
@@ -116,7 +116,7 @@ public class PMDASMClassLoaderTest {
     @Test
     public void testCachingMemoryConsumption() throws Exception {
 	MockedClassLoader mockedClassLoader = new MockedClassLoader();
-	PMDASMClassLoader cl = new PMDASMClassLoader(mockedClassLoader);
+	PMDASMClassLoader cl = PMDASMClassLoader.getInstance(mockedClassLoader);
 
 	Runtime runtime = Runtime.getRuntime();
 	System.gc();


### PR DESCRIPTION
This improves the performance for big projects, for us the time went from 2 hr 58 min down to 54 min.
Without this a new PMDASMClassLoader was created for each compilation unit and one looses the caching performed by both the dontBother and java.lang.ClassLoader.
