### PR TITLE
[apex] Improving detection of test classes

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
@@ -50,6 +50,12 @@ public final class Helper {
                 return true;
             }
         }
+
+        final String className = node.getNode().getDefiningType().getApexName();
+        if (className.endsWith("Test")) {
+            return true;
+        }
+
         return false;
     }
 

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
@@ -468,4 +468,18 @@ public class Foo {
 }
 		]]></code>
 	</test-code>
+	
+	<test-code>
+		<description>Test method should yield no issues</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class FooTest {
+	public void bar(String contactId) {
+			Contact toDelete = [SELECT Id FROM Contact WHERE Id=: contactId];
+			delete toDelete;			
+	}
+}
+		]]></code>
+	</test-code>
+	
 </test-data>


### PR DESCRIPTION
Hi,

In older Apex versions one could mark the class as Test by naming it *Test.  
The new ways to mark the class as test were already supported. This is to support the old way.

Regards,
Sergey