### PR TITLE
[apex] Fix chained method line count for types

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/complexity/NcssTypeCountRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/complexity/NcssTypeCountRule.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.lang.apex.rule.complexity;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
-import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserEnum;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserInterface;
@@ -64,11 +63,6 @@ public class NcssTypeCountRule extends AbstractNcssCountRule {
         }
 
         return NumericConstants.ZERO;
-    }
-
-    @Override
-    public Object visit(ASTMethodCallExpression node, Object data) {
-        return countNodeChildren(node, data);
     }
 
     @Override

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/complexity/xml/NcssTypeCount.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/complexity/xml/NcssTypeCount.xml
@@ -78,5 +78,29 @@ public class Foo {
         <expected-problems>0</expected-problems>
         <code-ref id="long method"/>
     </test-code>
+
+	<test-code>
+        <description>Github issue #251 - lines are counted properly</description>
+        <rule-property name="minimum">10</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+@isTest
+private class AcceptanceTests_Test {
     
+    @isTest
+    private static void test() {
+        // Setup
+        Opportunity o1 = new Opportunity()
+                                    .add(new Contact().foo(1)  .bar(1).year(2012)  .bar(1).price(5)  .vol(100))
+                                    .add(new Contact().foo(1)  .bar(2).year(2013)  .bar(1).price(5)  .vol(110))
+                                    .add(new Contact().foo(1)  .bar(3).year(2014)  .bar(1).price(5)  .vol(120))
+                                    .add(new Contact().foo(1)  .bar(4).year(2015)  .bar(1).price(5)  .vol(130))
+                                    .persist();
+
+        // Verify
+        System.assert(attribute());
+    }
+}
+        ]]></code>
+    </test-code>    
 </test-data>


### PR DESCRIPTION
 - Fixes #251
 - The abstract parent class was already handling it properly, no need
    to override to visit to a method call.
