### PR TITLE
Refactored two test to stop using the deprecated ant class BuildFileTest

### DIFF
--- a/pmd-core/src/test/java/net/sourceforge/pmd/ant/CPDTaskTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/ant/CPDTaskTest.java
@@ -3,9 +3,13 @@
  */
 package net.sourceforge.pmd.ant;
 
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 
-import org.apache.tools.ant.BuildFileTest;
+import org.apache.tools.ant.BuildFileRule;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
 /**
@@ -13,20 +17,20 @@ import org.junit.Test;
  * @author Romain Pelisse <belaran@gmail.com>
  *
  */
-public class CPDTaskTest extends BuildFileTest {
+public class CPDTaskTest {
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-        configureProject("src/test/resources/net/sourceforge/pmd/ant/xml/cpdtasktest.xml");
+    @Rule
+    public final BuildFileRule buildRule = new BuildFileRule();
+
+    @Before
+    public void setUp() {
+        buildRule.configureProject("src/test/resources/net/sourceforge/pmd/ant/xml/cpdtasktest.xml");
     }
 
     @Test
     public void testBasic() {
-        executeTarget("testBasic");
-        // FIXME: This clearly needs to be improved - but I don't like to write
-        // test,
-        // so feel free to contribute :)
+        buildRule.executeTarget("testBasic");
+        // FIXME: This clearly needs to be improved - but I don't like to write test, so feel free to contribute :)
         assertTrue(new File("target/cpd.ant.tests").exists());
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/ant/PMDTaskTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/ant/PMDTaskTest.java
@@ -3,34 +3,62 @@
  */
 package net.sourceforge.pmd.ant;
 
-import org.apache.tools.ant.BuildFileTest;
+import static org.junit.Assert.fail;
+
+import org.apache.tools.ant.BuildException;
+import org.apache.tools.ant.BuildFileRule;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 
-public class PMDTaskTest extends BuildFileTest {
+public class PMDTaskTest {
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
-        configureProject("src/test/resources/net/sourceforge/pmd/ant/xml/pmdtasktest.xml");
+    @Rule
+    public final BuildFileRule buildRule = new BuildFileRule();
+
+    @Before
+    public void setUp() {
+        buildRule.configureProject("src/test/resources/net/sourceforge/pmd/ant/xml/pmdtasktest.xml");
     }
 
     @Test
     public void testFormatterWithNoToFileAttribute() {
-        expectBuildExceptionContaining("testFormatterWithNoToFileAttribute", "Valid Error Message", "toFile or toConsole needs to be specified in Formatter");
+        try {
+            buildRule.executeTarget("testFormatterWithNoToFileAttribute");
+            fail("This should throw an exception");
+        } catch (BuildException ex) {
+            Assert.assertEquals("toFile or toConsole needs to be specified in Formatter", ex.getMessage());
+        }
     }
 
     @Test
     public void testNoRuleSets() {
-        expectBuildExceptionContaining("testNoRuleSets", "Valid Error Message", "No rulesets specified");
+        try {
+            buildRule.executeTarget("testNoRuleSets");
+            fail("This should throw an exception");
+        } catch (BuildException ex) {
+            Assert.assertEquals("No rulesets specified", ex.getMessage());
+        }
     }
 
     @Test
     public void testBasic() {
-        executeTarget("testBasic");
+        buildRule.executeTarget("testBasic");
     }
 
     @Test
     public void testInvalidLanguageVersion() {
-        expectBuildExceptionContaining("testInvalidLanguageVersion", "Fail requested.", "The following language is not supported:<sourceLanguage name=\"java\" version=\"42\" />.");
+        try {
+            buildRule.executeTarget("testInvalidLanguageVersion");
+            Assert.assertEquals(
+                    "The following language is not supported:<sourceLanguage name=\"java\" version=\"42\" />.",
+                    buildRule.getLog());
+            fail("This should throw an exception");
+        } catch (BuildException ex) {
+            Assert.assertEquals(
+                    "The following language is not supported:<sourceLanguage name=\"java\" version=\"42\" />.",
+                    ex.getMessage());
+        }
     }
 }


### PR DESCRIPTION
Seems BuildFileTest was deprecated in ant 1.9.4

https://svn.apache.org/repos/asf/ant/core/trunk/src/tests/junit/org/apache/tools/ant/BuildFileTest.java

Following this ant tutorial

https://ant.apache.org/manual/tutorial-writing-tasks.html

I refactored two tests to avoid the deprecation