### PR TITLE
pmd: set variableName for a java violation with an ASTFormalParameter node

### DIFF
--- a/pmd/src/main/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolation.java
+++ b/pmd/src/main/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolation.java
@@ -9,6 +9,7 @@ import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
@@ -100,7 +101,6 @@ public class JavaRuleViolation extends ParametricRuleViolation<JavaNode> {
 	}
 
 	private void setVariableNameIfExists(Node node) {
-		variableName = "";
 		if (node instanceof ASTFieldDeclaration) {
 			variableName = ((ASTFieldDeclaration) node).getVariableName();
 		} else if (node instanceof ASTLocalVariableDeclaration) {
@@ -110,6 +110,10 @@ public class JavaRuleViolation extends ParametricRuleViolation<JavaNode> {
 			variableName = node.jjtGetChild(0).getImage();
 		} else if (node instanceof ASTVariableDeclaratorId) {
 			variableName = node.getImage();
+		} else if (node instanceof ASTFormalParameter) {
+		    setVariableNameIfExists(node.getFirstChildOfType(ASTVariableDeclaratorId.class));
+		} else {
+		    variableName = "";
 		}
 	}
 }

--- a/pmd/src/test/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolationTest.java
+++ b/pmd/src/test/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolationTest.java
@@ -1,0 +1,43 @@
+package net.sourceforge.pmd.lang.java.rule;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.StringReader;
+
+import net.sourceforge.pmd.RuleContext;
+import net.sourceforge.pmd.lang.Language;
+import net.sourceforge.pmd.lang.LanguageVersionHandler;
+import net.sourceforge.pmd.lang.ParserOptions;
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
+import net.sourceforge.pmd.lang.java.symboltable.ScopeAndDeclarationFinder;
+
+import org.junit.Test;
+
+/**
+ * @author Philip Graf
+ */
+public class JavaRuleViolationTest {
+    
+    /**
+     * Verifies that {@link JavaRuleViolation} sets the variable name for an {@link ASTFormalParameter} node.
+     */
+    @Test
+    public void testASTFormalParameterVariableName() {
+        ASTCompilationUnit ast = parse("class Foo { void bar(int x) {} }");
+        final ASTFormalParameter node = ast.getFirstChildOfType(ASTFormalParameter.class);
+        final RuleContext context = new RuleContext();
+        final JavaRuleViolation violation = new JavaRuleViolation(null, context, node, null);
+        assertEquals("x", violation.getVariableName());
+    }
+    
+    private ASTCompilationUnit parse(final String code) {
+        final LanguageVersionHandler languageVersionHandler = Language.JAVA.getDefaultVersion().getLanguageVersionHandler();
+        final ParserOptions options = languageVersionHandler.getDefaultParserOptions();
+        final ASTCompilationUnit ast = (ASTCompilationUnit) languageVersionHandler.getParser(options).parse(null, new StringReader(code));
+        // set scope of AST nodes
+        ast.jjtAccept(new ScopeAndDeclarationFinder(), null);
+        return ast;
+    }
+    
+}


### PR DESCRIPTION
Extends JavaRuleViolation to also set the member "variableName" when the
provided node is of type ASTFormalParameter.
