### PR TITLE
Add Builder pattern check to the MissingStaticMethodInNonInstantiatableClass rule

### DIFF
--- a/pmd-java/src/main/resources/rulesets/java/design.xml
+++ b/pmd-java/src/main/resources/rulesets/java/design.xml
@@ -843,6 +843,21 @@ A class that has private constructors and does not have any static methods or fi
                     ]
             ) > 0]
         ) = 0
+  and
+  count(//ClassOrInterfaceDeclaration
+            [@Nested='true']
+            [@Static='true']
+            [@Public='true']
+            [.//MethodDeclaration
+              [@Public='true']
+              [.//ReturnStatement//AllocationExpression
+                [ClassOrInterfaceType
+                    [@Image = //ClassOrInterfaceDeclaration/@Image]
+                ]
+                [./Arguments//PrimaryPrefix/@ThisModifier='true']
+              ]
+            ]
+       ) = 0
 ]
     ]]>
               </value>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/MissingStaticMethodInNonInstantiatableClass.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/MissingStaticMethodInNonInstantiatableClass.xml
@@ -180,4 +180,36 @@ public class AccountSelectionSubForm extends Form implements WidgetEventListener
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Check Builder pattern</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public final class BacklogElementParameters {
+    private final Long backlogId;
+    private final String name;
+
+    private BacklogElementParameters(final BacklogElementParameters.Builder builder) {
+        this.backlogId = builder.backlogId;
+        this.name = builder.name;
+    }
+
+    public static class Builder {
+        public Builder backlogId(final Long backlogId) {
+            this.backlogId = backlogId;
+            return this;
+        }
+
+        public Builder name(final String name) {
+            this.name = name;
+            return this;
+        }
+
+        public BacklogElementParameters build() {
+            return new BacklogElementParameters(this);
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
This will prevent flagging the class if it has the Builder Pattern and the constructor is private.