### PR TITLE
[JUnit] Check assertion message present in assertEquals with delta

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/junit/JUnitAssertionsShouldIncludeMessageRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/junit/JUnitAssertionsShouldIncludeMessageRule.java
@@ -4,6 +4,7 @@
 package net.sourceforge.pmd.lang.java.rule.junit;
 
 import net.sourceforge.pmd.lang.java.ast.ASTArguments;
+import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
@@ -13,47 +14,66 @@ import java.util.List;
 
 public class JUnitAssertionsShouldIncludeMessageRule extends AbstractJUnitRule {
 
-    private static class AssertionCall {
-        public int args;
-        public String name;
+    private class AssertionCall {
+        private final int argumentsCount;
+        private final String assertionName;
 
-        public AssertionCall(int args, String name) {
-            this.args = args;
-            this.name = name;
+        public AssertionCall(String assertionName, int argumentsCount) {
+            this.argumentsCount = argumentsCount;
+            this.assertionName = assertionName;
+        }
+
+        public void check(Object ctx, ASTArguments node) {
+            if (node.getArgumentCount() == argumentsCount
+                    && node.jjtGetParent().jjtGetParent() instanceof ASTPrimaryExpression) {
+                ASTPrimaryExpression primary = (ASTPrimaryExpression) node.jjtGetParent().jjtGetParent();
+                if (primary.jjtGetChild(0) instanceof ASTPrimaryPrefix
+                        && primary.jjtGetChild(0).jjtGetNumChildren() > 0
+                        && primary.jjtGetChild(0).jjtGetChild(0) instanceof ASTName) {
+                    ASTName name = (ASTName) primary.jjtGetChild(0).jjtGetChild(0);
+
+                    if (name.hasImageEqualTo(this.assertionName)) {
+                        if (isException(node)) {
+                            return;
+                        }
+                        JUnitAssertionsShouldIncludeMessageRule.this.addViolation(ctx, name);
+                    }
+                }
+            }
+        }
+
+        protected boolean isException(ASTArguments node) {
+            return false;
         }
     }
 
     private List<AssertionCall> checks = new ArrayList<AssertionCall>();
 
     public JUnitAssertionsShouldIncludeMessageRule() {
-        checks.add(new AssertionCall(2, "assertArrayEquals"));
-        checks.add(new AssertionCall(2, "assertEquals"));
-        checks.add(new AssertionCall(1, "assertFalse"));
-        checks.add(new AssertionCall(1, "assertNotNull"));
-        checks.add(new AssertionCall(2, "assertNotSame"));
-        checks.add(new AssertionCall(1, "assertNull"));
-        checks.add(new AssertionCall(2, "assertSame"));
-        checks.add(new AssertionCall(2, "assertThat"));
-        checks.add(new AssertionCall(1, "assertTrue"));
-        checks.add(new AssertionCall(0, "fail"));
+        checks.add(new AssertionCall("assertArrayEquals", 2));
+        checks.add(new AssertionCall("assertEquals", 2));
+        checks.add(new AssertionCall("assertFalse", 1));
+        checks.add(new AssertionCall("assertNotNull", 1));
+        checks.add(new AssertionCall("assertNotSame", 2));
+        checks.add(new AssertionCall("assertNull", 1));
+        checks.add(new AssertionCall("assertSame", 2));
+        checks.add(new AssertionCall("assertThat", 2));
+        checks.add(new AssertionCall("assertTrue", 1));
+        checks.add(new AssertionCall("fail", 0));
+
+        checks.add(new AssertionCall("assertEquals", 3) {
+            @Override
+            protected boolean isException(ASTArguments node) {
+                ASTExpression firstArgument = node.getFirstDescendantOfType(ASTExpression.class);
+                return firstArgument.getType() == null || firstArgument.getType() == String.class;
+            }
+        });
     }
 
     public Object visit(ASTArguments node, Object data) {
         for (AssertionCall call : checks) {
-            check(data, node, call.args, call.name);
+            call.check(data, node);
         }
         return super.visit(node, data);
-    }
-
-    private void check(Object ctx, ASTArguments node, int args, String targetMethodName) {
-        if (node.getArgumentCount() == args && node.jjtGetParent().jjtGetParent() instanceof ASTPrimaryExpression) {
-            ASTPrimaryExpression primary = (ASTPrimaryExpression) node.jjtGetParent().jjtGetParent();
-            if (primary.jjtGetChild(0) instanceof ASTPrimaryPrefix && primary.jjtGetChild(0).jjtGetNumChildren() > 0 && primary.jjtGetChild(0).jjtGetChild(0) instanceof ASTName) {
-                ASTName name = (ASTName) primary.jjtGetChild(0).jjtGetChild(0);
-                if (name.hasImageEqualTo(targetMethodName)) {
-                    addViolation(ctx, name);
-                }
-            }
-        }
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/junit/xml/JUnitAssertionsShouldIncludeMessage.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/junit/xml/JUnitAssertionsShouldIncludeMessage.xml
@@ -44,6 +44,35 @@ public class Foo extends TestCase {
     </test-code>
     <test-code>
         <description><![CDATA[
+assertEquals with string variable as message ok
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import junit.framework.TestCase;
+public class Foo extends TestCase {
+ public void test1() {
+  String s = "1 != 1";
+  assertEquals(s, 1, 1);
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+assertEquals with delta ok
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import junit.framework.TestCase;
+public class Foo extends TestCase {
+ public void test1() {
+  assertEquals("foo", 1, 2, 3);
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
 assertEquals bad
      ]]></description>
         <expected-problems>1</expected-problems>
@@ -52,6 +81,35 @@ import junit.framework.TestCase;
 public class Foo extends TestCase {
  public void test1() {
   assertEquals(1, 1);
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+assertEquals with delta bad
+     ]]></description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import junit.framework.TestCase;
+public class Foo extends TestCase {
+ public void test1() {
+  assertEquals(1, 2, 3);
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+assertEquals with delta but missing assertion message not ok
+     ]]></description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import junit.framework.TestCase;
+public class Foo extends TestCase {
+ public void test1() {
+  double d = 1;
+  assertEquals(d, 1, 1);
  }
 }
      ]]></code>


### PR DESCRIPTION
A missing assertion message for assertEquals(double, double, double)
is detected in most cases now. If the assertEquals method has two
arguments, an assertion message is missing, if the assertEquals method
has three arguments, the first one has to be a string.

Pmd will only print an error if the first argument type has been
determined (getType() != null) and isn't a String. Therefore
assertEquals(getInt(), getInt(), getInt()) won't be detected as an
error. However, double d = 1.0; assertEquals(d, 1.0, 1.0); will be
detected.

The JUnitAssertionsShouldIncludeMessageRule.check method has been moved
to the inner class AssertionCall and has been expanded by an
isException hook. The assertEquals with three arguments check overrides
the isException method, returns true if the first argument can't be
determined or is a String and if so, no violation will be added. Also
the constructor arguments have been swapped for readability.

https://sourceforge.net/p/pmd/bugs/1313/

*---End of commit message---*

I have *not* tested this against a big project. If I have to, please provide a link with a howto (I can't find it anymore :worried:)