### PR TITLE
pmd-eclipse: Fix "maven-dependency-plugin ... is not supported by m2e"

### DIFF
--- a/pmd-eclipse-plugin/net.sourceforge.pmd.eclipse.plugin/pom.xml
+++ b/pmd-eclipse-plugin/net.sourceforge.pmd.eclipse.plugin/pom.xml
@@ -67,7 +67,7 @@
                     <artifactId>
                       maven-dependency-plugin
                     </artifactId>
-                    <versionRange>[2.7,)</versionRange>
+                    <versionRange>[0,)</versionRange>
                     <goals>
                       <goal>copy-dependencies</goal>
                     </goals>


### PR DESCRIPTION
After importing the projects into Eclipse, m2e had the following error:

maven-dependency-plugin (goals "copy-dependencies", "unpack") is not
supported by m2e.

The error can be suppressed by adding a pluginExecutionFilter for m2e.
This does not affect the command-line build.
