### PR TITLE
Add ConstantsInInterface rule. Effective Java, 19

### DIFF
--- a/pmd-java/src/main/resources/rulesets/java/design.xml
+++ b/pmd-java/src/main/resources/rulesets/java/design.xml
@@ -1961,7 +1961,7 @@ better placed in classes or enums. See Effective Java, item 19.
         </description>
         <priority>3</priority>
         <properties>
-        <property name="ignoreIfHasMethods" type="Boolean" description="Whether to ignore constants in interfaces if the interface defines any methods" value="false"/>
+        <property name="ignoreIfHasMethods" type="Boolean" description="Whether to ignore constants in interfaces if the interface defines any methods" value="true"/>
             <property name="xpath">
                 <value>
 <![CDATA[

--- a/pmd-java/src/main/resources/rulesets/java/design.xml
+++ b/pmd-java/src/main/resources/rulesets/java/design.xml
@@ -1949,4 +1949,50 @@ public final class Foo {
          </example>
        </rule>
     
+    <rule name="ConstantsInInterface"
+   		  language="java"
+          since="5.5"
+          message="Avoid constants in interfaces. Interfaces define types, constants are implementation details better placed in classes or enums. See Effective Java, item 19."
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/rules/java/design.html#ConstantsInInterface">
+        <description>
+Avoid constants in interfaces. Interfaces should define types, constants are implementation details
+better placed in classes or enums. See Effective Java, item 19.
+        </description>
+        <priority>3</priority>
+        <properties>
+        <property name="ignoreIfHasMethods" type="Boolean" description="Whether to ignore constants in interfaces if the interface defines any methods" value="false"/>
+            <property name="xpath">
+                <value>
+<![CDATA[
+//ClassOrInterfaceDeclaration[@Interface='true'][$ignoreIfHasMethods='false' or not(.//MethodDeclaration)]//FieldDeclaration
+ ]]>
+                </value>
+            </property>
+        </properties>
+        <example>
+<![CDATA[
+public interface ConstantInterface {
+    public static final int CONST1 = 1; // violation, no fields allowed in interface!
+    static final int CONST2 = 1; // violation, no fields allowed in interface!
+    final int CONST3 = 1; // violation, no fields allowed in interface!
+    int CONST4 = 1; // violation, no fields allowed in interface!
+}
+
+// with ignoreIfHasMethods = false
+public interface AnotherConstantInterface {
+    public static final int CONST1 = 1; // violation, no fields allowed in interface!
+    
+    int anyMethod();
+}
+
+// with ignoreIfHasMethods = true
+public interface YetAnotherConstantInterface {
+    public static final int CONST1 = 1; // no violation
+    
+    int anyMethod();
+}
+ ]]>
+        </example>
+    </rule>
 </ruleset>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/DesignRulesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/DesignRulesTest.java
@@ -73,5 +73,6 @@ public class DesignRulesTest extends SimpleAggregatorTst {
         addRule(RULESET, "UseNotifyAllInsteadOfNotify");
         addRule(RULESET, "UseUtilityClass");
         addRule(RULESET, "UseVarargs");
+        addRule(RULESET, "ConstantsInInterface");
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ConstantsInInterface.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ConstantsInInterface.xml
@@ -18,6 +18,7 @@ public interface Foo {
         <description><![CDATA[
 constants in interface, with methods, ignoreIfHasMethods is false
      ]]></description>
+        <rule-property name="ignoreIfHasMethods">false</rule-property>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 public interface AnotherConstantInterface {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ConstantsInInterface.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ConstantsInInterface.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data>
+    <test-code>
+        <description><![CDATA[
+constants in interface, no methods
+     ]]></description>
+        <expected-problems>4</expected-problems>
+        <code><![CDATA[
+public interface Foo {
+  public static final int CONST1 = 1;
+  static final int CONST2 = 1;
+  final int CONST3 = 1;
+  int CONST4 = 1;
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+constants in interface, with methods, ignoreIfHasMethods is false
+     ]]></description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public interface AnotherConstantInterface {
+  public static final int CONST1 = 1;
+  
+  int anyMethod();
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+constants in interface, with methods, ignoreIfHasMethods is true
+     ]]></description>
+        <rule-property name="ignoreIfHasMethods">true</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public interface AnotherConstantInterface {
+  public static final int CONST1 = 1;
+  
+  int anyMethod();
+}
+     ]]></code>
+    </test-code>
+</test-data>


### PR DESCRIPTION
Implemented a new rule to enforce Effective Java, item 19. Constants in interface.

It can be absoutely strict, not allowing fields on interfaces, or relaxed (default), to just not alllow interfaces consisting solely of constants; which better matches the Effective Java definition.