### PR TITLE
[java] Fix classscope references

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/ClassNameDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/ClassNameDeclaration.java
@@ -6,16 +6,12 @@ package net.sourceforge.pmd.lang.java.symboltable;
 
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTEnumDeclaration;
+import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.symboltable.AbstractNameDeclaration;
 
 public class ClassNameDeclaration extends AbstractNameDeclaration implements TypedNameDeclaration {
 
-    public ClassNameDeclaration(ASTClassOrInterfaceDeclaration node) {
-        super(node);
-    }
-
-    public ClassNameDeclaration(ASTEnumDeclaration node) {
+    public ClassNameDeclaration(JavaNode node) {
         super(node);
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/ClassScope.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/ClassScope.java
@@ -73,9 +73,16 @@ public class ClassScope extends AbstractJavaScope {
 
     private boolean isEnum;
 
-    public ClassScope(final String className) {
+    /**
+     * The current class scope declaration. Technically it belongs to out parent scope,
+     * but knowing it we can better resolve this, super and direct class references such as Foo.X
+     */
+    private final ClassNameDeclaration classDeclaration;
+
+    public ClassScope(final String className, final ClassNameDeclaration classNameDeclaration) {
         this.className = Objects.requireNonNull(className);
         anonymousInnerClassCounter.set(Integer.valueOf(1));
+        this.classDeclaration = classNameDeclaration;
     }
 
     /**
@@ -84,13 +91,16 @@ public class ClassScope extends AbstractJavaScope {
      * <p>FIXME - should have name like Foo$1, not Anonymous$1 to get this working
      * right, the parent scope needs to be passed in when instantiating a
      * ClassScope</p>
+     * 
+     * @param classNameDeclaration The declaration of this class, as known to the parent scope.
      */
-    public ClassScope() {
+    public ClassScope(final ClassNameDeclaration classNameDeclaration) {
         // this.className = getParent().getEnclosingClassScope().getClassName()
         // + "$" + String.valueOf(anonymousInnerClassCounter);
         int v = anonymousInnerClassCounter.get().intValue();
         this.className = "Anonymous$" + v;
         anonymousInnerClassCounter.set(v + 1);
+        classDeclaration = classNameDeclaration;
     }
 
     public void setIsEnum(boolean isEnum) {
@@ -156,31 +166,12 @@ public class ClassScope extends AbstractJavaScope {
     }
 
     protected Set<NameDeclaration> findVariableHere(JavaNameOccurrence occurrence) {
-        Map<MethodNameDeclaration, List<NameOccurrence>> methodDeclarations = getMethodDeclarations();
-        Map<VariableNameDeclaration, List<NameOccurrence>> variableDeclarations = getVariableDeclarations();
         if (occurrence.isThisOrSuper() || className.equals(occurrence.getImage())) {
-            if (variableDeclarations.isEmpty() && methodDeclarations.isEmpty()) {
-                // this could happen if you do this:
-                // public class Foo {
-                // private String x = super.toString();
-                // }
-                return Collections.emptySet();
-            }
-            // return any name declaration, since all we really want is to get
-            // the scope
-            // for example, if there's a
-            // public class Foo {
-            // private static final int X = 2;
-            // private int y = Foo.X;
-            // }
-            // we'll look up Foo just to get a handle to the class scope
-            // and then we'll look up X.
-            if (!variableDeclarations.isEmpty()) {
-                return Collections.<NameDeclaration>singleton(variableDeclarations.keySet().iterator().next());
-            }
-            return Collections.<NameDeclaration>singleton(methodDeclarations.keySet().iterator().next());
+            // Reference to ourselves!
+            return Collections.<NameDeclaration>singleton(classDeclaration);
         }
 
+        Map<MethodNameDeclaration, List<NameOccurrence>> methodDeclarations = getMethodDeclarations();
         Set<NameDeclaration> result = new HashSet<>();
         if (occurrence.isMethodOrConstructorInvocation()) {
             final boolean hasAuxclasspath = getEnclosingScope(SourceFileScope.class).hasAuxclasspath();
@@ -244,6 +235,8 @@ public class ClassScope extends AbstractJavaScope {
                 images.add(clipClassName(occurrence.getImage()));
             }
         }
+
+        Map<VariableNameDeclaration, List<NameOccurrence>> variableDeclarations = getVariableDeclarations();
         ImageFinderFunction finder = new ImageFinderFunction(images);
         Applier.apply(finder, variableDeclarations.keySet().iterator());
         if (finder.getDecl() != null) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/ScopeAndDeclarationFinder.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/ScopeAndDeclarationFinder.java
@@ -131,10 +131,14 @@ public class ScopeAndDeclarationFinder extends JavaParserVisitorAdapter {
      *             if the scope stack is empty.
      */
     private void createClassScope(JavaNode node) {
+        Scope s = ((JavaNode) node.jjtGetParent()).getScope();
+        ClassNameDeclaration classNameDeclaration = new ClassNameDeclaration(node);
+        s.addDeclaration(classNameDeclaration);
+
         if (node instanceof ASTClassOrInterfaceBodyDeclaration) {
-            addScope(new ClassScope(), node);
+            addScope(new ClassScope(classNameDeclaration), node);
         } else {
-            addScope(new ClassScope(node.getImage()), node);
+            addScope(new ClassScope(node.getImage(), classNameDeclaration), node);
         }
     }
 
@@ -171,8 +175,6 @@ public class ScopeAndDeclarationFinder extends JavaParserVisitorAdapter {
     @Override
     public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
         createClassScope(node);
-        Scope s = ((JavaNode) node.jjtGetParent()).getScope();
-        s.addDeclaration(new ClassNameDeclaration(node));
         cont(node);
         return data;
     }
@@ -181,8 +183,6 @@ public class ScopeAndDeclarationFinder extends JavaParserVisitorAdapter {
     public Object visit(ASTEnumDeclaration node, Object data) {
         createClassScope(node);
         ((ClassScope) node.getScope()).setIsEnum(true);
-        Scope s = ((JavaNode) node.jjtGetParent()).getScope();
-        s.addDeclaration(new ClassNameDeclaration(node));
         cont(node);
         return data;
     }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symboltable/ClassScopeTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symboltable/ClassScopeTest.java
@@ -48,16 +48,18 @@ public class ClassScopeTest extends STBBaseTst {
     // FIXME - these will break when this goes from Anonymous$1 to Foo$1
     @Test
     public void testAnonymousInnerClassName() {
-        ClassScope s = new ClassScope("Foo");
-        s = new ClassScope();
+        ClassNameDeclaration classDeclaration = new ClassNameDeclaration(null);
+        ClassScope s = new ClassScope("Foo", classDeclaration);
+        s = new ClassScope(classDeclaration);
         assertEquals("Anonymous$1", s.getClassName());
-        s = new ClassScope();
+        s = new ClassScope(classDeclaration);
         assertEquals("Anonymous$2", s.getClassName());
     }
 
     @Test
     public void testContains() {
-        ClassScope s = new ClassScope("Foo");
+        ClassNameDeclaration classDeclaration = new ClassNameDeclaration(null);
+        ClassScope s = new ClassScope("Foo", classDeclaration);
         ASTVariableDeclaratorId node = new ASTVariableDeclaratorId(1);
         node.setImage("bar");
         s.addDeclaration(new VariableNameDeclaration(node));
@@ -66,7 +68,8 @@ public class ClassScopeTest extends STBBaseTst {
 
     @Test
     public void testCantContainsSuperToString() {
-        ClassScope s = new ClassScope("Foo");
+        ClassNameDeclaration classDeclaration = new ClassNameDeclaration(null);
+        ClassScope s = new ClassScope("Foo", classDeclaration);
         JavaNode node = new DummyJavaNode(1);
         node.setImage("super.toString");
         assertFalse(s.contains(new JavaNameOccurrence(node, node.getImage())));
@@ -74,7 +77,8 @@ public class ClassScopeTest extends STBBaseTst {
 
     @Test
     public void testContainsStaticVariablePrefixedWithClassName() {
-        ClassScope s = new ClassScope("Foo");
+        ClassNameDeclaration classDeclaration = new ClassNameDeclaration(null);
+        ClassScope s = new ClassScope("Foo", classDeclaration);
         ASTVariableDeclaratorId node = new ASTVariableDeclaratorId(1);
         node.setImage("X");
         s.addDeclaration(new VariableNameDeclaration(node));


### PR DESCRIPTION
 - A bunch of closely related issues fixed:
   - References to `this`, `super` and `Classname` were very badly resolved
      (pointed to variables, methods, or nothing at all on empty classes)
   - Annotations would not be registered by their parent scopes.

I mark it for version 5.5.4, since I don't think this will merge nicely into branch 4.x (at least, most of the symboltable changes when we improved the performance weren't merged to that branch)

This changeset is fundamental to my work on [#1496](https://sourceforge.net/p/pmd/bugs/1496/), since the bad resolution of `this`, `super` and `Classname` are introducing false positives on my test code.