### PR TITLE
[java] Fix NPE error in CPD reported under #185

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/cpd/JavaTokenizer.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/cpd/JavaTokenizer.java
@@ -255,7 +255,16 @@ public class JavaTokenizer implements Tokenizer {
                 break;
 
             default:
-                // other tokens are not relevant to process
+                /*
+                 * Did we find a "class" token not followed by an identifier? i.e:
+                 * expectThrows(IllegalStateException.class, () -> {
+                 *  newSearcher(r).search(parentQuery.build(), c);
+                 * });
+                 */
+                if (storeNextIdentifier) {
+                    classMembersIndentations.pop();
+                    storeNextIdentifier = false;
+                }
                 break;
             }
         }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/cpd/JavaTokensTokenizerTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/cpd/JavaTokensTokenizerTest.java
@@ -202,4 +202,25 @@ public class JavaTokensTokenizerTest {
         // Enum constructor
         assertEquals("Foo", tokenList.get(13).toString());
     }
+    
+    @Test
+    public void testIgnoreIdentifiersWithClassKeyword() throws IOException {
+        JavaTokenizer t = new JavaTokenizer();
+        t.setIgnoreAnnotations(false);
+        t.setIgnoreIdentifiers(true);
+
+        SourceCode sourceCode = new SourceCode(new SourceCode.StringCodeLoader(
+                "package foo.bar.baz;" + PMD.EOL + "public class Foo {" + PMD.EOL + "Foo() {" + PMD.EOL
+                        + "}" + PMD.EOL + "public void bar() {" + PMD.EOL + "Bar.baz(Foo.class, () -> {});" 
+                        + PMD.EOL + "}" + PMD.EOL + "}" + PMD.EOL
+        ));
+        Tokens tokens = new Tokens();
+        t.tokenize(sourceCode, tokens);
+        TokenEntry.getEOF();
+        List<TokenEntry> tokenList = tokens.getTokens();
+
+        // Class constructor
+        assertEquals("Foo", tokenList.get(4).toString());
+        assertEquals(String.valueOf(JavaParserConstants.IDENTIFIER), tokenList.get(11).toString());
+    }
 }


### PR DESCRIPTION
This fixes a NPE scenario when ignoring identifiers when analyzing the Lucene source code as identified in #185.

The OOM error is still not resolved.

