### PR TITLE
[java] Fix ClassCastException on CloneMethodMustImplementCloneable

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/rules/CloneMethodMustImplementCloneable.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/rules/CloneMethodMustImplementCloneable.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.java.typeresolution.rules;
 import java.util.Arrays;
 import java.util.List;
 
+import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTBlock;
 import net.sourceforge.pmd.lang.java.ast.ASTBlockStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
@@ -30,75 +31,81 @@ public class CloneMethodMustImplementCloneable extends AbstractJavaRule {
 
     @Override
     public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
-	ASTImplementsList impl = node.getFirstChildOfType(ASTImplementsList.class);
-	if (impl != null && impl.jjtGetParent().equals(node)) {
-	    for (int ix = 0; ix < impl.jjtGetNumChildren(); ix++) {
-		ASTClassOrInterfaceType type = (ASTClassOrInterfaceType) impl.jjtGetChild(ix);
-		if (type.getType() == null) {
-		    if ("Cloneable".equals(type.getImage())) {
-			return data;
-		    }
-		} else if (type.getType().equals(Cloneable.class)) {
-		    return data;
-		} else {
-		    List<Class<?>> implementors = Arrays.asList(type.getType().getInterfaces());
-		    if (implementors.contains(Cloneable.class)) {
-			return data;
-		    }
-		}
-	    }
-	}
-	if (node.jjtGetNumChildren() != 0 && node.jjtGetChild(0) instanceof ASTExtendsList) {
-	    ASTClassOrInterfaceType type = (ASTClassOrInterfaceType) node.jjtGetChild(0).jjtGetChild(0);
-	    Class<?> clazz = type.getType();
-	    if (clazz != null && clazz.equals(Cloneable.class)) {
-		return data;
-	    }
-	    while (clazz != null && !Object.class.equals(clazz)) {
-		if (Arrays.asList(clazz.getInterfaces()).contains(Cloneable.class)) {
-		    return data;
-		}
-		clazz = clazz.getSuperclass();
-	    }
-	}
-
-	return super.visit(node, data);
+        ASTImplementsList impl = node.getFirstChildOfType(ASTImplementsList.class);
+        if (impl != null && impl.jjtGetParent().equals(node)) {
+            for (int ix = 0; ix < impl.jjtGetNumChildren(); ix++) {
+            	Node child = impl.jjtGetChild(ix);
+            	
+            	if (child.getClass() != ASTClassOrInterfaceType.class) {
+            		continue;
+            	}
+            	
+                ASTClassOrInterfaceType type = (ASTClassOrInterfaceType) child;
+                if (type.getType() == null) {
+                    if ("Cloneable".equals(type.getImage())) {
+                        return data;
+                    }
+                } else if (type.getType().equals(Cloneable.class)) {
+                    return data;
+                } else {
+                    List<Class<?>> implementors = Arrays.asList(type.getType().getInterfaces());
+                    if (implementors.contains(Cloneable.class)) {
+                        return data;
+                    }
+                }
+            }
+        }
+        if (node.jjtGetNumChildren() != 0 && node.jjtGetChild(0) instanceof ASTExtendsList) {
+            ASTClassOrInterfaceType type = (ASTClassOrInterfaceType) node.jjtGetChild(0).jjtGetChild(0);
+            Class<?> clazz = type.getType();
+            if (clazz != null && clazz.equals(Cloneable.class)) {
+                return data;
+            }
+            while (clazz != null && !Object.class.equals(clazz)) {
+                if (Arrays.asList(clazz.getInterfaces()).contains(Cloneable.class)) {
+                    return data;
+                }
+                clazz = clazz.getSuperclass();
+            }
+        }
+    
+        return super.visit(node, data);
     }
 
     @Override
     public Object visit(ASTMethodDeclaration node, Object data) {
-	ASTClassOrInterfaceDeclaration classOrInterface = node
-		.getFirstParentOfType(ASTClassOrInterfaceDeclaration.class);
-	if (classOrInterface != null && //Don't analyze enums, which cannot subclass clone()
-		(node.isFinal() || classOrInterface.isFinal())) {
-	    if (node.findDescendantsOfType(ASTBlock.class).size() == 1) {
-		List<ASTBlockStatement> blocks = node.findDescendantsOfType(ASTBlockStatement.class);
-		if (blocks.size() == 1) {
-		    ASTBlockStatement block = blocks.get(0);
-		    ASTClassOrInterfaceType type = block.getFirstDescendantOfType(ASTClassOrInterfaceType.class);
-		    if (type != null && type.getType() != null && type.getNthParent(9).equals(node)
-			    && type.getType().equals(CloneNotSupportedException.class)) {
-			return data;
-		    } else if (type != null && type.getType() == null
-			    && "CloneNotSupportedException".equals(type.getImage())) {
-			return data;
-		    }
-		}
-	    }
-	}
-	return super.visit(node, data);
+        ASTClassOrInterfaceDeclaration classOrInterface = node
+            .getFirstParentOfType(ASTClassOrInterfaceDeclaration.class);
+        if (classOrInterface != null && //Don't analyze enums, which cannot subclass clone()
+            (node.isFinal() || classOrInterface.isFinal())) {
+            if (node.findDescendantsOfType(ASTBlock.class).size() == 1) {
+                List<ASTBlockStatement> blocks = node.findDescendantsOfType(ASTBlockStatement.class);
+                if (blocks.size() == 1) {
+                    ASTBlockStatement block = blocks.get(0);
+                    ASTClassOrInterfaceType type = block.getFirstDescendantOfType(ASTClassOrInterfaceType.class);
+                    if (type != null && type.getType() != null && type.getNthParent(9).equals(node)
+                            && type.getType().equals(CloneNotSupportedException.class)) {
+                        return data;
+                    } else if (type != null && type.getType() == null
+                            && "CloneNotSupportedException".equals(type.getImage())) {
+                        return data;
+                    }
+                }
+            }
+        }
+        return super.visit(node, data);
     }
 
     @Override
     public Object visit(ASTMethodDeclarator node, Object data) {
-	if (!"clone".equals(node.getImage())) {
-	    return data;
-	}
-	int countParams = ((ASTFormalParameters) node.jjtGetChild(0)).jjtGetNumChildren();
-	if (countParams != 0) {
-	    return data;
-	}
-	addViolation(data, node);
-	return data;
+        if (!"clone".equals(node.getImage())) {
+            return data;
+        }
+        int countParams = ((ASTFormalParameters) node.jjtGetChild(0)).jjtGetNumChildren();
+        if (countParams != 0) {
+            return data;
+        }
+        addViolation(data, node);
+        return data;
     }
 }


### PR DESCRIPTION
 - Java 8 code allows for things such as
    `class UnmodifiableList<T> implements @Readonly List<@Readonly T> {}`
    where not all token in the ASTImplementsList are ASTClassOrInterfaceType

I took the chance to fix indentation of this file since it was messy. Important changes are lines 37-43 (diff ignoring whitespace)