### PR TITLE
[Apex] Improving open redirect detection for static fields & assignment operations

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexOpenRedirectRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexOpenRedirectRule.java
@@ -102,6 +102,11 @@ public class ApexOpenRedirectRule extends AbstractApexRule {
             }
         } else {
             if (node instanceof ASTField) {
+                /* sergey.gorbaty: 
+                 * Apex Jorje parser is returning a null from Field.getFieldInfo(), but the info is available from an inner field. 
+                 * DO NOT attempt to optimize this block without checking that Jorje parser actually fixed its bug.
+                 * 
+                 */
                 try {
                     final Field f = node.getNode().getClass().getDeclaredField("fieldInfo");
                     f.setAccessible(true);

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexOpenRedirect.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexOpenRedirect.xml
@@ -169,7 +169,21 @@ public class Foo {
 }
 		]]></code>
 	</test-code> 
-	
+	<test-code>
+		<description>Safe pageReference object concatenation</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+
+	static PageReference redirect(String otherStuff) {
+		String test1;
+		test1 = '/' + otherStuff;
+    	PageReference pr = new PageReference(test1);
+	    return pr;
+	}
+}
+		]]></code>
+	</test-code> 
 	<test-code>
 		<description>Static link pageReference object</description>
 		<expected-problems>0</expected-problems>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexOpenRedirect.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexOpenRedirect.xml
@@ -2,7 +2,7 @@
 
 <test-data>
 
-	<test-code>
+	 <test-code>
 		<description>PageReference open redirect with unsafe variable
 			concatenation
 		</description>
@@ -111,11 +111,11 @@ public class Foo {
 	</test-code>
 	
 	<test-code>
-		<description>PageReference as a field</description>
-		<expected-problems>1</expected-problems>
+		<description>PageReference to a literal field</description>
+		<expected-problems>0</expected-problems>
 		<code><![CDATA[
 public class Foo {
-	String test1 = '';
+	String test1 = 'string';
     PageReference pr = new PageReference(test1);
 
 	static PageReference redirect() {
@@ -168,7 +168,22 @@ public class Foo {
 	}
 }
 		]]></code>
+	</test-code> 
+	
+	<test-code>
+		<description>Static link pageReference object</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	private static final String EMAILAUTHOR_URL = '/_ui/core/email/author/EmailAuthor';
+	
+	static PageReference redirect() {
+    	return new PageReference(EMAILAUTHOR_URL);
+	}
+}
+		]]></code>
 	</test-code>
+
 
 	
 </test-data>


### PR DESCRIPTION
Hi,

This change improves two things.
A. It appears that Apex compiler does not report static fields the same way as non-static. Fixed.
B. Assignment operations were ignored and caused FPs. Fixed.

Thanks!
Sergey
