### PR TITLE
[java] Fix same package import from default package

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/TypeSet.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/TypeSet.java
@@ -239,7 +239,7 @@ public class TypeSet {
          */
         public CurrentPackageResolver(PMDASMClassLoader pmdClassLoader, String pkg) {
             super(pmdClassLoader);
-            if (pkg == null) {
+            if (pkg == null || pkg.length() == 0) {
                 this.pkg = null;
             } else {
                 this.pkg = pkg + ".";


### PR DESCRIPTION
 - If the package was passed as an empty string rather than a `null`, we
    would attempt to load classes such as `.Foo` rather than `Foo`.