### PR TITLE
Fix NPE with empty rulesets.

### DIFF
--- a/pmd/src/main/java/net/sourceforge/pmd/RuleSetReferenceId.java
+++ b/pmd/src/main/java/net/sourceforge/pmd/RuleSetReferenceId.java
@@ -251,11 +251,13 @@ public class RuleSetReferenceId {
      */
     public static List<RuleSetReferenceId> parse(String referenceString) {
 	List<RuleSetReferenceId> references = new ArrayList<RuleSetReferenceId>();
-	if (referenceString.indexOf(',') == -1) {
-	    references.add(new RuleSetReferenceId(referenceString));
-	} else {
-	    for (String name : referenceString.split(",")) {
-		references.add(new RuleSetReferenceId(name));
+	if (referenceString != null && referenceString.trim().length() > 0) {
+	    if (referenceString.indexOf(',') == -1) {
+		references.add(new RuleSetReferenceId(referenceString));
+	    } else {
+		for (String name : referenceString.split(",")) {
+		    references.add(new RuleSetReferenceId(name));
+		}
 	    }
 	}
 	return references;

--- a/pmd/src/main/java/net/sourceforge/pmd/processor/AbstractPMDProcessor.java
+++ b/pmd/src/main/java/net/sourceforge/pmd/processor/AbstractPMDProcessor.java
@@ -56,7 +56,7 @@ public abstract class AbstractPMDProcessor {
 			return factory.createRuleSets(configuration.getRuleSets());
 		} catch (RuleSetNotFoundException rsnfe) {
 			// should not happen: parent already created a ruleset
-			return null;
+			return new RuleSets();
 		}
 	}
 	


### PR DESCRIPTION
This is the fix for bug #1155 (https://sourceforge.net/p/pmd/bugs/1155/)

The whole code is in dire need of revisiting its behaviour when a
value is null or empty. Same goes for e.g. createRules whether it
should return null values (then the caller will have to deal with it)
or empty Rulesets.

Catching and discarding the ruleset not found exception looks pretty
suspicious.
