### PR TITLE
[apex] Detection of missing Apex CRUD checks for SOQL/DML operations

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
@@ -241,7 +241,8 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
 		final ASTMethod wrappingMethod = node.getFirstParentOfType(ASTMethod.class);
 		final ASTUserClass wrappingClass = node.getFirstParentOfType(ASTUserClass.class);
 
-		if (Helper.isTestMethodOrClass(wrappingClass) || Helper.isTestMethodOrClass(wrappingMethod)) {
+		if ((wrappingClass != null && Helper.isTestMethodOrClass(wrappingClass))
+				|| (wrappingMethod != null && Helper.isTestMethodOrClass(wrappingMethod))) {
 			return;
 		}
 
@@ -322,7 +323,8 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
 		final ASTMethod wrappingMethod = node.getFirstParentOfType(ASTMethod.class);
 		final ASTUserClass wrappingClass = node.getFirstParentOfType(ASTUserClass.class);
 
-		if (Helper.isTestMethodOrClass(wrappingClass) || Helper.isTestMethodOrClass(wrappingMethod)) {
+		if ((wrappingClass != null && Helper.isTestMethodOrClass(wrappingClass))
+				|| (wrappingMethod != null && Helper.isTestMethodOrClass(wrappingMethod))) {
 			return;
 		}
 
@@ -346,7 +348,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
 
 			if (varToTypeMapping.containsKey(variableWithClass.toString())) {
 				String type = varToTypeMapping.get(variableWithClass.toString());
-					
+
 				validateCRUDCheckPresent(node, data, ANY, type);
 
 			}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
@@ -1,0 +1,222 @@
+package net.sourceforge.pmd.lang.apex.rule.security;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+
+import apex.jorje.data.ast.Identifier;
+import net.sourceforge.pmd.lang.apex.ast.ASTDmlDeleteStatement;
+import net.sourceforge.pmd.lang.apex.ast.ASTDmlInsertStatement;
+import net.sourceforge.pmd.lang.apex.ast.ASTDmlUpdateStatement;
+import net.sourceforge.pmd.lang.apex.ast.ASTDottedExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
+import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTReferenceExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTSoqlExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
+import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration;
+import net.sourceforge.pmd.lang.apex.ast.ASTVariableExpression;
+import net.sourceforge.pmd.lang.apex.ast.AbstractApexNode;
+import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+
+/**
+ * Finding missed CRUD checks.
+ * 
+ * @author sergey.gorbaty
+ *
+ */
+public class ApexCRUDViolationRule extends AbstractApexRule {
+	private final HashMap<String, String> varToTypeMapping = new HashMap<>();
+	private final HashMap<String, String> typeToDMLOperationMapping = new HashMap<>();
+	private final HashSet<String> esapiCheckedTypes = new HashSet<>();
+
+	private static final String IS_CREATEABLE = "isCreateable";
+	private static final String IS_DELETABLE = "isDeletable";
+	private static final String IS_UPDATEABLE = "isUpdateable";
+
+	private static final String S_OBJECT_TYPE = "sObjectType";
+	private static final String GET_DESCRIBE = "getDescribe";
+
+	// ESAPI.accessController().isAuthorizedToView(Lead.sObject, fields)
+	private static final String[] ESAPI_ISAUTHORIZED = new String[] { "ESAPI", "accessController",
+			"isAuthorizedToView" };
+	private static final String[] RESERVED_KEYS_FLS = new String[] { "Schema", S_OBJECT_TYPE };
+
+	// private static final String FIELDS = "fields";
+	// private static final String GET_MAP = "getMap";
+
+	public ApexCRUDViolationRule() {
+		setProperty(CODECLIMATE_CATEGORIES, new String[] { "Security" });
+		setProperty(CODECLIMATE_REMEDIATION_MULTIPLIER, 100);
+		setProperty(CODECLIMATE_BLOCK_HIGHLIGHTING, false);
+	}
+
+	@Override
+	public Object visit(ASTMethodCallExpression node, Object data) {
+		final String method = node.getNode().getMethodName();
+		final ASTReferenceExpression ref = node.getFirstChildOfType(ASTReferenceExpression.class);
+		if (ref == null) {
+			return data;
+		}
+
+		List<Identifier> a = ref.getNode().getJadtIdentifiers();
+		if (!a.isEmpty()) {
+			extractObjectAndFields(a, method, node.getNode().getDefiningType().getApexName());
+		} else {
+			// see if ESAPI
+			if (Helper.isMethodCallChain(node, ESAPI_ISAUTHORIZED)) {
+				extractObjectTypeFromESAPI(node);
+			}
+
+			// see if getDescribe()
+			final ASTDottedExpression dottedExpr = ref.getFirstChildOfType(ASTDottedExpression.class);
+			if (dottedExpr != null) {
+				final ASTMethodCallExpression nestedMethodCall = dottedExpr
+						.getFirstChildOfType(ASTMethodCallExpression.class);
+				if (nestedMethodCall != null) {
+					if (isLastMethodName(nestedMethodCall, S_OBJECT_TYPE, GET_DESCRIBE)) {
+						String resolvedType = getType(nestedMethodCall);
+						typeToDMLOperationMapping.put(resolvedType, method);
+					}
+				}
+			}
+
+		}
+
+		return data;
+	}
+
+	@Override
+	public Object visit(ASTDmlInsertStatement node, Object data) {
+		checkForCRUD(node, data, IS_CREATEABLE);
+		return data;
+	}
+
+	@Override
+	public Object visit(ASTDmlDeleteStatement node, Object data) {
+		checkForCRUD(node, data, IS_DELETABLE);
+		return data;
+	}
+
+	@Override
+	public Object visit(ASTDmlUpdateStatement node, Object data) {
+		checkForCRUD(node, data, IS_UPDATEABLE);
+		return data;
+	}
+
+	@Override
+	public Object visit(ASTSoqlExpression node, Object data) {
+		final ASTVariableDeclaration variable = node.getFirstParentOfType(ASTVariableDeclaration.class);
+		if (variable != null) {
+			String type = variable.getNode().getLocalInfo().getType().getApexName();
+			StringBuilder sb = new StringBuilder().append(variable.getNode().getDefiningType().getApexName())
+					.append(":").append(variable.getNode().getLocalInfo().getName());
+			varToTypeMapping.put(sb.toString(), type);
+		}
+		return data;
+	}
+
+	@Override
+	public Object visit(final ASTVariableDeclaration node, Object data) {
+		String type = node.getNode().getLocalInfo().getType().getApexName();
+		StringBuilder sb = new StringBuilder().append(node.getNode().getDefiningType().getApexName()).append(":")
+				.append(node.getNode().getLocalInfo().getName());
+		varToTypeMapping.put(sb.toString(), type);
+
+		return data;
+
+	}
+
+	private boolean isLastMethodName(final ASTMethodCallExpression methodNode, final String className,
+			final String methodName) {
+		final ASTReferenceExpression reference = methodNode.getFirstChildOfType(ASTReferenceExpression.class);
+		if (reference.getNode().getJadtIdentifiers().size() > 0) {
+			if (reference.getNode().getJadtIdentifiers().get(reference.getNode().getJadtIdentifiers().size() - 1).value
+					.equalsIgnoreCase(className) && Helper.isMethodName(methodNode, methodName)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	private String getType(final ASTMethodCallExpression methodNode) {
+		final ASTReferenceExpression reference = methodNode.getFirstChildOfType(ASTReferenceExpression.class);
+		if (reference.getNode().getJadtIdentifiers().size() > 0) {
+			return new StringBuilder().append(reference.getNode().getDefiningType().getApexName()).append(":")
+					.append(reference.getNode().getJadtIdentifiers().get(0).value).toString();
+		}
+		return "";
+	}
+
+	private void extractObjectAndFields(final List<Identifier> listIdentifiers, final String method,
+			final String definingType) {
+		final List<String> strings = listIdentifiers.stream().map(id -> id.value).collect(Collectors.toList());
+
+		int flsIndex = Collections.lastIndexOfSubList(strings, Arrays.asList(RESERVED_KEYS_FLS));
+		if (flsIndex != -1) {
+			String objectTypeName = strings.get(flsIndex + RESERVED_KEYS_FLS.length);
+			typeToDMLOperationMapping.put(definingType + ":" + objectTypeName, method);
+			// TODO: add real FLS check
+			// if (FIELDS.equalsIgnoreCase(strings.get(++flsIndex +
+			// RESERVED_KEYS_FLS.length))) {
+			// String fieldName = strings.get(++flsIndex +
+			// RESERVED_KEYS_FLS.length);
+			// }
+
+		}
+	}
+
+	private void checkForCRUD(final AbstractApexNode<?> node, final Object data, final String CRUDMethod) {
+		final ASTMethod wrappingMethod = node.getFirstParentOfType(ASTMethod.class);
+		final ASTUserClass wrappingClass = node.getFirstParentOfType(ASTUserClass.class);
+
+		if (Helper.isTestMethodOrClass(wrappingClass) || Helper.isTestMethodOrClass(wrappingMethod)) {
+			return;
+		}
+
+		final ASTVariableExpression variable = node.getFirstChildOfType(ASTVariableExpression.class);
+		if (variable != null) {
+			StringBuilder sb = new StringBuilder().append(node.getNode().getDefiningType().getApexName()).append(":")
+					.append(variable.getNode().getIdentifier().value);
+
+			String type = varToTypeMapping.get(sb.toString());
+			if (type != null) {
+				StringBuilder typeCheck = new StringBuilder().append(node.getNode().getDefiningType()).append(":")
+						.append(type);
+
+				if (!typeToDMLOperationMapping.containsKey(typeCheck.toString())) {
+					if (!esapiCheckedTypes.contains(typeCheck.toString())) {
+						addViolation(data, node);
+					}
+				} else {
+					boolean properChecksHappened = typeToDMLOperationMapping.get(typeCheck.toString())
+							.equalsIgnoreCase(CRUDMethod);
+					if (!properChecksHappened) {
+						addViolation(data, node);
+					}
+				}
+			}
+		}
+	}
+
+	private void extractObjectTypeFromESAPI(final ASTMethodCallExpression node) {
+		final ASTVariableExpression var = node.getFirstChildOfType(ASTVariableExpression.class);
+		if (var != null) {
+			final ASTReferenceExpression reference = var.getFirstChildOfType(ASTReferenceExpression.class);
+			if (reference != null) {
+				List<Identifier> identifiers = reference.getNode().getJadtIdentifiers();
+				if (identifiers.size() == 1) {
+					StringBuilder sb = new StringBuilder().append(node.getNode().getDefiningType().getApexName())
+							.append(":").append(identifiers.get(0).value);
+					esapiCheckedTypes.add(sb.toString());
+				}
+
+			}
+		}
+
+	}
+}

--- a/pmd-apex/src/main/resources/rulesets/apex/ruleset.xml
+++ b/pmd-apex/src/main/resources/rulesets/apex/ruleset.xml
@@ -322,5 +322,16 @@
             <property name="cc_block_highlighting" value="false"/>
         </properties>
     </rule>	
+
+      <rule ref="rulesets/apex/security.xml/ApexCRUDViolation" message="Validate CRUD permission before DML operation">
+        <priority>3</priority>
+
+        <properties>
+            <!-- relevant for Code Climate output only -->
+            <property name="cc_categories" value="Security"/>
+            <property name="cc_remediation_points_multiplier" value="150"/>
+            <property name="cc_block_highlighting" value="false"/>
+        </properties>
+    </rule>	
 	
 </ruleset>

--- a/pmd-apex/src/main/resources/rulesets/apex/ruleset.xml
+++ b/pmd-apex/src/main/resources/rulesets/apex/ruleset.xml
@@ -253,7 +253,7 @@
          <property name="cc_block_highlighting" value="false" />
       </properties>
    </rule>
-   <rule ref="rulesets/apex/security.xml/ApexCRUDViolation" message="Validate CRUD permission before DML operation">
+   <rule ref="rulesets/apex/security.xml/ApexCRUDViolation" message="Validate CRUD permission before SOQL/DML operation">
        <priority>3</priority>
        <properties>
           <!-- relevant for Code Climate output only -->

--- a/pmd-apex/src/main/resources/rulesets/apex/security.xml
+++ b/pmd-apex/src/main/resources/rulesets/apex/security.xml
@@ -163,5 +163,30 @@ public class Foo {
     ]]>
         </example>
 	</rule>
+	
+	<rule name="ApexCRUDViolation" since="5.5.3"
+		message="Validate CRUD permission before DML operation"
+		class="net.sourceforge.pmd.lang.apex.rule.security.ApexCRUDViolationRule"
+		externalInfoUrl="${pmd.website.baseurl}/rules/apex/security.html#ApexCRUDViolationRule">
+		<description>
+            Validate CRUD permission before DML operation
+        </description>
+		<priority>3</priority>
+		<example>
+            <![CDATA[
+public class Foo {
+	public Contact foo(String status, String ID) {
+		Contact c = [SELECT Status__c FROM Contact WHERE Id=:ID];
+		if (!Schema.sObjectType.Contact.fields.Name.isUpdateable()){
+      		return null;
+    	}
+    	c.Status__c = status;
+    	update c;
+    	return c;
+	}
+}
+    ]]>
+        </example>
+	</rule>
 
 </ruleset>

--- a/pmd-apex/src/main/resources/rulesets/apex/security.xml
+++ b/pmd-apex/src/main/resources/rulesets/apex/security.xml
@@ -165,11 +165,11 @@ public class Foo {
 	</rule>
 	
 	<rule name="ApexCRUDViolation" since="5.5.3"
-		message="Validate CRUD permission before DML operation"
+		message="Validate CRUD permission before SOQL/DML operation"
 		class="net.sourceforge.pmd.lang.apex.rule.security.ApexCRUDViolationRule"
 		externalInfoUrl="${pmd.website.baseurl}/rules/apex/security.html#ApexCRUDViolationRule">
 		<description>
-            Validate CRUD permission before DML operation
+            Validate CRUD permission before SOQL/SOSL/DML operation
         </description>
 		<priority>3</priority>
 		<example>

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/SecurityRulesTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/SecurityRulesTest.java
@@ -16,6 +16,7 @@ public class SecurityRulesTest extends SimpleAggregatorTst {
 		addRule(RULESET, "ApexSOQLInjection");
 		addRule(RULESET, "ApexSharingViolations");
 		addRule(RULESET, "ApexInsecureEndpoint");
+		addRule(RULESET, "ApexCRUDViolation");
 
 	}
 

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
@@ -2,6 +2,66 @@
 
 <test-data>
 
+<test-code>
+		<description>Proper CRUD,FLS via getters</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[ 
+public class Foo { 
+	public Contact MyWriteOnlyProp { get; set; }
+	
+	public void foo(String newName, String tempID) { 
+		if (Contact.sObjectType.getDescribe().isCreateable()) {
+			MyWriteOnlyProp = new Contact(FirstName = 'First', LastName = 'Last', Phone = '414-414-4414');
+			upsert MyWriteOnlyProp;
+		}
+	} 
+	
+} 
+]]></code>
+	</test-code>
+
+
+<test-code>
+		<description>No CRUD,FLS via getters</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[ 
+public class Foo { 
+	public Contact MyWriteOnlyProp { get; set; }
+	
+	public void foo(String newName, String tempID) { 
+			MyWriteOnlyProp = new Contact(FirstName = 'First', LastName = 'Last', Phone = '414-414-4414');
+			upsert MyWriteOnlyProp;
+	} 
+} 
+]]></code>
+	</test-code>
+
+	<test-code>
+		<description>CRUD,FLS via upsert</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[ 
+public class Foo { 
+	public void foo(String newName, String tempID) { 
+		if (Contact.sObjectType.getDescribe().isCreateable()) {
+			Contact myCon = new Contact(FirstName = 'First', LastName = 'Last', Phone = '414-414-4414');
+			upsert myCon;
+		}
+	} 
+} ]]></code>
+	</test-code>
+
+	<test-code>
+		<description> No CRUD,FLS via upsert</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[ 
+public class Foo { 
+	public void foo(String newName, String tempID) { 
+		Contact myCon = new Contact(FirstName = 'First', LastName = 'Last', Phone = '414-414-4414');
+		upsert myCon;
+	} 
+} ]]></code>
+	</test-code>
+
 	<test-code>
 		<description>Proper CRUD,FLS via ESAPI</description>
 		<expected-problems>0</expected-problems>
@@ -136,6 +196,5 @@ public class Foo {
 }
 		]]></code>
 	</test-code>
-
 
 </test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<test-data>
+
+	<test-code>
+		<description>Proper CRUD,FLS via ESAPI</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[ 
+public class Foo { 
+	public void foo(String newName, String tempID) { 
+		Contact c = [SELECT Name FROM Contact WHERE Id=:tempID];
+		List<String> fieldsToView = new List<String> { 'name' };
+		if (ESAPI.accessController().isAuthorizedToView(Contact.sObject, fieldsToView)) { 
+			c.Name = newName; 
+			update c; 
+		}
+	} 
+} ]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Improper CRUD,FLS via ESAPI</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[ 
+public class Foo { 
+	public void foo(String newName, String tempID) { 
+		Contact c = [SELECT Name FROM Contact WHERE Id=:tempID];
+		List<String> fieldsToView = new List<String> { 'name' };
+		if (ESAPI.accessController().isAuthorizedToView(Lead.sObject, fieldsToView)) { 
+			c.Name = newName; 
+			update c; 
+		}
+	} 
+} ]]></code>
+	</test-code>
+
+	<test-code>
+		<description>CRUD,FLS check for update</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[ 
+public class Foo { 
+	public void foo(String newName, String tempID) { 
+		Contact c = [SELECT Name FROM Contact WHERE Id=:tempID]; 
+		if(Schema.sObjectType.Contact.fields.Name.isUpdateable()) {
+			c.Name = newName; 
+			update c; 
+		}
+	} 
+} ]]></code>
+	</test-code>
+
+
+	<test-code>
+		<description>No CRUD,FLS check for update</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[ 
+public class Foo { 
+	public void foo(String newName, String tempID) { 
+		Contact c = [SELECT Name FROM Contact WHERE Id=:tempID]; 
+		c.Name = newName; 
+		update c; 
+	} 
+} ]]></code>
+	</test-code>
+
+
+	<test-code>
+		<description>Proper CRUD,FLS check for update</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[ 
+public class Foo { 
+	public Contact foo(String newName, String tempID) { 
+		Contact c = [SELECT Name FROM Contact WHERE Id=:tempID]; 
+		if (!Schema.sObjectType.Contact.fields.Name.isUpdateable()){ 
+			return null; 
+		} 
+		c.Name = newName; 
+		update c; 
+		return c; 
+	} 
+} ]]></code>
+	</test-code>
+
+	<test-code>
+		<description>No CRUD check for insert</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void foo() {
+		Contact myCon = new Contact(FirstName = 'First', LastName = 'Last', Phone = '414-414-4414');
+		insert myCon;
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Proper CRUD check for insert</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void foo() {
+		if (Contact.sObjectType.getDescribe().isCreateable()) {
+			Contact myCon = new Contact(FirstName = 'First', LastName = 'Last', Phone = '414-414-4414');
+			insert myCon;
+		}	
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>No CRUD check for delete</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void bar(String contactId) {
+			Contact toDelete = [SELECT Id FROM Contact WHERE Id=: contactId];
+			delete toDelete;			
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Proper CRUD check for delete</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void bar(String contactId) {
+		if (Contact.sObjectType.getDescribe().isDeletable()) {
+			Contact toDelete = [SELECT Id FROM Contact WHERE Id=: contactId];
+			delete toDelete;
+		}	
+	}
+}
+		]]></code>
+	</test-code>
+
+
+</test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <test-data>
-
-
 	<test-code>
 		<description>No CRUD,FLS needed via sObject property</description>
 		<expected-problems>1</expected-problems>
@@ -94,7 +92,6 @@ public class Foo {
 ]]></code>
 	</test-code>
 
-
 	<test-code>
 		<description>No CRUD,FLS via sObject property, write is not protected
 		</description>
@@ -106,6 +103,38 @@ public class Foo {
 	public void foo(String newName, String tempID) { 
 			MyWriteOnlyProp = new Contact(FirstName = 'First', LastName = 'Last', Phone = '414-414-4414');
 			insert MyWriteOnlyProp;
+	} 
+} 
+]]></code>
+	</test-code>
+
+	<test-code>
+		<description>No CRUD,FLS for List insertion </description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[ 
+public class Foo { 
+	public List<Contact> MyWriteOnlyProp { get; set; }
+	
+	public void foo(String newName, String tempID) { 
+			MyWriteOnlyProp.add(new Contact(FirstName = 'First', LastName = 'Last', Phone = '414-414-4414'));
+			insert MyWriteOnlyProp;
+	} 
+} 
+]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Proper CRUD,FLS for List insertion </description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[ 
+public class Foo { 
+	public List<Contact> MyWriteOnlyProp { get; set; }
+	
+	public void foo(String newName, String tempID) { 
+			MyWriteOnlyProp.add(new Contact(FirstName = 'First', LastName = 'Last', Phone = '414-414-4414'));
+			if(Contact.sObjectType.getDescribe().isCreateable()) {
+				insert MyWriteOnlyProp;
+			}
 	} 
 } 
 ]]></code>
@@ -325,6 +354,22 @@ public class Foo {
 	public void bar(String contactId) {
 		if (Contact.sObjectType.getDescribe().isAccessible()) {
 			Contact toDelete = [SELECT Id FROM Contact WHERE Id=: contactId];		
+			if (Contact.sObjectType.getDescribe().isDeletable()) {
+				delete toDelete;
+			}	
+		}
+	}
+}
+		]]></code>
+	</test-code>
+	<test-code>
+		<description>Proper CRUD check for a list of sObject</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void bar(String contactId) {
+		if (Contact.sObjectType.getDescribe().isAccessible()) {
+			List<Contact> contacts = [SELECT Id FROM Contact];		
 			if (Contact.sObjectType.getDescribe().isDeletable()) {
 				delete toDelete;
 			}	

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
@@ -2,8 +2,82 @@
 
 <test-data>
 
-<test-code>
-		<description>Proper CRUD,FLS via getters</description>
+
+	<test-code>
+		<description>No CRUD,FLS needed via sObject property</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[ 
+public class Foo { 
+	public Contact contactProperty { get; set; }
+	
+	public void foo(String tempID) {
+	 		contactProperty = [SELECT Name FROM Contact WHERE Id=:tempID];
+	} 
+} 
+]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Proper FLS check </description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[ 
+public class Foo { 
+	public void foo(String newName, String tempID) { 
+		List<String> fieldsToView = new List<String> { 'name' };
+		if (ESAPI.accessController().isAuthorizedToUpdate(Contact.sObject, fieldsToView)) { 
+			Contact c = [SELECT Name FROM Contact WHERE Id=:tempID]; 
+			c.Name = newName;
+			update c; 
+		}
+	} 
+} ]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Proper FLS fall-through check </description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[ 
+public class Foo { 
+	public void foo(String newName, String tempID) { 
+		if (Schema.sObjectType.Contact.fields.Name.isUpdateable()) {
+			Contact c = [SELECT Name FROM Contact WHERE Id=:tempID]; 
+			c.Name = newName;
+			update c; 
+		}
+	} 
+} ]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Improper accessibility CRUD </description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[ 
+public class Foo { 
+	public Contact foo(String tempID) { 
+		Contact c = [SELECT Name FROM Contact WHERE Id=:tempID];
+		return c;
+	} 
+} ]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Proper accessibility CRUD,FLS </description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[ 
+public class Foo { 
+	public Contact foo(String tempID) { 
+		if (Contact.sObjectType.getDescribe().isAccessible()) {
+			Contact c = [SELECT Name FROM Contact WHERE Id=:tempID];
+			return c;
+		}
+		return null;
+	} 
+} ]]></code>
+	</test-code>
+
+
+	<test-code>
+		<description>Proper CRUD,FLS via property</description>
 		<expected-problems>0</expected-problems>
 		<code><![CDATA[ 
 public class Foo { 
@@ -12,7 +86,7 @@ public class Foo {
 	public void foo(String newName, String tempID) { 
 		if (Contact.sObjectType.getDescribe().isCreateable()) {
 			MyWriteOnlyProp = new Contact(FirstName = 'First', LastName = 'Last', Phone = '414-414-4414');
-			upsert MyWriteOnlyProp;
+			insert MyWriteOnlyProp;
 		}
 	} 
 	
@@ -21,8 +95,9 @@ public class Foo {
 	</test-code>
 
 
-<test-code>
-		<description>No CRUD,FLS via getters</description>
+	<test-code>
+		<description>No CRUD,FLS via sObject property, write is not protected
+		</description>
 		<expected-problems>1</expected-problems>
 		<code><![CDATA[ 
 public class Foo { 
@@ -30,19 +105,49 @@ public class Foo {
 	
 	public void foo(String newName, String tempID) { 
 			MyWriteOnlyProp = new Contact(FirstName = 'First', LastName = 'Last', Phone = '414-414-4414');
-			upsert MyWriteOnlyProp;
+			insert MyWriteOnlyProp;
 	} 
 } 
 ]]></code>
 	</test-code>
 
 	<test-code>
-		<description>CRUD,FLS via upsert</description>
+		<description>No CRUD,FLS via String property</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[ 
+public class Foo { 
+	public String nameProperty { get; set; }
+	
+	public void foo(String tempID) {
+	 		Contact c = [SELECT Name FROM Contact WHERE Id=:tempID];
+			nameProperty = c.Name;
+	} 
+} 
+]]></code>
+	</test-code>
+
+
+	<test-code>
+		<description>Proper CRUD,FLS via upsert</description>
 		<expected-problems>0</expected-problems>
 		<code><![CDATA[ 
 public class Foo { 
 	public void foo(String newName, String tempID) { 
-		if (Contact.sObjectType.getDescribe().isCreateable()) {
+		if (Contact.sObjectType.getDescribe().isCreateable() && Contact.sObjectType.getDescribe().isUpdateable()) {
+			Contact myCon = new Contact(FirstName = 'First', LastName = 'Last', Phone = '414-414-4414');
+			upsert myCon;
+		}
+	} 
+} ]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Partial CRUD,FLS via upsert</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[ 
+public class Foo { 
+	public void foo(String newName, String tempID) { 
+		if (Contact.sObjectType.getDescribe().isUpdateable()) {
 			Contact myCon = new Contact(FirstName = 'First', LastName = 'Last', Phone = '414-414-4414');
 			upsert myCon;
 		}
@@ -52,7 +157,7 @@ public class Foo {
 
 	<test-code>
 		<description> No CRUD,FLS via upsert</description>
-		<expected-problems>1</expected-problems>
+		<expected-problems>2</expected-problems>
 		<code><![CDATA[ 
 public class Foo { 
 	public void foo(String newName, String tempID) { 
@@ -63,13 +168,15 @@ public class Foo {
 	</test-code>
 
 	<test-code>
-		<description>Proper CRUD,FLS via ESAPI</description>
-		<expected-problems>0</expected-problems>
+		<description>Improper CRUD,FLS via ESAPI 1</description>
+		<expected-problems>2</expected-problems>
 		<code><![CDATA[ 
 public class Foo { 
 	public void foo(String newName, String tempID) { 
+		// missing accessibility check
 		Contact c = [SELECT Name FROM Contact WHERE Id=:tempID];
 		List<String> fieldsToView = new List<String> { 'name' };
+		// wrong ESAPI check
 		if (ESAPI.accessController().isAuthorizedToView(Contact.sObject, fieldsToView)) { 
 			c.Name = newName; 
 			update c; 
@@ -78,14 +185,37 @@ public class Foo {
 } ]]></code>
 	</test-code>
 
+
+
 	<test-code>
-		<description>Improper CRUD,FLS via ESAPI</description>
-		<expected-problems>1</expected-problems>
+		<description>Proper CRUD,FLS via ESAPI</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[ 
+public class Foo { 
+	public void foo(String newName, String tempID) {
+		List<String> fieldsToView = new List<String> { 'name' };
+		if (ESAPI.accessController().isAuthorizedToView(Contact.sObject, fieldsToView)) { 
+			Contact c = [SELECT Name FROM Contact WHERE Id=:tempID];
+			if (ESAPI.accessController().isAuthorizedToUpdate(Contact.sObject, fieldsToView)) { 
+				c.Name = newName; 
+				update c; 
+			}
+		}
+	} 
+} ]]></code>
+	</test-code>
+
+
+	<test-code>
+		<description>Improper CRUD,FLS via ESAPI 2</description>
+		<expected-problems>2</expected-problems>
 		<code><![CDATA[ 
 public class Foo { 
 	public void foo(String newName, String tempID) { 
+		// missing accessibility check
 		Contact c = [SELECT Name FROM Contact WHERE Id=:tempID];
 		List<String> fieldsToView = new List<String> { 'name' };
+		// wrong object check
 		if (ESAPI.accessController().isAuthorizedToView(Lead.sObject, fieldsToView)) { 
 			c.Name = newName; 
 			update c; 
@@ -100,10 +230,13 @@ public class Foo {
 		<code><![CDATA[ 
 public class Foo { 
 	public void foo(String newName, String tempID) { 
-		Contact c = [SELECT Name FROM Contact WHERE Id=:tempID]; 
-		if(Schema.sObjectType.Contact.fields.Name.isUpdateable()) {
-			c.Name = newName; 
-			update c; 
+		List<String> fieldsToView = new List<String> { 'name' };
+		if (ESAPI.accessController().isAuthorizedToView(Contact.sObject, fieldsToView)) { 
+			Contact c = [SELECT Name FROM Contact WHERE Id=:tempID]; 
+			if(Schema.sObjectType.Contact.fields.Name.isUpdateable()) {
+				c.Name = newName; 
+				update c; 
+			}
 		}
 	} 
 } ]]></code>
@@ -112,7 +245,7 @@ public class Foo {
 
 	<test-code>
 		<description>No CRUD,FLS check for update</description>
-		<expected-problems>1</expected-problems>
+		<expected-problems>2</expected-problems>
 		<code><![CDATA[ 
 public class Foo { 
 	public void foo(String newName, String tempID) { 
@@ -130,11 +263,13 @@ public class Foo {
 		<code><![CDATA[ 
 public class Foo { 
 	public Contact foo(String newName, String tempID) { 
-		Contact c = [SELECT Name FROM Contact WHERE Id=:tempID]; 
-		if (!Schema.sObjectType.Contact.fields.Name.isUpdateable()){ 
-			return null; 
-		} 
-		c.Name = newName; 
+		if (Contact.sObjectType.getDescribe().isAccessible()) {
+			Contact c = [SELECT Name FROM Contact WHERE Id=:tempID]; 
+			if (!Schema.sObjectType.Contact.fields.Name.isUpdateable()){ 
+				return null; 
+			} 
+			c.Name = newName; 
+		}
 		update c; 
 		return c; 
 	} 
@@ -171,7 +306,7 @@ public class Foo {
 
 	<test-code>
 		<description>No CRUD check for delete</description>
-		<expected-problems>1</expected-problems>
+		<expected-problems>2</expected-problems>
 		<code><![CDATA[
 public class Foo {
 	public void bar(String contactId) {
@@ -188,13 +323,14 @@ public class Foo {
 		<code><![CDATA[
 public class Foo {
 	public void bar(String contactId) {
-		if (Contact.sObjectType.getDescribe().isDeletable()) {
-			Contact toDelete = [SELECT Id FROM Contact WHERE Id=: contactId];
-			delete toDelete;
-		}	
+		if (Contact.sObjectType.getDescribe().isAccessible()) {
+			Contact toDelete = [SELECT Id FROM Contact WHERE Id=: contactId];		
+			if (Contact.sObjectType.getDescribe().isDeletable()) {
+				delete toDelete;
+			}	
+		}
 	}
 }
 		]]></code>
 	</test-code>
-
 </test-data>


### PR DESCRIPTION
Hi @jsotuyod,

This is an improved version of the rule I recently submitted.

It detects:
- missing Create,Update,Delete checks in DML operations
- missing Read checks before SOQL 

The checks can be added via ESAPI or using native API and this rule properly detects checks.
Some checks are blanket ones: when you do Field level check you get CRUD for free, when you perform any CUD check before accessing SOQL you get Read check for free. This rule accounts for that.

Almost everyone does CRUD checks incorrectly, I've spent a lot of time consulting internally to get this one right. 