### PR TITLE
#1370 ConsecutiveAppendsShouldReuse not detected properly on StringBuffer

### DIFF
--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/strings/xml/ConsecutiveAppendsShouldReuse.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/strings/xml/ConsecutiveAppendsShouldReuse.xml
@@ -207,4 +207,17 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>#1370 ConsecutiveAppendsShouldReuse not detected properly on StringBuffer</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void foo() {
+        final StringBuffer stringBuffer;
+        stringBuffer = new StringBuffer().append("agrego ").append("un ");
+        stringBuffer.append("string ");
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Now the rule search for appends after a contructor call even when the variable is declared in another block.
Added a new test for this case.
Issue: http://sourceforge.net/p/pmd/bugs/1370/
