### PR TITLE
Adding support for WSDL rules

### DIFF
--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/wsdl/WsdlLanguageModule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/wsdl/WsdlLanguageModule.java
@@ -17,7 +17,6 @@ public class WsdlLanguageModule extends BaseLanguageModule {
     public WsdlLanguageModule() {
         super(NAME, null, TERSE_NAME, XmlRuleChainVisitor.class, "wsdl");
         addVersion("", new XmlHandler(), true);
-        System.err.println("Carregou modulo WSDL");
     }
 
 }

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/wsdl/WsdlLanguageModule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/wsdl/WsdlLanguageModule.java
@@ -1,0 +1,23 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+package net.sourceforge.pmd.lang.wsdl;
+
+import net.sourceforge.pmd.lang.BaseLanguageModule;
+import net.sourceforge.pmd.lang.xml.XmlHandler;
+import net.sourceforge.pmd.lang.xml.rule.XmlRuleChainVisitor;
+
+/**
+ * Created by bernardo-macedo on 24.06.15.
+ */
+public class WsdlLanguageModule extends BaseLanguageModule {
+    public static final String NAME = "WSDL";
+    public static final String TERSE_NAME = "wsdl";
+
+    public WsdlLanguageModule() {
+        super(NAME, null, TERSE_NAME, XmlRuleChainVisitor.class, "wsdl");
+        addVersion("", new XmlHandler(), true);
+        System.err.println("Carregou modulo WSDL");
+    }
+
+}

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/wsdl/rule/AbstractWsdlRule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/wsdl/rule/AbstractWsdlRule.java
@@ -1,0 +1,19 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+package net.sourceforge.pmd.lang.wsdl.rule;
+
+import net.sourceforge.pmd.lang.LanguageRegistry;
+import net.sourceforge.pmd.lang.wsdl.WsdlLanguageModule;
+import net.sourceforge.pmd.lang.xml.rule.AbstractXmlRule;
+
+/**
+ * Created by bernardo-macedo on 24.06.15.
+ */
+public class AbstractWsdlRule extends AbstractXmlRule {
+
+    public AbstractWsdlRule() {
+        super(LanguageRegistry.getLanguage(WsdlLanguageModule.NAME));
+    }
+
+}

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/AbstractXmlRule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/AbstractXmlRule.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.xml.rule;
 import java.util.List;
 
 import net.sourceforge.pmd.RuleContext;
+import net.sourceforge.pmd.lang.Language;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.ParserOptions;
 import net.sourceforge.pmd.lang.ast.Node;
@@ -33,6 +34,15 @@ public class AbstractXmlRule extends AbstractRule implements ImmutableLanguage {
 
     public AbstractXmlRule() {
 	super.setLanguage(LanguageRegistry.getLanguage(XmlLanguageModule.NAME));
+	defineProperties();
+    }
+    
+    protected AbstractXmlRule(Language language) {
+	super.setLanguage(language);
+	defineProperties();
+    }
+    
+    private void defineProperties() {
 	definePropertyDescriptor(COALESCING_DESCRIPTOR);
 	definePropertyDescriptor(EXPAND_ENTITY_REFERENCES_DESCRIPTOR);
 	definePropertyDescriptor(IGNORING_COMMENTS_DESCRIPTOR);

--- a/pmd-xml/src/main/resources/META-INF/services/net.sourceforge.pmd.lang.Language
+++ b/pmd-xml/src/main/resources/META-INF/services/net.sourceforge.pmd.lang.Language
@@ -1,2 +1,3 @@
 net.sourceforge.pmd.lang.xml.XmlLanguageModule
 net.sourceforge.pmd.lang.xsl.XslLanguageModule
+net.sourceforge.pmd.lang.wsdl.WsdlLanguageModule

--- a/pmd-xml/src/test/java/net/sourceforge/pmd/lang/wsdl/rule/AbstractWsdlRuleTest.java
+++ b/pmd-xml/src/test/java/net/sourceforge/pmd/lang/wsdl/rule/AbstractWsdlRuleTest.java
@@ -1,0 +1,67 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+package net.sourceforge.pmd.lang.wsdl.rule;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.StringReader;
+import java.util.ArrayList;
+import java.util.List;
+
+import net.sourceforge.pmd.RuleContext;
+import net.sourceforge.pmd.lang.LanguageRegistry;
+import net.sourceforge.pmd.lang.Parser;
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.wsdl.WsdlLanguageModule;
+import net.sourceforge.pmd.lang.wsdl.rule.AbstractWsdlRule;
+import net.sourceforge.pmd.lang.xml.XmlParserOptions;
+import net.sourceforge.pmd.lang.xml.ast.XmlNode;
+
+import org.junit.Test;
+
+public class AbstractWsdlRuleTest {
+
+    @Test
+    public void testVisit() throws Exception {
+        String source = "<?xml version=\"1.0\"?><foo abc=\"abc\"><bar/></foo>";
+        XmlParserOptions parserOptions = new XmlParserOptions();
+        Parser parser =
+                LanguageRegistry.getLanguage(WsdlLanguageModule.NAME).getDefaultVersion().getLanguageVersionHandler()
+                        .getParser(parserOptions);
+        XmlNode xmlNode = (XmlNode) parser.parse(null, new StringReader(source));
+        List<XmlNode> nodes = new ArrayList<XmlNode>();
+        nodes.add(xmlNode);
+
+        MyRule rule = new MyRule();
+        rule.apply(nodes, null);
+
+        assertEquals(3, rule.visitedNodes.size());
+        assertEquals("document", rule.visitedNodes.get(0).toString());
+        assertEquals("foo", rule.visitedNodes.get(1).toString());
+        assertEquals("bar", rule.visitedNodes.get(2).toString());
+    }
+
+    private static class MyRule extends AbstractWsdlRule {
+        final List<XmlNode> visitedNodes = new ArrayList<XmlNode>();
+
+        public MyRule() {
+        }
+
+        @Override
+        public void apply(List<? extends Node> nodes, RuleContext ctx) {
+            visitedNodes.clear();
+            super.apply(nodes, ctx);
+        }
+
+        @Override
+        protected void visit(XmlNode node, RuleContext ctx) {
+            visitedNodes.add(node);
+            super.visit(node, ctx);
+        }
+    }
+
+    public static junit.framework.Test suite() {
+        return new junit.framework.JUnit4TestAdapter(AbstractWsdlRuleTest.class);
+    }
+}


### PR DESCRIPTION
WSDL files are basically XML files but with extension "wsdl". Since PMD looks for the file extension in order to decide which parser to use, WSDL could not be verified without a language module specific for handling this kind of extension.
The changes I've made just create a new WsdlLanguageModule that uses the XML parser but recognizes WSDL files. Also, in order to create WSDL rules, one must extend the AbstractWsdlRule class.
Apart from that, the new module was added to the service file "net.sourceforge.pmd.lang.Language" and a test was created for the new abstract rule.