### PR TITLE
Change EmptyMethodInAbstractClassShouldBeAbstract rule's description.

### DIFF
--- a/pmd-java/src/main/resources/rulesets/java/design.xml
+++ b/pmd-java/src/main/resources/rulesets/java/design.xml
@@ -1598,9 +1598,8 @@ public class Foo {  //Should be final
           message="An empty method in an abstract class should be abstract instead"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/design.html#EmptyMethodInAbstractClassShouldBeAbstract">
         <description>
-Empty methods in an abstract class should be tagged as abstract. This helps to remove their inapproprate 
+Empty or auto-generated methods in an abstract class should be tagged as abstract. This helps to remove their inapproprate 
 usage by developers who should be implementing their own versions in the concrete subclasses.
-Auto-generated methods could trigger this rule.
         </description>
         <priority>1</priority>
         <properties>

--- a/pmd-java/src/main/resources/rulesets/java/design.xml
+++ b/pmd-java/src/main/resources/rulesets/java/design.xml
@@ -1599,7 +1599,8 @@ public class Foo {  //Should be final
           externalInfoUrl="${pmd.website.baseurl}/rules/java/design.html#EmptyMethodInAbstractClassShouldBeAbstract">
         <description>
 Empty methods in an abstract class should be tagged as abstract. This helps to remove their inapproprate 
-usage by developers who should be implementing their own versions in the concrete subclasses. 
+usage by developers who should be implementing their own versions in the concrete subclasses.
+Auto-generated methods could trigger this rule.
         </description>
         <priority>1</priority>
         <properties>


### PR DESCRIPTION
Now mention that auto-generated methods should trigger this rule. 