### PR TITLE
[javascript] Templatestring grammar fix

### DIFF
--- a/pmd-javascript/etc/grammar/es5.jj
+++ b/pmd-javascript/etc/grammar/es5.jj
@@ -200,7 +200,16 @@ TOKEN :
       | "'"
         <SINGLE_STRING_LITERAL_BODY>
         "'"
+      | "`"
+        <BACKTICK_STRING_LITERAL_BODY>
+        "`"
   > : NOREGEXP
+|
+  < #BACKTICK_STRING_LITERAL_BODY:(   
+          ("\\" ~[] )
+        | (~["`", "\\"])
+        )*
+  >
 |
   < #SINGLE_STRING_LITERAL_BODY:(   
           ( "\\" ~[ "\r" , "\n" , "\u2028" , "\u2029"] )

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/cpd/EcmascriptTokenizerTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/cpd/EcmascriptTokenizerTest.java
@@ -118,4 +118,36 @@ public class EcmascriptTokenizerTest {
         sb.append( "}" ).append(PMD.EOL);
         return sb.toString();
     }
+
+    @Test
+    public void testTemplateStrings() throws IOException {
+        Tokenizer t = new EcmascriptTokenizer();
+        SourceCode sourceCode = new SourceCode( new SourceCode.StringCodeLoader(
+                  "export default class DrawLocation extends joint.shapes.basic.Generic {\n"
+                + "  constructor(location: ILocation) {\n"
+                + "    this.markup = `<g>\n"
+                + "        <path class=\"location\"/>\n"
+                + "        <text x=\"0\" y=\"0\" text-anchor=\"middle\" class=\"location-text\"></text>\n"
+                + "\n"
+                + "        <path class=\"location\"/>\n"
+                + "        <circle class=\"location-circle\"/>\n"
+                + "        ${drawIndicators.Check.markup}\n"
+                + "\n"
+                + "      </g>`;\n"
+                + "  }\n"
+                + "\n"
+                + "}") );
+        final Tokens tokens = new Tokens();
+        t.tokenize(sourceCode, tokens);
+        final String templateString = "`<g>\n"
+                + "        <path class=\"location\"/>\n"
+                + "        <text x=\"0\" y=\"0\" text-anchor=\"middle\" class=\"location-text\"></text>\n"
+                + "\n"
+                + "        <path class=\"location\"/>\n"
+                + "        <circle class=\"location-circle\"/>\n"
+                + "        ${drawIndicators.Check.markup}\n"
+                + "\n"
+                + "      </g>`";
+        assertEquals(templateString, tokens.getTokens().get(24).toString());
+    }
 }


### PR DESCRIPTION
Template strings as documented here were not tokenized correctly: http://www.ecma-international.org/ecma-262/6.0/#sec-template-literal-lexical-components

We would like to merge this into the 5.3.x branch, since we need to support Java 1.6.

This is a duplicate of adangel/pmd#38.