### PR TITLE
[core] Ant Task Formatter encoding issue with XMLRenderer

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/Formatter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/Formatter.java
@@ -1,19 +1,21 @@
 /**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 package net.sourceforge.pmd.ant;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.tools.ant.BuildException;
 import org.apache.tools.ant.types.Parameter;
 
@@ -57,12 +59,27 @@ public class Formatter {
     }
 
     public void start(String baseDir) {
+
+        Properties properties = createProperties();
+        
+        Charset charset;
+        {
+            String s = (String) properties.get("encoding");
+            if (null == s) {
+                charset = Charset.forName("UTF-8");
+                properties.put("encoding", charset.name());
+            }
+            else {
+                charset = Charset.forName(s);
+            }
+        }
+
         try {
             if (toConsole) {
-                writer = new BufferedWriter(new OutputStreamWriter(System.out));
+                writer = new BufferedWriter(new OutputStreamWriter(System.out, charset));
             }
             if (toFile != null) {
-                writer = getToFileWriter(baseDir);
+                writer = getToFileWriter(baseDir, toFile, charset);
             }
             renderer = createRenderer();
             renderer.setWriter(writer);
@@ -131,11 +148,29 @@ public class Formatter {
         return properties;
     }
 
-    private Writer getToFileWriter(String baseDir) throws IOException {
-        if (!toFile.isAbsolute()) {
-            return new BufferedWriter(
-                    new FileWriter(new File(baseDir + System.getProperty("file.separator") + toFile.getPath())));
+    private static final Writer getToFileWriter(String baseDir, File toFile, Charset charset) throws IOException {
+        final File file;
+        if (toFile.isAbsolute()) {
+            file = toFile;
         }
-        return new BufferedWriter(new FileWriter(toFile));
+        else {
+            file = new File(baseDir + System.getProperty("file.separator") + toFile.getPath());
+        }
+
+        OutputStream output = null;
+        Writer writer = null;
+        boolean isOnError = true;
+        try {
+            output = new FileOutputStream(file);
+            writer = new OutputStreamWriter(output, charset);
+            writer = new BufferedWriter(writer);
+            isOnError = false;
+        }
+        finally {
+            if (isOnError) {
+                IOUtils.closeQuietly(output, writer);
+            }
+        }
+        return writer;
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/Formatter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/Formatter.java
@@ -203,10 +203,10 @@ public class Formatter {
             try {
                 Field f = Console.class.getDeclaredField("cs");
                 f.setAccessible(true);
-                    Object res = f.get(console);
-                    if (res instanceof Charset) {
-                        return ((Charset) res).name();
-                    }
+                Object res = f.get(console);
+                if (res instanceof Charset) {
+                    return ((Charset) res).name();
+                }
             } catch (NoSuchFieldException e) {
                 // fall-through
             } catch (IllegalAccessException e) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/Formatter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/Formatter.java
@@ -1,6 +1,7 @@
 /**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
+
 package net.sourceforge.pmd.ant;
 
 import java.io.BufferedWriter;
@@ -69,8 +70,7 @@ public class Formatter {
             if (null == s) {
                 charset = StandardCharsets.UTF_8;
                 properties.put("encoding", charset.name());
-            }
-            else {
+            } else {
                 charset = Charset.forName(s);
             }
         }
@@ -149,12 +149,11 @@ public class Formatter {
         return properties;
     }
 
-    private static final Writer getToFileWriter(String baseDir, File toFile, Charset charset) throws IOException {
+    private static Writer getToFileWriter(String baseDir, File toFile, Charset charset) throws IOException {
         final File file;
         if (toFile.isAbsolute()) {
             file = toFile;
-        }
-        else {
+        } else {
             file = new File(baseDir + System.getProperty("file.separator") + toFile.getPath());
         }
 
@@ -166,8 +165,7 @@ public class Formatter {
             writer = new OutputStreamWriter(output, charset);
             writer = new BufferedWriter(writer);
             isOnError = false;
-        }
-        finally {
+        } finally {
             if (isOnError) {
                 IOUtils.closeQuietly(output);
                 IOUtils.closeQuietly(writer);                

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/Formatter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/Formatter.java
@@ -68,9 +68,29 @@ public class Formatter {
         {
             String s = (String) properties.get("encoding");
             if (null == s) {
-                charset = StandardCharsets.UTF_8;
-                properties.put("encoding", charset.name());
-            } else {
+
+                if (toConsole) {
+                    if(null == System.console()) {
+                        // pipe or redirect, no interactive console.
+                        s = System.getProperty("file.encoding");
+                    } else {
+                        s = System.getProperty("sun.stdout.encoding");
+                    }
+                }
+
+                if (null == s) {
+                    charset = StandardCharsets.UTF_8;
+                } else {
+                    charset = Charset.forName(s);
+                }
+
+                // Configures the encoding for the renderer.
+                final Parameter parameter = new Parameter();
+                parameter.setName("encoding");
+                parameter.setValue(charset.name());
+                parameters.add(parameter);
+            }
+            else {
                 charset = Charset.forName(s);
             }
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/Formatter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/Formatter.java
@@ -76,7 +76,6 @@ public class Formatter {
                 if (toConsole) {
                     s = getConsoleEncoding();
                     if (null == s) {
-                        // highly unlikely.
                         s = System.getProperty("file.encoding");
                     }
                 }
@@ -212,8 +211,9 @@ public class Formatter {
             } catch (IllegalAccessException e) {
                 // fall-through
             }
+            return getNativeConsoleEncoding();
         }
-        return getNativeConsoleEncoding();
+        return null;
     }
 
     private static String getNativeConsoleEncoding() {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/Formatter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/Formatter.java
@@ -70,7 +70,7 @@ public class Formatter {
             if (null == s) {
 
                 if (toConsole) {
-                    if(null == System.console()) {
+                    if (null == System.console()) {
                         // pipe or redirect, no interactive console.
                         s = System.getProperty("file.encoding");
                     } else {
@@ -89,8 +89,7 @@ public class Formatter {
                 parameter.setName("encoding");
                 parameter.setValue(charset.name());
                 parameters.add(parameter);
-            }
-            else {
+            } else {
                 charset = Charset.forName(s);
             }
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/Formatter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/Formatter.java
@@ -11,6 +11,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -66,7 +67,7 @@ public class Formatter {
         {
             String s = (String) properties.get("encoding");
             if (null == s) {
-                charset = Charset.forName("UTF-8");
+                charset = StandardCharsets.UTF_8;
                 properties.put("encoding", charset.name());
             }
             else {
@@ -168,7 +169,8 @@ public class Formatter {
         }
         finally {
             if (isOnError) {
-                IOUtils.closeQuietly(output, writer);
+                IOUtils.closeQuietly(output);
+                IOUtils.closeQuietly(writer);                
             }
         }
         return writer;


### PR DESCRIPTION
Hi,

The writers in the Ant task's formatter use the default platform's encoding (for instance cp1252 on Western Windows) and the XMLRenderer sets the default XML encoding to UTF-8. This may lead to incorrect XML encoding, detected for instance when the XML file is sent to a XSLT task.
This goes undetected as long as the characters in the XML file are in the ASCII subset, which is frequently the case with code, usually in plain Latin language. In my case, the issue was raised because of the localized formatting of some line numbers greater than 999, due to the localized thousand separator 0xA0, which is out of the ASCII subset.

I modified the Formatter class to always use a charset for writers. When no encoding is specified, UTF-8 is used instead of the default platform's encoding.

I strongly recommend to *always set the encoding parameter* of the formatter element. It should be reflected as so in the Ant Task documentation.

```xml
<pmd encoding="cp1252"> <!-- source encoding -->
  <formatter type="xml" toFile="pmd.xml">
    <param name="encoding" value="UTF-8" /> <!-- report encoding -->
  </formatter>
  <fileset dir="src/main/java">
    <include name="**/*.java"/>
  </fileset>
</pmd>
```
Note: when digging into sourceforge issues for similar bugs, I found [Bug 877: Output with encoding CP1252](https://sourceforge.net/p/pmd/bugs/877/) . Not the same task, but the same symptoms, probably the same cause ?