### PR TITLE
[core] Fix IOException loading rulesets under concurrency

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
@@ -299,6 +299,15 @@ public class PMD {
             return 0;
         } finally {
             Benchmarker.mark(Benchmark.Reporting, System.nanoTime() - reportStart, 0);
+
+            /*
+             * Make sure it's our own classloader before attempting to close it....
+             * Maven + Jacoco provide us with a cloaseable classloader that if closed
+             * will throw a ClassNotFoundException.
+            */
+            if (configuration.getClassLoader() instanceof ClasspathClassLoader) {
+                IOUtil.tryCloseClassLoader(configuration.getClassLoader());
+            }
         }
     }
 
@@ -405,10 +414,6 @@ public class PMD {
         
         // Persist the analysis cache
         configuration.getAnalysisCache().persist();
-
-        if (configuration.getClassLoader() instanceof ClasspathClassLoader) {
-            IOUtil.tryCloseClassLoader(configuration.getClassLoader());
-        }
     }
 
     private static void sortFiles(final PMDConfiguration configuration, final List<DataSource> files) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
@@ -4,7 +4,6 @@
 
 package net.sourceforge.pmd.ant.internal;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -269,19 +268,8 @@ public class PMDTaskImpl {
         try {
             doTask();
         } finally {
-            tryClose(configuration.getClassLoader());
             logManager.close();
             IOUtil.tryCloseClassLoader(configuration.getClassLoader());
-        }
-    }
-
-    private static void tryClose(ClassLoader classLoader) {
-        if (classLoader instanceof Closeable) {
-            try {
-                ((Closeable) classLoader).close();
-            } catch (IOException ignore) {
-                // do nothing.
-            }
         }
     }
 


### PR DESCRIPTION
 - Fixes #234
 - When a single JVM runs multiple PMD instances under different threads,
    connections to PMD jars (and streams opened to read standard rulesets)
    are shared, causing race conditions where one thread may cause the other
    to close it's streams. This in tun produces IOExceptions.
 - This happens in Gradle when enabling parallel builds. I believe it can happen
    under Maven with -T1C too, but has not been able to reproduce it.
 - I take the chance to clean up classloader closing code.

This bug was introduced in PMD 5.5.1 and 5.4.2, when we fixed the leaked file handlers.