### PR TITLE
Add SLF4j Logger type to MoreThanOneLogger rule

### DIFF
--- a/pmd/src/main/java/net/sourceforge/pmd/lang/java/rule/logging/MoreThanOneLoggerRule.java
+++ b/pmd/src/main/java/net/sourceforge/pmd/lang/java/rule/logging/MoreThanOneLoggerRule.java
@@ -22,6 +22,8 @@ public class MoreThanOneLoggerRule extends AbstractJavaRule {
     private static final Class<?> LOG4J_LOGGER;
 
     private static final Class<?> JAVA_LOGGER;
+    
+    private static final Class<?> SLF4J_LOGGER;
 
     static {
 	Class<?> c;
@@ -37,6 +39,12 @@ public class MoreThanOneLoggerRule extends AbstractJavaRule {
 	    c = null;
 	}
 	JAVA_LOGGER = c;
+	try {
+	    c = Class.forName("org.slf4j.Logger");
+	} catch (Throwable t) {
+	    c = null;
+	}
+	SLF4J_LOGGER = c;
     }
 
     private Stack<Integer> stack = new Stack<Integer>();
@@ -84,7 +92,9 @@ public class MoreThanOneLoggerRule extends AbstractJavaRule {
 		Node classOrIntType = reftypeNode.jjtGetChild(0);
 		if (classOrIntType instanceof ASTClassOrInterfaceType) {
 		    Class<?> clazzType = ((ASTClassOrInterfaceType) classOrIntType).getType();
-		    if (clazzType != null && (clazzType.equals(LOG4J_LOGGER) || clazzType.equals(JAVA_LOGGER))
+		    if (clazzType != null && (clazzType.equals(LOG4J_LOGGER) 
+		                           || clazzType.equals(JAVA_LOGGER) 
+		                           || clazzType.equals(SLF4J_LOGGER))
 			    || clazzType == null && "Logger".equals(classOrIntType.getImage())) {
 			++count;
 		    }


### PR DESCRIPTION
We just ran into a situation where the maven-pmd-plugin running under Maven 3.0.5 has different behavior than when it runs under Maven 3.2.1, in the sense that the older Maven version does not put org.slf4j.\* on the plugin classpath automatically, but in 3.2.1 it does, via plexus.core. This causes the MoreThanOneLogger rule to correctly identify the use of more than one SLF4j Logger in 3.0.5 when the SLF4j API is not on the classpath (because its name is "Logger"), but the rule fails to catch the same case when the SLF4j API is added to the classpath in 3.2.1. 

This rule should apply equally to Log4j, JCL, and SLF4j Loggers.
