### PR TITLE
[java] Even faster symboltable

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/SourceFileScope.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/SourceFileScope.java
@@ -26,6 +26,7 @@ public class SourceFileScope extends AbstractJavaScope {
 
     private final String packageImage;
     private final TypeSet types;
+    private Map<String, Node> qualifiedTypeNames;
 
     public SourceFileScope(final ClassLoader classLoader) {
         this(classLoader, "");
@@ -136,7 +137,12 @@ public class SourceFileScope extends AbstractJavaScope {
      * @return set of all types in this source file.
      */
     public Map<String, Node> getQualifiedTypeNames() {
-        return getSubTypes(null, this);
+        if (qualifiedTypeNames != null) {
+            return qualifiedTypeNames;
+        }
+
+        qualifiedTypeNames = getSubTypes(null, this);
+        return qualifiedTypeNames;
     }
 
     private Map<String, Node> getSubTypes(String qualifyingName, Scope subType) {

--- a/src/site/markdown/overview/changelog.md
+++ b/src/site/markdown/overview/changelog.md
@@ -20,7 +20,7 @@ than a 50% speedup). Future releases will keep improving on this area.
 Once again, *Symbol Table* has been an area of great performance improvements.
 This time we were able to further improve it's performance by roughly 10% on all
 supported languages. In *Java* in particular, several more improvements were possible,
-improving *Symbol Table* performance by a whooping 30%, that's over 5X faster
+improving *Symbol Table* performance by a whooping 80%, that's over 15X faster
 than PMD 5.5.1, when we first started working on it.
 
 Java developers will also appreciate the revamp of `CloneMethodMustImplementCloneable`,


### PR DESCRIPTION
`getQualifiedTypeNames` gets called millions of times, since it's extensibly used to determine argument types, variable types, and match methods. Even if it's a relatively small and simple method, the sheer number of calls make it a big bottleneck, and the continuous creation of strings and maps puts pressure on the GC.

Even if the code could be later improved to not rely so heavily on this method call, the memoization of the result is low-hanging fruit from which we can benefit right away, which produces a huge impact (3X improvement from master)