### PR TITLE
[java] Make ClasspathClassLoader parallel capable

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/ClasspathClassLoader.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/ClasspathClassLoader.java
@@ -29,6 +29,10 @@ public class ClasspathClassLoader extends URLClassLoader {
 
     private static final Logger LOG = Logger.getLogger(ClasspathClassLoader.class.getName());
 
+    static {
+        registerAsParallelCapable();
+    }
+
     public ClasspathClassLoader(String classpath, ClassLoader parent) throws IOException {
         super(initURLs(classpath), parent);
     }


### PR DESCRIPTION
 - It's just a bunch of static methods with no state on a URLClassLoader

This is just the finishing touch on #101, it was missing back then, posibly because he wasn't running with the `-auxclasspath` argument.

I also changed new lines to unix-style, check with `?w=1` to see the trivial change.