### PR TITLE
pmd: fix ignored property minimumLength of rule AvoidDuplicateLiterals

### DIFF
--- a/pmd/src/main/java/net/sourceforge/pmd/lang/java/rule/strings/AvoidDuplicateLiteralsRule.java
+++ b/pmd/src/main/java/net/sourceforge/pmd/lang/java/rule/strings/AvoidDuplicateLiteralsRule.java
@@ -127,14 +127,16 @@ public class AvoidDuplicateLiteralsRule extends AbstractJavaRule {
             }
         }
 
+        minLength = 2 + getProperty(MINIMUM_LENGTH_DESCRIPTOR);
+        
         super.visit(node, data);
 
         processResults(data);
 
-        minLength = 2 + getProperty(MINIMUM_LENGTH_DESCRIPTOR);
-
         return data;
     }
+       
+
 
 	private void processResults(Object data) {
 

--- a/pmd/src/test/resources/net/sourceforge/pmd/lang/java/rule/strings/xml/AvoidDuplicateLiterals.xml
+++ b/pmd/src/test/resources/net/sourceforge/pmd/lang/java/rule/strings/xml/AvoidDuplicateLiterals.xml
@@ -123,4 +123,46 @@ public class Foo {
 }
      ]]></code>
     </test-code>
+    <test-code>
+        <description><![CDATA[
+minimum length property, minimum length reached
+     ]]></description>
+        <expected-problems>1</expected-problems>
+        <rule-property name="minimumLength">5</rule-property>
+        <code><![CDATA[
+public class Foo {
+ private void bar() {
+    buz("Howdy"); buz("Howdy"); buz("Howdy"); buz("Howdy");
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+minimum length property, minimum length not reached
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <rule-property name="minimumLength">5</rule-property>
+        <code><![CDATA[
+public class Foo {
+ private void bar() {
+    buz("foo"); buz("foo"); buz("foo"); buz("foo");
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+minimum length property, default value
+     ]]></description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ private void bar() {
+    buz("foo"); buz("foo"); buz("foo"); buz("foo");
+    buz("fo"); buz("fo"); buz("fo"); buz("fo");
+ }
+}
+     ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
The rule AvoidDuplicateLiterals ignores its property minimumLength
because it is set not until after the source code has been analyzed.
This change fixes the problem and provides tests.
