### PR TITLE
Add a naming rule called IsDoesNotReturnBoolean

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/naming/IsDoesNotReturnBooleanRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/naming/IsDoesNotReturnBooleanRule.java
@@ -1,0 +1,20 @@
+import net.sourceforge.pmd.lang.java.ast.*;
+import net.sourceforge.pmd.lang.java.rule.*;
+
+public class IsDoesNotReturnBooleanRule extends AbstractJavaRule 
+{
+    public Object visit(ASTMethodDeclaration node, Object data) 
+    {	
+        String nameOfMethod = node.getMethodName();
+        ASTType a = (ASTType) node.getResultType().jjtGetChild(0); // Is first child always ASTType
+        
+        if(nameOfMethod.startsWith("is") && (nameOfMethod.charAt(2) > 64) && (nameOfMethod.charAt(2) < 91)) // after is a capital letter expected to not addViolation to a method called isotherm or so
+        {
+        	 if(!(a.getType().getName().equals("boolean")))
+        	 {
+        		 addViolation(data, node);
+        	 }
+        }
+        return super.visit(node,data);
+    }
+}

--- a/pmd-java/src/main/resources/rulesets/java/naming.xml
+++ b/pmd-java/src/main/resources/rulesets/java/naming.xml
@@ -597,4 +597,20 @@ public interface GenericDao<EF extends BaseModel, K extends Serializable> {
      ]]></example>
     </rule>
 
+<rule name="IsDoesNotReturnBoolean"
+          message="Linguistics Antipattern - Method name starts with is but does not return boolean"
+          class="IsDoesNotReturnBooleanRule">
+      <description>
+      Linguistics Antipattern - Method name starts with is but does not return boolean
+      </description>
+        <priority>3</priority>
+ 
+      <example>
+<![CDATA[
+	int isValid(); // should return boolean
+	boolean isValid(); // try to achieve this
+]]>
+      </example>
+    </rule>
+
 </ruleset>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/naming/NamingRulesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/naming/NamingRulesTest.java
@@ -31,5 +31,6 @@ public class NamingRulesTest extends SimpleAggregatorTst {
         addRule(RULESET, "SuspiciousHashcodeMethodName");
         addRule(RULESET, "VariableNamingConventions");
         addRule(RULESET, "GenericsNaming");
+        addRule(RULESET, "IsDoesNotReturnBoolean");
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/naming/xml/IsDoesNotReturnBoolean.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/naming/xml/IsDoesNotReturnBoolean.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data>
+    <test-code>
+        <description><![CDATA[
+param
+     ]]></description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    	int isValid() // Here it triggers
+	{
+		return 1;
+	}
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+none
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+	int isotherm() // shouldnt trigger
+	{
+		return 1;
+	}
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+none
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+	boolean isValid() // shouldnt trigger
+	{
+		return 1;
+	}
+}
+     ]]></code>
+    </test-code>
+
+</test-data>


### PR DESCRIPTION
According to article Linguistics antipatterns: what they are and how developers percieve them, a method starting with isX and not returning boolean introduces a code smell, reduces maintainability mainly. Feedbacks are appreciated