### PR TITLE
[core] Resolve #180 - refactor pmd processors

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/SourceCodeProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/SourceCodeProcessor.java
@@ -90,6 +90,7 @@ public class SourceCodeProcessor {
             }
 
             try {
+                ruleSets.start(ctx);
                 processSource(sourceCode, ruleSets, ctx);
             } catch (ParseException pe) {
                 configuration.getAnalysisCache().analysisFailed(ctx.getSourceCodeFile());
@@ -99,6 +100,7 @@ public class SourceCodeProcessor {
                 throw new PMDException("Error while processing " + ctx.getSourceCodeFilename(), e);
             } finally {
                 IOUtils.closeQuietly(sourceCode);
+                ruleSets.end(ctx);
             }
         }
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/processor/MonoThreadProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/processor/MonoThreadProcessor.java
@@ -4,23 +4,12 @@
 
 package net.sourceforge.pmd.processor;
 
-import java.io.BufferedInputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
-import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.PMDConfiguration;
-import net.sourceforge.pmd.PMDException;
 import net.sourceforge.pmd.Report;
-import net.sourceforge.pmd.RuleContext;
-import net.sourceforge.pmd.RuleSetFactory;
-import net.sourceforge.pmd.RuleSets;
-import net.sourceforge.pmd.SourceCodeProcessor;
 import net.sourceforge.pmd.renderers.Renderer;
-import net.sourceforge.pmd.util.datasource.DataSource;
 
 /**
  * @author Romain Pelisse &lt;belaran@gmail.com&gt;
@@ -28,60 +17,25 @@ import net.sourceforge.pmd.util.datasource.DataSource;
  */
 public final class MonoThreadProcessor extends AbstractPMDProcessor {
 
-    private static final Logger LOG = Logger.getLogger(MonoThreadProcessor.class.getName());
-
+    private final List<Report> reports = new ArrayList<>();
+    
     public MonoThreadProcessor(PMDConfiguration configuration) {
         super(configuration);
     }
 
-    public void processFiles(RuleSetFactory ruleSetFactory, List<DataSource> files, RuleContext ctx,
-            List<Renderer> renderers) {
-
-        // single threaded execution
-
-        RuleSets rs = createRuleSets(ruleSetFactory);
-        configuration.getAnalysisCache().checkValidity(rs, configuration.getClassLoader());
-        SourceCodeProcessor processor = new SourceCodeProcessor(configuration);
-
-        for (DataSource dataSource : files) {
-            String niceFileName = filenameFrom(dataSource);
-
-            Report report = PMD.setupReport(rs, ctx, niceFileName);
-
-            if (LOG.isLoggable(Level.FINE)) {
-                LOG.fine("Processing " + ctx.getSourceCodeFilename());
-            }
-            rs.start(ctx);
-
-            for (Renderer r : renderers) {
-                r.startFileAnalysis(dataSource);
-            }
-
-            try {
-                InputStream stream = new BufferedInputStream(dataSource.getInputStream());
-                ctx.setLanguageVersion(null);
-                processor.processSourceCode(stream, rs, ctx);
-            } catch (PMDException pmde) {
-                if (LOG.isLoggable(Level.FINE)) {
-                    LOG.log(Level.FINE, "Error while processing file: " + niceFileName, pmde.getCause());
-                }
-
-                report.addError(new Report.ProcessingError(pmde.getMessage(), niceFileName));
-            } catch (IOException ioe) {
-                // unexpected exception: log and stop executor service
-                addError(report, "Unable to read source file", ioe, niceFileName);
-            } catch (RuntimeException re) {
-                // unexpected exception: log and stop executor service
-                addError(report, "RuntimeException while processing file", re, niceFileName);
-            }
-
-            rs.end(ctx);
-            super.renderReports(renderers, ctx.getReport());
-        }
+    @Override
+    protected void runAnalysis(PmdRunnable runnable) {
+        // single thread execution, run analysis on same thread
+        reports.add(runnable.call());
     }
 
-    private void addError(Report report, String msg, Exception ex, String fileName) {
-        LOG.log(Level.FINE, msg, ex);
-        report.addError(new Report.ProcessingError(ex.getMessage(), fileName));
+    @Override
+    protected void collectReports(List<Renderer> renderers) {
+        for (Report r : reports) {
+            super.renderReports(renderers, r);
+        }
+
+        // Since this thread may run PMD again, clean up th runnable
+        PmdRunnable.reset();
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/processor/MultiThreadProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/processor/MultiThreadProcessor.java
@@ -6,18 +6,17 @@ package net.sourceforge.pmd.processor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
 
 import net.sourceforge.pmd.PMDConfiguration;
 import net.sourceforge.pmd.Report;
-import net.sourceforge.pmd.RuleContext;
-import net.sourceforge.pmd.RuleSetFactory;
-import net.sourceforge.pmd.RuleSets;
 import net.sourceforge.pmd.renderers.Renderer;
-import net.sourceforge.pmd.util.datasource.DataSource;
 
 /**
  * @author Romain Pelisse &lt;belaran@gmail.com&gt;
@@ -25,62 +24,46 @@ import net.sourceforge.pmd.util.datasource.DataSource;
  */
 public class MultiThreadProcessor extends AbstractPMDProcessor {
 
+    private ThreadFactory factory;
+    private ExecutorService executor;
+    private CompletionService<Report> completionService;
+    private List<Future<Report>> tasks = new ArrayList<>();
+    
     public MultiThreadProcessor(final PMDConfiguration configuration) {
         super(configuration);
+
+        factory = new PmdThreadFactory();
+        executor = Executors.newFixedThreadPool(configuration.getThreads(), factory);
+        completionService = new ExecutorCompletionService<>(executor);
     }
 
-    /**
-     * Run PMD on a list of files using multiple threads.
-     */
-    public void processFiles(final RuleSetFactory ruleSetFactory, final List<DataSource> files, final RuleContext ctx,
-            final List<Renderer> renderers) {
-
-        RuleSets rs = createRuleSets(ruleSetFactory);
-        rs.start(ctx);
-        configuration.getAnalysisCache().checkValidity(rs, configuration.getClassLoader());
-
-        PmdThreadFactory factory = new PmdThreadFactory(ruleSetFactory, ctx);
-        ExecutorService executor = Executors.newFixedThreadPool(configuration.getThreads(), factory);
-        List<Future<Report>> tasks = new ArrayList<>(files.size());
-
-        for (DataSource dataSource : files) {
-            String niceFileName = filenameFrom(dataSource);
-
-            PmdRunnable r = new PmdRunnable(executor, configuration, dataSource, niceFileName, renderers);
-            Future<Report> future = executor.submit(r);
-            tasks.add(future);
-        }
-        executor.shutdown();
-
-        processReports(renderers, tasks);
-
-        rs.end(ctx);
-        super.renderReports(renderers, ctx.getReport());
-
+    @Override
+    protected void runAnalysis(PmdRunnable runnable) {
+        // multi-threaded execution, dispatch analysis to worker threads
+        tasks.add(completionService.submit(runnable));
     }
 
-    private void processReports(final List<Renderer> renderers, List<Future<Report>> tasks) {
-
-        while (!tasks.isEmpty()) {
-            Future<Report> future = tasks.remove(0);
-            Report report = null;
-            try {
-                report = future.get();
-            } catch (InterruptedException ie) {
-                Thread.currentThread().interrupt();
-                future.cancel(true);
-            } catch (ExecutionException ee) {
-                Throwable t = ee.getCause();
-                if (t instanceof RuntimeException) {
-                    throw (RuntimeException) t;
-                } else if (t instanceof Error) {
-                    throw (Error) t;
-                } else {
-                    throw new IllegalStateException("PmdRunnable exception", t);
-                }
+    @Override
+    protected void collectReports(List<Renderer> renderers) {
+        // Collect result analysis, waiting for termination if needed
+        try {
+            for (int i = 0; i < tasks.size(); i++) {
+                final Report report = completionService.take().get();
+                super.renderReports(renderers, report);
             }
-
-            super.renderReports(renderers, report);
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        } catch (ExecutionException ee) {
+            Throwable t = ee.getCause();
+            if (t instanceof RuntimeException) {
+                throw (RuntimeException) t;
+            } else if (t instanceof Error) {
+                throw (Error) t;
+            } else {
+                throw new IllegalStateException("PmdRunnable exception", t);
+            }
+        } finally {
+            executor.shutdownNow();
         }
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/processor/PmdThreadFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/processor/PmdThreadFactory.java
@@ -7,24 +7,13 @@ package net.sourceforge.pmd.processor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import net.sourceforge.pmd.RuleContext;
-import net.sourceforge.pmd.RuleSetFactory;
-
 public class PmdThreadFactory implements ThreadFactory {
 
-    private final RuleSetFactory ruleSetFactory;
-    private final RuleContext ctx;
     private final AtomicInteger counter = new AtomicInteger();
-
-    public PmdThreadFactory(RuleSetFactory ruleSetFactory, RuleContext ctx) {
-        this.ruleSetFactory = ruleSetFactory;
-        this.ctx = ctx;
-    }
 
     @Override
     public Thread newThread(Runnable r) {
-        Thread t = PmdRunnable.createThread(counter.incrementAndGet(), r, ruleSetFactory, ctx);
-        return t;
+        return new Thread(r, "PmdThread " + counter.incrementAndGet());
     }
 
 }

--- a/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
@@ -219,9 +219,7 @@ public abstract class RuleTst {
             ctx.setLanguageVersion(languageVersion);
             ctx.setIgnoreExceptions(false);
             RuleSet rules = new RuleSetFactory().createSingleRuleRuleSet(rule);
-            rules.start(ctx);
             p.getSourceCodeProcessor().processSourceCode(new StringReader(code), new RuleSets(rules), ctx);
-            rules.end(ctx);
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/src/site/markdown/customizing/howtowritearule.md
+++ b/src/site/markdown/customizing/howtowritearule.md
@@ -271,7 +271,7 @@ rule that checks stuff across the all source code? Let's take a dummy example. L
 rule that count how many Expression Node you have in your source code (told you, it was a dummy example :) ).
 
 You realize quite simply. You just have to add static field to the RulesContext, as an attribute, and uses
-Rule.start() and Rule.end() hook to initialized and finalize your rule's implementation:
+`Rule.start()` and `Rule.end()` hooks to initialize and finalize your rule's implementation:
 
     package net.sourceforge.pmd.rules;
     
@@ -309,9 +309,9 @@ Rule.start() and Rule.end() hook to initialized and finalize your rule's impleme
            }
     }
 
-As you can see in this example, the method start will be call the first time the rule is going to be used,
-so you can initialize properly your rule here. Once the rule will have finished to parses the source code,
-the method end() will be invoke you can assert there if, or not, your rule has been violated.
+As you can see in this example, the method `start()` will be called once per file, right before it's analysis starts,
+so you can initialize properly your rule here. Once the rule have finished analying the file's source code,
+the method `end()` will be invoked you can assert there if your rule has been violated or not.
 
 <em>
 Note that the example logs a violation **without** a proper classname. This is not really a good idea.


### PR DESCRIPTION
 - SourceCodeProcessor now consistently calls rule sets start / end
    if cache is not up to date
 - Both Mono and MultiThread Processors rely on PmdRunnable, just using
    different execution strategies
 - This also fixes https://sourceforge.net/p/pmd/bugs/1511/

@adangel I'm not sure this will merge nicely into PMD 5.4.4 (or even if we want to merge this completely to PMD 5.4.x / 5.5.x  rather than only the start / end changes). Let me know what you think and I'll split this if needed.
