### PR TITLE
[core] Fix shortname computation for reltive paths

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/datasource/FileDataSource.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/datasource/FileDataSource.java
@@ -39,7 +39,7 @@ public class FileDataSource implements DataSource {
     private String glomName(boolean shortNames, String inputFileName, File file) {
         if (shortNames && inputFileName.indexOf(',') == -1) {
             if (new File(inputFileName).isDirectory()) {
-                return trimAnyPathSep(file.getAbsolutePath().substring(inputFileName.length()));
+                return trimAnyPathSep(file.getPath().substring(inputFileName.length()));
             } else {
                 if (inputFileName.indexOf(FILE_SEPARATOR.charAt(0)) == -1) {
                     return inputFileName;


### PR DESCRIPTION
 - Fixes #256
 - When using relative paths, both the file's path and the inputFileName
    are relative, so we can safely compare them directly.
