### PR TITLE
Add UselessQualifiedThisRule

### DIFF
--- a/pmd-java/src/main/resources/rulesets/java/unnecessary.xml
+++ b/pmd-java/src/main/resources/rulesets/java/unnecessary.xml
@@ -275,5 +275,55 @@ public class Foo {
     ]]>
     </example>
   </rule>
-  
+
+  <rule name="UselessQualifiedThis"
+      language="java"
+      since="5.3.3"
+      message="Useless qualified this usage in the same class."
+      class="net.sourceforge.pmd.lang.rule.XPathRule"
+      externalInfoUrl="${pmd.website.baseurl}/rules/java/unnecessary.html#UselessQualifiedThis">
+    <description>Look for qualified this usages in the same class.</description>
+    <priority>3</priority>
+    <properties>
+       <property name="xpath">
+          <value>
+          <![CDATA[
+//PrimaryExpression[
+  PrimaryPrefix/Name[@Image] and PrimarySuffix[@Arguments='false']
+  and ancestor::ClassOrInterfaceBodyDeclaration[1][@AnonymousInnerClass='false']
+]/PrimaryPrefix/Name[@Image = ancestor::ClassOrInterfaceDeclaration[1]/@Image]
+          ]]>
+          </value>
+       </property>
+    </properties>
+    <example>
+    <![CDATA[
+public class Foo {
+    final Foo otherFoo = Foo.this;  // use "this" directly
+
+    public void doSomething() {
+         final Foo anotherFoo = Foo.this;  // use "this" directly
+    }
+
+    private ActionListener returnListener() {
+        return new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                doSomethingWithQualifiedThis(Foo.this);  // This is fine
+            }
+        };
+    }
+
+    private class Foo3 {
+        final Foo myFoo = Foo.this;  // This is fine
+    }
+
+    private class Foo2 {
+        final Foo2 myFoo2 = Foo2.this;  // Use "this" direclty
+    }
+}
+    ]]>
+    </example>
+  </rule>
+
 </ruleset>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/unnecessary/UnnecessaryRulesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/unnecessary/UnnecessaryRulesTest.java
@@ -21,5 +21,6 @@ public class UnnecessaryRulesTest extends SimpleAggregatorTst {
         addRule(RULESET, "UselessOverridingMethod");
         addRule(RULESET, "UselessOperationOnImmutable");
         addRule(RULESET, "UselessParentheses");
+        addRule(RULESET, "UselessQualifiedThis");
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/unnecessary/xml/UselessQualifiedThis.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/unnecessary/xml/UselessQualifiedThis.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data>
+    <test-code>
+        <description>
+            <![CDATA[
+Qualified this as field
+            ]]>
+        </description>
+        <expected-problems>1</expected-problems>
+        <code>
+            <![CDATA[
+public class Foo {
+    final Foo otherFoo = Foo.this;
+}
+            ]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>
+            <![CDATA[
+Qualified this in a method
+            ]]>
+        </description>
+        <expected-problems>1</expected-problems>
+        <code>
+            <![CDATA[
+public class Foo {
+    public void doSomething() {
+         final Foo anotherFoo = Foo.this;
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>
+            <![CDATA[
+Qualified this in a Inner Class
+            ]]>
+        </description>
+        <expected-problems>0</expected-problems>
+        <code>
+            <![CDATA[
+public class Foo {
+    private ActionListener returnListener() {
+        return new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                doSomethingWithQualifiedThis(Foo.this);
+            }
+        };
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>
+            <![CDATA[
+Qualified this in a Nested Class
+            ]]>
+        </description>
+        <expected-problems>0</expected-problems>
+        <code>
+            <![CDATA[
+public class Foo {
+    private class Foo3 {
+        final Foo myFoo = Foo.this;
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>
+            <![CDATA[
+Qualified this in a Nested Class part 2
+            ]]>
+        </description>
+        <expected-problems>1</expected-problems>
+        <code>
+            <![CDATA[
+public class Foo {
+    private class Foo2 {
+        final Foo2 myFoo2 = Foo2.this;
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>
+            <![CDATA[
+Qualified this all in one
+            ]]>
+        </description>
+        <expected-problems>3</expected-problems>
+        <code>
+            <![CDATA[
+public class Foo {
+    final Foo otherFoo = Foo.this;
+
+    public void doSomething() {
+         final Foo anotherFoo = Foo.this;
+    }
+
+    private ActionListener returnListener() {
+        return new ActionListener() {
+            @Override
+            public void actionPerformed(ActionEvent e) {
+                doSomethingWithQualifiedThis(Foo.this);
+            }
+        };
+    }
+
+    private class Foo3 {
+        final Foo myFoo = Foo.this;
+    }
+
+    private class Foo2 {
+        final Foo2 myFoo2 = Foo2.this;
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+
+</test-data>


### PR DESCRIPTION
I have added this rule to look for qualified this usages in the same class.

for example
```java
public class Foo {
    public void doSomething() {
         final Foo anotherFoo = Foo.this;  // use "this" directly
    }
}
```

The rule has been added in the useless.xml file and the test in their corresponding folder.