### PR TITLE
Add 'ignore-methods' property to NPathComplexity and CyclomaticComplexity

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/stat/StatisticalRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/stat/StatisticalRule.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.rule.stat;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.lang.rule.properties.DoubleProperty;
 import net.sourceforge.pmd.lang.rule.properties.IntegerProperty;
+import net.sourceforge.pmd.lang.rule.properties.StringMultiProperty;
 import net.sourceforge.pmd.stat.DataPoint;
 
 /**
@@ -21,6 +22,7 @@ public interface StatisticalRule extends Rule {
     DoubleProperty SIGMA_DESCRIPTOR = new DoubleProperty("sigma", "Sigma value", 0d, 100d, null, 1.0f);
     DoubleProperty MINIMUM_DESCRIPTOR = new DoubleProperty("minimum", "Minimum reporting threshold", 0d, 100d, null, 2.0f);
     IntegerProperty TOP_SCORE_DESCRIPTOR = new IntegerProperty("topscore", "Top score value", 1, 100, null, 3.0f);
+    StringMultiProperty IGNORE_METHODS = new StringMultiProperty("ignore-methods", "Methods to ignore", new String[0], 3.0f, ',');
 
     void addDataPoint(DataPoint point);
     Object[] getViolationParameters(DataPoint point);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codesize/CyclomaticComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codesize/CyclomaticComplexityRule.java
@@ -10,6 +10,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTForStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTWhileStatement;
+import net.sourceforge.pmd.lang.rule.stat.StatisticalRule;
 
 /**
  * @author Donald A. Leckie,
@@ -18,6 +19,11 @@ import net.sourceforge.pmd.lang.java.ast.ASTWhileStatement;
  * @since January 14, 2003
  */
 public class CyclomaticComplexityRule extends StdCyclomaticComplexityRule {
+
+    public CyclomaticComplexityRule(){
+        super();
+        setProperty(StatisticalRule.IGNORE_METHODS, new String[0]);
+    }
 
   @Override
 public Object visit(ASTIfStatement node, Object data) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codesize/NPathComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codesize/NPathComplexityRule.java
@@ -36,6 +36,7 @@ public class NPathComplexityRule extends AbstractStatisticalJavaRule {
     public NPathComplexityRule() {
         super();
         setProperty(MINIMUM_DESCRIPTOR, 200d);
+        definePropertyDescriptor(IGNORE_METHODS);
     }
 
     private int complexityMultipleOf(JavaNode node, int npathStart, Object data) {
@@ -66,6 +67,17 @@ public class NPathComplexityRule extends AbstractStatisticalJavaRule {
 
     @Override
     public Object visit(ASTMethodDeclaration node, Object data) {
+
+        String[] methodsToIgnore = getProperty(IGNORE_METHODS);
+        if (methodsToIgnore != null) {
+            for (String m : methodsToIgnore) {
+                if (node.getMethodName().equals(m)) {
+                    //ignoring this method
+                    return 0;
+                }
+            }
+        }
+
         int npath = complexityMultipleOf(node, 1, data);
 
         DataPoint point = new DataPoint();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codesize/StdCyclomaticComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codesize/StdCyclomaticComplexityRule.java
@@ -24,6 +24,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTWhileStatement;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.rule.properties.BooleanProperty;
 import net.sourceforge.pmd.lang.rule.properties.IntegerProperty;
+import net.sourceforge.pmd.lang.rule.stat.StatisticalRule;
 
 /**
  * Implements the standard cyclomatic complexity rule 
@@ -80,6 +81,7 @@ public class StdCyclomaticComplexityRule extends AbstractJavaRule {
       definePropertyDescriptor(REPORT_LEVEL_DESCRIPTOR);
       definePropertyDescriptor(SHOW_CLASSES_COMPLEXITY_DESCRIPTOR);
       definePropertyDescriptor(SHOW_METHODS_COMPLEXITY_DESCRIPTOR);
+      definePropertyDescriptor(StatisticalRule.IGNORE_METHODS);
   }
 
   @Override
@@ -182,7 +184,9 @@ public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
 
   @Override
 public Object visit(ASTMethodDeclaration node, Object data) {
-    entryStack.push( new Entry( node ) );
+      if (ignoreMethod(node)) return data;
+
+      entryStack.push( new Entry( node ) );
     super.visit( node, data );
 	    Entry methodEntry = entryStack.pop();
     if (!isSuppressed(node)) {
@@ -213,7 +217,21 @@ public Object visit(ASTMethodDeclaration node, Object data) {
     return data;
   }
 
-  @Override
+    private boolean ignoreMethod(ASTMethodDeclaration node) {
+        Object data;
+        String[] methodsToIgnore = getProperty(StatisticalRule.IGNORE_METHODS);
+        if (methodsToIgnore != null) {
+            for (String m : methodsToIgnore) {
+                if (node.getMethodName().equals(m)) {
+                    //ignoring with method name
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
 public Object visit(ASTEnumDeclaration node, Object data) {
     entryStack.push( new Entry( node ) );
     super.visit( node, data );

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codesize/xml/CyclomaticComplexity.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codesize/xml/CyclomaticComplexity.xml
@@ -183,4 +183,42 @@ public class Test {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>Ignore method</description>
+        <rule-property name="reportLevel">2</rule-property>
+        <rule-property name="ignore-methods">foo</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void foo() {
+        if (a == 1) {
+        } else {
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description>Ignore multiple methods</description>
+        <rule-property name="reportLevel">1</rule-property>
+        <rule-property name="ignore-methods">foo,foo2</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>The class 'Foo' has a Cyclomatic Complexity of 1 (Highest = 0).</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    public void foo() {
+        if (a == 1) {
+        } else {
+        }
+    }
+    public void foo2() {
+        if (a == 1) {
+        } else {
+        }
+    }
+}
+     ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codesize/xml/NPathComplexity.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codesize/xml/NPathComplexity.xml
@@ -92,4 +92,18 @@ class Bar
         </expected-messages>
         <code-ref id="bug3484404"/>
     </test-code>
+    <test-code>
+        <description>ignore method</description>
+        <rule-property name="minimum">1.0</rule-property>
+        <rule-property name="ignore-methods">hashCode</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ public int hashCode() {
+  if (true) {List buz = new ArrayList();}
+  return 0;
+ }
+}
+     ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-test/src/main/java/net/sourceforge/pmd/AbstractRuleSetFactoryTest.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/AbstractRuleSetFactoryTest.java
@@ -2,6 +2,7 @@
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 package net.sourceforge.pmd;
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -462,9 +463,15 @@ public abstract class AbstractRuleSetFactoryTest {
             assertEquals(message + ", Rule property descriptor ",
                     propertyDescriptors1, propertyDescriptors2);
             for (int j = 0; j < propertyDescriptors1.size(); j++) {
-                assertEquals(message + ", Rule property value " + j, rule1
-                        .getProperty(propertyDescriptors1.get(j)), rule2
-                        .getProperty(propertyDescriptors2.get(j)));
+                if (rule1.getProperty(propertyDescriptors2.get(j)) instanceof Object[] ){
+                    assertArrayEquals(message + ", Rule property value " + j,
+                            ((Object[]) rule1.getProperty(propertyDescriptors1.get(j))),
+                            (Object[]) rule2.getProperty(propertyDescriptors2.get(j)));
+                } else {
+                    assertEquals(message + ", Rule property value " + j, rule1
+                            .getProperty(propertyDescriptors1.get(j)), rule2
+                            .getProperty(propertyDescriptors2.get(j)));
+                }
             }
             assertEquals(message + ", Rule property descriptor count",
                     propertyDescriptors1.size(), propertyDescriptors2.size());


### PR DESCRIPTION
It would be very useful if we could skip running those rules (NPathComplexity and CyclomaticComplexity) on certain methods, for example 'hashCode' and 'equals'. Many times those are auto generated methods and it is better to leave them as is. 