### PR TITLE
[java] Avoid creating a new String to qualify types

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/ClassScope.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/ClassScope.java
@@ -365,7 +365,7 @@ public class ClassScope extends AbstractJavaScope {
         for (String qualified : qualifiedNames) {
             int fullLength = qualified.length();
             if (qualified.endsWith(typeImage)
-                    && (fullLength == nameLength || qualified.substring(0, fullLength - nameLength).endsWith("."))) {
+                    && (fullLength == nameLength || qualified.charAt(fullLength - nameLength - 1) == '.')) {
                 return qualified;
             }
         }

--- a/src/site/markdown/overview/changelog.md
+++ b/src/site/markdown/overview/changelog.md
@@ -6,11 +6,15 @@
 
 **Feature Requests and Improvements:**
 
+*   java
+    *   Type Resolution performance improved by ~15%
+
 **New/Modified/Deprecated Rules:**
 
 **Pull Requests:**
 
 *   [#123](https://github.com/pmd/pmd/pull/123): \[apex] Changing method names to lowercase so casing doesn't matter
+*   [#126](https://github.com/pmd/pmd/pull/126): \[java] Avoid creating a new String to qualify types
 
 **Bugfixes:**
 


### PR DESCRIPTION
 - This is now slightly faster, which for a method that gets called
    over 1 million times on large projects is significant.
 - We should still look for ways to reduce the number of calls to this
    method.


This alone was enough to shave ~15% from analysis time when running the exact same test as used in #117

The baseline for PMD 5.5.2 was:

```
--------------------------------<<< Summary >>>--------------------------------
Segment                                         Time (secs)

Collect files:                                        0.241
Load rules:                                           0.053
Parser:                                               6.216
Symbol table:                                        16.711
RuleChain visit:                                      0.290
Reporting:                                            0.055
Rule total:                                           0.000
Rule chain rule total:                                0.000
Rule Average (0 rules):                               0.000
RuleChain Average (4 rules):                          0.216

-----------------------------<<< Final Summary >>>-----------------------------
Total                                           Time (secs)

Measured total:                                      24.432
Non-measured total:                                   0.547
Total PMD:                                           24.979
```

This single change produces:

```
--------------------------------<<< Summary >>>--------------------------------
Segment                                         Time (secs)

Collect files:                                        0.285
Load rules:                                           0.054
Parser:                                               6.106
Symbol table:                                        13.346
RuleChain visit:                                      0.275
Reporting:                                            0.051
Rule total:                                           0.000
Rule chain rule total:                                0.000
Rule Average (0 rules):                               0.000
RuleChain Average (4 rules):                          0.224

-----------------------------<<< Final Summary >>>-----------------------------
Total                                           Time (secs)

Measured total:                                      21.014
Non-measured total:                                   0.590
Total PMD:                                           21.603
```

All numbers are close enough to disregard measuring noise, the only significant difference is for Symbol Table being 3.4 secs faster.