### PR TITLE
[apex] Add support for safe ID assignment from URL param 

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromURLParamRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromURLParamRule.java
@@ -91,7 +91,7 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
         ASTMethodCallExpression methodCall = node.getFirstChildOfType(ASTMethodCallExpression.class);
         if (methodCall != null) {
             String retType = getReturnType(node);
-            if (retType.equalsIgnoreCase("string")) {
+            if ("string".equalsIgnoreCase(retType)) {
                 processInlineMethodCalls(methodCall, data, true);
             }
         }
@@ -170,7 +170,7 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
                 }
 
                 if (left != null) {
-                    if (varType == null || !varType.equalsIgnoreCase("id")) {
+                    if (varType == null || !"id".equalsIgnoreCase(varType)) {
                         urlParameterStrings.add(Helper.getFQVariableName(left));
                     }
                 }
@@ -207,7 +207,7 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
                 varType = ((ASTVariableDeclaration) node).getNode().getLocalInfo().getType().getApexName();
             }
 
-            if (varType == null || !varType.equalsIgnoreCase("id")) {
+            if (varType == null || !"id".equalsIgnoreCase(varType)) {
                 processInlineMethodCalls(methodCallAssignment, data, false);
             }
         }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
@@ -178,6 +178,13 @@ public final class Helper {
         return sb.toString();
     }
 
+    static String getVariableType(final ASTField variable) {
+        Field n = variable.getNode();
+        StringBuilder sb = new StringBuilder().append(n.getDefiningType().getApexName()).append(":")
+                .append(n.getFieldInfo().getName());
+        return sb.toString();
+    }
+    
     static String getFQVariableName(final ASTFieldDeclaration variable) {
         FieldDeclaration n = variable.getNode();
         String name = "";

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexXSSFromURLParam.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexXSSFromURLParam.xml
@@ -14,6 +14,47 @@ public class Foo {
 	</test-code>
 
 	<test-code>
+		<description>Safe cast to ID</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public ID test1() {
+		return ApexPages.currentPage().getParameters().get('foo');
+	}		
+}
+		]]></code>
+	</test-code>
+
+
+	<test-code>
+		<description>Safe ID concatenation
+		</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public String test1() {
+		ID bas = ApexPages.currentPage().getParameters().get('foo');
+		return 'text' + bas;
+	}		
+}
+		]]></code>
+	</test-code>
+
+
+	<test-code>
+		<description>Safe ID
+		</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		ID bas = yoyo(ApexPages.currentPage().getParameters().get('foo'));
+	}		
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
 		<description>URL parameter in return statement concatenation
 		</description>
 		<expected-problems>1</expected-problems>


### PR DESCRIPTION
Casting to a String to ID would perform proper checks in Apex and result in safe, XSS-free, variable.
This code makes sure PMD never flags it.
