### PR TITLE
[java] Qualify references to inner classes of imports

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/ClassScope.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/ClassScope.java
@@ -387,6 +387,15 @@ public class ClassScope extends AbstractJavaScope {
             return qualified;
         }
 
+        // Is it an inner class of an explicit import?
+        int dotIndex = typeImage.indexOf('.');
+        if (dotIndex != -1) {
+            qualified = findQualifiedName(typeImage.substring(0, dotIndex), fileScope.getExplicitImports());
+            if (qualified != null) {
+                return qualified.concat(typeImage.substring(dotIndex));
+            }
+        }
+
         return typeImage;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/TypeSet.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/TypeSet.java
@@ -472,6 +472,18 @@ public class TypeSet {
 
             return c;
         }
+
+        @Override
+        public boolean couldResolve(String name) {
+            /*
+             * We can always try!
+             * If a file used an explicit import on A.Inner, the class loader will register
+             * A.Inner can't be resolved even if A$Inner can.
+             * If a second file used A.Inner without an explicit import, we would end here,
+             * super.couldResolve("A.Inner") will return false, but we CAN resolve it as A$Inner.
+             */
+            return true;
+        }
     }
 
     public void setASTCompilationUnitPackage(String pkg) {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symboltable/ClassScopeTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symboltable/ClassScopeTest.java
@@ -163,6 +163,14 @@ public class ClassScopeTest extends STBBaseTst {
     }
 
     @Test
+    public void testNestedClassesOfImportResolution() {
+        parseCode(NESTED_CLASSES_OF_IMPORT);
+        final ASTClassOrInterfaceDeclaration n = acu.findDescendantsOfType(ASTClassOrInterfaceDeclaration.class).get(0);
+        final ClassScope c = (ClassScope) n.getScope();
+        assertEquals(EnumTest.class, c.resolveType("TheInnerClass.EnumTest"));
+    }
+
+    @Test
     public void testNestedClassesResolution() {
         parseForClass(InnerClass.class);
         final ASTClassOrInterfaceDeclaration n = acu.findDescendantsOfType(ASTClassOrInterfaceDeclaration.class).get(0);
@@ -349,5 +357,11 @@ public class ClassScopeTest extends STBBaseTst {
             "import net.sourceforge.pmd.lang.java.symboltable.testdata.InnerClass.TheInnerClass.EnumTest;" + PMD.EOL
             + "public class Foo {" + PMD.EOL
             + " public EnumTest e;" + PMD.EOL
+            + "}" + PMD.EOL;
+
+    private static final String NESTED_CLASSES_OF_IMPORT =
+            "import net.sourceforge.pmd.lang.java.symboltable.testdata.InnerClass.TheInnerClass;" + PMD.EOL
+            + "public class Foo {" + PMD.EOL
+            + " public TheInnerClass.EnumTest e;" + PMD.EOL
             + "}" + PMD.EOL;
 }


### PR DESCRIPTION
 - Given an import on `a.Foo`, references to `Foo.Inner` should be qualified
    as `a.Foo.Inner`.
 - This fixes a couple of wrong missing classes.
 - The test also brought to light another issue with resolvers that would fail
    to resolve even a qualified inner class if not explicitly imported under
    certain circumstances.
