### PR TITLE
[java] JunitTestsShouldIncludeAssertRule now handles AllocationExpression correctly

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/junit/JUnitTestsShouldIncludeAssertRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/junit/JUnitTestsShouldIncludeAssertRule.java
@@ -138,9 +138,17 @@ public class JUnitTestsShouldIncludeAssertRule extends AbstractJUnitRule {
             Map<String, List<NameOccurrence>> expectables) {
         
         if (expression != null) {
+            
             ASTPrimaryExpression pe = expression.getFirstChildOfType(ASTPrimaryExpression.class);
             if (pe != null) {
-                String img = pe.jjtGetChild(0).jjtGetChild(0).getImage();
+                Node subChild = pe.jjtGetChild(0).jjtGetChild(0);
+
+                // case of eg AllocationExpression
+                if (!(subChild instanceof ASTName)) {
+                    return false;
+                }
+
+                String img = subChild.getImage();
                 if (img.indexOf(".") == -1) {
                     return false;
                 }
@@ -160,4 +168,3 @@ public class JUnitTestsShouldIncludeAssertRule extends AbstractJUnitRule {
         return false;
     }
 }
-

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/junit/JUnitTestsShouldIncludeAssertRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/junit/JUnitTestsShouldIncludeAssertRule.java
@@ -142,12 +142,12 @@ public class JUnitTestsShouldIncludeAssertRule extends AbstractJUnitRule {
             ASTPrimaryExpression pe = expression.getFirstChildOfType(ASTPrimaryExpression.class);
             if (pe != null) {
                 Node subChild = pe.jjtGetChild(0).jjtGetChild(0);
-
+                
                 // case of eg AllocationExpression
                 if (!(subChild instanceof ASTName)) {
                     return false;
                 }
-
+                
                 String img = subChild.getImage();
                 if (img.indexOf(".") == -1) {
                     return false;

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/junit/xml/JUnitTestsShouldIncludeAssert.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/junit/xml/JUnitTestsShouldIncludeAssert.xml
@@ -312,4 +312,21 @@ public class SimpleExpectedExceptionTest {
  }
         ]]></code>
     </test-code>    
+    <test-code>
+        <description>#330 Rule treats AllocationExpression correctly</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+	
+import org.junit.*;
+import javafx.embed.swing.JFXPanel;
+
+public class BaseConsoleTest extends UART {
+    @Test 
+    public void testInitialize() throws InterruptedException {
+        new JFXPanel(); // AllocationExpression
+    }
+}
+        ]]></code>
+    </test-code>
+
 </test-data>


### PR DESCRIPTION
**Fixes issue:** #330 

**PR Description:** The exception reported in the issue was caused by some statements in the Test methods, statements of the form `new JFXPanel();` (with no left hand side). The java compiler parses that as a `StatementExpression/PrimaryExpression` (visited by the rule), but instead of having a `PrimaryPrefix/Name` as children, this prim expression had a `PrimaryPrefix/AllocationExpression` as a child. That messed up the check for methods that start with "expect", as it relied on checking the Name descendant of the StatementExpression (an AllocationExpression has no Name and its image is null apparently).

**Solution:** Check whether the PrimaryPrefix contains a Name