### PR TITLE
Use Path instead of string to check file exclusions to fix windows-on…

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
@@ -10,6 +10,7 @@ import java.io.FilenameFilter;
 import java.io.Reader;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -277,7 +278,7 @@ public class CPDConfiguration extends AbstractConfiguration {
         }
 
         final FilenameFilter languageFilter = language.getFileFilter();
-        final Set<String> exclusions = new HashSet<String>();
+        final Set<Path> exclusions = new HashSet<Path>();
 
         if (excludes != null) {
             FileFinder finder = new FileFinder();
@@ -285,10 +286,10 @@ public class CPDConfiguration extends AbstractConfiguration {
                 if (excludedFile.isDirectory()) {
                     List<File> files = finder.findFilesFrom(excludedFile, languageFilter, true);
                     for (File f : files) {
-                        exclusions.add(f.getAbsolutePath());
+                        exclusions.add(f.toPath());
                     }
                 } else {
-                    exclusions.add(excludedFile.getAbsolutePath());
+                    exclusions.add(excludedFile.toPath());
                 }
             }
         }
@@ -296,7 +297,7 @@ public class CPDConfiguration extends AbstractConfiguration {
         FilenameFilter filter = new FilenameFilter() {
             public boolean accept(File dir, String name) {
                 File f = new File(dir, name);
-                if (exclusions.contains(f.getAbsolutePath())) {
+                if (exclusions.contains(f.toPath())) {
                     System.err.println("Excluding " + f.getAbsolutePath());
                     return false;
                 }


### PR DESCRIPTION
This fixes a bug i encountered where files were not being properly excluded on Windows.

The issue was that case-sensitive string comparisons were being used to compare file paths. The fix is to use the Path class which uses case-insensitive comparisons on Windows.