### PR TITLE
BooleanGetMethodName: Don't report bad method names on @Override

### DIFF
--- a/pmd-java/src/main/resources/rulesets/java/naming.xml
+++ b/pmd-java/src/main/resources/rulesets/java/naming.xml
@@ -509,6 +509,7 @@ MethodDeclarator[count(FormalParameters/FormalParameter) = 0 or $checkParameteri
                 [starts-with(@Image, 'get')]
 and
 ResultType/Type/PrimitiveType[@Image = 'boolean']
+and not(../Annotation//Name[@Image = 'Override'])
 ]
 ]]>
                 </value>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/naming/xml/BooleanGetMethodName.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/naming/xml/BooleanGetMethodName.xml
@@ -35,6 +35,20 @@ public class Foo {
     </test-code>
     <test-code>
         <description><![CDATA[
+Should not match on methods annotated with @Override
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo implements Toggleable {
+    @Override
+    public boolean getEnabled() {
+        return true;
+    }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
 Should match on multiple parameters when checkParameterizedMethods = true
      ]]></description>
         <expected-problems>1</expected-problems>


### PR DESCRIPTION
If a method is annotated as an `@Override` `BooleanGetMethodName` should not be reported on it. If it's our own code, a single report on the interface / class actually defining it is enough, if it's in a library, there is nothing we can do about it.

Weirdly, this was already addressed for `MethodNamingConventions` in issue #1343 