### PR TITLE
Add CloneMethodMustBePublic rule

### DIFF
--- a/pmd-java/src/main/resources/rulesets/java/clone.xml
+++ b/pmd-java/src/main/resources/rulesets/java/clone.xml
@@ -128,5 +128,56 @@ public class MyClass {
         </example>
     </rule>
 
-</ruleset>
+    <rule name="CloneMethodMustBePublic"
+        language="java"
+        since="5.4.0"
+        message="clone() method must be public if the class implements Cloneable"
+        class="net.sourceforge.pmd.lang.rule.XPathRule"
+        externalInfoUrl="${pmd.website.baseurl}/rules/java/clone.html#CloneMethodMustBePublic">
+        <description>
+The java Manual says "By convention, classes that implement this interface should override
+Object.clone (which is protected) with a public method."
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
+//MethodDeclaration[@Public='false']
+[
+MethodDeclarator/@Image = 'clone'
+and MethodDeclarator/FormalParameters/@ParameterCount = 0
+]
+                    ]]>
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
+public class Foo implements Cloneable {
+    @Override
+    protected Object clone() throws CloneNotSupportedException { // Violation, must be public
+    }
+}
 
+public class Foo implements Cloneable {
+    @Override
+    protected Foo clone() { // Violation, must be public
+    }
+}
+
+public class Foo implements Cloneable {
+    @Override
+    public Object clone() // Ok
+    }
+}
+
+public class Foo implements Cloneable {
+    @Override
+    public Foo clone() { //Ok
+    }
+}
+            ]]>
+        </example>
+    </rule>
+</ruleset>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/clone/CloneRulesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/clone/CloneRulesTest.java
@@ -14,5 +14,6 @@ public class CloneRulesTest extends SimpleAggregatorTst {
         addRule(RULESET, "CloneMethodMustImplementCloneable");
         addRule(RULESET, "CloneThrowsCloneNotSupportedException");
         addRule(RULESET, "ProperCloneImplementation");
+        addRule(RULESET, "CloneMethodMustBePublic");
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/clone/xml/CloneMethodMustBePublic.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/clone/xml/CloneMethodMustBePublic.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data>
+    <test-code>
+        <description>
+            <![CDATA[
+protected method clone
+            ]]>
+        </description>
+        <expected-problems>1</expected-problems>
+        <code>
+            <![CDATA[
+public class Foo implements Cloneable {
+    @Override
+    protected Object clone() throws CloneNotSupportedException {
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>
+            <![CDATA[
+protected method clone 2
+            ]]>
+        </description>
+        <expected-problems>1</expected-problems>
+        <code>
+            <![CDATA[
+public class Object implements Cloneable {
+    @Override
+    protected Object clone() {
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>
+            <![CDATA[
+public method clone
+            ]]>
+        </description>
+        <expected-problems>0</expected-problems>
+        <code>
+            <![CDATA[
+public class Foo implements Cloneable {
+    @Override
+    public Object clone() {
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>
+            <![CDATA[
+public method clone 2
+            ]]>
+        </description>
+        <expected-problems>0</expected-problems>
+        <code>
+            <![CDATA[
+public class Foo implements Cloneable {
+    @Override
+    public Foo clone() {
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+    
+    <test-code>
+        <description>
+            <![CDATA[
+final class with protected clone method
+            ]]>
+        </description>
+        <expected-problems>1</expected-problems>
+        <code>
+            <![CDATA[
+public final class Foo implements Cloneable {
+    @Override
+    protected Object clone() {
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>
+            <![CDATA[
+final class with public method
+            ]]>
+        </description>
+        <expected-problems>0</expected-problems>
+        <code>
+            <![CDATA[
+public final class Foo implements Cloneable {
+    @Override
+    public Foo clone() {
+    }
+}
+            ]]>
+        </code>
+    </test-code>
+</test-data>


### PR DESCRIPTION
As says in the [java docs](http://docs.oracle.com/javase/7/docs/api/java/lang/Cloneable.html) "By convention, classes that implement this interface should override Object.clone (which is protected) with a public method".
