### PR TITLE
[apex] Fixed SOQL injection detection for escaped vars 

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
@@ -143,6 +143,13 @@ public class ApexSOQLInjectionRule extends AbstractApexRule {
             }
         }
 
+        final ASTMethodCallExpression methodCall = node.getFirstChildOfType(ASTMethodCallExpression.class);
+        if (methodCall != null) {
+            if (Helper.isMethodName(methodCall, STRING, ESCAPE_SINGLE_QUOTES)) {
+                isSafeVariable = true;
+            }
+        }
+
         final ASTLiteralExpression literal = node.getFirstChildOfType(ASTLiteralExpression.class);
         if (literal != null) {
 

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSOQLInjection.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSOQLInjection.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <test-data>
- 	<test-code>
+	<test-code>
 		<description>Potentially unsafe SOQL on concatenation of variables 1
 		</description>
 		<expected-problems>1</expected-problems>
@@ -191,6 +191,53 @@ public class Foo {
 	</test-code>
 
 	<test-code>
+		<description>Dynamic SOQL with Integer
+		</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		Integer field1 = 4; 
+		Database.query('SELECT Id FROM Account LIMIT ' + field1);		
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Dynamic safe escaped SOQL with multipart
+		</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1() {
+		String name = 'Name';
+		String someQuery = 'SELECT Id, ' + name + ' FROM ' + String.escapeSingleQuotes(objectName);
+        Database.query(someQuery);
+        
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Dynamic safe escaped SOQL with multipart
+		</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public void test1(String objectName) {
+		String name = 'Name';
+		String someQuery = 'SELECT Id, ' + name + ' FROM ' + objectName;
+        Database.query(someQuery);
+        
+	}
+}
+		]]></code>
+	</test-code>
+
+
+	<test-code>
 		<description>Unsafe SOQL merged from many variables</description>
 		<expected-problems>1</expected-problems>
 		<code><![CDATA[
@@ -206,19 +253,5 @@ public class Foo {
 }
 		]]></code>
 	</test-code>
-	
-	<test-code>
-		<description>Dynamic SOQL with Integer
-		</description>
-		<expected-problems>0</expected-problems>
-		<code><![CDATA[
-public class Foo {
-	public void test1() {
-		Integer field1 = 4; 
-		Database.query('SELECT Id FROM Account LIMIT ' + field1);		
-	}
-}
-		]]></code>
-	</test-code>
-		
+
 </test-data>


### PR DESCRIPTION
Fixed a bug when you have an escaped variable not being detected. 
