### PR TITLE
[core] Language file filter not applied when a command line spec contains …

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/FileUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/FileUtil.java
@@ -103,7 +103,8 @@ public final class FileUtil {
 		    throw new RuntimeException("Archive file " + file.getName() + " can't be opened");
 		}
 	    } else {
-		dataSources.add(new FileDataSource(file));
+			if(filenameFilter.accept(file, file.getName()))
+		        dataSources.add(new FileDataSource(file));
 	    }
 	} else {
 	    // Match files, or directories which are not excluded.


### PR DESCRIPTION
When the -d command line option contains a file or files these files are sent to the parser even though no rules are specified for them. If directories are specified with -d files not matching a language are filtered out beforehand.

The effect of the bug is that when for instance a SQL file is added as a file to the command line the parser will run, even though the result is not needed by any checks. And if the parser contains an error that will trigger ;)

----

> [fjalvingh] Another but related issue is related to the language filter that is used to "filter" files in directories that should be scanned. This filter list is constructed from the rules selected. The filter is however not applied to the FILES that are added on the command line..

> [adangel] Regarding the second issue: Are you taking about CPD or PMD? At least for CPD, this is correct behavior, as it is assumed that you know what you do, if you explicitely name the files on the command line :) See also https://github.com/adangel/pmd/pull/30 . For PMD, I would expect the same behavior...

> [fjalvingh] So, the issue is with PMD. And I think it is easy to prove that the behavior is wrong. If I start PMD with a rule set that does not contain any PLSQL rules, then parsing of these files is useless because the only result they can possibly give is parsing errors - no rule violations. So even if I do pass them on the command line - the result is just a longer run time (and a loop if you're unlucky ;)
> Hope I explained it well.. By itself this issue is not a real problem; it's just inconsistent in my opinion.

_from https://sourceforge.net/p/pmd/bugs/1536/_
