### PR TITLE
Fix ClassCastException in UselessOverridingMethodRule.

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/unnecessary/UselessOverridingMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/unnecessary/UselessOverridingMethodRule.java
@@ -130,7 +130,7 @@ public class UselessOverridingMethodRule extends AbstractJavaRule {
             return super.visit(node, data);
         }
 
-        ASTStatement statement = (ASTStatement) block.jjtGetChild(0).jjtGetChild(0);
+        Node statement = block.jjtGetChild(0).jjtGetChild(0);
         if (statement.jjtGetChild(0).jjtGetNumChildren() == 0) {
             return data; // skips empty return statements
         }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/unnecessary/xml/UselessOverridingMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/unnecessary/xml/UselessOverridingMethod.xml
@@ -373,5 +373,28 @@ public class Example extends PersistentObject {
 }
      ]]></code>
     </test-code>
+    <test-code>
+        <description><![CDATA[
+ClassCastException in statement cast
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.Comparator;
+import javax.annotation.Nonnull;
 
+public class AnonymousClassConstructor {
+
+	public void method() {
+		@SuppressWarnings("unused")
+		final Comparator<Long> comparator = new Comparator<Long>() {
+
+			@Override
+			public int compare(@Nonnull Long o1, @Nonnull Long o2) {
+				return 0;
+			}
+		};
+	}
+}
+     ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Removed unnecessary cast  on the statement var since it isn't always a ASTStatement.
Since the only method called is jjtGetChild() the Node interface is more than enough to work with.

Added a new test where the statement is a LocalVariableDeclaration
 