### PR TITLE
[core] Integration test for the binary distribution file

### DIFF
--- a/pmd-dist/pom.xml
+++ b/pmd-dist/pom.xml
@@ -170,7 +170,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pmd-dist/pom.xml
+++ b/pmd-dist/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>pmd-dist</artifactId>
     <name>PMD Distribution Packages</name>
-    <packaging>pom</packaging>
+    <packaging>jar</packaging>
 
     <parent>
         <groupId>net.sourceforge.pmd</groupId>
@@ -52,6 +52,19 @@
                                 <descriptor>src/main/assembly/src.xml</descriptor>
                             </descriptors>
                         </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>2.19.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>
@@ -152,6 +165,13 @@
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-xml</artifactId>
             <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/pmd-dist/pom.xml
+++ b/pmd-dist/pom.xml
@@ -173,6 +173,12 @@
             <version>4.11</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.13</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistTest.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistTest.java
@@ -7,6 +7,12 @@ package net.sourceforge.pmd.it;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.io.IOException;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 import org.junit.Test;
 
@@ -14,9 +20,42 @@ import net.sourceforge.pmd.PMD;
 
 public class BinaryDistTest {
 
+    private File getBinaryDistribution() {
+        return new File(".", "target/pmd-bin-" + PMD.VERSION + ".zip");
+    }
+
     @Test
     public void testFileExistence() {
-        File file = new File(".", "target/pmd-bin-" + PMD.VERSION + ".zip");
+        File file = getBinaryDistribution();
         assertTrue(file.exists());
+    }
+
+    private Set<String> getExpectedFileNames() {
+        Set<String> result = new HashSet<>();
+        String basedir = "pmd-bin-" + PMD.VERSION + "/";
+        result.add(basedir);
+        result.add(basedir + "bin/run.sh");
+        result.add(basedir + "bin/pmd.bat");
+        result.add(basedir + "bin/cpd.bat");
+        result.add(basedir + "lib/pmd-core-" + PMD.VERSION + ".jar");
+        result.add(basedir + "lib/pmd-java-" + PMD.VERSION + ".jar");
+        return result;
+    }
+
+    @Test
+    public void testZipFileContent() throws IOException {
+        Set<String> expectedFileNames = getExpectedFileNames();
+
+        ZipFile zip = new ZipFile(getBinaryDistribution());
+
+        Enumeration<? extends ZipEntry> entries = zip.entries();
+        while (entries.hasMoreElements()) {
+            ZipEntry entry = entries.nextElement();
+            expectedFileNames.remove(entry.getName());
+        }
+
+        zip.close();
+
+        assertTrue(expectedFileNames.isEmpty());
     }
 }

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistTest.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistTest.java
@@ -1,0 +1,22 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.it;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import org.junit.Test;
+
+import net.sourceforge.pmd.PMD;
+
+public class BinaryDistTest {
+
+    @Test
+    public void testFileExistence() {
+        File file = new File(".", "target/pmd-bin-" + PMD.VERSION + ".zip");
+        assertTrue(file.exists());
+    }
+}

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistributionIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistributionIT.java
@@ -21,20 +21,15 @@ import org.junit.Test;
 
 import net.sourceforge.pmd.PMD;
 
-public class BinaryDistTest {
+public class BinaryDistributionIT {
 
     private File getBinaryDistribution() {
         return new File(".", "target/pmd-bin-" + PMD.VERSION + ".zip");
     }
 
-    private File getSourceDistribution() {
-        return new File(".", "target/pmd-src-" + PMD.VERSION + ".zip");
-    }
-
     @Test
     public void testFileExistence() {
         assertTrue(getBinaryDistribution().exists());
-        assertTrue(getSourceDistribution().exists());
     }
 
     private Set<String> getExpectedFileNames() {

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistributionIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistributionIT.java
@@ -68,11 +68,15 @@ public class BinaryDistributionIT {
 
         try {
             ZipFileExtractor.extractZipFile(getBinaryDistribution().toPath(), tempDir);
+            PMDExecutionResult result;
 
-            PMDExecutionResult result = PMDExecutor.runPMD(tempDir, srcDir, "java-basic");
+            result = PMDExecutor.runPMD(tempDir, "-h");
+            result.assertPMDExecutionResult(1, "apex, java, ecmascript, jsp, plsql, vm, xml, xsl, wsdl, pom");
+
+            result = PMDExecutor.runPMDRules(tempDir, srcDir, "java-basic");
             result.assertPMDExecutionResult(4, "JumbledIncrementer.java:8:");
 
-            result = PMDExecutor.runPMD(tempDir, srcDir, "java-design");
+            result = PMDExecutor.runPMDRules(tempDir, srcDir, "java-design");
             result.assertPMDExecutionResult(0, "");
         } finally {
             FileUtils.forceDelete(tempDir.toFile());

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/PMDExecutionResult.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/PMDExecutionResult.java
@@ -1,0 +1,39 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.it;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
+
+/**
+ * Collects the result of a PMD execution in order to verify it.
+ *
+ * @author Andreas Dangel
+ */
+public class PMDExecutionResult {
+    private final int exitCode;
+    private final String output;
+
+    PMDExecutionResult(int theExitCode, String theOutput) {
+        this.exitCode = theExitCode;
+        this.output = theOutput;
+    }
+
+    /**
+     * Asserts that PMD exited with the expected exit code and that the given expected
+     * output is contained in the actual PMD output.
+     *
+     * @param expectedExitCode the exit code, e.g. 0 if no rule violations are expected, or 4 if violations are found
+     * @param expectedOutput the output to search for
+     */
+    public void assertPMDExecutionResult(int expectedExitCode, String expectedOutput) {
+        assertEquals("PMD exited with wrong code", expectedExitCode, exitCode);
+        assertNotNull("No output found", output);
+        if (!output.contains(expectedOutput)) {
+            fail("Expected output '" + expectedOutput + "' not present.\nComplete output:\n\n" + output);
+        }
+    }
+}

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/PMDExecutor.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/PMDExecutor.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.it;
 
 import java.nio.file.Path;
+import java.util.Arrays;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.SystemUtils;
@@ -27,9 +28,10 @@ public class PMDExecutor {
         // this is a helper class only
     }
 
-    private static PMDExecutionResult runPMDUnix(Path tempDir, String sourceDirectory, String ruleset) throws Exception {
+    private static PMDExecutionResult runPMDUnix(Path tempDir, String ... arguments) throws Exception {
         String cmd = tempDir.resolve(PMD_BIN_PREFIX + PMD.VERSION + "/bin/run.sh").toAbsolutePath().toString();
-        ProcessBuilder pb = new ProcessBuilder(cmd, "pmd", SOURCE_DIRECTORY_FLAG, sourceDirectory, RULESET_FLAG, ruleset, FORMAT_FLAG, FORMATTER);
+        ProcessBuilder pb = new ProcessBuilder(cmd, "pmd");
+        pb.command().addAll(Arrays.asList(arguments));
         pb.redirectErrorStream(true);
         Process process = pb.start();
         String output = IOUtils.toString(process.getInputStream());
@@ -38,9 +40,10 @@ public class PMDExecutor {
         return new PMDExecutionResult(result, output);
     }
 
-    private static PMDExecutionResult runPMDWindows(Path tempDir, String sourceDirectory, String ruleset) throws Exception {
+    private static PMDExecutionResult runPMDWindows(Path tempDir, String ... arguments) throws Exception {
         String cmd = tempDir.resolve(PMD_BIN_PREFIX + PMD.VERSION + "/bin/pmd.bat").toAbsolutePath().toString();
-        ProcessBuilder pb = new ProcessBuilder(cmd, SOURCE_DIRECTORY_FLAG, sourceDirectory, RULESET_FLAG, ruleset, FORMAT_FLAG, FORMATTER);
+        ProcessBuilder pb = new ProcessBuilder(cmd);
+        pb.command().addAll(Arrays.asList(arguments));
         pb.redirectErrorStream(true);
         Process process = pb.start();
         String output = IOUtils.toString(process.getInputStream());
@@ -58,11 +61,26 @@ public class PMDExecutor {
      * @return collected result of the execution
      * @throws Exception if the execution fails for any reason (executable not found, ...)
      */
-    public static PMDExecutionResult runPMD(Path tempDir, String sourceDirectory, String ruleset) throws Exception {
+    public static PMDExecutionResult runPMDRules(Path tempDir, String sourceDirectory, String ruleset) throws Exception {
         if (SystemUtils.IS_OS_WINDOWS) {
-            return runPMDWindows(tempDir, sourceDirectory, ruleset);
+            return runPMDWindows(tempDir, SOURCE_DIRECTORY_FLAG, sourceDirectory, RULESET_FLAG, ruleset, FORMAT_FLAG, FORMATTER);
         } else {
-            return runPMDUnix(tempDir, sourceDirectory, ruleset);
+            return runPMDUnix(tempDir, SOURCE_DIRECTORY_FLAG, sourceDirectory, RULESET_FLAG, ruleset, FORMAT_FLAG, FORMATTER);
+        }
+    }
+
+    /**
+     * Executes PMD found in tempDir with the given command line arguments.
+     * @param tempDir the directory, to which the binary distribution has been extracted
+     * @param arguments the arguments to execute PMD with
+     * @return collected result of the execution
+     * @throws Exception if the execution fails for any reason (executable not found, ...)
+     */
+    public static PMDExecutionResult runPMD(Path tempDir, String ... arguments) throws Exception {
+        if (SystemUtils.IS_OS_WINDOWS) {
+            return runPMDWindows(tempDir, arguments);
+        } else {
+            return runPMDUnix(tempDir, arguments);
         }
     }
 }

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/PMDExecutor.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/PMDExecutor.java
@@ -1,0 +1,68 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.it;
+
+import java.nio.file.Path;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.SystemUtils;
+
+import net.sourceforge.pmd.PMD;
+
+/**
+ * Executes PMD from command line. Deals with the differences, when PMD is run on Windows or on Linux.
+ *
+ * @author Andreas Dangel
+ */
+public class PMDExecutor {
+    private static final String PMD_BIN_PREFIX = "pmd-bin-";
+    private static final String SOURCE_DIRECTORY_FLAG = "-d";
+    private static final String RULESET_FLAG = "-R";
+    private static final String FORMAT_FLAG = "-f";
+    private static final String FORMATTER = "text";
+
+    private PMDExecutor() {
+        // this is a helper class only
+    }
+
+    private static PMDExecutionResult runPMDUnix(Path tempDir, String sourceDirectory, String ruleset) throws Exception {
+        String cmd = tempDir.resolve(PMD_BIN_PREFIX + PMD.VERSION + "/bin/run.sh").toAbsolutePath().toString();
+        ProcessBuilder pb = new ProcessBuilder(cmd, "pmd", SOURCE_DIRECTORY_FLAG, sourceDirectory, RULESET_FLAG, ruleset, FORMAT_FLAG, FORMATTER);
+        pb.redirectErrorStream(true);
+        Process process = pb.start();
+        String output = IOUtils.toString(process.getInputStream());
+
+        int result = process.waitFor();
+        return new PMDExecutionResult(result, output);
+    }
+
+    private static PMDExecutionResult runPMDWindows(Path tempDir, String sourceDirectory, String ruleset) throws Exception {
+        String cmd = tempDir.resolve(PMD_BIN_PREFIX + PMD.VERSION + "/bin/pmd.bat").toAbsolutePath().toString();
+        ProcessBuilder pb = new ProcessBuilder(cmd, SOURCE_DIRECTORY_FLAG, sourceDirectory, RULESET_FLAG, ruleset, FORMAT_FLAG, FORMATTER);
+        pb.redirectErrorStream(true);
+        Process process = pb.start();
+        String output = IOUtils.toString(process.getInputStream());
+
+        int result = process.waitFor();
+        return new PMDExecutionResult(result, output);
+    }
+
+    /**
+     * Executes the PMD found in tempDir against the given sourceDirectory path with the given ruleset.
+     *
+     * @param tempDir the directory, to which the binary distribution has been extracted
+     * @param sourceDirectory the source directory, that PMD should analyze
+     * @param ruleset the ruleset, that PMD should execute
+     * @return collected result of the execution
+     * @throws Exception if the execution fails for any reason (executable not found, ...)
+     */
+    public static PMDExecutionResult runPMD(Path tempDir, String sourceDirectory, String ruleset) throws Exception {
+        if (SystemUtils.IS_OS_WINDOWS) {
+            return runPMDWindows(tempDir, sourceDirectory, ruleset);
+        } else {
+            return runPMDUnix(tempDir, sourceDirectory, ruleset);
+        }
+    }
+}

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/SourceDistributionIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/SourceDistributionIT.java
@@ -1,0 +1,24 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.it;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+
+import org.junit.Test;
+
+import net.sourceforge.pmd.PMD;
+
+public class SourceDistributionIT {
+    private File getSourceDistribution() {
+        return new File(".", "target/pmd-src-" + PMD.VERSION + ".zip");
+    }
+
+    @Test
+    public void testFileExistence() {
+        assertTrue(getSourceDistribution().exists());
+    }
+}

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/ZipFileExtractor.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/ZipFileExtractor.java
@@ -1,0 +1,62 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.it;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.Enumeration;
+
+import org.apache.commons.compress.archivers.zip.ZipArchiveEntry;
+import org.apache.commons.compress.archivers.zip.ZipFile;
+import org.apache.commons.io.IOUtils;
+
+/**
+ * Extracts a zip file with preserving the unix file permissions.
+ *
+ * @author Andreas Dangel
+ */
+public class ZipFileExtractor {
+    // unix file permission for executable flag by owner
+    private static final int OWNER_EXECUTABLE = 0x40;
+
+    private ZipFileExtractor() {
+        // Helper class
+    }
+
+    /**
+     * Extracts the given zip file into the tempDir.
+     * @param zipPath the zip file to extract
+     * @param tempDir the target directory
+     * @throws Exception if any error happens during extraction
+     */
+    public static void extractZipFile(Path zipPath, Path tempDir) throws Exception {
+        ZipFile zip = new ZipFile(zipPath.toFile());
+        try {
+            Enumeration<ZipArchiveEntry> entries = zip.getEntries();
+            while (entries.hasMoreElements()) {
+                ZipArchiveEntry entry = entries.nextElement();
+                File file = tempDir.resolve(entry.getName()).toFile();
+                if (entry.isDirectory()) {
+                    assertTrue(file.mkdirs());
+                } else {
+                    try (InputStream data = zip.getInputStream(entry);
+                         OutputStream fileOut = new FileOutputStream(file);) {
+                        IOUtils.copy(data, fileOut);
+                    }
+                    if ((entry.getUnixMode() & OWNER_EXECUTABLE) == OWNER_EXECUTABLE) {
+                        file.setExecutable(true);
+                    }
+                }
+            }
+        } finally {
+            zip.close();
+        }
+    }
+}

--- a/pmd-dist/src/test/resources/sample-source/JumbledIncrementer.java
+++ b/pmd-dist/src/test/resources/sample-source/JumbledIncrementer.java
@@ -1,0 +1,13 @@
+/**
+ * Sample file which triggers the JumbledIncrementerRule on line 8.
+ * Used in the integration tests.
+ */
+public class JumbledIncrementer {
+    public void foo() {
+        for (int i = 0; i < 10; i++) {          // only references 'i'
+            for (int k = 0; k < 20; i++) {      // references both 'i' and 'k'
+                System.out.println("Hello");
+            }
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -269,6 +269,7 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
         <antlr.version>4.5.2-1</antlr.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <pmd.website.baseurl>http://pmd.sourceforge.net/snapshot/${project.artifactId}</pmd.website.baseurl>
 
         <argLine>-Xmx512m -Dfile.encoding=${project.build.sourceEncoding}</argLine>


### PR DESCRIPTION
When we do automatic releases from travis by pushing a tag, we need to automate the "last resort" check: Extract the generated zip file, execute PMD against a well known source, check, that there are violations. This should prevent us from accidentally releasing broken binaries.

I've verified that the build still works under Windows.

I'll be working on the deploy script for travis next (see also https://github.com/pmd/pmd/compare/master...Monits:deploy-from-travis).

We should merge this PR for 5.4.5, 5.5.4 and master.
