### PR TITLE
[java] fixes #1552 continue does not require break

### DIFF
--- a/pmd-java/src/main/resources/rulesets/java/design.xml
+++ b/pmd-java/src/main/resources/rulesets/java/design.xml
@@ -944,8 +944,9 @@ may indicate problematic behaviour. Empty cases are ignored as these indicate an
 //SwitchStatement
 [(count(.//BreakStatement)
  + count(BlockStatement//Statement/ReturnStatement)
+ + count(BlockStatement//Statement/ContinueStatement)
  + count(BlockStatement//Statement/ThrowStatement)
- + count(BlockStatement//Statement/IfStatement[@Else='true' and Statement[2][ReturnStatement|ThrowStatement]]/Statement[1][ReturnStatement|ThrowStatement])
+ + count(BlockStatement//Statement/IfStatement[@Else='true' and Statement[2][ReturnStatement|ContinueStatement|ThrowStatement]]/Statement[1][ReturnStatement|ContinueStatement|ThrowStatement])
  + count(SwitchLabel[name(following-sibling::node()) = 'SwitchLabel'])
  + count(SwitchLabel[count(following-sibling::node()) = 0])
   < count (SwitchLabel))]

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/MissingBreakInSwitch.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/MissingBreakInSwitch.xml
@@ -194,4 +194,29 @@ public class Foo {
 }
     ]]></code>
   </test-code>
+  <test-code>
+    <description>#1552  MissingBreakInSwitch - False positive for continue</description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+public class DemoMissingBreakContinue {
+public DemoMissingBreakContinue() {
+method();
+}
+
+private void method() {
+    for (int i = 0; i < 10; i = i + 1) {
+        switch (i) {
+        case 1:
+            break;
+        case 2:
+            continue; //PMD complains about missing break which would be unreachable code
+        default:
+            break;
+        }
+    }
+}
+
+}
+    ]]></code>
+  </test-code>
 </test-data>


### PR DESCRIPTION
Similar to RETURN after a CONTINUE statement break is not required in a
case section