### PR TITLE
[apex] Whitelisting String.isEmpty and casting  

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromURLParamRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromURLParamRule.java
@@ -36,7 +36,6 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
 	private static final String[] ID_VALUEOF = new String[] { "ID", "valueOf" };
 	private static final String[] DOUBLE_VALUEOF = new String[] { "Double", "valueOf" };
 	private static final String[] STRING_ISEMPTY = new String[] { "String", "isEmpty" };
-	
 
 	private static final Set<String> urlParameterString = new HashSet<>();
 
@@ -73,7 +72,7 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
 		processInlineMethodCalls(node, data, false);
 		return data;
 	}
-	
+
 	@Override
 	public Object visit(ASTReturnStatement node, Object data) {
 		ASTBinaryExpression binaryExpression = node.getFirstChildOfType(ASTBinaryExpression.class);
@@ -85,24 +84,26 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
 		if (methodCall != null) {
 			processInlineMethodCalls(methodCall, data, true);
 		}
-		
+
 		List<ASTVariableExpression> nodes = node.findChildrenOfType(ASTVariableExpression.class);
-		
+
 		for (ASTVariableExpression varExpression : nodes) {
-			StringBuilder sb = new StringBuilder().append(varExpression.getNode().getDefiningType().getApexName()).append(":")
-					.append(varExpression.getNode().getIdentifier().value);
+			StringBuilder sb = new StringBuilder().append(varExpression.getNode().getDefiningType().getApexName())
+					.append(":").append(varExpression.getNode().getIdentifier().value);
 
 			if (urlParameterString.contains(sb.toString())) {
 				addViolation(data, nodes.get(0));
 			}
 		}
-		
+
 		return data;
 	}
 
 	private boolean isEscapingMethod(ASTMethodCallExpression methodNode) {
 		return isMethodCallChain(methodNode, HTML_ESCAPING) || isMethodCallChain(methodNode, JS_ESCAPING)
-				|| isMethodCallChain(methodNode, JSINHTML_ESCAPING) || isMethodCallChain(methodNode, URL_ESCAPING);
+				|| isMethodCallChain(methodNode, JSINHTML_ESCAPING) || isMethodCallChain(methodNode, URL_ESCAPING)
+				|| isMethodCallChain(methodNode, INTEGER_VALUEOF) || isMethodCallChain(methodNode, DOUBLE_VALUEOF)
+				|| isMethodCallChain(methodNode, STRING_ISEMPTY) || isMethodCallChain(methodNode, ID_VALUEOF);
 	}
 
 	private void processInlineMethodCalls(ASTMethodCallExpression methodNode, Object data, final boolean isNested) {
@@ -188,7 +189,7 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
 					processBinaryExpression(o, data);
 				}
 			}
-			
+
 		}
 			break;
 		case 2: {
@@ -215,7 +216,7 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
 		if (nestedBinaryExpression != null) {
 			processBinaryExpression(nestedBinaryExpression, data);
 		}
-		
+
 		ASTMethodCallExpression methodCallAssignment = node.getFirstChildOfType(ASTMethodCallExpression.class);
 		if (methodCallAssignment != null) {
 			processInlineMethodCalls(methodCallAssignment, data, true);
@@ -224,7 +225,8 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
 		final List<ASTVariableExpression> nodes = node.findChildrenOfType(ASTVariableExpression.class);
 		for (ASTVariableExpression n : nodes) {
 			final VariableExpression expression = n.getNode();
-			StringBuilder sb = new StringBuilder().append(expression.getDefiningType().getApexName()).append(":").append(expression.getIdentifier().value);
+			StringBuilder sb = new StringBuilder().append(expression.getDefiningType().getApexName()).append(":")
+					.append(expression.getIdentifier().value);
 
 			if (urlParameterString.contains(sb.toString())) {
 				addViolation(data, n);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromURLParamRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromURLParamRule.java
@@ -35,6 +35,8 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
 	private static final String[] INTEGER_VALUEOF = new String[] { "Integer", "valueOf" };
 	private static final String[] ID_VALUEOF = new String[] { "ID", "valueOf" };
 	private static final String[] DOUBLE_VALUEOF = new String[] { "Double", "valueOf" };
+	private static final String[] STRING_ISEMPTY = new String[] { "String", "isEmpty" };
+	
 
 	private static final Set<String> urlParameterString = new HashSet<>();
 
@@ -153,7 +155,7 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
 
 			// safe method
 			if (isMethodCallChain(methodNode, INTEGER_VALUEOF) || isMethodCallChain(methodNode, ID_VALUEOF)
-					|| isMethodCallChain(methodNode, DOUBLE_VALUEOF)) {
+					|| isMethodCallChain(methodNode, DOUBLE_VALUEOF) || isMethodCallChain(methodNode, STRING_ISEMPTY)) {
 				return;
 			}
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/SecurityRulesTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/SecurityRulesTest.java
@@ -8,15 +8,15 @@ public class SecurityRulesTest extends SimpleAggregatorTst {
 
 	@Override
 	public void setUp() {
-		addRule(RULESET, "ApexBadCrypto");
-		addRule(RULESET, "ApexXSSFromEscapeFalse");
+//		addRule(RULESET, "ApexBadCrypto");
+//		addRule(RULESET, "ApexXSSFromEscapeFalse");
 		addRule(RULESET, "ApexXSSFromURLParam");
-		addRule(RULESET, "ApexCSRF");
-		addRule(RULESET, "ApexOpenRedirect");
-		addRule(RULESET, "ApexSOQLInjection");
-		addRule(RULESET, "ApexSharingViolations");
-		addRule(RULESET, "ApexInsecureEndpoint");
-		addRule(RULESET, "ApexCRUDViolation");
+//		addRule(RULESET, "ApexCSRF");
+//		addRule(RULESET, "ApexOpenRedirect");
+//		addRule(RULESET, "ApexSOQLInjection");
+//		addRule(RULESET, "ApexSharingViolations");
+//		addRule(RULESET, "ApexInsecureEndpoint");
+//		addRule(RULESET, "ApexCRUDViolation");
 
 	}
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/SecurityRulesTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/SecurityRulesTest.java
@@ -8,15 +8,15 @@ public class SecurityRulesTest extends SimpleAggregatorTst {
 
 	@Override
 	public void setUp() {
-//		addRule(RULESET, "ApexBadCrypto");
-//		addRule(RULESET, "ApexXSSFromEscapeFalse");
+		addRule(RULESET, "ApexBadCrypto");
+		addRule(RULESET, "ApexXSSFromEscapeFalse");
 		addRule(RULESET, "ApexXSSFromURLParam");
-//		addRule(RULESET, "ApexCSRF");
-//		addRule(RULESET, "ApexOpenRedirect");
-//		addRule(RULESET, "ApexSOQLInjection");
-//		addRule(RULESET, "ApexSharingViolations");
-//		addRule(RULESET, "ApexInsecureEndpoint");
-//		addRule(RULESET, "ApexCRUDViolation");
+		addRule(RULESET, "ApexCSRF");
+		addRule(RULESET, "ApexOpenRedirect");
+		addRule(RULESET, "ApexSOQLInjection");
+		addRule(RULESET, "ApexSharingViolations");
+		addRule(RULESET, "ApexInsecureEndpoint");
+		addRule(RULESET, "ApexCRUDViolation");
 
 	}
 

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexXSSFromURLParam.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexXSSFromURLParam.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <test-data>
-
 	<test-code>
 		<description>URL parameter in return statement</description>
 		<expected-problems>1</expected-problems>
@@ -15,7 +14,8 @@ public class Foo {
 	</test-code>
 
 	<test-code>
-		<description>URL parameter in return statement concatenation</description>
+		<description>URL parameter in return statement concatenation
+		</description>
 		<expected-problems>1</expected-problems>
 		<code><![CDATA[
 public class Foo {
@@ -28,7 +28,8 @@ public class Foo {
 
 	<test-code>
 		<description>URL parameter used without being escaped in return
-			statement</description>
+			statement
+		</description>
 		<expected-problems>1</expected-problems>
 		<code><![CDATA[
 public class Foo {
@@ -42,7 +43,8 @@ public class Foo {
 
 	<test-code>
 		<description>URL parameter used without being escaped in return
-			statement concatenation</description>
+			statement concatenation
+		</description>
 		<expected-problems>1</expected-problems>
 		<code><![CDATA[
 public class Foo {
@@ -56,13 +58,27 @@ public class Foo {
 
 	<test-code>
 		<description>URL parameter used without being escaped in return
-			statement concatenation 2</description>
+			statement concatenation 2
+		</description>
 		<expected-problems>1</expected-problems>
 		<code><![CDATA[
 public class Foo {
 	public String test1() {
 		String bas = ApexPages.currentPage().getParameters().get('foo');
 		return 'text' + bas + 'ttt';
+	}		
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Safe URL parameter cast to Integer
+		</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public Integer test1() {
+		return Integer.valueOf(ApexPages.currentPage().getParameters().get('foo'));
 	}		
 }
 		]]></code>
@@ -113,7 +129,8 @@ public class Foo {
 
 	<test-code>
 		<description>URL parameter passed to escaping function and then
-			assigned</description>
+			assigned
+		</description>
 		<expected-problems>0</expected-problems>
 		<code><![CDATA[
 public class Foo {
@@ -210,7 +227,8 @@ public class Foo {
 
 	<test-code>
 		<description>URL parameter passed to a function with variable
-			declaration</description>
+			declaration
+		</description>
 		<expected-problems>1</expected-problems>
 		<code><![CDATA[
 public class Foo {
@@ -223,7 +241,8 @@ public class Foo {
 
 	<test-code>
 		<description>Safe URL parameter passed to a function with variable
-			declaration</description>
+			declaration
+		</description>
 		<expected-problems>0</expected-problems>
 		<code><![CDATA[
 public class Foo {
@@ -261,7 +280,8 @@ public class Foo {
 	</test-code>
 
 	<test-code>
-		<description>URL parameter type casting is a safety check</description>
+		<description>URL parameter type casting is a safety check
+		</description>
 		<expected-problems>0</expected-problems>
 		<code><![CDATA[
 public class Foo {
@@ -269,6 +289,32 @@ public class Foo {
 		String baz, bas;
 		bas = ApexPages.currentPage().getParameters().get('foo');
 		baz = Integer.valueOf(bas);
+	}		
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>URL parameter type empty check</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		String baz, bas;
+		bas = ApexPages.currentPage().getParameters().get('foo');
+		boolean isEmpty = String.isEmpty(bas);
+	}		
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>URL parameter type empty check</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		boolean isEmpty = String.isEmpty(ApexPages.currentPage().getParameters().get('foo'););
 	}		
 }
 		]]></code>
@@ -286,8 +332,5 @@ public class Foo {
 	}		
 }
 		]]></code>
-
-
 	</test-code>
-
 </test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexXSSFromURLParam.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexXSSFromURLParam.xml
@@ -314,7 +314,7 @@ public class Foo {
 		<code><![CDATA[
 public class Foo {
 	public void test1() {
-		boolean isEmpty = String.isEmpty(ApexPages.currentPage().getParameters().get('foo'););
+		boolean isEmpty = String.isEmpty(ApexPages.currentPage().getParameters().get('foo'));
 	}		
 }
 		]]></code>


### PR DESCRIPTION
Hi @jsotuyod,

This is to reduce FPs when URL param variable passed to String.isEmpty.

Cheers,
Sergey