### PR TITLE
[java] Fix grammar for annotation members

### DIFF
--- a/pmd-java/etc/grammar/Java.jjt
+++ b/pmd-java/etc/grammar/Java.jjt
@@ -1,4 +1,9 @@
 /**
+ * Change lookahead for AnnotationMethodDeclaration in AnnotationTypeMemberDeclaration.
+ * Bug #206
+ *
+ * Juan Martin Sotuyo Dodero 01/2017
+ *====================================================================
  * Simplify VariableDeclaratorId, forbidding illegal sequences such as
  * this[] and MyClass.this[]
  *
@@ -2279,7 +2284,7 @@ void AnnotationTypeMemberDeclaration():
 {
  modifiers = Modifiers()
  (
-   LOOKAHEAD(3) AnnotationMethodDeclaration(modifiers)
+   LOOKAHEAD(Type() <IDENTIFIER> "(") AnnotationMethodDeclaration(modifiers)
   |
    ClassOrInterfaceDeclaration(modifiers)
   |

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
@@ -136,6 +136,15 @@ public class ParserCornersTest extends ParserTst {
         String c = IOUtils.toString(this.getClass().getResourceAsStream("Bug1530.java"));
         parseJava18(c);
     }
+    
+    @Test
+    public void testBug206() throws Exception {
+        String code = "public @interface Foo {" + PMD.EOL
+            + "static final ThreadLocal<Interner<Integer>> interner =" + PMD.EOL
+            + "    ThreadLocal.withInitial(Interners::newStrongInterner);" + PMD.EOL
+            + "}";
+        parseJava18(code);
+    }
 
     /**
      * This triggered bug #1484 UnusedLocalVariable - false positive -


### PR DESCRIPTION
 - The lookahead (3 tokens) was too small, and without reaching the opening
    parenthesis assumes it is parsing a method and not a field.
 - Using a larger lookahead solves the issue.
 - Fixes #206 