### PR TITLE
[core] [java] Close opened file handles

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
@@ -199,8 +199,7 @@ public class RuleSetFactory {
 
     private synchronized RuleSet createRuleSet(RuleSetReferenceId ruleSetReferenceId,
             boolean withDeprecatedRuleReferences) throws RuleSetNotFoundException {
-        return parseRuleSetNode(ruleSetReferenceId, ruleSetReferenceId.getInputStream(this.classLoader),
-                withDeprecatedRuleReferences);
+        return parseRuleSetNode(ruleSetReferenceId, withDeprecatedRuleReferences);
     }
 
     /**
@@ -233,18 +232,17 @@ public class RuleSetFactory {
      * 
      * @param ruleSetReferenceId The RuleSetReferenceId of the RuleSet being
      *            parsed.
-     * @param inputStream InputStream containing the RuleSet XML configuration.
      * @param withDeprecatedRuleReferences whether rule references that are
      *            deprecated should be ignored or not
      * @return The new RuleSet.
      */
-    private RuleSet parseRuleSetNode(RuleSetReferenceId ruleSetReferenceId, InputStream inputStream,
-            boolean withDeprecatedRuleReferences) {
-        if (!ruleSetReferenceId.isExternal()) {
-            throw new IllegalArgumentException("Cannot parse a RuleSet from a non-external reference: <"
-                    + ruleSetReferenceId + ">.");
-        }
-        try {
+    private RuleSet parseRuleSetNode(RuleSetReferenceId ruleSetReferenceId,
+                                     boolean withDeprecatedRuleReferences) throws RuleSetNotFoundException {
+        try (InputStream inputStream = ruleSetReferenceId.getInputStream(this.classLoader)){
+            if (!ruleSetReferenceId.isExternal()) {
+                throw new IllegalArgumentException("Cannot parse a RuleSet from a non-external reference: <"
+                        + ruleSetReferenceId + ">.");
+            }
             DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
             InputSource inputSource;
             if (compatibilityFilter != null) {
@@ -288,8 +286,6 @@ public class RuleSetFactory {
             return classNotFoundProblem(iae);
         } catch (ParserConfigurationException pce) {
             return classNotFoundProblem(pce);
-        } catch (RuleSetNotFoundException rsnfe) {
-            return classNotFoundProblem(rsnfe);
         } catch (IOException ioe) {
             return classNotFoundProblem(ioe);
         } catch (SAXException se) {
@@ -629,9 +625,9 @@ public class RuleSetFactory {
      */
     private boolean containsRule(RuleSetReferenceId ruleSetReferenceId, String ruleName) {
         boolean found = false;
-        try {
+        try (InputStream ruleSet = ruleSetReferenceId.getInputStream(classLoader)) {
             DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-            Document document = builder.parse(ruleSetReferenceId.getInputStream(classLoader));
+            Document document = builder.parse(ruleSet);
             Element ruleSetElement = document.getDocumentElement();
 
             NodeList rules = ruleSetElement.getElementsByTagName("rule");

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
@@ -3,6 +3,7 @@
  */
 package net.sourceforge.pmd.ant.internal;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -266,7 +267,18 @@ public class PMDTaskImpl {
         try {
             doTask();
         } finally {
+            tryClose(configuration.getClassLoader());
             logManager.close();
+        }
+    }
+
+    private static void tryClose(ClassLoader classLoader) {
+        if (classLoader instanceof Closeable) {
+            try {
+                ((Closeable) classLoader).close();
+            } catch (IOException ignore) {
+                // do nothing.
+            }
         }
     }
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryTest.java
@@ -524,7 +524,7 @@ public class RuleSetFactoryTest {
      * Rule reference can't be resolved - ref is used instead of class and the class is old (pmd 4.3 and not pmd 5).
      * @throws Exception any error
      */
-    @Test(expected = RuntimeException.class)
+    @Test(expected = RuleSetNotFoundException.class)
     public void testBug1202() throws Exception {
         RuleSetReferenceId ref = createRuleSetReferenceId("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + 
                 "<ruleset>\n" +

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/PMDASMClassLoader.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/PMDASMClassLoader.java
@@ -85,8 +85,8 @@ public final class PMDASMClassLoader extends ClassLoader {
         if (dontBother.containsValue(name)) {
             throw new ClassNotFoundException(name);
         }
-        try {
-            ClassReader reader = new ClassReader(getResourceAsStream(name.replace('.', '/') + ".class"));
+        try (InputStream classResource = getResourceAsStream(name.replace('.', '/') + ".class")) {
+            ClassReader reader = new ClassReader(classResource);
             PMDASMVisitor asmVisitor = new PMDASMVisitor(name);
             reader.accept(asmVisitor, 0);
 
@@ -95,10 +95,11 @@ public final class PMDASMClassLoader extends ClassLoader {
                 inner = new ArrayList<>(inner); // to avoid
                                                       // ConcurrentModificationException
                 for (String str : inner) {
-                    InputStream i = getResourceAsStream(str.replace('.', '/') + ".class");
-                    if (i != null) {
-                        reader = new ClassReader(i);
-                        reader.accept(asmVisitor, 0);
+                    try (InputStream i = getResourceAsStream(str.replace('.', '/') + ".class")) {
+                        if (i != null) {
+                            reader = new ClassReader(i);
+                            reader.accept(asmVisitor, 0);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
When loading resources via `Classloader.getResourceAsStream` then these `InputStreams` need to be closed. If not, then on Windows the loaded files cannot be edited or deleted.

It would also be good to close all created `URLClassLoader`s after e.g. finishing the execution of the Ant task - this would also free the file handles allocated through these. I can open another PR for doing that.

We are enabling the Gradle daemon by default for Gradle 3.0. Issues like these will make the use of PMD for Windows developers much more inconvenient, since they have to kill the Gradle daemon in order to continue working each time the pmd Gradle task is invoked.