### PR TITLE
[java] Revamp UnusedModifier

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotationTypeDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotationTypeDeclaration.java
@@ -21,4 +21,8 @@ public class ASTAnnotationTypeDeclaration extends AbstractJavaAccessTypeNode {
         return visitor.visit(this, data);
     }
 
+    public boolean isNested() {
+        return jjtGetParent() instanceof ASTClassOrInterfaceBodyDeclaration
+                || jjtGetParent() instanceof ASTAnnotationTypeMemberDeclaration;
+    }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassOrInterfaceDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassOrInterfaceDeclaration.java
@@ -31,7 +31,8 @@ public class ASTClassOrInterfaceDeclaration extends AbstractJavaAccessTypeNode {
     }
 
     public boolean isNested() {
-        return jjtGetParent() instanceof ASTClassOrInterfaceBodyDeclaration;
+        return jjtGetParent() instanceof ASTClassOrInterfaceBodyDeclaration
+                || jjtGetParent() instanceof ASTAnnotationTypeMemberDeclaration;
     }
 
     public boolean isInterface() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/unusedcode/UnusedModifierRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/unusedcode/UnusedModifierRule.java
@@ -5,6 +5,8 @@
 package net.sourceforge.pmd.lang.java.rule.unusedcode;
 
 import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.java.ast.ASTAnnotationMethodDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTAnnotationTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTEnumDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
@@ -13,37 +15,70 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
 public class UnusedModifierRule extends AbstractJavaRule {
 
-    public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
+    @Override
+    public Object visit(ASTEnumDeclaration node, Object data) {
+        if (node.isStatic()) {
+            // a static enum
+            addViolation(data, node, getMessage());
+        }
+
+        return super.visit(node, data);
+    }
+
+    public Object visit(ASTAnnotationTypeDeclaration node, Object data) {
+        if (node.isAbstract()) {
+            // an abstract annotation
+            addViolation(data, node, getMessage());
+        }
+
         if (!node.isNested()) {
             return super.visit(node, data);
         }
 
-        ASTClassOrInterfaceDeclaration parentClassOrInterface = node
-                .getFirstParentOfType(ASTClassOrInterfaceDeclaration.class);
-        ASTEnumDeclaration parentEnum = node.getFirstParentOfType(ASTEnumDeclaration.class);
+        Node parent = node.jjtGetParent().jjtGetParent().jjtGetParent();
+        boolean isParentInterfaceOrAnnotation = parent instanceof ASTAnnotationTypeDeclaration ||
+                parent instanceof ASTClassOrInterfaceDeclaration && ((ASTClassOrInterfaceDeclaration) parent).isInterface();
 
-        if (node.isInterface() && node.isPublic()) {
-            // a public interface
-            if (parentClassOrInterface != null && parentClassOrInterface.isInterface()) {
-                // within a interface
-                addViolation(data, node, getMessage());
-            }
+        // a public annotation within an interface or annotation
+        if (node.isPublic() && isParentInterfaceOrAnnotation) {
+            addViolation(data, node, getMessage());
+        }
+
+        if (node.isStatic()) {
+            // a static annotation
+            addViolation(data, node, getMessage());
+        }
+
+        return super.visit(node, data);
+    }
+
+    public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
+        if (node.isInterface() && node.isAbstract()) {
+            // an abstract interface
+            addViolation(data, node, getMessage());
+        }
+
+        if (!node.isNested()) {
+            return super.visit(node, data);
+        }
+
+        Node parent = node.jjtGetParent().jjtGetParent().jjtGetParent();
+        boolean isParentInterfaceOrAnnotation = parent instanceof ASTAnnotationTypeDeclaration ||
+                parent instanceof ASTClassOrInterfaceDeclaration && ((ASTClassOrInterfaceDeclaration) parent).isInterface();
+
+        // a public interface within an interface or annotation
+        if (node.isInterface() && node.isPublic() && isParentInterfaceOrAnnotation) {
+            addViolation(data, node, getMessage());
         }
 
         if (node.isInterface() && node.isStatic()) {
             // a static interface
-            if (parentClassOrInterface != null || parentEnum != null) {
-                // within a interface, class or enum
-                addViolation(data, node, getMessage());
-            }
+            addViolation(data, node, getMessage());
         }
 
-        if (!node.isInterface() && (node.isPublic() || node.isStatic())) {
-            // a public and/or static class
-            if (parentClassOrInterface != null && parentClassOrInterface.isInterface()) {
-                // within a interface
-                addViolation(data, node, getMessage());
-            }
+        // a public and/or static class within an interface or annotation
+        if (!node.isInterface() && (node.isPublic() || node.isStatic()) && isParentInterfaceOrAnnotation) {
+            addViolation(data, node, getMessage());
         }
 
         return super.visit(node, data);
@@ -63,11 +98,19 @@ public class UnusedModifierRule extends AbstractJavaRule {
         return super.visit(node, data);
     }
 
+    public Object visit(ASTAnnotationMethodDeclaration node, Object data) {
+        if (node.isPublic() || node.isAbstract()) {
+            check(node, data);
+        }
+        return super.visit(node, data);
+    }
+
     private void check(Node fieldOrMethod, Object data) {
         // third ancestor could be an AllocationExpression
         // if this is a method in an anonymous inner class
         Node parent = fieldOrMethod.jjtGetParent().jjtGetParent().jjtGetParent();
-        if (parent instanceof ASTClassOrInterfaceDeclaration
+        if (parent instanceof ASTAnnotationTypeDeclaration ||
+                parent instanceof ASTClassOrInterfaceDeclaration
                 && ((ASTClassOrInterfaceDeclaration) parent).isInterface()) {
             addViolation(data, fieldOrMethod);
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/unusedcode/UnusedModifierRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/unusedcode/UnusedModifierRule.java
@@ -36,8 +36,8 @@ public class UnusedModifierRule extends AbstractJavaRule {
         }
 
         Node parent = node.jjtGetParent().jjtGetParent().jjtGetParent();
-        boolean isParentInterfaceOrAnnotation = parent instanceof ASTAnnotationTypeDeclaration ||
-                parent instanceof ASTClassOrInterfaceDeclaration && ((ASTClassOrInterfaceDeclaration) parent).isInterface();
+        boolean isParentInterfaceOrAnnotation = parent instanceof ASTAnnotationTypeDeclaration
+                || parent instanceof ASTClassOrInterfaceDeclaration && ((ASTClassOrInterfaceDeclaration) parent).isInterface();
 
         // a public annotation within an interface or annotation
         if (node.isPublic() && isParentInterfaceOrAnnotation) {
@@ -63,8 +63,8 @@ public class UnusedModifierRule extends AbstractJavaRule {
         }
 
         Node parent = node.jjtGetParent().jjtGetParent().jjtGetParent();
-        boolean isParentInterfaceOrAnnotation = parent instanceof ASTAnnotationTypeDeclaration ||
-                parent instanceof ASTClassOrInterfaceDeclaration && ((ASTClassOrInterfaceDeclaration) parent).isInterface();
+        boolean isParentInterfaceOrAnnotation = parent instanceof ASTAnnotationTypeDeclaration
+                || parent instanceof ASTClassOrInterfaceDeclaration && ((ASTClassOrInterfaceDeclaration) parent).isInterface();
 
         // a public interface within an interface or annotation
         if (node.isInterface() && node.isPublic() && isParentInterfaceOrAnnotation) {
@@ -109,8 +109,8 @@ public class UnusedModifierRule extends AbstractJavaRule {
         // third ancestor could be an AllocationExpression
         // if this is a method in an anonymous inner class
         Node parent = fieldOrMethod.jjtGetParent().jjtGetParent().jjtGetParent();
-        if (parent instanceof ASTAnnotationTypeDeclaration ||
-                parent instanceof ASTClassOrInterfaceDeclaration
+        if (parent instanceof ASTAnnotationTypeDeclaration
+                || parent instanceof ASTClassOrInterfaceDeclaration
                 && ((ASTClassOrInterfaceDeclaration) parent).isInterface()) {
             addViolation(data, fieldOrMethod);
         }

--- a/pmd-java/src/main/resources/rulesets/java/unusedcode.xml
+++ b/pmd-java/src/main/resources/rulesets/java/unusedcode.xml
@@ -103,13 +103,21 @@ public class Foo {
           class="net.sourceforge.pmd.lang.java.rule.unusedcode.UnusedModifierRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/unusedcode.html#UnusedModifier">
      <description>
-Fields in interfaces are automatically public static final, and methods are public abstract.
-Classes or interfaces nested in an interface are automatically public and static (all nested interfaces are automatically static).
+Fields in interfaces and annotations are automatically `public static final`, and methods are `public abstract`.
+Classes, interfaces or annotations nested in an interface or annotation are automatically `public static`
+(all nested interfaces and annotations are automatically static).
+Nested enums are automatically `static`.
 For historical reasons, modifiers which are implied by the context are accepted by the compiler, but are superfluous.
      </description>
         <priority>3</priority>
      <example>
  <![CDATA[
+ public @interface Annotation {
+  public abstract void bar(); 		// both abstract and public are ignored by the compiler
+  public static final int X = 0; 	// public, static, and final all ignored
+  public static class Bar {} 		// public, static ignored
+  public static interface Baz {} 	// ditto
+}
 public interface Foo {
   public abstract void bar(); 		// both abstract and public are ignored by the compiler
   public static final int X = 0; 	// public, static, and final all ignored
@@ -118,6 +126,9 @@ public interface Foo {
 }
 public class Bar {
   public static interface Baz {} // static ignored
+  public static enum FoorBar { // static ignored
+    FOO;
+  }
 }
  ]]>
      </example>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/unusedcode/xml/UnusedModifier.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/unusedcode/xml/UnusedModifier.xml
@@ -296,4 +296,136 @@ public enum TestEnum {
 }
         ]]></code>
     </test-code>
+    
+    <test-code>
+        <description>Unnecessary public on annotation element</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public @interface TestAnnotation {
+    public String message();
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Unnecessary abstract on annotation element</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public @interface TestAnnotation {
+    abstract String message();
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Unnecessary final on annotation field</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public @interface TestAnnotation {
+    final String message = "MESSAGE";
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Unnecessary static on annotation field</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public @interface TestAnnotation {
+    static String message = "MESSAGE";
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Unnecessary public on annotation field</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public @interface TestAnnotation {
+    public String message = "MESSAGE";
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Unnecessary public on annotation nested class</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public @interface TestAnnotation {
+    public class Inner {
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Unnecessary static on annotation nested class</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public @interface TestAnnotation {
+    static class Inner {
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Unnecessary public on annotation nested interface</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public @interface TestAnnotation {
+    public interface Inner {
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Unnecessary public on annotation nested annotation</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public @interface TestAnnotation {
+    public @interface Inner {
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Unnecessary static on annotation nested enum</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public @interface TestAnnotation {
+    public static enum Inner {
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Unnecessary static on interface nested enum</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public interface TestInterface {
+    public static enum Inner {
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Unnecessary static on class nested enum</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class TestClass {
+    public static enum Inner {
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Unnecessary abstract on interface</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public abstract interface TestInterface {
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Unnecessary abstract on annotation</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public abstract @interface TestAnnotation {
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
 - This covers a ton of missing cases
 - Fixes #246
 - Fixes #247
 - Fixes #248
 - Notice `isNested` has been improved on `ASTClassOrInterfaceDeclaration`
    to cover being nested in an annotation definition
