### PR TITLE
[apex] Ignoring certain rules in Batch classes, Queueable, and install scripts

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
@@ -96,6 +96,10 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
 
     @Override
     public Object visit(ASTUserClass node, Object data) {
+        if (Helper.isTestMethodOrClass(node) || Helper.isSystemLevelClass(node)) {
+            return data; // stops all the rules
+        }
+
         for (ASTMethod n : node.findDescendantsOfType(ASTMethod.class)) {
             StringBuilder sb = new StringBuilder().append(n.getNode().getDefiningType().getApexName()).append(":")
                     .append(n.getNode().getMethodInfo().getCanonicalName()).append(":")

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCSRFRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCSRFRule.java
@@ -5,6 +5,8 @@
 package net.sourceforge.pmd.lang.apex.rule.security;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
+import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
+import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 
 /**
@@ -21,6 +23,15 @@ public class ApexCSRFRule extends AbstractApexRule {
         setProperty(CODECLIMATE_CATEGORIES, new String[] { "Security" });
         setProperty(CODECLIMATE_REMEDIATION_MULTIPLIER, 100);
         setProperty(CODECLIMATE_BLOCK_HIGHLIGHTING, false);
+    }
+
+    @Override
+    public Object visit(ASTUserClass node, Object data) {
+        if (Helper.isTestMethodOrClass(node) || Helper.isSystemLevelClass(node)) {
+            return data; // stops all the rules
+        }
+
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexOpenRedirectRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexOpenRedirectRule.java
@@ -44,8 +44,8 @@ public class ApexOpenRedirectRule extends AbstractApexRule {
 
     @Override
     public Object visit(ASTUserClass node, Object data) {
-        if (Helper.isTestMethodOrClass(node)) {
-            return data;
+        if (Helper.isTestMethodOrClass(node) || Helper.isSystemLevelClass(node)) {
+            return data; // stops all the rules
         }
 
         List<ASTAssignmentExpression> assignmentExprs = node.findDescendantsOfType(ASTAssignmentExpression.class);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
@@ -46,8 +46,8 @@ public class ApexSOQLInjectionRule extends AbstractApexRule {
     @Override
     public Object visit(ASTUserClass node, Object data) {
 
-        if (Helper.isTestMethodOrClass(node)) {
-            return data;
+        if (Helper.isTestMethodOrClass(node) || Helper.isSystemLevelClass(node)) {
+            return data; // stops all the rules
         }
 
         final List<ASTFieldDeclaration> fieldExpr = node.findDescendantsOfType(ASTFieldDeclaration.class);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSharingViolationsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSharingViolationsRule.java
@@ -33,6 +33,11 @@ public class ApexSharingViolationsRule extends AbstractApexRule {
 
     @Override
     public Object visit(ASTUserClass node, Object data) {
+
+        if (Helper.isTestMethodOrClass(node) || Helper.isSystemLevelClass(node)) {
+            return data; // stops all the rules
+        }
+
         if (!Helper.isTestMethodOrClass(node)) {
             boolean sharingFound = isSharingPresent(node);
             checkForSharingDeclaration(node, data, sharingFound);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromEscapeFalseRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromEscapeFalseRule.java
@@ -29,8 +29,8 @@ public class ApexXSSFromEscapeFalseRule extends AbstractApexRule {
 
     @Override
     public Object visit(ASTUserClass node, Object data) {
-        if (Helper.isTestMethodOrClass(node)) {
-            return data;
+        if (Helper.isTestMethodOrClass(node) || Helper.isSystemLevelClass(node)) {
+            return data; // stops all the rules
         }
 
         List<ASTMethodCallExpression> methodCalls = node.findDescendantsOfType(ASTMethodCallExpression.class);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromURLParamRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromURLParamRule.java
@@ -13,9 +13,11 @@ import net.sourceforge.pmd.lang.apex.ast.ASTBinaryExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTReturnStatement;
+import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration;
 import net.sourceforge.pmd.lang.apex.ast.ASTVariableExpression;
 import net.sourceforge.pmd.lang.apex.ast.AbstractApexNode;
+import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 
 /**
@@ -50,6 +52,15 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
         setProperty(CODECLIMATE_CATEGORIES, new String[] { "Security" });
         setProperty(CODECLIMATE_REMEDIATION_MULTIPLIER, 50);
         setProperty(CODECLIMATE_BLOCK_HIGHLIGHTING, false);
+    }
+
+    @Override
+    public Object visit(ASTUserClass node, Object data) {
+        if (Helper.isTestMethodOrClass(node) || Helper.isSystemLevelClass(node)) {
+            return data; // stops all the rules
+        }
+
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
@@ -3,6 +3,20 @@
 <test-data>
 
 	<test-code>
+		<description>Scheduled classes don't need crud, run as system
+		</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[ 
+class FooBatchJob implements Database.Batchable < sObject > , Database.Stateful { 	
+	public void justGiveMeFoo() {
+	 	AggregateResult[] test = [SELECT Id FROM Opportunity];
+	} 
+} 
+]]></code>
+	</test-code>
+
+
+	<test-code>
 		<description>Complex SOQL</description>
 		<expected-problems>0</expected-problems>
 		<code><![CDATA[ 
@@ -70,7 +84,8 @@ public class Foo {
 
 
 	<test-code>
-		<description>Proper CRUD checks for Aggregate Result return</description>
+		<description>Proper CRUD checks for Aggregate Result return
+		</description>
 		<expected-problems>0</expected-problems>
 		<code><![CDATA[ 
 public class Foo { 	
@@ -785,4 +800,4 @@ public class MyProfilePageController {
 	
 ]]></code>
 	</test-code>
- </test-data>
+</test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCSRF.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCSRF.xml
@@ -16,7 +16,22 @@ public class Foo {
 		]]></code>
 	</test-code>
 
-<test-code>
+
+	<test-code>
+		<description>Queueable class</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo implements Queueable {
+
+	public Foo() {
+		List<Account> accounts = [SELECT Id FROM Account LIMIT 1];
+		upsert accounts;	
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
 		<description>Apex CSRF in init method</description>
 		<expected-problems>1</expected-problems>
 		<code><![CDATA[
@@ -29,7 +44,7 @@ public class Foo {
 }
 		]]></code>
 	</test-code>
-	
+
 	<test-code>
 		<description>Apex CSRF in init method</description>
 		<expected-problems>0</expected-problems>
@@ -43,8 +58,8 @@ public class Foo {
 }
 		]]></code>
 	</test-code>
-	
-		<test-code>
+
+	<test-code>
 		<description>Apex CSRF in constructor</description>
 		<expected-problems>0</expected-problems>
 		<code><![CDATA[

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexOpenRedirect.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexOpenRedirect.xml
@@ -2,7 +2,20 @@
 
 <test-data>
 
-	 <test-code>
+	<test-code>
+		<description>Schedulable class doesn't need check for open redirect
+		</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo implements Queueable {
+	public PageReference redirect() {
+	    return new PageReference(test1 + 'something later');
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
 		<description>PageReference open redirect with unsafe variable
 			concatenation
 		</description>
@@ -15,7 +28,7 @@ public class Foo {
 }
 		]]></code>
 	</test-code>
-	
+
 	<test-code>
 		<description>PageReference open redirect with variable</description>
 		<expected-problems>1</expected-problems>
@@ -84,9 +97,10 @@ public class Foo {
 }
 		]]></code>
 	</test-code>
-	
+
 	<test-code>
-		<description>PageReference redirect in test class should be ignored</description>
+		<description>PageReference redirect in test class should be ignored
+		</description>
 		<expected-problems>0</expected-problems>
 		<code><![CDATA[
 @isTest
@@ -96,10 +110,11 @@ public class Foo {
 	}
 }
 		]]></code>
-	</test-code> 
-	
+	</test-code>
+
 	<test-code>
-		<description>PageReference redirect in test method should be ignored</description>
+		<description>PageReference redirect in test method should be ignored
+		</description>
 		<expected-problems>0</expected-problems>
 		<code><![CDATA[
 public class Foo {
@@ -109,7 +124,7 @@ public class Foo {
 }
 		]]></code>
 	</test-code>
-	
+
 	<test-code>
 		<description>PageReference to a literal field</description>
 		<expected-problems>0</expected-problems>
@@ -124,7 +139,7 @@ public class Foo {
 }
 		]]></code>
 	</test-code>
-	
+
 	<test-code>
 		<description>Safe pageReference as a field</description>
 		<expected-problems>0</expected-problems>
@@ -138,8 +153,8 @@ public class Foo {
 	}
 }
 		]]></code>
-	</test-code> 
-	
+	</test-code>
+
 	<test-code>
 		<description>Unsafe pageReference object</description>
 		<expected-problems>1</expected-problems>
@@ -154,7 +169,7 @@ public class Foo {
 }
 		]]></code>
 	</test-code>
-	
+
 	<test-code>
 		<description>Safe pageReference object</description>
 		<expected-problems>0</expected-problems>
@@ -168,7 +183,7 @@ public class Foo {
 	}
 }
 		]]></code>
-	</test-code> 
+	</test-code>
 	<test-code>
 		<description>Safe pageReference object concatenation</description>
 		<expected-problems>0</expected-problems>
@@ -183,7 +198,7 @@ public class Foo {
 	}
 }
 		]]></code>
-	</test-code> 
+	</test-code>
 	<test-code>
 		<description>Static link pageReference object</description>
 		<expected-problems>0</expected-problems>
@@ -199,5 +214,5 @@ public class Foo {
 	</test-code>
 
 
-	
+
 </test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSharingViolations.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSharingViolations.xml
@@ -3,11 +3,12 @@
 <test-data>
 
 	<test-code>
-		<description>Apex class without sharing</description>
+		<description>Apex class that is queued</description>
 		<expected-problems>0</expected-problems>
 		<code><![CDATA[
-public class Foo {
+public class FooBar implements Database.Batchable {
 	public void test1() {
+		List<Account> accounts = [SELECT Id FROM Account LIMIT 1];
 	}
 }
 		]]></code>


### PR DESCRIPTION
Certain classes run in system mode by design (async jobs, scheduled and install scripts). 
This CL makes sure we don't create false positives for those cases.

