### PR TITLE
[java] Simplify lambda parsing

### DIFF
--- a/pmd-java/etc/grammar/Java.jjt
+++ b/pmd-java/etc/grammar/Java.jjt
@@ -1812,8 +1812,7 @@ void PrimaryPrefix() :
   Literal()
 | LOOKAHEAD(2) "this" {jjtThis.setUsesThisModifier();}
 | "super" {jjtThis.setUsesSuperModifier();}
-| LOOKAHEAD( "(" ")" "->" ) LambdaExpression()
-| LOOKAHEAD( VariableDeclaratorId() "->" ) LambdaExpression()
+| LOOKAHEAD( <IDENTIFIER> "->" ) LambdaExpression()
 | LOOKAHEAD( "(" VariableDeclaratorId() ( "," VariableDeclaratorId() )* ")" "->" ) LambdaExpression()
 | LOOKAHEAD( FormalParameters() "->" ) LambdaExpression()
 | LOOKAHEAD(3) "(" Expression() ")"

--- a/pmd-java/etc/grammar/Java.jjt
+++ b/pmd-java/etc/grammar/Java.jjt
@@ -1,4 +1,8 @@
 /**
+ * Improve lambda detection in PrimaryPrefix to improve parsing performance.
+ *
+ * Juan Martin Sotuyo Dodero 10/2016
+ *====================================================================
  * Fix for an expression within an additive expression that was
  * wrongly taken as a cast expression.
  * Bug #1484
@@ -1809,12 +1813,9 @@ void PrimaryPrefix() :
 | LOOKAHEAD(2) "this" {jjtThis.setUsesThisModifier();}
 | "super" {jjtThis.setUsesSuperModifier();}
 | LOOKAHEAD( "(" ")" "->" ) LambdaExpression()
-| LOOKAHEAD( <IDENTIFIER> "->" ) LambdaExpression()
-| LOOKAHEAD( "(" VariableDeclaratorId() ")" "->" ) LambdaExpression()
-| LOOKAHEAD( "(" VariableDeclaratorId() "," VariableDeclaratorId() ["," VariableDeclaratorId()] ")" "->" ) LambdaExpression()
-| LOOKAHEAD( "(" FormalParameter() ")" "->" ) LambdaExpression()
-| LOOKAHEAD( "(" FormalParameter() "," FormalParameter() ["," FormalParameter() ] ")" "->" ) LambdaExpression()
-| LOOKAHEAD( LambdaExpression() ) LambdaExpression()
+| LOOKAHEAD( VariableDeclaratorId() "->" ) LambdaExpression()
+| LOOKAHEAD( "(" VariableDeclaratorId() ( "," VariableDeclaratorId() )* ")" "->" ) LambdaExpression()
+| LOOKAHEAD( FormalParameters() "->" ) LambdaExpression()
 | LOOKAHEAD(3) "(" Expression() ")"
 | AllocationExpression()
 | LOOKAHEAD( ResultType() "." "class" ) ResultType() "." "class"


### PR DESCRIPTION
 - Handle less scenarios
 - Have scenarios be defined more broadly (ie: allow more than 3 params)
 - This improves parsing performance by roughly ~10%