### PR TITLE
[java] Future-proof DontImportJavaLangRule

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/imports/DontImportJavaLangRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/imports/DontImportJavaLangRule.java
@@ -8,7 +8,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
 public class DontImportJavaLangRule extends AbstractJavaRule {
-    private static final String IMPORT_JAVA_LANG = "java.lang.";
+    private static final String IMPORT_JAVA_LANG = "java.lang";
 
     @Override
     public Object visit(ASTImportDeclaration node, Object data) {
@@ -19,9 +19,11 @@ public class DontImportJavaLangRule extends AbstractJavaRule {
 
         String img = node.jjtGetChild(0).getImage();
         if (img.startsWith(IMPORT_JAVA_LANG)) {
-            if (img.indexOf('.', IMPORT_JAVA_LANG.length() + 1) != -1) {
-                // Importing from a subpackage / inner class
-                return data;
+            if (!IMPORT_JAVA_LANG.equals(img)) {
+                if (img.indexOf('.', IMPORT_JAVA_LANG.length() + 1) != -1 || node.isImportOnDemand()) {
+                    // Importing from a subpackage / inner class
+                    return data;
+                }
             }
             addViolation(data, node);
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/imports/DontImportJavaLangRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/imports/DontImportJavaLangRule.java
@@ -8,6 +8,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
 public class DontImportJavaLangRule extends AbstractJavaRule {
+    private static final String IMPORT_JAVA_LANG = "java.lang.";
 
     @Override
     public Object visit(ASTImportDeclaration node, Object data) {
@@ -17,11 +18,9 @@ public class DontImportJavaLangRule extends AbstractJavaRule {
         }
 
         String img = node.jjtGetChild(0).getImage();
-        if (img.startsWith("java.lang")) {
-            if (img.startsWith("java.lang.ref") || img.startsWith("java.lang.reflect")
-                    || img.startsWith("java.lang.annotation") || img.startsWith("java.lang.instrument")
-                    || img.startsWith("java.lang.management") || img.startsWith("java.lang.Thread.")
-                    || img.startsWith("java.lang.ProcessBuilder.") || img.startsWith("java.lang.invoke.")) {
+        if (img.startsWith(IMPORT_JAVA_LANG)) {
+            if (img.indexOf('.', IMPORT_JAVA_LANG.length() + 1) != -1) {
+                // Importing from a subpackage / inner class
                 return data;
             }
             addViolation(data, node);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/imports/DontImportJavaLangRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/imports/DontImportJavaLangRule.java
@@ -21,7 +21,7 @@ public class DontImportJavaLangRule extends AbstractJavaRule {
             if (img.startsWith("java.lang.ref") || img.startsWith("java.lang.reflect")
                     || img.startsWith("java.lang.annotation") || img.startsWith("java.lang.instrument")
                     || img.startsWith("java.lang.management") || img.startsWith("java.lang.Thread.")
-                    || img.startsWith("java.lang.ProcessBuilder.")) {
+                    || img.startsWith("java.lang.ProcessBuilder.") || img.startsWith("java.lang.invoke.")) {
                 return data;
             }
             addViolation(data, node);

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/imports/xml/DontImportJavaLang.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/imports/xml/DontImportJavaLang.xml
@@ -31,6 +31,7 @@ import java.lang.reflect.*;
 import java.lang.annotation.*;
 import java.lang.instrument.*;
 import java.lang.management.*;
+import java.lang.ProcessBuilder.*;
 public class Foo {}
      ]]></code>
     </test-code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/imports/xml/DontImportJavaLang.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/imports/xml/DontImportJavaLang.xml
@@ -64,4 +64,13 @@ import java.lang.ProcessBuilder.Redirect;
 public class Foo {}
         ]]></code>
     </test-code>
+    <test-code>
+        <description>import java.lang.invoke.MethodHandles: #1031 false DontImportJavaLang</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.lang.invoke.MethodHandles;
+
+public class Foo {}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `mvn test` passes.
 - [x] `mvn checkstyle:check` passes. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
In Java 7+ there was a new class added under the java.lang package. Specifically  java.lang.invoke.MethodHandles.

MethodHandles provides a handy utility in which to obtain the current class name amongst other things. A technique that is gaining in popularity is to use MethodHandles to obtain the class name when getting a logger, for example

`private final Logger log = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());`

However, using this triggers a PMD violation

```
<?xml version="1.0" encoding="UTF-8"?>
<pmd version="5.5.1" timestamp="2017-04-07T07:19:26.058">
<file name="...">
<violation beginline="18" endline="18" begincolumn="1" endcolumn="38" rule="DontImportJavaLang" ruleset="Import Statements" package="..." externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/imports.html#DontImportJavaLang" priority="4">
Avoid importing anything from the package java.lang
</violation>
</file>
</pmd>
```

This pull request adds java.lang.invoke. to the existing exceptions to this rule to when using Java 7+.

Resolves #338 
Resolves #339 
