### PR TITLE
[java] fixes #1554 do not report missing break in last case block

### DIFF
--- a/pmd-java/src/main/resources/rulesets/java/design.xml
+++ b/pmd-java/src/main/resources/rulesets/java/design.xml
@@ -947,7 +947,7 @@ may indicate problematic behaviour. Empty cases are ignored as these indicate an
  + count(BlockStatement//Statement/ThrowStatement)
  + count(BlockStatement//Statement/IfStatement[@Else='true' and Statement[2][ReturnStatement|ThrowStatement]]/Statement[1][ReturnStatement|ThrowStatement])
  + count(SwitchLabel[name(following-sibling::node()) = 'SwitchLabel'])
- + count(SwitchLabel[count(following-sibling::node()) = 0])
+ + count(SwitchLabel[not(following-sibling::SwitchLabel)])
   < count (SwitchLabel))]
     ]]>
               </value>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/MissingBreakInSwitch.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/MissingBreakInSwitch.xml
@@ -115,7 +115,6 @@ public class Foo {
         break;
       default :
         s2 = (short)(s + 2);
-        // and missing break here!
     }
   }
 }
@@ -191,6 +190,24 @@ public class Foo {
         }
       }
     }
+}
+    ]]></code>
+  </test-code>
+  <test-code>
+    <description>MissingBreakInSwitch - break not required in last case block</description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+public class MissingBreakLastCaseBlock {
+	public void method() {
+		switch (2) {
+		case 1:
+			break;
+		case 2:
+			break;
+		default:
+			String var = "Do not complain about missing break in last case block";
+		}
+	}
 }
     ]]></code>
   </test-code>


### PR DESCRIPTION
Similar to case sections directly followed by the next case, we can
ignore missing breaks in the very last case section.