### PR TITLE
[vf] Setting the tab size to 4 for VF

### DIFF
--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/VfParser.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/VfParser.java
@@ -14,7 +14,6 @@ import net.sourceforge.pmd.lang.TokenManager;
 import net.sourceforge.pmd.lang.ast.AbstractTokenManager;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.ast.ParseException;
-import net.sourceforge.pmd.lang.ast.SimpleCharStream;
 
 /**
  * Adapter for the VfParser.
@@ -36,7 +35,7 @@ public class VfParser extends AbstractParser {
 
     public Node parse(String fileName, Reader source) throws ParseException {
         AbstractTokenManager.setFileName(fileName);
-        return new net.sourceforge.pmd.lang.vf.ast.VfParser(new SimpleCharStream(source)).CompilationUnit();
+        return new net.sourceforge.pmd.lang.vf.ast.VfParser(new VfSimpleCharStream(source)).CompilationUnit();
     }
 
     public Map<Integer, String> getSuppressMap() {

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/VfSimpleCharStream.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/VfSimpleCharStream.java
@@ -1,0 +1,22 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.vf;
+
+import java.io.Reader;
+
+import net.sourceforge.pmd.lang.ast.SimpleCharStream;
+
+/**
+ * @author sergey.gorbaty
+ *
+ */
+public class VfSimpleCharStream extends SimpleCharStream {
+
+    public VfSimpleCharStream(Reader dstream) {
+        super(dstream);
+        tabSize = 4;
+    }
+
+}

--- a/pmd-visualforce/src/test/resources/net/sourceforge/pmd/lang/vf/rule/security/xml/VfUnescapeEl.xml
+++ b/pmd-visualforce/src/test/resources/net/sourceforge/pmd/lang/vf/rule/security/xml/VfUnescapeEl.xml
@@ -7,9 +7,9 @@ Has multiple resources but starts with a safe one
      ]]></description>
 		<expected-problems>0</expected-problems>
 		<code><![CDATA[
-<apex:page>
-<link rel="stylesheet" type="text/css" href="{!$Resource.SDEFExtJS}/{!anotherRes}" id="ext-all-css"/>
-</apex:page>
+	<apex:page>
+		<link rel="stylesheet" type="text/css" href="{!$Resource.SDEFExtJS}/{!anotherRes}" id="ext-all-css"/>
+	</apex:page>
 ]]></code>
 		<source-type>vf</source-type>
 	</test-code>


### PR DESCRIPTION
JavaCC by default uses 8 as tab size but most editors use 4. 
That means all column numbers are off by 4, hence the fix.