### PR TITLE
[java] Support generics in method references

### DIFF
--- a/pmd-java/etc/grammar/Java.jjt
+++ b/pmd-java/etc/grammar/Java.jjt
@@ -1,4 +1,9 @@
 /**
+ * Allow method references to specify generics.
+ * Bug #207
+ *
+ * Juan Martin Sotuyo Dodero 01/2017
+ *====================================================================
  * Simplify VariableDeclaratorId, forbidding illegal sequences such as
  * this[] and MyClass.this[]
  *
@@ -1812,7 +1817,7 @@ Token t;
 void MethodReference() :
 {Token t; checkForBadMethodReferenceUsage();}
 {
-  "::" ("new" {jjtThis.setImage("new");} | t=<IDENTIFIER> {jjtThis.setImage(t.image);} )
+  "::" ("new" {jjtThis.setImage("new");} | [TypeArguments()] t=<IDENTIFIER> {jjtThis.setImage(t.image);} )
 }
 
 void PrimaryPrefix() :

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
@@ -136,6 +136,12 @@ public class ParserCornersTest extends ParserTst {
         String c = IOUtils.toString(this.getClass().getResourceAsStream("Bug1530.java"));
         parseJava18(c);
     }
+    
+    @Test
+    public void testGitHubBug207() throws Exception {
+        String c = IOUtils.toString(this.getClass().getResourceAsStream("GitHubBug207.java"));
+        parseJava18(c);
+    }
 
     /**
      * This triggered bug #1484 UnusedLocalVariable - false positive -

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/GitHubBug207.java
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/GitHubBug207.java
@@ -1,0 +1,5 @@
+public class GitHubBug207 {
+    private static HttpMessageWriter<Resource> resourceHttpMessageWriter(BodyInserter.Context context) {
+        return context.map(BodyInserters::<Resource>cast);
+    }
+}


### PR DESCRIPTION
 - Fixes #207
 - Extend the Java grammar to support generics in method references: `Type::<Generic>method`