### PR TITLE
[apex] Bug fix for FP: open redirect for strings prefixed with / is safe

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexOpenRedirectRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexOpenRedirectRule.java
@@ -66,12 +66,30 @@ public class ApexOpenRedirectRule extends AbstractApexRule {
     }
 
     private void findSafeLiterals(AbstractApexNode<?> node) {
+        ASTBinaryExpression binaryExp = node.getFirstChildOfType(ASTBinaryExpression.class);
+        if (binaryExp != null) {
+            findSafeLiterals(binaryExp);
+        }
+
         ASTLiteralExpression literal = node.getFirstChildOfType(ASTLiteralExpression.class);
         if (literal != null) {
-            ASTVariableExpression variable = node.getFirstChildOfType(ASTVariableExpression.class);
-            if (variable != null) {
-                listOfStringLiteralVariables.add(Helper.getFQVariableName(variable));
+            int index = literal.jjtGetChildIndex();
+            if (index == 0) {
+                if (node instanceof ASTVariableDeclaration) {
+                    addVariable(node);
+                } else {
+                    ASTVariableDeclaration parent = node.getFirstParentOfType(ASTVariableDeclaration.class);
+                    addVariable(parent);
+
+                }
             }
+        }
+    }
+
+    private void addVariable(AbstractApexNode<?> node) {
+        ASTVariableExpression variable = node.getFirstChildOfType(ASTVariableExpression.class);
+        if (variable != null) {
+            listOfStringLiteralVariables.add(Helper.getFQVariableName(variable));
         }
     }
 

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexOpenRedirect.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexOpenRedirect.xml
@@ -138,6 +138,37 @@ public class Foo {
 	}
 }
 		]]></code>
+	</test-code> 
+	
+	<test-code>
+		<description>Unsafe pageReference object</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+
+	static PageReference redirect(String otherStuff) {
+		String test1 = otherStuff + '/';
+    	PageReference pr = new PageReference(test1);
+	    return pr;
+	}
+}
+		]]></code>
 	</test-code>
+	
+	<test-code>
+		<description>Safe pageReference object</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+
+	static PageReference redirect(String otherStuff) {
+		String test1 = '/' + otherStuff;
+    	PageReference pr = new PageReference(test1);
+	    return pr;
+	}
+}
+		]]></code>
+	</test-code>
+
 	
 </test-data>


### PR DESCRIPTION
Hi!

I've fixed a bug where if you have a string prefixed with a literal it would not be considered safe.
Now it's all good.

Regards,
Sergey