### PR TITLE
[apex] Adding String.IsNotBlank to the whitelist to prevent False positives

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromURLParamRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromURLParamRule.java
@@ -42,6 +42,7 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
     private static final String[] BOOLEAN_VALUEOF = new String[] { "Boolean", "valueOf" };
     private static final String[] STRING_ISEMPTY = new String[] { "String", "isEmpty" };
     private static final String[] STRING_ISBLANK = new String[] { "String", "isBlank" };
+    private static final String[] STRING_ISNOTBLANK = new String[] { "String", "isNotBlank" };
 
     private final Set<String> urlParameterStrings = new HashSet<>();
 
@@ -118,7 +119,8 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
                 || Helper.isMethodCallChain(methodNode, ID_VALUEOF)
                 // safe boolean methods
                 || Helper.isMethodCallChain(methodNode, STRING_ISEMPTY)
-                || Helper.isMethodCallChain(methodNode, STRING_ISBLANK);
+                || Helper.isMethodCallChain(methodNode, STRING_ISBLANK)
+                || Helper.isMethodCallChain(methodNode, STRING_ISNOTBLANK);
     }
 
     private void processInlineMethodCalls(ASTMethodCallExpression methodNode, Object data, final boolean isNested) {

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexXSSFromURLParam.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexXSSFromURLParam.xml
@@ -295,6 +295,20 @@ public class Foo {
 	</test-code>
 
 	<test-code>
+		<description>IsNotBlank check</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		String baz, bas;
+		bas = ApexPages.currentPage().getParameters().get('foo');
+		boolean isNotBlank = String.isNotBlank(bas);
+	}		
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
 		<description>URL parameter type empty check</description>
 		<expected-problems>0</expected-problems>
 		<code><![CDATA[
@@ -365,7 +379,7 @@ public class Foo {
 		]]></code>
 	</test-code>
 
-<test-code>
+	<test-code>
 		<description>Casting applied to a method call
 		</description>
 		<expected-problems>0</expected-problems>
@@ -378,8 +392,8 @@ public class Foo {
 }
 		]]></code>
 	</test-code>
-	
-		<test-code>
+
+	<test-code>
 		<description>URL parameter method passing</description>
 		<expected-problems>0</expected-problems>
 		<code><![CDATA[


### PR DESCRIPTION
Adding another esoteric API to prevent false positives for this XSS from URL param rule.
