### PR TITLE
Update mvn-plugin.md

### DIFF
--- a/src/site/markdown/usage/mvn-plugin.md
+++ b/src/site/markdown/usage/mvn-plugin.md
@@ -78,7 +78,7 @@ the report to html source files, and the file encoding:
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
         <configuration>
-            <linkXref>true</linkXref>
+            <linkXRef>true</linkXRef>
             <sourceEncoding>ISO-8859-1</sourceEncoding>
             <minimumTokens>30</minimumTokens>
             <targetJdk>1.4</targetJdk>


### PR DESCRIPTION
The correct name of the property to configure linking to source code is `linkXRef` and not `linkXref`. If you use `<linkXRef>false</linkXRef>` then the warning "[WARNING] Unable to locate Source XRef to link to - DISABLED" is no longer printed. See also http://stackoverflow.com/a/18390459/40064