### PR TITLE
Standard and modified cyclomatic complexity

### DIFF
--- a/pmd/src/main/java/net/sourceforge/pmd/lang/java/rule/codesize/ModifiedCyclomaticComplexityRule.java
+++ b/pmd/src/main/java/net/sourceforge/pmd/lang/java/rule/codesize/ModifiedCyclomaticComplexityRule.java
@@ -1,0 +1,29 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+package net.sourceforge.pmd.lang.java.rule.codesize;
+
+import net.sourceforge.pmd.lang.java.ast.ASTSwitchStatement;
+import net.sourceforge.pmd.lang.java.ast.JavaNode;
+
+
+/**
+ * Implements the modified cyclomatic complexity rule 
+ * <p>
+ * Modified rules: Same as standard cyclomatic complexity, but
+ * switch statement plus all cases count as 1.
+ * 
+ * @author Alan Hohn, based on work by Donald A. Leckie
+ * 
+ * @since June 18, 2014
+ */
+public class ModifiedCyclomaticComplexityRule extends StdCyclomaticComplexityRule {
+
+  @Override
+  public Object visit(ASTSwitchStatement node, Object data) {
+    entryStack.peek().bumpDecisionPoints();
+    visit((JavaNode) node, data);
+    return data;
+  }
+
+}

--- a/pmd/src/main/java/net/sourceforge/pmd/lang/java/rule/codesize/StdCyclomaticComplexityRule.java
+++ b/pmd/src/main/java/net/sourceforge/pmd/lang/java/rule/codesize/StdCyclomaticComplexityRule.java
@@ -1,0 +1,282 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+package net.sourceforge.pmd.lang.java.rule.codesize;
+
+import java.util.List;
+import java.util.Stack;
+
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
+import net.sourceforge.pmd.lang.java.ast.ASTBlockStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTCatchStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBodyDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.lang.java.ast.ASTConditionalExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTDoStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTEnumDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTForStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTLiteral;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclarator;
+import net.sourceforge.pmd.lang.java.ast.ASTName;
+import net.sourceforge.pmd.lang.java.ast.ASTSwitchLabel;
+import net.sourceforge.pmd.lang.java.ast.ASTSwitchStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTWhileStatement;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
+import net.sourceforge.pmd.lang.rule.properties.BooleanProperty;
+import net.sourceforge.pmd.lang.rule.properties.IntegerProperty;
+
+/**
+ * Implements the standard cyclomatic complexity rule 
+ * <p>
+ * Standard rules: +1 for each decision point, including case statements
+ * but not including boolean operators unlike CyclomaticComplexityRule.
+ * 
+ * @author Alan Hohn, based on work by Donald A. Leckie
+ * 
+ * @since June 18, 2014
+ */
+public class StdCyclomaticComplexityRule extends AbstractJavaRule {
+
+    public static final IntegerProperty REPORT_LEVEL_DESCRIPTOR = new IntegerProperty("reportLevel",
+	    "Cyclomatic Complexity reporting threshold", 1, 30, 10, 1.0f);
+
+    public static final BooleanProperty SHOW_CLASSES_COMPLEXITY_DESCRIPTOR = new BooleanProperty("showClassesComplexity",
+	"Add class average violations to the report", true, 2.0f);
+
+    public static final BooleanProperty SHOW_METHODS_COMPLEXITY_DESCRIPTOR = new BooleanProperty("showMethodsComplexity",
+	"Add method average violations to the report", true, 3.0f);
+
+  private int reportLevel;
+  private boolean showClassesComplexity = true;
+  private boolean showMethodsComplexity = true;
+
+  protected static class Entry {
+    private Node node;
+    private int decisionPoints = 1;
+    public int highestDecisionPoints;
+    public int methodCount;
+
+    private Entry(Node node) {
+      this.node = node;
+    }
+
+    public void bumpDecisionPoints() {
+      decisionPoints++;
+    }
+
+    public void bumpDecisionPoints(int size) {
+      decisionPoints += size;
+    }
+
+    public int getComplexityAverage() {
+      return (double) methodCount == 0 ? 1
+          : (int) Math.rint( (double) decisionPoints / (double) methodCount );
+    }
+  }
+
+  protected Stack<Entry> entryStack = new Stack<Entry>();
+
+  public StdCyclomaticComplexityRule() {
+      definePropertyDescriptor(REPORT_LEVEL_DESCRIPTOR);
+      definePropertyDescriptor(SHOW_CLASSES_COMPLEXITY_DESCRIPTOR);
+      definePropertyDescriptor(SHOW_METHODS_COMPLEXITY_DESCRIPTOR);
+  }
+
+  @Override
+public Object visit(ASTCompilationUnit node, Object data) {
+    reportLevel = getProperty(REPORT_LEVEL_DESCRIPTOR);
+    showClassesComplexity = getProperty(SHOW_CLASSES_COMPLEXITY_DESCRIPTOR);
+    showMethodsComplexity = getProperty(SHOW_METHODS_COMPLEXITY_DESCRIPTOR);
+    super.visit( node, data );
+    return data;
+  }
+
+  @Override
+public Object visit(ASTIfStatement node, Object data) {
+    entryStack.peek().bumpDecisionPoints();
+    super.visit( node, data );
+    return data;
+  }
+
+  @Override
+public Object visit(ASTCatchStatement node, Object data) {
+    entryStack.peek().bumpDecisionPoints();
+    super.visit( node, data );
+    return data;
+  }
+
+  @Override
+public Object visit(ASTForStatement node, Object data) {
+    entryStack.peek().bumpDecisionPoints();
+    super.visit( node, data );
+    return data;
+  }
+
+  @Override
+public Object visit(ASTDoStatement node, Object data) {
+    entryStack.peek().bumpDecisionPoints();
+    super.visit( node, data );
+    return data;
+  }
+
+  @Override
+public Object visit(ASTSwitchStatement node, Object data) {
+    Entry entry = entryStack.peek();
+
+    int childCount = node.jjtGetNumChildren();
+    int lastIndex = childCount - 1;
+    for ( int n = 0; n < lastIndex; n++ ) {
+      Node childNode = node.jjtGetChild( n );
+      if ( childNode instanceof ASTSwitchLabel ) {
+        // default is generally not considered a decision (same as "else")
+        ASTSwitchLabel sl = (ASTSwitchLabel) childNode;
+        if ( !sl.isDefault() ) {
+          childNode = node.jjtGetChild( n + 1 );
+          if ( childNode instanceof ASTBlockStatement ) {
+            entry.bumpDecisionPoints();
+          }
+        }
+      }
+    }
+    super.visit( node, data );
+    return data;
+  }
+
+  @Override
+public Object visit(ASTWhileStatement node, Object data) {
+    entryStack.peek().bumpDecisionPoints();
+    super.visit( node, data );
+    return data;
+  }
+
+  @Override
+public Object visit(ASTConditionalExpression node, Object data) {
+    if ( node.isTernary() ) {
+      entryStack.peek().bumpDecisionPoints();
+      super.visit( node, data );
+    }
+    return data;
+  }
+
+  @Override
+public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
+    if ( node.isInterface() ) {
+      return data;
+    }
+
+    entryStack.push( new Entry( node ) );
+    super.visit( node, data );
+    if ( showClassesComplexity ) {
+    	Entry classEntry = entryStack.pop();
+	    if ( classEntry.getComplexityAverage() >= reportLevel
+	        || classEntry.highestDecisionPoints >= reportLevel ) {
+	      addViolation( data, node, new String[] {
+	          "class",
+	          node.getImage(),
+	          classEntry.getComplexityAverage() + " (Highest = "
+	              + classEntry.highestDecisionPoints + ')' } );
+	    }
+    }
+    return data;
+  }
+
+  @Override
+public Object visit(ASTMethodDeclaration node, Object data) {
+    entryStack.push( new Entry( node ) );
+    super.visit( node, data );
+	    Entry methodEntry = entryStack.pop();
+    if (!isSuppressed(node)) {
+	    int methodDecisionPoints = methodEntry.decisionPoints;
+	    Entry classEntry = entryStack.peek();
+	    classEntry.methodCount++;
+	    classEntry.bumpDecisionPoints( methodDecisionPoints );
+
+	    if ( methodDecisionPoints > classEntry.highestDecisionPoints ) {
+	      classEntry.highestDecisionPoints = methodDecisionPoints;
+	    }
+
+	    ASTMethodDeclarator methodDeclarator = null;
+	    for ( int n = 0; n < node.jjtGetNumChildren(); n++ ) {
+	      Node childNode = node.jjtGetChild( n );
+	      if ( childNode instanceof ASTMethodDeclarator ) {
+	        methodDeclarator = (ASTMethodDeclarator) childNode;
+	        break;
+	      }
+	    }
+
+	    if ( showMethodsComplexity && methodEntry.decisionPoints >= reportLevel ) {
+	        addViolation( data, node, new String[] { "method",
+	            methodDeclarator == null ? "" : methodDeclarator.getImage(),
+	            String.valueOf( methodEntry.decisionPoints ) } );
+	      }
+    }
+    return data;
+  }
+
+  @Override
+public Object visit(ASTEnumDeclaration node, Object data) {
+    entryStack.push( new Entry( node ) );
+    super.visit( node, data );
+    Entry classEntry = entryStack.pop();
+    if ( classEntry.getComplexityAverage() >= reportLevel
+        || classEntry.highestDecisionPoints >= reportLevel ) {
+      addViolation( data, node, new String[] {
+          "class",
+          node.getImage(),
+          classEntry.getComplexityAverage() + "(Highest = "
+              + classEntry.highestDecisionPoints + ')' } );
+    }
+    return data;
+  }
+
+  @Override
+public Object visit(ASTConstructorDeclaration node, Object data) {
+    entryStack.push( new Entry( node ) );
+    super.visit( node, data );
+    Entry constructorEntry = entryStack.pop();
+    if (!isSuppressed(node)) {
+    int constructorDecisionPointCount = constructorEntry.decisionPoints;
+    Entry classEntry = entryStack.peek();
+    classEntry.methodCount++;
+    classEntry.decisionPoints += constructorDecisionPointCount;
+    if ( constructorDecisionPointCount > classEntry.highestDecisionPoints ) {
+      classEntry.highestDecisionPoints = constructorDecisionPointCount;
+    }
+    if ( showMethodsComplexity && constructorEntry.decisionPoints >= reportLevel ) {
+      addViolation( data, node, new String[] { "constructor",
+          classEntry.node.getImage(),
+          String.valueOf( constructorDecisionPointCount ) } );
+    }
+    }
+    return data;
+  }
+
+  private boolean isSuppressed(Node node) {
+      boolean result = false;
+
+      ASTClassOrInterfaceBodyDeclaration parent = node.getFirstParentOfType(ASTClassOrInterfaceBodyDeclaration.class);
+      List<ASTAnnotation> annotations = parent.findChildrenOfType(ASTAnnotation.class);
+      for (ASTAnnotation a : annotations) {
+          ASTName name = a.getFirstDescendantOfType(ASTName.class);
+          if ("SuppressWarnings".equals(name.getImage())) {
+              List<ASTLiteral> literals = a.findDescendantsOfType(ASTLiteral.class);
+              for (ASTLiteral l : literals) {
+                  if (l.isStringLiteral() && "\"PMD.CyclomaticComplexity\"".equals(l.getImage())) {
+                      result = true;
+                      break;
+                  }
+              }
+          }
+          if (result) {
+              break;
+          }
+      }
+
+      return result;
+  }
+}

--- a/pmd/src/main/resources/rulesets/java/codesize.xml
+++ b/pmd/src/main/resources/rulesets/java/codesize.xml
@@ -200,6 +200,119 @@ public class Foo {		// This has a Cyclomatic Complexity = 12
    </example>
 </rule>
 
+    <rule   name="StdCyclomaticComplexity"
+          since="5.1.2"
+          message = "The {0} ''{1}'' has a Standard Cyclomatic Complexity of {2}."
+          class="net.sourceforge.pmd.lang.java.rule.codesize.StdCyclomaticComplexityRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/codesize.html#StdCyclomaticComplexity">
+   <description>
+      <![CDATA[
+Complexity directly affects maintenance costs is determined by the number of decision points in a method 
+plus one for the method entry.  The decision points include 'if', 'while', 'for', and 'case labels' calls.  
+Generally, numbers ranging from 1-4 denote low complexity, 5-7 denote moderate complexity, 8-10 denote
+high complexity, and 11+ is very high complexity.
+    ]]>
+   </description>
+   <priority>3</priority>
+   <example>
+<![CDATA[
+public class Foo {    // This has a Cyclomatic Complexity = 12
+1   public void example()  {
+2       if (a == b || (c == d && e == f))  { // Only one
+3           if (a1 == b1) {
+                fiddle();
+4           } else if a2 == b2) {
+                fiddle();
+            }  else {
+                fiddle();
+            }
+5       } else if (c == d) {
+6           while (c == d) {
+                fiddle();
+            }
+7        } else if (e == f) {
+8           for (int n = 0; n < h; n++) {
+                fiddle();
+            }
+        } else{
+            switch (z) {
+9               case 1:
+                    fiddle();
+                    break;
+10              case 2:
+                    fiddle();
+                    break;
+11              case 3:
+                    fiddle();
+                    break;
+12              default:
+                    fiddle();
+                    break;
+            }
+        }
+    }
+}
+]]>
+   </example>
+</rule>
+
+    <rule   name="ModifiedCyclomaticComplexity"
+          since="5.1.2"
+          message = "The {0} ''{1}'' has a Modified Cyclomatic Complexity of {2}."
+          class="net.sourceforge.pmd.lang.java.rule.codesize.ModifiedCyclomaticComplexityRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/codesize.html#ModifiedCyclomaticComplexity">
+   <description>
+      <![CDATA[
+Complexity directly affects maintenance costs is determined by the number of decision points in a method 
+plus one for the method entry.  The decision points include 'if', 'while', 'for', and 'case labels' calls.  
+Generally, numbers ranging from 1-4 denote low complexity, 5-7 denote moderate complexity, 8-10 denote
+high complexity, and 11+ is very high complexity. Modified complexity treats switch statements as a single
+decision point.
+    ]]>
+   </description>
+   <priority>3</priority>
+   <example>
+<![CDATA[
+public class Foo {    // This has a Cyclomatic Complexity = 9
+1   public void example()  {
+2       if (a == b)  {
+3           if (a1 == b1) {
+                fiddle();
+4           } else if a2 == b2) {
+                fiddle();
+            }  else {
+                fiddle();
+            }
+5       } else if (c == d) {
+6           while (c == d) {
+                fiddle();
+            }
+7        } else if (e == f) {
+8           for (int n = 0; n < h; n++) {
+                fiddle();
+            }
+        } else{
+9           switch (z) {
+                case 1:
+                    fiddle();
+                    break;
+                case 2:
+                    fiddle();
+                    break;
+                case 3:
+                    fiddle();
+                    break;
+                default:
+                    fiddle();
+                    break;
+            }
+        }
+    }
+}
+]]>
+   </example>
+</rule>
+
     <rule name="ExcessivePublicCount"
     since="1.04"
     message="This class has a bunch of public methods and attributes"

--- a/pmd/src/test/java/net/sourceforge/pmd/lang/java/rule/codesize/ModifiedCyclomaticComplexityTest.java
+++ b/pmd/src/test/java/net/sourceforge/pmd/lang/java/rule/codesize/ModifiedCyclomaticComplexityTest.java
@@ -1,0 +1,74 @@
+ /**
+  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+  */
+package net.sourceforge.pmd.lang.java.rule.codesize;
+ 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+import java.util.Iterator;
+
+import net.sourceforge.pmd.Report;
+import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.RuleViolation;
+import net.sourceforge.pmd.testframework.RuleTst;
+import net.sourceforge.pmd.testframework.SimpleAggregatorTst;
+import net.sourceforge.pmd.testframework.TestDescriptor;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+
+@RunWith(SimpleAggregatorTst.CustomXmlTestClassMethodsRunner.class)
+public class ModifiedCyclomaticComplexityTest extends RuleTst {
+     private Rule rule;
+     private TestDescriptor[] tests;
+ 
+     @Before public void setUp() {
+         rule = findRule("java-codesize", "ModifiedCyclomaticComplexity");
+         tests = extractTestsFromXml(rule);
+     }
+ 
+     @Test
+     public void testOneMethod() throws Throwable {
+         rule.setProperty(ModifiedCyclomaticComplexityRule.REPORT_LEVEL_DESCRIPTOR, 1);
+         Report report = new Report();
+         runTestFromString(tests[0].getCode(), rule, report);
+         Iterator<RuleViolation> i = report.iterator();
+         RuleViolation rv = i.next();
+         assertNotSame(rv.getDescription().indexOf("Highest = 1"), -1);
+     }
+ 
+     @Test
+     public void testNastyComplicatedMethod() throws Throwable {
+         rule.setProperty(ModifiedCyclomaticComplexityRule.REPORT_LEVEL_DESCRIPTOR, 8);
+         Report report = new Report();
+         runTestFromString(tests[1].getCode(), rule, report);
+         Iterator<RuleViolation> i = report.iterator();
+         RuleViolation rv = i.next();
+         assertNotSame(rv.getDescription().indexOf("Highest = 9"), -1);
+     }
+ 
+     @Test
+     public void testConstructor() throws Throwable {
+         rule.setProperty(ModifiedCyclomaticComplexityRule.REPORT_LEVEL_DESCRIPTOR, 1);
+         Report report = new Report();
+         runTestFromString(tests[2].getCode(), rule, report);
+         Iterator<RuleViolation> i = report.iterator();
+         RuleViolation rv = i.next();
+         assertNotSame(rv.getDescription().indexOf("Highest = 1"), -1);
+     }
+ 
+     @Test
+     public void testLessComplicatedThanReportLevel() throws Throwable {
+         rule.setProperty(ModifiedCyclomaticComplexityRule.REPORT_LEVEL_DESCRIPTOR, 10);
+         Report report = new Report();
+         runTestFromString(tests[0].getCode(), rule, report);
+         assertEquals(0, report.size());
+     }
+
+     public static junit.framework.Test suite() {
+         return new junit.framework.JUnit4TestAdapter(ModifiedCyclomaticComplexityTest.class);
+     }
+ }

--- a/pmd/src/test/java/net/sourceforge/pmd/lang/java/rule/codesize/StdCyclomaticComplexityTest.java
+++ b/pmd/src/test/java/net/sourceforge/pmd/lang/java/rule/codesize/StdCyclomaticComplexityTest.java
@@ -1,0 +1,92 @@
+ /**
+  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+  */
+package net.sourceforge.pmd.lang.java.rule.codesize;
+ 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+
+import java.util.Iterator;
+
+import net.sourceforge.pmd.Report;
+import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.RuleViolation;
+import net.sourceforge.pmd.testframework.RuleTst;
+import net.sourceforge.pmd.testframework.SimpleAggregatorTst;
+import net.sourceforge.pmd.testframework.SimpleAggregatorTst.CustomXmlTestClassMethodsRunner;
+import net.sourceforge.pmd.testframework.TestDescriptor;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runner.notification.Failure;
+
+
+@RunWith(SimpleAggregatorTst.CustomXmlTestClassMethodsRunner.class)
+public class StdCyclomaticComplexityTest extends RuleTst {
+     private Rule rule;
+     private TestDescriptor[] tests;
+ 
+     @Before public void setUp() {
+         rule = findRule("java-codesize", "StdCyclomaticComplexity");
+         tests = extractTestsFromXml(rule);
+     }
+ 
+     @Test
+     public void testOneMethod() throws Throwable {
+         rule.setProperty(StdCyclomaticComplexityRule.REPORT_LEVEL_DESCRIPTOR, 1);
+         Report report = new Report();
+         runTestFromString(tests[0].getCode(), rule, report);
+         Iterator<RuleViolation> i = report.iterator();
+         RuleViolation rv = i.next();
+         assertNotSame(rv.getDescription().indexOf("Highest = 1"), -1);
+     }
+ 
+     @Test
+     public void testNastyComplicatedMethod() throws Throwable {
+         rule.setProperty(StdCyclomaticComplexityRule.REPORT_LEVEL_DESCRIPTOR, 10);
+         Report report = new Report();
+         runTestFromString(tests[1].getCode(), rule, report);
+         Iterator<RuleViolation> i = report.iterator();
+         RuleViolation rv = i.next();
+         assertNotSame(rv.getDescription().indexOf("Highest = 11"), -1);
+     }
+ 
+     @Test
+     public void testConstructor() throws Throwable {
+         rule.setProperty(StdCyclomaticComplexityRule.REPORT_LEVEL_DESCRIPTOR, 1);
+         Report report = new Report();
+         runTestFromString(tests[2].getCode(), rule, report);
+         Iterator<RuleViolation> i = report.iterator();
+         RuleViolation rv = i.next();
+         assertNotSame(rv.getDescription().indexOf("Highest = 1"), -1);
+     }
+ 
+     @Test
+     public void testLessComplicatedThanReportLevel() throws Throwable {
+         rule.setProperty(StdCyclomaticComplexityRule.REPORT_LEVEL_DESCRIPTOR, 10);
+         Report report = new Report();
+         runTestFromString(tests[0].getCode(), rule, report);
+         assertEquals(0, report.size());
+     }
+
+     @Test
+     public void testRemainingTestCases() {
+         for (int i = 0; i < tests.length; i++) {
+             if (i == 0 || i == 1 || i == 2) {
+                 continue; // skip - covered by above test methods
+             }
+
+             try {
+                 runTest(tests[i]);
+             } catch (Throwable t) {
+                 Failure f = CustomXmlTestClassMethodsRunner.createFailure(rule, t);
+                 CustomXmlTestClassMethodsRunner.addFailure(f);
+             }
+         }
+     }
+
+     public static junit.framework.Test suite() {
+         return new junit.framework.JUnit4TestAdapter(StdCyclomaticComplexityTest.class);
+     }
+ }

--- a/pmd/src/test/resources/net/sourceforge/pmd/lang/java/rule/codesize/xml/ModifiedCyclomaticComplexity.xml
+++ b/pmd/src/test/resources/net/sourceforge/pmd/lang/java/rule/codesize/xml/ModifiedCyclomaticComplexity.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data>
+    <test-code>
+        <description><![CDATA[
+Simple method
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ public void foo() {}
+}
+     ]]></code>
+    </test-code>
+    <code-fragment id="basic-violation">
+    <![CDATA[
+public class Foo {
+ public void example() {
+  int x = 0;
+  int a = 0;
+  int b = 0;
+  int c = 0;
+  int d = 0;
+  int a1 = 0;
+  int a2 = 0;
+  int b1 = 0;
+  int b2 = 0;
+  int z = 0;
+  int h = 0;
+  int e = 0;
+  int f = 0;
+
+  if (a == b) {
+      if (a1 == b1) {
+   x = 2;
+      } else if (a2 == b2) {
+   x = 2;
+      } else {
+   x = 2;
+      }
+  } else if (c == d) {
+      while (c == d) {
+   x = 2;
+      }
+  } else if (e == f) {
+      for (int n = 0; n < h; n++) {
+   x = 2;
+      }
+  } else {
+      switch (z) {
+      case 1:
+   x = 2;
+   break;
+
+      case 2:
+   x = 2;
+   break;
+
+      case 3:
+   x = 2;
+   break;
+
+      default:
+   x = 2;
+   break;
+      }
+  }
+ }
+}
+     ]]>
+    </code-fragment>
+    <test-code>
+        <description><![CDATA[
+Complicated method
+     ]]></description>
+        <expected-problems>2</expected-problems>
+        <code-ref id="basic-violation"/>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+Constructor
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ public Foo() {}
+}
+     ]]></code>
+    </test-code>
+</test-data>

--- a/pmd/src/test/resources/net/sourceforge/pmd/lang/java/rule/codesize/xml/StdCyclomaticComplexity.xml
+++ b/pmd/src/test/resources/net/sourceforge/pmd/lang/java/rule/codesize/xml/StdCyclomaticComplexity.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data>
+    <test-code>
+        <description><![CDATA[
+Simple method
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ public void foo() {}
+}
+     ]]></code>
+    </test-code>
+    <code-fragment id="basic-violation">
+    <![CDATA[
+public class Foo {
+ public void example() {
+  int x = 0;
+  int a = 0;
+  int b = 0;
+  int c = 0;
+  int d = 0;
+  int a1 = 0;
+  int a2 = 0;
+  int b1 = 0;
+  int b2 = 0;
+  int z = 0;
+  int h = 0;
+  int e = 0;
+  int f = 0;
+
+  if (a == b) {
+      if (a1 == b1) {
+   x = 2;
+      } else if (a2 == b2) {
+   x = 2;
+      } else {
+   x = 2;
+      }
+  } else if (c == d) {
+      while (c == d) {
+   x = 2;
+      }
+  } else if (e == f) {
+      for (int n = 0; n < h; n++) {
+   x = 2;
+      }
+  } else {
+      switch (z) {
+      case 1:
+   x = 2;
+   break;
+
+      case 2:
+   x = 2;
+   break;
+
+      case 3:
+   x = 2;
+   break;
+
+      default:
+   x = 2;
+   break;
+      }
+  }
+ }
+}
+     ]]>
+    </code-fragment>
+    <test-code>
+        <description><![CDATA[
+Complicated method
+     ]]></description>
+        <expected-problems>2</expected-problems>
+        <code-ref id="basic-violation"/>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+Constructor
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ public Foo() {}
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description>
+        	<![CDATA[
+Testing new parameter showClassMethods
+     		]]>
+     	</description>
+        <rule-property name="showClassesComplexity">false</rule-property>
+        <expected-problems>1</expected-problems>
+       <code-ref id="basic-violation"/>
+    </test-code>
+    <test-code>
+        <description>
+        	<![CDATA[
+Testing new parameter showMethodsMethods
+     		]]>
+     	</description>
+        <rule-property name="showMethodsComplexity">false</rule-property>
+        <expected-problems>1</expected-problems>
+       <code-ref id="basic-violation"/>
+    </test-code>
+  <test-code>
+        <description>
+        	<![CDATA[
+Testing default value of showClassMethods and showClassesComplexity
+     		]]>
+     	</description>
+        <expected-problems>2</expected-problems>
+       <code-ref id="basic-violation"/>
+    </test-code>
+    <code-fragment id="constructor-violation"><![CDATA[
+public class Test {
+  public Test() {
+    if (a == 1) {
+      if (b == 2) {
+        System.out.println("b");
+      } else if (b == 1) {
+      }
+    } else {
+    }
+  }
+}
+    ]]></code-fragment>
+    <test-code>
+        <description>#984 Cyclomatic complexity should treat constructors like methods: 1 - showMethodsComplexity=true</description>
+        <rule-property name="showClassesComplexity">false</rule-property>
+        <rule-property name="showMethodsComplexity">true</rule-property>
+        <rule-property name="reportLevel">1</rule-property>
+        <expected-problems>1</expected-problems>
+        <code-ref id="constructor-violation"/>
+    </test-code>
+    <test-code>
+        <description>#984 Cyclomatic complexity should treat constructors like methods: 2 - showMethodsComplexity=false</description>
+        <rule-property name="showClassesComplexity">false</rule-property>
+        <rule-property name="showMethodsComplexity">false</rule-property>
+        <rule-property name="reportLevel">1</rule-property>
+        <expected-problems>0</expected-problems>
+        <code-ref id="constructor-violation"/>
+    </test-code>
+    <test-code reinitializeRule="true">
+        <description>#985 Suppressed methods shouldn't affect avg CyclomaticComplexity</description>
+        <rule-property name="reportLevel">2</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Test {
+  @SuppressWarnings("PMD.CyclomaticComplexity")
+  public Test() {
+    if (a == 1) {
+      if (b == 2) {
+        System.out.println("b");
+      } else if (b == 1) {
+      }
+    } else {
+    }
+  }
+}
+        ]]></code>
+    </test-code>
+</test-data>


### PR DESCRIPTION
Provides a couple additional rules for variants on cyclomatic complexity. The first (standard) considers composite Boolean expressions as a single decision point. The second (modified) also considers an entire switch / case statement as a single decision point. 
