### PR TITLE
[java] Symbol table can now handle inner classes

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/AbstractScope.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/symboltable/AbstractScope.java
@@ -70,19 +70,17 @@ public abstract class AbstractScope implements Scope {
         declarationsPerClass.put(declaration, new ArrayList<NameOccurrence>());
     }
 
+    @SuppressWarnings("unchecked")
     @Override
     public <T extends Scope> T getEnclosingScope(Class<T> clazz) {
-        T result = null;
         Scope current = this;
-        while (result == null && current != null) {
+        while (current != null) {
             if (clazz.isAssignableFrom(current.getClass())) {
-                @SuppressWarnings("unchecked")
-                T cast = (T)current;
-                result = cast;
+                return (T) current;
             }
             current = current.getParent();
         }
-        return result;
+        return null;
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/ClassScope.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/ClassScope.java
@@ -536,6 +536,10 @@ public class ClassScope extends AbstractJavaScope {
                 typeImage), determineSuper(declaringNode));
     }
 
+    public Class<?> resolveType(final String name) {
+        return this.getEnclosingScope(SourceFileScope.class).resolveType(qualifyTypeName(name));
+    }
+
     /**
      * Tries to resolve a given typeImage as a generic Type. If the Generic Type
      * is found, any defined ClassOrInterfaceType below this type declaration is

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/ScopeAndDeclarationFinder.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/ScopeAndDeclarationFinder.java
@@ -139,11 +139,12 @@ public class ScopeAndDeclarationFinder extends JavaParserVisitorAdapter {
         SourceFileScope scope;
         ASTPackageDeclaration n = node.getPackageDeclaration();
         if (n != null) {
-            scope = new SourceFileScope(n.jjtGetChild(0).getImage());
+            scope = new SourceFileScope(classLoader, n.jjtGetChild(0).getImage());
         } else {
-            scope = new SourceFileScope();
+            scope = new SourceFileScope(classLoader);
         }
-        scope.configureImports(classLoader, node.findChildrenOfType(ASTImportDeclaration.class));
+        scope.configureImports(node.findChildrenOfType(ASTImportDeclaration.class));
+
         scopes.push(scope);
         node.setScope(scope);
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/SourceFileScope.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/SourceFileScope.java
@@ -23,15 +23,17 @@ import net.sourceforge.pmd.lang.symboltable.Scope;
  */
 public class SourceFileScope extends AbstractJavaScope {
 
-    private String packageImage;
-    private TypeSet types;
+    private final String packageImage;
+    private final TypeSet types;
 
-    public SourceFileScope() {
-        this("");
+    public SourceFileScope(final ClassLoader classLoader) {
+        this(classLoader, "");
     }
 
-    public SourceFileScope(String packageImage) {
+    public SourceFileScope(final ClassLoader classLoader, final String packageImage) {
+        this.types = new TypeSet(classLoader);
         this.packageImage = packageImage;
+        types.setASTCompilationUnitPackage(packageImage);
     }
 
     /**
@@ -39,9 +41,7 @@ public class SourceFileScope extends AbstractJavaScope {
      * @param classLoader the class loader to use to find additional classes
      * @param imports the import declarations
      */
-    public void configureImports(ClassLoader classLoader, List<ASTImportDeclaration> imports) {
-        this.types = new TypeSet(classLoader);
-        types.setASTCompilationUnitPackage(packageImage);
+    public void configureImports(final List<ASTImportDeclaration> imports) {
         for (ASTImportDeclaration i : imports) {
             if (i.isImportOnDemand()) {
                 types.addImport(i.getImportedName() + ".*");
@@ -72,11 +72,7 @@ public class SourceFileScope extends AbstractJavaScope {
      * @return the class or <code>null</code> if no class could be found
      */
     public Class<?> resolveType(String name) {
-        try {
-            return types.findClass(name);
-        } catch (ClassNotFoundException e) {
-            return null;
-        }
+        return types.findClass(name);
     }
 
     public String getPackageName() {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symboltable/STBBaseTst.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symboltable/STBBaseTst.java
@@ -1,20 +1,23 @@
 package net.sourceforge.pmd.lang.java.symboltable;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.StringReader;
+
+import org.apache.commons.io.IOUtils;
 
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.lang.LanguageVersionHandler;
 import net.sourceforge.pmd.lang.java.JavaLanguageModule;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
-import net.sourceforge.pmd.lang.java.symboltable.SymbolFacade;
 
 public abstract class STBBaseTst {
 
     protected ASTCompilationUnit acu;
     protected SymbolFacade stb;
 
-    protected void parseCode(String code) {
+    protected void parseCode(final String code) {
         parseCode(code, LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getDefaultVersion());
     }
 
@@ -22,10 +25,30 @@ public abstract class STBBaseTst {
         parseCode(code, LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
     }
 
-    protected void parseCode(String code, LanguageVersion languageVersion) {
-   	  LanguageVersionHandler languageVersionHandler = languageVersion.getLanguageVersionHandler();
-	acu = (ASTCompilationUnit)languageVersionHandler.getParser(languageVersionHandler.getDefaultParserOptions()).parse(null, new StringReader(code));
+    protected void parseCode(final String code, final LanguageVersion languageVersion) {
+        final LanguageVersionHandler languageVersionHandler = languageVersion.getLanguageVersionHandler();
+        acu = (ASTCompilationUnit) languageVersionHandler.getParser(languageVersionHandler.getDefaultParserOptions())
+                .parse(null, new StringReader(code));
         stb = new SymbolFacade();
         stb.initializeWith(acu);
+    }
+
+    // Note: If you're using Eclipse or some other IDE to run this test, you
+    // _must_ have the src/test/java folder in the classpath. Normally the IDE
+    // doesn't put source directories themselves directly in the classpath, only
+    // the output directories are in the classpath.
+    protected void parseForClass(final Class<?> clazz) {
+        final String sourceFile = clazz.getName().replace('.', '/') + ".java";
+        final InputStream is = STBBaseTst.class.getClassLoader().getResourceAsStream(sourceFile);
+        if (is == null) {
+            throw new IllegalArgumentException("Unable to find source file " + sourceFile + " for " + clazz);
+        }
+        final String source;
+        try {
+            source = IOUtils.toString(is);
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
+        parseCode(source, LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getDefaultVersion());
     }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symboltable/testdata/InnerClass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symboltable/testdata/InnerClass.java
@@ -1,0 +1,23 @@
+package net.sourceforge.pmd.lang.java.symboltable.testdata;
+
+public class InnerClass {
+	public static class TheInnerClass {
+	    public static enum EnumTest {
+	        THREE, FOUR;
+	    }
+	}
+	
+	enum EnumTest {
+	    ONE,
+	    TWO;
+	}
+
+	public void foo(TheInnerClass arg) {
+	}
+	
+	public void bar(InnerClass.TheInnerClass arg) {
+	}
+	
+	public void baz(EnumTest e) {
+	}
+}

--- a/src/site/markdown/overview/changelog.md
+++ b/src/site/markdown/overview/changelog.md
@@ -12,11 +12,14 @@
 
 *   [#123](https://github.com/pmd/pmd/pull/123): \[apex] Changing method names to lowercase so casing doesn't matter
 *   [#124](https://github.com/pmd/pmd/pull/124): \[java] CPD: Properly handle enums with `-ignore-identifiers`
+*   [#134](https://github.com/pmd/pmd/pull/134): \[java] Symbol table can now handle inner classes
 
 **Bugfixes:**
 
 *   apex-apexunit
     *    [#1543](https://sourceforge.net/p/pmd/bugs/1543/): \[apex] ApexUnitTestClassShouldHaveAsserts assumes APEX is case sensitive
+*   Java
+    *    [#1545](https://sourceforge.net/p/pmd/bugs/1545/): \[java] Symbol Table fails to resolve inner classes
 *   General
     *    [#1542](https://sourceforge.net/p/pmd/bugs/1542/): \[java] CPD throws an NPE when parsing enums with -ignore-identifiers
 


### PR DESCRIPTION
 - Types are now attempted to be resolved as inner classes if it fails as public
 - ClassScope offers a `resolveType` method that qualifies the name as per local rules
    before resolution
 - Fixes issue https://sourceforge.net/p/pmd/bugs/1545/

This is the last step before I can unify symbol table and type resolution logic as stated in #132 