### PR TITLE
[apex] Dynamic SOQL is safe against Integer, Boolean, Double

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
@@ -96,6 +96,10 @@ public class ApexSOQLInjectionRule extends AbstractApexRule {
         if (literal != null) {
             if (left != null) {
                 Object o = literal.getNode().getLiteral();
+                if (o instanceof Integer || o instanceof Boolean || o instanceof Double) {
+                    safeVariables.add(Helper.getFQVariableName(left));
+                }
+
                 if (o instanceof String) {
                     if (SELECT_PATTERN.matcher((String) o).matches()) {
                         selectContainingVariables.put(Helper.getFQVariableName(left), Boolean.TRUE);

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSOQLInjection.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSOQLInjection.xml
@@ -206,4 +206,19 @@ public class Foo {
 }
 		]]></code>
 	</test-code>
+	
+	<test-code>
+		<description>Dynamic SOQL with Integer
+		</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		Integer field1 = 4; 
+		Database.query('SELECT Id FROM Account LIMIT ' + field1);		
+	}
+}
+		]]></code>
+	</test-code>
+		
 </test-data>


### PR DESCRIPTION
Should not report Integer, Double, Boolean when merged into a dynamic SOQL query.


