### PR TITLE
[java] JUnitTestsShouldIncludeAssertRule supports @Rule annotated ExpectedExceptions

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/junit/JUnitTestsShouldIncludeAssertRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/junit/JUnitTestsShouldIncludeAssertRule.java
@@ -13,11 +13,10 @@ import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
 import net.sourceforge.pmd.lang.java.ast.ASTNormalAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
 import net.sourceforge.pmd.lang.java.ast.ASTStatementExpression;
 
 public class JUnitTestsShouldIncludeAssertRule extends AbstractJUnitRule {
-
+    
     @Override
     public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
         if (node.isInterface()) {
@@ -25,7 +24,7 @@ public class JUnitTestsShouldIncludeAssertRule extends AbstractJUnitRule {
         }
         return super.visit(node, data);
     }
-
+    
     @Override
     public Object visit(ASTMethodDeclaration method, Object data) {
         if (isJUnitMethod(method, data)) {
@@ -35,7 +34,7 @@ public class JUnitTestsShouldIncludeAssertRule extends AbstractJUnitRule {
         }
         return data;
     }
-
+    
     private boolean containsAssert(Node n, boolean assertFound) {
         if (!assertFound) {
             if (n instanceof ASTStatementExpression) {
@@ -54,7 +53,7 @@ public class JUnitTestsShouldIncludeAssertRule extends AbstractJUnitRule {
         }
         return false;
     }
-
+    
     /**
      * Tells if the node contains a Test annotation with an expected exception.
      */
@@ -74,22 +73,18 @@ public class JUnitTestsShouldIncludeAssertRule extends AbstractJUnitRule {
         }
         return false;
     }
-
+    
     /**
      * Tells if the expression is an assert statement or not.
      */
     private boolean isAssertOrFailStatement(ASTStatementExpression expression) {
-        if (expression != null && expression.jjtGetNumChildren() > 0
-                && expression.jjtGetChild(0) instanceof ASTPrimaryExpression) {
-            ASTPrimaryExpression pe = (ASTPrimaryExpression) expression.jjtGetChild(0);
-            if (pe.jjtGetNumChildren() > 0 && pe.jjtGetChild(0) instanceof ASTPrimaryPrefix) {
-                ASTPrimaryPrefix pp = (ASTPrimaryPrefix) pe.jjtGetChild(0);
-                if (pp.jjtGetNumChildren() > 0 && pp.jjtGetChild(0) instanceof ASTName) {
-                    String img = ((ASTName) pp.jjtGetChild(0)).getImage();
-                    if (img != null && (img.startsWith("assert") || img.startsWith("fail")
-                            || img.startsWith("Assert.assert") || img.startsWith("Assert.fail"))) {
-                        return true;
-                    }
+        if (expression != null) {
+            ASTPrimaryExpression pe = expression.getFirstChildOfType(ASTPrimaryExpression.class);
+            if (pe != null) {
+                String img = pe.jjtGetChild(0).jjtGetChild(0).getImage();
+                if (img != null && (img.startsWith("assert") || img.startsWith("fail")
+                        || img.startsWith("Assert.assert") || img.startsWith("Assert.fail"))) {
+                    return true;
                 }
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/junit/JUnitTestsShouldIncludeAssertRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/junit/JUnitTestsShouldIncludeAssertRule.java
@@ -82,16 +82,13 @@ public class JUnitTestsShouldIncludeAssertRule extends AbstractJUnitRule {
             Node parent = decl.getNode().jjtGetParent().jjtGetParent().jjtGetParent();
             if (parent.hasDescendantOfType(ASTAnnotation.class)
                     && parent.getFirstChildOfType(ASTFieldDeclaration.class) != null) {
-                if (!"Rule"
-                        .equals(parent.getFirstDescendantOfType(ASTMarkerAnnotation.class).jjtGetChild(0).getImage())) {
-                    System.out.println(
-                            parent.getFirstDescendantOfType(ASTMarkerAnnotation.class).jjtGetChild(0).getImage());
+                String annot = parent.getFirstDescendantOfType(ASTMarkerAnnotation.class).jjtGetChild(0).getImage();
+                if (!"Rule".equals(annot) && !"org.junit.Rule".equals(annot)) {
                     continue;
                 }
 
                 Node type = parent.getFirstDescendantOfType(ASTReferenceType.class);
                 if (!"ExpectedException".equals(type.jjtGetChild(0).getImage())) {
-                    System.out.println(type.jjtGetChild(0).getImage());
                     continue;
                 }
                 result.put(decl.getName(), decls.get(decl));

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/junit/JUnitTestsShouldIncludeAssertRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/junit/JUnitTestsShouldIncludeAssertRule.java
@@ -4,7 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.junit;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -37,64 +37,76 @@ public class JUnitTestsShouldIncludeAssertRule extends AbstractJUnitRule {
     @Override
     public Object visit(ASTMethodDeclaration method, Object data) {
         if (isJUnitMethod(method, data)) {
-            if (!containsAssert(method.getBlock(), false) && !containsExpect(method.jjtGetParent())) {
-                addViolation(data, method);
+            if (!isExpectAnnotated(method.jjtGetParent())) {
+                Scope classScope = method.getScope().getParent();
+                Map<String, List<NameOccurrence>> expectables = getRuleAnnotatedExpectedExceptions(classScope);
+
+                if (!containsExpectOrAssert(method.getBlock(), false, expectables)) {
+                    addViolation(data, method);
+                }
             }
         }
         return data;
     }
     
-    private List<NameDeclaration> getRuleAnnotatedExpectedExceptions(Scope classScope) {
-        List<NameDeclaration> result = new ArrayList<>();
-        Map<NameDeclaration, List<NameOccurrence>> decls = classScope.getDeclarations();
-
-        for (NameDeclaration decl : decls.keySet()) {
-            Node parent = decl.getNode().jjtGetParent().jjtGetParent().jjtGetParent();
-            if (parent.hasDescendantOfType(ASTAnnotation.class)
-                    && parent.jjtGetChild(1) instanceof ASTFieldDeclaration) {
-                if (!"Rule"
-                        .equals(parent.getFirstDescendantOfType(ASTMarkerAnnotation.class).jjtGetChild(0).getImage())) {
-                    System.out.println(
-                            parent.getFirstDescendantOfType(ASTMarkerAnnotation.class).jjtGetChild(0).getImage());
-                    continue;
-                }
-
-                Node type = parent.getFirstDescendantOfType(ASTReferenceType.class);
-                if (!"ExpectedException".equals(type.jjtGetChild(0).getImage())) {
-                    System.out.println(type.jjtGetChild(0).getImage());
-                    continue;
-                }
-
-                result.add(decl);
-            }
-        }
-
-        return result;
-    }
-    
-    private boolean containsAssert(Node n, boolean assertFound) {
-        if (!assertFound) {
+    private boolean containsExpectOrAssert(Node n, boolean found, Map<String, List<NameOccurrence>> expectables) {
+        if (!found) {
             if (n instanceof ASTStatementExpression) {
-                if (isAssertOrFailStatement((ASTStatementExpression) n)) {
+                if (isExpectStatement((ASTStatementExpression) n, expectables)
+                        || isAssertOrFailStatement((ASTStatementExpression) n)) {
                     return true;
                 }
-            }
-            if (!assertFound) {
-                for (int i = 0; i < n.jjtGetNumChildren() && !assertFound; i++) {
+            } else {
+                for (int i = 0; i < n.jjtGetNumChildren(); i++) {
                     Node c = n.jjtGetChild(i);
-                    if (containsAssert(c, assertFound)) {
+                    if (containsExpectOrAssert(c, found, expectables)) {
                         return true;
                     }
                 }
             }
         }
         return false;
+
     }
-    
+
+    /**
+     * Gets a list of NameDeclarations for all the fields that have type
+     * ExpectedException and have a Rule annotation.
+     *
+     * @param classScope
+     *            The class scope to search for
+     * @return See description
+     */
+    private Map<String, List<NameOccurrence>> getRuleAnnotatedExpectedExceptions(Scope classScope) {
+        Map<String, List<NameOccurrence>> result = new HashMap<>();
+        Map<NameDeclaration, List<NameOccurrence>> decls = classScope.getDeclarations();
+        
+        for (NameDeclaration decl : decls.keySet()) {
+            Node parent = decl.getNode().jjtGetParent().jjtGetParent().jjtGetParent();
+            if (parent.hasDescendantOfType(ASTAnnotation.class)
+                    && parent.getFirstChildOfType(ASTFieldDeclaration.class) != null) {
+                if (!"Rule"
+                        .equals(parent.getFirstDescendantOfType(ASTMarkerAnnotation.class).jjtGetChild(0).getImage())) {
+                    System.out.println(
+                            parent.getFirstDescendantOfType(ASTMarkerAnnotation.class).jjtGetChild(0).getImage());
+                    continue;
+                }
+                
+                Node type = parent.getFirstDescendantOfType(ASTReferenceType.class);
+                if (!"ExpectedException".equals(type.jjtGetChild(0).getImage())) {
+                    System.out.println(type.jjtGetChild(0).getImage());
+                    continue;
+                }
+                result.put(decl.getName(), decls.get(decl));
+            }
+        }
+        return result;
+    }
+
     /**
      * Tells if the node contains a Test annotation with an expected exception.
      */
-    private boolean containsExpect(Node methodParent) {
+    private boolean isExpectAnnotated(Node methodParent) {
         List<ASTNormalAnnotation> annotations = methodParent.findDescendantsOfType(ASTNormalAnnotation.class);
         for (ASTNormalAnnotation annotation : annotations) {
             ASTName name = annotation.getFirstChildOfType(ASTName.class);
@@ -122,6 +134,32 @@ public class JUnitTestsShouldIncludeAssertRule extends AbstractJUnitRule {
                 if (img != null && (img.startsWith("assert") || img.startsWith("fail")
                         || img.startsWith("Assert.assert") || img.startsWith("Assert.fail"))) {
                     return true;
+                }
+            }
+        }
+        return false;
+    }
+    
+    private boolean isExpectStatement(ASTStatementExpression expression,
+            Map<String, List<NameOccurrence>> expectables) {
+
+        if (expression != null) {
+            ASTPrimaryExpression pe = expression.getFirstChildOfType(ASTPrimaryExpression.class);
+            if (pe != null) {
+                String img = pe.jjtGetChild(0).jjtGetChild(0).getImage();
+                if (img.indexOf(".") == -1) {
+                    return false;
+                }
+                String varname = img.split("\\.")[0];
+                
+                if (!expectables.containsKey(varname)) {
+                    return false;
+                }
+                
+                for (NameOccurrence occ : expectables.get(varname)) {
+                    if (occ.getLocation() == pe.jjtGetChild(0).jjtGetChild(0) && img.startsWith(varname + ".expect")) {
+                        return true;
+                    }
                 }
             }
         }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/junit/xml/JUnitTestsShouldIncludeAssert.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/junit/xml/JUnitTestsShouldIncludeAssert.xml
@@ -271,7 +271,7 @@ public class Foo_Test
 }
         ]]></code>
     </test-code>
-      <test-code>
+    <test-code>
         <description>#285 Issues with @Rule annotation and ExpectedException</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
@@ -281,19 +281,11 @@ public class SimpleExpectedExceptionTest {
      public ExpectedException thrown= ExpectedException.none();
 
      @Test
-     public void throwsNothing() {
-         // no exception expected, none thrown: passes.
-     }
-
-     @Test
      public void throwsExceptionWithSpecificType() {
          thrown.expect(NullPointerException.class);
          throw new NullPointerException();
      }
  }
         ]]></code>
-    </test-code>
-    
-    
-    
+    </test-code>    
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/junit/xml/JUnitTestsShouldIncludeAssert.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/junit/xml/JUnitTestsShouldIncludeAssert.xml
@@ -285,6 +285,13 @@ public class SimpleExpectedExceptionTest {
          thrown.expect(NullPointerException.class);
          throw new NullPointerException();
      }
+     
+     @Test
+  	public void throwsIllegalArgumentExceptionIfIconIsNull() {
+    	thrown.expect(IllegalArgumentException.class);
+    	thrown.expectMessage("Icon is null, not a file, or doesn't exist.");
+    	new DigitalAssetManager(null, null);
+  	} 
  }
         ]]></code>
     </test-code>    

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/junit/xml/JUnitTestsShouldIncludeAssert.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/junit/xml/JUnitTestsShouldIncludeAssert.xml
@@ -278,7 +278,7 @@ public class Foo_Test
 import org.junit.*;
 public class SimpleExpectedExceptionTest {
      @Rule
-     public ExpectedException thrown= ExpectedException.none();
+     public ExpectedException thrown = ExpectedException.none();
 
      @Test
      public void throwsExceptionWithSpecificType() {
@@ -292,6 +292,23 @@ public class SimpleExpectedExceptionTest {
     	thrown.expectMessage("Icon is null, not a file, or doesn't exist.");
     	new DigitalAssetManager(null, null);
   	} 
+ }
+        ]]></code>
+    </test-code>    
+    <test-code>
+        <description>#285 Follow-up for @org.junit.Rule</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.junit.*;
+public class SimpleExpectedExceptionTest {
+     @org.junit.Rule
+     public ExpectedException thrown = ExpectedException.none();
+
+     @Test
+     public void throwsExceptionWithSpecificType() {
+         thrown.expect(NullPointerException.class);
+         throw new NullPointerException();
+     }
  }
         ]]></code>
     </test-code>    

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/junit/xml/JUnitTestsShouldIncludeAssert.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/junit/xml/JUnitTestsShouldIncludeAssert.xml
@@ -271,4 +271,29 @@ public class Foo_Test
 }
         ]]></code>
     </test-code>
+      <test-code>
+        <description>#285 Issues with @Rule annotation and ExpectedException</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.junit.*;
+public class SimpleExpectedExceptionTest {
+     @Rule
+     public ExpectedException thrown= ExpectedException.none();
+
+     @Test
+     public void throwsNothing() {
+         // no exception expected, none thrown: passes.
+     }
+
+     @Test
+     public void throwsExceptionWithSpecificType() {
+         thrown.expect(NullPointerException.class);
+         throw new NullPointerException();
+     }
+ }
+        ]]></code>
+    </test-code>
+    
+    
+    
 </test-data>


### PR DESCRIPTION
**Fixes:** #285 
**PR Description:** JUnitTestsShouldIncludeAssertRule no longer reports methods which are not annotated with `@Test(expected=<exceptionclass>)` nor contain assert statements, provided the test class has a field of type `ExpectedException` annotated with `@Rule`, and the Test calls at least one method starting by `expect` on that field.

See #285 for more details.