### PR TITLE
Bring back the old CPDConfiguration constructor

### DIFF
--- a/pmd/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
+++ b/pmd/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
@@ -82,6 +82,19 @@ public class CPDConfiguration extends AbstractConfiguration {
 		}
 	}
 
+	public CPDConfiguration()
+	{
+	}
+
+	@Deprecated
+	public CPDConfiguration(int minimumTileSize, Language language, String encoding)
+	{
+		setMinimumTileSize(minimumTileSize);
+		setLanguage(language);
+		setEncoding(encoding);
+	}
+
+
 	public void setEncoding(String encoding) {
 	    this.encoding = encoding;
 	}


### PR DESCRIPTION
Removing it will break at least the maven pmd plugin which uses it and probably other users, too. 
