### PR TITLE
[core] Cache rule violations

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/SourceCodeProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/SourceCodeProcessor.java
@@ -86,6 +86,9 @@ public class SourceCodeProcessor {
         if (ruleSets.applies(ctx.getSourceCodeFile())) {
             // Is the cache up to date?
             if (configuration.getAnalysisCache().isUpToDate(ctx.getSourceCodeFile())) {
+                for (final RuleViolation rv : configuration.getAnalysisCache().getCachedViolations(ctx.getSourceCodeFile())) {
+                    ctx.getReport().addRuleViolation(rv);
+                }
                 return;
             }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/AnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/AnalysisCache.java
@@ -5,8 +5,10 @@
 package net.sourceforge.pmd.cache;
 
 import java.io.File;
+import java.util.List;
 
 import net.sourceforge.pmd.RuleSets;
+import net.sourceforge.pmd.RuleViolation;
 import net.sourceforge.pmd.ThreadSafeReportListener;
 
 /**
@@ -24,8 +26,14 @@ public interface AnalysisCache extends ThreadSafeReportListener {
      * @param sourceFile The file to check in the cache
      * @return True if the cache is a hit, false otherwise
      */
-    // TODO : In the future we may want to return the List<RuleViolation> to be directly added to the report
     boolean isUpToDate(File sourceFile);
+
+    /**
+     * Retrieves cached violations for the given file. Make sure to call {@link #isUpToDate(File)} first.
+     * @param sourceFile The file to check in the cache
+     * @return The list of cached violations.
+     */
+    List<RuleViolation> getCachedViolations(File sourceFile);
 
     /**
      * Notifies the cache that analysis of the given file has failed and should not be cached

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/AnalysisResult.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/AnalysisResult.java
@@ -26,13 +26,13 @@ public class AnalysisResult {
     private final long fileChecksum;
     private final List<RuleViolation> violations;
 
-    public AnalysisResult(final long fileChecksum) {
+    public AnalysisResult(final long fileChecksum, final List<RuleViolation> violations) {
         this.fileChecksum = fileChecksum;
-        violations = new ArrayList<>();
+        this.violations = violations;
     }
 
     public AnalysisResult(final File sourceFile) {
-        this(computeFileChecksum(sourceFile));
+        this(computeFileChecksum(sourceFile), new ArrayList<RuleViolation>());
     }
 
     private static long computeFileChecksum(final File sourceFile) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/CachedRuleMapper.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/CachedRuleMapper.java
@@ -1,0 +1,38 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.cache;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.RuleSets;
+
+/**
+ * A mapper from rule class names to rule instances for cached rules.
+ */
+public class CachedRuleMapper {
+
+    private final Map<String, Rule> ruleByClassName = new HashMap<>();
+
+    /**
+     * Finds a rule instance for the given rule class name
+     * @param className The name of the rule class that generated the cache entry
+     * @return The requested rule
+     */
+    public Rule getRuleForClass(final String className) {
+        return ruleByClassName.get(className);
+    }
+
+    /**
+     * Initialize the mapper with the given rulesets.
+     * @param rs The rulesets from which to retrieve rules.
+     */
+    public void initialize(final RuleSets rs) {
+        for (final Rule r : rs.getAllRules()) {
+            ruleByClassName.put(r.getRuleClass(), r);
+        }
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/CachedRuleViolation.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/CachedRuleViolation.java
@@ -1,0 +1,160 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.cache;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+
+import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.RuleViolation;
+
+/**
+ * A {@link RuleViolation} implementation that is immutable, and therefore cache friendly
+ */
+public final class CachedRuleViolation implements RuleViolation {
+
+    private final CachedRuleMapper mapper;
+
+    private final String description;
+    private final String fileName;
+    private final String ruleClassName;
+    private final int beginLine;
+    private final int beginColumn;
+    private final int endLine;
+    private final int endColumn;
+    private final String packageName;
+    private final String className;
+    private final String methodName;
+    private final String variableName;
+
+    private CachedRuleViolation(final CachedRuleMapper mapper, final String description,
+            final String fileName, final String ruleClassName, final int beginLine,
+            final int beginColumn, final int endLine, final int endColumn, final String packageName,
+            final String className, final String methodName, final String variableName) {
+        this.mapper = mapper;
+        this.description = description;
+        this.fileName = fileName;
+        this.ruleClassName = ruleClassName;
+        this.beginLine = beginLine;
+        this.beginColumn = beginColumn;
+        this.endLine = endLine;
+        this.endColumn = endColumn;
+        this.packageName = packageName;
+        this.className = className;
+        this.methodName = methodName;
+        this.variableName = variableName;
+    }
+
+    @Override
+    public Rule getRule() {
+        // The mapper may be initialized after cache is loaded, so use it lazily
+        return mapper.getRuleForClass(ruleClassName);
+    }
+
+    @Override
+    public String getDescription() {
+        return description;
+    }
+
+    @Override
+    public boolean isSuppressed() {
+        return false; // By definition, if cached, it was not suppressed
+    }
+
+    @Override
+    public String getFilename() {
+        return fileName;
+    }
+
+    @Override
+    public int getBeginLine() {
+        return beginLine;
+    }
+
+    @Override
+    public int getBeginColumn() {
+        return beginColumn;
+    }
+
+    @Override
+    public int getEndLine() {
+        return endLine;
+    }
+
+    @Override
+    public int getEndColumn() {
+        return endColumn;
+    }
+
+    @Override
+    public String getPackageName() {
+        return packageName;
+    }
+
+    @Override
+    public String getClassName() {
+        return className;
+    }
+
+    @Override
+    public String getMethodName() {
+        return methodName;
+    }
+
+    @Override
+    public String getVariableName() {
+        return variableName;
+    }
+
+    /**
+     * Helper method to load a {@link CachedRuleViolation} from an input stream.
+     *
+     * @param stream The stream from which to load the violation.
+     * @param mapper The mapper to be used to obtain rule instances from the active rulesets.
+     * @return The loaded rule violation.
+     * @throws IOException
+     */
+    /* package */ static CachedRuleViolation loadFromStream(final DataInputStream stream,
+            final CachedRuleMapper mapper) throws IOException {
+        final String description = stream.readUTF();
+        final String fileName = stream.readUTF();
+        final String ruleClassName = stream.readUTF();
+        final int beginLine = stream.readInt();
+        final int beginColumn = stream.readInt();
+        final int endLine = stream.readInt();
+        final int endColumn = stream.readInt();
+        final String packageName = stream.readUTF();
+        final String className = stream.readUTF();
+        final String methodName = stream.readUTF();
+        final String variableName = stream.readUTF();
+
+        return new CachedRuleViolation(mapper, description, fileName, ruleClassName, beginLine, beginColumn,
+                endLine, endColumn, packageName, className, methodName, variableName);
+    }
+
+    /**
+     * Helper method to store a {@link RuleViolation} in an output stream to be later
+     * retrieved as a {@link CachedRuleViolation}
+     *
+     * @param stream The stream on which to store the violation.
+     * @param violation The rule violation to cache.
+     * @throws IOException
+     */
+    /* package */ static void storeToStream(final DataOutputStream stream,
+            final RuleViolation violation) throws IOException {
+        stream.writeUTF(violation.getDescription());
+        stream.writeUTF(violation.getFilename());
+        stream.writeUTF(violation.getRule().getRuleClass());
+        stream.writeInt(violation.getBeginLine());
+        stream.writeInt(violation.getBeginColumn());
+        stream.writeInt(violation.getEndLine());
+        stream.writeInt(violation.getEndColumn());
+        stream.writeUTF(violation.getPackageName());
+        stream.writeUTF(violation.getClassName());
+        stream.writeUTF(violation.getMethodName());
+        stream.writeUTF(violation.getVariableName());
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/CachedRuleViolation.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/CachedRuleViolation.java
@@ -113,14 +113,14 @@ public final class CachedRuleViolation implements RuleViolation {
      * Helper method to load a {@link CachedRuleViolation} from an input stream.
      *
      * @param stream The stream from which to load the violation.
+     * @param fileName The name of the file on which this rule was reported.
      * @param mapper The mapper to be used to obtain rule instances from the active rulesets.
      * @return The loaded rule violation.
      * @throws IOException
      */
     /* package */ static CachedRuleViolation loadFromStream(final DataInputStream stream,
-            final CachedRuleMapper mapper) throws IOException {
+            final String fileName, final CachedRuleMapper mapper) throws IOException {
         final String description = stream.readUTF();
-        final String fileName = stream.readUTF();
         final String ruleClassName = stream.readUTF();
         final int beginLine = stream.readInt();
         final int beginColumn = stream.readInt();
@@ -146,7 +146,6 @@ public final class CachedRuleViolation implements RuleViolation {
     /* package */ static void storeToStream(final DataOutputStream stream,
             final RuleViolation violation) throws IOException {
         stream.writeUTF(violation.getDescription());
-        stream.writeUTF(violation.getFilename());
         stream.writeUTF(violation.getRule().getRuleClass());
         stream.writeInt(violation.getBeginLine());
         stream.writeInt(violation.getBeginColumn());

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/FileAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/FileAnalysisCache.java
@@ -65,7 +65,7 @@ public class FileAnalysisCache extends AbstractAnalysisCache {
                         final int countViolations = inputStream.readInt();
                         final List<RuleViolation> violations = new ArrayList<>(countViolations);
                         for (int i = 0; i < countViolations; i++) {
-                            violations.add(CachedRuleViolation.loadFromStream(inputStream, ruleMapper));
+                            violations.add(CachedRuleViolation.loadFromStream(inputStream, fileName, ruleMapper));
                         }
 
                         fileResultsCache.put(fileName, new AnalysisResult(checksum, violations));

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/NoopAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/NoopAnalysisCache.java
@@ -5,6 +5,8 @@
 package net.sourceforge.pmd.cache;
 
 import java.io.File;
+import java.util.Collections;
+import java.util.List;
 
 import net.sourceforge.pmd.RuleSets;
 import net.sourceforge.pmd.RuleViolation;
@@ -43,5 +45,10 @@ public class NoopAnalysisCache implements AnalysisCache {
     @Override
     public void checkValidity(final RuleSets ruleSets, final ClassLoader classLoader) {
         // noop
+    }
+
+    @Override
+    public List<RuleViolation> getCachedViolations(File sourceFile) {
+        return Collections.emptyList();
     }
 }


### PR DESCRIPTION
 - This is phase 2 of the implementation plan for [#1538](https://sourceforge.net/p/pmd/bugs/1538/)
 - This allows to completely ignore unmodified files, even if they had violations

#### Normal run, no cache

```
./pmd-dist/target/pmd-bin-5.6.0-SNAPSHOT/bin/run.sh pmd -d ./ -b -f text -R java-basic -r report-new-no-cache.text -t 0 -auxclasspath file:///home/jmsotuyo/pmd/auxclasspath
```

```
-----------------------------<<< Final Summary >>>-----------------------------
Total                                           Time (secs)

Measured total:                                      33.205
Non-measured total:                                   0.884
Total PMD:                                           34.089
```


#### Non existing cache

```
./pmd-dist/target/pmd-bin-5.6.0-SNAPSHOT/bin/run.sh pmd -d ./ -b -f text -R java-basic -r report-new.text -t 0 -auxclasspath file:///home/jmsotuyo/pmd/auxclasspath -cache pmd.cache
```

```
-----------------------------<<< Final Summary >>>-----------------------------
Total                                           Time (secs)

Measured total:                                      31.880
Non-measured total:                                   1.091
Total PMD:                                           32.971
```

#### Primed cache, no local changes

```
./pmd-dist/target/pmd-bin-5.6.0-SNAPSHOT/bin/run.sh pmd -d ./ -b -f text -R java-basic -r report-new-cache.text -t 0 -auxclasspath file:///home/jmsotuyo/pmd/auxclasspath -cache pmd.cache
```

```
--------------------------------<<< Summary >>>--------------------------------
Segment                                         Time (secs)

Collect files:                                        0.260
Load rules:                                           0.142
Reporting:                                            0.025
Rule total:                                           0.000
Rule chain rule total:                                0.000
Rule Average (0 rules):                               0.000
RuleChain Average (0 rules):                          0.000
-----------------------------<<< Final Summary >>>-----------------------------
Total                                           Time (secs)

Measured total:                                       0.427
Non-measured total:                                   0.842
Total PMD:                                            1.270
```

**Notice 0 rules were run either as part of the rule chain or standalone.**


#### Primed cache, whitespace changes to single file

```
./pmd-dist/target/pmd-bin-5.6.0-SNAPSHOT/bin/run.sh pmd -d ./ -b -f text -R java-basic -r report-new-cache-changed.text -t 0 -auxclasspath file:///home/jmsotuyo/pmd/auxclasspath -cache pmd.cache
```

```
--------------------------------<<< Summary >>>--------------------------------
Segment                                         Time (secs)

Collect files:                                        0.289
Load rules:                                           0.138
Parser:                                               0.081
Symbol table:                                         0.034
Type resolution:                                      0.026
RuleChain visit:                                      0.001
Reporting:                                            0.030
Rule total:                                           0.000
Rule chain rule total:                                0.000
Rule Average (8 rules):                               0.001
RuleChain Average (16 rules):                         0.003

-----------------------------<<< Final Summary >>>-----------------------------
Total                                           Time (secs)

Measured total:                                       0.648
Non-measured total:                                   0.809
Total PMD:                                            1.457
```

#### Results validation

```
$ md5sum report-new*
587e508424038c22badfeaf3e9fb0ea1  report-new-cache-changed.text
587e508424038c22badfeaf3e9fb0ea1  report-new-cache.text
587e508424038c22badfeaf3e9fb0ea1  report-new-no-cache.text
587e508424038c22badfeaf3e9fb0ea1  report-new.text
```