### PR TITLE
[plsql] Added correct parse of IS [NOT] NULL and multiline DML

### DIFF
--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -929,6 +929,7 @@ ASTExceptionHandler ExceptionHandler() :
 
 void Skip2NextTerminator(String initiator,String terminator) :
 {
+  Token beginToken = getToken(0);
   Token t = getToken(1);
   int count = (initiator == null) ? 0 : 1;
   if(t.image.equals(initiator)) count++;
@@ -938,7 +939,9 @@ void Skip2NextTerminator(String initiator,String terminator) :
     t = getToken(1);
 	  if(t.image.equals(initiator)) count++;
 	  if(t.image.equals(terminator)) count--;
-	  if(null != t.specialToken || t.kind == EOF)
+    if((null != t.specialToken && beginToken.kind != SELECT && beginToken.kind != INSERT && beginToken.kind != UPDATE && beginToken.kind != DELETE && beginToken.kind != MERGE) || t.kind == EOF)
+        return;
+    if (t.specialToken != null && "/".equals(t.image))
 	    return;
   }
 }

--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -38,6 +38,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  * Andreas Dangel 11/2016
  */
 
+ /**
+ * Added ASTIsNullCondition node
+ *
+ * Sergey Yanzin 11/2016
+ */
+
 //
 options {
 	DEBUG_PARSER = false ;
@@ -1972,10 +1978,31 @@ ASTUnaryExpressionNotPlusMinus UnaryExpressionNotPlusMinus() :
   (<NOT>) {sb.append(" NOT "); } 
   (simpleNode = UnaryExpression(false) ) { sb.append(simpleNode.getImage()); }
   |
-   (simpleNode = IsOfTypeCondition() ) {sb.append(simpleNode.getImage()); }
+   (simpleNode = IsNullCondition() ) {sb.append(simpleNode.getImage()); } 
   )
  { 
  jjtThis.setImage(sb.toString()); return jjtThis; 
+ }
+}
+ASTIsNullCondition IsNullCondition() :  //yanzin
+{ PLSQLNode simpleNode = null; PLSQLNode name = null; StringBuilder sb = new StringBuilder(); }
+{
+  (
+    LOOKAHEAD(<IDENTIFIER> <IS> (<NOT> <NULL>|<NULL>))
+    (
+		(name = Name()) {sb.append(name.getImage());} <IS> {sb.append(" IS");} [<NOT> {sb.append(" NOT");}] <NULL> {sb.append(" NULL");} 
+	)
+	|
+	(
+		simpleNode = IsOfTypeCondition() 
+	) 
+	{ 
+		sb.append(simpleNode.getImage()); 
+	}
+  )
+  {
+    jjtThis.setImage(sb.toString());
+	return jjtThis;
  }
 }
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLParserVisitorAdapter.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLParserVisitorAdapter.java
@@ -691,6 +691,11 @@ public class PLSQLParserVisitorAdapter implements PLSQLParserVisitor {
         }
 
     @Override
+    public Object visit(ASTIsNullCondition node, Object data) {
+        return visit((PLSQLNode) node, data);
+    }
+
+    @Override
     public Object visit(ASTIsOfTypeCondition node, Object data) {
         return visit((PLSQLNode) node, data);
     }

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractPLSQLRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractPLSQLRule.java
@@ -790,6 +790,11 @@ public abstract class AbstractPLSQLRule extends AbstractRule implements PLSQLPar
         return visit((PLSQLNode) node, data);
 	}
 
+	@Override
+	public Object visit(ASTIsNullCondition node, Object data) {
+        return visit((PLSQLNode) node, data);
+	}
+
   /*
    * Treat all Executable Code 
    */

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/PLSQLParserTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/PLSQLParserTest.java
@@ -62,6 +62,16 @@ public class PLSQLParserTest extends AbstractPLSQLParserTst {
     }
 
     @Test
+    public void testSingleLineSelect() throws Exception {
+        parsePLSQL(IOUtils.toString(PLSQLParserTest.class.getResourceAsStream("ast/SingleLineSelect.pls")));
+    }
+
+    @Test
+    public void testMultiLineSelect() throws Exception {
+        parsePLSQL(IOUtils.toString(PLSQLParserTest.class.getResourceAsStream("ast/MultiLineSelect.pls")));
+    }
+
+    @Test
     public void testIsNull() throws Exception {
         parsePLSQL(IOUtils.toString(PLSQLParserTest.class.getResourceAsStream("ast/IsNull.pls")));
     }

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/PLSQLParserTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/PLSQLParserTest.java
@@ -60,4 +60,9 @@ public class PLSQLParserTest extends AbstractPLSQLParserTst {
     public void testBug1520Using() throws Exception {
         parsePLSQL(IOUtils.toString(PLSQLParserTest.class.getResourceAsStream("ast/Using.pls")));
     }
+
+    @Test
+    public void testIsNull() throws Exception {
+        parsePLSQL(IOUtils.toString(PLSQLParserTest.class.getResourceAsStream("ast/IsNull.pls")));
+    }
 }

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/IsNull.pls
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/IsNull.pls
@@ -1,0 +1,16 @@
+PROCEDURE IsNull (
+  dummy IN number
+)
+is
+  V_BUF varchar(1);
+BEGIN
+
+IF V_BUF IS NULL THEN
+  null;
+end if;
+
+IF V_BUF IS NOT NULL THEN
+  null;
+end if;
+
+end;

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/MultiLineSelect.pls
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/MultiLineSelect.pls
@@ -1,0 +1,10 @@
+PROCEDURE IsNull (
+  inStatusId IN number
+)
+is
+  V_BUF varchar(1);
+BEGIN
+select '1'  
+into V_BUF 
+from dual;
+end;

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/SingleLineSelect.pls
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/SingleLineSelect.pls
@@ -1,0 +1,8 @@
+PROCEDURE IsNull (
+  inStatusId IN number
+)
+is
+  V_BUF varchar(1);
+BEGIN
+select '1' into V_BUF from dual;
+end;


### PR DESCRIPTION
fixed crash of parsing following code (from unittest):
IF V_BUF IS NULL THEN
null;
end if;