### PR TITLE
[plsql] Fix PMD issue 1531- endless loop followed by OOM while parsing (PL)SQL

### DIFF
--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -917,6 +917,8 @@ void Skip2NextTerminator(String initiator,String terminator) :
     t = getToken(1);
 	  if(t.image.equals(initiator)) count++;
 	  if(t.image.equals(terminator)) count--;
+	  if(null != t.specialToken || t.kind == EOF)
+	    return;
   }
 }
 {


### PR DESCRIPTION
This should fix the issue. The root cause was a loop that would not terminate on error or EOF condition while scanning for an end delimiter.