### PR TITLE
[apex] Fix #183 - Count whole expressions as 1 line

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/complexity/AbstractNcssCountRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/complexity/AbstractNcssCountRule.java
@@ -16,7 +16,6 @@ import net.sourceforge.pmd.lang.apex.ast.ASTReturnStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTThrowStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTTryCatchFinallyBlockStatement;
-import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration;
 import net.sourceforge.pmd.lang.apex.ast.ASTWhileLoopStatement;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractStatisticalApexRule;
@@ -159,12 +158,7 @@ public abstract class AbstractNcssCountRule extends AbstractStatisticalApexRule 
     }
 
     @Override
-    public Object visit(ASTVariableDeclaration node, Object data) {
-        return countNodeChildren(node, data);
-    }
-
-    @Override
     public Object visit(ASTMethodCallExpression node, Object data) {
-        return countNodeChildren(node, data);
+        return NumericConstants.ONE;
     }
 }

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/complexity/xml/NcssMethodCount.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/complexity/xml/NcssMethodCount.xml
@@ -103,5 +103,28 @@ public class Foo {
 }
 		]]></code>
     </test-code>
+    <test-code>
+        <description>Github issue #183 - lines are counted properly</description>
+        <rule-property name="minimum">10</rule-property>
+        <expected-problems>0</expected-problems>
+        <code>
+@isTest
+private class AcceptanceTests_Test {
     
+    @isTest
+    private static void test() {
+        // Setup
+        Opportunity o1 = new Opportunity()
+                                    .add(new Contact().foo(1)  .bar(1).year(2012)  .bar(1).price(5)  .vol(100))
+                                    .add(new Contact().foo(1)  .bar(2).year(2013)  .bar(1).price(5)  .vol(110))
+                                    .add(new Contact().foo(1)  .bar(3).year(2014)  .bar(1).price(5)  .vol(120))
+                                    .add(new Contact().foo(1)  .bar(4).year(2015)  .bar(1).price(5)  .vol(130))
+                                    .persist();
+
+        // Verify
+        System.assert(attribute());
+    }
+}
+        </code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
 - This is consistent with how we count "lines" in other languages.
 - Notice we are not actually counting lines, so multiline expressions are
    counted as 1.
 - Having multiple variable declarations together is still counting 1 per variable.
 - Fixes #183 
