### PR TITLE
[core] [java] [plsql] Reduce memory allocations during symbol table

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/ImageFinderFunction.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/ImageFinderFunction.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.symboltable;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -13,15 +14,15 @@ import net.sourceforge.pmd.util.UnaryFunction;
 
 public class ImageFinderFunction implements UnaryFunction<NameDeclaration> {
 
-    private Set<String> images = new HashSet<>();
+    private final Set<String> images;
     private NameDeclaration decl;
 
     public ImageFinderFunction(String img) {
-        images.add(img);
+        images = Collections.singleton(img);
     }
 
     public ImageFinderFunction(List<String> imageList) {
-        images.addAll(imageList);
+        images = new HashSet<>(imageList);
     }
 
     public void applyTo(NameDeclaration nameDeclaration) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/LocalScope.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/LocalScope.java
@@ -4,7 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.symboltable;
 
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -49,16 +49,15 @@ public class LocalScope extends AbstractJavaScope {
     }
 
     public Set<NameDeclaration> findVariableHere(JavaNameOccurrence occurrence) {
-        Set<NameDeclaration> result = new HashSet<>();
         if (occurrence.isThisOrSuper() || occurrence.isMethodOrConstructorInvocation()) {
-            return result;
+            return Collections.emptySet();
         }
         DeclarationFinderFunction finder = new DeclarationFinderFunction(occurrence);
         Applier.apply(finder, getVariableDeclarations().keySet().iterator());
         if (finder.getDecl() != null) {
-            result.add(finder.getDecl());
+            return Collections.singleton(finder.getDecl());
         }
-        return result;
+        return Collections.emptySet();
     }
 
     public String toString() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/MethodScope.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/MethodScope.java
@@ -4,7 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.symboltable;
 
-import java.util.HashSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -55,16 +55,15 @@ public class MethodScope extends AbstractJavaScope {
     }
 
     public Set<NameDeclaration> findVariableHere(JavaNameOccurrence occurrence) {
-        Set<NameDeclaration> result = new HashSet<>();
         if (occurrence.isThisOrSuper() || occurrence.isMethodOrConstructorInvocation()) {
-            return result;
+            return Collections.emptySet();
         }
         ImageFinderFunction finder = new ImageFinderFunction(occurrence.getImage());
         Applier.apply(finder, getVariableDeclarations().keySet().iterator());
         if (finder.getDecl() != null) {
-            result.add(finder.getDecl());
+            return Collections.singleton(finder.getDecl());
         }
-        return result;
+        return Collections.emptySet();
     }
 
     public String getName() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/OccurrenceFinder.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/OccurrenceFinder.java
@@ -15,12 +15,17 @@ import net.sourceforge.pmd.lang.symboltable.Scope;
 
 public class OccurrenceFinder extends JavaParserVisitorAdapter {
 
+    // Maybe do some sort of State pattern thingy for when NameDeclaration
+    // is empty/not empty?
+    private final Set<NameDeclaration> declarations = new HashSet<>();
+
+    private final Set<NameDeclaration> additionalDeclarations = new HashSet<>();
+
     public Object visit(ASTPrimaryExpression node, Object data) {
         NameFinder nameFinder = new NameFinder(node);
 
-        // Maybe do some sort of State pattern thingy for when NameDeclaration
-        // is empty/not empty?
-        Set<NameDeclaration> declarations = new HashSet<>();
+        declarations.clear();
+        additionalDeclarations.clear();
 
         List<JavaNameOccurrence> names = nameFinder.getNames();
         for (JavaNameOccurrence occ : names) {
@@ -37,7 +42,6 @@ public class OccurrenceFinder extends JavaParserVisitorAdapter {
                     break;
                 }
             } else {
-                Set<NameDeclaration> additionalDeclarations = new HashSet<>();
                 for (NameDeclaration decl : declarations) {
                     // now we've got a scope we're starting with, so work from
                     // there

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/SourceFileScope.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/SourceFileScope.java
@@ -4,8 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.symboltable;
 
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -121,13 +121,12 @@ public class SourceFileScope extends AbstractJavaScope {
     }
 
     protected Set<NameDeclaration> findVariableHere(JavaNameOccurrence occ) {
-        Set<NameDeclaration> result = new HashSet<>();
         ImageFinderFunction finder = new ImageFinderFunction(occ.getImage());
         Applier.apply(finder, getDeclarations().keySet().iterator());
         if (finder.getDecl() != null) {
-            result.add(finder.getDecl());
+            return Collections.singleton(finder.getDecl());
         }
-        return result;
+        return Collections.emptySet();
     }
 
     /**
@@ -141,8 +140,13 @@ public class SourceFileScope extends AbstractJavaScope {
     }
 
     private Map<String, Node> getSubTypes(String qualifyingName, Scope subType) {
-        Map<String, Node> types = new HashMap<>();
-        for (ClassNameDeclaration c : subType.getDeclarations(ClassNameDeclaration.class).keySet()) {
+        Set<ClassNameDeclaration> classDeclarations = subType.getDeclarations(ClassNameDeclaration.class).keySet();
+        if (classDeclarations.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, Node> types = new HashMap<>((int) (classDeclarations.size() / 0.75f) + 1);
+        for (ClassNameDeclaration c : classDeclarations) {
             String typeName = c.getName();
             if (qualifyingName != null) {
                 typeName = qualifyingName + "." + typeName;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/TypeSet.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/TypeSet.java
@@ -227,7 +227,7 @@ public class TypeSet {
      * Resolver that uses the current package to resolve a simple class name.
      */
     public static class CurrentPackageResolver extends AbstractResolver {
-        private String pkg;
+        private final String pkg;
 
         /**
          * Creates a new {@link CurrentPackageResolver}
@@ -239,11 +239,19 @@ public class TypeSet {
          */
         public CurrentPackageResolver(PMDASMClassLoader pmdClassLoader, String pkg) {
             super(pmdClassLoader);
-            this.pkg = pkg;
+            if (pkg == null) {
+                this.pkg = null;
+            } else {
+                this.pkg = pkg + ".";
+            }
         }
 
         @Override
         public Class<?> resolve(String name) throws ClassNotFoundException {
+            if (name == null) {
+                throw new ClassNotFoundException();
+            }
+
             final String fqName = qualifyName(name);
             final Class<?> c = resolveMaybeInner(fqName, fqName);
 
@@ -264,7 +272,11 @@ public class TypeSet {
                 return name;
             }
 
-            return pkg + '.' + name;
+            /*
+             * String.concat is bad in general, but for simple 2 string concatenation, it's the fastest
+             * See http://www.rationaljava.com/2015/02/the-optimum-method-to-concatenate.html
+             */
+            return pkg.concat(name);
         }
     }
 
@@ -303,7 +315,11 @@ public class TypeSet {
                 return clazz;
             }
 
-            clazz = pmdClassLoader.loadClass("java.lang." + name);
+            /*
+             * String.concat is bad in general, but for simple 2 string concatenation, it's the fastest
+             * See http://www.rationaljava.com/2015/02/the-optimum-method-to-concatenate.html
+             */
+            clazz = pmdClassLoader.loadClass("java.lang.".concat(name));
             CLASS_CACHE.putIfAbsent(name, clazz);
 
             return clazz;
@@ -311,7 +327,11 @@ public class TypeSet {
 
         @Override
         public boolean couldResolve(String name) {
-            return super.couldResolve("java.lang." + name);
+            /*
+             * String.concat is bad in general, but for simple 2 string concatenation, it's the fastest
+             * See http://www.rationaljava.com/2015/02/the-optimum-method-to-concatenate.html
+             */
+            return super.couldResolve("java.lang.".concat(name));
         }
     }
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/ImageFinderFunction.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/ImageFinderFunction.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.plsql.symboltable;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -13,15 +14,15 @@ import net.sourceforge.pmd.util.UnaryFunction;
 
 public class ImageFinderFunction implements UnaryFunction<NameDeclaration> {
 
-    private Set<String> images = new HashSet<>();
+    private final Set<String> images;
     private NameDeclaration decl;
 
     public ImageFinderFunction(String img) {
-        images.add(img);
+        images = Collections.singleton(img);
     }
 
     public ImageFinderFunction(List<String> imageList) {
-        images.addAll(imageList);
+        images = new HashSet<>(imageList);
     }
 
     public void applyTo(NameDeclaration nameDeclaration) {


### PR DESCRIPTION
Reduce the number of allocations and collection resizing performed during symbol table.

When analyzing a large codebase such as PMD's, this an reduce the number of GC cycles by ~30%, and the reduced overhead, plus skipping allocations / reallocations / copies, produce a speedup of up to 20%.

There is still plenty of opportunities to build upon this and keep improving. The symbol table codebase is hungry for Maps and Sets.