### PR TITLE
Add CloneMethodReturnTypeMustMatchClassName rule

### DIFF
--- a/pmd-java/src/main/resources/rulesets/java/clone.xml
+++ b/pmd-java/src/main/resources/rulesets/java/clone.xml
@@ -128,5 +128,44 @@ public class MyClass {
         </example>
     </rule>
 
-</ruleset>
+    <rule name="CloneMethodReturnTypeMustMatchClassName"
+        language="java"
+        since="5.4.0"
+        message="The return type of the clone() method must be the class name when implements Cloneable"
+        class="net.sourceforge.pmd.lang.rule.XPathRule"
+        externalInfoUrl="${pmd.website.baseurl}/rules/java/clone.html#CloneMethodReturnTypeMustMatchClassName">
+        <description>
+If a class implements cloneable the return type of the method clone() must be the class name.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
+//MethodDeclaration
+[
+MethodDeclarator/@Image = 'clone'
+and MethodDeclarator/FormalParameters/@ParameterCount = 0
+and not (ResultType//ClassOrInterfaceType/@Image = ancestor::ClassOrInterfaceDeclaration[1]/@Image)
+]
+                    ]]>
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
+public class Foo implements Cloneable {
+    @Override
+    protected Object clone() { // Violation, Object must be Foo
+    }
+}
 
+public class Foo implements Cloneable {
+    @Override
+    public Foo clone() { //Ok
+    }
+}
+            ]]>
+        </example>
+    </rule>
+</ruleset>

--- a/pmd-java/src/main/resources/rulesets/java/clone.xml
+++ b/pmd-java/src/main/resources/rulesets/java/clone.xml
@@ -130,6 +130,7 @@ public class MyClass {
 
     <rule name="CloneMethodReturnTypeMustMatchClassName"
         language="java"
+        minimumLanguageVersion="1.5"
         since="5.4.0"
         message="The return type of the clone() method must be the class name when implements Cloneable"
         class="net.sourceforge.pmd.lang.rule.XPathRule"

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/clone/CloneRulesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/clone/CloneRulesTest.java
@@ -14,5 +14,6 @@ public class CloneRulesTest extends SimpleAggregatorTst {
         addRule(RULESET, "CloneMethodMustImplementCloneable");
         addRule(RULESET, "CloneThrowsCloneNotSupportedException");
         addRule(RULESET, "ProperCloneImplementation");
+        addRule(RULESET, "CloneMethodReturnTypeMustMatchClassName");
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/clone/xml/CloneMethodReturnTypeMustMatchClassName.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/clone/xml/CloneMethodReturnTypeMustMatchClassName.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data>
+    <test-code>
+        <description>
+            <![CDATA[
+protected method clone with Object as return type
+            ]]>
+        </description>
+        <expected-problems>1</expected-problems>
+        <code>
+            <![CDATA[
+public class Foo implements Cloneable {
+    @Override
+    protected Object clone() {
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>
+            <![CDATA[
+public method clone with Object as return type
+            ]]>
+        </description>
+        <expected-problems>1</expected-problems>
+        <code>
+            <![CDATA[
+public class Foo implements Cloneable {
+    @Override
+    public Object clone() {
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>
+            <![CDATA[
+final class with public method clone
+            ]]>
+        </description>
+        <expected-problems>0</expected-problems>
+        <code>
+            <![CDATA[
+public final class Foo implements Cloneable {
+    @Override
+    public Foo clone() {
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>
+            <![CDATA[
+final class with public method clone with Object as return type
+            ]]>
+        </description>
+        <expected-problems>1</expected-problems>
+        <code>
+            <![CDATA[
+public final class Foo implements Cloneable {
+    @Override
+    public Object clone() {
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>
+            <![CDATA[
+protected method clone with return type as the class name
+            ]]>
+        </description>
+        <expected-problems>0</expected-problems>
+        <code>
+            <![CDATA[
+public class Foo implements Cloneable {
+    @Override
+    protected Foo clone() {
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>
+            <![CDATA[
+public method clone with return type as the class name
+            ]]>
+        </description>
+        <expected-problems>0</expected-problems>
+        <code>
+            <![CDATA[
+public class Foo implements Cloneable {
+    @Override
+    public Foo clone() {
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+</test-data>


### PR DESCRIPTION
If we have a class that implements cloneable the return type of our clone method should match with the class name instead of returning Object.

This makes sense since clone is expected to return an exact copy of the object; and since the return type is not part of the signature, it's still a valid override.

```java
public class Foo implements Cloneable {
    @Override
    public Object clone() { // Should be Foo
    }
}
```
This is not required by the contract of Object.clone (even the [Javadoc says so] (http://docs.oracle.com/javase/7/docs/api/java/lang/Object.html#clone)), but is a sane default; and exceptions may suppress this rule were needed.