### PR TITLE
[apex] CRUD/FLS rule - add support for fields

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.apex.rule.security;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -26,6 +27,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTDmlUpsertStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTDottedExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTField;
 import net.sourceforge.pmd.lang.apex.ast.ASTFieldDeclaration;
+import net.sourceforge.pmd.lang.apex.ast.ASTFieldDeclarationStatements;
 import net.sourceforge.pmd.lang.apex.ast.ASTIfElseBlockStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
 import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
@@ -42,6 +44,7 @@ import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.ast.Node;
 
 import apex.jorje.data.ast.Identifier;
+import apex.jorje.data.ast.TypeRef;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 
@@ -162,6 +165,25 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
 
     @Override
     public Object visit(final ASTFieldDeclaration node, Object data) {
+        ASTFieldDeclarationStatements field = node.getFirstParentOfType(ASTFieldDeclarationStatements.class);
+        if (field != null) {
+            try {
+                TypeRef a = field.getNode().getTypeName();
+                Field f = a.getClass().getDeclaredField("className");
+                f.setAccessible(true);
+                if (f.get(a) instanceof ArrayList<?>) {
+                    @SuppressWarnings("unchecked")
+                    ArrayList<Identifier> innerField = (ArrayList<Identifier>) f.get(a);
+                    if (!innerField.isEmpty()) {
+                        String type = innerField.get(0).value;
+                        addVariableToMapping(Helper.getFQVariableName(node), type);
+                    }
+                }
+
+            } catch (NoSuchFieldException | IllegalArgumentException | IllegalAccessException | SecurityException e) {
+            }
+
+        }
         final ASTSoqlExpression soql = node.getFirstChildOfType(ASTSoqlExpression.class);
         if (soql != null) {
             checkForAccessibility(soql, data);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
@@ -15,6 +15,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTDmlUpdateStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTDmlUpsertStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTDottedExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTField;
+import net.sourceforge.pmd.lang.apex.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTModifierNode;
 import net.sourceforge.pmd.lang.apex.ast.ASTNewNameValueObjectExpression;
@@ -25,11 +26,13 @@ import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration;
 import net.sourceforge.pmd.lang.apex.ast.ASTVariableExpression;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 
+import apex.jorje.data.ast.Identifier;
 import apex.jorje.data.ast.TypeRef.ClassTypeRef;
 import apex.jorje.semantic.ast.expression.MethodCallExpression;
 import apex.jorje.semantic.ast.expression.NewNameValueObjectExpression;
 import apex.jorje.semantic.ast.expression.VariableExpression;
 import apex.jorje.semantic.ast.member.Field;
+import apex.jorje.semantic.ast.statement.FieldDeclaration;
 import apex.jorje.semantic.ast.statement.VariableDeclaration;
 
 /**
@@ -172,6 +175,24 @@ public final class Helper {
         Field n = variable.getNode();
         StringBuilder sb = new StringBuilder().append(n.getDefiningType().getApexName()).append(":")
                 .append(n.getFieldInfo().getName());
+        return sb.toString();
+    }
+
+    static String getFQVariableName(final ASTFieldDeclaration variable) {
+        FieldDeclaration n = variable.getNode();
+        String name = "";
+
+        try {
+            java.lang.reflect.Field f = n.getClass().getDeclaredField("name");
+            f.setAccessible(true);
+            Identifier nameField = (Identifier) f.get(n);
+            name = nameField.value;
+
+        } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+
+        StringBuilder sb = new StringBuilder().append(n.getDefiningType().getApexName()).append(":").append(name);
         return sb.toString();
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
@@ -189,7 +189,6 @@ public final class Helper {
             name = nameField.value;
 
         } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
-            e.printStackTrace();
         }
 
         StringBuilder sb = new StringBuilder().append(n.getDefiningType().getApexName()).append(":").append(name);

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
@@ -622,7 +622,7 @@ public class Foo {
 	</test-code> 
 
 	<test-code>
-		<description>Control flow with nested statementsL</description>
+		<description>Control flow with nested statements</description>
 		<expected-problems>0</expected-problems>
 		<code><![CDATA[ 
 public class Foo { 	
@@ -644,5 +644,20 @@ public class Foo {
 	
 ]]></code>
 	</test-code>	
+	
+	<test-code>
+		<description>Field detection</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[ 
+public class MyProfilePageController { 	
+	private User currentUser;
 
+    public MyProfilePageController() {
+        currentUser = [SELECT id FROM User WHERE id = :UserInfo.getUserId()];
+    } 
+}
+	
+]]></code>
+	</test-code>
+	
 </test-data>


### PR DESCRIPTION
FieldDeclaration by far has the worst API in Apex Jorje binary.
I cannot get any basic information out of it without resorting to Reflection. 
Here I needed two pieces of information: field type and name. I had to use reflection to get both.
ASTFieldDeclaration.getNode().getFieldInfo() is returning null.
