### PR TITLE
fix Nullpointer Exception when using -l jsp

### DIFF
--- a/pmd/src/main/java/net/sourceforge/pmd/cli/PMDParameters.java
+++ b/pmd/src/main/java/net/sourceforge/pmd/cli/PMDParameters.java
@@ -117,7 +117,11 @@ public class PMDParameters {
     	configuration.setSuppressMarker(params.getSuppressmarker());
     	configuration.setThreads(params.getThreads()); 
     	for ( LanguageVersion language : LanguageVersion.findVersionsForLanguageTerseName( params.getLanguage() ) ) {
-        	configuration.getLanguageVersionDiscoverer().setDefaultLanguageVersion(language.getLanguage().getVersion(params.getVersion()));    		
+        	LanguageVersion languageVersion = language.getLanguage().getVersion(params.getVersion());
+        	if (languageVersion == null) {
+            		languageVersion = language.getLanguage().getDefaultVersion();
+        	}
+        	configuration.getLanguageVersionDiscoverer().setDefaultLanguageVersion(languageVersion);
     	}
         try {
             configuration.prependClasspath(params.getAuxclasspath());


### PR DESCRIPTION
Hi guys,
when using PMD to check some JSP I noticed a NPex:

Exception in thread "main" java.lang.NullPointerException
        at net.sourceforge.pmd.lang.LanguageVersionDiscoverer.setDefaultLanguageVersion(LanguageVersionDiscoverer.java:25)
        at net.sourceforge.pmd.cli.PMDParameters.transformParametersIntoConfiguration(PMDParameters.java:121)
        at net.sourceforge.pmd.PMD.run(PMD.java:356)
        at net.sourceforge.pmd.cli.PMDCommandLineInterface.run(PMDCommandLineInterface.java:158)
        at net.sourceforge.pmd.PMD.main(PMD.java:344)

The reason is that as the default version (Java 7) is not found in the JSP language no default language version is found for JSP. I could not workaround this as there is no version I can specifiy for JSP. I changed the code to use the default version in this case.

Greetings
