### PR TITLE
[java] Fix parser error (issue 1530)

### DIFF
--- a/pmd-java/etc/grammar/Java.jjt
+++ b/pmd-java/etc/grammar/Java.jjt
@@ -1,4 +1,11 @@
 /**
+ * Fix for regression introduced in previous changeset.
+ * The syntactic lookahead was not properly handled by javacc,
+ * so it was converted to a semantic one
+ * Bug #1530
+ *
+ * Juan Martin Sotuyo Dodero 10/2016
+ *====================================================================
  * Fix for an expression within an additive expression that was
  * wrongly taken as a cast expression.
  * Bug #1484
@@ -1761,7 +1768,7 @@ void UnaryExpressionNotPlusMinus() #UnaryExpressionNotPlusMinus((jjtn000.getImag
 {}
 {
  ( "~" {jjtThis.setImage("~");} | "!" {jjtThis.setImage("!");} ) UnaryExpression()
-| LOOKAHEAD("(" <IDENTIFIER> ")" "+") PostfixExpression()
+| LOOKAHEAD( { getToken(1).kind == LPAREN && getToken(2).kind == IDENTIFIER && getToken(3).kind == RPAREN && getToken(4).kind == PLUS } ) PostfixExpression()
 | LOOKAHEAD( CastExpression() ) CastExpression()
 | LOOKAHEAD("(" Type() ")" "(") CastExpression()
 | PostfixExpression()
@@ -1843,9 +1850,8 @@ void PrimarySuffix() :
 }
 
 void Literal() :
-{}
-{
 { Token t;}
+{
   t=<INTEGER_LITERAL> { checkForBadNumericalLiteralslUsage(t); jjtThis.setImage(t.image); jjtThis.setIntLiteral();}
 | t=<FLOATING_POINT_LITERAL> { checkForBadNumericalLiteralslUsage(t); jjtThis.setImage(t.image); jjtThis.setFloatLiteral();}
 | t=<HEX_FLOATING_POINT_LITERAL> { checkForBadHexFloatingPointLiteral(); checkForBadNumericalLiteralslUsage(t); jjtThis.setImage(t.image); jjtThis.setFloatLiteral();}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
@@ -130,6 +130,12 @@ public class ParserCornersTest extends ParserTst {
         String c = IOUtils.toString(this.getClass().getResourceAsStream("Bug1429.java"));
         parseJava18(c);
     }
+    
+    @Test
+    public void testBug1530ParseError() throws Exception {
+        String c = IOUtils.toString(this.getClass().getResourceAsStream("Bug1530.java"));
+        parseJava18(c);
+    }
 
     /**
      * This triggered bug #1484 UnusedLocalVariable - false positive - parenthesis

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/Bug1530.java
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/Bug1530.java
@@ -1,0 +1,5 @@
+public class Bug1530 {
+	public void incChild() {
+        ((PathElement) stack.getLastLeaf().getUserObject()).currentChild++;
+    }
+}


### PR DESCRIPTION
 - Added a test case to show the regression
 - Changed the grammar to handle it properly

I don't fully understand why JavaCC fails to properly use the syntactic lookahead, but it's fully working. All tests green.