### PR TITLE
[core] Allow for thread-safe report listeners

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
@@ -270,7 +270,7 @@ public class PMD {
 
             RuleContext ctx = new RuleContext();
             final AtomicInteger violations = new AtomicInteger(0);
-            ctx.getReport().addListener(new ReportListener() {
+            ctx.getReport().addListener(new ThreadSafeReportListener() {
                 @Override
                 public void ruleViolationAdded(RuleViolation ruleViolation) {
                     violations.incrementAndGet();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
@@ -61,7 +61,7 @@ public class Report implements Iterable<RuleViolation> {
         Report report = new Report();
 
         // overtake the listener
-        report.addSynchronizedListeners(ctx.getReport().getSynchronizedListeners());
+        report.addListeners(ctx.getReport().getListeners());
 
         ctx.setReport(report);
         ctx.setSourceCodeFilename(fileName);
@@ -279,7 +279,9 @@ public class Report implements Iterable<RuleViolation> {
      *
      * @param listener
      *            the listener
+     * @deprecated Use {@link #addListener(ThreadSafeReportListener)}
      */
+    @Deprecated
     public void addListener(ReportListener listener) {
         listeners.add(new SynchronizedReportListener(listener));
     }
@@ -321,7 +323,7 @@ public class Report implements Iterable<RuleViolation> {
         int index = Collections.binarySearch(violations, violation, RuleViolationComparator.INSTANCE);
         violations.add(index < 0 ? -index - 1 : index, violation);
         violationTree.addRuleViolation(violation);
-        for (ReportListener listener : listeners) {
+        for (ThreadSafeReportListener listener : listeners) {
             listener.ruleViolationAdded(violation);
         }
     }
@@ -334,7 +336,7 @@ public class Report implements Iterable<RuleViolation> {
      */
     public void addMetric(Metric metric) {
         metrics.add(metric);
-        for (ReportListener listener : listeners) {
+        for (ThreadSafeReportListener listener : listeners) {
             listener.metricAdded(metric);
         }
     }
@@ -522,17 +524,17 @@ public class Report implements Iterable<RuleViolation> {
         return end - start;
     }
 
-    public List<ThreadSafeReportListener> getSynchronizedListeners() {
+    public List<ThreadSafeReportListener> getListeners() {
         return listeners;
     }
 
     /**
      * Adds all given listeners to this report
      *
-     * @param synchronizedListeners
+     * @param allListeners
      *            the report listeners
      */
-    public void addSynchronizedListeners(List<ThreadSafeReportListener> synchronizedListeners) {
-        listeners.addAll(synchronizedListeners);
+    public void addListeners(List<ThreadSafeReportListener> allListeners) {
+        listeners.addAll(allListeners);
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
@@ -40,7 +40,7 @@ public class Report implements Iterable<RuleViolation> {
     // a bit
     private final List<RuleViolation> violations = new ArrayList<>();
     private final Set<Metric> metrics = new HashSet<>();
-    private final List<SynchronizedReportListener> listeners = new ArrayList<>();
+    private final List<ThreadSafeReportListener> listeners = new ArrayList<>();
     private List<ProcessingError> errors;
     private List<RuleConfigurationError> configErrors;
     private Map<Integer, String> linesToSuppress = new HashMap<>();
@@ -284,6 +284,16 @@ public class Report implements Iterable<RuleViolation> {
         listeners.add(new SynchronizedReportListener(listener));
     }
 
+    /**
+     * Registers a report listener
+     *
+     * @param listener
+     *            the listener
+     */
+    public void addListener(ThreadSafeReportListener listener) {
+        listeners.add(listener);
+    }
+
     public List<SuppressedViolation> getSuppressedRuleViolations() {
         return suppressedRuleViolations;
     }
@@ -512,7 +522,7 @@ public class Report implements Iterable<RuleViolation> {
         return end - start;
     }
 
-    public List<SynchronizedReportListener> getSynchronizedListeners() {
+    public List<ThreadSafeReportListener> getSynchronizedListeners() {
         return listeners;
     }
 
@@ -522,7 +532,7 @@ public class Report implements Iterable<RuleViolation> {
      * @param synchronizedListeners
      *            the report listeners
      */
-    public void addSynchronizedListeners(List<SynchronizedReportListener> synchronizedListeners) {
+    public void addSynchronizedListeners(List<ThreadSafeReportListener> synchronizedListeners) {
         listeners.addAll(synchronizedListeners);
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ReportListener.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ReportListener.java
@@ -9,7 +9,9 @@ import net.sourceforge.pmd.stat.Metric;
 /**
  * Listener to be informed about found violations. Note: Suppressed violations
  * are not reported to this listener.
+ * @deprecated Use {@link ThreadSafeReportListener} instead.
  */
+@Deprecated
 public interface ReportListener {
     /**
      * A new violation has been found.

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleContext.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleContext.java
@@ -52,7 +52,7 @@ public class RuleContext {
      */
     public RuleContext(RuleContext ruleContext) {
         this.attributes = ruleContext.attributes;
-        this.report.addSynchronizedListeners(ruleContext.getReport().getSynchronizedListeners());
+        this.report.addListeners(ruleContext.getReport().getListeners());
     }
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/SynchronizedReportListener.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/SynchronizedReportListener.java
@@ -8,7 +8,9 @@ import net.sourceforge.pmd.stat.Metric;
 
 /**
  * Wraps a report listener in order to synchronize calls to it.
+ * @deprecated This is an over-locking listener. Implement your own minimizing synchronization.
  */
+@Deprecated
 public final class SynchronizedReportListener implements ThreadSafeReportListener {
 
     private final ReportListener wrapped;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/SynchronizedReportListener.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/SynchronizedReportListener.java
@@ -9,7 +9,7 @@ import net.sourceforge.pmd.stat.Metric;
 /**
  * Wraps a report listener in order to synchronize calls to it.
  */
-public final class SynchronizedReportListener implements ReportListener {
+public final class SynchronizedReportListener implements ThreadSafeReportListener {
 
     private final ReportListener wrapped;
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ThreadSafeReportListener.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ThreadSafeReportListener.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd;
 
+import net.sourceforge.pmd.stat.Metric;
+
 /**
  * Marker interface for report listeners that, being thread-safe, need not
  * extra synchronization.
@@ -12,5 +14,19 @@ package net.sourceforge.pmd;
  * Same file violations are guaranteed to be reported serially.
  */
 public interface ThreadSafeReportListener extends ReportListener {
+    /**
+     * A new violation has been found.
+     *
+     * @param ruleViolation
+     *            the found violation.
+     */
+    void ruleViolationAdded(RuleViolation ruleViolation);
 
+    /**
+     * A new metric point has been reported.
+     *
+     * @param metric
+     *            the metric
+     */
+    void metricAdded(Metric metric);
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ThreadSafeReportListener.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ThreadSafeReportListener.java
@@ -1,0 +1,16 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd;
+
+/**
+ * Marker interface for report listeners that, being thread-safe, need not
+ * extra synchronization.
+ * 
+ * Thread-safety is required only for concurrently notifying about different files.
+ * Same file violations are guaranteed to be reported serially.
+ */
+public interface ThreadSafeReportListener extends ReportListener {
+
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/AnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/AnalysisCache.java
@@ -6,13 +6,13 @@ package net.sourceforge.pmd.cache;
 
 import java.io.File;
 
-import net.sourceforge.pmd.ReportListener;
 import net.sourceforge.pmd.RuleSets;
+import net.sourceforge.pmd.ThreadSafeReportListener;
 
 /**
  * An analysis cache for incremental analysis.
  */
-public interface AnalysisCache extends ReportListener {
+public interface AnalysisCache extends ThreadSafeReportListener {
 
     /**
      * Persist the analysis results on whatever means is used by the cache

--- a/pmd-core/src/test/java/net/sourceforge/pmd/processor/MultiThreadProcessorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/processor/MultiThreadProcessorTest.java
@@ -16,10 +16,10 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import net.sourceforge.pmd.PMDConfiguration;
-import net.sourceforge.pmd.ReportListener;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.RuleSetFactory;
 import net.sourceforge.pmd.RuleViolation;
+import net.sourceforge.pmd.ThreadSafeReportListener;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.rule.AbstractRule;
 import net.sourceforge.pmd.renderers.Renderer;
@@ -105,7 +105,7 @@ public class MultiThreadProcessorTest {
         }
     }
 
-    private static class SimpleReportListener implements ReportListener {
+    private static class SimpleReportListener implements ThreadSafeReportListener {
         public AtomicInteger violations = new AtomicInteger(0);
 
         @Override


### PR DESCRIPTION
 - This follows discussion on https://github.com/pmd/pmd/pull/125#discussion_r87666694
 - We add a marker interface for thread-safe listeners, and implement it were appropriate.
 - Breaking change: `getSynchronizedListeners` and `addSynchronizedListeners` now handle
    `List<ThreadSafeReportListener>`.
 - We may mark the non-thread-safe methods and interfaces as deprecated and force everyone
    to handle synchronization on their own for future releases.
