### PR TITLE
Fix ArrayIndexOutOfBoundsException for AccessorClassGeneration rule

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AccessorClassGenerationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AccessorClassGenerationRule.java
@@ -162,6 +162,13 @@ public class AccessorClassGenerationRule extends AbstractJavaRule {
                 String interfaceName = node.getImage();
                 int formerID = getClassID();
                 setClassID(classDataList.size());
+                // TODO
+                // this is a hack to bail out here
+                // but I'm not sure why this is happening
+                // TODO
+                if (formerID == -1 || formerID >= classDataList.size()) {
+                    return null;
+                }
                 ClassData newClassData = new ClassData(interfaceName);
                 // store the names of any outer classes of this class in the
                 // classQualifyingName List


### PR DESCRIPTION
For interfaces like:

`public @interface Something
{
    public interface SomthingElse{};
}`

We get the following exception

Exception applying rule AccessorClassGeneration on file <path to java class>, continuing with next rule
java.lang.ArrayIndexOutOfBoundsException: -1
	at java.util.ArrayList.elementData(ArrayList.java:400)
	at java.util.ArrayList.get(ArrayList.java:413)
	at net.sourceforge.pmd.lang.java.rule.design.AccessorClassGenerationRule.visit(AccessorClassGenerationRule.java:168)

As a quick around I extended the hack to verify the classID value before any action. This, in the meanwhile the team get a final solution.