### PR TITLE
Change CheckResultSet to allow for the result of the navigation methods to be returned

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/basic/CheckResultSetRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/basic/CheckResultSetRule.java
@@ -14,6 +14,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
+import net.sourceforge.pmd.lang.java.ast.ASTReturnStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTType;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
@@ -68,7 +69,8 @@ public class CheckResultSetRule extends AbstractJavaRule {
         String var = getResultSetVariableName(image);
         if (var != null && resultSetVariables.containsKey(var)
                 && node.getFirstParentOfType(ASTIfStatement.class) == null
-                && node.getFirstParentOfType(ASTWhileStatement.class) == null) {
+                && node.getFirstParentOfType(ASTWhileStatement.class) == null
+                && node.getFirstParentOfType(ASTReturnStatement.class) == null) {
 
             addViolation(data, resultSetVariables.get(var));
         }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/basic/xml/CheckResultSet.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/basic/xml/CheckResultSet.xml
@@ -308,4 +308,18 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>Allow the result of ResultSet navigation methods to be returned</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.sql.ResultSet;
+
+public class Foo {
+    public boolean bar() {
+        ResultSet results = stmt.executeQuery();
+        return results.next();
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
I would like to change the CheckResultSet rule to allow for returning the result of one of the navigation methods (next, first, last, previous). This is for the case when you are attempting to see if the query returned data, but you don't need to work with the data, such as checking the existence of a database column.

You can work around this currently with:
```java
if (resultSet.next()) {
    return true;
}
return false;
```
But it would be much nicer to just do:
```java
return resultSet.next();
```