### PR TITLE
Fix rendering CommentDefaultAccessModifier description as code

### DIFF
--- a/pmd-java/src/main/resources/rulesets/java/comments.xml
+++ b/pmd-java/src/main/resources/rulesets/java/comments.xml
@@ -82,11 +82,9 @@ A rule for the politically correct... we don't want to offend anyone.
       message="Missing commented default access modifier"
       externalInfoUrl="${pmd.website.baseurl}/rules/java/comments.html#CommentDefaultAccessModifier">
     <description>
-        <![CDATA[
         To avoid mistakes if we want that a Method, Field or Nested class have a default access modifier
         we must add a comment at the beginning of the Method, Field or Nested class.
         By default the comment must be /* default */, if you want another, you have to provide a regex.
-        ]]>
     </description>
     <priority>3</priority>
     <properties>


### PR DESCRIPTION
Right now description of this rule is rendered like that:
![image](https://cloud.githubusercontent.com/assets/5467276/10418183/fce86c30-7053-11e5-8f7e-5bc2f404946c.png)
I don't think this was intentional.