### PR TITLE
[java] Allow annotations for UnnecessaryLocalBeforeReturnRule

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UnnecessaryLocalBeforeReturnRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UnnecessaryLocalBeforeReturnRule.java
@@ -7,12 +7,14 @@ package net.sourceforge.pmd.lang.java.rule.design;
 import java.util.List;
 import java.util.Map;
 
+import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
 import net.sourceforge.pmd.lang.java.ast.ASTReturnStatement;
+import net.sourceforge.pmd.lang.java.ast.AccessNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
 import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
@@ -45,12 +47,13 @@ public class UnnecessaryLocalBeforeReturnRule extends AbstractJavaRule {
         Map<VariableNameDeclaration, List<NameOccurrence>> vars = name.getScope()
                 .getDeclarations(VariableNameDeclaration.class);
         for (Map.Entry<VariableNameDeclaration, List<NameOccurrence>> entry : vars.entrySet()) {
+            VariableNameDeclaration variableDeclaration = entry.getKey();
             List<NameOccurrence> usages = entry.getValue();
 
             if (usages.size() == 1) { // If there is more than 1 usage, then it's not only returned
                 NameOccurrence occ = usages.get(0);
 
-                if (occ.getLocation().equals(name)) {
+                if (occ.getLocation().equals(name) && isNotAnnotated(variableDeclaration)) {
                     String var = name.getImage();
                     if (var.indexOf('.') != -1) {
                         var = var.substring(0, var.indexOf('.'));
@@ -60,6 +63,11 @@ public class UnnecessaryLocalBeforeReturnRule extends AbstractJavaRule {
             }
         }
         return data;
+    }
+
+    private boolean isNotAnnotated(VariableNameDeclaration variableDeclaration) {
+        AccessNode accessNodeParent = variableDeclaration.getAccessNodeParent();
+        return !accessNodeParent.hasDescendantOfType(ASTAnnotation.class);
     }
 
     /**

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UnnecessaryLocalBeforeReturn.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UnnecessaryLocalBeforeReturn.xml
@@ -126,4 +126,24 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#933 UnnecessaryLocalBeforeReturn false positive for SuppressWarnings annotation</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class UnnecessaryLocalBeforeReturnCase {
+    private <T extends UserVisibleEventTypeValue<?>> T findEventTypeValueByName(Class<T> entityClass, String eventTypeName, String eventTypeValueName) {
+        Criteria criteria = this.session.createCriteria(entityClass)
+            .add(Restrictions.eq(UserVisibleEventTypeValue_.internalName, eventTypeValueName))
+            .createCriteria(UserVisibleEventTypeValue_.type)
+                .add(Restrictions.eq(UserVisibleEventType_.name, eventTypeName))
+                .setCacheable(true);
+
+        @SuppressWarnings("unchecked")
+        T result = (T) criteria.uniqueResult();
+        return result;
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/src/site/markdown/overview/changelog.md
+++ b/src/site/markdown/overview/changelog.md
@@ -277,6 +277,7 @@ This new rule is part of the `java-design` ruleset.
     *   [#232](https://github.com/pmd/pmd/issues/232): \[java] SimplifiedTernary: Incorrect ternary operation can be simplified.
 *   java-design
     *   [#1448](https://sourceforge.net/p/pmd/bugs/1448/): \[java] ImmutableField: Private field in inner class gives false positive with lambdas
+    *   [#933](https://sourceforge.net/p/pmd/bugs/933/): \[java] UnnecessaryLocalBeforeReturn false positive for SuppressWarnings annotation
     *   [#1495](https://sourceforge.net/p/pmd/bugs/1495/): \[java] UnnecessaryLocalBeforeReturn with assert
     *   [#1496](https://sourceforge.net/p/pmd/bugs/1496/): \[java] New Rule: AccesorMethodGeneration - complements accessor class rule
     *   [#1512](https://sourceforge.net/p/pmd/bugs/1512/): \[java] Combine rules AvoidConstantsInInterface and ConstantsInInterface


### PR DESCRIPTION
Just stumbled across an old bug report: https://sourceforge.net/p/pmd/bugs/933/
