### PR TITLE
New rule: AvoidProtectedMethodsInFinalClassNotExtending

### DIFF
--- a/pmd/src/main/resources/rulesets/java/design.xml
+++ b/pmd/src/main/resources/rulesets/java/design.xml
@@ -1769,4 +1769,38 @@ of Object-Oriented Systems. Springer, Berlin, 1 edition, October 2006. Page 80.
         </description>
         <priority>3</priority>
     </rule>
+    
+    <rule name="AvoidProtectedMethodInFinalClassNotExtending"
+   		language="java"
+    			 since="5.0"
+             message="Avoid protected methods in a final class that doesn't extend anything other than Object.  Change to private or package access."
+             class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/design.html#AvoidProtectedMethodInFinalClassNotExtending">
+         <description>
+Do not use protected methods in most final classes since they cannot be subclassed. This should 
+only be allowed in final classes that extend other classes with protected methods (whose
+visibility cannot be reduced). Clarify your intent by using private or package access modifiers instead.
+         </description>
+         <priority>3</priority>
+         <properties>
+             <property name="xpath">
+                 <value>
+<![CDATA[
+//ClassOrInterfaceDeclaration[@Final='true' and not(ExtendsList)]
+/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration
+/MethodDeclaration[@Protected='true']
+ ]]>
+                 </value>
+             </property>
+         </properties>
+        <example>
+<![CDATA[
+public final class Foo {
+  private int bar() {}
+  protected int baz() {} // Foo cannot be subclassed, and doesn't extend anything, so is baz() really private or package visible? 
+}
+ ]]>
+         </example>
+       </rule>
+    
 </ruleset>

--- a/pmd/src/test/java/net/sourceforge/pmd/lang/java/rule/design/DesignRulesTest.java
+++ b/pmd/src/test/java/net/sourceforge/pmd/lang/java/rule/design/DesignRulesTest.java
@@ -22,6 +22,7 @@ public class DesignRulesTest extends SimpleAggregatorTst {
         addRule(RULESET, "AvoidDeeplyNestedIfStmts");
         addRule(RULESET, "AvoidInstanceofChecksInCatchClause");
         addRule(RULESET, "AvoidProtectedFieldInFinalClass");
+        addRule(RULESET, "AvoidProtectedMethodInFinalClassNotExtending");
         addRule(RULESET, "AvoidReassigningParameters");
         addRule(RULESET, "AvoidSynchronizedAtMethodLevel");
         addRule(RULESET, "BadComparison");

--- a/pmd/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidProtectedMethodInFinalClassNotExtending.xml
+++ b/pmd/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidProtectedMethodInFinalClassNotExtending.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data>
+    <test-code>
+        <description><![CDATA[
+ok, protected method in non final class
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ protected int bar() {}
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+bad, protected method in final class that doesn't extend anything
+     ]]></description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public final class Foo {
+ protected int bar(){}
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+bad, protected method in final class that doesn't extend anything but implements interface
+     ]]></description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public final class Foo implements Serializable {
+ protected int bar(){}
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+ok, protected method in final class that does extend something
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public final class Foo extends Bar {
+ protected int bar(){}
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+ok, private method in final class
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public final class Foo {
+ private int bar(){}
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+protected method in non-final inner class is ok
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public final class Foo {
+ private class Bar { protected int baz(){} }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+protected method in final inner class that extends something is ok
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public final class Foo {
+ private final class Bar extends Serializable { protected int baz(){} }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+protected method in final inner class that does not extend something is bad
+     ]]></description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ private final class Bar { protected int baz(){} }
+}
+     ]]></code>
+    </test-code>
+</test-data>


### PR DESCRIPTION
New XPath rule to find protected methods in final classes that don't extend something.
