### PR TITLE
[apex] Support for Aggregate Result in CRUD rules

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
@@ -57,6 +57,8 @@ import com.google.common.collect.ListMultimap;
  */
 public class ApexCRUDViolationRule extends AbstractApexRule {
     private static final Pattern VOID_OR_STRING_PATTERN = Pattern.compile("^(string|void)$", Pattern.CASE_INSENSITIVE);
+    private static final Pattern SELECT_FROM_PATTERN = Pattern.compile("^[\\S|\\s]+?FROM[\\s]+?(\\S+)",
+            Pattern.CASE_INSENSITIVE);
 
     private final HashMap<String, String> varToTypeMapping = new HashMap<>();
     private final ListMultimap<String, String> typeToDMLOperationMapping = ArrayListMultimap.create();
@@ -543,7 +545,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     private String getTypeFromSOQLQuery(final ASTSoqlExpression node) {
         final String canonQuery = node.getNode().getCanonicalQuery();
 
-        Matcher m = Pattern.compile("^[\\S|\\s]+?FROM[\\s]+?(\\S+)", Pattern.CASE_INSENSITIVE).matcher(canonQuery);
+        Matcher m = SELECT_FROM_PATTERN.matcher(canonQuery);
         while (m.find()) {
             return new StringBuffer().append(node.getNode().getDefiningType().getApexName()).append(":")
                     .append(m.group(1)).toString();

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
@@ -3,6 +3,37 @@
 <test-data>
 
 	<test-code>
+		<description>Proper CRUD checks for Aggregate Result</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[ 
+public class Foo { 	
+	public void justGiveMeFoo() {
+		if (Opportunity.sObjectType.getDescribe().isAccessible()) {
+	 		return;
+	 	}
+	 	AggregateResult[] test = [SELECT Id FROM Opportunity];
+	} 
+} 
+]]></code>
+	</test-code>
+
+
+	<test-code>
+		<description>Proper CRUD checks for Aggregate Result return</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[ 
+public class Foo { 	
+	public AggregateResult[] justGiveMeFoo() {
+		if (Opportunity.sObjectType.getDescribe().isAccessible()) {
+	 		return null;
+	 	}
+	 	return [SELECT Id FROM Opportunity];
+	} 
+} 
+]]></code>
+	</test-code>
+
+	<test-code>
 		<description>Not a getter</description>
 		<expected-problems>1</expected-problems>
 		<code><![CDATA[ 
@@ -688,7 +719,7 @@ public class Foo {
 } 
 ]]></code>
 	</test-code>
-	
+
 	<test-code>
 		<description>Field detection</description>
 		<expected-problems>1</expected-problems>
@@ -703,5 +734,4 @@ public class MyProfilePageController {
 	
 ]]></code>
 	</test-code>
-	
 </test-data>


### PR DESCRIPTION
SOQL supports generic way of referring to a query results, e.g.
```List<AggregateResult> res = [SELECT Id From Account];```
This caused CRUD to flag this line as a finding even if correct CRUD check was performed.
This improvement addresses the problem.
