### PR TITLE
#1371 InsufficientStringBufferDeclaration not detected properly on StringBuffer

### DIFF
--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/strings/xml/InsufficientStringBufferDeclaration.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/strings/xml/InsufficientStringBufferDeclaration.xml
@@ -982,4 +982,18 @@ public class Test {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>
+#1371 InsufficientStringBufferDeclaration not detected properly on StringBuffer
+        </description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class StringBufferTest {
+    public void test() {
+        final StringBuffer stringBuffer = new StringBuffer().append("Added ").append(" a ");
+        stringBuffer.append("string ");
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Added a new method to obtaint the lenght of strings added in appends after a contructor call.

Removed an else statement from the method getConstructorLength since we can have more than one literal in the block (with appends after the constructor call)

New test added for this change.
Fix: http://sourceforge.net/p/pmd/bugs/1371/
