### PR TITLE
Add a no args constructor to CPDConfiguration.

### DIFF
--- a/pmd/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
+++ b/pmd/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
@@ -33,7 +33,11 @@ public class CPDConfiguration extends AbstractConfiguration {
 
          skipDuplicates = findBooleanSwitch(args, "--skip-duplicate-files");
     }
-    
+
+    public CPDConfiguration()
+    {
+    }
+
 	public CPDConfiguration(int theMinTileSize, Language theLanguage, String theEncoding) {
 		minimumTileSize = theMinTileSize;
 		language = theLanguage;


### PR DESCRIPTION
This allows API users to build a path forward from the 5.0.x versions
of the API to 5.1.x.
