### PR TITLE
#1370 ConsecutiveAppendsShouldReuse not detected properly on StringBuffer

### DIFF
--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/strings/xml/ConsecutiveAppendsShouldReuse.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/strings/xml/ConsecutiveAppendsShouldReuse.xml
@@ -207,4 +207,16 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>#1370 ConsecutiveAppendsShouldReuse not detected properly on StringBuffer</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void foo() {
+        final StringBuffer stringBuffer = new StringBuffer().append("agrego ").append("un ");
+        stringBuffer.append("string ");
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Added new append validation.

Check for an append even when the block first child is a LocalVariableDeclaration.
Added a new test to check the validation.

Issue: http://sourceforge.net/p/pmd/bugs/1370/