### PR TITLE
Add rule for unnecessary literal boolean in ternary operators

### DIFF
--- a/pmd-java/src/main/resources/rulesets/java/basic.xml
+++ b/pmd-java/src/main/resources/rulesets/java/basic.xml
@@ -795,6 +795,59 @@ public class Count {
     </example>
   </rule>
 
+  <rule name="SimplifiedTernary"
+    language="java"
+    since="5.3.2"
+    message="Ternary operators that can be simplified with || or &amp;&amp;"
+    class="net.sourceforge.pmd.lang.rule.XPathRule"
+    externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#SimplifiedTernary">
+    <description>
+        <![CDATA[
+Look for ternary operators with the form condition ? literalBoolean : foo
+or condition ? foo : literalBoolean.
+
+These expressions can be simplified respectively to
+condition || foo  when the literalBoolean is true
+!condition && foo when the literalBoolean is false
+or
+!condition || foo when the literalBoolean is true
+condition && foo  when the literalBoolean is false
+        ]]>
+    </description>
+    <priority>3</priority>
+    <properties>
+        <property name="xpath">
+            <value><![CDATA[
+//ConditionalExpression[not(PrimaryExpression//BooleanLiteral) and (Expression//BooleanLiteral)]
+|
+//ConditionalExpression[not(Expression//BooleanLiteral) and (PrimaryExpression//BooleanLiteral)]
+]]>
+            </value>
+        </property>
+    </properties>
+    <example>
+        <![CDATA[
+public class Foo {
+    public boolean test() {
+        return condition ? true : something(); // can be as simple as return condition || something();
+    }
+
+    public void test2() {
+        final boolean value = condition ? false : something(); // can be as simple as value = !condition && something();
+    }
+
+    public boolean test3() {
+        return condition ? something() : true; // can be as simple as return !condition || something();
+    }
+
+    public void test4() {
+        final boolean otherValue = condition ? something() : false; // can be as simple as condition && something();
+    }
+}
+        ]]>
+    </example>
+  </rule>
+
     <rule deprecated="true" ref="rulesets/java/empty.xml/EmptyCatchBlock" />
     <rule deprecated="true" ref="rulesets/java/empty.xml/EmptyIfStmt" />
     <rule deprecated="true" ref="rulesets/java/empty.xml/EmptyWhileStmt" />

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/basic/BasicRulesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/basic/BasicRulesTest.java
@@ -37,5 +37,6 @@ public class BasicRulesTest extends SimpleAggregatorTst {
         addRule(RULESET, "ReturnFromFinallyBlock");
         addRule(RULESET, "DontCallThreadRun");
         addRule(RULESET, "DontUseFloatTypeForLoopIndices");
+        addRule(RULESET, "SimplifiedTernary");
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/basic/xml/SimplifiedTernary.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/basic/xml/SimplifiedTernary.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data>
+    <test-code>
+        <description>
+            <![CDATA[
+condition ? true : foo
+            ]]>
+        </description>
+        <expected-problems>1</expected-problems>
+        <code>
+            <![CDATA[
+public class Foo {
+    public boolean test() {
+        return condition ? true : something();
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+    <test-code>
+        <description>
+            <![CDATA[
+condition ? false : foo
+            ]]>
+        </description>
+        <expected-problems>1</expected-problems>
+        <code>
+            <![CDATA[
+public class Foo {
+    public void test() {
+        final boolean value = condition ? false : something();
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+    <test-code>
+        <description>
+            <![CDATA[
+condition ? foo : true
+            ]]>
+        </description>
+        <expected-problems>1</expected-problems>
+        <code>
+            <![CDATA[
+public class Foo {
+    public boolean test() {
+        return condition ? something() : true;
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+    <test-code>
+        <description>
+            <![CDATA[
+condition ? foo : false
+            ]]>
+        </description>
+        <expected-problems>1</expected-problems>
+        <code>
+            <![CDATA[
+public class Foo {
+    public void test() {
+        final boolean otherValue = condition ? something() : false;
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+    <test-code>
+        <description>
+            <![CDATA[
+condition ? true : false
+            ]]>
+        </description>
+        <expected-problems>0</expected-problems>
+        <code>
+            <![CDATA[
+public class Foo {
+    public boolean test() {
+        return condition ? true : false; // Existing rule
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+</test-data>


### PR DESCRIPTION
I have added a rule to check when a ternary operator has a literal boolean.

For example, if we have
```
condition ? true : otherThingToReturn(); 
```
it can be written as simple as
```
condition || otherThingToReturn() 
```

I have added this rule in basic.xml ruleset of the PMD-java code and the test cases in the corresponding folders.