### PR TITLE
Fix run.sh for paths with spaces

### DIFF
--- a/pmd-dist/src/main/scripts/run.sh
+++ b/pmd-dist/src/main/scripts/run.sh
@@ -123,4 +123,4 @@ cygwin_paths
 
 java_heapsize_settings
 
-java ${HEAPSIZE} -cp "${classpath}" "${CLASSNAME}" ${@}
+java ${HEAPSIZE} -cp "${classpath}" "${CLASSNAME}" "$@"


### PR DESCRIPTION
When redirecting arguments, "$@" must be used.