### PR TITLE
Bug 881 BeanMembersShouldSerialize - Skipping the setter check for final fields

### DIFF
--- a/pmd/src/main/java/net/sourceforge/pmd/lang/java/rule/javabeans/BeanMembersShouldSerializeRule.java
+++ b/pmd/src/main/java/net/sourceforge/pmd/lang/java/rule/javabeans/BeanMembersShouldSerializeRule.java
@@ -80,7 +80,8 @@ public class BeanMembersShouldSerializeRule extends AbstractJavaRule {
 	    boolean hasGetMethod = Arrays.binarySearch(methNameArray, "get" + varName) >= 0
 		    || Arrays.binarySearch(methNameArray, "is" + varName) >= 0;
 	    boolean hasSetMethod = Arrays.binarySearch(methNameArray, "set" + varName) >= 0;
-	    if (!hasGetMethod || !hasSetMethod) {
+	    // Note that a Setter method is not applicable to a final variable...
+	    if (!hasGetMethod || (!decl.getAccessNodeParent().isFinal() && !hasSetMethod)) {
 		addViolation(data, decl.getNode(), decl.getImage());
 	    }
 	}


### PR DESCRIPTION
[Bug 881](https://sourceforge.net/p/pmd/bugs/881/) has the [BeanMembersShouldSerialize](http://pmd.sourceforge.net/pmd-5.0.5/rules/java/javabeans.html#BeanMembersShouldSerialize) rule being applied to final fields -- but since they are final, they can't have setters.  This modification tweaks the rule to only check for a setter for fields that are not marked final.
