### PR TITLE
Improves JDK8 support for default methods and static methods in interfaces

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/dcd/asm/TypeSignatureVisitor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/dcd/asm/TypeSignatureVisitor.java
@@ -51,13 +51,13 @@ public class TypeSignatureVisitor extends SignatureVisitor {
     }
 
     public TypeSignatureVisitor() {
-        super(Opcodes.ASM4);
+        super(Opcodes.ASM5);
         p = new PrintVisitor();
         init();
     }
 
     public TypeSignatureVisitor(PrintVisitor parent) {
-        super(Opcodes.ASM4);
+        super(Opcodes.ASM5);
         p = new PrintVisitor(parent);
         init();
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/dcd/asm/TypeSignatureVisitor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/dcd/asm/TypeSignatureVisitor.java
@@ -6,11 +6,9 @@ package net.sourceforge.pmd.dcd.asm;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.List;
-
-import net.sourceforge.pmd.dcd.ClassLoaderUtil;
-
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.signature.SignatureVisitor;
+import net.sourceforge.pmd.dcd.ClassLoaderUtil;
 
 public class TypeSignatureVisitor extends SignatureVisitor {
 
@@ -43,9 +41,11 @@ public class TypeSignatureVisitor extends SignatureVisitor {
     private List<Class<?>> parameterTypes = new ArrayList<Class<?>>(0);
 
     private final PrintVisitor p;
+
     protected void println(String s) {
         p.println(s);
     }
+
     protected void printlnIndent(String s) {
         p.printlnIndent(s);
     }
@@ -53,236 +53,236 @@ public class TypeSignatureVisitor extends SignatureVisitor {
     public TypeSignatureVisitor() {
         super(Opcodes.ASM4);
         p = new PrintVisitor();
-	init();
+        init();
     }
 
     public TypeSignatureVisitor(PrintVisitor parent) {
-	super(Opcodes.ASM4);
-	p = new PrintVisitor(parent);
-	init();
+        super(Opcodes.ASM4);
+        p = new PrintVisitor(parent);
+        init();
     }
 
     public void init() {
-	typeType = FIELD_TYPE;
-	type = null;
-	arrayDimensions = 0;
-	parameterTypes.clear();
+        typeType = FIELD_TYPE;
+        type = null;
+        arrayDimensions = 0;
+        parameterTypes.clear();
     }
 
     public Class<?> getFieldType() {
-	popType();
-	if (fieldType == null) {
-	    throw new RuntimeException();
-	}
-	return fieldType;
+        popType();
+        if (fieldType == null) {
+            throw new RuntimeException();
+        }
+        return fieldType;
     }
 
     public Class<?> getMethodReturnType() {
-	popType();
-	if (returnType == null) {
-	    throw new RuntimeException();
-	}
-	return returnType;
+        popType();
+        if (returnType == null) {
+            throw new RuntimeException();
+        }
+        return returnType;
     }
 
     public Class<?>[] getMethodParameterTypes() {
-	popType();
-	if (parameterTypes == null) {
-	    throw new RuntimeException();
-	}
-	if (parameterTypes != null) {
-	    return parameterTypes.toArray(new Class<?>[parameterTypes.size()]);
-	} else {
-	    return null;
-	}
+        popType();
+        if (parameterTypes == null) {
+            throw new RuntimeException();
+        }
+        if (parameterTypes != null) {
+            return parameterTypes.toArray(new Class<?>[parameterTypes.size()]);
+        } else {
+            return null;
+        }
     }
 
     private void pushType(int type) {
-	this.typeType = type;
+        this.typeType = type;
     }
 
     private void popType() {
-	switch (typeType) {
-	case NO_TYPE:
-	    break;
-	case FIELD_TYPE:
-	    fieldType = getType();
-	    break;
-	case RETURN_TYPE:
-	    returnType = getType();
-	    break;
-	case PARAMETER_TYPE:
-	    parameterTypes.add(getType());
-	    break;
-	default:
-	    throw new RuntimeException("Unknown type type: " + typeType);
-	}
+        switch (typeType) {
+            case NO_TYPE:
+                break;
+            case FIELD_TYPE:
+                fieldType = getType();
+                break;
+            case RETURN_TYPE:
+                returnType = getType();
+                break;
+            case PARAMETER_TYPE:
+                parameterTypes.add(getType());
+                break;
+            default:
+                throw new RuntimeException("Unknown type type: " + typeType);
+        }
 
-	typeType = NO_TYPE;
-	type = null;
-	arrayDimensions = 0;
+        typeType = NO_TYPE;
+        type = null;
+        arrayDimensions = 0;
     }
 
     private Class<?> getType() {
-	Class<?> type = null;
-	if (this.type != null) {
-	    type = this.type;
-	    for (int i = 0; i < arrayDimensions; i++) {
-		// Is there another way to get Array Classes?
-		Object array = Array.newInstance(type, 0);
-		type = array.getClass();
-	    }
-	}
-	return type;
+        Class<?> type = null;
+        if (this.type != null) {
+            type = this.type;
+            for (int i = 0; i < arrayDimensions; i++) {
+                // Is there another way to get Array Classes?
+                Object array = Array.newInstance(type, 0);
+                type = array.getClass();
+            }
+        }
+        return type;
     }
 
     public SignatureVisitor visitArrayType() {
-	if (TRACE) {
-	    println("visitArrayType:");
-	}
-	arrayDimensions++;
-	return this;
+        if (TRACE) {
+            println("visitArrayType:");
+        }
+        arrayDimensions++;
+        return this;
     }
 
     public void visitBaseType(char descriptor) {
-	if (TRACE) {
-	    println("visitBaseType:");
-	    printlnIndent("descriptor: " + descriptor);
-	}
-	switch (descriptor) {
-	case 'B':
-	    type = Byte.TYPE;
-	    break;
-	case 'C':
-	    type = Character.TYPE;
-	    break;
-	case 'D':
-	    type = Double.TYPE;
-	    break;
-	case 'F':
-	    type = Float.TYPE;
-	    break;
-	case 'I':
-	    type = Integer.TYPE;
-	    break;
-	case 'J':
-	    type = Long.TYPE;
-	    break;
-	case 'S':
-	    type = Short.TYPE;
-	    break;
-	case 'Z':
-	    type = Boolean.TYPE;
-	    break;
-	case 'V':
-	    type = Void.TYPE;
-	    break;
-	default:
-	    throw new RuntimeException("Unknown baseType descriptor: " + descriptor);
-	}
+        if (TRACE) {
+            println("visitBaseType:");
+            printlnIndent("descriptor: " + descriptor);
+        }
+        switch (descriptor) {
+            case 'B':
+                type = Byte.TYPE;
+                break;
+            case 'C':
+                type = Character.TYPE;
+                break;
+            case 'D':
+                type = Double.TYPE;
+                break;
+            case 'F':
+                type = Float.TYPE;
+                break;
+            case 'I':
+                type = Integer.TYPE;
+                break;
+            case 'J':
+                type = Long.TYPE;
+                break;
+            case 'S':
+                type = Short.TYPE;
+                break;
+            case 'Z':
+                type = Boolean.TYPE;
+                break;
+            case 'V':
+                type = Void.TYPE;
+                break;
+            default:
+                throw new RuntimeException("Unknown baseType descriptor: " + descriptor);
+        }
     }
 
     public SignatureVisitor visitClassBound() {
-	if (TRACE) {
-	    println("visitClassBound:");
-	}
-	return this;
+        if (TRACE) {
+            println("visitClassBound:");
+        }
+        return this;
     }
 
     public void visitClassType(String name) {
-	if (TRACE) {
-	    println("visitClassType:");
-	    printlnIndent("name: " + name);
-	}
-	name = ClassLoaderUtil.fromInternalForm(name);
-	this.type = ClassLoaderUtil.getClass(name);
+        if (TRACE) {
+            println("visitClassType:");
+            printlnIndent("name: " + name);
+        }
+        name = ClassLoaderUtil.fromInternalForm(name);
+        this.type = ClassLoaderUtil.getClass(name);
     }
 
     public void visitEnd() {
-	if (TRACE) {
-	    println("visitEnd:");
-	}
-	popType();
+        if (TRACE) {
+            println("visitEnd:");
+        }
+        popType();
     }
 
     public SignatureVisitor visitExceptionType() {
-	if (TRACE) {
-	    println("visitExceptionType:");
-	}
-	return this;
+        if (TRACE) {
+            println("visitExceptionType:");
+        }
+        return this;
     }
 
     public void visitFormalTypeParameter(String name) {
-	if (TRACE) {
-	    println("visitFormalTypeParameter:");
-	    printlnIndent("name: " + name);
-	}
+        if (TRACE) {
+            println("visitFormalTypeParameter:");
+            printlnIndent("name: " + name);
+        }
     }
 
     public void visitInnerClassType(String name) {
-	if (TRACE) {
-	    println("visitInnerClassType:");
-	    printlnIndent("name: " + name);
-	}
+        if (TRACE) {
+            println("visitInnerClassType:");
+            printlnIndent("name: " + name);
+        }
     }
 
     public SignatureVisitor visitInterface() {
-	if (TRACE) {
-	    println("visitInterface:");
-	}
-	return this;
+        if (TRACE) {
+            println("visitInterface:");
+        }
+        return this;
     }
 
     public SignatureVisitor visitInterfaceBound() {
-	if (TRACE) {
-	    println("visitInterfaceBound:");
-	}
-	return this;
+        if (TRACE) {
+            println("visitInterfaceBound:");
+        }
+        return this;
     }
 
     public SignatureVisitor visitParameterType() {
-	if (TRACE) {
-	    println("visitParameterType:");
-	}
-	popType();
-	pushType(PARAMETER_TYPE);
-	return this;
+        if (TRACE) {
+            println("visitParameterType:");
+        }
+        popType();
+        pushType(PARAMETER_TYPE);
+        return this;
     }
 
     public SignatureVisitor visitReturnType() {
-	if (TRACE) {
-	    println("visitReturnType:");
-	}
-	popType();
-	pushType(RETURN_TYPE);
-	return this;
+        if (TRACE) {
+            println("visitReturnType:");
+        }
+        popType();
+        pushType(RETURN_TYPE);
+        return this;
     }
 
     public SignatureVisitor visitSuperclass() {
-	if (TRACE) {
-	    println("visitSuperclass:");
-	}
-	return this;
+        if (TRACE) {
+            println("visitSuperclass:");
+        }
+        return this;
     }
 
     public void visitTypeArgument() {
-	if (TRACE) {
-	    println("visitTypeArgument:");
-	}
+        if (TRACE) {
+            println("visitTypeArgument:");
+        }
     }
 
     public SignatureVisitor visitTypeArgument(char wildcard) {
-	if (TRACE) {
-	    println("visitTypeArgument:");
-	    printlnIndent("wildcard: " + wildcard);
-	}
-	return this;
+        if (TRACE) {
+            println("visitTypeArgument:");
+            printlnIndent("wildcard: " + wildcard);
+        }
+        return this;
     }
 
     public void visitTypeVariable(String name) {
-	if (TRACE) {
-	    println("visitTypeVariable:");
-	    printlnIndent("name: " + name);
-	}
+        if (TRACE) {
+            println("visitTypeVariable:");
+            printlnIndent("name: " + name);
+        }
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/dcd/graph/UsageGraphBuilder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/dcd/graph/UsageGraphBuilder.java
@@ -8,11 +8,6 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
-import net.sourceforge.pmd.dcd.asm.PrintVisitor;
-import net.sourceforge.pmd.dcd.asm.TypeSignatureVisitor;
-import net.sourceforge.pmd.util.filter.Filter;
-
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.Attribute;
 import org.objectweb.asm.ClassReader;
@@ -22,424 +17,431 @@ import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.signature.SignatureReader;
+import net.sourceforge.pmd.dcd.asm.PrintVisitor;
+import net.sourceforge.pmd.dcd.asm.TypeSignatureVisitor;
+import net.sourceforge.pmd.util.filter.Filter;
 
 /**
  * Utility class used to build a UsageGraph.
  */
 public class UsageGraphBuilder {
 
-	/**
-	 * Should trace level logging be enabled.  This is a development debugging
-	 * option.
-	 */
-	private static final boolean TRACE = false;
-	private static final boolean INDEX = true;
+    /**
+     * Should trace level logging be enabled.  This is a development debugging
+     * option.
+     */
+    private static final boolean TRACE = false;
+    private static final boolean INDEX = true;
 
-	protected final UsageGraph usageGraph;
-	protected final Filter<String> classFilter;
+    protected final UsageGraph usageGraph;
+    protected final Filter<String> classFilter;
 
-	public UsageGraphBuilder(Filter<String> classFilter) {
-		this.classFilter = classFilter;
-		this.usageGraph = new UsageGraph(classFilter);
-	}
+    public UsageGraphBuilder(Filter<String> classFilter) {
+        this.classFilter = classFilter;
+        this.usageGraph = new UsageGraph(classFilter);
+    }
 
-	public void index(String name) {
-		try {
-			String className = getClassName(name);
-			String classResourceName = getResourceName(name);
-			if (classFilter.filter(className)) {
-				if (!usageGraph.isClass(className)) {
-					usageGraph.defineClass(className);
-					InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream(
-							classResourceName + ".class");
-					ClassReader classReader = new ClassReader(inputStream);
-					classReader.accept(getNewClassVisitor(), 0);
-				}
-			}
-		} catch (IOException e) {
-			throw new RuntimeException("For " + name + ": " + e.getMessage(), e);
-		}
-	}
+    public void index(String name) {
+        try {
+            String className = getClassName(name);
+            String classResourceName = getResourceName(name);
+            if (classFilter.filter(className)) {
+                if (!usageGraph.isClass(className)) {
+                    usageGraph.defineClass(className);
+                    InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream(
+                            classResourceName + ".class");
+                    ClassReader classReader = new ClassReader(inputStream);
+                    classReader.accept(getNewClassVisitor(), 0);
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("For " + name + ": " + e.getMessage(), e);
+        }
+    }
 
-	public UsageGraph getUsageGraph() {
-		return usageGraph;
-	}
+    public UsageGraph getUsageGraph() {
+        return usageGraph;
+    }
 
-	private ClassVisitor getNewClassVisitor() {
-		return new MyClassVisitor();
-	}
+    private ClassVisitor getNewClassVisitor() {
+        return new MyClassVisitor();
+    }
 
-	// ASM visitor to on Class files to build a UsageGraph
-	class MyClassVisitor extends ClassVisitor {
-	    private final PrintVisitor p;
-	    protected void println(String s) {
-	        p.println(s);
-	    }
-	    protected void printlnIndent(String s) {
-	        p.printlnIndent(s);
-	    }
-	    
-	    public MyClassVisitor() {
-	        super(Opcodes.ASM4);
-	        p = new PrintVisitor();
-	    }
-
-	    private String className;
-
-		public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
-			if (TRACE) {
-				println("visit:");
-				printlnIndent("version: " + version);
-				printlnIndent("access: " + access);
-				printlnIndent("name: " + name);
-				printlnIndent("signature: " + signature);
-				printlnIndent("superName: " + superName);
-				printlnIndent("interfaces: " + asList(interfaces));
-			}
-			this.className = getClassName(name);
-		}
-
-		public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
-			if (TRACE) {
-				println("visitAnnotation:");
-				printlnIndent("desc: " + desc);
-				printlnIndent("visible: " + visible);
-			}
-			return null;
-		}
-
-		public void visitAttribute(Attribute attr) {
-			if (TRACE) {
-				println("visitAttribute:");
-				printlnIndent("attr: " + attr);
-			}
-		}
-
-		public void visitEnd() {
-			if (TRACE) {
-				println("visitEnd:");
-			}
-		}
-
-		public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
-			if (TRACE) {
-				println("visitField:");
-				printlnIndent("access: " + access);
-				printlnIndent("name: " + name);
-				printlnIndent("desc: " + desc);
-				printlnIndent("signature: " + signature);
-				printlnIndent("value: " + value);
-			}
-			if (INDEX) {
-				SignatureReader signatureReader = new SignatureReader(desc);
-				TypeSignatureVisitor visitor = new TypeSignatureVisitor(p);
-				signatureReader.acceptType(visitor);
-				if (TRACE) {
-					printlnIndent("fieldType: " + visitor.getFieldType());
-				}
-
-				usageGraph.defineField(className, name, desc);
-			}
-			return null;
-		}
-
-		public void visitInnerClass(String name, String outerName, String innerName, int access) {
-			if (TRACE) {
-				println("visitInnerClass:");
-				printlnIndent("name: " + name);
-				printlnIndent("outerName: " + outerName);
-				printlnIndent("innerName: " + innerName);
-				printlnIndent("access: " + access);
-			}
-			index(name);
-		}
-
-		public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
-			MemberNode memberNode = null;
-			if (TRACE) {
-				println("visitMethod:");
-				printlnIndent("access: " + access);
-				printlnIndent("name: " + name);
-				printlnIndent("desc: " + desc);
-				printlnIndent("signature: " + signature);
-				printlnIndent("exceptions: " + asList(exceptions));
-			}
-			if (INDEX) {
-				memberNode = usageGraph.defineMethod(className, name, desc);
-			}
-			return getNewMethodVisitor(p, memberNode);
-		}
-
-		public void visitOuterClass(String owner, String name, String desc) {
-			if (TRACE) {
-				println("visitOuterClass:");
-				printlnIndent("owner: " + owner);
-				printlnIndent("name: " + name);
-				printlnIndent("desc: " + desc);
-			}
-		}
-
-		public void visitSource(String source, String debug) {
-			if (TRACE) {
-				println("visitSource:");
-				printlnIndent("source: " + source);
-				printlnIndent("debug: " + debug);
-			}
-		}
-	}
-
-	protected MethodVisitor getNewMethodVisitor(PrintVisitor parent, MemberNode usingMemberNode) {
-		return new MyMethodVisitor(parent, usingMemberNode);
-	}
-
-	protected class MyMethodVisitor extends MethodVisitor {
+    // ASM visitor to on Class files to build a UsageGraph
+    class MyClassVisitor extends ClassVisitor {
         private final PrintVisitor p;
+
         protected void println(String s) {
             p.println(s);
         }
+
         protected void printlnIndent(String s) {
             p.printlnIndent(s);
         }
-        
-		private final MemberNode usingMemberNode;
 
-		public MyMethodVisitor(PrintVisitor parent, MemberNode usingMemberNode) {
+        public MyClassVisitor() {
+            super(Opcodes.ASM4);
+            p = new PrintVisitor();
+        }
+
+        private String className;
+
+        public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+            if (TRACE) {
+                println("visit:");
+                printlnIndent("version: " + version);
+                printlnIndent("access: " + access);
+                printlnIndent("name: " + name);
+                printlnIndent("signature: " + signature);
+                printlnIndent("superName: " + superName);
+                printlnIndent("interfaces: " + asList(interfaces));
+            }
+            this.className = getClassName(name);
+        }
+
+        public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+            if (TRACE) {
+                println("visitAnnotation:");
+                printlnIndent("desc: " + desc);
+                printlnIndent("visible: " + visible);
+            }
+            return null;
+        }
+
+        public void visitAttribute(Attribute attr) {
+            if (TRACE) {
+                println("visitAttribute:");
+                printlnIndent("attr: " + attr);
+            }
+        }
+
+        public void visitEnd() {
+            if (TRACE) {
+                println("visitEnd:");
+            }
+        }
+
+        public FieldVisitor visitField(int access, String name, String desc, String signature, Object value) {
+            if (TRACE) {
+                println("visitField:");
+                printlnIndent("access: " + access);
+                printlnIndent("name: " + name);
+                printlnIndent("desc: " + desc);
+                printlnIndent("signature: " + signature);
+                printlnIndent("value: " + value);
+            }
+            if (INDEX) {
+                SignatureReader signatureReader = new SignatureReader(desc);
+                TypeSignatureVisitor visitor = new TypeSignatureVisitor(p);
+                signatureReader.acceptType(visitor);
+                if (TRACE) {
+                    printlnIndent("fieldType: " + visitor.getFieldType());
+                }
+
+                usageGraph.defineField(className, name, desc);
+            }
+            return null;
+        }
+
+        public void visitInnerClass(String name, String outerName, String innerName, int access) {
+            if (TRACE) {
+                println("visitInnerClass:");
+                printlnIndent("name: " + name);
+                printlnIndent("outerName: " + outerName);
+                printlnIndent("innerName: " + innerName);
+                printlnIndent("access: " + access);
+            }
+            index(name);
+        }
+
+        public MethodVisitor visitMethod(int access, String name, String desc, String signature, String[] exceptions) {
+            MemberNode memberNode = null;
+            if (TRACE) {
+                println("visitMethod:");
+                printlnIndent("access: " + access);
+                printlnIndent("name: " + name);
+                printlnIndent("desc: " + desc);
+                printlnIndent("signature: " + signature);
+                printlnIndent("exceptions: " + asList(exceptions));
+            }
+            if (INDEX) {
+                memberNode = usageGraph.defineMethod(className, name, desc);
+            }
+            return getNewMethodVisitor(p, memberNode);
+        }
+
+        public void visitOuterClass(String owner, String name, String desc) {
+            if (TRACE) {
+                println("visitOuterClass:");
+                printlnIndent("owner: " + owner);
+                printlnIndent("name: " + name);
+                printlnIndent("desc: " + desc);
+            }
+        }
+
+        public void visitSource(String source, String debug) {
+            if (TRACE) {
+                println("visitSource:");
+                printlnIndent("source: " + source);
+                printlnIndent("debug: " + debug);
+            }
+        }
+    }
+
+    protected MethodVisitor getNewMethodVisitor(PrintVisitor parent, MemberNode usingMemberNode) {
+        return new MyMethodVisitor(parent, usingMemberNode);
+    }
+
+    protected class MyMethodVisitor extends MethodVisitor {
+        private final PrintVisitor p;
+
+        protected void println(String s) {
+            p.println(s);
+        }
+
+        protected void printlnIndent(String s) {
+            p.printlnIndent(s);
+        }
+
+        private final MemberNode usingMemberNode;
+
+        public MyMethodVisitor(PrintVisitor parent, MemberNode usingMemberNode) {
             super(Opcodes.ASM4);
             p = parent;
-			this.usingMemberNode = usingMemberNode;
-		}
+            this.usingMemberNode = usingMemberNode;
+        }
 
-		public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
-			if (TRACE) {
-				println("visitAnnotation:");
-				printlnIndent("desc: " + desc);
-				printlnIndent("visible: " + visible);
-			}
-			return null;
-		}
+        public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+            if (TRACE) {
+                println("visitAnnotation:");
+                printlnIndent("desc: " + desc);
+                printlnIndent("visible: " + visible);
+            }
+            return null;
+        }
 
-		public AnnotationVisitor visitAnnotationDefault() {
-			if (TRACE) {
-				println("visitAnnotationDefault:");
-			}
-			return null;
-		}
+        public AnnotationVisitor visitAnnotationDefault() {
+            if (TRACE) {
+                println("visitAnnotationDefault:");
+            }
+            return null;
+        }
 
-		public void visitAttribute(Attribute attr) {
-			if (TRACE) {
-				println("visitAttribute:");
-				printlnIndent("attr: " + attr);
-			}
-		}
+        public void visitAttribute(Attribute attr) {
+            if (TRACE) {
+                println("visitAttribute:");
+                printlnIndent("attr: " + attr);
+            }
+        }
 
-		public void visitCode() {
-			if (TRACE) {
-				println("visitCode:");
-			}
-		}
+        public void visitCode() {
+            if (TRACE) {
+                println("visitCode:");
+            }
+        }
 
-		public void visitEnd() {
-			if (TRACE) {
-				println("visitEnd:");
-			}
-		}
+        public void visitEnd() {
+            if (TRACE) {
+                println("visitEnd:");
+            }
+        }
 
-		public void visitFieldInsn(int opcode, String owner, String name, String desc) {
-			if (TRACE) {
-				println("visitFieldInsn:");
-				printlnIndent("opcode: " + opcode);
-				printlnIndent("owner: " + owner);
-				printlnIndent("name: " + name);
-				printlnIndent("desc: " + desc);
-			}
-			if (INDEX) {
-				String className = getClassName(owner);
-				usageGraph.usageField(className, name, desc, usingMemberNode);
-			}
-		}
+        public void visitFieldInsn(int opcode, String owner, String name, String desc) {
+            if (TRACE) {
+                println("visitFieldInsn:");
+                printlnIndent("opcode: " + opcode);
+                printlnIndent("owner: " + owner);
+                printlnIndent("name: " + name);
+                printlnIndent("desc: " + desc);
+            }
+            if (INDEX) {
+                String className = getClassName(owner);
+                usageGraph.usageField(className, name, desc, usingMemberNode);
+            }
+        }
 
-		public void visitFrame(int type, int local, Object[] local2, int stack, Object[] stack2) {
-			if (TRACE) {
-				println("visitFrame:");
-				printlnIndent("type: " + type);
-				printlnIndent("local: " + local);
-				printlnIndent("local2: " + asList(local2));
-				printlnIndent("stack: " + stack);
-				printlnIndent("stack2: " + asList(stack2));
-			}
-		}
+        public void visitFrame(int type, int local, Object[] local2, int stack, Object[] stack2) {
+            if (TRACE) {
+                println("visitFrame:");
+                printlnIndent("type: " + type);
+                printlnIndent("local: " + local);
+                printlnIndent("local2: " + asList(local2));
+                printlnIndent("stack: " + stack);
+                printlnIndent("stack2: " + asList(stack2));
+            }
+        }
 
-		public void visitIincInsn(int var, int increment) {
-			if (TRACE) {
-				println("visitIincInsn:");
-				printlnIndent("var: " + var);
-				printlnIndent("increment: " + increment);
-			}
-		}
+        public void visitIincInsn(int var, int increment) {
+            if (TRACE) {
+                println("visitIincInsn:");
+                printlnIndent("var: " + var);
+                printlnIndent("increment: " + increment);
+            }
+        }
 
-		public void visitInsn(int opcode) {
-			if (TRACE) {
-				println("visitInsn:");
-				printlnIndent("opcode: " + opcode);
-			}
-		}
+        public void visitInsn(int opcode) {
+            if (TRACE) {
+                println("visitInsn:");
+                printlnIndent("opcode: " + opcode);
+            }
+        }
 
-		public void visitIntInsn(int opcode, int operand) {
-			if (TRACE) {
-				println("visitIntInsn:");
-				printlnIndent("opcode: " + opcode);
-				printlnIndent("operand: " + operand);
-			}
-		}
+        public void visitIntInsn(int opcode, int operand) {
+            if (TRACE) {
+                println("visitIntInsn:");
+                printlnIndent("opcode: " + opcode);
+                printlnIndent("operand: " + operand);
+            }
+        }
 
-		public void visitJumpInsn(int opcode, Label label) {
-			if (TRACE) {
-				println("visitJumpInsn:");
-				printlnIndent("opcode: " + opcode);
-				printlnIndent("label: " + label);
-			}
-		}
+        public void visitJumpInsn(int opcode, Label label) {
+            if (TRACE) {
+                println("visitJumpInsn:");
+                printlnIndent("opcode: " + opcode);
+                printlnIndent("label: " + label);
+            }
+        }
 
-		public void visitLabel(Label label) {
-			if (TRACE) {
-				println("visitLabel:");
-				printlnIndent("label: " + label);
-			}
-		}
+        public void visitLabel(Label label) {
+            if (TRACE) {
+                println("visitLabel:");
+                printlnIndent("label: " + label);
+            }
+        }
 
-		public void visitLdcInsn(Object cst) {
-			if (TRACE) {
-				println("visitLdcInsn:");
-				printlnIndent("cst: " + cst);
-			}
-		}
+        public void visitLdcInsn(Object cst) {
+            if (TRACE) {
+                println("visitLdcInsn:");
+                printlnIndent("cst: " + cst);
+            }
+        }
 
-		public void visitLineNumber(int line, Label start) {
-			if (TRACE) {
-				println("visitLineNumber:");
-				printlnIndent("line: " + line);
-				printlnIndent("start: " + start);
-			}
-		}
+        public void visitLineNumber(int line, Label start) {
+            if (TRACE) {
+                println("visitLineNumber:");
+                printlnIndent("line: " + line);
+                printlnIndent("start: " + start);
+            }
+        }
 
-		public void visitLocalVariable(String name, String desc, String signature, Label start, Label end, int index) {
-			if (TRACE) {
-				println("visitLocalVariable:");
-				printlnIndent("name: " + name);
-				printlnIndent("desc: " + desc);
-				printlnIndent("signature: " + signature);
-				printlnIndent("start: " + start);
-				printlnIndent("end: " + end);
-				printlnIndent("index: " + index);
-			}
-		}
+        public void visitLocalVariable(String name, String desc, String signature, Label start, Label end, int index) {
+            if (TRACE) {
+                println("visitLocalVariable:");
+                printlnIndent("name: " + name);
+                printlnIndent("desc: " + desc);
+                printlnIndent("signature: " + signature);
+                printlnIndent("start: " + start);
+                printlnIndent("end: " + end);
+                printlnIndent("index: " + index);
+            }
+        }
 
-		public void visitLookupSwitchInsn(Label dflt, int[] keys, Label[] labels) {
-			if (TRACE) {
-				println("visitLookupSwitchInsn:");
-				printlnIndent("dflt: " + dflt);
-				printlnIndent("keys: " + asList(keys));
-				printlnIndent("labels: " + asList(labels));
-			}
-		}
+        public void visitLookupSwitchInsn(Label dflt, int[] keys, Label[] labels) {
+            if (TRACE) {
+                println("visitLookupSwitchInsn:");
+                printlnIndent("dflt: " + dflt);
+                printlnIndent("keys: " + asList(keys));
+                printlnIndent("labels: " + asList(labels));
+            }
+        }
 
-		public void visitMaxs(int maxStack, int maxLocals) {
-			if (TRACE) {
-				println("visitMaxs:");
-				printlnIndent("maxStack: " + maxStack);
-				printlnIndent("maxLocals: " + maxLocals);
-			}
-		}
+        public void visitMaxs(int maxStack, int maxLocals) {
+            if (TRACE) {
+                println("visitMaxs:");
+                printlnIndent("maxStack: " + maxStack);
+                printlnIndent("maxLocals: " + maxLocals);
+            }
+        }
 
-		public void visitMethodInsn(int opcode, String owner, String name, String desc) {
-			if (TRACE) {
-				println("visitMethodInsn:");
-				printlnIndent("opcode: " + opcode);
-				printlnIndent("owner: " + owner);
-				printlnIndent("name: " + name);
-				printlnIndent("desc: " + desc);
-			}
-			if (INDEX) {
-				String className = getClassName(owner);
-				usageGraph.usageMethod(className, name, desc, usingMemberNode);
-			}
-		}
+        public void visitMethodInsn(int opcode, String owner, String name, String desc) {
+            if (TRACE) {
+                println("visitMethodInsn:");
+                printlnIndent("opcode: " + opcode);
+                printlnIndent("owner: " + owner);
+                printlnIndent("name: " + name);
+                printlnIndent("desc: " + desc);
+            }
+            if (INDEX) {
+                String className = getClassName(owner);
+                usageGraph.usageMethod(className, name, desc, usingMemberNode);
+            }
+        }
 
-		public void visitMultiANewArrayInsn(String desc, int dims) {
-			if (TRACE) {
-				println("visitMultiANewArrayInsn:");
-				printlnIndent("desc: " + desc);
-				printlnIndent("dims: " + dims);
-			}
-		}
+        public void visitMultiANewArrayInsn(String desc, int dims) {
+            if (TRACE) {
+                println("visitMultiANewArrayInsn:");
+                printlnIndent("desc: " + desc);
+                printlnIndent("dims: " + dims);
+            }
+        }
 
-		public AnnotationVisitor visitParameterAnnotation(int parameter, String desc, boolean visible) {
-			if (TRACE) {
-				println("visitParameterAnnotation:");
-				printlnIndent("parameter: " + parameter);
-				printlnIndent("desc: " + desc);
-				printlnIndent("visible: " + visible);
-			}
-			return null;
-		}
+        public AnnotationVisitor visitParameterAnnotation(int parameter, String desc, boolean visible) {
+            if (TRACE) {
+                println("visitParameterAnnotation:");
+                printlnIndent("parameter: " + parameter);
+                printlnIndent("desc: " + desc);
+                printlnIndent("visible: " + visible);
+            }
+            return null;
+        }
 
-		public void visitTableSwitchInsn(int min, int max, Label dflt, Label[] labels) {
-			if (TRACE) {
-				println("visitTableSwitchInsn:");
-				printlnIndent("min: " + min);
-				printlnIndent("max: " + max);
-				printlnIndent("dflt: " + dflt);
-				printlnIndent("labels: " + asList(labels));
-			}
-		}
+        public void visitTableSwitchInsn(int min, int max, Label dflt, Label[] labels) {
+            if (TRACE) {
+                println("visitTableSwitchInsn:");
+                printlnIndent("min: " + min);
+                printlnIndent("max: " + max);
+                printlnIndent("dflt: " + dflt);
+                printlnIndent("labels: " + asList(labels));
+            }
+        }
 
-		public void visitTryCatchBlock(Label start, Label end, Label handler, String type) {
-			if (TRACE) {
-				println("visitTryCatchBlock:");
-				printlnIndent("start: " + start);
-				printlnIndent("end: " + end);
-				printlnIndent("handler: " + handler);
-				printlnIndent("type: " + type);
-			}
-		}
+        public void visitTryCatchBlock(Label start, Label end, Label handler, String type) {
+            if (TRACE) {
+                println("visitTryCatchBlock:");
+                printlnIndent("start: " + start);
+                printlnIndent("end: " + end);
+                printlnIndent("handler: " + handler);
+                printlnIndent("type: " + type);
+            }
+        }
 
-		public void visitTypeInsn(int opcode, String desc) {
-			if (TRACE) {
-				println("visitTypeInsn:");
-				printlnIndent("opcode: " + opcode);
-				printlnIndent("desc: " + desc);
-			}
-		}
+        public void visitTypeInsn(int opcode, String desc) {
+            if (TRACE) {
+                println("visitTypeInsn:");
+                printlnIndent("opcode: " + opcode);
+                printlnIndent("desc: " + desc);
+            }
+        }
 
-		public void visitVarInsn(int opcode, int var) {
-			if (TRACE) {
-				println("visitVarInsn:");
-				printlnIndent("opcode: " + opcode);
-				printlnIndent("var: " + var);
-			}
-		}
-	}
+        public void visitVarInsn(int opcode, int var) {
+            if (TRACE) {
+                println("visitVarInsn:");
+                printlnIndent("opcode: " + opcode);
+                printlnIndent("var: " + var);
+            }
+        }
+    }
 
-	private static String getResourceName(String name) {
-		return name.replace('.', '/');
-	}
+    private static String getResourceName(String name) {
+        return name.replace('.', '/');
+    }
 
-	static String getClassName(String name) {
-		return name.replace('/', '.');
-	}
+    static String getClassName(String name) {
+        return name.replace('/', '.');
+    }
 
-	private static List<Integer> asList(int[] array) {
-		List<Integer> list = null;
-		if (array != null) {
-			list = new ArrayList<Integer>(array.length);
-			for (int i : array) {
-				list.add(i);
-			}
-		}
-		return list;
-	}
+    private static List<Integer> asList(int[] array) {
+        List<Integer> list = null;
+        if (array != null) {
+            list = new ArrayList<Integer>(array.length);
+            for (int i : array) {
+                list.add(i);
+            }
+        }
+        return list;
+    }
 
-	private static List<Object> asList(Object[] array) {
-		return array != null ? Arrays.asList(array) : null;
-	}
+    private static List<Object> asList(Object[] array) {
+        return array != null ? Arrays.asList(array) : null;
+    }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/dcd/graph/UsageGraphBuilder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/dcd/graph/UsageGraphBuilder.java
@@ -80,7 +80,7 @@ public class UsageGraphBuilder {
         }
 
         public MyClassVisitor() {
-            super(Opcodes.ASM4);
+            super(Opcodes.ASM5);
             p = new PrintVisitor();
         }
 
@@ -206,7 +206,7 @@ public class UsageGraphBuilder {
         private final MemberNode usingMemberNode;
 
         public MyMethodVisitor(PrintVisitor parent, MemberNode usingMemberNode) {
-            super(Opcodes.ASM4);
+            super(Opcodes.ASM5);
             p = parent;
             this.usingMemberNode = usingMemberNode;
         }
@@ -353,13 +353,14 @@ public class UsageGraphBuilder {
             }
         }
 
-        public void visitMethodInsn(int opcode, String owner, String name, String desc) {
+        public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
             if (TRACE) {
                 println("visitMethodInsn:");
                 printlnIndent("opcode: " + opcode);
                 printlnIndent("owner: " + owner);
                 printlnIndent("name: " + name);
                 printlnIndent("desc: " + desc);
+                printlnIndent("itf: " + itf);
             }
             if (INDEX) {
                 String className = getClassName(owner);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/visitors/PMDASMVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/visitors/PMDASMVisitor.java
@@ -3,6 +3,10 @@
  */
 package net.sourceforge.pmd.lang.java.typeresolution.visitors;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.Attribute;
 import org.objectweb.asm.ClassVisitor;
@@ -14,11 +18,6 @@ import org.objectweb.asm.Type;
 import org.objectweb.asm.signature.SignatureReader;
 import org.objectweb.asm.signature.SignatureVisitor;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 public class PMDASMVisitor extends ClassVisitor {
 
     public PMDASMVisitor() {
@@ -27,380 +26,381 @@ public class PMDASMVisitor extends ClassVisitor {
 
     private Map<String, String> packages = new HashMap<String, String>();
 
-	private AnnotationVisitor annotationVisitor = new PMDAnnotationVisitor(this);
+    private AnnotationVisitor annotationVisitor = new PMDAnnotationVisitor(this);
 
-	private FieldVisitor fieldVisitor = new PMDFieldVisitor(this);
+    private FieldVisitor fieldVisitor = new PMDFieldVisitor(this);
 
-	private SignatureVisitor sigVisitor = new PMDSignatureVisitor(this);
+    private SignatureVisitor sigVisitor = new PMDSignatureVisitor(this);
 
-	private MethodVisitor methodVisitor = new PMDMethodVisitor(this);
+    private MethodVisitor methodVisitor = new PMDMethodVisitor(this);
 
-	public List<String> innerClasses;
+    public List<String> innerClasses;
 
-	public Map<String, String> getPackages() {
-		return packages;
-	}
+    public Map<String, String> getPackages() {
+        return packages;
+    }
 
-	public List<String> getInnerClasses() {
-		return innerClasses;
-	}
+    public List<String> getInnerClasses() {
+        return innerClasses;
+    }
 
-	private String parseClassName(String name) {
-		if (name == null) {
-			return null;
-		}
+    private String parseClassName(String name) {
+        if (name == null) {
+            return null;
+        }
 
-		String className = name;
-		int n = name.lastIndexOf('/');
-		if (n > -1) {
-			className = name.substring(n + 1);
-		}
-		name = name.replace('/', '.');
-		packages.put(className, name);
-		n = className.indexOf('$');
-		if (n > -1) {
-			//TODO I don't think the first one, with Class$Inner is needed - come back and check
-			packages.put(className.substring(n + 1), name);
-			packages.put(className.replace('$', '.'), name);
-		}
+        String className = name;
+        int n = name.lastIndexOf('/');
+        if (n > -1) {
+            className = name.substring(n + 1);
+        }
+        name = name.replace('/', '.');
+        packages.put(className, name);
+        n = className.indexOf('$');
+        if (n > -1) {
+            //TODO I don't think the first one, with Class$Inner is needed - come back and check
+            packages.put(className.substring(n + 1), name);
+            packages.put(className.replace('$', '.'), name);
+        }
 
-		return name;
-	}
+        return name;
+    }
 
-	private void parseClassName(String[] names) {
-		if (names != null) {
-			for (String s : names) {
-				parseClassName(s);
-			}
-		}
-	}
+    private void parseClassName(String[] names) {
+        if (names != null) {
+            for (String s : names) {
+                parseClassName(s);
+            }
+        }
+    }
 
-	private void extractSignature(String sig) {
-		if (sig != null) {
-			new SignatureReader(sig).accept(sigVisitor);
-		}
-	}
+    private void extractSignature(String sig) {
+        if (sig != null) {
+            new SignatureReader(sig).accept(sigVisitor);
+        }
+    }
 
 	/* Start ClassVisitor implementations */
 
-	public void visit(int version, int access, String name, String sig, String superName, String[] interfaces) {
-		parseClassName(name);
-		parseClassName(interfaces);
-		if (sig != null) {
-			extractSignature(sig);
-		}
-	}
+    public void visit(int version, int access, String name, String sig, String superName, String[] interfaces) {
+        parseClassName(name);
+        parseClassName(interfaces);
+        if (sig != null) {
+            extractSignature(sig);
+        }
+    }
 
-	public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
-		addType(Type.getType(desc));
-		return annotationVisitor;
-	}
+    public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+        addType(Type.getType(desc));
+        return annotationVisitor;
+    }
 
-	public FieldVisitor visitField(int access, String name, String desc, String sig, Object value) {
-		if (sig != null) {
-			extractSignature(sig);
-		}
+    public FieldVisitor visitField(int access, String name, String desc, String sig, Object value) {
+        if (sig != null) {
+            extractSignature(sig);
+        }
 
-		addType(Type.getType(desc));
-		if (value instanceof Type) {
-			addType((Type) value);
-		}
-		return fieldVisitor;
-	}
+        addType(Type.getType(desc));
+        if (value instanceof Type) {
+            addType((Type) value);
+        }
+        return fieldVisitor;
+    }
 
-	public MethodVisitor visitMethod(int access, String name, String desc, String sig, String[] exceptions) {
-		if (sig != null) {
-			extractSignature(sig);
-		}
-		addMethodDesc(desc);
-		parseClassName(exceptions);
-		return methodVisitor;
-	}
+    public MethodVisitor visitMethod(int access, String name, String desc, String sig, String[] exceptions) {
+        if (sig != null) {
+            extractSignature(sig);
+        }
+        addMethodDesc(desc);
+        parseClassName(exceptions);
+        return methodVisitor;
+    }
 
-	public void visitSource(String source, String debug) {
-	}
+    public void visitSource(String source, String debug) {
+    }
 
-	public void visitInnerClass(String name, String outerName, String innerName, int access) {
-		if (innerClasses == null) {
-			innerClasses = new ArrayList<String>();
-		}
-		if (!innerClasses.contains(name.replace('/', '.'))) {
-			innerClasses.add(name.replace('/', '.'));
-		}
-		packages.put(innerName, name.replace('/', '.'));
-	}
+    public void visitInnerClass(String name, String outerName, String innerName, int access) {
+        if (innerClasses == null) {
+            innerClasses = new ArrayList<String>();
+        }
+        if (!innerClasses.contains(name.replace('/', '.'))) {
+            innerClasses.add(name.replace('/', '.'));
+        }
+        packages.put(innerName, name.replace('/', '.'));
+    }
 
-	public void visitOuterClass(String owner, String name, String desc) {
-	}
+    public void visitOuterClass(String owner, String name, String desc) {
+    }
 
-	public void visitEnd() {
-	}
+    public void visitEnd() {
+    }
 
-	private void addMethodDesc(String desc) {
-		addTypes(desc);
-		addType(Type.getReturnType(desc));
-	}
+    private void addMethodDesc(String desc) {
+        addTypes(desc);
+        addType(Type.getReturnType(desc));
+    }
 
-	private void addTypes(String desc) {
-		Type[] types = Type.getArgumentTypes(desc);
-		for (Type type : types) {
-			addType(type);
-		}
-	}
+    private void addTypes(String desc) {
+        Type[] types = Type.getArgumentTypes(desc);
+        for (Type type : types) {
+            addType(type);
+        }
+    }
 
-	private void addType(Type t) {
-		switch (t.getSort()) {
-		case Type.ARRAY:
-			addType(t.getElementType());
-			break;
-		case Type.OBJECT:
-			parseClassName(t.getClassName().replace('.', '/'));
-			break;
-		default:
-		    // Do nothing
-		    break;
-		}
-	}
+    private void addType(Type t) {
+        switch (t.getSort()) {
+            case Type.ARRAY:
+                addType(t.getElementType());
+                break;
+            case Type.OBJECT:
+                parseClassName(t.getClassName().replace('.', '/'));
+                break;
+            default:
+                // Do nothing
+                break;
+        }
+    }
 
-	public void visitAttribute(Attribute attr) {
-	}
+    public void visitAttribute(Attribute attr) {
+    }
 
 	/*
-	 * Start visitors
+     * Start visitors
 	 */
 
-	private static class PMDFieldVisitor extends FieldVisitor {
+    private static class PMDFieldVisitor extends FieldVisitor {
 
-		private PMDASMVisitor parent;
+        private PMDASMVisitor parent;
 
-		public PMDFieldVisitor(PMDASMVisitor visitor) {
-		    super(Opcodes.ASM4);
-			parent = visitor;
-		}
-
-		public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
-			parent.addType(Type.getType(desc));
-			return parent.annotationVisitor;
-		}
-
-		public void visitAttribute(Attribute attr) {
-		}
-
-		public void visitEnd() {
-		}
-	}
-
-	private static class PMDAnnotationVisitor extends AnnotationVisitor {
-		private PMDASMVisitor parent;
-
-		public PMDAnnotationVisitor(PMDASMVisitor visitor) {
+        public PMDFieldVisitor(PMDASMVisitor visitor) {
             super(Opcodes.ASM4);
-			parent = visitor;
-		}
+            parent = visitor;
+        }
 
-		public AnnotationVisitor visitAnnotation(String name, String desc) {
-			parent.addType(Type.getType(desc));
-			return this;
-		}
+        public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+            parent.addType(Type.getType(desc));
+            return parent.annotationVisitor;
+        }
 
-		public void visitEnum(String name, String desc, String value) {
-			parent.addType(Type.getType(desc));
-		}
+        public void visitAttribute(Attribute attr) {
+        }
 
-		public AnnotationVisitor visitArray(String name) {
-			return this;
-		}
+        public void visitEnd() {
+        }
+    }
 
-		public void visitEnd() {
-		}
+    private static class PMDAnnotationVisitor extends AnnotationVisitor {
+        private PMDASMVisitor parent;
 
-		public void visit(String name, Object value) {
-			if (value instanceof Type) {
-				parent.addType((Type) value);
-			}
-		}
-	}
-
-	private static class PMDSignatureVisitor extends SignatureVisitor {
-		private PMDASMVisitor parent;
-
-		public PMDSignatureVisitor(PMDASMVisitor visitor) {
+        public PMDAnnotationVisitor(PMDASMVisitor visitor) {
             super(Opcodes.ASM4);
-			this.parent = visitor;
-		}
+            parent = visitor;
+        }
 
-		public void visitFormalTypeParameter(String name) {
-		}
+        public AnnotationVisitor visitAnnotation(String name, String desc) {
+            parent.addType(Type.getType(desc));
+            return this;
+        }
 
-		public SignatureVisitor visitClassBound() {
-			return this;
-		}
+        public void visitEnum(String name, String desc, String value) {
+            parent.addType(Type.getType(desc));
+        }
 
-		public SignatureVisitor visitInterfaceBound() {
-			return this;
-		}
+        public AnnotationVisitor visitArray(String name) {
+            return this;
+        }
 
-		public SignatureVisitor visitSuperclass() {
-			return this;
-		}
+        public void visitEnd() {
+        }
 
-		public SignatureVisitor visitInterface() {
-			return this;
-		}
+        public void visit(String name, Object value) {
+            if (value instanceof Type) {
+                parent.addType((Type) value);
+            }
+        }
+    }
 
-		public SignatureVisitor visitParameterType() {
-			return this;
-		}
+    private static class PMDSignatureVisitor extends SignatureVisitor {
+        private PMDASMVisitor parent;
 
-		public SignatureVisitor visitReturnType() {
-			return this;
-		}
-
-		public SignatureVisitor visitExceptionType() {
-			return this;
-		}
-
-		public void visitBaseType(char descriptor) {
-		}
-
-		public void visitTypeVariable(String name) {
-		}
-
-		public SignatureVisitor visitArrayType() {
-			return this;
-		}
-
-		public void visitClassType(String name) {
-			parent.parseClassName(name);
-		}
-
-		public void visitInnerClassType(String name) {
-			parent.parseClassName(name);
-		}
-
-		public void visitTypeArgument() {
-		}
-
-		public SignatureVisitor visitTypeArgument(char wildcard) {
-			return this;
-		}
-
-		public void visitEnd() {
-		}
-	}
-
-	private static class PMDMethodVisitor extends MethodVisitor {
-		private PMDASMVisitor parent;
-
-		public PMDMethodVisitor(PMDASMVisitor visitor) {
+        public PMDSignatureVisitor(PMDASMVisitor visitor) {
             super(Opcodes.ASM4);
-			parent = visitor;
-		}
+            this.parent = visitor;
+        }
 
-		public AnnotationVisitor visitParameterAnnotation(int parameter, String desc, boolean visible) {
-			parent.addType(Type.getType(desc));
-			return parent.annotationVisitor;
-		}
+        public void visitFormalTypeParameter(String name) {
+        }
 
-		public AnnotationVisitor visitAnnotation(String name, String desc) {
-			parent.addType(Type.getType(desc));
-			return parent.annotationVisitor;
-		}
+        public SignatureVisitor visitClassBound() {
+            return this;
+        }
 
-		public void visitTypeInsn(int opcode, String desc) {
-			if (desc.charAt(0) == '[') {
-				parent.addType(Type.getType(desc));
-			} else {
-				parent.parseClassName(desc);
-			}
-		}
+        public SignatureVisitor visitInterfaceBound() {
+            return this;
+        }
 
-		public void visitFieldInsn(int opcode, String owner, String name, String desc) {
-			parent.parseClassName(owner);
-			parent.addType(Type.getType(desc));
-		}
+        public SignatureVisitor visitSuperclass() {
+            return this;
+        }
 
-		public void visitMethodInsn(int opcode, String owner, String name, String desc) {
-			parent.parseClassName(owner);
-			parent.addMethodDesc(desc);
-		}
+        public SignatureVisitor visitInterface() {
+            return this;
+        }
 
-	    /**
-	     * the constant to be loaded on the stack. This parameter must be a non null
-	     * Integer, a Float, a Long, a Double a String (or a Type for .class
-	     * constants, for classes whose version is 49.0 or more).
-	     *
-	     * @see org.objectweb.asm.MethodVisitor#visitLdcInsn(java.lang.Object)
-	     */
-	    public void visitLdcInsn(Object cst) {
-	        if (cst instanceof Type) {
-	        	parent.addType((Type) cst);
-	        } else if (cst instanceof String) {
-	            parent.parseClassName((String) cst);
-	        }
-	    }
-		public void visitMultiANewArrayInsn(String desc, int dims) {
-			parent.addType(Type.getType(desc));
-		}
+        public SignatureVisitor visitParameterType() {
+            return this;
+        }
 
-		public void visitLocalVariable(String name, String desc, String sig, Label start, Label end, int index) {
-			parent.extractSignature(sig);
-		}
+        public SignatureVisitor visitReturnType() {
+            return this;
+        }
 
-		public void visitCode() {
-		}
+        public SignatureVisitor visitExceptionType() {
+            return this;
+        }
 
-		public void visitFrame(int type, int nLocal, Object[] local, int nStack, Object[] stack) {
-		}
+        public void visitBaseType(char descriptor) {
+        }
 
-		public void visitInsn(int opcode) {
-		}
+        public void visitTypeVariable(String name) {
+        }
 
-		public void visitIntInsn(int opcode, int operand) {
-		}
+        public SignatureVisitor visitArrayType() {
+            return this;
+        }
 
-		public void visitVarInsn(int opcode, int var) {
-		}
+        public void visitClassType(String name) {
+            parent.parseClassName(name);
+        }
 
-		public void visitJumpInsn(int opcode, Label label) {
-		}
+        public void visitInnerClassType(String name) {
+            parent.parseClassName(name);
+        }
 
-		public void visitLabel(Label label) {
-		}
+        public void visitTypeArgument() {
+        }
 
-		public void visitIincInsn(int var, int increment) {
-		}
+        public SignatureVisitor visitTypeArgument(char wildcard) {
+            return this;
+        }
 
-		public void visitTableSwitchInsn(int min, int max, Label dflt, Label[] labels) {
-		}
+        public void visitEnd() {
+        }
+    }
 
-		public void visitLookupSwitchInsn(Label dflt, int[] keys, Label[] labels) {
-		}
+    private static class PMDMethodVisitor extends MethodVisitor {
+        private PMDASMVisitor parent;
 
-		public void visitTryCatchBlock(Label start, Label end, Label handler, String type) {
-			parent.parseClassName(type);
-		}
+        public PMDMethodVisitor(PMDASMVisitor visitor) {
+            super(Opcodes.ASM4);
+            parent = visitor;
+        }
 
-		public void visitLineNumber(int line, Label start) {
-		}
+        public AnnotationVisitor visitParameterAnnotation(int parameter, String desc, boolean visible) {
+            parent.addType(Type.getType(desc));
+            return parent.annotationVisitor;
+        }
 
-		public void visitMaxs(int maxStack, int maxLocals) {
-		}
+        public AnnotationVisitor visitAnnotation(String name, String desc) {
+            parent.addType(Type.getType(desc));
+            return parent.annotationVisitor;
+        }
 
-		public AnnotationVisitor visitAnnotationDefault() {
-			return parent.annotationVisitor;
-		}
+        public void visitTypeInsn(int opcode, String desc) {
+            if (desc.charAt(0) == '[') {
+                parent.addType(Type.getType(desc));
+            } else {
+                parent.parseClassName(desc);
+            }
+        }
 
-		public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
-			parent.addType(Type.getType(desc));
-			return parent.annotationVisitor;
-		}
+        public void visitFieldInsn(int opcode, String owner, String name, String desc) {
+            parent.parseClassName(owner);
+            parent.addType(Type.getType(desc));
+        }
 
-		public void visitEnd() {
-		}
+        public void visitMethodInsn(int opcode, String owner, String name, String desc) {
+            parent.parseClassName(owner);
+            parent.addMethodDesc(desc);
+        }
 
-		public void visitAttribute(Attribute attr) {
-		}
+        /**
+         * the constant to be loaded on the stack. This parameter must be a non null
+         * Integer, a Float, a Long, a Double a String (or a Type for .class
+         * constants, for classes whose version is 49.0 or more).
+         *
+         * @see org.objectweb.asm.MethodVisitor#visitLdcInsn(java.lang.Object)
+         */
+        public void visitLdcInsn(Object cst) {
+            if (cst instanceof Type) {
+                parent.addType((Type) cst);
+            } else if (cst instanceof String) {
+                parent.parseClassName((String) cst);
+            }
+        }
 
-	}
+        public void visitMultiANewArrayInsn(String desc, int dims) {
+            parent.addType(Type.getType(desc));
+        }
+
+        public void visitLocalVariable(String name, String desc, String sig, Label start, Label end, int index) {
+            parent.extractSignature(sig);
+        }
+
+        public void visitCode() {
+        }
+
+        public void visitFrame(int type, int nLocal, Object[] local, int nStack, Object[] stack) {
+        }
+
+        public void visitInsn(int opcode) {
+        }
+
+        public void visitIntInsn(int opcode, int operand) {
+        }
+
+        public void visitVarInsn(int opcode, int var) {
+        }
+
+        public void visitJumpInsn(int opcode, Label label) {
+        }
+
+        public void visitLabel(Label label) {
+        }
+
+        public void visitIincInsn(int var, int increment) {
+        }
+
+        public void visitTableSwitchInsn(int min, int max, Label dflt, Label[] labels) {
+        }
+
+        public void visitLookupSwitchInsn(Label dflt, int[] keys, Label[] labels) {
+        }
+
+        public void visitTryCatchBlock(Label start, Label end, Label handler, String type) {
+            parent.parseClassName(type);
+        }
+
+        public void visitLineNumber(int line, Label start) {
+        }
+
+        public void visitMaxs(int maxStack, int maxLocals) {
+        }
+
+        public AnnotationVisitor visitAnnotationDefault() {
+            return parent.annotationVisitor;
+        }
+
+        public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
+            parent.addType(Type.getType(desc));
+            return parent.annotationVisitor;
+        }
+
+        public void visitEnd() {
+        }
+
+        public void visitAttribute(Attribute attr) {
+        }
+
+    }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/visitors/PMDASMVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/visitors/PMDASMVisitor.java
@@ -21,7 +21,7 @@ import org.objectweb.asm.signature.SignatureVisitor;
 public class PMDASMVisitor extends ClassVisitor {
 
     public PMDASMVisitor() {
-        super(Opcodes.ASM4);
+        super(Opcodes.ASM5);
     }
 
     private Map<String, String> packages = new HashMap<String, String>();
@@ -173,7 +173,7 @@ public class PMDASMVisitor extends ClassVisitor {
         private PMDASMVisitor parent;
 
         public PMDFieldVisitor(PMDASMVisitor visitor) {
-            super(Opcodes.ASM4);
+            super(Opcodes.ASM5);
             parent = visitor;
         }
 
@@ -193,7 +193,7 @@ public class PMDASMVisitor extends ClassVisitor {
         private PMDASMVisitor parent;
 
         public PMDAnnotationVisitor(PMDASMVisitor visitor) {
-            super(Opcodes.ASM4);
+            super(Opcodes.ASM5);
             parent = visitor;
         }
 
@@ -224,7 +224,7 @@ public class PMDASMVisitor extends ClassVisitor {
         private PMDASMVisitor parent;
 
         public PMDSignatureVisitor(PMDASMVisitor visitor) {
-            super(Opcodes.ASM4);
+            super(Opcodes.ASM5);
             this.parent = visitor;
         }
 
@@ -292,7 +292,7 @@ public class PMDASMVisitor extends ClassVisitor {
         private PMDASMVisitor parent;
 
         public PMDMethodVisitor(PMDASMVisitor visitor) {
-            super(Opcodes.ASM4);
+            super(Opcodes.ASM5);
             parent = visitor;
         }
 
@@ -319,7 +319,7 @@ public class PMDASMVisitor extends ClassVisitor {
             parent.addType(Type.getType(desc));
         }
 
-        public void visitMethodInsn(int opcode, String owner, String name, String desc) {
+        public void visitMethodInsn(int opcode, String owner, String name, String desc, boolean itf) {
             parent.parseClassName(owner);
             parent.addMethodDesc(desc);
         }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
@@ -57,7 +57,7 @@ public class ClassTypeResolverTest {
 
     @Test
     public void acceptanceTest() {
-        ASTCompilationUnit acu = parseAndTypeResolveForClass(ArrayListFound.class);
+        ASTCompilationUnit acu = parseAndTypeResolveForClass15(ArrayListFound.class);
         assertEquals(ArrayListFound.class, acu.getFirstDescendantOfType(ASTTypeDeclaration.class).getType());
         assertEquals(ArrayListFound.class, acu.getFirstDescendantOfType(ASTClassOrInterfaceDeclaration.class).getType());
         ASTImportDeclaration id = acu.getFirstDescendantOfType(ASTImportDeclaration.class);
@@ -70,7 +70,7 @@ public class ClassTypeResolverTest {
         assertEquals(ArrayList.class, acu.getFirstDescendantOfType(ASTVariableDeclarator.class).getType());
         assertEquals(ArrayList.class, acu.getFirstDescendantOfType(ASTFieldDeclaration.class).getType());
 
-        acu = parseAndTypeResolveForClass(DefaultJavaLangImport.class);
+        acu = parseAndTypeResolveForClass15(DefaultJavaLangImport.class);
         assertEquals(String.class, acu.getFirstDescendantOfType(ASTClassOrInterfaceType.class).getType());
         assertEquals(Override.class, acu.findDescendantsOfType(ASTName.class).get(1).getType());
     }
@@ -80,7 +80,7 @@ public class ClassTypeResolverTest {
      */
     @Test
     public void testEnumAnonymousInnerClass() {
-        ASTCompilationUnit acu = parseAndTypeResolveForClass(EnumWithAnonymousInnerClass.class);
+        ASTCompilationUnit acu = parseAndTypeResolveForClass15(EnumWithAnonymousInnerClass.class);
         Class<?> inner = acu.getFirstDescendantOfType(ASTAllocationExpression.class)
                 .getFirstDescendantOfType(ASTClassOrInterfaceType.class).getType();
         assertEquals("net.sourceforge.pmd.typeresolution.testdata.EnumWithAnonymousInnerClass$1",
@@ -89,7 +89,7 @@ public class ClassTypeResolverTest {
 
     @Test
     public void testExtraTopLevelClass() throws ClassNotFoundException {
-        ASTCompilationUnit acu = parseAndTypeResolveForClass(ExtraTopLevelClass.class);
+        ASTCompilationUnit acu = parseAndTypeResolveForClass15(ExtraTopLevelClass.class);
         Class<?> theExtraTopLevelClass = Class.forName("net.sourceforge.pmd.typeresolution.testdata.TheExtraTopLevelClass");
         // First class
         ASTTypeDeclaration typeDeclaration = (ASTTypeDeclaration) acu.jjtGetChild(1);
@@ -105,7 +105,7 @@ public class ClassTypeResolverTest {
 
     @Test
     public void testInnerClass() throws ClassNotFoundException {
-        ASTCompilationUnit acu = parseAndTypeResolveForClass(InnerClass.class);
+        ASTCompilationUnit acu = parseAndTypeResolveForClass15(InnerClass.class);
         Class<?> theInnerClass = Class.forName("net.sourceforge.pmd.typeresolution.testdata.InnerClass$TheInnerClass");
         // Outer class
         ASTTypeDeclaration typeDeclaration = acu.getFirstDescendantOfType(ASTTypeDeclaration.class);
@@ -122,7 +122,7 @@ public class ClassTypeResolverTest {
 
     @Test
     public void testAnonymousInnerClass() throws ClassNotFoundException {
-        ASTCompilationUnit acu = parseAndTypeResolveForClass(AnonymousInnerClass.class);
+        ASTCompilationUnit acu = parseAndTypeResolveForClass15(AnonymousInnerClass.class);
         Class<?> theAnonymousInnerClass = Class.forName("net.sourceforge.pmd.typeresolution.testdata.AnonymousInnerClass$1");
         // Outer class
         ASTTypeDeclaration typeDeclaration = acu.getFirstDescendantOfType(ASTTypeDeclaration.class);
@@ -137,7 +137,7 @@ public class ClassTypeResolverTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testLiterals() throws JaxenException {
-        ASTCompilationUnit acu = parseAndTypeResolveForClass(Literals.class);
+        ASTCompilationUnit acu = parseAndTypeResolveForClass15(Literals.class);
         List<ASTLiteral> literals = acu.findChildNodesWithXPath("//Literal");
         int index = 0;
 
@@ -288,7 +288,7 @@ public class ClassTypeResolverTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testUnaryNumericPromotion() throws JaxenException {
-        ASTCompilationUnit acu = parseAndTypeResolveForClass(Promotion.class);
+        ASTCompilationUnit acu = parseAndTypeResolveForClass15(Promotion.class);
         List<ASTExpression> expressions = acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'unaryNumericPromotion']]//Expression[UnaryExpression]");
         int index = 0;
 
@@ -307,7 +307,7 @@ public class ClassTypeResolverTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testBinaryNumericPromotion() throws JaxenException {
-        ASTCompilationUnit acu = parseAndTypeResolveForClass(Promotion.class);
+        ASTCompilationUnit acu = parseAndTypeResolveForClass15(Promotion.class);
         List<ASTExpression> expressions = acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'binaryNumericPromotion']]//Expression[AdditiveExpression]");
         int index = 0;
 
@@ -375,7 +375,7 @@ public class ClassTypeResolverTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testBinaryStringPromotion() throws JaxenException {
-        ASTCompilationUnit acu = parseAndTypeResolveForClass(Promotion.class);
+        ASTCompilationUnit acu = parseAndTypeResolveForClass15(Promotion.class);
         List<ASTExpression> expressions = acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'binaryStringPromotion']]//Expression");
         int index = 0;
 
@@ -392,7 +392,7 @@ public class ClassTypeResolverTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testUnaryLogicalOperators() throws JaxenException {
-        ASTCompilationUnit acu = parseAndTypeResolveForClass(Operators.class);
+        ASTCompilationUnit acu = parseAndTypeResolveForClass15(Operators.class);
         List<ASTExpression> expressions = acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'unaryLogicalOperators']]//Expression");
         int index = 0;
 
@@ -406,7 +406,7 @@ public class ClassTypeResolverTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testBinaryLogicalOperators() throws JaxenException {
-        ASTCompilationUnit acu = parseAndTypeResolveForClass(Operators.class);
+        ASTCompilationUnit acu = parseAndTypeResolveForClass15(Operators.class);
         List<ASTExpression> expressions = acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'binaryLogicalOperators']]//Expression");
         int index = 0;
 
@@ -431,7 +431,7 @@ public class ClassTypeResolverTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testUnaryNumericOperators() throws JaxenException {
-        ASTCompilationUnit acu = parseAndTypeResolveForClass(Operators.class);
+        ASTCompilationUnit acu = parseAndTypeResolveForClass15(Operators.class);
         List<TypeNode> expressions = new ArrayList<TypeNode>();
         expressions.addAll(acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'unaryNumericOperators']]//Expression"));
         expressions.addAll(acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'unaryNumericOperators']]//PostfixExpression"));
@@ -453,7 +453,7 @@ public class ClassTypeResolverTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testBinaryNumericOperators() throws JaxenException {
-        ASTCompilationUnit acu = parseAndTypeResolveForClass(Operators.class);
+        ASTCompilationUnit acu = parseAndTypeResolveForClass15(Operators.class);
         List<ASTExpression> expressions = acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'binaryNumericOperators']]//Expression");
         int index = 0;
 
@@ -473,7 +473,7 @@ public class ClassTypeResolverTest {
     @Test
     @SuppressWarnings("unchecked")
     public void testAssignmentOperators() throws JaxenException {
-        ASTCompilationUnit acu = parseAndTypeResolveForClass(Operators.class);
+        ASTCompilationUnit acu = parseAndTypeResolveForClass15(Operators.class);
         List<ASTStatementExpression> expressions = acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'assignmentOperators']]//StatementExpression");
         int index = 0;
 
@@ -498,16 +498,20 @@ public class ClassTypeResolverTest {
         return new junit.framework.JUnit4TestAdapter(ClassTypeResolverTest.class);
     }
 
+    private ASTCompilationUnit parseAndTypeResolveForClass15(Class<?> clazz) {
+        return parseAndTypeResolveForClass(clazz, "1.5");
+    }
+
     // Note: If you're using Eclipse or some other IDE to run this test, you _must_ have the regress folder in
     // the classpath.  Normally the IDE doesn't put source directories themselves directly in the classpath, only
     // the output directories are in the classpath.
-    private ASTCompilationUnit parseAndTypeResolveForClass(Class<?> clazz) {
+    private ASTCompilationUnit parseAndTypeResolveForClass(Class<?> clazz, String version) {
         String sourceFile = clazz.getName().replace('.', '/') + ".java";
         InputStream is = ClassTypeResolverTest.class.getClassLoader().getResourceAsStream(sourceFile);
         if (is == null) {
             throw new IllegalArgumentException("Unable to find source file " + sourceFile + " for " + clazz);
         }
-        LanguageVersionHandler languageVersionHandler = LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5").getLanguageVersionHandler();
+        LanguageVersionHandler languageVersionHandler = LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion(version).getLanguageVersionHandler();
         ASTCompilationUnit acu = (ASTCompilationUnit) languageVersionHandler.getParser(languageVersionHandler.getDefaultParserOptions()).parse(null, new InputStreamReader(is));
         languageVersionHandler.getSymbolFacade().start(acu);
         languageVersionHandler.getTypeResolutionFacade(ClassTypeResolverTest.class.getClassLoader()).start(acu);

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
@@ -5,12 +5,12 @@ package net.sourceforge.pmd.typeresolution;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
-
+import org.jaxen.JaxenException;
+import org.junit.Test;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersionHandler;
 import net.sourceforge.pmd.lang.java.JavaLanguageModule;
@@ -44,476 +44,473 @@ import net.sourceforge.pmd.typeresolution.testdata.Literals;
 import net.sourceforge.pmd.typeresolution.testdata.Operators;
 import net.sourceforge.pmd.typeresolution.testdata.Promotion;
 
-import org.jaxen.JaxenException;
-import org.junit.Test;
-
 
 public class ClassTypeResolverTest {
 
-	@Test
-	public void testClassNameExists() {
-		ClassTypeResolver classTypeResolver = new ClassTypeResolver();
-		assertEquals(true, classTypeResolver.classNameExists("java.lang.System"));
-		assertEquals(false, classTypeResolver.classNameExists("im.sure.that.this.does.not.Exist"));
-		assertEquals(true, classTypeResolver.classNameExists("java.awt.List"));
-	}
-
-	@Test
-	public void acceptanceTest() {
-		ASTCompilationUnit acu = parseAndTypeResolveForClass(ArrayListFound.class);
-		assertEquals(ArrayListFound.class, acu.getFirstDescendantOfType(ASTTypeDeclaration.class).getType());
-		assertEquals(ArrayListFound.class, acu.getFirstDescendantOfType(ASTClassOrInterfaceDeclaration.class).getType());
-		ASTImportDeclaration id = acu.getFirstDescendantOfType(ASTImportDeclaration.class);
-		assertEquals("java.util", id.getPackage().getName());
-		assertEquals(ArrayList.class, id.getType());
-		assertEquals(ArrayList.class, acu.getFirstDescendantOfType(ASTClassOrInterfaceType.class).getType());
-		assertEquals(ArrayList.class, acu.getFirstDescendantOfType(ASTReferenceType.class).getType());
-		assertEquals(ArrayList.class, acu.getFirstDescendantOfType(ASTType.class).getType());
-		assertEquals(ArrayList.class, acu.getFirstDescendantOfType(ASTVariableDeclaratorId.class).getType());
-		assertEquals(ArrayList.class, acu.getFirstDescendantOfType(ASTVariableDeclarator.class).getType());
-		assertEquals(ArrayList.class, acu.getFirstDescendantOfType(ASTFieldDeclaration.class).getType());
-
-		acu = parseAndTypeResolveForClass(DefaultJavaLangImport.class);
-		assertEquals(String.class, acu.getFirstDescendantOfType(ASTClassOrInterfaceType.class).getType());
-		assertEquals(Override.class, acu.findDescendantsOfType(ASTName.class).get(1).getType());
-	}
-
-	/**
-	 * See bug #1138 Anonymous inner class in enum causes NPE
-	 */
-	@Test
-	public void testEnumAnonymousInnerClass() {
-	    ASTCompilationUnit acu = parseAndTypeResolveForClass(EnumWithAnonymousInnerClass.class);
-	    Class<?> inner = acu.getFirstDescendantOfType(ASTAllocationExpression.class)
-	            .getFirstDescendantOfType(ASTClassOrInterfaceType.class).getType();
-	    assertEquals("net.sourceforge.pmd.typeresolution.testdata.EnumWithAnonymousInnerClass$1",
-	            inner.getName());
-	}
-
-	@Test
-	public void testExtraTopLevelClass() throws ClassNotFoundException {
-		ASTCompilationUnit acu = parseAndTypeResolveForClass(ExtraTopLevelClass.class);
-		Class<?> theExtraTopLevelClass = Class.forName("net.sourceforge.pmd.typeresolution.testdata.TheExtraTopLevelClass");
-		// First class
-		ASTTypeDeclaration typeDeclaration = (ASTTypeDeclaration)acu.jjtGetChild(1);
-		assertEquals(ExtraTopLevelClass.class, typeDeclaration.getType());
-		assertEquals(ExtraTopLevelClass.class,
-				typeDeclaration.getFirstDescendantOfType(ASTClassOrInterfaceDeclaration.class).getType());
-		// Second class
-		typeDeclaration = (ASTTypeDeclaration)acu.jjtGetChild(2);
-		assertEquals(theExtraTopLevelClass, typeDeclaration.getType());
-		assertEquals(theExtraTopLevelClass,
-				typeDeclaration.getFirstDescendantOfType(ASTClassOrInterfaceDeclaration.class).getType());
-	}
-
-	@Test
-	public void testInnerClass() throws ClassNotFoundException {
-		ASTCompilationUnit acu = parseAndTypeResolveForClass(InnerClass.class);
-		Class<?> theInnerClass = Class.forName("net.sourceforge.pmd.typeresolution.testdata.InnerClass$TheInnerClass");
-		// Outer class
-		ASTTypeDeclaration typeDeclaration = acu.getFirstDescendantOfType(ASTTypeDeclaration.class);
-		assertEquals(InnerClass.class, typeDeclaration.getType());
-		ASTClassOrInterfaceDeclaration outerClassDeclaration = typeDeclaration.getFirstDescendantOfType(ASTClassOrInterfaceDeclaration.class);
-		assertEquals(InnerClass.class, outerClassDeclaration.getType());
-		// Inner class
-		assertEquals(theInnerClass,
-				outerClassDeclaration.getFirstDescendantOfType(ASTClassOrInterfaceDeclaration.class).getType());
-		// Method parameter as inner class
-		ASTFormalParameter formalParameter = typeDeclaration.getFirstDescendantOfType(ASTFormalParameter.class);
-		assertEquals(theInnerClass, formalParameter.getTypeNode().getType());
-	}
-
-	@Test
-	public void testAnonymousInnerClass() throws ClassNotFoundException {
-		ASTCompilationUnit acu = parseAndTypeResolveForClass(AnonymousInnerClass.class);
-		Class<?> theAnonymousInnerClass = Class.forName("net.sourceforge.pmd.typeresolution.testdata.AnonymousInnerClass$1");
-		// Outer class
-		ASTTypeDeclaration typeDeclaration = acu.getFirstDescendantOfType(ASTTypeDeclaration.class);
-		assertEquals(AnonymousInnerClass.class, typeDeclaration.getType());
-		ASTClassOrInterfaceDeclaration outerClassDeclaration = typeDeclaration.getFirstDescendantOfType(ASTClassOrInterfaceDeclaration.class);
-		assertEquals(AnonymousInnerClass.class, outerClassDeclaration.getType());
-		// Anonymous Inner class
-		assertEquals(theAnonymousInnerClass,
-				outerClassDeclaration.getFirstDescendantOfType(ASTAllocationExpression.class).getType());
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	public void testLiterals() throws JaxenException {
-		ASTCompilationUnit acu = parseAndTypeResolveForClass(Literals.class);
-		List<ASTLiteral> literals = acu.findChildNodesWithXPath("//Literal");
-		int index = 0;
-
-		// String s = "s";
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(String.class, literals.get(index++).getType());
-
-		// boolean boolean1 = false;
-		assertEquals(Boolean.TYPE, literals.get(index).getFirstDescendantOfType(ASTBooleanLiteral.class).getType());
-		assertEquals(Boolean.TYPE, literals.get(index++).getType());
-
-		// boolean boolean2 = true;
-		assertEquals(Boolean.TYPE, literals.get(index).getFirstDescendantOfType(ASTBooleanLiteral.class).getType());
-		assertEquals(Boolean.TYPE, literals.get(index++).getType());
-
-		// Object obj = null;
-		assertNull(literals.get(index).getFirstDescendantOfType(ASTNullLiteral.class).getType());
-		assertNull(literals.get(index++).getType());
-
-		// byte byte1 = 0;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Integer.TYPE, literals.get(index++).getType());
-
-		// byte byte2 = 0x0F;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Integer.TYPE, literals.get(index++).getType());
-
-		// byte byte3 = -007;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Integer.TYPE, literals.get(index++).getType());
-
-		// short short1 = 0;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Integer.TYPE, literals.get(index++).getType());
-
-		// short short2 = 0x0F;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Integer.TYPE, literals.get(index++).getType());
-
-		// short short3 = -007;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Integer.TYPE, literals.get(index++).getType());
-
-		// char char1 = 0;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Integer.TYPE, literals.get(index++).getType());
-
-		// char char2 = 0x0F;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Integer.TYPE, literals.get(index++).getType());
-
-		// char char3 = 007;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Integer.TYPE, literals.get(index++).getType());
-
-		// char char4 = 'a';
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Character.TYPE, literals.get(index++).getType());
-
-		// int int1 = 0;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Integer.TYPE, literals.get(index++).getType());
-
-		// int int2 = 0x0F;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Integer.TYPE, literals.get(index++).getType());
-
-		// int int3 = -007;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Integer.TYPE, literals.get(index++).getType());
-
-		// int int4 = 'a';
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Character.TYPE, literals.get(index++).getType());
-
-		// long long1 = 0;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Integer.TYPE, literals.get(index++).getType());
-
-		// long long2 = 0x0F;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Integer.TYPE, literals.get(index++).getType());
-
-		// long long3 = -007;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Integer.TYPE, literals.get(index++).getType());
-
-		// long long4 = 0L;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Long.TYPE, literals.get(index++).getType());
-
-		// long long5 = 0x0Fl;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Long.TYPE, literals.get(index++).getType());
-
-		// long long6 = -007L;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Long.TYPE, literals.get(index++).getType());
-
-		// long long7 = 'a';
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Character.TYPE, literals.get(index++).getType());
-
-		// float float1 = 0.0f;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Float.TYPE, literals.get(index++).getType());
-
-		// float float2 = -10e+01f;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Float.TYPE, literals.get(index++).getType());
-
-		// float float3 = 0x08.08p3f;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Float.TYPE, literals.get(index++).getType());
-
-		// float float4 = 0xFF;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Integer.TYPE, literals.get(index++).getType());
-
-		// float float5 = 'a';
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Character.TYPE, literals.get(index++).getType());
-
-		// double double1 = 0.0;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Double.TYPE, literals.get(index++).getType());
-
-		// double double2 = -10e+01;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Double.TYPE, literals.get(index++).getType());
-
-		// double double3 = 0x08.08p3;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Double.TYPE, literals.get(index++).getType());
-
-		// double double4 = 0xFF;
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Integer.TYPE, literals.get(index++).getType());
-
-		// double double5 = 'a';
-		assertEquals(0, literals.get(index).jjtGetNumChildren());
-		assertEquals(Character.TYPE, literals.get(index++).getType());
-
-		// Make sure we got them all.
-		assertEquals("All literals not tested", index, literals.size());
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	public void testUnaryNumericPromotion() throws JaxenException {
-		ASTCompilationUnit acu = parseAndTypeResolveForClass(Promotion.class);
-		List<ASTExpression> expressions = acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'unaryNumericPromotion']]//Expression[UnaryExpression]");
-		int index = 0;
-
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Long.TYPE, expressions.get(index++).getType());
-		assertEquals(Float.TYPE, expressions.get(index++).getType());
-		assertEquals(Double.TYPE, expressions.get(index++).getType());
-
-		// Make sure we got them all.
-		assertEquals("All expressions not tested", index, expressions.size());
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	public void testBinaryNumericPromotion() throws JaxenException {
-		ASTCompilationUnit acu = parseAndTypeResolveForClass(Promotion.class);
-		List<ASTExpression> expressions = acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'binaryNumericPromotion']]//Expression[AdditiveExpression]");
-		int index = 0;
-
-		// LHS = byte
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Long.TYPE, expressions.get(index++).getType());
-		assertEquals(Float.TYPE, expressions.get(index++).getType());
-		assertEquals(Double.TYPE, expressions.get(index++).getType());
-		// LHS = short
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Long.TYPE, expressions.get(index++).getType());
-		assertEquals(Float.TYPE, expressions.get(index++).getType());
-		assertEquals(Double.TYPE, expressions.get(index++).getType());
-		// LHS = char
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Long.TYPE, expressions.get(index++).getType());
-		assertEquals(Float.TYPE, expressions.get(index++).getType());
-		assertEquals(Double.TYPE, expressions.get(index++).getType());
-		// LHS = int
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Long.TYPE, expressions.get(index++).getType());
-		assertEquals(Float.TYPE, expressions.get(index++).getType());
-		assertEquals(Double.TYPE, expressions.get(index++).getType());
-		// LHS = long
-		assertEquals(Long.TYPE, expressions.get(index++).getType());
-		assertEquals(Long.TYPE, expressions.get(index++).getType());
-		assertEquals(Long.TYPE, expressions.get(index++).getType());
-		assertEquals(Long.TYPE, expressions.get(index++).getType());
-		assertEquals(Long.TYPE, expressions.get(index++).getType());
-		assertEquals(Float.TYPE, expressions.get(index++).getType());
-		assertEquals(Double.TYPE, expressions.get(index++).getType());
-		// LHS = float
-		assertEquals(Float.TYPE, expressions.get(index++).getType());
-		assertEquals(Float.TYPE, expressions.get(index++).getType());
-		assertEquals(Float.TYPE, expressions.get(index++).getType());
-		assertEquals(Float.TYPE, expressions.get(index++).getType());
-		assertEquals(Float.TYPE, expressions.get(index++).getType());
-		assertEquals(Float.TYPE, expressions.get(index++).getType());
-		assertEquals(Double.TYPE, expressions.get(index++).getType());
-		// LHS = double
-		assertEquals(Double.TYPE, expressions.get(index++).getType());
-		assertEquals(Double.TYPE, expressions.get(index++).getType());
-		assertEquals(Double.TYPE, expressions.get(index++).getType());
-		assertEquals(Double.TYPE, expressions.get(index++).getType());
-		assertEquals(Double.TYPE, expressions.get(index++).getType());
-		assertEquals(Double.TYPE, expressions.get(index++).getType());
-		assertEquals(Double.TYPE, expressions.get(index++).getType());
-
-		// Make sure we got them all.
-		assertEquals("All expressions not tested", index, expressions.size());
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	public void testBinaryStringPromotion() throws JaxenException {
-		ASTCompilationUnit acu = parseAndTypeResolveForClass(Promotion.class);
-		List<ASTExpression> expressions = acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'binaryStringPromotion']]//Expression");
-		int index = 0;
-
-		assertEquals(String.class, expressions.get(index++).getType());
-		assertEquals(String.class, expressions.get(index++).getType());
-		assertEquals(String.class, expressions.get(index++).getType());
-		assertEquals(String.class, expressions.get(index++).getType());
-		assertEquals(String.class, expressions.get(index++).getType());
-
-		// Make sure we got them all.
-		assertEquals("All expressions not tested", index, expressions.size());
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	public void testUnaryLogicalOperators() throws JaxenException {
-		ASTCompilationUnit acu = parseAndTypeResolveForClass(Operators.class);
-		List<ASTExpression> expressions = acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'unaryLogicalOperators']]//Expression");
-		int index = 0;
-
-		assertEquals(Boolean.TYPE, expressions.get(index++).getType());
-		assertEquals(Boolean.TYPE, expressions.get(index++).getType());
-
-		// Make sure we got them all.
-		assertEquals("All expressions not tested", index, expressions.size());
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	public void testBinaryLogicalOperators() throws JaxenException {
-		ASTCompilationUnit acu = parseAndTypeResolveForClass(Operators.class);
-		List<ASTExpression> expressions = acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'binaryLogicalOperators']]//Expression");
-		int index = 0;
-
-		assertEquals(Boolean.TYPE, expressions.get(index++).getType());
-		assertEquals(Boolean.TYPE, expressions.get(index++).getType());
-		assertEquals(Boolean.TYPE, expressions.get(index++).getType());
-		assertEquals(Boolean.TYPE, expressions.get(index++).getType());
-		assertEquals(Boolean.TYPE, expressions.get(index++).getType());
-		assertEquals(Boolean.TYPE, expressions.get(index++).getType());
-		assertEquals(Boolean.TYPE, expressions.get(index++).getType());
-		assertEquals(Boolean.TYPE, expressions.get(index++).getType());
-		assertEquals(Boolean.TYPE, expressions.get(index++).getType());
-		assertEquals(Boolean.TYPE, expressions.get(index++).getType());
-		assertEquals(Boolean.TYPE, expressions.get(index++).getType());
-		assertEquals(Boolean.TYPE, expressions.get(index++).getType());
-		assertEquals(Boolean.TYPE, expressions.get(index++).getType());
-
-		// Make sure we got them all.
-		assertEquals("All expressions not tested", index, expressions.size());
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	public void testUnaryNumericOperators() throws JaxenException {
-		ASTCompilationUnit acu = parseAndTypeResolveForClass(Operators.class);
-		List<TypeNode> expressions = new ArrayList<TypeNode>();
-		expressions.addAll(acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'unaryNumericOperators']]//Expression"));
-		expressions.addAll(acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'unaryNumericOperators']]//PostfixExpression"));
-		expressions.addAll(acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'unaryNumericOperators']]//PreIncrementExpression"));
-		expressions.addAll(acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'unaryNumericOperators']]//PreDecrementExpression"));
-		int index = 0;
-
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Double.TYPE, expressions.get(index++).getType());
-		assertEquals(Double.TYPE, expressions.get(index++).getType());
-		assertEquals(Double.TYPE, expressions.get(index++).getType());
-		assertEquals(Double.TYPE, expressions.get(index++).getType());
-
-		// Make sure we got them all.
-		assertEquals("All expressions not tested", index, expressions.size());
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	public void testBinaryNumericOperators() throws JaxenException {
-		ASTCompilationUnit acu = parseAndTypeResolveForClass(Operators.class);
-		List<ASTExpression> expressions = acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'binaryNumericOperators']]//Expression");
-		int index = 0;
-
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-		assertEquals(Integer.TYPE, expressions.get(index++).getType());
-
-		// Make sure we got them all.
-		assertEquals("All expressions not tested", index, expressions.size());
-	}
-
-	@Test
-	@SuppressWarnings("unchecked")
-	public void testAssignmentOperators() throws JaxenException {
-		ASTCompilationUnit acu = parseAndTypeResolveForClass(Operators.class);
-		List<ASTStatementExpression> expressions = acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'assignmentOperators']]//StatementExpression");
-		int index = 0;
-
-		assertEquals(Long.TYPE, expressions.get(index++).getType());
-		assertEquals(Long.TYPE, expressions.get(index++).getType());
-		assertEquals(Long.TYPE, expressions.get(index++).getType());
-		assertEquals(Long.TYPE, expressions.get(index++).getType());
-		assertEquals(Long.TYPE, expressions.get(index++).getType());
-		assertEquals(Long.TYPE, expressions.get(index++).getType());
-		assertEquals(Long.TYPE, expressions.get(index++).getType());
-		assertEquals(Long.TYPE, expressions.get(index++).getType());
-		assertEquals(Long.TYPE, expressions.get(index++).getType());
-		assertEquals(Long.TYPE, expressions.get(index++).getType());
-		assertEquals(Long.TYPE, expressions.get(index++).getType());
-		assertEquals(Long.TYPE, expressions.get(index++).getType());
-
-		// Make sure we got them all.
-		assertEquals("All expressions not tested", index, expressions.size());
-	}
-
-	public static junit.framework.Test suite() {
-		return new junit.framework.JUnit4TestAdapter(ClassTypeResolverTest.class);
-	}
-
-	// Note: If you're using Eclipse or some other IDE to run this test, you _must_ have the regress folder in
-	// the classpath.  Normally the IDE doesn't put source directories themselves directly in the classpath, only
-	// the output directories are in the classpath.
-	private ASTCompilationUnit parseAndTypeResolveForClass(Class<?> clazz) {
-		String sourceFile = clazz.getName().replace('.', '/') + ".java";
-		InputStream is = ClassTypeResolverTest.class.getClassLoader().getResourceAsStream(sourceFile);
-		if (is == null) {
-			throw new IllegalArgumentException("Unable to find source file " + sourceFile + " for " + clazz);
-		}
-		LanguageVersionHandler languageVersionHandler = LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5").getLanguageVersionHandler();
-		ASTCompilationUnit acu = (ASTCompilationUnit)languageVersionHandler.getParser(languageVersionHandler.getDefaultParserOptions()).parse(null, new InputStreamReader(is));
-		languageVersionHandler.getSymbolFacade().start(acu);
-		languageVersionHandler.getTypeResolutionFacade(ClassTypeResolverTest.class.getClassLoader()).start(acu);
-		return acu;
-	}
+    @Test
+    public void testClassNameExists() {
+        ClassTypeResolver classTypeResolver = new ClassTypeResolver();
+        assertEquals(true, classTypeResolver.classNameExists("java.lang.System"));
+        assertEquals(false, classTypeResolver.classNameExists("im.sure.that.this.does.not.Exist"));
+        assertEquals(true, classTypeResolver.classNameExists("java.awt.List"));
+    }
+
+    @Test
+    public void acceptanceTest() {
+        ASTCompilationUnit acu = parseAndTypeResolveForClass(ArrayListFound.class);
+        assertEquals(ArrayListFound.class, acu.getFirstDescendantOfType(ASTTypeDeclaration.class).getType());
+        assertEquals(ArrayListFound.class, acu.getFirstDescendantOfType(ASTClassOrInterfaceDeclaration.class).getType());
+        ASTImportDeclaration id = acu.getFirstDescendantOfType(ASTImportDeclaration.class);
+        assertEquals("java.util", id.getPackage().getName());
+        assertEquals(ArrayList.class, id.getType());
+        assertEquals(ArrayList.class, acu.getFirstDescendantOfType(ASTClassOrInterfaceType.class).getType());
+        assertEquals(ArrayList.class, acu.getFirstDescendantOfType(ASTReferenceType.class).getType());
+        assertEquals(ArrayList.class, acu.getFirstDescendantOfType(ASTType.class).getType());
+        assertEquals(ArrayList.class, acu.getFirstDescendantOfType(ASTVariableDeclaratorId.class).getType());
+        assertEquals(ArrayList.class, acu.getFirstDescendantOfType(ASTVariableDeclarator.class).getType());
+        assertEquals(ArrayList.class, acu.getFirstDescendantOfType(ASTFieldDeclaration.class).getType());
+
+        acu = parseAndTypeResolveForClass(DefaultJavaLangImport.class);
+        assertEquals(String.class, acu.getFirstDescendantOfType(ASTClassOrInterfaceType.class).getType());
+        assertEquals(Override.class, acu.findDescendantsOfType(ASTName.class).get(1).getType());
+    }
+
+    /**
+     * See bug #1138 Anonymous inner class in enum causes NPE
+     */
+    @Test
+    public void testEnumAnonymousInnerClass() {
+        ASTCompilationUnit acu = parseAndTypeResolveForClass(EnumWithAnonymousInnerClass.class);
+        Class<?> inner = acu.getFirstDescendantOfType(ASTAllocationExpression.class)
+                .getFirstDescendantOfType(ASTClassOrInterfaceType.class).getType();
+        assertEquals("net.sourceforge.pmd.typeresolution.testdata.EnumWithAnonymousInnerClass$1",
+                inner.getName());
+    }
+
+    @Test
+    public void testExtraTopLevelClass() throws ClassNotFoundException {
+        ASTCompilationUnit acu = parseAndTypeResolveForClass(ExtraTopLevelClass.class);
+        Class<?> theExtraTopLevelClass = Class.forName("net.sourceforge.pmd.typeresolution.testdata.TheExtraTopLevelClass");
+        // First class
+        ASTTypeDeclaration typeDeclaration = (ASTTypeDeclaration) acu.jjtGetChild(1);
+        assertEquals(ExtraTopLevelClass.class, typeDeclaration.getType());
+        assertEquals(ExtraTopLevelClass.class,
+                typeDeclaration.getFirstDescendantOfType(ASTClassOrInterfaceDeclaration.class).getType());
+        // Second class
+        typeDeclaration = (ASTTypeDeclaration) acu.jjtGetChild(2);
+        assertEquals(theExtraTopLevelClass, typeDeclaration.getType());
+        assertEquals(theExtraTopLevelClass,
+                typeDeclaration.getFirstDescendantOfType(ASTClassOrInterfaceDeclaration.class).getType());
+    }
+
+    @Test
+    public void testInnerClass() throws ClassNotFoundException {
+        ASTCompilationUnit acu = parseAndTypeResolveForClass(InnerClass.class);
+        Class<?> theInnerClass = Class.forName("net.sourceforge.pmd.typeresolution.testdata.InnerClass$TheInnerClass");
+        // Outer class
+        ASTTypeDeclaration typeDeclaration = acu.getFirstDescendantOfType(ASTTypeDeclaration.class);
+        assertEquals(InnerClass.class, typeDeclaration.getType());
+        ASTClassOrInterfaceDeclaration outerClassDeclaration = typeDeclaration.getFirstDescendantOfType(ASTClassOrInterfaceDeclaration.class);
+        assertEquals(InnerClass.class, outerClassDeclaration.getType());
+        // Inner class
+        assertEquals(theInnerClass,
+                outerClassDeclaration.getFirstDescendantOfType(ASTClassOrInterfaceDeclaration.class).getType());
+        // Method parameter as inner class
+        ASTFormalParameter formalParameter = typeDeclaration.getFirstDescendantOfType(ASTFormalParameter.class);
+        assertEquals(theInnerClass, formalParameter.getTypeNode().getType());
+    }
+
+    @Test
+    public void testAnonymousInnerClass() throws ClassNotFoundException {
+        ASTCompilationUnit acu = parseAndTypeResolveForClass(AnonymousInnerClass.class);
+        Class<?> theAnonymousInnerClass = Class.forName("net.sourceforge.pmd.typeresolution.testdata.AnonymousInnerClass$1");
+        // Outer class
+        ASTTypeDeclaration typeDeclaration = acu.getFirstDescendantOfType(ASTTypeDeclaration.class);
+        assertEquals(AnonymousInnerClass.class, typeDeclaration.getType());
+        ASTClassOrInterfaceDeclaration outerClassDeclaration = typeDeclaration.getFirstDescendantOfType(ASTClassOrInterfaceDeclaration.class);
+        assertEquals(AnonymousInnerClass.class, outerClassDeclaration.getType());
+        // Anonymous Inner class
+        assertEquals(theAnonymousInnerClass,
+                outerClassDeclaration.getFirstDescendantOfType(ASTAllocationExpression.class).getType());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testLiterals() throws JaxenException {
+        ASTCompilationUnit acu = parseAndTypeResolveForClass(Literals.class);
+        List<ASTLiteral> literals = acu.findChildNodesWithXPath("//Literal");
+        int index = 0;
+
+        // String s = "s";
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(String.class, literals.get(index++).getType());
+
+        // boolean boolean1 = false;
+        assertEquals(Boolean.TYPE, literals.get(index).getFirstDescendantOfType(ASTBooleanLiteral.class).getType());
+        assertEquals(Boolean.TYPE, literals.get(index++).getType());
+
+        // boolean boolean2 = true;
+        assertEquals(Boolean.TYPE, literals.get(index).getFirstDescendantOfType(ASTBooleanLiteral.class).getType());
+        assertEquals(Boolean.TYPE, literals.get(index++).getType());
+
+        // Object obj = null;
+        assertNull(literals.get(index).getFirstDescendantOfType(ASTNullLiteral.class).getType());
+        assertNull(literals.get(index++).getType());
+
+        // byte byte1 = 0;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Integer.TYPE, literals.get(index++).getType());
+
+        // byte byte2 = 0x0F;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Integer.TYPE, literals.get(index++).getType());
+
+        // byte byte3 = -007;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Integer.TYPE, literals.get(index++).getType());
+
+        // short short1 = 0;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Integer.TYPE, literals.get(index++).getType());
+
+        // short short2 = 0x0F;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Integer.TYPE, literals.get(index++).getType());
+
+        // short short3 = -007;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Integer.TYPE, literals.get(index++).getType());
+
+        // char char1 = 0;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Integer.TYPE, literals.get(index++).getType());
+
+        // char char2 = 0x0F;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Integer.TYPE, literals.get(index++).getType());
+
+        // char char3 = 007;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Integer.TYPE, literals.get(index++).getType());
+
+        // char char4 = 'a';
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Character.TYPE, literals.get(index++).getType());
+
+        // int int1 = 0;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Integer.TYPE, literals.get(index++).getType());
+
+        // int int2 = 0x0F;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Integer.TYPE, literals.get(index++).getType());
+
+        // int int3 = -007;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Integer.TYPE, literals.get(index++).getType());
+
+        // int int4 = 'a';
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Character.TYPE, literals.get(index++).getType());
+
+        // long long1 = 0;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Integer.TYPE, literals.get(index++).getType());
+
+        // long long2 = 0x0F;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Integer.TYPE, literals.get(index++).getType());
+
+        // long long3 = -007;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Integer.TYPE, literals.get(index++).getType());
+
+        // long long4 = 0L;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Long.TYPE, literals.get(index++).getType());
+
+        // long long5 = 0x0Fl;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Long.TYPE, literals.get(index++).getType());
+
+        // long long6 = -007L;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Long.TYPE, literals.get(index++).getType());
+
+        // long long7 = 'a';
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Character.TYPE, literals.get(index++).getType());
+
+        // float float1 = 0.0f;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Float.TYPE, literals.get(index++).getType());
+
+        // float float2 = -10e+01f;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Float.TYPE, literals.get(index++).getType());
+
+        // float float3 = 0x08.08p3f;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Float.TYPE, literals.get(index++).getType());
+
+        // float float4 = 0xFF;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Integer.TYPE, literals.get(index++).getType());
+
+        // float float5 = 'a';
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Character.TYPE, literals.get(index++).getType());
+
+        // double double1 = 0.0;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Double.TYPE, literals.get(index++).getType());
+
+        // double double2 = -10e+01;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Double.TYPE, literals.get(index++).getType());
+
+        // double double3 = 0x08.08p3;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Double.TYPE, literals.get(index++).getType());
+
+        // double double4 = 0xFF;
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Integer.TYPE, literals.get(index++).getType());
+
+        // double double5 = 'a';
+        assertEquals(0, literals.get(index).jjtGetNumChildren());
+        assertEquals(Character.TYPE, literals.get(index++).getType());
+
+        // Make sure we got them all.
+        assertEquals("All literals not tested", index, literals.size());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testUnaryNumericPromotion() throws JaxenException {
+        ASTCompilationUnit acu = parseAndTypeResolveForClass(Promotion.class);
+        List<ASTExpression> expressions = acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'unaryNumericPromotion']]//Expression[UnaryExpression]");
+        int index = 0;
+
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Long.TYPE, expressions.get(index++).getType());
+        assertEquals(Float.TYPE, expressions.get(index++).getType());
+        assertEquals(Double.TYPE, expressions.get(index++).getType());
+
+        // Make sure we got them all.
+        assertEquals("All expressions not tested", index, expressions.size());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testBinaryNumericPromotion() throws JaxenException {
+        ASTCompilationUnit acu = parseAndTypeResolveForClass(Promotion.class);
+        List<ASTExpression> expressions = acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'binaryNumericPromotion']]//Expression[AdditiveExpression]");
+        int index = 0;
+
+        // LHS = byte
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Long.TYPE, expressions.get(index++).getType());
+        assertEquals(Float.TYPE, expressions.get(index++).getType());
+        assertEquals(Double.TYPE, expressions.get(index++).getType());
+        // LHS = short
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Long.TYPE, expressions.get(index++).getType());
+        assertEquals(Float.TYPE, expressions.get(index++).getType());
+        assertEquals(Double.TYPE, expressions.get(index++).getType());
+        // LHS = char
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Long.TYPE, expressions.get(index++).getType());
+        assertEquals(Float.TYPE, expressions.get(index++).getType());
+        assertEquals(Double.TYPE, expressions.get(index++).getType());
+        // LHS = int
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Long.TYPE, expressions.get(index++).getType());
+        assertEquals(Float.TYPE, expressions.get(index++).getType());
+        assertEquals(Double.TYPE, expressions.get(index++).getType());
+        // LHS = long
+        assertEquals(Long.TYPE, expressions.get(index++).getType());
+        assertEquals(Long.TYPE, expressions.get(index++).getType());
+        assertEquals(Long.TYPE, expressions.get(index++).getType());
+        assertEquals(Long.TYPE, expressions.get(index++).getType());
+        assertEquals(Long.TYPE, expressions.get(index++).getType());
+        assertEquals(Float.TYPE, expressions.get(index++).getType());
+        assertEquals(Double.TYPE, expressions.get(index++).getType());
+        // LHS = float
+        assertEquals(Float.TYPE, expressions.get(index++).getType());
+        assertEquals(Float.TYPE, expressions.get(index++).getType());
+        assertEquals(Float.TYPE, expressions.get(index++).getType());
+        assertEquals(Float.TYPE, expressions.get(index++).getType());
+        assertEquals(Float.TYPE, expressions.get(index++).getType());
+        assertEquals(Float.TYPE, expressions.get(index++).getType());
+        assertEquals(Double.TYPE, expressions.get(index++).getType());
+        // LHS = double
+        assertEquals(Double.TYPE, expressions.get(index++).getType());
+        assertEquals(Double.TYPE, expressions.get(index++).getType());
+        assertEquals(Double.TYPE, expressions.get(index++).getType());
+        assertEquals(Double.TYPE, expressions.get(index++).getType());
+        assertEquals(Double.TYPE, expressions.get(index++).getType());
+        assertEquals(Double.TYPE, expressions.get(index++).getType());
+        assertEquals(Double.TYPE, expressions.get(index++).getType());
+
+        // Make sure we got them all.
+        assertEquals("All expressions not tested", index, expressions.size());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testBinaryStringPromotion() throws JaxenException {
+        ASTCompilationUnit acu = parseAndTypeResolveForClass(Promotion.class);
+        List<ASTExpression> expressions = acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'binaryStringPromotion']]//Expression");
+        int index = 0;
+
+        assertEquals(String.class, expressions.get(index++).getType());
+        assertEquals(String.class, expressions.get(index++).getType());
+        assertEquals(String.class, expressions.get(index++).getType());
+        assertEquals(String.class, expressions.get(index++).getType());
+        assertEquals(String.class, expressions.get(index++).getType());
+
+        // Make sure we got them all.
+        assertEquals("All expressions not tested", index, expressions.size());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testUnaryLogicalOperators() throws JaxenException {
+        ASTCompilationUnit acu = parseAndTypeResolveForClass(Operators.class);
+        List<ASTExpression> expressions = acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'unaryLogicalOperators']]//Expression");
+        int index = 0;
+
+        assertEquals(Boolean.TYPE, expressions.get(index++).getType());
+        assertEquals(Boolean.TYPE, expressions.get(index++).getType());
+
+        // Make sure we got them all.
+        assertEquals("All expressions not tested", index, expressions.size());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testBinaryLogicalOperators() throws JaxenException {
+        ASTCompilationUnit acu = parseAndTypeResolveForClass(Operators.class);
+        List<ASTExpression> expressions = acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'binaryLogicalOperators']]//Expression");
+        int index = 0;
+
+        assertEquals(Boolean.TYPE, expressions.get(index++).getType());
+        assertEquals(Boolean.TYPE, expressions.get(index++).getType());
+        assertEquals(Boolean.TYPE, expressions.get(index++).getType());
+        assertEquals(Boolean.TYPE, expressions.get(index++).getType());
+        assertEquals(Boolean.TYPE, expressions.get(index++).getType());
+        assertEquals(Boolean.TYPE, expressions.get(index++).getType());
+        assertEquals(Boolean.TYPE, expressions.get(index++).getType());
+        assertEquals(Boolean.TYPE, expressions.get(index++).getType());
+        assertEquals(Boolean.TYPE, expressions.get(index++).getType());
+        assertEquals(Boolean.TYPE, expressions.get(index++).getType());
+        assertEquals(Boolean.TYPE, expressions.get(index++).getType());
+        assertEquals(Boolean.TYPE, expressions.get(index++).getType());
+        assertEquals(Boolean.TYPE, expressions.get(index++).getType());
+
+        // Make sure we got them all.
+        assertEquals("All expressions not tested", index, expressions.size());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testUnaryNumericOperators() throws JaxenException {
+        ASTCompilationUnit acu = parseAndTypeResolveForClass(Operators.class);
+        List<TypeNode> expressions = new ArrayList<TypeNode>();
+        expressions.addAll(acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'unaryNumericOperators']]//Expression"));
+        expressions.addAll(acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'unaryNumericOperators']]//PostfixExpression"));
+        expressions.addAll(acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'unaryNumericOperators']]//PreIncrementExpression"));
+        expressions.addAll(acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'unaryNumericOperators']]//PreDecrementExpression"));
+        int index = 0;
+
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Double.TYPE, expressions.get(index++).getType());
+        assertEquals(Double.TYPE, expressions.get(index++).getType());
+        assertEquals(Double.TYPE, expressions.get(index++).getType());
+        assertEquals(Double.TYPE, expressions.get(index++).getType());
+
+        // Make sure we got them all.
+        assertEquals("All expressions not tested", index, expressions.size());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testBinaryNumericOperators() throws JaxenException {
+        ASTCompilationUnit acu = parseAndTypeResolveForClass(Operators.class);
+        List<ASTExpression> expressions = acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'binaryNumericOperators']]//Expression");
+        int index = 0;
+
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+        assertEquals(Integer.TYPE, expressions.get(index++).getType());
+
+        // Make sure we got them all.
+        assertEquals("All expressions not tested", index, expressions.size());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testAssignmentOperators() throws JaxenException {
+        ASTCompilationUnit acu = parseAndTypeResolveForClass(Operators.class);
+        List<ASTStatementExpression> expressions = acu.findChildNodesWithXPath("//Block[preceding-sibling::MethodDeclarator[@Image = 'assignmentOperators']]//StatementExpression");
+        int index = 0;
+
+        assertEquals(Long.TYPE, expressions.get(index++).getType());
+        assertEquals(Long.TYPE, expressions.get(index++).getType());
+        assertEquals(Long.TYPE, expressions.get(index++).getType());
+        assertEquals(Long.TYPE, expressions.get(index++).getType());
+        assertEquals(Long.TYPE, expressions.get(index++).getType());
+        assertEquals(Long.TYPE, expressions.get(index++).getType());
+        assertEquals(Long.TYPE, expressions.get(index++).getType());
+        assertEquals(Long.TYPE, expressions.get(index++).getType());
+        assertEquals(Long.TYPE, expressions.get(index++).getType());
+        assertEquals(Long.TYPE, expressions.get(index++).getType());
+        assertEquals(Long.TYPE, expressions.get(index++).getType());
+        assertEquals(Long.TYPE, expressions.get(index++).getType());
+
+        // Make sure we got them all.
+        assertEquals("All expressions not tested", index, expressions.size());
+    }
+
+    public static junit.framework.Test suite() {
+        return new junit.framework.JUnit4TestAdapter(ClassTypeResolverTest.class);
+    }
+
+    // Note: If you're using Eclipse or some other IDE to run this test, you _must_ have the regress folder in
+    // the classpath.  Normally the IDE doesn't put source directories themselves directly in the classpath, only
+    // the output directories are in the classpath.
+    private ASTCompilationUnit parseAndTypeResolveForClass(Class<?> clazz) {
+        String sourceFile = clazz.getName().replace('.', '/') + ".java";
+        InputStream is = ClassTypeResolverTest.class.getClassLoader().getResourceAsStream(sourceFile);
+        if (is == null) {
+            throw new IllegalArgumentException("Unable to find source file " + sourceFile + " for " + clazz);
+        }
+        LanguageVersionHandler languageVersionHandler = LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5").getLanguageVersionHandler();
+        ASTCompilationUnit acu = (ASTCompilationUnit) languageVersionHandler.getParser(languageVersionHandler.getDefaultParserOptions()).parse(null, new InputStreamReader(is));
+        languageVersionHandler.getSymbolFacade().start(acu);
+        languageVersionHandler.getTypeResolutionFacade(ClassTypeResolverTest.class.getClassLoader()).start(acu);
+        return acu;
+    }
 }

--- a/pmd-java8/pom.xml
+++ b/pmd-java8/pom.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>pmd-java8</artifactId>
+    <name>PMD Java 8 Integration</name>
+
+    <parent>
+        <groupId>net.sourceforge.pmd</groupId>
+        <artifactId>pmd</artifactId>
+        <version>5.3.0-SNAPSHOT</version>
+    </parent>
+
+    <properties>
+        <config.basedir>${basedir}/../pmd-core</config.basedir>
+        <java.version>1.8</java.version>
+    </properties>
+
+    <build>
+        <testResources>
+            <testResource>
+                <directory>${basedir}/src/test/resources</directory>
+            </testResource>
+            <testResource>
+                <directory>${basedir}/src/test/java</directory>
+                <includes>
+                    <include>**/testdata/*.java</include>
+                </includes>
+            </testResource>
+        </testResources>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+        <plugins>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <configuration>
+                    <useDefaultDelimiters>false</useDefaultDelimiters>
+                    <delimiters>
+                        <delimiter>${*}</delimiter>
+                    </delimiters>
+                </configuration>
+            </plugin>
+
+            <!--<plugin>-->
+                <!--<groupId>org.apache.maven.plugins</groupId>-->
+                <!--<artifactId>maven-antrun-plugin</artifactId>-->
+                <!--<inherited>true</inherited>-->
+                <!--<executions>-->
+                    <!--<execution>-->
+                        <!--<id>generate-sources</id>-->
+                        <!--<phase>generate-sources</phase>-->
+                        <!--<configuration>-->
+                            <!--<target>-->
+                                <!--<ant antfile="src/main/ant/alljavacc.xml">-->
+                                    <!--<property name="target" value="${project.build.directory}/generated-sources/javacc" />-->
+                                    <!--<property name="javacc.jar" value="${settings.localRepository}/net/java/dev/javacc/javacc/${javacc.version}/javacc-${javacc.version}.jar" />-->
+                                <!--</ant>-->
+                            <!--</target>-->
+                        <!--</configuration>-->
+                        <!--<goals>-->
+                            <!--<goal>run</goal>-->
+                        <!--</goals>-->
+                    <!--</execution>-->
+                    <!--<execution>-->
+                        <!--<id>pmd-clean</id>-->
+                        <!--<phase>clean</phase>-->
+                        <!--<configuration>-->
+                            <!--<target>-->
+                                <!--<echo>PMD specific tasks: cleaning generated xdocs</echo>-->
+                                <!--<delete quiet="true">-->
+                                    <!--<fileset dir="${basedir}/src/site/xdoc/rules/" includes="**/*.xml" />-->
+                                    <!--<fileset dir="${basedir}/src/site/xdoc/" includes="mergedruleset.xml" />-->
+                                    <!--<fileset dir="${basedir}/src/site/" includes="site.xml" />-->
+                                <!--</delete>-->
+                            <!--</target>-->
+                        <!--</configuration>-->
+                        <!--<goals>-->
+                            <!--<goal>run</goal>-->
+                        <!--</goals>-->
+                    <!--</execution>-->
+                <!--</executions>-->
+            <!--</plugin>-->
+
+            <!--<plugin>-->
+                <!--<groupId>org.codehaus.mojo</groupId>-->
+                <!--<artifactId>build-helper-maven-plugin</artifactId>-->
+                <!--<executions>-->
+                    <!--<execution>-->
+                        <!--<id>add-javacc-generated-sources</id>-->
+                        <!--<goals>-->
+                            <!--<goal>add-source</goal>-->
+                        <!--</goals>-->
+                        <!--<configuration>-->
+                            <!--<sources>-->
+                                <!--<source>${project.build.directory}/generated-sources/javacc</source>-->
+                            <!--</sources>-->
+                        <!--</configuration>-->
+                    <!--</execution>-->
+                <!--</executions>-->
+            <!--</plugin>-->
+
+            <plugin>
+                <groupId>net.sourceforge.pmd</groupId>
+                <artifactId>pmd-build</artifactId>
+                <configuration>
+                    <rulesetsDirectory>${basedir}/src/main/resources/rulesets</rulesetsDirectory>
+                    <siteXml>${basedir}/src/site/site.pre.xml</siteXml>
+                    <siteXmlTarget>${basedir}/src/site/site.xml</siteXmlTarget>
+                    <target>${basedir}/src/site/xdoc/rules</target>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>pre-site</phase>
+                        <goals>
+                            <goal>pmd-pre-site</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <dependency>
+            <groupId>net.sourceforge.pmd</groupId>
+            <artifactId>pmd-java</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>jaxen</groupId>
+            <artifactId>jaxen</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.java.dev.javacc</groupId>
+            <artifactId>javacc</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.pmd</groupId>
+            <artifactId>pmd-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.saxon</groupId>
+            <artifactId>saxon</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>net.sourceforge.saxon</groupId>
+            <artifactId>saxon</artifactId>
+            <classifier>dom</classifier>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>net.sourceforge.pmd</groupId>
+            <artifactId>pmd-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/pmd-java8/src/test/java/net/sourceforge/pmd/lang/java/bugs/InterfaceMethodTest.java
+++ b/pmd-java8/src/test/java/net/sourceforge/pmd/lang/java/bugs/InterfaceMethodTest.java
@@ -1,0 +1,39 @@
+package net.sourceforge.pmd.lang.java.bugs;
+
+//import java.util.stream.IntStream;
+//import static java.util.stream.Collectors.toList;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import org.junit.Ignore;
+import org.junit.Test;
+import net.sourceforge.pmd.lang.LanguageRegistry;
+import net.sourceforge.pmd.lang.LanguageVersionHandler;
+import net.sourceforge.pmd.lang.java.JavaLanguageModule;
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.typeresolution.testdata.UsesJavaStreams;
+
+@Ignore
+public class InterfaceMethodTest {
+
+    @Test
+    public void should_not_fail() {
+        ASTCompilationUnit acu = parseAndTypeResolveForClass(UsesJavaStreams.class);
+    }
+
+    // Note: If you're using Eclipse or some other IDE to run this test, you _must_ have the regress folder in
+    // the classpath.  Normally the IDE doesn't put source directories themselves directly in the classpath, only
+    // the output directories are in the classpath.
+    private ASTCompilationUnit parseAndTypeResolveForClass(Class<?> clazz) {
+        String sourceFile = clazz.getName().replace('.', '/') + ".java";
+        InputStream is = InterfaceMethodTest.class.getClassLoader().getResourceAsStream(sourceFile);
+        if (is == null) {
+            throw new IllegalArgumentException("Unable to find source file " + sourceFile + " for " + clazz);
+        }
+        LanguageVersionHandler languageVersionHandler = LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.8").getLanguageVersionHandler();
+        ASTCompilationUnit acu = (ASTCompilationUnit)languageVersionHandler.getParser(languageVersionHandler.getDefaultParserOptions()).parse(null, new InputStreamReader(is));
+        languageVersionHandler.getSymbolFacade().start(acu);
+        languageVersionHandler.getTypeResolutionFacade(InterfaceMethodTest.class.getClassLoader()).start(acu);
+        return acu;
+    }
+}

--- a/pmd-java8/src/test/java/net/sourceforge/pmd/lang/java/bugs/Java8MultipleLambdasTest.java
+++ b/pmd-java8/src/test/java/net/sourceforge/pmd/lang/java/bugs/Java8MultipleLambdasTest.java
@@ -1,0 +1,48 @@
+package net.sourceforge.pmd.lang.java.bugs;
+
+import java.io.StringReader;
+import org.junit.Ignore;
+import org.junit.Test;
+import net.sourceforge.pmd.PMD;
+import net.sourceforge.pmd.lang.LanguageRegistry;
+import net.sourceforge.pmd.lang.LanguageVersionHandler;
+import net.sourceforge.pmd.lang.java.JavaLanguageModule;
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.lang.java.symboltable.SymbolFacade;
+
+@Ignore
+public class Java8MultipleLambdasTest {
+
+    private static final String MULTIPLE_JAVA_8_LAMBDAS =
+            "public class MultipleLambdas {" + PMD.EOL +
+            "  Observer a = (o, arg) -> System.out.println(\"a_\" + arg);" + PMD.EOL +
+            "  Observer b = (o, arg) -> System.out.println(\"b_\" + arg);" + PMD.EOL +
+            "}";
+
+    @Test
+    public void should_not_fail() {
+        parseCode(MULTIPLE_JAVA_8_LAMBDAS);
+    }
+
+    private void parseCode(String code) {
+        LanguageVersionHandler languageVersionHandler = LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getDefaultVersion().getLanguageVersionHandler();
+        ASTCompilationUnit acu = (ASTCompilationUnit) languageVersionHandler.getParser(languageVersionHandler.getDefaultParserOptions()).parse(null, new StringReader(code));
+        SymbolFacade stb = new SymbolFacade();
+        stb.initializeWith(acu);
+    }
+
+
+    // Was failing with :
+    // java.lang.RuntimeException: Variable: image = 'i', line = 3 is already in the symbol table
+    //    at net.AbstractJavaScope.checkForDuplicatedNameDeclaration(AbstractJavaScope.java:27)
+    //    at net.sourceforge.pmd.lang.java.symboltable.AbstractJavaScope.addDeclaration(AbstractJavaScope.java:21)
+    //    at net.sourceforge.pmd.lang.java.symboltable.ScopeAndDeclarationFinder.visit(ScopeAndDeclarationFinder.java:294)
+    //    at net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId.jjtAccept(ASTVariableDeclaratorId.java:30)
+    //    at net.AbstractJavaNode.childrenAccept(AbstractJavaNode.java:55)
+    //    at net.sourceforge.pmd.lang.java.ast.JavaParserVisitorAdapter.visit(JavaParserVisitorAdapter.java:9)
+    //    at net.sourceforge.pmd.lang.java.ast.JavaParserVisitorAdapter.visit(JavaParserVisitorAdapter.java:455)
+    //    at net.sourceforge.pmd.lang.java.ast.ASTLambdaExpression.jjtAccept(ASTLambdaExpression.java:21)
+    //    at net.sourceforge.pmd.lang.java.ast.AbstractJavaNode.childrenAccept(AbstractJavaNode.java:55)
+    //    at net.sourceforge.pmd.lang.java.ast.JavaParserVisitorAdapter.visit(JavaParserVisitorAdapter.java:9)
+    //    at net.sourceforge.pmd.lang.java.ast.JavaParserVisitorAdapter.visit(JavaParserVisitorAdapter.java:312)
+}

--- a/pmd-java8/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverJava8Test.java
+++ b/pmd-java8/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverJava8Test.java
@@ -1,0 +1,53 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+package net.sourceforge.pmd.typeresolution;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import org.junit.Test;
+import net.sourceforge.pmd.lang.LanguageRegistry;
+import net.sourceforge.pmd.lang.LanguageVersionHandler;
+import net.sourceforge.pmd.lang.java.JavaLanguageModule;
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.typeresolution.testdata.UsesJavaStreams;
+import net.sourceforge.pmd.typeresolution.testdata.UsesRepeatableAnnotations;
+
+
+public class ClassTypeResolverJava8Test {
+
+    @Test
+    public void interface_method_should_be_parseable() {
+        ASTCompilationUnit acu = parseAndTypeResolveForClass18(UsesJavaStreams.class);
+    }
+
+    @Test
+    public void repeatable_annotations_method_should_be_parseable() {
+        ASTCompilationUnit acu = parseAndTypeResolveForClass18(UsesRepeatableAnnotations.class);
+    }
+
+
+    public static junit.framework.Test suite() {
+        return new junit.framework.JUnit4TestAdapter(ClassTypeResolverJava8Test.class);
+    }
+
+    private ASTCompilationUnit parseAndTypeResolveForClass18(Class<?> clazz) {
+        return parseAndTypeResolveForClass(clazz, "1.8");
+    }
+
+    // Note: If you're using Eclipse or some other IDE to run this test, you _must_ have the regress folder in
+    // the classpath.  Normally the IDE doesn't put source directories themselves directly in the classpath, only
+    // the output directories are in the classpath.
+    private ASTCompilationUnit parseAndTypeResolveForClass(Class<?> clazz, String version) {
+        String sourceFile = clazz.getName().replace('.', '/') + ".java";
+        InputStream is = ClassTypeResolverJava8Test.class.getClassLoader().getResourceAsStream(sourceFile);
+        if (is == null) {
+            throw new IllegalArgumentException("Unable to find source file " + sourceFile + " for " + clazz);
+        }
+        LanguageVersionHandler languageVersionHandler = LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion(version).getLanguageVersionHandler();
+        ASTCompilationUnit acu = (ASTCompilationUnit) languageVersionHandler.getParser(languageVersionHandler.getDefaultParserOptions()).parse(null, new InputStreamReader(is));
+        languageVersionHandler.getSymbolFacade().start(acu);
+        languageVersionHandler.getTypeResolutionFacade(ClassTypeResolverJava8Test.class.getClassLoader()).start(acu);
+        return acu;
+    }
+}

--- a/pmd-java8/src/test/java/net/sourceforge/pmd/typeresolution/testdata/UsesJavaStreams.java
+++ b/pmd-java8/src/test/java/net/sourceforge/pmd/typeresolution/testdata/UsesJavaStreams.java
@@ -1,0 +1,15 @@
+package net.sourceforge.pmd.typeresolution.testdata;
+
+public class UsesJavaStreams {
+    interface WithStaticAndDefaultMethod {
+        static void performOn() { }
+        default void myToString() {}
+    }
+
+    class ImplWithStaticAndDefaultMethod implements WithStaticAndDefaultMethod {}
+
+    public void performStuff() {
+        WithStaticAndDefaultMethod.performOn();
+        new ImplWithStaticAndDefaultMethod().myToString();
+    }
+}

--- a/pmd-java8/src/test/java/net/sourceforge/pmd/typeresolution/testdata/UsesRepeatableAnnotations.java
+++ b/pmd-java8/src/test/java/net/sourceforge/pmd/typeresolution/testdata/UsesRepeatableAnnotations.java
@@ -1,0 +1,21 @@
+package net.sourceforge.pmd.typeresolution.testdata;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import net.sourceforge.pmd.typeresolution.testdata.UsesRepeatableAnnotations.Multitude;
+
+@Multitude("1")
+@Multitude("2")
+@Multitude("3")
+@Multitude("4")
+public class UsesRepeatableAnnotations {
+
+    @Repeatable(Multitudes.class)
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Multitude { String value(); }
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @interface Multitudes { Multitude[] value(); }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -848,6 +848,16 @@
         </profile>
 
         <profile>
+            <id>jdk8-integration</id>
+            <activation>
+                <jdk>1.8</jdk>
+            </activation>
+            <modules>
+                <module>pmd-java8</module>
+            </modules>
+        </profile>
+
+        <profile>
             <id>jdk9-disabled</id>
             <activation>
                 <jdk>!1.9</jdk>


### PR DESCRIPTION
Current version of PMD fails on classes with default methods or static methods. JDK8 has updated semantics for `invokespecial` / `invokestatic` opcodes, upgrading to ASM 5 is not enough to support Java 8 opcodes like in commit 9b91690. In order to support these new semantics it is necessary to indicate to ASM to use the updated `ASM5` op code dictionary. Also this PR replaces the deprecated `visitMethodInsn` with the new version that takes an additional `boolean`

This PR also brings another maven module to allow to test PMD with JDK8 code, however for that one must run maven with the JDK 8.

Here's the stacktrace of the current failure

```
java.lang.IllegalArgumentException: INVOKESPECIAL/STATIC on interfaces require ASM 5
	at org.objectweb.asm.MethodVisitor.visitMethodInsn(Unknown Source) ~[asm-5.0.3.jar:5.0.3]
	at org.objectweb.asm.ClassReader.a(Unknown Source) ~[asm-5.0.3.jar:5.0.3]
	at org.objectweb.asm.ClassReader.b(Unknown Source) ~[asm-5.0.3.jar:5.0.3]
	at org.objectweb.asm.ClassReader.accept(Unknown Source) ~[asm-5.0.3.jar:5.0.3]
	at org.objectweb.asm.ClassReader.accept(Unknown Source) ~[asm-5.0.3.jar:5.0.3]
	at net.sourceforge.pmd.lang.java.typeresolution.PMDASMClassLoader.getImportedClasses(PMDASMClassLoader.java:77) ~[pmd-java-5.2.1.jar:na]
	at net.sourceforge.pmd.lang.java.typeresolution.ClassTypeResolver.populateClassName(ClassTypeResolver.java:728) ~[pmd-java-5.2.1.jar:na]
	at net.sourceforge.pmd.lang.java.typeresolution.ClassTypeResolver.visit(ClassTypeResolver.java:153) ~[pmd-java-5.2.1.jar:na]
	at net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit.jjtAccept(ASTCompilationUnit.java:42) ~[pmd-java-5.2.1.jar:na]
	at net.sourceforge.pmd.lang.java.typeresolution.TypeResolutionFacade.initializeWith(TypeResolutionFacade.java:17) ~[pmd-java-5.2.1.jar:na]
	at net.sourceforge.pmd.lang.java.AbstractJavaHandler$5.start(AbstractJavaHandler.java:88) ~[pmd-java-5.2.1.jar:na]
	at net.sourceforge.pmd.SourceCodeProcessor.usesTypeResolution(SourceCodeProcessor.java:127) ~[pmd-core-5.2.1.jar:na]
	at net.sourceforge.pmd.SourceCodeProcessor.processSource(SourceCodeProcessor.java:142) ~[pmd-core-5.2.1.jar:na]
	at net.sourceforge.pmd.SourceCodeProcessor.processSourceCode(SourceCodeProcessor.java:76) ~[pmd-core-5.2.1.jar:na]
	at net.sourceforge.pmd.SourceCodeProcessor.processSourceCode(SourceCodeProcessor.java:43) ~[pmd-core-5.2.1.jar:na]
```