### PR TITLE
[core] Incremental analysis

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
@@ -356,6 +356,9 @@ public class PMD {
 
         sortFiles(configuration, files);
 
+        // Make sure the cache is listening for analysis results
+        ctx.getReport().addListener(configuration.getAnalysisCache());
+        
         /*
          * Check if multithreaded support is available. ExecutorService can also
          * be disabled if threadCount is not positive, e.g. using the
@@ -366,6 +369,9 @@ public class PMD {
         } else {
             new MonoThreadProcessor(configuration).processFiles(ruleSetFactory, files, ctx, renderers);
         }
+        
+        // Persist the analysis cache
+        configuration.getAnalysisCache().persist();
 
         if (configuration.getClassLoader() instanceof ClasspathClassLoader) {
             IOUtil.tryCloseClassLoader(configuration.getClassLoader());

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
@@ -580,7 +580,7 @@ public class PMDConfiguration extends AbstractConfiguration {
 
     public void setAnalysisCacheLocation(final String cacheLocation) {
         if (cacheLocation != null) {
-            setAnalysisCache(FileAnalysisCache.fromFile(new File(cacheLocation)));
+            setAnalysisCache(new FileAnalysisCache(new File(cacheLocation)));
         }
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
@@ -3,11 +3,15 @@
  */
 package net.sourceforge.pmd;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 
+import net.sourceforge.pmd.cache.AnalysisCache;
+import net.sourceforge.pmd.cache.FileAnalysisCache;
+import net.sourceforge.pmd.cache.NoopAnalysisCache;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.lang.LanguageVersionDiscoverer;
@@ -109,6 +113,7 @@ public class PMDConfiguration extends AbstractConfiguration {
 
     private boolean stressTest;
     private boolean benchmark;
+    private AnalysisCache analysisCache = new NoopAnalysisCache();
 
     /**
      * Get the suppress marker. This is the source level marker used to indicate a
@@ -551,5 +556,31 @@ public class PMDConfiguration extends AbstractConfiguration {
      */
     public void setRuleSetFactoryCompatibilityEnabled(boolean ruleSetFactoryCompatibilityEnabled) {
         this.ruleSetFactoryCompatibilityEnabled = ruleSetFactoryCompatibilityEnabled;
+    }
+
+    /**
+     * Retrieves the currently used analysis cache. Will never be null.
+     * 
+     * @return The currently used analysis cache. Never null.
+     */
+    public AnalysisCache getAnalysisCache() {
+        return analysisCache ;
+    }
+    
+    /**
+     * Sets the analysis cache to be used.
+     * 
+     * @param cache The analysis cache to be used.
+     */
+    public void setAnalysisCache(final AnalysisCache cache) {
+        if (cache != null) {
+            analysisCache = cache;
+        }
+    }
+
+    public void setAnalysisCacheLocation(final String cacheLocation) {
+        if (cacheLocation != null) {
+            setAnalysisCache(FileAnalysisCache.fromFile(new File(cacheLocation)));
+        }
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
@@ -568,18 +568,29 @@ public class PMDConfiguration extends AbstractConfiguration {
     }
     
     /**
-     * Sets the analysis cache to be used.
+     * Sets the analysis cache to be used. Setting a
+     * value of <code>null</code> will cause a Noop AnalysisCache to be used.
      * 
      * @param cache The analysis cache to be used.
      */
     public void setAnalysisCache(final AnalysisCache cache) {
-        if (cache != null) {
+        if (cache == null) {
+            analysisCache = new NoopAnalysisCache();
+        } else {
             analysisCache = cache;
         }
     }
 
+    /**
+     * Sets the location of the analysis cache to be used. This will automatically configure
+     * and appropriate AnalysisCache implementation.
+     * 
+     * @param cacheLocation The location of the analysis cache to be used.
+     */
     public void setAnalysisCacheLocation(final String cacheLocation) {
-        if (cacheLocation != null) {
+        if (cacheLocation == null) {
+            setAnalysisCache(new NoopAnalysisCache());
+        } else {
             setAnalysisCache(new FileAnalysisCache(new File(cacheLocation)));
         }
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Random;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -36,6 +37,8 @@ public class RuleSet {
     private static final Logger LOG = Logger.getLogger(RuleSet.class.getName());
     private static final String MISSING_RULE = "Missing rule";
 
+    private final long checksum;
+    
     private List<Rule> rules = new ArrayList<>();
     private String fileName;
     private String name = "";
@@ -46,6 +49,23 @@ public class RuleSet {
     private List<String> includePatterns = new ArrayList<>(0);
 
     private Filter<File> filter;
+
+    /**
+     * Creates a new RuleSet with the given checksum.
+     * @param checksum A checksum of the ruleset, should change
+     * only if the ruleset was configured differently
+     */
+    public RuleSet(final long checksum) {
+        this.checksum = checksum;
+    }
+    
+    /**
+     * Creates a new RuleSet with a random checksum.
+     * Notice this means the results for this analysis will not be cached.
+     */
+    public RuleSet() {
+        this(new Random().nextLong());
+    }
 
     /**
      * A convenience constructor
@@ -530,5 +550,15 @@ public class RuleSet {
                 collector.add(rule);
             }
         }
+    }
+
+    /**
+     * Retrieves a checksum for this ruleset. Should take into account all
+     * rules and configuration, any changes should trigger a fingerprint change
+     * 
+     * @return The ruleset's checksum
+     */
+    public long getChecksum() {
+        return checksum;
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSets.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSets.java
@@ -23,7 +23,7 @@ public class RuleSets {
     /**
      * Map of RuleLanguage on RuleSet.
      */
-    private Collection<RuleSet> ruleSets = new ArrayList<>();
+    private List<RuleSet> ruleSets = new ArrayList<>();
 
     /**
      * RuleChain for efficient AST visitation.

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSets.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSets.java
@@ -203,4 +203,18 @@ public class RuleSets {
 		   ruleSet.removeDysfunctionalRules(collector);
 		}
 	}
+
+	/**
+	 * Retrieves a checksum of the rulesets being used.
+	 * Any change to any rule of any ruleset should trigger a checksum change.
+	 * 
+	 * @return The checksum for this ruleset collection.
+	 */
+	public long getChecksum() {
+	    long checksum = 1;
+	    for (final RuleSet ruleSet : ruleSets) {
+	        checksum = checksum * 31 + ruleSet.getChecksum();
+        }
+	    return checksum;
+	}
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/SourceCodeProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/SourceCodeProcessor.java
@@ -100,7 +100,7 @@ public class SourceCodeProcessor {
         long start = System.nanoTime();
         Node rootNode = parser.parse(ctx.getSourceCodeFilename(), sourceCode);
         ctx.getReport().suppress(parser.getSuppressMap());
-        long end = System.nanoTime();        
+        long end = System.nanoTime();
         Benchmarker.mark(Benchmark.Parser, end - start, 0);
         return rootNode;
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/SourceCodeProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/SourceCodeProcessor.java
@@ -28,7 +28,7 @@ public class SourceCodeProcessor {
     private final PMDConfiguration configuration;
 
     public SourceCodeProcessor(PMDConfiguration configuration) {
-    	this.configuration = configuration;
+        this.configuration = configuration;
     }
     
     
@@ -43,11 +43,11 @@ public class SourceCodeProcessor {
      * @see #processSourceCode(Reader, RuleSets, RuleContext)
      */
     public void processSourceCode(InputStream sourceCode, RuleSets ruleSets, RuleContext ctx) throws PMDException {
-		try {
-		    processSourceCode(new InputStreamReader(sourceCode, configuration.getSourceEncoding()), ruleSets, ctx);
-		} catch (UnsupportedEncodingException uee) {
-		    throw new PMDException("Unsupported encoding exception: " + uee.getMessage());
-		}
+        try {
+            processSourceCode(new InputStreamReader(sourceCode, configuration.getSourceEncoding()), ruleSets, ctx);
+        } catch (UnsupportedEncodingException uee) {
+            throw new PMDException("Unsupported encoding exception: " + uee.getMessage());
+        }
     }
     
     
@@ -64,96 +64,102 @@ public class SourceCodeProcessor {
      * @param sourceCode The Reader to analyze.
      * @param ruleSets The collection of rules to process against the file.
      * @param ctx The context in which PMD is operating.
+     * @param cache The analysis cache being used.
      * @throws PMDException if the input encoding is unsupported, the input stream could
      *                      not be parsed, or other error is encountered.
      */
     public void processSourceCode(Reader sourceCode, RuleSets ruleSets, RuleContext ctx) throws PMDException {
-    	determineLanguage(ctx);
+        determineLanguage(ctx);
 
-		// make sure custom XPath functions are initialized
-		Initializer.initialize();
+        // make sure custom XPath functions are initialized
+        Initializer.initialize();
 
-	    // Coarse check to see if any RuleSet applies to file, will need to do a finer RuleSet specific check later
-		 if (ruleSets.applies(ctx.getSourceCodeFile())) {
+        // Coarse check to see if any RuleSet applies to file, will need to do a finer RuleSet specific check later
+        if (ruleSets.applies(ctx.getSourceCodeFile())) {
+            // Is the cache up to date?
+            if (configuration.getAnalysisCache().isUpToDate(ctx.getSourceCodeFile())) {
+                return;
+            }
 
-		try {
-			processSource(sourceCode, ruleSets,ctx);
-
-		} catch (ParseException pe) {
-		    throw new PMDException("Error while parsing " + ctx.getSourceCodeFilename(), pe);
-		} catch (Exception e) {
-		    throw new PMDException("Error while processing " + ctx.getSourceCodeFilename(), e);
-		} finally {
-		    IOUtils.closeQuietly(sourceCode);
-		}
-		}
+            try {
+                processSource(sourceCode, ruleSets,ctx);
+            } catch (ParseException pe) {
+                configuration.getAnalysisCache().analysisFailed(ctx.getSourceCodeFile());
+                throw new PMDException("Error while parsing " + ctx.getSourceCodeFilename(), pe);
+            } catch (Exception e) {
+                configuration.getAnalysisCache().analysisFailed(ctx.getSourceCodeFile());
+                throw new PMDException("Error while processing " + ctx.getSourceCodeFilename(), e);
+            } finally {
+                IOUtils.closeQuietly(sourceCode);
+            }
+        }
     }
 
     
     private Node parse(RuleContext ctx, Reader sourceCode, Parser parser) {
-		long start = System.nanoTime();
-		Node rootNode = parser.parse(ctx.getSourceCodeFilename(), sourceCode);
-		ctx.getReport().suppress(parser.getSuppressMap());
-		long end = System.nanoTime();    	
-		Benchmarker.mark(Benchmark.Parser, end - start, 0);
-		return rootNode;
+        long start = System.nanoTime();
+        Node rootNode = parser.parse(ctx.getSourceCodeFilename(), sourceCode);
+        ctx.getReport().suppress(parser.getSuppressMap());
+        long end = System.nanoTime();        
+        Benchmarker.mark(Benchmark.Parser, end - start, 0);
+        return rootNode;
     }
 
     private void symbolFacade(Node rootNode, LanguageVersionHandler languageVersionHandler) {
-    	long start = System.nanoTime();
-		languageVersionHandler.getSymbolFacade(configuration.getClassLoader()).start(rootNode);
-		long end = System.nanoTime();
-		Benchmarker.mark(Benchmark.SymbolTable, end - start, 0);
+        long start = System.nanoTime();
+        languageVersionHandler.getSymbolFacade(configuration.getClassLoader()).start(rootNode);
+        long end = System.nanoTime();
+        Benchmarker.mark(Benchmark.SymbolTable, end - start, 0);
     }
     
 //    private ParserOptions getParserOptions(final LanguageVersionHandler languageVersionHandler) {
-//		// TODO Handle Rules having different parser options.
-//		ParserOptions parserOptions = languageVersionHandler.getDefaultParserOptions();
-//		parserOptions.setSuppressMarker(configuration.getSuppressMarker());
-//		return parserOptions;
+//        // TODO Handle Rules having different parser options.
+//        ParserOptions parserOptions = languageVersionHandler.getDefaultParserOptions();
+//        parserOptions.setSuppressMarker(configuration.getSuppressMarker());
+//        return parserOptions;
 //    }
 
     private void usesDFA(LanguageVersion languageVersion, Node rootNode, RuleSets ruleSets, Language language ) {
 
-		if (ruleSets.usesDFA(language)) {
-		    long start = System.nanoTime();
-		    VisitorStarter dataFlowFacade = languageVersion.getLanguageVersionHandler().getDataFlowFacade();
-		    dataFlowFacade.start(rootNode);
-		    long end = System.nanoTime();
-		    Benchmarker.mark(Benchmark.DFA, end - start, 0);
-		}
+        if (ruleSets.usesDFA(language)) {
+            long start = System.nanoTime();
+            VisitorStarter dataFlowFacade = languageVersion.getLanguageVersionHandler().getDataFlowFacade();
+            dataFlowFacade.start(rootNode);
+            long end = System.nanoTime();
+            Benchmarker.mark(Benchmark.DFA, end - start, 0);
+        }
     }
 
     private void usesTypeResolution(LanguageVersion languageVersion, Node rootNode, RuleSets ruleSets, Language language) {
-	
-		if (ruleSets.usesTypeResolution(language)) {
-		    long start = System.nanoTime();
-		    languageVersion.getLanguageVersionHandler().getTypeResolutionFacade(configuration.getClassLoader()).start(rootNode);
-		    long end = System.nanoTime();
-		    Benchmarker.mark(Benchmark.TypeResolution, end - start, 0);
-		}
+    
+        if (ruleSets.usesTypeResolution(language)) {
+            long start = System.nanoTime();
+            languageVersion.getLanguageVersionHandler().getTypeResolutionFacade(configuration.getClassLoader()).start(rootNode);
+            long end = System.nanoTime();
+            Benchmarker.mark(Benchmark.TypeResolution, end - start, 0);
+        }
     }
     
     private void processSource(Reader sourceCode, RuleSets ruleSets, RuleContext ctx) {
-		LanguageVersion languageVersion = ctx.getLanguageVersion();
-		LanguageVersionHandler languageVersionHandler = languageVersion.getLanguageVersionHandler();
-		Parser parser = PMD.parserFor(languageVersion, configuration);
-		
-		Node rootNode = parse(ctx, sourceCode, parser);
-		symbolFacade(rootNode, languageVersionHandler);
-		Language language = languageVersion.getLanguage();
-		usesDFA(languageVersion, rootNode, ruleSets, language);
-		usesTypeResolution(languageVersion, rootNode, ruleSets,language);
-		
-		List<Node> acus = Collections.singletonList(rootNode);
-		ruleSets.apply(acus, ctx, language);
-	}
+        LanguageVersion languageVersion = ctx.getLanguageVersion();
+        LanguageVersionHandler languageVersionHandler = languageVersion.getLanguageVersionHandler();
+        Parser parser = PMD.parserFor(languageVersion, configuration);
+        
+        Node rootNode = parse(ctx, sourceCode, parser);
+        symbolFacade(rootNode, languageVersionHandler);
+        Language language = languageVersion.getLanguage();
+        usesDFA(languageVersion, rootNode, ruleSets, language);
+        usesTypeResolution(languageVersion, rootNode, ruleSets,language);
+        
+        List<Node> acus = Collections.singletonList(rootNode);
+        ruleSets.apply(acus, ctx, language);
+    }
 
-	private void determineLanguage(RuleContext ctx) {
-		// If LanguageVersion of the source file is not known, make a determination
-		if (ctx.getLanguageVersion() == null) {
-		    LanguageVersion languageVersion = configuration.getLanguageVersionOfFile(ctx.getSourceCodeFilename());
-		    ctx.setLanguageVersion(languageVersion);
-		}
+    private void determineLanguage(RuleContext ctx) {
+        // If LanguageVersion of the source file is not known, make a determination
+        if (ctx.getLanguageVersion() == null) {
+            LanguageVersion languageVersion = configuration.getLanguageVersionOfFile(ctx.getSourceCodeFilename());
+            ctx.setLanguageVersion(languageVersion);
+        }
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/SourceCodeProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/SourceCodeProcessor.java
@@ -82,7 +82,7 @@ public class SourceCodeProcessor {
             }
 
             try {
-                processSource(sourceCode, ruleSets,ctx);
+                processSource(sourceCode, ruleSets, ctx);
             } catch (ParseException pe) {
                 configuration.getAnalysisCache().analysisFailed(ctx.getSourceCodeFile());
                 throw new PMDException("Error while parsing " + ctx.getSourceCodeFilename(), pe);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/PMDTask.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/PMDTask.java
@@ -34,6 +34,7 @@ public class PMDTask extends Task {
     private int maxRuleViolations = 0;
     private String failuresPropertyName;
     private SourceLanguage sourceLanguage;
+    private String cacheLocation;
     private final Collection<RuleSetWrapper> nestedRules = new ArrayList<>();
 
     @Override
@@ -243,5 +244,13 @@ public class PMDTask extends Task {
 
     public void setNoRuleSetCompatibility(boolean noRuleSetCompatibility) {
         this.noRuleSetCompatibility = noRuleSetCompatibility;
+    }
+
+    public String getCacheLocation() {
+        return cacheLocation;
+    }
+
+    public void setCacheLocation(String cacheLocation) {
+        this.cacheLocation = cacheLocation;
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
@@ -77,6 +77,7 @@ public class PMDTaskImpl {
         configuration.setThreads(task.getThreads());
         this.failuresPropertyName = task.getFailuresPropertyName();
         configuration.setMinimumPriority(RulePriority.valueOf(task.getMinimumPriority()));
+        configuration.setAnalysisCacheLocation(task.getCacheLocation());
 
         SourceLanguage version = task.getSourceLanguage();
         if (version != null) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/AbstractAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/AbstractAnalysisCache.java
@@ -1,3 +1,6 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
 package net.sourceforge.pmd.cache;
 
 import java.io.File;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/AbstractAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/AbstractAnalysisCache.java
@@ -1,0 +1,109 @@
+package net.sourceforge.pmd.cache;
+
+import java.io.File;
+import java.net.URLClassLoader;
+import java.util.Arrays;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.logging.Logger;
+
+import net.sourceforge.pmd.PMD;
+import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.RuleSets;
+import net.sourceforge.pmd.RuleViolation;
+import net.sourceforge.pmd.stat.Metric;
+
+/**
+ * Abstract implementation of the analysis cache. Handles all operations, except for persistence.
+ */
+public abstract class AbstractAnalysisCache implements AnalysisCache {
+
+    protected static final Logger LOG = Logger.getLogger(AbstractAnalysisCache.class.getName());
+    protected final String pmdVersion;
+    protected final ConcurrentMap<String, AnalysisResult> fileResultsCache;
+    protected final ConcurrentMap<String, AnalysisResult> updatedResultsCache;
+    protected long rulesetChecksum;
+    protected long classpathChecksum;
+    
+    /**
+     * Creates a new empty cache
+     */
+    public AbstractAnalysisCache() {
+        pmdVersion = PMD.VERSION;
+        fileResultsCache = new ConcurrentHashMap<>();
+        updatedResultsCache = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public boolean isUpToDate(final File sourceFile) {
+        // There is a new file being analyzed, prepare entry in updated cache
+        final AnalysisResult updatedResult = new AnalysisResult(sourceFile);
+        updatedResultsCache.put(sourceFile.getPath(), updatedResult);
+        
+        // Now check the old cache
+        final AnalysisResult analysisResult = fileResultsCache.get(sourceFile.getPath());
+        
+        if (analysisResult == null) {
+            // new file, need to analyze it
+            return false;
+        }
+        
+        return analysisResult.getFileChecksum() == updatedResult.getFileChecksum();
+    }
+
+    @Override
+    public void analysisFailed(final File sourceFile) {
+        updatedResultsCache.remove(sourceFile.getPath());
+    }
+
+    @Override
+    public void checkValidity(final RuleSets ruleSets, final ClassLoader classLoader) {
+        boolean cacheIsValid = true;
+        
+        if (ruleSets.getChecksum() != rulesetChecksum) {
+            LOG.info("Analysis cache invalidated, rulesets changed.");
+            cacheIsValid = false;
+        }
+        
+        final long classLoaderChecksum;
+        if (classLoader instanceof URLClassLoader) {
+            final URLClassLoader urlClassLoader = (URLClassLoader) classLoader;
+            classLoaderChecksum = Arrays.hashCode(urlClassLoader.getURLs());
+            
+            if (cacheIsValid && classLoaderChecksum != classpathChecksum) {
+                // Do we even care?
+                for (final Rule r : ruleSets.getAllRules()) {
+                    if (r.usesDFA() || r.usesTypeResolution()) {
+                        LOG.info("Analysis cache invalidated, classpath changed.");
+                        cacheIsValid = false;
+                        break;
+                    }
+                }
+            }
+        } else {
+            classLoaderChecksum = 0;
+        }
+        
+        if (!cacheIsValid) {
+            // Clear the cache
+            fileResultsCache.clear();
+        }
+        
+        // Update the local checksums
+        rulesetChecksum = ruleSets.getChecksum();
+        classpathChecksum = classLoaderChecksum;
+    }
+
+    @Override
+    public void ruleViolationAdded(final RuleViolation ruleViolation) {
+        final AnalysisResult analysisResult = updatedResultsCache.get(ruleViolation.getFilename());
+        
+        analysisResult.addViolation(ruleViolation);
+    }
+
+    @Override
+    public void metricAdded(final Metric metric) {
+        // Not interested in metrics
+    }
+
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/AnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/AnalysisCache.java
@@ -1,0 +1,33 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+package net.sourceforge.pmd.cache;
+
+import java.io.File;
+
+import net.sourceforge.pmd.ReportListener;
+
+/**
+ * An analysis cache for incremental analysis.
+ */
+public interface AnalysisCache extends ReportListener {
+
+    /**
+     * Persist the analysis results on whatever means is used by the cache
+     */
+    void persist();
+
+    /**
+     * Check if a given file is up to date in the cache and can be skipped from analysis
+     * @param sourceFile The file to check in the cache
+     * @return True if the cache is a hit, false otherwise
+     */
+    // TODO : In the future we may want to return the List<RuleViolation> to be directly added to the report
+    boolean isUpToDate(File sourceFile);
+
+    /**
+     * Notifies the cache that analysis of the given file has failed and should not be cached
+     * @param sourceFile The file whose analysis failed
+     */
+    void analysisFailed(File sourceFile);
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/AnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/AnalysisCache.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.cache;
 import java.io.File;
 
 import net.sourceforge.pmd.ReportListener;
+import net.sourceforge.pmd.RuleSets;
 
 /**
  * An analysis cache for incremental analysis.
@@ -30,4 +31,11 @@ public interface AnalysisCache extends ReportListener {
      * @param sourceFile The file whose analysis failed
      */
     void analysisFailed(File sourceFile);
+    
+    /**
+     * Checks if the cache is valid for the configured rulesets and class loader.
+     * @param ruleSets The rulesets configured for this analysis.
+     * @param classLoader The class loader configured for this analysis.
+     */
+    void checkValidity(RuleSets ruleSets, ClassLoader classLoader);
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/AnalysisResult.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/AnalysisResult.java
@@ -1,3 +1,6 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
 package net.sourceforge.pmd.cache;
 
 import java.io.BufferedInputStream;
@@ -13,6 +16,10 @@ import org.apache.commons.io.IOUtils;
 
 import net.sourceforge.pmd.RuleViolation;
 
+/**
+ * The result of a single file analysis.
+ * Includes a checksum of the file and the complete list of violations detected.
+ */
 public class AnalysisResult {
 
     private final long fileChecksum;
@@ -22,11 +29,11 @@ public class AnalysisResult {
         this.fileChecksum = fileChecksum;
         violations = new ArrayList<>();
     }
-    
+
     public AnalysisResult(final File sourceFile) {
         this(computeFileChecksum(sourceFile));
     }
-    
+
     private static long computeFileChecksum(final File sourceFile) {
         try (
             final CheckedInputStream stream = new CheckedInputStream(
@@ -34,15 +41,16 @@ public class AnalysisResult {
         ) {
             // Just read it, the CheckedInputStream will update the checksum on it's own
             IOUtils.skipFully(stream, sourceFile.length());
-            
+
             return stream.getChecksum().getValue();
         } catch (final IOException e) {
-            // TODO : Handle this
+            // We don't really care, if it's unreadable
+            // the analysis will fail and report the error on it's own
         }
-        
+
         return 0;
     }
-    
+
     public long getFileChecksum() {
         return fileChecksum;
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/AnalysisResult.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/AnalysisResult.java
@@ -1,0 +1,61 @@
+package net.sourceforge.pmd.cache;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.Adler32;
+import java.util.zip.CheckedInputStream;
+
+import org.apache.commons.io.IOUtils;
+
+import net.sourceforge.pmd.RuleViolation;
+
+public class AnalysisResult {
+
+    private final long fileChecksum;
+    private final List<RuleViolation> violations;
+
+    public AnalysisResult(final long fileChecksum) {
+        this.fileChecksum = fileChecksum;
+        violations = new ArrayList<>();
+    }
+    
+    public AnalysisResult(final File sourceFile) {
+        this(computeFileChecksum(sourceFile));
+    }
+    
+    private static long computeFileChecksum(final File sourceFile) {
+        try (
+            final CheckedInputStream stream = new CheckedInputStream(
+               new BufferedInputStream(new FileInputStream(sourceFile)), new Adler32());
+        ) {
+            // Just read it, the CheckedInputStream will update the checksum on it's own
+            IOUtils.skipFully(stream, sourceFile.length());
+            
+            return stream.getChecksum().getValue();
+        } catch (final IOException e) {
+            // TODO : Handle this
+        }
+        
+        return 0;
+    }
+    
+    public long getFileChecksum() {
+        return fileChecksum;
+    }
+
+    public List<RuleViolation> getViolations() {
+        return violations;
+    }
+
+    public void addViolations(final List<RuleViolation> violations) {
+        this.violations.addAll(violations);
+    }
+
+    public void addViolation(final RuleViolation ruleViolation) {
+        this.violations.add(ruleViolation);
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/FileAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/FileAnalysisCache.java
@@ -4,51 +4,38 @@ import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.EOFException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.net.URLClassLoader;
-import java.util.Arrays;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.logging.Logger;
 
 import net.sourceforge.pmd.PMD;
-import net.sourceforge.pmd.Rule;
-import net.sourceforge.pmd.RuleSets;
-import net.sourceforge.pmd.RuleViolation;
-import net.sourceforge.pmd.stat.Metric;
 
-public class FileAnalysisCache implements AnalysisCache {
+/**
+ * An analysis cache backed by a regular file.
+ */
+public class FileAnalysisCache extends AbstractAnalysisCache {
 
-    private static final Logger LOG = Logger.getLogger(FileAnalysisCache.class.getName());
-    
-    // TODO : Add benchmark info to cache?
-    
     private final File cacheFile;
-    private final String pmdVersion;
-    private final ConcurrentMap<String, AnalysisResult> fileResultsCache;
-    private final ConcurrentMap<String, AnalysisResult> updatedResultsCache;
     
-    private long rulesetChecksum;
-    private long classpathChecksum;
-
     /**
-     * Creates a new empty cache for the given PMD version
+     * Creates a new empty cache
      * @param cache The file on which to store analysis cache
-     * @param pmdVersion The version of PMD used to generate this cache
      */
-    private FileAnalysisCache(final File cache, final String pmdVersion) {
-        this.pmdVersion = pmdVersion;
+    private FileAnalysisCache(final File cache) {
+        super();
         this.cacheFile = cache;
-        fileResultsCache = new ConcurrentHashMap<>();
-        updatedResultsCache = new ConcurrentHashMap<>();
     }
 
+    /**
+     * Loads / creates a cache backed by the given file.
+     * @param cacheFile The file which backs the file analysis cache.
+     * @return The new / loaded cache.
+     */
     public static FileAnalysisCache fromFile(final File cacheFile) {
-        final FileAnalysisCache cache = new FileAnalysisCache(cacheFile, PMD.VERSION);
+        final FileAnalysisCache cache = new FileAnalysisCache(cacheFile);
         
         if (cacheFile.exists()) {
             try (
@@ -74,9 +61,10 @@ public class FileAnalysisCache implements AnalysisCache {
                 } else {
                     LOG.info("Analysis cache invalidated, PMD version changed.");
                 }
+            } catch (final EOFException e) {
+                LOG.warning("Cache file " + cacheFile.getPath() + " is malformed, will not be used for current analysis");
             } catch (final IOException e) {
-                // TODO : Handle this!
-                LOG.severe("Could not load analysis cache to file.");
+                LOG.severe("Could not load analysis cache to file. " + e.getMessage());
             }
         }
         
@@ -102,79 +90,7 @@ public class FileAnalysisCache implements AnalysisCache {
                 }
             }
         } catch (final IOException e) {
-            // TODO : Handle this!
-            LOG.severe("Could not store analysis cache to file.");
+            LOG.severe("Could not persist analysis cache to file. " + e.getMessage());
         }
-    }
-
-    // TODO : In the future we may want to return the List<RuleViolation> to be directly added to the report
-    @Override
-    public boolean isUpToDate(final File sourceFile) {
-        // There is a new file being analyzed, prepare entry in updated cache
-        final AnalysisResult updatedResult = new AnalysisResult(sourceFile);
-        updatedResultsCache.put(sourceFile.getPath(), updatedResult);
-        
-        // Now check the old cache
-        final AnalysisResult analysisResult = fileResultsCache.get(sourceFile.getPath());
-        
-        if (analysisResult == null) {
-            // new file, need to analyze it
-            return false;
-        }
-        
-        return analysisResult.getFileChecksum() == updatedResult.getFileChecksum();
-    }
-
-    @Override
-    public void analysisFailed(final File sourceFile) {
-        updatedResultsCache.remove(sourceFile.getPath());
-    }
-
-    @Override
-    public void checkValidity(final RuleSets ruleSets, final ClassLoader classLoader) {
-        boolean cacheIsValid = true;
-        
-        if (ruleSets.getChecksum() != rulesetChecksum) {
-            cacheIsValid = false;
-        }
-        
-        final long classLoaderChecksum;
-        if (classLoader instanceof URLClassLoader) {
-            final URLClassLoader urlClassLoader = (URLClassLoader) classLoader;
-            classLoaderChecksum = Arrays.hashCode(urlClassLoader.getURLs());
-            
-            if (cacheIsValid && classLoaderChecksum != classpathChecksum) {
-                // Do we even care?
-                for (final Rule r : ruleSets.getAllRules()) {
-                    if (r.usesDFA() || r.usesTypeResolution()) {
-                        cacheIsValid = false;
-                        break;
-                    }
-                }
-            }
-        } else {
-            classLoaderChecksum = 0;
-        }
-        
-        if (!cacheIsValid) {
-            // Clear the cache
-            fileResultsCache.clear();
-        }
-        
-        // Update the local checksums
-        rulesetChecksum = ruleSets.getChecksum();
-        classpathChecksum = classLoaderChecksum;
-    }
-
-    @Override
-    public void ruleViolationAdded(final RuleViolation ruleViolation) {
-        final AnalysisResult analysisResult = updatedResultsCache.get(ruleViolation.getFilename());
-        
-        analysisResult.addViolation(ruleViolation);
-    }
-
-    @Override
-    public void metricAdded(final Metric metric) {
-        // Not interested in metrics
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/FileAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/FileAnalysisCache.java
@@ -1,0 +1,130 @@
+package net.sourceforge.pmd.cache;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.logging.Logger;
+
+import net.sourceforge.pmd.PMD;
+import net.sourceforge.pmd.RuleViolation;
+import net.sourceforge.pmd.stat.Metric;
+
+public class FileAnalysisCache implements AnalysisCache {
+
+    private static final Logger LOG = Logger.getLogger(FileAnalysisCache.class.getName());
+    
+    // TODO : Add benchmark info to cache?
+    
+    private final File cache;
+    private final String pmdVersion;
+    // TODO : Add a ruleset checksum
+    // TODO : Add a classpath checksum
+    private final ConcurrentMap<String, AnalysisResult> fileResultsCache;
+    private final ConcurrentMap<String, AnalysisResult> updatedResultsCache;
+
+    /**
+     * Creates a new empty cache for the given PMD version
+     * @param cache The file on which to store analysis cache
+     * @param pmdVersion The version of PMD used to generate this cache
+     */
+    private FileAnalysisCache(final File cache, final String pmdVersion) {
+        this.pmdVersion = pmdVersion;
+        this.cache = cache;
+        fileResultsCache = new ConcurrentHashMap<>();
+        updatedResultsCache = new ConcurrentHashMap<>();
+    }
+
+    public static FileAnalysisCache fromFile(final File cacheFile) {
+        final FileAnalysisCache cache = new FileAnalysisCache(cacheFile, PMD.VERSION);
+        
+        if (cacheFile.exists()) {
+            try (
+                final DataInputStream inputStream = new DataInputStream(
+                    new BufferedInputStream(new FileInputStream(cacheFile)));
+            ) {
+                final String cacheVersion = inputStream.readUTF();
+                
+                if (PMD.VERSION.equals(cacheVersion)) {
+                    // Cache is valid, load the rest
+                    while (inputStream.available() > 0) {
+                        final String fileName = inputStream.readUTF();
+                        final long checksum = inputStream.readLong();
+                        
+                        cache.fileResultsCache.put(fileName, new AnalysisResult(checksum));
+                    }
+                } else {
+                    LOG.info("Analysis cache invalidated, PMD version changed.");
+                }
+            } catch (final IOException e) {
+                // TODO : Handle this!
+                LOG.severe("Could not load analysis cache to file.");
+            }
+        }
+        
+        return cache;
+    }
+
+    @Override
+    public void persist() {
+        try (
+            final DataOutputStream outputStream = new DataOutputStream(
+                new BufferedOutputStream(new FileOutputStream(cache)));
+        ) {
+            outputStream.writeUTF(pmdVersion);
+            
+            for (final Map.Entry<String, AnalysisResult> resultEntry : updatedResultsCache.entrySet()) {
+                // TODO : In the future, we want to persist all violations, for now, just store files with NO violations
+                if (resultEntry.getValue().getViolations().isEmpty()) {
+                    outputStream.writeUTF(resultEntry.getKey());
+                    outputStream.writeLong(resultEntry.getValue().getFileChecksum());
+                }
+            }
+        } catch (final IOException e) {
+            // TODO : Handle this!
+            LOG.severe("Could not store analysis cache to file.");
+        }
+    }
+
+    // TODO : In the future we may want to return the List<RuleViolation> to be directly added to the report
+    @Override
+    public boolean isUpToDate(final File sourceFile) {
+        // There is a new file being analyzed, prepare entry in updated cache
+        final AnalysisResult updatedResult = new AnalysisResult(sourceFile);
+        updatedResultsCache.put(sourceFile.getPath(), updatedResult);
+        
+        // Now check the old cache
+        final AnalysisResult analysisResult = fileResultsCache.get(sourceFile.getPath());
+        
+        if (analysisResult == null) {
+            // new file, need to analyze it
+            return false;
+        }
+        
+        return analysisResult.getFileChecksum() == updatedResult.getFileChecksum();
+    }
+
+    @Override
+    public void analysisFailed(final File sourceFile) {
+        updatedResultsCache.remove(sourceFile.getPath());
+    }
+
+    @Override
+    public void ruleViolationAdded(final RuleViolation ruleViolation) {
+        final AnalysisResult analysisResult = updatedResultsCache.get(ruleViolation.getFilename());
+        
+        analysisResult.addViolation(ruleViolation);
+    }
+
+    @Override
+    public void metricAdded(final Metric metric) {
+        // Not interested in metrics
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/FileAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/FileAnalysisCache.java
@@ -21,22 +21,21 @@ public class FileAnalysisCache extends AbstractAnalysisCache {
     private final File cacheFile;
     
     /**
-     * Creates a new empty cache
+     * Creates a new cache backed by the given file, and attempts to load pre-existing data from it.
      * @param cache The file on which to store analysis cache
      */
-    private FileAnalysisCache(final File cache) {
+    public FileAnalysisCache(final File cache) {
         super();
         this.cacheFile = cache;
+
+        loadFromFile(cache);
     }
 
     /**
-     * Loads / creates a cache backed by the given file.
+     * Loads cache data from the given file.
      * @param cacheFile The file which backs the file analysis cache.
-     * @return The new / loaded cache.
      */
-    public static FileAnalysisCache fromFile(final File cacheFile) {
-        final FileAnalysisCache cache = new FileAnalysisCache(cacheFile);
-        
+    private void loadFromFile(final File cacheFile) {
         if (cacheFile.exists()) {
             try (
                 final DataInputStream inputStream = new DataInputStream(
@@ -48,15 +47,15 @@ public class FileAnalysisCache extends AbstractAnalysisCache {
                     // Cache seems valid, load the rest
                     
                     // Get checksums
-                    cache.rulesetChecksum = inputStream.readLong();
-                    cache.classpathChecksum = inputStream.readLong();
+                    rulesetChecksum = inputStream.readLong();
+                    classpathChecksum = inputStream.readLong();
                     
                     // Cached results
                     while (inputStream.available() > 0) {
                         final String fileName = inputStream.readUTF();
                         final long checksum = inputStream.readLong();
                         
-                        cache.fileResultsCache.put(fileName, new AnalysisResult(checksum));
+                        fileResultsCache.put(fileName, new AnalysisResult(checksum));
                     }
                 } else {
                     LOG.info("Analysis cache invalidated, PMD version changed.");
@@ -67,8 +66,6 @@ public class FileAnalysisCache extends AbstractAnalysisCache {
                 LOG.severe("Could not load analysis cache to file. " + e.getMessage());
             }
         }
-        
-        return cache;
     }
 
     @Override

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/FileAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/FileAnalysisCache.java
@@ -1,3 +1,6 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
 package net.sourceforge.pmd.cache;
 
 import java.io.BufferedInputStream;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/NoopAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/NoopAnalysisCache.java
@@ -2,6 +2,7 @@ package net.sourceforge.pmd.cache;
 
 import java.io.File;
 
+import net.sourceforge.pmd.RuleSets;
 import net.sourceforge.pmd.RuleViolation;
 import net.sourceforge.pmd.stat.Metric;
 
@@ -32,6 +33,11 @@ public class NoopAnalysisCache implements AnalysisCache {
 
     @Override
     public void analysisFailed(final File sourceFile) {
+        // noop
+    }
+
+    @Override
+    public void checkValidity(final RuleSets ruleSets, final ClassLoader classLoader) {
         // noop
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/NoopAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/NoopAnalysisCache.java
@@ -1,3 +1,6 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
 package net.sourceforge.pmd.cache;
 
 import java.io.File;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/NoopAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/NoopAnalysisCache.java
@@ -1,0 +1,37 @@
+package net.sourceforge.pmd.cache;
+
+import java.io.File;
+
+import net.sourceforge.pmd.RuleViolation;
+import net.sourceforge.pmd.stat.Metric;
+
+/**
+ * A NOOP analysis cache. Easier / safer than null-checking. 
+ */
+public class NoopAnalysisCache implements AnalysisCache {
+
+    @Override
+    public void ruleViolationAdded(final RuleViolation ruleViolation) {
+        // noop
+    }
+
+    @Override
+    public void metricAdded(final Metric metric) {
+        // noop
+    }
+
+    @Override
+    public void persist() {
+        // noop
+    }
+
+    @Override
+    public boolean isUpToDate(final File sourceFile) {
+        return false;
+    }
+
+    @Override
+    public void analysisFailed(final File sourceFile) {
+        // noop
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cli/PMDParameters.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cli/PMDParameters.java
@@ -86,6 +86,9 @@ public class PMDParameters {
 
     @Parameter(names = "-norulesetcompatibility", description = "Disable the ruleset compatibility filter. The filter is active by default and tries automatically 'fix' old ruleset files with old rule names")
     private boolean noRuleSetCompatibility = false;
+    
+    @Parameter(names = "-cache", description = "Specify the location of the cache file for incremental analysis.")
+    private String cacheLocation = null;
 
     // this has to be a public static class, so that JCommander can use it!
     public static class PropertyConverter implements IStringConverter<Properties> {
@@ -147,6 +150,7 @@ public class PMDParameters {
         configuration.setSuppressMarker(params.getSuppressmarker());
         configuration.setThreads(params.getThreads());
         configuration.setFailOnViolation(params.isFailOnViolation());
+        configuration.setAnalysisCacheLocation(params.cacheLocation);
 
         LanguageVersion languageVersion = LanguageRegistry.findLanguageVersionByTerseName(params.getLanguage() + " " + params.getVersion());
         if(languageVersion != null) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/processor/MonoThreadProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/processor/MonoThreadProcessor.java
@@ -39,6 +39,7 @@ public final class MonoThreadProcessor extends AbstractPMDProcessor {
 		// single threaded execution
 
 		RuleSets rs = createRuleSets(ruleSetFactory);
+		configuration.getAnalysisCache().checkValidity(rs, configuration.getClassLoader());
 		SourceCodeProcessor processor = new SourceCodeProcessor(configuration);
 		
 		for (DataSource dataSource : files) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/processor/MultiThreadProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/processor/MultiThreadProcessor.java
@@ -38,6 +38,7 @@ public class MultiThreadProcessor extends AbstractPMDProcessor {
 
 		RuleSets rs = createRuleSets(ruleSetFactory);
 		rs.start(ctx);
+		configuration.getAnalysisCache().checkValidity(rs, configuration.getClassLoader());
 
 		PmdThreadFactory factory = new PmdThreadFactory(ruleSetFactory, ctx);
 		ExecutorService executor = Executors.newFixedThreadPool(

--- a/pmd-core/src/test/java/net/sourceforge/pmd/ConfigurationTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/ConfigurationTest.java
@@ -181,7 +181,7 @@ public class ConfigurationTest {
         
         final File cacheFile = File.createTempFile("pmd-", ".cache");
         cacheFile.deleteOnExit();
-        final FileAnalysisCache analysisCache = FileAnalysisCache.fromFile(cacheFile);
+        final FileAnalysisCache analysisCache = new FileAnalysisCache(cacheFile);
         configuration.setAnalysisCache(analysisCache);
         assertSame("Confgured cache not stored", analysisCache, configuration.getAnalysisCache());
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/ConfigurationTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/ConfigurationTest.java
@@ -4,168 +4,203 @@
 package net.sourceforge.pmd;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Properties;
 
+import org.junit.Test;
+
 import junit.framework.JUnit4TestAdapter;
+import net.sourceforge.pmd.cache.FileAnalysisCache;
+import net.sourceforge.pmd.cache.NoopAnalysisCache;
 import net.sourceforge.pmd.renderers.CSVRenderer;
 import net.sourceforge.pmd.renderers.Renderer;
 import net.sourceforge.pmd.util.ClasspathClassLoader;
-
-import org.junit.Test;
 
 public class ConfigurationTest {
 
     @Test
     public void testSuppressMarker() {
-	PMDConfiguration configuration = new PMDConfiguration();
-	assertEquals("Default suppress marker", PMD.SUPPRESS_MARKER, configuration.getSuppressMarker());
-	configuration.setSuppressMarker("CUSTOM_MARKER");
-	assertEquals("Changed suppress marker", "CUSTOM_MARKER", configuration.getSuppressMarker());
+    	PMDConfiguration configuration = new PMDConfiguration();
+    	assertEquals("Default suppress marker", PMD.SUPPRESS_MARKER, configuration.getSuppressMarker());
+    	configuration.setSuppressMarker("CUSTOM_MARKER");
+    	assertEquals("Changed suppress marker", "CUSTOM_MARKER", configuration.getSuppressMarker());
     }
 
     @Test
     public void testThreads() {
-	PMDConfiguration configuration = new PMDConfiguration();
-	assertEquals("Default threads", Runtime.getRuntime().availableProcessors(), configuration.getThreads());
-	configuration.setThreads(0);
-	assertEquals("Changed threads", 0, configuration.getThreads());
+    	PMDConfiguration configuration = new PMDConfiguration();
+    	assertEquals("Default threads", Runtime.getRuntime().availableProcessors(), configuration.getThreads());
+    	configuration.setThreads(0);
+    	assertEquals("Changed threads", 0, configuration.getThreads());
     }
 
     @Test
     public void testClassLoader() throws IOException {
-	PMDConfiguration configuration = new PMDConfiguration();
-	assertEquals("Default ClassLoader", PMDConfiguration.class.getClassLoader(), configuration.getClassLoader());
-	configuration.prependClasspath("some.jar");
-	assertEquals("Prepended ClassLoader class", ClasspathClassLoader.class, configuration.getClassLoader()
-		.getClass());
-	URL[] urls = ((ClasspathClassLoader) configuration.getClassLoader()).getURLs();
-	assertEquals("urls length", 1, urls.length);
-	assertTrue("url[0]", urls[0].toString().endsWith("/some.jar"));
-	assertEquals("parent classLoader", PMDConfiguration.class.getClassLoader(), configuration.getClassLoader()
-		.getParent());
-	configuration.setClassLoader(null);
-	assertEquals("Revert to default ClassLoader", PMDConfiguration.class.getClassLoader(), configuration
-		.getClassLoader());
+    	PMDConfiguration configuration = new PMDConfiguration();
+    	assertEquals("Default ClassLoader", PMDConfiguration.class.getClassLoader(), configuration.getClassLoader());
+    	configuration.prependClasspath("some.jar");
+    	assertEquals("Prepended ClassLoader class", ClasspathClassLoader.class, configuration.getClassLoader()
+    		.getClass());
+    	URL[] urls = ((ClasspathClassLoader) configuration.getClassLoader()).getURLs();
+    	assertEquals("urls length", 1, urls.length);
+    	assertTrue("url[0]", urls[0].toString().endsWith("/some.jar"));
+    	assertEquals("parent classLoader", PMDConfiguration.class.getClassLoader(), configuration.getClassLoader()
+    		.getParent());
+    	configuration.setClassLoader(null);
+    	assertEquals("Revert to default ClassLoader", PMDConfiguration.class.getClassLoader(), configuration
+    		.getClassLoader());
     }
 
     @Test
     public void testRuleSets() {
-	PMDConfiguration configuration = new PMDConfiguration();
-	assertEquals("Default RuleSets", null, configuration.getRuleSets());
-	configuration.setRuleSets("/rulesets/basic.xml");
-	assertEquals("Changed RuleSets", "/rulesets/basic.xml", configuration.getRuleSets());
+    	PMDConfiguration configuration = new PMDConfiguration();
+    	assertEquals("Default RuleSets", null, configuration.getRuleSets());
+    	configuration.setRuleSets("/rulesets/basic.xml");
+    	assertEquals("Changed RuleSets", "/rulesets/basic.xml", configuration.getRuleSets());
     }
 
     @Test
     public void testMinimumPriority() {
-	PMDConfiguration configuration = new PMDConfiguration();
-	assertEquals("Default minimum priority", RulePriority.LOW, configuration.getMinimumPriority());
-	configuration.setMinimumPriority(RulePriority.HIGH);
-	assertEquals("Changed minimum priority", RulePriority.HIGH, configuration.getMinimumPriority());
+    	PMDConfiguration configuration = new PMDConfiguration();
+    	assertEquals("Default minimum priority", RulePriority.LOW, configuration.getMinimumPriority());
+    	configuration.setMinimumPriority(RulePriority.HIGH);
+    	assertEquals("Changed minimum priority", RulePriority.HIGH, configuration.getMinimumPriority());
     }
 
     @Test
     public void testSourceEncoding() {
-	PMDConfiguration configuration = new PMDConfiguration();
-	assertEquals("Default source encoding", System.getProperty("file.encoding"), configuration.getSourceEncoding());
-	configuration.setSourceEncoding("some_other_encoding");
-	assertEquals("Changed source encoding", "some_other_encoding", configuration.getSourceEncoding());
+    	PMDConfiguration configuration = new PMDConfiguration();
+    	assertEquals("Default source encoding", System.getProperty("file.encoding"), configuration.getSourceEncoding());
+    	configuration.setSourceEncoding("some_other_encoding");
+    	assertEquals("Changed source encoding", "some_other_encoding", configuration.getSourceEncoding());
     }
 
     @Test
     public void testInputPaths() {
-	PMDConfiguration configuration = new PMDConfiguration();
-	assertEquals("Default input paths", null, configuration.getInputPaths());
-	configuration.setInputPaths("a,b,c");
-	assertEquals("Changed input paths", "a,b,c", configuration.getInputPaths());
+    	PMDConfiguration configuration = new PMDConfiguration();
+    	assertEquals("Default input paths", null, configuration.getInputPaths());
+    	configuration.setInputPaths("a,b,c");
+    	assertEquals("Changed input paths", "a,b,c", configuration.getInputPaths());
     }
 
     @Test
     public void testReportShortNames() {
-	PMDConfiguration configuration = new PMDConfiguration();
-	assertEquals("Default report short names", false, configuration.isReportShortNames());
-	configuration.setReportShortNames(true);
-	assertEquals("Changed report short names", true, configuration.isReportShortNames());
+    	PMDConfiguration configuration = new PMDConfiguration();
+    	assertEquals("Default report short names", false, configuration.isReportShortNames());
+    	configuration.setReportShortNames(true);
+    	assertEquals("Changed report short names", true, configuration.isReportShortNames());
     }
 
     @Test
     public void testReportFormat() {
-	PMDConfiguration configuration = new PMDConfiguration();
-	assertEquals("Default report format", null, configuration.getReportFormat());
-	configuration.setReportFormat("csv");
-	assertEquals("Changed report format", "csv", configuration.getReportFormat());
+    	PMDConfiguration configuration = new PMDConfiguration();
+    	assertEquals("Default report format", null, configuration.getReportFormat());
+    	configuration.setReportFormat("csv");
+    	assertEquals("Changed report format", "csv", configuration.getReportFormat());
     }
 
     @Test
     public void testCreateRenderer() {
-	PMDConfiguration configuration = new PMDConfiguration();
-	configuration.setReportFormat("csv");
-	Renderer renderer = configuration.createRenderer();
-	assertEquals("Renderer class", CSVRenderer.class, renderer.getClass());
-	assertEquals("Default renderer show suppressed violations", false, renderer.isShowSuppressedViolations());
+    	PMDConfiguration configuration = new PMDConfiguration();
+    	configuration.setReportFormat("csv");
+    	Renderer renderer = configuration.createRenderer();
+    	assertEquals("Renderer class", CSVRenderer.class, renderer.getClass());
+    	assertEquals("Default renderer show suppressed violations", false, renderer.isShowSuppressedViolations());
 
-	configuration.setShowSuppressedViolations(true);
-	renderer = configuration.createRenderer();
-	assertEquals("Renderer class", CSVRenderer.class, renderer.getClass());
-	assertEquals("Changed renderer show suppressed violations", true, renderer.isShowSuppressedViolations());
+    	configuration.setShowSuppressedViolations(true);
+    	renderer = configuration.createRenderer();
+    	assertEquals("Renderer class", CSVRenderer.class, renderer.getClass());
+    	assertEquals("Changed renderer show suppressed violations", true, renderer.isShowSuppressedViolations());
     }
 
     @Test
     public void testReportFile() {
-	PMDConfiguration configuration = new PMDConfiguration();
-	assertEquals("Default report file", null, configuration.getReportFile());
-	configuration.setReportFile("somefile");
-	assertEquals("Changed report file", "somefile", configuration.getReportFile());
+    	PMDConfiguration configuration = new PMDConfiguration();
+    	assertEquals("Default report file", null, configuration.getReportFile());
+    	configuration.setReportFile("somefile");
+    	assertEquals("Changed report file", "somefile", configuration.getReportFile());
     }
 
     @Test
     public void testShowSuppressedViolations() {
-	PMDConfiguration configuration = new PMDConfiguration();
-	assertEquals("Default show suppressed violations", false, configuration.isShowSuppressedViolations());
-	configuration.setShowSuppressedViolations(true);
-	assertEquals("Changed show suppressed violations", true, configuration.isShowSuppressedViolations());
+    	PMDConfiguration configuration = new PMDConfiguration();
+    	assertEquals("Default show suppressed violations", false, configuration.isShowSuppressedViolations());
+    	configuration.setShowSuppressedViolations(true);
+    	assertEquals("Changed show suppressed violations", true, configuration.isShowSuppressedViolations());
     }
 
     @Test
     public void testReportProperties() {
-	PMDConfiguration configuration = new PMDConfiguration();
-	assertEquals("Default report properties size", 0, configuration.getReportProperties().size());
-	configuration.getReportProperties().put("key", "value");
-	assertEquals("Changed report properties size", 1, configuration.getReportProperties().size());
-	assertEquals("Changed report properties value", "value", configuration.getReportProperties().get("key"));
-	configuration.setReportProperties(new Properties());
-	assertEquals("Replaced report properties size", 0, configuration.getReportProperties().size());
+    	PMDConfiguration configuration = new PMDConfiguration();
+    	assertEquals("Default report properties size", 0, configuration.getReportProperties().size());
+    	configuration.getReportProperties().put("key", "value");
+    	assertEquals("Changed report properties size", 1, configuration.getReportProperties().size());
+    	assertEquals("Changed report properties value", "value", configuration.getReportProperties().get("key"));
+    	configuration.setReportProperties(new Properties());
+    	assertEquals("Replaced report properties size", 0, configuration.getReportProperties().size());
     }
 
     @Test
     public void testDebug() {
-	PMDConfiguration configuration = new PMDConfiguration();
-	assertEquals("Default debug", false, configuration.isDebug());
-	configuration.setDebug(true);
-	assertEquals("Changed debug", true, configuration.isDebug());
+    	PMDConfiguration configuration = new PMDConfiguration();
+    	assertEquals("Default debug", false, configuration.isDebug());
+    	configuration.setDebug(true);
+    	assertEquals("Changed debug", true, configuration.isDebug());
     }
 
     @Test
     public void testStressTest() {
-	PMDConfiguration configuration = new PMDConfiguration();
-	assertEquals("Default stress test", false, configuration.isStressTest());
-	configuration.setStressTest(true);
-	assertEquals("Changed stress test", true, configuration.isStressTest());
+    	PMDConfiguration configuration = new PMDConfiguration();
+    	assertEquals("Default stress test", false, configuration.isStressTest());
+    	configuration.setStressTest(true);
+    	assertEquals("Changed stress test", true, configuration.isStressTest());
     }
 
     @Test
     public void testBenchmark() {
-	PMDConfiguration configuration = new PMDConfiguration();
-	assertEquals("Default benchmark", false, configuration.isBenchmark());
-	configuration.setBenchmark(true);
-	assertEquals("Changed benchmark", true, configuration.isBenchmark());
+    	PMDConfiguration configuration = new PMDConfiguration();
+    	assertEquals("Default benchmark", false, configuration.isBenchmark());
+    	configuration.setBenchmark(true);
+    	assertEquals("Changed benchmark", true, configuration.isBenchmark());
+    }
+    
+    @Test
+    public void testAnalysisCache() throws IOException {
+        final PMDConfiguration configuration = new PMDConfiguration();
+        assertNotNull("Default cache is null", configuration.getAnalysisCache());
+        assertTrue("Default cache is not a noop",
+                configuration.getAnalysisCache() instanceof NoopAnalysisCache);
+        configuration.setAnalysisCache(null);
+        assertNotNull("Default cache was set to null", configuration.getAnalysisCache());
+        
+        final File cacheFile = File.createTempFile("pmd-", ".cache");
+        cacheFile.deleteOnExit();
+        final FileAnalysisCache analysisCache = FileAnalysisCache.fromFile(cacheFile);
+        configuration.setAnalysisCache(analysisCache);
+        assertSame("Confgured cache not stored", analysisCache, configuration.getAnalysisCache());
+    }
+    
+    @Test
+    public void testAnalysisCacheLocation() throws IOException {
+        final PMDConfiguration configuration = new PMDConfiguration();
+        
+        configuration.setAnalysisCacheLocation(null);
+        assertNotNull("Null cache location accepted", configuration.getAnalysisCache());
+        assertTrue("Null cache location accepted", configuration.getAnalysisCache() instanceof NoopAnalysisCache);
+        
+        configuration.setAnalysisCacheLocation("pmd.cache");
+        assertNotNull("Not null cache location produces null cache", configuration.getAnalysisCache());
+        assertTrue("File cache location doesn't produce a file cache",
+                configuration.getAnalysisCache() instanceof FileAnalysisCache);
     }
 
     public static junit.framework.Test suite() {
-	return new JUnit4TestAdapter(ConfigurationTest.class);
+        return new JUnit4TestAdapter(ConfigurationTest.class);
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cache/FileAnalysisCacheTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cache/FileAnalysisCacheTest.java
@@ -44,32 +44,32 @@ public class FileAnalysisCacheTest {
 
     @Test
     public void testLoadFromNonExistingFile() throws IOException {
-        final FileAnalysisCache cache = FileAnalysisCache.fromFile(unexistingCacheFile);
+        final FileAnalysisCache cache = new FileAnalysisCache(unexistingCacheFile);
         assertNotNull("Cache creation from non existing file failed.", cache);
     }
     
     @Test
     public void testLoadFromEmptyFile() throws IOException {
-        final FileAnalysisCache cache = FileAnalysisCache.fromFile(emptyCacheFile);
+        final FileAnalysisCache cache = new FileAnalysisCache(emptyCacheFile);
         assertNotNull("Cache creation from empty file failed.", cache);
     }
     
     @Test
     public void testLoadFromDirectory() throws IOException {
-        final FileAnalysisCache cache = FileAnalysisCache.fromFile(tempFolder.getRoot());
+        final FileAnalysisCache cache = new FileAnalysisCache(tempFolder.getRoot());
         // TODO
     }
     
     @Test
     public void testLoadFromUnreadableFile() throws IOException {
         emptyCacheFile.setReadable(false);
-        final FileAnalysisCache cache = FileAnalysisCache.fromFile(emptyCacheFile);
+        final FileAnalysisCache cache = new FileAnalysisCache(emptyCacheFile);
         // TODO
     }
 
     @Test
     public void testStoreCreatesFile() {
-        final FileAnalysisCache cache = FileAnalysisCache.fromFile(unexistingCacheFile);
+        final FileAnalysisCache cache = new FileAnalysisCache(unexistingCacheFile);
         cache.persist();
         assertTrue("Cache file doesn't exist after store", unexistingCacheFile.exists());
     }
@@ -77,7 +77,7 @@ public class FileAnalysisCacheTest {
     @Test
     public void testStoreOnUnwritableFile() {
         emptyCacheFile.setWritable(false);
-        final FileAnalysisCache cache = FileAnalysisCache.fromFile(emptyCacheFile);
+        final FileAnalysisCache cache = new FileAnalysisCache(emptyCacheFile);
         cache.persist();
         // TODO : make proper assertions!
         assertTrue("Cache file doesn't exist after store", emptyCacheFile.exists());
@@ -85,7 +85,7 @@ public class FileAnalysisCacheTest {
 
     @Test
     public void testStoreSkipsFilesWithViolations() {
-        final FileAnalysisCache cache = FileAnalysisCache.fromFile(newCacheFile);
+        final FileAnalysisCache cache = new FileAnalysisCache(newCacheFile);
         cache.isUpToDate(sourceFile);
 
         final RuleViolation rv = mock(RuleViolation.class);
@@ -94,7 +94,7 @@ public class FileAnalysisCacheTest {
         cache.ruleViolationAdded(rv);
         cache.persist();
 
-        final FileAnalysisCache reloadedCache = FileAnalysisCache.fromFile(newCacheFile);
+        final FileAnalysisCache reloadedCache = new FileAnalysisCache(newCacheFile);
         assertFalse("Cache believes unmodified file with violations is up to date",
                 reloadedCache.isUpToDate(sourceFile));
     }
@@ -106,7 +106,7 @@ public class FileAnalysisCacheTest {
 
         setupCacheWithFiles(newCacheFile, rs, cl, sourceFile);
 
-        final FileAnalysisCache reloadedCache = FileAnalysisCache.fromFile(newCacheFile);
+        final FileAnalysisCache reloadedCache = new FileAnalysisCache(newCacheFile);
         reloadedCache.checkValidity(rs, cl);
         assertTrue("Cache believes unmodified file is not up to date without ruleset / classpath changes",
                 reloadedCache.isUpToDate(sourceFile));
@@ -119,7 +119,7 @@ public class FileAnalysisCacheTest {
         
         setupCacheWithFiles(newCacheFile, rs, cl, sourceFile);
         
-        final FileAnalysisCache reloadedCache = FileAnalysisCache.fromFile(newCacheFile);
+        final FileAnalysisCache reloadedCache = new FileAnalysisCache(newCacheFile);
         when(rs.getChecksum()).thenReturn(1L);
         reloadedCache.checkValidity(rs, cl);
         assertFalse("Cache believes unmodified file is up to date after ruleset changed",
@@ -133,7 +133,7 @@ public class FileAnalysisCacheTest {
         
         setupCacheWithFiles(newCacheFile, rs, cl, sourceFile);
         
-        final FileAnalysisCache reloadedCache = FileAnalysisCache.fromFile(newCacheFile);
+        final FileAnalysisCache reloadedCache = new FileAnalysisCache(newCacheFile);
         when(cl.getURLs()).thenReturn(new URL[] { tempFolder.newFile().toURI().toURL(), });
         reloadedCache.checkValidity(rs, cl);
         assertTrue("Cache believes unmodified file is not up to date after classpath changed when no rule cares",
@@ -147,7 +147,7 @@ public class FileAnalysisCacheTest {
         
         setupCacheWithFiles(newCacheFile, rs, cl, sourceFile);
         
-        final FileAnalysisCache reloadedCache = FileAnalysisCache.fromFile(newCacheFile);
+        final FileAnalysisCache reloadedCache = new FileAnalysisCache(newCacheFile);
         when(cl.getURLs()).thenReturn(new URL[] { tempFolder.newFile().toURI().toURL(), });
         final net.sourceforge.pmd.Rule r = mock(net.sourceforge.pmd.Rule.class);
         when(r.usesDFA()).thenReturn(true);
@@ -159,7 +159,7 @@ public class FileAnalysisCacheTest {
 
     @Test
     public void testUnknownFileIsNotUpToDate() throws IOException {
-        final FileAnalysisCache cache = FileAnalysisCache.fromFile(newCacheFile);
+        final FileAnalysisCache cache = new FileAnalysisCache(newCacheFile);
         assertFalse("Cache believes an unknown file is up to date",
                 cache.isUpToDate(sourceFile));
     }
@@ -168,7 +168,7 @@ public class FileAnalysisCacheTest {
     public void testFileIsUpToDate() throws IOException {
         setupCacheWithFiles(newCacheFile, mock(RuleSets.class), mock(ClassLoader.class), sourceFile);
         
-        final FileAnalysisCache cache = FileAnalysisCache.fromFile(newCacheFile);
+        final FileAnalysisCache cache = new FileAnalysisCache(newCacheFile);
         assertTrue("Cache believes a known, unchanged file is not up to date",
                 cache.isUpToDate(sourceFile));
     }
@@ -180,7 +180,7 @@ public class FileAnalysisCacheTest {
         // Edit the file
         Files.write(Paths.get(sourceFile.getAbsolutePath()), "some text".getBytes());
         
-        final FileAnalysisCache cache = FileAnalysisCache.fromFile(newCacheFile);
+        final FileAnalysisCache cache = new FileAnalysisCache(newCacheFile);
         assertFalse("Cache believes a known, changed file is up to date",
                 cache.isUpToDate(sourceFile));
     }
@@ -188,7 +188,7 @@ public class FileAnalysisCacheTest {
     private void setupCacheWithFiles(final File cacheFile, final RuleSets ruleSets,
             final ClassLoader classLoader, final File... files) {
         // Setup a cache file with an entry for an empty Source.java with no violations
-        final FileAnalysisCache cache = FileAnalysisCache.fromFile(cacheFile);
+        final FileAnalysisCache cache = new FileAnalysisCache(cacheFile);
         cache.checkValidity(ruleSets, classLoader);
         
         for (final File f : files) {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cache/FileAnalysisCacheTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cache/FileAnalysisCacheTest.java
@@ -55,16 +55,14 @@ public class FileAnalysisCacheTest {
     }
     
     @Test
-    public void testLoadFromDirectory() throws IOException {
-        final FileAnalysisCache cache = new FileAnalysisCache(tempFolder.getRoot());
-        // TODO
+    public void testLoadFromDirectoryShouldntThrow() throws IOException {
+        new FileAnalysisCache(tempFolder.getRoot());
     }
     
     @Test
-    public void testLoadFromUnreadableFile() throws IOException {
+    public void testLoadFromUnreadableFileShouldntThrow() throws IOException {
         emptyCacheFile.setReadable(false);
-        final FileAnalysisCache cache = new FileAnalysisCache(emptyCacheFile);
-        // TODO
+        new FileAnalysisCache(emptyCacheFile);
     }
 
     @Test
@@ -75,12 +73,10 @@ public class FileAnalysisCacheTest {
     }
 
     @Test
-    public void testStoreOnUnwritableFile() {
+    public void testStoreOnUnwritableFileShouldntThrow() {
         emptyCacheFile.setWritable(false);
         final FileAnalysisCache cache = new FileAnalysisCache(emptyCacheFile);
         cache.persist();
-        // TODO : make proper assertions!
-        assertTrue("Cache file doesn't exist after store", emptyCacheFile.exists());
     }
 
     @Test

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cache/FileAnalysisCacheTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cache/FileAnalysisCacheTest.java
@@ -3,17 +3,24 @@ package net.sourceforge.pmd.cache;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Collections;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import net.sourceforge.pmd.RuleSets;
 import net.sourceforge.pmd.RuleViolation;
 
 public class FileAnalysisCacheTest {
@@ -86,14 +93,60 @@ public class FileAnalysisCacheTest {
     }
 
     @Test
-    public void testStoreSkipsFilesThatFailedProcessing() {
-        final FileAnalysisCache cache = FileAnalysisCache.fromFile(emptyCacheFile);
-        cache.isUpToDate(sourceFile);
-        cache.analysisFailed(sourceFile);
-        cache.persist();
-
+    public void testCacheValidityWithNoChanges() {
+        final RuleSets rs = mock(RuleSets.class);
+        final URLClassLoader cl = mock(URLClassLoader.class);
+        
+        setupCacheWithFiles(emptyCacheFile, rs, cl, sourceFile);
+        
         final FileAnalysisCache reloadedCache = FileAnalysisCache.fromFile(emptyCacheFile);
-        assertFalse("Cache believes unmodified file that failed processing is up to date",
+        reloadedCache.checkValidity(rs, cl);
+        assertTrue("Cache believes unmodified file is not up to date without ruleset / classpath changes",
+                reloadedCache.isUpToDate(sourceFile));
+    }
+    
+    @Test
+    public void testRulesetChangeInvalidatesCache() {
+        final RuleSets rs = mock(RuleSets.class);
+        final URLClassLoader cl = mock(URLClassLoader.class);
+        
+        setupCacheWithFiles(emptyCacheFile, rs, cl, sourceFile);
+        
+        final FileAnalysisCache reloadedCache = FileAnalysisCache.fromFile(emptyCacheFile);
+        when(rs.getChecksum()).thenReturn(1L);
+        reloadedCache.checkValidity(rs, cl);
+        assertFalse("Cache believes unmodified file is up to date after ruleset changed",
+                reloadedCache.isUpToDate(sourceFile));
+    }
+    
+    @Test
+    public void testClasspathChangeWithoutDFAorTypeResolutionDoesNotInvalidatesCache() throws MalformedURLException, IOException {
+        final RuleSets rs = mock(RuleSets.class);
+        final URLClassLoader cl = mock(URLClassLoader.class);
+        
+        setupCacheWithFiles(emptyCacheFile, rs, cl, sourceFile);
+        
+        final FileAnalysisCache reloadedCache = FileAnalysisCache.fromFile(emptyCacheFile);
+        when(cl.getURLs()).thenReturn(new URL[] { tempFolder.newFile().toURI().toURL(), });
+        reloadedCache.checkValidity(rs, cl);
+        assertTrue("Cache believes unmodified file is not up to date after classpath changed when no rule cares",
+                reloadedCache.isUpToDate(sourceFile));
+    }
+    
+    @Test
+    public void testClasspathChangeInvalidatesCache() throws MalformedURLException, IOException {
+        final RuleSets rs = mock(RuleSets.class);
+        final URLClassLoader cl = mock(URLClassLoader.class);
+        
+        setupCacheWithFiles(emptyCacheFile, rs, cl, sourceFile);
+        
+        final FileAnalysisCache reloadedCache = FileAnalysisCache.fromFile(emptyCacheFile);
+        when(cl.getURLs()).thenReturn(new URL[] { tempFolder.newFile().toURI().toURL(), });
+        final net.sourceforge.pmd.Rule r = mock(net.sourceforge.pmd.Rule.class);
+        when(r.usesDFA()).thenReturn(true);
+        when(rs.getAllRules()).thenReturn(Collections.singleton(r));
+        reloadedCache.checkValidity(rs, cl);
+        assertFalse("Cache believes unmodified file is up to date after classpath changed",
                 reloadedCache.isUpToDate(sourceFile));
     }
 
@@ -106,7 +159,7 @@ public class FileAnalysisCacheTest {
 
     @Test
     public void testFileIsUpToDate() throws IOException {
-        setupCacheWithFiles(emptyCacheFile, sourceFile);
+        setupCacheWithFiles(emptyCacheFile, mock(RuleSets.class), mock(ClassLoader.class), sourceFile);
         
         final FileAnalysisCache cache = FileAnalysisCache.fromFile(emptyCacheFile);
         assertTrue("Cache believes a known, unchanged file is not up to date",
@@ -115,7 +168,7 @@ public class FileAnalysisCacheTest {
     
     @Test
     public void testFileIsNotUpToDateWhenEdited() throws IOException {
-        setupCacheWithFiles(emptyCacheFile, sourceFile);
+        setupCacheWithFiles(emptyCacheFile, mock(RuleSets.class), mock(ClassLoader.class), sourceFile);
         
         // Edit the file
         Files.write(Paths.get(sourceFile.getAbsolutePath()), "some text".getBytes());
@@ -125,9 +178,12 @@ public class FileAnalysisCacheTest {
                 cache.isUpToDate(sourceFile));
     }
 
-    private void setupCacheWithFiles(final File cacheFile, final File... files) {
+    private void setupCacheWithFiles(final File cacheFile, final RuleSets ruleSets,
+            final ClassLoader classLoader, final File... files) {
         // Setup a cache file with an entry for an empty Source.java with no violations
         final FileAnalysisCache cache = FileAnalysisCache.fromFile(cacheFile);
+        cache.checkValidity(ruleSets, classLoader);
+        
         for (final File f : files) {
             cache.isUpToDate(f);
         }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cache/FileAnalysisCacheTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cache/FileAnalysisCacheTest.java
@@ -1,3 +1,6 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
 package net.sourceforge.pmd.cache;
 
 import static org.junit.Assert.assertFalse;

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cache/FileAnalysisCacheTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cache/FileAnalysisCacheTest.java
@@ -1,0 +1,205 @@
+package net.sourceforge.pmd.cache;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import net.sourceforge.pmd.RuleViolation;
+
+public class FileAnalysisCacheTest {
+    
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+    
+    private File unexistingCacheFile;
+    private File emptyCacheFile;
+    
+    private File sourceFile;
+    
+    @Before
+    public void setUp() throws IOException {
+        unexistingCacheFile = new File(tempFolder.getRoot(), "non-existing-file.cache");
+        emptyCacheFile = tempFolder.newFile();
+        sourceFile = tempFolder.newFile("Source.java");
+    }
+
+    @Test
+    public void testLoadFromNonExistingFile() throws IOException {
+        final FileAnalysisCache cache = FileAnalysisCache.fromFile(unexistingCacheFile);
+        assertNotNull("Cache creation from non existing file failed.", cache);
+    }
+    
+    @Test
+    public void testLoadFromEmptyFile() throws IOException {
+        final FileAnalysisCache cache = FileAnalysisCache.fromFile(emptyCacheFile);
+        assertNotNull("Cache creation from empty file failed.", cache);
+    }
+    
+    @Test
+    public void testLoadFromDirectory() throws IOException {
+        final FileAnalysisCache cache = FileAnalysisCache.fromFile(tempFolder.getRoot());
+        // TODO
+    }
+    
+    @Test
+    public void testLoadFromUnreadableFile() throws IOException {
+        emptyCacheFile.setReadable(false);
+        final FileAnalysisCache cache = FileAnalysisCache.fromFile(emptyCacheFile);
+        // TODO
+    }
+
+    @Test
+    public void testStoreCreatesFile() {
+        final FileAnalysisCache cache = FileAnalysisCache.fromFile(unexistingCacheFile);
+        cache.persist();
+        assertTrue("Cache file doesn't exist after store", unexistingCacheFile.exists());
+    }
+    
+    @Test
+    public void testStoreOnUnwritableFile() {
+        emptyCacheFile.setWritable(false);
+        final FileAnalysisCache cache = FileAnalysisCache.fromFile(emptyCacheFile);
+        cache.persist();
+        assertTrue("Cache file doesn't exist after store", emptyCacheFile.exists());
+    }
+    
+    @Test
+    public void testStoreSkipsFilesWithViolations() {
+        final FileAnalysisCache cache = FileAnalysisCache.fromFile(emptyCacheFile);
+        cache.isUpToDate(sourceFile);
+        cache.ruleViolationAdded(new DummyRuleViolation(sourceFile));
+        cache.persist();
+        
+        final FileAnalysisCache reloadedCache = FileAnalysisCache.fromFile(emptyCacheFile);
+        assertFalse("Cache believes unmodified file with violations is up to date",
+                reloadedCache.isUpToDate(sourceFile));
+    }
+
+    @Test
+    public void testStoreSkipsFilesThatFailedProcessing() {
+        final FileAnalysisCache cache = FileAnalysisCache.fromFile(emptyCacheFile);
+        cache.isUpToDate(sourceFile);
+        cache.analysisFailed(sourceFile);
+        cache.persist();
+
+        final FileAnalysisCache reloadedCache = FileAnalysisCache.fromFile(emptyCacheFile);
+        assertFalse("Cache believes unmodified file that failed processing is up to date",
+                reloadedCache.isUpToDate(sourceFile));
+    }
+
+    @Test
+    public void testUnknownFileIsNotUpToDate() throws IOException {
+        final FileAnalysisCache cache = FileAnalysisCache.fromFile(unexistingCacheFile);
+        assertFalse("Cache believes an unknown file is up to date",
+                cache.isUpToDate(sourceFile));
+    }
+
+    @Test
+    public void testFileIsUpToDate() throws IOException {
+        setupCacheWithFiles(emptyCacheFile, sourceFile);
+        
+        final FileAnalysisCache cache = FileAnalysisCache.fromFile(emptyCacheFile);
+        assertTrue("Cache believes a known, unchanged file is not up to date",
+                cache.isUpToDate(sourceFile));
+    }
+    
+    @Test
+    public void testFileIsNotUpToDateWhenEdited() throws IOException {
+        setupCacheWithFiles(emptyCacheFile, sourceFile);
+        
+        // Edit the file
+        Files.write(Paths.get(sourceFile.getAbsolutePath()), "some text".getBytes());
+        
+        final FileAnalysisCache cache = FileAnalysisCache.fromFile(emptyCacheFile);
+        assertFalse("Cache believes a known, changed file is up to date",
+                cache.isUpToDate(sourceFile));
+    }
+
+    private void setupCacheWithFiles(final File cacheFile, final File... files) {
+        // Setup a cache file with an entry for an empty Source.java with no violations
+        final FileAnalysisCache cache = FileAnalysisCache.fromFile(cacheFile);
+        for (final File f : files) {
+            cache.isUpToDate(f);
+        }
+        cache.persist();
+    }
+    
+    private static class DummyRuleViolation implements RuleViolation {
+        
+        private final File f;
+        
+        public DummyRuleViolation(final File f) {
+            this.f = f;
+        }
+
+        @Override
+        public boolean isSuppressed() {
+            return false;
+        }
+        
+        @Override
+        public String getVariableName() {
+            return null;
+        }
+        
+        @Override
+        public net.sourceforge.pmd.Rule getRule() {
+            return null;
+        }
+        
+        @Override
+        public String getPackageName() {
+            return null;
+        }
+        
+        @Override
+        public String getMethodName() {
+            return null;
+        }
+        
+        @Override
+        public String getFilename() {
+            return f.getPath();
+        }
+        
+        @Override
+        public int getEndLine() {
+            return 0;
+        }
+        
+        @Override
+        public int getEndColumn() {
+            return 0;
+        }
+        
+        @Override
+        public String getDescription() {
+            return null;
+        }
+        
+        @Override
+        public String getClassName() {
+            return null;
+        }
+        
+        @Override
+        public int getBeginLine() {
+            return 0;
+        }
+        
+        @Override
+        public int getBeginColumn() {
+            return 0;
+        }
+    }
+}

--- a/src/site/markdown/overview/changelog.md
+++ b/src/site/markdown/overview/changelog.md
@@ -6,11 +6,15 @@
 
 **Feature Requests and Improvements:**
 
+*   Core
+    *     [#1538](https://sourceforge.net/p/pmd/bugs/1538/): \[core] Incremental analysis - All PMD analysis can now run incrementally using a local file cache. This can greatly reduce the analysis time when running from CLI or tools such as Ant, Maven or Gradle. New CLI and tasks `cache` argument i exposed.
+
 **New/Modified/Deprecated Rules:**
 
 **Pull Requests:**
 
 *   [#123](https://github.com/pmd/pmd/pull/123): \[apex] Changing method names to lowercase so casing doesn't matter
+*   [#125](https://github.com/pmd/pmd/pull/125): \[core] Incremental analysis
 
 **Bugfixes:**
 


### PR DESCRIPTION
 - Implement stage 1 of incremental analysis as per https://sourceforge.net/p/pmd/bugs/1538/

This turned out to be much simpler to implement than expected, however, I'd love to have some in-depth peer review. There are actually a couple points on which I'm not completely sure and would love some feedback.

The results are really promising (always analyzing the complete PMD source code):

## Mono thread - java-braces - noop cache

`-d ./ -b -f text -r no-cache.report -R java-braces -threads 0`

```
-----------------------------<<< Final Summary >>>-----------------------------
Total                                           Time (secs)

Measured total:                                      25.381
Non-measured total:                                   0.729
Total PMD:                                           26.111
```

## Mono thread - java-braces - empty file cache

`-d ./ -b -f text -r empty-cache.report -R java-braces -threads 0 -cache pmd.cache`

```
-----------------------------<<< Final Summary >>>-----------------------------
Total                                           Time (secs)

Measured total:                                      25.892
Non-measured total:                                   0.867
Total PMD:                                           26.759
```

~0.65 overhead for writing the file cache.


## Mono thread - java-braces - primed file cache

`-d ./ -b -f text -r primed-cache.report -R java-braces -threads 0 -cache pmd.cache`

```
-----------------------------<<< Final Summary >>>-----------------------------
Total                                           Time (secs)

Measured total:                                      13.451
Non-measured total:                                   0.680
Total PMD:                                           14.131
```

Huge gains since we skipped analyzing several files altogether.

Of course, all reports are exactly the same:

```
$ md5sum *.report
37c884377d83fc07a57775acbb7b9679  empty-cache.report
37c884377d83fc07a57775acbb7b9679  no-cache.report
37c884377d83fc07a57775acbb7b9679  primed-cache.report
```

I repeated the experiment with a somewhat more complex ruleset: http://static.monits.com/pmd.xml. More rules raises the chances of having violations, and therefore, the misses on the cache (wihch right now only saves files with no violations).

## Mono thread - http://static.monits.com/pmd.xml - no cache

```
-----------------------------<<< Final Summary >>>-----------------------------
Total                                           Time (secs)

Measured total:                                      67.455
Non-measured total:                                   1.184
Total PMD:                                           68.639
```

## Mono thread - http://static.monits.com/pmd.xml - outdated file cache

We are reusing the cache from the previous run, but the ruleset changed, invalidating it. So we have the extra cost of loading, and no benefits. This is the worst case scenario.

```
INFO: Analysis cache invalidated, rulesets changed.

-----------------------------<<< Final Summary >>>-----------------------------
Total                                           Time (secs)

Measured total:                                      69.944
Non-measured total:                                   1.477
Total PMD:                                           71.421
```

~2.8 overhead for reading & writing the file cache.


## Mono thread - http://static.monits.com/pmd.xml - primed file cache

```
-----------------------------<<< Final Summary >>>-----------------------------
Total                                           Time (secs)

Measured total:                                      44.166
Non-measured total:                                   0.982
Total PMD:                                           45.148
```

Once again, significant gains, even with a much lower hit ratio.

```
$ md5sum *.report
91bfc759db88d53abe5dfb7ba0ddf47d  no-cache.report
91bfc759db88d53abe5dfb7ba0ddf47d  old-cache.report
91bfc759db88d53abe5dfb7ba0ddf47d  primed-cache.report
```


















## Multi thread (4 threads) - http://static.monits.com/pmd.xml - no cache

```
-----------------------------<<< Final Summary >>>-----------------------------
Total                                           Time (secs)

Measured total:                                     151.734
Non-measured total:                                -104.830
Total PMD:                                           46.904
```

## Multi thread (4 threads) - http://static.monits.com/pmd.xml - empty file cache

```
-----------------------------<<< Final Summary >>>-----------------------------
Total                                           Time (secs)

Measured total:                                     163.697
Non-measured total:                                -113.610
Total PMD:                                           50.087
```

~3.1 secs overhead


## Multi thread (4 threads) - http://static.monits.com/pmd.xml - primed file cache

```
-----------------------------<<< Final Summary >>>-----------------------------
Total                                           Time (secs)

Measured total:                                     116.428
Non-measured total:                                 -81.296
Total PMD:                                           35.131
```

Once again, significant gains, even with a much lower hit ratio.

```
$ md5sum *.report
91bfc759db88d53abe5dfb7ba0ddf47d  empty-cache.report
91bfc759db88d53abe5dfb7ba0ddf47d  no-cache.report
91bfc759db88d53abe5dfb7ba0ddf47d  primed-cache.report
```

I still need to run this through a profiler. The overhead, specially for reading, seems to be a little excesive, 'though I see nothing obvious in the code (I'm using a `BufferedInputStream`), and it could also be a meassuring error (the problem with single run measurements when difference is smaller than the noise).