### PR TITLE
Keep constructor names under ignoreIdentifiers

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/cpd/JavaTokenizer.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/cpd/JavaTokenizer.java
@@ -21,6 +21,8 @@ public class JavaTokenizer implements Tokenizer {
     private boolean ignoreAnnotations;
     private boolean ignoreLiterals;
     private boolean ignoreIdentifiers;
+    
+    private boolean constructorCandidate;
 
     public void setProperties(Properties properties) {
         ignoreAnnotations = Boolean.parseBoolean(properties.getProperty(IGNORE_ANNOTATIONS, "false"));
@@ -63,9 +65,18 @@ public class JavaTokenizer implements Tokenizer {
                 || currentToken.kind == JavaParserConstants.FLOATING_POINT_LITERAL)) {
             image = String.valueOf(currentToken.kind);
         }
-        if (ignoreIdentifiers && currentToken.kind == JavaParserConstants.IDENTIFIER) {
+        if (ignoreIdentifiers && !constructorCandidate
+                && currentToken.kind == JavaParserConstants.IDENTIFIER) {
             image = String.valueOf(currentToken.kind);
         }
+        
+        // Can the next token be a constructor identifier?
+        constructorCandidate = currentToken.kind == JavaParserConstants.PRIVATE
+                || currentToken.kind == JavaParserConstants.PROTECTED
+                || currentToken.kind == JavaParserConstants.PUBLIC
+                || currentToken.kind == JavaParserConstants.LBRACE
+                || currentToken.kind == JavaParserConstants.RBRACE;
+        
         tokenEntries.add(new TokenEntry(image, fileName, currentToken.beginLine));
     }
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/cpd/JavaTokensTokenizerTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/cpd/JavaTokensTokenizerTest.java
@@ -4,6 +4,9 @@
 package net.sourceforge.pmd.cpd;
 
 import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+
 import net.sourceforge.pmd.PMD;
 
 import org.junit.Test;
@@ -203,6 +206,34 @@ public class JavaTokensTokenizerTest {
         assertEquals(1, tokens.size());
     }
 
+    @Test
+    public void testIgnoreIdentifiersDontAffectConstructors() throws Throwable {
+        JavaTokenizer t = new JavaTokenizer();
+        t.setIgnoreAnnotations(false);
+        t.setIgnoreIdentifiers(true);
+        
+        SourceCode sourceCode = new SourceCode(
+            new SourceCode.StringCodeLoader(
+                "package foo.bar.baz;" + PMD.EOL +
+                "public class Foo extends Bar {" + PMD.EOL +
+                	"public Foo(int i) { super(i); }" + PMD.EOL +
+                	"private Foo(int i, String s) { super(i, s); }" + PMD.EOL +
+                	"/* default */ Foo(int i, String s, Object o) { super(i, s, o); }" + PMD.EOL +
+                "}" +PMD.EOL
+
+            ));
+        Tokens tokens = new Tokens();
+        t.tokenize(sourceCode, tokens);
+        TokenEntry.getEOF();
+        List<TokenEntry> tokenList = tokens.getTokens();
+        
+        // First constructor
+        assertEquals("Foo", tokenList.get(7).toString());
+        // Second constructor
+        assertEquals("Foo", tokenList.get(19).toString());
+        // Third constructor
+        assertEquals("Foo", tokenList.get(35).toString());
+    }
 
     public static junit.framework.Test suite() {
         return new junit.framework.JUnit4TestAdapter(JavaTokensTokenizerTest.class);


### PR DESCRIPTION
 - Unrelated classes that just happen to have matching constructor types
    (maybe sibling classes extending the same base class, and simply
    calling super on all constructors) should not be reported as copy-pasted
 - If you copied a whole class, CPD should still match it due to other
    member methods / fields, only case it would no longer catch is that of
    a class exclusively containing constructors, but that should probably be
    a PMD rule, and not catched by CPD itself