### PR TITLE
[java] Fix false positive with UseStringBufferForStringAppendsRule

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/optimizations/UseStringBufferForStringAppendsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/optimizations/UseStringBufferForStringAppendsRule.java
@@ -19,7 +19,7 @@ import net.sourceforge.pmd.lang.java.typeresolution.TypeHelper;
 import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
 
 public class UseStringBufferForStringAppendsRule extends AbstractJavaRule {
-
+    
     @Override
     public Object visit(ASTVariableDeclaratorId node, Object data) {
         if (!TypeHelper.isA(node, String.class) || node.isArray()) {
@@ -46,13 +46,12 @@ public class UseStringBufferForStringAppendsRule extends AbstractJavaRule {
                 continue;
             }
             ASTConditionalExpression conditional = name.getFirstParentOfType(ASTConditionalExpression.class);
-            if (conditional != null
-                    && (name.jjtGetParent().jjtGetParent().jjtGetParent() == conditional
-                            || name.jjtGetParent().jjtGetParent().jjtGetParent().jjtGetParent() == conditional)
+            Node thirdParent = name.jjtGetParent().jjtGetParent().jjtGetParent();
+            if (conditional != null && (thirdParent == conditional || thirdParent.jjtGetParent() == conditional)
                     && conditional.getFirstParentOfType(ASTStatementExpression.class) == statement) {
                 // is used in ternary as only option (not appended to other
                 // string)
-                
+
                 continue;
             }
             if (statement.jjtGetNumChildren() > 0 && statement.jjtGetChild(0) instanceof ASTPrimaryExpression) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/optimizations/UseStringBufferForStringAppendsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/optimizations/UseStringBufferForStringAppendsRule.java
@@ -46,10 +46,13 @@ public class UseStringBufferForStringAppendsRule extends AbstractJavaRule {
                 continue;
             }
             ASTConditionalExpression conditional = name.getFirstParentOfType(ASTConditionalExpression.class);
-            if (conditional != null && name.jjtGetParent().jjtGetParent().jjtGetParent() == conditional
+            if (conditional != null
+                    && (name.jjtGetParent().jjtGetParent().jjtGetParent() == conditional
+                            || name.jjtGetParent().jjtGetParent().jjtGetParent().jjtGetParent() == conditional)
                     && conditional.getFirstParentOfType(ASTStatementExpression.class) == statement) {
-                // is used in ternary as only option (not appendend to other
+                // is used in ternary as only option (not appended to other
                 // string)
+                
                 continue;
             }
             if (statement.jjtGetNumChildren() > 0 && statement.jjtGetChild(0) instanceof ASTPrimaryExpression) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/optimizations/UseStringBufferForStringAppendsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/optimizations/UseStringBufferForStringAppendsRule.java
@@ -46,13 +46,15 @@ public class UseStringBufferForStringAppendsRule extends AbstractJavaRule {
                 continue;
             }
             ASTConditionalExpression conditional = name.getFirstParentOfType(ASTConditionalExpression.class);
-            Node thirdParent = name.jjtGetParent().jjtGetParent().jjtGetParent();
-            if (conditional != null && (thirdParent == conditional || thirdParent.jjtGetParent() == conditional)
-                    && conditional.getFirstParentOfType(ASTStatementExpression.class) == statement) {
-                // is used in ternary as only option (not appended to other
-                // string)
 
-                continue;
+            if (conditional != null) {
+                Node thirdParent = name.jjtGetParent().jjtGetParent().jjtGetParent();
+                if ((thirdParent == conditional || thirdParent.jjtGetParent() == conditional)
+                        && conditional.getFirstParentOfType(ASTStatementExpression.class) == statement) {
+                    // is used in ternary as only option (not appended to other
+                    // string)
+                    continue;
+                }
             }
             if (statement.jjtGetNumChildren() > 0 && statement.jjtGetChild(0) instanceof ASTPrimaryExpression) {
                 ASTName astName = statement.jjtGetChild(0).getFirstDescendantOfType(ASTName.class);

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/optimizations/xml/UseStringBufferForStringAppends.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/optimizations/xml/UseStringBufferForStringAppends.xml
@@ -160,6 +160,7 @@ public class UseStringBuffer {
     public void foo2() {
         String country = request.getParameter("country");
         country = (country == null) ? "USA" : country;
+        country = (country != null) ? country : "USA";
     }
 }
         ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/optimizations/xml/UseStringBufferForStringAppends.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/optimizations/xml/UseStringBufferForStringAppends.xml
@@ -160,6 +160,17 @@ public class UseStringBuffer {
     public void foo2() {
         String country = request.getParameter("country");
         country = (country == null) ? "USA" : country;
+    }
+}
+        ]]></code>
+    </test-code>
+	<test-code>
+        <description>#222 False positive when inverting ternary expression arguments</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void bar() {
+        String country = request.getParameter("country");
         country = (country != null) ? country : "USA";
     }
 }


### PR DESCRIPTION
Fixes #222 
**PR Description:** This fixes a bug which caused a false positive from UseStringBufferForStringAppendsRule on a snippet such as
```java
String country = request.getParameter("country");
country = (country != null) ? country : "USA";
```

The reason the rule trigerred a false positive in that case and not when inverting the ternary's parameters (`(country != null) ? "USA" : country;`) is that both parameters are not symmetrical (see [java spec](https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.25) here). The first is an `Expression` while the other is a `PrimaryExpression`. The first being an `Expression` actually adds one parent to the name occurence. For instance for the following statement:
```java
country = (country != null) ? country : country;
```
the AST of the right-hand side expression looks like this : 
```
ConditionalExpression
    PrimaryExpression
    Expression
        PrimaryExpression
            PrimaryPrefix
                Name @Image="country"
    PrimaryExpression
        PrimaryPrefix
            Name @Image="country"
```

Since in the visitor the name occurence is not reported if its *third* parent is the conditional expression, it did not catch the fact that when used as first argument, the name occurence actually has the conditional expression as its *fourth* parent.

**Solution:** Check for the third and the fourth parent of the name occurence