### PR TITLE
[apex] Bug fix, detects both Apex fields and class members

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexOpenRedirectRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexOpenRedirectRule.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Set;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTBinaryExpression;
-import net.sourceforge.pmd.lang.apex.ast.ASTFieldDeclaration;
+import net.sourceforge.pmd.lang.apex.ast.ASTField;
 import net.sourceforge.pmd.lang.apex.ast.ASTLiteralExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
 import net.sourceforge.pmd.lang.apex.ast.ASTNewObjectExpression;
@@ -33,6 +33,7 @@ public class ApexOpenRedirectRule extends AbstractApexRule {
     private final Set<String> listOfStringLiteralVariables = new HashSet<>();
 
     public ApexOpenRedirectRule() {
+        super.addRuleChainVisit(ASTUserClass.class);
         setProperty(CODECLIMATE_CATEGORIES, new String[] { "Security" });
         setProperty(CODECLIMATE_REMEDIATION_MULTIPLIER, 100);
         setProperty(CODECLIMATE_BLOCK_HIGHLIGHTING, false);
@@ -49,8 +50,8 @@ public class ApexOpenRedirectRule extends AbstractApexRule {
             findSafeLiterals(varDecl);
         }
 
-        List<ASTFieldDeclaration> fieldDecl = node.findDescendantsOfType(ASTFieldDeclaration.class);
-        for (ASTFieldDeclaration fDecl : fieldDecl) {
+        List<ASTField> fieldDecl = node.findDescendantsOfType(ASTField.class);
+        for (ASTField fDecl : fieldDecl) {
             findSafeLiterals(fDecl);
         }
 
@@ -58,9 +59,9 @@ public class ApexOpenRedirectRule extends AbstractApexRule {
         for (ASTNewObjectExpression newObj : newObjects) {
             checkNewObjects(newObj, data);
         }
-        
+
         listOfStringLiteralVariables.clear();
-        
+
         return data;
     }
 

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexOpenRedirect.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexOpenRedirect.xml
@@ -110,4 +110,34 @@ public class Foo {
 		]]></code>
 	</test-code>
 	
+	<test-code>
+		<description>PageReference as a field</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	String test1 = '';
+    PageReference pr = new PageReference(test1);
+
+	static PageReference redirect() {
+	    return pr;
+	}
+}
+		]]></code>
+	</test-code>
+	
+	<test-code>
+		<description>Safe pageReference as a field</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	String test1 = '';
+    PageReference pr = new PageReference('/' + test1);
+
+	static PageReference redirect() {
+	    return pr;
+	}
+}
+		]]></code>
+	</test-code>
+	
 </test-data>


### PR DESCRIPTION
Hi @jsotuyod,

This is a bug fix, previously it would only detect Apex fields but ignore Apex class members.
With this fix both are checked. 

Regards,
Sergey