### PR TITLE
pmd: make ReportTree implement Iterable<RuleViolation>

### DIFF
--- a/pmd/src/main/java/net/sourceforge/pmd/Report.java
+++ b/pmd/src/main/java/net/sourceforge/pmd/Report.java
@@ -20,7 +20,7 @@ import net.sourceforge.pmd.util.EmptyIterator;
 import net.sourceforge.pmd.util.NumericConstants;
 import net.sourceforge.pmd.util.StringUtil;
 
-public class Report {
+public class Report implements Iterable<RuleViolation> {
 
     public static Report createReport(RuleContext ctx, String fileName) {
 	Report report = new Report();
@@ -263,6 +263,7 @@ public class Report {
         return violationTree.iterator();
     }
 
+    @Override
     public Iterator<RuleViolation> iterator() {
         return violations.iterator();
     }

--- a/pmd/src/main/java/net/sourceforge/pmd/lang/dfa/report/ReportTree.java
+++ b/pmd/src/main/java/net/sourceforge/pmd/lang/dfa/report/ReportTree.java
@@ -81,6 +81,7 @@ public class ReportTree implements Iterable<RuleViolation> {
 		}
 	}
 
+	@Override
 	public Iterator<RuleViolation> iterator() {
 		return new TreeIterator();
 	}


### PR DESCRIPTION
With the two changes we can easily iterate over a Report or ReportTree using the
for-each loop of Java 5 instead of using Report.iterator() or ReportTree.iterator().

Instead of

``` java
ReportTree tree = ...
for (Iterator<RuleViolation> iter = tree.iterator(); iter.hasNext;) {
    RuleViolation rv = iter.next();
    ...
}
```

we can write

``` java
ReportTree tree = ...
for (RuleViolation rv : tree) {
    ...
}
```
