### PR TITLE
Added capability in Java and JSP parser for tracking tokens.

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
@@ -14,6 +14,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import net.sourceforge.pmd.lang.ast.xpath.Attribute;
 import net.sourceforge.pmd.lang.ast.xpath.DocumentNavigator;
 import net.sourceforge.pmd.lang.dfa.DataFlowNode;
+import net.sourceforge.pmd.lang.ast.GenericToken;
 
 import org.jaxen.BaseXPath;
 import org.jaxen.JaxenException;
@@ -397,4 +398,22 @@ public abstract class AbstractNode implements Node {
     public void setUserData(Object userData) {
         this.userData = userData;
     }
+    
+    protected GenericToken firstToken, lastToken;
+
+	public GenericToken jjtGetFirstToken() {
+		return firstToken;
+	}
+
+	public void jjtSetFirstToken(GenericToken token) {
+		this.firstToken = token;
+	}
+
+	public GenericToken jjtGetLastToken() {
+		return lastToken;
+	}
+
+	public void jjtSetLastToken(GenericToken token) {
+		this.lastToken = token;
+	}
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/GenericToken.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/GenericToken.java
@@ -1,0 +1,5 @@
+package net.sourceforge.pmd.lang.ast;
+
+public class GenericToken {
+
+}

--- a/pmd-java/etc/grammar/Java.jjt
+++ b/pmd-java/etc/grammar/Java.jjt
@@ -1,4 +1,8 @@
 /**
+ * Added capability for Tracking Tokens.
+ *
+ * Amit Kumar Prasad 10/2015
+ *====================================================================
  * Fix for Lambda expressions without variables.
  *
  * Andreas Dangel 11/2014
@@ -104,6 +108,7 @@ options {
   MULTI = true;
   VISITOR = true;
   NODE_USES_PARSER = true;
+  TRACK_TOKENS = true;
   NODE_PACKAGE="net.sourceforge.pmd.lang.java.ast";
 
   //DEBUG_PARSER = true;

--- a/pmd-java/src/main/ant/alljavacc.xml
+++ b/pmd-java/src/main/ant/alljavacc.xml
@@ -81,6 +81,12 @@ public class]]></replacevalue>
   }
 ]]></replacevalue>
         </replace>
+    	<replace file="${target}/net/sourceforge/pmd/lang/java/ast/Token.java">
+    		<replacetoken>public class Token</replacetoken>
+    	    <replacevalue><![CDATA[import net.sourceforge.pmd.lang.ast.GenericToken;
+
+public class Token extends GenericToken]]></replacevalue>
+    	</replace>
 
         <delete>
             <fileset dir="${target}/net/sourceforge/pmd/lang/java/ast">

--- a/pmd-jsp/etc/grammar/JspParser.jjt
+++ b/pmd-jsp/etc/grammar/JspParser.jjt
@@ -1,4 +1,9 @@
-    /* JSP Parser for PMD.
+/* 
+ * Added capability for Tracking Tokens.
+ *
+ * Amit Kumar Prasad 10/2015
+ *====================================================================
+ * JSP Parser for PMD.
  * It supports supports more-or-less well written JSP files.
  * The JSP Document style is supported, except for inline DTD.
  * The JSP Page style (<% ... %>) is supported.
@@ -16,6 +21,7 @@ options {
 	
 	MULTI=true;
 	VISITOR=true;
+	TRACK_TOKENS = true;
 } 
 
 PARSER_BEGIN(JspParser)

--- a/pmd-jsp/src/main/ant/alljavacc.xml
+++ b/pmd-jsp/src/main/ant/alljavacc.xml
@@ -61,6 +61,12 @@
 
 public class]]></replacevalue>
         </replace>
+    	<replace file="${target}/net/sourceforge/pmd/lang/jsp/ast/Token.java">
+    	    <replacetoken>public class Token</replacetoken>
+    	    <replacevalue><![CDATA[import net.sourceforge.pmd.lang.ast.GenericToken;
+
+public class Token extends GenericToken]]></replacevalue>
+		</replace>
 
         <delete>
             <fileset dir="${target}/net/sourceforge/pmd/lang/jsp/ast">


### PR DESCRIPTION
Added capability in Java and JSP parser for tracking tokens. It is often useful to keep track of each node's first and last token so that input can be easily reproduced again. Ref - https://javacc.java.net/doc/JJTree.html