### PR TITLE
[core] Create missing intermediate directories for cache

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/FileAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/FileAnalysisCache.java
@@ -73,6 +73,14 @@ public class FileAnalysisCache extends AbstractAnalysisCache {
 
     @Override
     public void persist() {
+        // Create directories missing along the way
+        if (!cacheFile.exists()) {
+            final File parentFile = cacheFile.getAbsoluteFile().getParentFile();
+            if (parentFile != null && !parentFile.exists()) {
+                parentFile.mkdirs();
+            }
+        }
+
         try (
             final DataOutputStream outputStream = new DataOutputStream(
                 new BufferedOutputStream(new FileOutputStream(cacheFile)));


### PR DESCRIPTION
  If the cache location points to a file within a non-existing directory
   make sure to create it for storage to succeed.