### PR TITLE
[core] Text renderer with columns

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/AtomRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/AtomRenderer.java
@@ -1,0 +1,54 @@
+package net.sourceforge.pmd.renderers;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Iterator;
+
+import net.sourceforge.pmd.PMD;
+import net.sourceforge.pmd.RuleViolation;
+
+public class AtomRenderer extends AbstractIncrementingRenderer {
+
+	public static final String NAME = "atomtext";
+
+	public AtomRenderer() {
+		super(NAME, "Atom text format.");
+	}
+
+
+    public String defaultFileExtension() { return "txt"; }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void start() throws IOException {
+    }
+    
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void renderFileViolations(Iterator<RuleViolation> violations) throws IOException {
+		Writer writer = getWriter();
+		StringBuilder buf = new StringBuilder();
+
+		while (violations.hasNext()) {
+			buf.setLength(0);
+			RuleViolation rv = violations.next();
+			buf.append(rv.getFilename());
+			buf.append(':').append(Integer.toString(rv.getBeginLine()));
+			buf.append(':').append(Integer.toString(rv.getBeginColumn()));
+			buf.append(":\t").append(rv.getDescription()).append(PMD.EOL);
+			writer.write(buf.toString());
+		}
+	}
+	
+	/**
+     * {@inheritDoc}
+     */
+    @Override
+    public void end() throws IOException {
+    }
+
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/RendererFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/RendererFactory.java
@@ -31,6 +31,7 @@ public class RendererFactory {
 	map.put(IDEAJRenderer.NAME, IDEAJRenderer.class);
 	map.put(TextColorRenderer.NAME, TextColorRenderer.class);
 	map.put(TextRenderer.NAME, TextRenderer.class);
+	map.put(AtomRenderer.NAME, AtomRenderer.class);
 	map.put(TextPadRenderer.NAME, TextPadRenderer.class);
 	map.put(EmacsRenderer.NAME, EmacsRenderer.class);
 	map.put(CSVRenderer.NAME, CSVRenderer.class);

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/AtomRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/AtomRendererTest.java
@@ -1,0 +1,36 @@
+package net.sourceforge.pmd.renderers;
+
+import net.sourceforge.pmd.PMD;
+import net.sourceforge.pmd.Report.ProcessingError;
+
+public class AtomRendererTest extends AbstractRendererTst {
+
+	@Override
+	public Renderer getRenderer() {
+		return new AtomRenderer();
+	}
+
+	@Override
+	public String getExpected() {
+		return "n/a:1:1:\tblah" + PMD.EOL;
+	}
+
+	@Override
+	public String getExpectedEmpty() {
+		return "";
+	}
+
+	@Override
+	public String getExpectedMultiple() {
+		return "n/a:1:1:\tblah" + PMD.EOL + "n/a:1:1:\tblah" + PMD.EOL;
+	}
+
+	@Override
+	public String getExpectedError(ProcessingError error) {
+		return "";
+	}
+
+	public static junit.framework.Test suite() {
+		return new junit.framework.JUnit4TestAdapter(AtomRendererTest.class);
+	}
+}


### PR DESCRIPTION
As a part of a plugin for Atom build script to run PMD I need access to columns, which default text renderer doesn't produce. This PR is to add that to a new AtomText renderer.