### PR TITLE
Add check to Boxed booleans in UseAssertTrueInsteadOfAssertEquals rule

### DIFF
--- a/pmd-java/src/main/resources/rulesets/java/junit.xml
+++ b/pmd-java/src/main/resources/rulesets/java/junit.xml
@@ -403,18 +403,25 @@ public class MyTestCase extends TestCase {
 	<rule name="UseAssertTrueInsteadOfAssertEquals"
 		language="java"
 		since="5.0"
-		message="Use assertTrue(x)/assertFalse(x) instead of assertEquals(true, x)/assertEquals(false, x)."
+		message="Use assertTrue(x)/assertFalse(x) instead of assertEquals(true, x)/assertEquals(false, x)
+		or assertEquals(Boolean.TRUE, x)/assertEquals(Boolean.FALSE, x)."
 		class="net.sourceforge.pmd.lang.rule.XPathRule"
 		externalInfoUrl="${pmd.website.baseurl}/rules/java/junit.html#UseAssertTrueInsteadOfAssertEquals">
 		<description>
-When asserting a value is the same as a boolean literal, use assertTrue/assertFalse, instead of assertEquals.
+When asserting a value is the same as a literal or Boxed boolean, use assertTrue/assertFalse, instead of assertEquals.
 		</description>
 		<priority>3</priority>
 		<properties>
 			<property name="xpath">
 				<value>
 <![CDATA[
-//PrimaryExpression[PrimaryPrefix/Name[@Image = 'assertEquals']][PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Literal/BooleanLiteral]
+//PrimaryExpression[PrimaryPrefix/Name[@Image = 'assertEquals']]
+[
+  PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Literal/BooleanLiteral
+  or
+  PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix
+  /Name[(@Image = 'Boolean.TRUE' or @Image = 'Boolean.FALSE')]
+]
 ]]>
 			</value>
 			</property>
@@ -430,6 +437,10 @@ public class MyTestCase extends TestCase {
 		assertEquals("myVar is true", true, myVar);
 		// Bad
 		assertEquals("myVar is false", false, myVar);
+		// Bad
+		assertEquals("myVar is true", Boolean.TRUE, myVar);
+		// Bad
+		assertEquals("myVar is false", Boolean.FALSE, myVar);
 	}
 }
 ]]>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/junit/xml/UseAssertTrueInsteadOfAssertEquals.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/junit/xml/UseAssertTrueInsteadOfAssertEquals.xml
@@ -51,4 +51,46 @@ public class TestWithAssertEquals {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>
+            <![CDATA[
+JUnit Test contains assertEquals with Boxed booleans
+            ]]>
+        </description>
+        <expected-problems>8</expected-problems>
+        <code><![CDATA[
+public class Foo {
+	public void test() {
+		final boolean myVar = true;
+		assertEquals("myVar is true", Boolean.TRUE, myVar);
+		assertEquals("myVar is true", myVar, Boolean.TRUE);
+		assertEquals(Boolean.TRUE, myVar);
+		assertEquals(myVar, Boolean.TRUE);
+		assertEquals("myVar is false", Boolean.FALSE, myVar);
+		assertEquals("myVar is false", myVar, Boolean.FALSE);
+		assertEquals(myVar, Boolean.FALSE);
+		assertEquals(Boolean.FALSE, myVar);
+		assertTrue(myVar);
+	}
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description>
+            <![CDATA[
+JUnit Test contains assertEquals with Boxed booleans as param
+            ]]>
+        </description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+	public void test() {
+		assertEquals(methodWithBooleanParam(Boolean.TRUE), "a String value", "they should be equal!");
+	}
+	public String methodWithBooleanParam(Boolean param) {
+		return "a String value";
+	}
+}
+     ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
I modified the UseAssertTrueInsteadOfAssertEquals rule and tests to look for assertEqual with Boxed booleans as it is being done with the literal booleans.