### PR TITLE
[java] [apex] Fix for 1501: CyclomaticComplexity rule causes OOM when class reporting is disabled

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codesize/StdCyclomaticComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codesize/StdCyclomaticComplexityRule.java
@@ -166,8 +166,8 @@ public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
 
     entryStack.push( new Entry( node ) );
     super.visit( node, data );
+    Entry classEntry = entryStack.pop();
     if ( showClassesComplexity ) {
-    	Entry classEntry = entryStack.pop();
 	    if ( classEntry.getComplexityAverage() >= reportLevel
 	        || classEntry.highestDecisionPoints >= reportLevel ) {
 	      addViolation( data, node, new String[] {


### PR DESCRIPTION
This fixes 1501: oom when the cyclomatic complexity rule is used without class file reporting.