### PR TITLE
[apex] New ruleset for Apex security

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexBadCryptoRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexBadCryptoRule.java
@@ -1,0 +1,109 @@
+package net.sourceforge.pmd.lang.apex.rule.security;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import net.sourceforge.pmd.lang.apex.ast.ASTFieldDeclaration;
+import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
+import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration;
+import net.sourceforge.pmd.lang.apex.ast.ASTVariableExpression;
+import net.sourceforge.pmd.lang.apex.ast.AbstractApexNode;
+import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+
+/**
+ * Finds encryption schemes using hardcoded IV, hardcoded key
+ * 
+ * @author sergey.gorbaty
+ *
+ */
+public class ApexBadCryptoRule extends AbstractApexRule {
+	private static final String VALUE_OF = "valueOf";
+	private static final String BLOB = "Blob";
+	private static final String ENCRYPT = "encrypt";
+	private static final String DECRYPT = "decrypt";
+	private static final String CRYPTO = "Crypto";
+	private static final String ENCRYPT_WITH_MANAGED_IV = "encryptWithManagedIV";
+	private static final String DECRYPT_WITH_MANAGED_IV = "decryptWithManagedIV";
+
+	final private Set<String> potentiallyStaticBlob = new HashSet<>();
+
+	public ApexBadCryptoRule() {
+		setProperty(CODECLIMATE_CATEGORIES, new String[] { "Security" });
+		setProperty(CODECLIMATE_REMEDIATION_MULTIPLIER, 100);
+		setProperty(CODECLIMATE_BLOCK_HIGHLIGHTING, false);
+	}
+
+	@Override
+	public Object visit(ASTUserClass node, Object data) {
+		if (Helper.isTestMethodOrClass(node)) {
+			return data;
+		}
+
+		List<ASTFieldDeclaration> fieldDecl = node.findDescendantsOfType(ASTFieldDeclaration.class);
+		for (ASTFieldDeclaration var : fieldDecl) {
+			findSafeVariables(var);
+		}
+
+		List<ASTVariableDeclaration> variableDecl = node.findDescendantsOfType(ASTVariableDeclaration.class);
+		for (ASTVariableDeclaration var : variableDecl) {
+			findSafeVariables(var);
+		}
+
+		List<ASTMethodCallExpression> methodCalls = node.findDescendantsOfType(ASTMethodCallExpression.class);
+		for (ASTMethodCallExpression methodCall : methodCalls) {
+			if (Helper.isMethodName(methodCall, CRYPTO, ENCRYPT) || Helper.isMethodName(methodCall, CRYPTO, DECRYPT)
+					|| Helper.isMethodName(methodCall, CRYPTO, ENCRYPT_WITH_MANAGED_IV)
+					|| Helper.isMethodName(methodCall, CRYPTO, DECRYPT_WITH_MANAGED_IV)) {
+
+				validateStaticIVorKey(methodCall, data);
+			}
+		}
+		return data;
+	}
+
+	private void findSafeVariables(AbstractApexNode<?> var) {
+		ASTMethodCallExpression methodCall = var.getFirstChildOfType(ASTMethodCallExpression.class);
+		if (methodCall != null && Helper.isMethodName(methodCall, BLOB, VALUE_OF)) {
+			ASTVariableExpression variable = var.getFirstChildOfType(ASTVariableExpression.class);
+			StringBuffer sb = new StringBuffer().append(variable.getNode().getDefiningType()).append(":")
+					.append(variable.getNode().getIdentifier().value);
+			potentiallyStaticBlob.add(sb.toString());
+		}
+	}
+
+	private void validateStaticIVorKey(ASTMethodCallExpression methodCall, Object data) {
+		// .encrypt('AES128', key, exampleIv, data);
+		int numberOfChildren = methodCall.jjtGetNumChildren();
+		switch (numberOfChildren) {
+		// matching signature to encrypt(
+		case 5:
+			Object potentialIV = methodCall.jjtGetChild(3);
+			reportIfHardCoded(data, potentialIV);
+			// no break on purpose
+
+			// matching signature to encryptWithManagedIV(
+		case 4:
+			Object potentialKey = methodCall.jjtGetChild(2);
+			reportIfHardCoded(data, potentialKey);
+			break;
+
+		default:
+			break;
+		}
+
+	}
+
+	private void reportIfHardCoded(Object data, Object potentialIV) {
+		if (potentialIV instanceof ASTVariableExpression) {
+			ASTVariableExpression variable = (ASTVariableExpression) potentialIV;
+			StringBuffer sb = new StringBuffer().append(variable.getNode().getDefiningType()).append(":")
+					.append(variable.getNode().getIdentifier().value);
+			if (potentiallyStaticBlob.contains(sb.toString())) {
+				addViolation(data, variable);
+			}
+		}
+	}
+
+}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCSRFRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCSRFRule.java
@@ -1,0 +1,50 @@
+package net.sourceforge.pmd.lang.apex.rule.security;
+
+import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
+import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+
+/**
+ * Constructor and init method might contain DML, which constitutes a CSRF
+ * vulnerability
+ * 
+ * @author sergey.gorbaty
+ *
+ */
+public class ApexCSRFRule extends AbstractApexRule {
+	public static final String INIT = "init";
+
+	public ApexCSRFRule() {
+		setProperty(CODECLIMATE_CATEGORIES, new String[] { "Security" });
+		setProperty(CODECLIMATE_REMEDIATION_MULTIPLIER, 100);
+		setProperty(CODECLIMATE_BLOCK_HIGHLIGHTING, false);
+	}
+
+	@Override
+	public Object visit(ASTMethod node, Object data) {
+		if (!Helper.isTestMethodOrClass(node)) {
+			checkForCSRF(node, data);
+		}
+		return data;
+	}
+
+	/**
+	 * @param node
+	 * @param data
+	 */
+	private void checkForCSRF(ASTMethod node, Object data) {
+		if (node.getNode().getMethodInfo().isConstructor()) {
+			if (Helper.foundAnyDML(node)) {
+				addViolation(data, node);
+			}
+
+		}
+
+		String name = node.getNode().getMethodInfo().getName();
+		if (name.equalsIgnoreCase(INIT)) {
+			if (Helper.foundAnyDML(node)) {
+				addViolation(data, node);
+			}
+		}
+
+	}
+}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexInsecureEndpointRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexInsecureEndpointRule.java
@@ -1,0 +1,128 @@
+package net.sourceforge.pmd.lang.apex.rule.security;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import apex.jorje.semantic.ast.expression.VariableExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTAssignmentExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTBinaryExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTFieldDeclaration;
+import net.sourceforge.pmd.lang.apex.ast.ASTLiteralExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration;
+import net.sourceforge.pmd.lang.apex.ast.ASTVariableExpression;
+import net.sourceforge.pmd.lang.apex.ast.AbstractApexNode;
+import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+
+/**
+ * Insecure HTTP endpoints passed to (req.setEndpoint)
+ * req.setHeader('Authorization') should use named credentials
+ * 
+ * @author sergey.gorbaty
+ *
+ */
+public class ApexInsecureEndpointRule extends AbstractApexRule {
+	private static final String SET_ENDPOINT = "setEndpoint";
+	private static final Pattern PATTERN = Pattern.compile("^http://.+?$", Pattern.CASE_INSENSITIVE);
+
+	private static final Set<String> httpEndpointStrings = new HashSet<>();
+
+	public ApexInsecureEndpointRule() {
+		setProperty(CODECLIMATE_CATEGORIES, new String[] { "Security" });
+		setProperty(CODECLIMATE_REMEDIATION_MULTIPLIER, 100);
+		setProperty(CODECLIMATE_BLOCK_HIGHLIGHTING, false);
+	}
+
+	@Override
+	public Object visit(ASTAssignmentExpression node, Object data) {
+		findInsecureEndpoints(node, data);
+		return data;
+	}
+
+	@Override
+	public Object visit(ASTVariableDeclaration node, Object data) {
+		findInsecureEndpoints(node, data);
+		return data;
+	}
+
+	@Override
+	public Object visit(ASTFieldDeclaration node, Object data) {
+		findInsecureEndpoints(node, data);
+		return data;
+	}
+
+	private void findInsecureEndpoints(AbstractApexNode<?> node, Object data) {
+		ASTVariableExpression variableNode = node.getFirstChildOfType(ASTVariableExpression.class);
+		findInnerInsecureEndpoints(node, variableNode);
+
+		ASTBinaryExpression binaryNode = node.getFirstChildOfType(ASTBinaryExpression.class);
+		if (binaryNode != null) {
+			
+			findInnerInsecureEndpoints(binaryNode, variableNode);
+		}
+
+	}
+
+	private void findInnerInsecureEndpoints(AbstractApexNode<?> node, ASTVariableExpression variableNode) {
+		ASTLiteralExpression literalNode = node.getFirstChildOfType(ASTLiteralExpression.class);
+		
+		if (literalNode != null && variableNode != null) {
+			Object o = literalNode.getNode().getLiteral();
+			if (o instanceof String) {
+				String literal = (String) o;
+				if (PATTERN.matcher(literal).matches()) {
+					VariableExpression varExpression = variableNode.getNode();
+					StringBuffer sb = new StringBuffer().append(varExpression.getDefiningType()).append(":")
+							.append(varExpression.getIdentifier().value);
+					httpEndpointStrings.add(sb.toString());
+				}
+			}
+		}
+	}
+
+	@Override
+	public Object visit(ASTMethodCallExpression node, Object data) {
+		processInsecureEndpoint(node, data);
+		return data;
+	}
+
+	private void processInsecureEndpoint(ASTMethodCallExpression node, Object data) {
+		if (!Helper.isMethodName(node, SET_ENDPOINT)) {
+			return;
+		}
+
+		ASTBinaryExpression binaryNode = node.getFirstChildOfType(ASTBinaryExpression.class);
+		if (binaryNode != null) {
+			runChecks(binaryNode, data);
+		}
+
+		runChecks(node, data);
+
+	}
+
+	private void runChecks(AbstractApexNode<?> node, Object data) {
+		ASTLiteralExpression literalNode = node.getFirstChildOfType(ASTLiteralExpression.class);
+		if (literalNode != null) {
+			Object o = literalNode.getNode().getLiteral();
+			if (o instanceof String) {
+				String literal = (String) o;
+				if (PATTERN.matcher(literal).matches()) {
+					addViolation(data, literalNode);
+				}
+			}
+		}
+
+		ASTVariableExpression variableNode = node.getFirstChildOfType(ASTVariableExpression.class);
+		if (variableNode != null) {
+			VariableExpression varExpression = variableNode.getNode();
+			StringBuffer sb = new StringBuffer().append(varExpression.getDefiningType()).append(":")
+					.append(varExpression.getIdentifier().value);
+			if (httpEndpointStrings.contains(sb.toString())) {
+				addViolation(data, variableNode);
+			}
+
+		}
+	}
+
+}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexOpenRedirectRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexOpenRedirectRule.java
@@ -1,0 +1,106 @@
+package net.sourceforge.pmd.lang.apex.rule.security;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import apex.jorje.data.ast.Identifier;
+import apex.jorje.data.ast.TypeRef.ClassTypeRef;
+import net.sourceforge.pmd.lang.apex.ast.ASTBinaryExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTFieldDeclaration;
+import net.sourceforge.pmd.lang.apex.ast.ASTLiteralExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTNewObjectExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration;
+import net.sourceforge.pmd.lang.apex.ast.ASTVariableExpression;
+import net.sourceforge.pmd.lang.apex.ast.AbstractApexNode;
+import net.sourceforge.pmd.lang.apex.ast.ApexNode;
+import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+
+/**
+ * Looking for potential Open redirect via PageReference variable input
+ * 
+ * @author sergey.gorbaty
+ */
+public class ApexOpenRedirectRule extends AbstractApexRule {
+	private final static String PAGEREFERENCE = "PageReference";
+	private final Set<String> listOfStringLiteralVariables = new HashSet<>();
+
+	public ApexOpenRedirectRule() {
+		setProperty(CODECLIMATE_CATEGORIES, new String[] { "Security" });
+		setProperty(CODECLIMATE_REMEDIATION_MULTIPLIER, 100);
+		setProperty(CODECLIMATE_BLOCK_HIGHLIGHTING, false);
+	}
+
+	@Override
+	public Object visit(ASTNewObjectExpression node, Object data) {
+		checkNewObjects(node, data);
+		return data;
+	}
+
+	@Override
+	public Object visit(ASTVariableDeclaration node, Object data) {
+		findSafeLiterals(node);
+
+		return data;
+	}
+
+	private void findSafeLiterals(AbstractApexNode<?> node) {
+		ASTLiteralExpression literal = node.getFirstChildOfType(ASTLiteralExpression.class);
+		if (literal != null) {
+			ASTVariableExpression variable = node.getFirstChildOfType(ASTVariableExpression.class);
+			if (variable != null) {
+				StringBuffer sb = new StringBuffer().append(variable.getNode().getDefiningType()).append(":")
+						.append(variable.getNode().getIdentifier().value);
+				listOfStringLiteralVariables.add(sb.toString());
+			}
+		}
+	}
+
+	@Override
+	public Object visit(ASTFieldDeclaration node, Object data) {
+		findSafeLiterals(node);
+		return data;
+	}
+
+	/**
+	 * Traverses all new declarations to find PageReferences
+	 * 
+	 * @param node
+	 * @param data
+	 */
+	private void checkNewObjects(ASTNewObjectExpression node, Object data) {
+		ClassTypeRef classRef = (ClassTypeRef) node.getNode().getTypeRef();
+		Identifier identifier = classRef.className.get(0);
+
+		if (identifier.value.equalsIgnoreCase(PAGEREFERENCE)) {
+			getObjectValue(node, data);
+		}
+	}
+
+	/**
+	 * Finds any variables being present in PageReference constructor
+	 * 
+	 * @param node
+	 *            - PageReference
+	 * @param data
+	 * 
+	 */
+	private void getObjectValue(ApexNode<?> node, Object data) {
+		// PageReference(foo);
+		final List<ASTVariableExpression> variableExpressions = node.findChildrenOfType(ASTVariableExpression.class);
+		for (ASTVariableExpression variable : variableExpressions) {
+			StringBuffer sb = new StringBuffer().append(variable.getNode().getDefiningType()).append(":")
+					.append(variable.getNode().getIdentifier().value);
+			if (variable.jjtGetChildIndex() == 0 && !listOfStringLiteralVariables.contains(sb.toString())) {
+				addViolation(data, variable);
+			}
+		}
+
+		// PageReference(foo + bar)
+		final List<ASTBinaryExpression> binaryExpressions = node.findChildrenOfType(ASTBinaryExpression.class);
+		for (ASTBinaryExpression z : binaryExpressions) {
+			getObjectValue(z, data);
+		}
+	}
+
+}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
@@ -1,0 +1,128 @@
+package net.sourceforge.pmd.lang.apex.rule.security;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import apex.jorje.semantic.ast.expression.VariableExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTAssignmentExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTBinaryExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTFieldDeclaration;
+import net.sourceforge.pmd.lang.apex.ast.ASTLiteralExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
+import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration;
+import net.sourceforge.pmd.lang.apex.ast.ASTVariableExpression;
+import net.sourceforge.pmd.lang.apex.ast.AbstractApexNode;
+import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+
+/**
+ * Detects if variables in Database.query(variable) is escaped with
+ * String.escapeSingleQuotes
+ * 
+ * @author sergey.gorbaty
+ *
+ */
+public class ApexSOQLInjectionRule extends AbstractApexRule {
+	private static final String JOIN = "join";
+	private static final String ESCAPE_SINGLE_QUOTES = "escapeSingleQuotes";
+	private static final String STRING = "String";
+	private final static String DATABASE = "Database";
+	private final static String QUERY = "query";
+	final private Set<String> safeVariables = new HashSet<>();
+
+	public ApexSOQLInjectionRule() {
+		setProperty(CODECLIMATE_CATEGORIES, new String[] { "Security" });
+		setProperty(CODECLIMATE_REMEDIATION_MULTIPLIER, 100);
+		setProperty(CODECLIMATE_BLOCK_HIGHLIGHTING, false);
+	}
+
+	private void findSanitizedVariables(AbstractApexNode<?> m) {
+		final ASTVariableExpression left = m.getFirstChildOfType(ASTVariableExpression.class);
+		final ASTLiteralExpression literal = m.getFirstChildOfType(ASTLiteralExpression.class);
+		final ASTMethodCallExpression right = m.getFirstChildOfType(ASTMethodCallExpression.class);
+
+		if (literal != null) {
+			if (left != null) {
+				final VariableExpression l = left.getNode();
+				StringBuffer sb = new StringBuffer().append(l.getDefiningType()).append(":")
+						.append(l.getIdentifier().value);
+				safeVariables.add(sb.toString());
+			}
+		}
+
+		if (right != null) {
+			if (Helper.isMethodName(right, STRING, ESCAPE_SINGLE_QUOTES)) {
+				if (left != null) {
+					final VariableExpression l = left.getNode();
+					StringBuffer sb = new StringBuffer().append(l.getDefiningType()).append(":")
+							.append(l.getIdentifier().value);
+					safeVariables.add(sb.toString());
+				}
+			}
+		}
+	}
+
+	private void reportChildren(ASTMethodCallExpression m, Object data) {
+		final List<ASTBinaryExpression> binaryExpr = m.findChildrenOfType(ASTBinaryExpression.class);
+		for (ASTBinaryExpression b : binaryExpr) {
+			List<ASTVariableExpression> vars = b.findDescendantsOfType(ASTVariableExpression.class);
+			for (ASTVariableExpression v : vars) {
+				final VariableExpression l = v.getNode();
+				StringBuffer sb = new StringBuffer().append(l.getDefiningType()).append(":")
+						.append(l.getIdentifier().value);
+
+				if (safeVariables.contains(sb.toString())) {
+					continue;
+				}
+				ASTMethodCallExpression parentCall = v.getFirstParentOfType(ASTMethodCallExpression.class);
+				boolean isSafeMethod = Helper.isMethodName(parentCall, STRING, ESCAPE_SINGLE_QUOTES)
+						|| Helper.isMethodName(parentCall, STRING, JOIN);
+
+				if (!isSafeMethod) {
+					addViolation(data, v);
+				}
+			}
+		}
+	}
+
+	@Override
+	public Object visit(ASTUserClass node, Object data) {
+
+		if (Helper.isTestMethodOrClass(node)) {
+			return data;
+		}
+
+		// baz = String.escapeSignleQuotes(...);
+		final List<ASTAssignmentExpression> assignmentCalls = node.findDescendantsOfType(ASTAssignmentExpression.class);
+
+		for (ASTAssignmentExpression a : assignmentCalls) {
+			findSanitizedVariables(a);
+		}
+
+		final List<ASTFieldDeclaration> fieldExpr = node.findDescendantsOfType(ASTFieldDeclaration.class);
+		for (ASTFieldDeclaration a : fieldExpr) {
+			findSanitizedVariables(a);
+		}
+
+		// String foo = String.escapeSignleQuotes(...);
+		final List<ASTVariableDeclaration> variableDecl = node.findDescendantsOfType(ASTVariableDeclaration.class);
+		for (ASTVariableDeclaration a : variableDecl) {
+			findSanitizedVariables(a);
+		}
+
+		// Database.query(...)
+		final List<ASTMethodCallExpression> potentialDbQueryCalls = node
+				.findDescendantsOfType(ASTMethodCallExpression.class);
+
+		for (ASTMethodCallExpression m : potentialDbQueryCalls) {
+
+			if (!Helper.isTestMethodOrClass(m) && Helper.isMethodName(m, DATABASE, QUERY)) {
+				reportChildren(m, data);
+			}
+		}
+
+		return data;
+	}
+
+}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSharingViolationsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSharingViolationsRule.java
@@ -1,0 +1,58 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+package net.sourceforge.pmd.lang.apex.rule.security;
+
+import apex.jorje.semantic.ast.modifier.OldModifiers.ModifierType;
+import apex.jorje.semantic.symbol.type.ModifierOrAnnotationTypeInfo;
+import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
+import net.sourceforge.pmd.lang.apex.ast.ApexNode;
+import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+
+/**
+ * Finds Apex class that do not define sharing
+ * 
+ * @author sergey.gorbaty
+ */
+public class ApexSharingViolationsRule extends AbstractApexRule {
+
+	public ApexSharingViolationsRule() {
+		setProperty(CODECLIMATE_CATEGORIES, new String[] { "Security" });
+		setProperty(CODECLIMATE_REMEDIATION_MULTIPLIER, 100);
+		setProperty(CODECLIMATE_BLOCK_HIGHLIGHTING, false);
+	}
+
+	@Override
+	public Object visit(ASTUserClass node, Object data) {
+		if (!Helper.isTestMethodOrClass(node)) {
+			checkForSharingDeclaration(node, data);
+		}
+		return data;
+	}
+
+	/**
+	 * Check if class has no sharing declared
+	 * 
+	 * @param node
+	 * @param data
+	 */
+	private void checkForSharingDeclaration(ApexNode<?> node, Object data) {
+		final boolean foundAnyDMLorSOQL = Helper.foundAnyDML(node) && Helper.foundAnySOQLorSOSL(node);
+		boolean sharingFound = false;
+
+		for (ModifierOrAnnotationTypeInfo type : node.getNode().getDefiningType().getModifiers().all()) {
+			if (type.getBytecodeName().equalsIgnoreCase(ModifierType.WithoutSharing.toString())) {
+				sharingFound = true;
+			}
+			if (type.getBytecodeName().equalsIgnoreCase(ModifierType.WithSharing.toString())) {
+				sharingFound = true;
+			}
+
+		}
+
+		if (!sharingFound && !Helper.isTestMethodOrClass(node) && foundAnyDMLorSOQL) {
+			addViolation(data, node);
+		}
+	}
+
+}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromEscapeFalseRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromEscapeFalseRule.java
@@ -1,0 +1,65 @@
+package net.sourceforge.pmd.lang.apex.rule.security;
+
+import java.util.List;
+
+import net.sourceforge.pmd.lang.apex.ast.ASTLiteralExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
+import net.sourceforge.pmd.lang.apex.ast.ASTVariableExpression;
+import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+
+/**
+ * Finds all .addError method calls that are not HTML escaped on purpose
+ * 
+ * @author sergey.gorbaty
+ *
+ */
+public class ApexXSSFromEscapeFalseRule extends AbstractApexRule {
+	private static final String ADD_ERROR = "addError";
+
+	public ApexXSSFromEscapeFalseRule() {
+		setProperty(CODECLIMATE_CATEGORIES, new String[] { "Security" });
+		setProperty(CODECLIMATE_REMEDIATION_MULTIPLIER, 100);
+		setProperty(CODECLIMATE_BLOCK_HIGHLIGHTING, false);
+	}
+
+	@Override
+	public Object visit(ASTUserClass node, Object data) {
+		if (Helper.isTestMethodOrClass(node)){
+			return data;
+		}
+		
+		List<ASTMethodCallExpression> methodCalls = node.findDescendantsOfType(ASTMethodCallExpression.class);
+		for (ASTMethodCallExpression methodCall : methodCalls) {
+			if (Helper.isMethodName(methodCall, ADD_ERROR)) {
+				validateBooleanParameter(methodCall, data);
+			}
+		}
+		return data;
+	}
+
+	private void validateBooleanParameter(ASTMethodCallExpression methodCall, Object data) {
+		int numberOfChildren = methodCall.jjtGetNumChildren();
+		if (numberOfChildren == 3) { // addError('',false)
+			Object potentialLiteral = methodCall.jjtGetChild(2);
+			if (potentialLiteral instanceof ASTLiteralExpression) {
+				ASTLiteralExpression parameter = (ASTLiteralExpression) potentialLiteral;
+				Object o = parameter.getNode().getLiteral();
+				if (o instanceof Boolean) {
+					Boolean paramValue = (Boolean) o;
+					if (paramValue.equals(Boolean.FALSE)) {
+						validateLiteralPresence(methodCall, data);
+					}
+				}
+			}
+		}
+	}
+
+	private void validateLiteralPresence(ASTMethodCallExpression methodCall, Object data) {
+		List<ASTVariableExpression> variables = methodCall.findDescendantsOfType(ASTVariableExpression.class);
+		for (ASTVariableExpression v : variables) {
+			addViolation(data, v);
+		}
+	}
+
+}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromURLParamRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromURLParamRule.java
@@ -1,0 +1,225 @@
+package net.sourceforge.pmd.lang.apex.rule.security;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import apex.jorje.semantic.ast.expression.VariableExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTAssignmentExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTBinaryExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTDottedExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTFieldDeclaration;
+import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTReferenceExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration;
+import net.sourceforge.pmd.lang.apex.ast.ASTVariableExpression;
+import net.sourceforge.pmd.lang.apex.ast.AbstractApexNode;
+import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+
+/**
+ * Detects potential XSS when controller extracts a variable from URL query and
+ * uses it without escaping first
+ * 
+ * @author sergey.gorbaty
+ *
+ */
+public class ApexXSSFromURLParamRule extends AbstractApexRule {
+	private static final String[] URL_PARAMETER_METHOD = new String[] { "ApexPages", "currentPage", "getParameters",
+			"get" };
+	private static final String[] HTML_ESCAPING = new String[] { "ESAPI", "encoder", "SFDC_HTMLENCODE" };
+	private static final String[] JS_ESCAPING = new String[] { "ESAPI", "encoder", "SFDC_JSENCODE" };
+	private static final String[] JSINHTML_ESCAPING = new String[] { "ESAPI", "encoder", "SFDC_JSINHTMLENCODE" };
+	private static final String[] URL_ESCAPING = new String[] { "ESAPI", "encoder", "SFDC_URLENCODE" };
+	private static final String[] INTEGER_VALUEOF = new String[] { "Integer", "valueOf" };
+	private static final String[] ID_VALUEOF = new String[] { "ID", "valueOf" };
+	private static final String[] DOUBLE_VALUEOF = new String[] { "Double", "valueOf" };
+
+	private static final Set<String> urlParameterString = new HashSet<>();
+
+	public ApexXSSFromURLParamRule() {
+		setProperty(CODECLIMATE_CATEGORIES, new String[] { "Security" });
+		setProperty(CODECLIMATE_REMEDIATION_MULTIPLIER, 50);
+		setProperty(CODECLIMATE_BLOCK_HIGHLIGHTING, false);
+	}
+
+	@Override
+	public Object visit(ASTAssignmentExpression node, Object data) {
+		findTaintedVariables(node, data);
+		processVariableAssignments(node, data, false);
+		return data;
+	}
+
+	@Override
+	public Object visit(ASTVariableDeclaration node, Object data) {
+		findTaintedVariables(node, data);
+		processVariableAssignments(node, data, true);
+		return data;
+	}
+
+	@Override
+	public Object visit(ASTFieldDeclaration node, Object data) {
+		findTaintedVariables(node, data);
+		processVariableAssignments(node, data, true);
+		return data;
+	}
+
+	@Override
+	public Object visit(ASTMethodCallExpression node, Object data) {
+		processEscapingMethodCalls(node, data);
+		processInlineMethodCalls(node, data, false);
+		return data;
+	}
+
+	private boolean isEscapingMethod(ASTMethodCallExpression methodNode) {
+		return isMethodCallChain(methodNode, HTML_ESCAPING) || isMethodCallChain(methodNode, JS_ESCAPING)
+				|| isMethodCallChain(methodNode, JSINHTML_ESCAPING) || isMethodCallChain(methodNode, URL_ESCAPING);
+	}
+
+	private void processInlineMethodCalls(ASTMethodCallExpression methodNode, Object data, final boolean isNested) {
+		ASTMethodCallExpression nestedCall = methodNode.getFirstChildOfType(ASTMethodCallExpression.class);
+		if (nestedCall != null) {
+
+			if (!isEscapingMethod(methodNode)) {
+				processInlineMethodCalls(nestedCall, data, true);
+			}
+		}
+
+		if (isMethodCallChain(methodNode, URL_PARAMETER_METHOD)) {
+			if (isNested) {
+				addViolation(data, methodNode);
+			}
+		}
+
+	}
+
+	private void findTaintedVariables(AbstractApexNode<?> node, Object data) {
+		final ASTMethodCallExpression right = node.getFirstChildOfType(ASTMethodCallExpression.class);
+		// Looks for: (String) foo =
+		// ApexPages.currentPage().getParameters().get(..)
+
+		if (right != null) {
+			if (isMethodCallChain(right, URL_PARAMETER_METHOD)) {
+				ASTVariableExpression left = node.getFirstChildOfType(ASTVariableExpression.class);
+
+				if (left != null) {
+					VariableExpression n = left.getNode();
+					StringBuffer sb = new StringBuffer().append(n.getDefiningType()).append(":")
+							.append(n.getIdentifier().value);
+					urlParameterString.add(sb.toString());
+				}
+			}
+
+			processEscapingMethodCalls(right, data);
+		}
+	}
+
+	private void processEscapingMethodCalls(ASTMethodCallExpression methodNode, Object data) {
+		ASTMethodCallExpression nestedCall = methodNode.getFirstChildOfType(ASTMethodCallExpression.class);
+		if (nestedCall != null) {
+			processEscapingMethodCalls(nestedCall, data);
+		}
+
+		ASTVariableExpression variable = methodNode.getFirstChildOfType(ASTVariableExpression.class);
+
+		if (variable != null) {
+
+			// safe method
+			if (isMethodCallChain(methodNode, INTEGER_VALUEOF) || isMethodCallChain(methodNode, ID_VALUEOF)
+					|| isMethodCallChain(methodNode, DOUBLE_VALUEOF)) {
+				return;
+			}
+
+			VariableExpression n = variable.getNode();
+			StringBuffer sb = new StringBuffer().append(n.getDefiningType()).append(":")
+					.append(n.getIdentifier().value);
+			if (urlParameterString.contains(sb.toString())) {
+				if (!isEscapingMethod(methodNode)) {
+					addViolation(data, variable);
+				}
+			}
+		}
+
+	}
+
+	private void processVariableAssignments(AbstractApexNode<?> node, Object data, final boolean reverseOrder) {
+		ASTMethodCallExpression methodCallAssignment = node.getFirstChildOfType(ASTMethodCallExpression.class);
+		if (methodCallAssignment != null) {
+			processInlineMethodCalls(methodCallAssignment, data, false);
+		}
+
+		List<ASTVariableExpression> nodes = node.findChildrenOfType(ASTVariableExpression.class);
+
+		switch (nodes.size()) {
+		case 1: {
+			// Look for: foo + bar
+			final List<ASTBinaryExpression> ops = node.findChildrenOfType(ASTBinaryExpression.class);
+			if (!ops.isEmpty()) {
+				for (ASTBinaryExpression o : ops) {
+					processBinaryExpression(o, data);
+				}
+			}
+		}
+			break;
+		case 2: {
+			// Look for: foo = bar;
+			final ASTVariableExpression r = reverseOrder ? nodes.get(0) : nodes.get(1);
+			final VariableExpression n = r.getNode();
+
+			StringBuffer sb = new StringBuffer().append(n.getDefiningType()).append(":")
+					.append(n.getIdentifier().value);
+
+			if (urlParameterString.contains(sb.toString())) {
+				addViolation(data, r);
+			}
+		}
+			break;
+		default:
+			break;
+		}
+
+	}
+
+	private void processBinaryExpression(AbstractApexNode<?> node, Object data) {
+		ASTMethodCallExpression methodCallAssignment = node.getFirstChildOfType(ASTMethodCallExpression.class);
+		if (methodCallAssignment != null) {
+			processInlineMethodCalls(methodCallAssignment, data, true);
+		}
+
+		final List<ASTVariableExpression> nodes = node.findChildrenOfType(ASTVariableExpression.class);
+		for (ASTVariableExpression n : nodes) {
+			final VariableExpression _n = n.getNode();
+			StringBuffer sb = new StringBuffer().append(_n.getDefiningType()).append(":").append(_n);
+
+			if (urlParameterString.contains(sb.toString())) {
+				addViolation(data, n);
+			}
+		}
+	}
+
+	private boolean isMethodCallChain(ASTMethodCallExpression methodNode, final String... methodNames) {
+		String methodName = methodNames[methodNames.length - 1];
+		if (Helper.isMethodName(methodNode, methodName)) {
+			ASTReferenceExpression reference = methodNode.getFirstChildOfType(ASTReferenceExpression.class);
+			if (reference != null) {
+				ASTDottedExpression dottedExpression = reference.getFirstChildOfType(ASTDottedExpression.class);
+				if (dottedExpression != null) {
+					ASTMethodCallExpression nestedMethod = dottedExpression
+							.getFirstChildOfType(ASTMethodCallExpression.class);
+					if (nestedMethod != null) {
+						String[] newMethodNames = Arrays.copyOf(methodNames, methodNames.length - 1);
+						return isMethodCallChain(nestedMethod, newMethodNames);
+					} else {
+						String[] newClassName = Arrays.copyOf(methodNames, methodNames.length - 1);
+						if (newClassName.length == 1) {
+							return Helper.isMethodName(methodNode, newClassName[0], methodName);
+						}
+					}
+				}
+
+			}
+		}
+
+		return false;
+	}
+}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
@@ -1,0 +1,86 @@
+package net.sourceforge.pmd.lang.apex.rule.security;
+
+import java.util.List;
+
+import apex.jorje.semantic.ast.expression.MethodCallExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTDmlDeleteStatement;
+import net.sourceforge.pmd.lang.apex.ast.ASTDmlInsertStatement;
+import net.sourceforge.pmd.lang.apex.ast.ASTDmlMergeStatement;
+import net.sourceforge.pmd.lang.apex.ast.ASTDmlUndeleteStatement;
+import net.sourceforge.pmd.lang.apex.ast.ASTDmlUpdateStatement;
+import net.sourceforge.pmd.lang.apex.ast.ASTDmlUpsertStatement;
+import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTModifierNode;
+import net.sourceforge.pmd.lang.apex.ast.ASTReferenceExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTSoqlExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTSoslExpression;
+import net.sourceforge.pmd.lang.apex.ast.ApexNode;
+
+public class Helper {
+	static boolean isTestMethodOrClass(final ApexNode<?> node) {
+		final List<ASTModifierNode> modifierNode = node.findChildrenOfType(ASTModifierNode.class);
+		for (ASTModifierNode m : modifierNode) {
+			if (m.getNode().getModifiers().isTest()) {
+				return true;
+			}
+			;
+		}
+		return false;
+	}
+
+	static boolean foundAnySOQLorSOSL(ApexNode<?> node) {
+		final List<ASTSoqlExpression> dmlSoqlExpression = node.findDescendantsOfType(ASTSoqlExpression.class);
+		final List<ASTSoslExpression> dmlSoslExpression = node.findDescendantsOfType(ASTSoslExpression.class);
+
+		if (dmlSoqlExpression.isEmpty() && dmlSoslExpression.isEmpty()) {
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Finds DML operations in a given node descendants' path
+	 * 
+	 * @param node
+	 * 
+	 * @return true if found DML operations in node descendants
+	 */
+	static boolean foundAnyDML(ApexNode<?> node) {
+
+		final List<ASTDmlUpsertStatement> dmlUpsertStatement = node.findDescendantsOfType(ASTDmlUpsertStatement.class);
+		final List<ASTDmlUpdateStatement> dmlUpdateStatement = node.findDescendantsOfType(ASTDmlUpdateStatement.class);
+		final List<ASTDmlUndeleteStatement> dmlUndeleteStatement = node
+				.findDescendantsOfType(ASTDmlUndeleteStatement.class);
+		final List<ASTDmlMergeStatement> dmlMergeStatement = node.findDescendantsOfType(ASTDmlMergeStatement.class);
+		final List<ASTDmlInsertStatement> dmlInsertStatement = node.findDescendantsOfType(ASTDmlInsertStatement.class);
+		final List<ASTDmlDeleteStatement> dmlDeleteStatement = node.findDescendantsOfType(ASTDmlDeleteStatement.class);
+
+		if (dmlUpsertStatement.isEmpty() && dmlUpdateStatement.isEmpty() && dmlUndeleteStatement.isEmpty()
+				&& dmlMergeStatement.isEmpty() && dmlInsertStatement.isEmpty() && dmlDeleteStatement.isEmpty()) {
+			return false;
+		}
+
+		return true;
+	}
+
+	static boolean isMethodName(ASTMethodCallExpression methodNode, String className, String methodName) {
+		ASTReferenceExpression reference = methodNode.getFirstChildOfType(ASTReferenceExpression.class);
+		if (reference.getNode().getJadtIdentifiers().size() == 1) {
+			if (reference.getNode().getJadtIdentifiers().get(0).value.equalsIgnoreCase(className)
+					&& isMethodName(methodNode, methodName)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	static boolean isMethodName(ASTMethodCallExpression m, String methodName) {
+		return isMethodName(m.getNode(), methodName);
+	}
+
+	static boolean isMethodName(MethodCallExpression m, String methodName) {
+		return m.getMethodName().equalsIgnoreCase(methodName);
+	}
+}

--- a/pmd-apex/src/main/resources/rulesets/apex/ruleset.xml
+++ b/pmd-apex/src/main/resources/rulesets/apex/ruleset.xml
@@ -157,7 +157,7 @@
 			<property name="cc_block_highlighting" value="false"/>
 		</properties>
 	</rule>
-
+    
 	<rule ref="rulesets/apex/apexunit.xml/ApexUnitTestShouldNotUseSeeAllDataTrue" message="@isTest(seeAllData=true) should not be used in Apex unit tests because it opens up the existing database data for unexpected modification by tests">
 		<priority>3</priority>
 
@@ -235,5 +235,92 @@
         	<property name="cc_block_highlighting" value="false"/>
        	</properties>
 	</rule>
+	
+	 <rule ref="rulesets/apex/security.xml/ApexSharingViolations" message="Apex classes should declare a sharing model if DML or SOQL is used">
+        <priority>3</priority>
+
+        <properties>
+            <!-- relevant for Code Climate output only -->
+            <property name="cc_categories" value="Security"/>
+            <property name="cc_remediation_points_multiplier" value="5"/>
+            <property name="cc_block_highlighting" value="false"/>
+        </properties>
+    </rule>
+
+ 	<rule ref="rulesets/apex/security.xml/ApexInsecureEndpoint" message="Apex callouts should use encrypted communication channels">
+        <priority>3</priority>
+        <properties>
+            <!-- relevant for Code Climate output only -->
+            <property name="cc_categories" value="Security"/>
+            <property name="cc_remediation_points_multiplier" value="5"/>
+            <property name="cc_block_highlighting" value="false"/>
+        </properties>
+     </rule>
+    
+	 <rule ref="rulesets/apex/security.xml/ApexCSRF" message="Avoid making DML operations in Apex class constructor/init method">
+        <priority>3</priority>
+
+        <properties>
+            <!-- relevant for Code Climate output only -->
+            <property name="cc_categories" value="Security"/>
+            <property name="cc_remediation_points_multiplier" value="150"/>
+            <property name="cc_block_highlighting" value="false"/>
+        </properties>
+    </rule>
+
+    <rule ref="rulesets/apex/security.xml/ApexOpenRedirect" message="Apex classes should safely redirect to a known location">
+        <priority>3</priority>
+
+        <properties>
+            <!-- relevant for Code Climate output only -->
+            <property name="cc_categories" value="Security"/>
+            <property name="cc_remediation_points_multiplier" value="75"/>
+            <property name="cc_block_highlighting" value="false"/>
+        </properties>
+    </rule>	
+    
+     <rule ref="rulesets/apex/security.xml/ApexSOQLInjection" message="Apex classes should escape variables merged in DML query">
+        <priority>3</priority>
+
+        <properties>
+            <!-- relevant for Code Climate output only -->
+            <property name="cc_categories" value="Security"/>
+            <property name="cc_remediation_points_multiplier" value="100"/>
+            <property name="cc_block_highlighting" value="false"/>
+        </properties>
+    </rule>	
+    
+    <rule ref="rulesets/apex/security.xml/ApexXSSFromURLParam" message="Apex classes should escape Strings obtained from URL parameters">
+        <priority>3</priority>
+
+        <properties>
+            <!-- relevant for Code Climate output only -->
+            <property name="cc_categories" value="Security"/>
+            <property name="cc_remediation_points_multiplier" value="100"/>
+            <property name="cc_block_highlighting" value="false"/>
+        </properties>
+    </rule>	
+    
+    <rule ref="rulesets/apex/security.xml/ApexXSSFromEscapeFalse" message="Apex classes should escape addError strings">
+        <priority>3</priority>
+
+        <properties>
+            <!-- relevant for Code Climate output only -->
+            <property name="cc_categories" value="Security"/>
+            <property name="cc_remediation_points_multiplier" value="100"/>
+            <property name="cc_block_highlighting" value="false"/>
+        </properties>
+    </rule>	
+    
+      <rule ref="rulesets/apex/security.xml/ApexBadCrypto" message="Apex Crypto should use random IV/key">
+        <priority>3</priority>
+
+        <properties>
+            <!-- relevant for Code Climate output only -->
+            <property name="cc_categories" value="Security"/>
+            <property name="cc_remediation_points_multiplier" value="100"/>
+            <property name="cc_block_highlighting" value="false"/>
+        </properties>
+    </rule>	
 	
 </ruleset>

--- a/pmd-apex/src/main/resources/rulesets/apex/rulesets.properties
+++ b/pmd-apex/src/main/resources/rulesets/apex/rulesets.properties
@@ -2,4 +2,4 @@
 # BSD-style license; for more info see http://pmd.sourceforge.net/license.html
 #
 
-rulesets.filenames=rulesets/apex/complexity.xml,rulesets/apex/performance.xml,rulesets/apex/style.xml,rulesets/apex/apexunit.xml
+rulesets.filenames=rulesets/apex/complexity.xml,rulesets/apex/performance.xml,rulesets/apex/style.xml,rulesets/apex/apexunit.xml,rulesets/apex/security.xml

--- a/pmd-apex/src/main/resources/rulesets/apex/security.xml
+++ b/pmd-apex/src/main/resources/rulesets/apex/security.xml
@@ -1,0 +1,167 @@
+<?xml version="1.0"?>
+
+<ruleset name="Security" xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+	<description>
+        These rules deal with different security problems that can occur within Apex.
+    </description>
+
+	<rule name="ApexSharingViolations" since="5.5.1"
+		message="Apex classes should declare a sharing model if DML or SOQL/SOSL is used"
+		class="net.sourceforge.pmd.lang.apex.rule.security.ApexSharingViolationsRule"
+		externalInfoUrl="${pmd.website.baseurl}/">
+		<description>
+            Avoid Apex classes declared with no explicit sharing mode if DML methods are used.
+        </description>
+		<priority>3</priority>
+		<example>
+            <![CDATA[
+public class without sharing Foo {
+// DML operation here
+}
+    ]]>
+        </example>
+	</rule>
+
+	<rule name="ApexOpenRedirect" since="5.5.1"
+		message="Apex classes should safely redirect to a known location"
+		class="net.sourceforge.pmd.lang.apex.rule.security.ApexOpenRedirectRule"
+		externalInfoUrl="${pmd.website.baseurl}/">
+		<description>
+            Avoid Apex controllers using PageReference to redirect to an unknown location
+        </description>
+		<priority>3</priority>
+		<example>
+            <![CDATA[
+public class without sharing Foo {
+	String unsafeLocation = ApexPage.getCurrentPage().getParameters.get('url_param');
+    PageReference page() {
+       return new PageReference(unsafeLocation);
+    }
+}
+    ]]>
+        </example>
+	</rule>
+
+
+	<rule name="ApexInsecureEndpoint" since="5.5.1"
+		message="Apex callouts should use encrypted communication channels"
+		class="net.sourceforge.pmd.lang.apex.rule.security.ApexInsecureEndpointRule"
+		externalInfoUrl="${pmd.website.baseurl}/">
+		<description>
+            Apex callouts should use encrypted communication channels
+        </description>
+		<priority>3</priority>
+		<example>
+            <![CDATA[
+public class without sharing Foo {
+    void foo() {
+		HttpRequest req = new HttpRequest();
+		req.setEndpoint('http://localhost:com');
+    }
+}
+    ]]>
+        </example>
+	</rule>
+
+	<rule name="ApexXSSFromURLParam" since="5.5.1"
+		message="Apex classes should escape/sanitize Strings obtained from URL parameters"
+		class="net.sourceforge.pmd.lang.apex.rule.security.ApexXSSFromURLParamRule"
+		externalInfoUrl="${pmd.website.baseurl}/">
+		<description>
+            Apex classes should escape/sanitize Strings obtained from URL parameters
+        </description>
+		<priority>3</priority>
+		<example>
+            <![CDATA[
+public class without sharing Foo {
+	String unescapedstring = ApexPage.getCurrentPage().getParameters.get('url_param');
+	String usedLater = unescapedstring;
+}
+    ]]>
+        </example>
+	</rule>
+
+
+	<rule name="ApexXSSFromEscapeFalse" since="5.5.1"
+	message="Apex classes should escape Strings in error messages"
+	class="net.sourceforge.pmd.lang.apex.rule.security.ApexXSSFromEscapeFalseRule"
+	externalInfoUrl="${pmd.website.baseurl}/">
+		<description>
+            Apex classes should escape Strings in error messages
+        </description>
+		<priority>3</priority>
+		<example>
+            <![CDATA[
+public class without sharing Foo {
+	Trigger.new[0].addError(vulnerableHTMLGoesHere, false);
+}
+    ]]>
+        </example>
+	</rule>
+
+	<rule name="ApexBadCrypto" since="5.5.1"
+		message="Apex classes should use random IV/key"
+		class="net.sourceforge.pmd.lang.apex.rule.security.ApexBadCryptoRule"
+		externalInfoUrl="${pmd.website.baseurl}/">
+		<description>
+            Apex classes should use random IV/key
+        </description>
+		<priority>3</priority>
+		<example>
+            <![CDATA[
+public class without sharing Foo {
+	Blob hardCodedIV = Blob.valueOf('Example of IV123');
+	Blob key = Crypto.generateAesKey(128);
+	Blob data = Blob.valueOf('Data to be encrypted');
+	Blob encrypted = Crypto.encrypt('AES128', key, hardCodedIV, data);
+}
+    ]]>
+        </example>
+	</rule>
+
+
+	<rule name="ApexCSRF" since="5.5.1"
+		message="Avoid making DML operations in Apex class constructor/init method"
+		class="net.sourceforge.pmd.lang.apex.rule.security.ApexCSRFRule"
+		externalInfoUrl="${pmd.website.baseurl}/">
+		<description>
+            Avoid DML actions in Apex class constructor/init method without CSRF protection
+        </description>
+		<priority>3</priority>
+		<example>
+            <![CDATA[
+public class Foo {
+	public init() {
+		insert data;
+	}
+
+	public Foo() {
+		insert data;
+	}
+}
+    ]]>
+        </example>
+	</rule>
+
+	<rule name="ApexSOQLInjection" since="5.5.1"
+		message="Avoid untrusted/unescaped variables in DML query"
+		class="net.sourceforge.pmd.lang.apex.rule.security.ApexSOQLInjectionRule"
+		externalInfoUrl="${pmd.website.baseurl}/">
+		<description>
+            Avoid merging untrusted/unescaped variables in DML operations 
+        </description>
+		<priority>3</priority>
+		<example>
+            <![CDATA[
+public class Foo {
+	public void test1(String t1) {
+		Database.query('SELECT Id FROM Account' + t1);		
+	}
+}
+    ]]>
+        </example>
+	</rule>
+
+</ruleset>

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/SecurityRulesTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/SecurityRulesTest.java
@@ -1,0 +1,22 @@
+package net.sourceforge.pmd.lang.apex.rule.security;
+
+import net.sourceforge.pmd.testframework.SimpleAggregatorTst;
+
+public class SecurityRulesTest extends SimpleAggregatorTst {
+
+	private static final String RULESET = "apex-security";
+
+	@Override
+	public void setUp() {
+		addRule(RULESET, "ApexBadCrypto");
+		addRule(RULESET, "ApexXSSFromEscapeFalse");
+		addRule(RULESET, "ApexXSSFromURLParam");
+		addRule(RULESET, "ApexCSRF");
+		addRule(RULESET, "ApexOpenRedirect");
+		addRule(RULESET, "ApexSOQLInjection");
+		addRule(RULESET, "ApexSharingViolations");
+		addRule(RULESET, "ApexInsecureEndpoint");
+
+	}
+
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexBadCrypto.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexBadCrypto.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<test-data>
+
+	<test-code>
+		<description>Apex Crypto hardcoded IV</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public Foo() {
+		Blob exampleIv = Blob.valueOf('0000000000000000');
+		Blob key = Crypto.generateAesKey(128);
+		Blob data = Blob.valueOf('Data to be encrypted');
+		Blob encrypted = Crypto.encrypt('AES128', key, exampleIv, data);
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Apex Crypto hardcoded key</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public Foo() {
+		Blob exampleIv = Crypto.generateAesKey(128);
+		Blob key = Blob.valueOf('0000000000000000'); 
+		Blob data = Blob.valueOf('Data to be encrypted');
+		Blob encrypted = Crypto.encrypt('AES128', key, exampleIv, data);
+	}
+}
+		]]></code>
+	</test-code>
+	<test-code>
+		<description>Apex Crypto Safe Random IV</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+
+	public test1() {
+		Blob exampleIv = Crypto.generateAesKey(128);
+		Blob key = Crypto.generateAesKey(128);
+		Blob data = Blob.valueOf('Data to be encrypted');
+		Blob encrypted = Crypto.encrypt('AES128', key, exampleIv, data);
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Apex Crypto Safe Random IV</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+
+	public test1() {
+		Blob key = Crypto.generateAesKey(128);
+		Blob data = Blob.valueOf('Data to be encrypted');
+		Blob encrypted = Crypto.encryptWithManagedIV('AES128', key, data);
+	}
+}
+		]]></code>
+	</test-code>
+
+<test-code>
+		<description>Apex Crypto Non safe Key</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+
+	public test1() {
+		Blob key =  Blob.valueOf('Key to be encrypted');
+		Blob data = Blob.valueOf('Data to be encrypted');
+		Blob encrypted = Crypto.encryptWithManagedIV('AES128', key, data);
+	}
+}
+		]]></code>
+	</test-code>
+
+
+</test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCSRF.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCSRF.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<test-data>
+
+	<test-code>
+		<description>Apex CSRF in constructor</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+
+	public Foo() {
+		List<Account> accounts = [SELECT Id FROM Account LIMIT 1];
+		upsert accounts;	
+	}
+}
+		]]></code>
+	</test-code>
+
+<test-code>
+		<description>Apex CSRF in init method</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+
+	public void init() {
+		List<Account> accounts = [SELECT Id FROM Account LIMIT 1];
+		upsert accounts;	
+	}
+}
+		]]></code>
+	</test-code>
+	
+	<test-code>
+		<description>Apex CSRF in init method</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+
+	public void init() {
+		List<Account> accounts = [SELECT Id FROM Account LIMIT 1];
+			
+	}
+}
+		]]></code>
+	</test-code>
+	
+		<test-code>
+		<description>Apex CSRF in constructor</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+
+	public Foo() {
+		List<Account> accounts = [SELECT Id FROM Account LIMIT 1];
+	}
+}
+		]]></code>
+	</test-code>
+
+</test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexInsecureEndpoint.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexInsecureEndpoint.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<test-data>
+
+	<test-code>
+		<description>Insecure callout endpoint variable concat</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	void foo() {
+		HttpRequest req = new HttpRequest();
+		req.setEndpoint('http://localhost:com' + somevar);
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Insecure callout endpoint</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	void foo() {
+		HttpRequest req = new HttpRequest();
+		req.setEndpoint('http://localhost:com');
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Secure callout endpoint</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	void foo() {
+		HttpRequest req = new HttpRequest();
+		req.setEndpoint('https://localhost:com');
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Insecure callout endpoint from a variable 1</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	void foo() {
+		String endpoint = 'http://localhost:3300';
+		HttpRequest req = new HttpRequest();
+		req.setEndpoint(endpoint);
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Insecure callout endpoint from a variable 2</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	void foo() {
+		String endpoint;
+		endpoint = 'http://localhost:3300' + someVar;
+		HttpRequest req = new HttpRequest();
+		req.setEndpoint(endpoint);
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Insecure callout endpoint from a variable 3</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	private String endpoint = 'http://localhost:3300';
+	void foo() {
+		HttpRequest req = new HttpRequest();
+		req.setEndpoint(endpoint);
+	}
+}
+		]]></code>
+	</test-code>
+</test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexOpenRedirect.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexOpenRedirect.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<test-data>
+
+	<test-code>
+		<description>PageReference open redirect with unsafe variable
+			concatenation
+		</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public PageReference redirect() {
+	    return new PageReference(test1 + 'something later');
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>PageReference open redirect with variable</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public PageReference redirect() {
+		return new PageReference(test);
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>PageReference open redirect with variable that comes from
+			a literal
+		</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public PageReference redirect() {
+		String test = 'hardcoded value here'; 
+		return new PageReference(test);
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>PageReference open redirect with variable concatenation
+		</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void redirect() {
+	    PageReference newTestPage = new PageReference('https://www.apex.com/myVFPage' + test);
+	}
+}
+		]]></code>
+	</test-code>
+
+
+	<test-code>
+		<description>PageReference open redirect with variable concatenation
+			obtained from a literal
+		</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void redirect() {
+		String test = 'hardcoded';
+	    PageReference newTestPage = new PageReference(test + 'something later');
+	}
+}
+		]]></code>
+	</test-code>
+
+
+	<test-code>
+		<description>PageReference redirect to literal</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public PageReference redirect() {
+	    return new PageReference('/apex/myVFPage');
+	}
+}
+		]]></code>
+	</test-code>
+
+</test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSOQLInjection.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSOQLInjection.xml
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<test-data>
+
+	<test-code>
+		<description>Safe SOQL + merged variable from a literal</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		String field1 = String.escapeSingleQuotes('yo'); 
+		Database.query('SELECT Id FROM Account WHERE Id =' + field1);
+	}		
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Safe SOQL + merged variable</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+
+	public void test1(String field1) {
+		field2 = String.escapeSingleQuotes(field1); 
+		Database.query('SELECT Id FROM Account WHERE Id =' + field2);		
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>No issue when SOQL is called</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		Database.query('SELECT Id FROM Account');		
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Potentially unsafe SOQL with variable concatenation
+		</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1(String t1) {
+		Database.query('SELECT Id FROM Account' + t1);		
+	}
+}
+		]]></code>
+	</test-code>
+	
+	<test-code>
+		<description>Potentially unsafe SOQL with multiple variable concatenation
+		</description>
+		<expected-problems>2</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1(String t1, String t2) {
+		Database.query('SELECT Id FROM Account ' + t1 + ' WHERE ' + t2 + ';');		
+	}
+}
+		]]></code>
+	</test-code>
+	
+	<test-code>
+		<description>Safe SOQL with List concatenation
+		</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1(List<String> t1) {
+		Database.query('SELECT Id FROM Account ' + string.join(t1, ','));		
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>SOQL + merged variable from literal
+		</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		String field1 = 'yo'; 
+		Database.query('SELECT Id FROM Account WHERE Id =' + field1);		
+	}
+}
+		]]></code>
+	</test-code>
+	<test-code>
+		<description>SOQL with merged with field variable 
+		</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public static String field1 = 'yo'; 
+	public void test1() {	
+		Database.query('SELECT Id FROM Account WHERE Id =' + field1 + 'string');		
+	}
+}
+		]]></code>
+	</test-code>
+	<test-code>
+		<description>SOQL with merged variable from literal 2
+		</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		String field1 = 'yo'; 
+		Database.query('SELECT Id FROM Account WHERE Id =' + field1 + 'string');		
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Safe SOQL + merged variable</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+		
+public class Foo {
+	public void test1(String field1) {
+		Database.query('SELECT Id FROM Account WHERE Id =' + String.escapeSingleQuotes(field1) + 'string');		
+	}
+}
+		]]></code>
+	</test-code>
+
+</test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSharingViolations.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSharingViolations.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<test-data>
+
+	<test-code>
+		<description>Apex class without sharing</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+	}
+}
+		]]></code>
+	</test-code>
+
+
+	<test-code>
+		<description>Apex class without any sharing declared with DML
+		</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		List<Account> accounts = [SELECT Id FROM Account LIMIT 1];
+		upsert accounts;
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Apex class with explicit sharing with DML</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public with sharing class Foo {
+	public void test1() {
+		List<Account> accounts = [SELECT Id FROM Account LIMIT 1];
+		upsert accounts;
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Apex class with explicit sharing with DML</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public without sharing class Foo {
+	public void test1() {
+		List<Account> accounts = [SELECT Id FROM Account LIMIT 1];
+		upsert accounts;
+	}
+}
+		]]></code>
+	</test-code>
+
+</test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexXSSFromEscapeFalse.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexXSSFromEscapeFalse.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<test-data>
+	<test-code>
+		<description>Add error variable with escape false</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1(String bad) {
+		Trigger.new[0].addError(bad, false);
+	}		
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Add error literal with escape false</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		Trigger.new[0].addError('something else', false);
+	}		
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Add error literal and variable with escape false
+		</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		Trigger.new[0].addError('something else' + bad, false);
+	}		
+}
+		]]></code>
+	</test-code>
+
+</test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexXSSFromURLParam.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexXSSFromURLParam.xml
@@ -1,0 +1,226 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<test-data>
+
+	  <test-code>
+		<description>URL parameter used without being escaped 1</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		String baz, bas;
+		bas = ApexPages.currentPage().getParameters().get('foo');
+		baz = bas;
+	}		
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>URL parameter passed to escaping function</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		String baz, bas;
+		bas = ApexPages.currentPage().getParameters().get('foo');
+		ESAPI.encoder().SFDC_HTMLENCODE(bas);
+	}		
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>URL parameter passed to a function without being escaped
+		</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		String baz, bas;
+		bas = ApexPages.currentPage().getParameters().get('foo');
+		foo(bas);
+	}		
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>URL parameter passed to escaping function and then
+			assigned</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		String baz, bas;
+		bas = ApexPages.currentPage().getParameters().get('foo');
+		baz = ESAPI.encoder().SFDC_HTMLENCODE(bas);
+	}		
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>URL parameter passed to a function and then assigned
+		</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		String baz, bas;
+		bas = ApexPages.currentPage().getParameters().get('foo');
+		baz = foo(bas);
+	}		
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>URL parameter used without being escaped 2</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		String foo = ApexPages.currentPage().getParameters().get('foo');
+		String bar = foo;
+
+	}		
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>URL parameter concatenation used without being escaped
+		</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		String baz = 'baz';
+		String foo = ApexPages.currentPage().getParameters().get('foo');
+		String bar = foo + baz;
+	}		
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>URL parameter concatenation used without being escaped
+		</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		String foo = ApexPages.currentPage().getParameters().get('foo');
+		String bar = 'baz' + foo;
+	}		
+}
+		]]></code>
+	</test-code> 
+	
+	 <test-code>
+		<description>URL parameter passed to a function</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		foo(ApexPages.currentPage().getParameters().get('foo'));
+	}		
+}
+		]]></code>
+	</test-code> 
+	
+	<test-code>
+		<description>Safe URL parameter passed to a function</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		foo(ESAPI.encoder().SFDC_HTMLENCODE(ApexPages.currentPage().getParameters().get('foo')));
+	}		
+}
+		]]></code>
+	</test-code> 
+	
+	<test-code>
+		<description>URL parameter passed to a function with variable declaration</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		String baz = foo(ApexPages.currentPage().getParameters().get('foo'));
+	}		
+}
+		]]></code>
+	</test-code>
+	
+	<test-code>
+		<description>Safe URL parameter passed to a function with variable declaration</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		String baz = foo(ESAPI.encoder().SFDC_HTMLENCODE(ApexPages.currentPage().getParameters().get('foo')));
+	}		
+}
+		]]></code>
+	</test-code> 
+	
+	 <test-code>
+		<description>URL parameter concatenated with variable
+		</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		String bar = 'foo' + ApexPages.currentPage().getParameters().get('foo');
+	}		
+}
+		]]></code>
+	</test-code> 
+	
+	<test-code>
+		<description>Safe URL parameter concatenated with variable
+		</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		String bar = 'foo' + ESAPI.encoder().SFDC_HTMLENCODE(ApexPages.currentPage().getParameters().get('foo'));
+	}		
+}
+		]]></code>
+	</test-code> 
+	
+	<test-code>
+		<description>URL parameter type casting is a safety check</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		String baz, bas;
+		bas = ApexPages.currentPage().getParameters().get('foo');
+		baz = Integer.valueOf(bas);
+	}		
+}
+		]]></code>
+	</test-code>
+	
+	<test-code>
+		<description>URL parameter method passing</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		String baz, bas;
+		bas = ApexPages.currentPage().getParameters().get('foo');
+		baz = incorrectEscaping(bas);
+	}		
+}
+		]]></code>
+		
+		
+	</test-code>
+
+
+</test-data>


### PR DESCRIPTION
Hi PMD!

I added a set of new rules that allows detection of the following potential security issues:
- Reflected XSS via URL parameter
- Reflected XSS via disabled escaping
- Sharing violation
- CSRF when DML happens in a controller constructor / init method
- Open Redirect detection
- SOQL injection from merging unescaped variables
- Insecure HTTP Endpoint 
- Unsafe crypto practices

All new code is accompanied with unit tests. 

More to come!

Cheers,
Sergey