### PR TITLE
Add a new rulesets for Maven's POM rules

### DIFF
--- a/pmd-xml/src/main/resources/rulesets/pom/basic.xml
+++ b/pmd-xml/src/main/resources/rulesets/pom/basic.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0"?>
+
+<ruleset name="Basic POM"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+  <description>
+The Basic POM Ruleset contains a collection of good practices regarding Maven's POM files.
+  </description>
+
+	<rule name="ProjectVersionAsDependencyVersion"
+    	 language="xml"
+         since="5.4"
+         message="Do not use project's version to express a dependency's version."
+         class="net.sourceforge.pmd.lang.rule.XPathRule"
+         externalInfoUrl="${pmd.website.baseurl}/rules/pom/basic.html#ProjectVersionAsDependencyVersion">
+     <description>
+ <![CDATA[
+Using that expression in dependency declarations seems like a shortcut, but it can go wrong. By far the most common problem is the use of
+${project.version} in a BOM or parent POM.
+ ]]>
+     </description>
+     <priority>3</priority>
+     <properties>
+         <property name="xpath">
+             <value>
+ <![CDATA[
+//dependency/version/text[contains(@Image,'{project.version}')]
+]]>
+             </value>
+         </property>
+     </properties>
+     <example>
+ <![CDATA[
+<project...>
+  ...
+  <dependency>
+    ...
+    <version>${project.dependency}</version>
+  </dependency>
+</project>
+ ]]>
+     </example>
+     </rule>
+</ruleset>

--- a/pmd-xml/src/main/resources/rulesets/pom/rulesets.properties
+++ b/pmd-xml/src/main/resources/rulesets/pom/rulesets.properties
@@ -1,0 +1,5 @@
+#
+# BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+#
+
+rulesets.filenames=rulesets/pom/basic.xml


### PR DESCRIPTION
Hi,

Given the capacities of XML ruling, I thought it might be interesting to have a ruleset regarding the (in)famous maven's POM file. The proposed ruled is probably controversial more than basic, but it's a start. Hopefully, it will trigger some more idea from the PMD community :) 