### PR TITLE
[vf] JSON.parse(..) and NOT(..) are safely evaluated

### DIFF
--- a/pmd-visualforce/etc/grammar/VfParser.jjt
+++ b/pmd-visualforce/etc/grammar/VfParser.jjt
@@ -145,7 +145,7 @@ PARSER_END(VfParser)
 	| <GE: ">=" >
 	| <LT: "<" >
 	| <GT: ">" >
-	| <EXCL: ("!"|"~"|"NOT") >
+	| <EXCL: ("!"|"~") >
 	| <PIPE_PIPE: "||" >
 	| <STRING_LITERAL: <QUOTED_STRING> >
 	| <DIGITS: (<NUM_CHAR>)+ (<DOT> (<NUM_CHAR>)+)? >
@@ -476,10 +476,10 @@ void UnaryExpression()  #void :
 {}
 {
 	  ( <PLUS> | <MINUS> ) UnaryExpression()
-	|  UnaryExpressionNotPlusMinus()
+	|  NegationExpression()
 }
 
-void UnaryExpressionNotPlusMinus() #void :
+void NegationExpression() #void :
 {}
 {
   ( <EXCL> ) UnaryExpression()

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/ast/VfParserVisitorAdapter.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/ast/VfParserVisitorAdapter.java
@@ -93,5 +93,5 @@ public class VfParserVisitorAdapter implements VfParserVisitor {
     public Object visit(ASTContent node, Object data) {
         return visit((VfNode) node, data);
     }
-
+    
 }

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/rule/security/VfUnescapeElRule.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/rule/security/VfUnescapeElRule.java
@@ -85,22 +85,24 @@ public class VfUnescapeElRule extends AbstractVfRule {
         }
         if (quoted) {
             // check escaping too
-            if (!(startsWithSafeResource(elExpression) || containsSafeFields(elExpression))) {
+            if (!(jsonParse || startsWithSafeResource(elExpression) || containsSafeFields(elExpression))) {
                 if (doesElContainAnyUnescapedIdentifiers(elExpression,
                         EnumSet.of(Escaping.JSENCODE, Escaping.JSINHTMLENCODE))) {
                     addViolation(data, elExpression);
                 }
             }
         } else {
-            if (!(jsonParse || startsWithSafeResource(elExpression) || containsSafeFields(elExpression))) {
+            if (!(startsWithSafeResource(elExpression) || containsSafeFields(elExpression))) {
                 addViolation(data, elExpression);
             }
         }
     }
 
     private boolean isJsonParse(ASTText prevText) {
-        if (prevText.getImage().endsWith("JSON.parse(") || prevText.getImage().endsWith("jQuery.parseJSON(")
-                || prevText.getImage().endsWith("$.parseJSON(")) {
+        final String text = (prevText.getImage().endsWith("'") || prevText.getImage().endsWith("'"))
+                ? prevText.getImage().substring(0, prevText.getImage().length() - 1) : prevText.getImage();
+
+        if (text.endsWith("JSON.parse(") || text.endsWith("jQuery.parseJSON(") || text.endsWith("$.parseJSON(")) {
             return true;
         }
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/rule/security/VfUnescapeElRule.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/rule/security/VfUnescapeElRule.java
@@ -93,7 +93,11 @@ public class VfUnescapeElRule extends AbstractVfRule {
             }
         } else {
             if (!(startsWithSafeResource(elExpression) || containsSafeFields(elExpression))) {
-                addViolation(data, elExpression);
+                final boolean hasUnscaped = doesElContainAnyUnescapedIdentifiers(elExpression,
+                        EnumSet.of(Escaping.JSENCODE, Escaping.JSINHTMLENCODE));
+                if (!(jsonParse && !hasUnscaped)) {
+                    addViolation(data, elExpression);
+                }
             }
         }
     }

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/rule/security/VfUnescapeElRule.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/rule/security/VfUnescapeElRule.java
@@ -230,20 +230,24 @@ public class VfUnescapeElRule extends AbstractVfRule {
         if (expression != null) {
             final ASTIdentifier id = expression.getFirstChildOfType(ASTIdentifier.class);
             if (id != null) {
-                switch (id.getImage().toLowerCase()) {
-                case "$component":
-                case "$objecttype":
-                case "$label":
-                case "$resource":
-                case "urlfor":
-                case "$site":
-                case "$page":
-                case "$action":
-                case "casesafeid":
-                case "$remoteaction":
-                    return true;
+                List<ASTArguments> args = expression.findChildrenOfType(ASTArguments.class);
+                if (!args.isEmpty()) {
+                    switch (id.getImage().toLowerCase()) {
+                    case "$component":
+                    case "$objecttype":
+                    case "$label":
+                    case "$resource":
+                    case "urlfor":
+                    case "$site":
+                    case "$page":
+                    case "$action":
+                    case "casesafeid":
+                    case "not":
+                    case "$remoteaction":
+                        return true;
 
-                default:
+                    default:
+                    }
                 }
             }
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/rule/security/VfUnescapeElRule.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/rule/security/VfUnescapeElRule.java
@@ -75,8 +75,10 @@ public class VfUnescapeElRule extends AbstractVfRule {
 
     private void processElInScriptContext(ASTElExpression elExpression, ASTText prevText, Object data) {
         boolean quoted = false;
+        boolean jsonParse = false;
 
         if (prevText != null) {
+            jsonParse = isJsonParse(prevText);
             if (isUnbalanced(prevText.getImage(), '\'') || isUnbalanced(prevText.getImage(), '\"')) {
                 quoted = true;
             }
@@ -90,10 +92,19 @@ public class VfUnescapeElRule extends AbstractVfRule {
                 }
             }
         } else {
-            if (!(startsWithSafeResource(elExpression) || containsSafeFields(elExpression))) {
+            if (!(jsonParse || startsWithSafeResource(elExpression) || containsSafeFields(elExpression))) {
                 addViolation(data, elExpression);
             }
         }
+    }
+
+    private boolean isJsonParse(ASTText prevText) {
+        if (prevText.getImage().endsWith("JSON.parse(") || prevText.getImage().endsWith("jQuery.parseJSON(")
+                || prevText.getImage().endsWith("$.parseJSON(")) {
+            return true;
+        }
+
+        return false;
     }
 
     private boolean isUnbalanced(String image, char pattern) {

--- a/pmd-visualforce/src/test/resources/net/sourceforge/pmd/lang/vf/rule/security/xml/VfUnescapeEl.xml
+++ b/pmd-visualforce/src/test/resources/net/sourceforge/pmd/lang/vf/rule/security/xml/VfUnescapeEl.xml
@@ -557,6 +557,7 @@ Safe unquoted followed by safe quoted
 ]]></code>
 		<source-type>vf</source-type>
 	</test-code>
+
 	<test-code>
 		<description><![CDATA[
 NOT method evaluates to safe boolean
@@ -572,5 +573,21 @@ NOT method evaluates to safe boolean
 		<source-type>vf</source-type>
 	</test-code>
 
+	<test-code>
+		<description><![CDATA[
+JSON.parse method evaluates to safe JSON
+     ]]></description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+<apex:page>
+	<script>
+		var x = JSON.parse({!yes});
+		jQuery.parseJSON({!yes});
+		$.parseJSON({!yes});
+	</script>
+</apex:page>
+]]></code>
+		<source-type>vf</source-type>
+	</test-code>
 
 </test-data>

--- a/pmd-visualforce/src/test/resources/net/sourceforge/pmd/lang/vf/rule/security/xml/VfUnescapeEl.xml
+++ b/pmd-visualforce/src/test/resources/net/sourceforge/pmd/lang/vf/rule/security/xml/VfUnescapeEl.xml
@@ -605,4 +605,20 @@ JSON.parse method evaluates non quoted EL to unsafe XSS
 		<source-type>vf</source-type>
 	</test-code>
 
+	<test-code>
+		<description><![CDATA[
+JSON.parse method evaluates escaped EL to safe JSON
+     ]]></description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+<apex:page>
+	<script>
+		var x = JSON.parse({!JSENCODE(yes)});
+	</script>
+</apex:page>
+]]></code>
+		<source-type>vf</source-type>
+	</test-code>
+
+
 </test-data>

--- a/pmd-visualforce/src/test/resources/net/sourceforge/pmd/lang/vf/rule/security/xml/VfUnescapeEl.xml
+++ b/pmd-visualforce/src/test/resources/net/sourceforge/pmd/lang/vf/rule/security/xml/VfUnescapeEl.xml
@@ -575,15 +575,30 @@ NOT method evaluates to safe boolean
 
 	<test-code>
 		<description><![CDATA[
-JSON.parse method evaluates to safe JSON
+JSON.parse method evaluates quoted EL to safe JSON
      ]]></description>
 		<expected-problems>0</expected-problems>
 		<code><![CDATA[
 <apex:page>
 	<script>
+		var x = JSON.parse('{!yes}');
+		jQuery.parseJSON('{!yes}');
+		$.parseJSON('{!yes}');
+	</script>
+</apex:page>
+]]></code>
+		<source-type>vf</source-type>
+	</test-code>
+
+	<test-code>
+		<description><![CDATA[
+JSON.parse method evaluates non quoted EL to unsafe XSS
+     ]]></description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+<apex:page>
+	<script>
 		var x = JSON.parse({!yes});
-		jQuery.parseJSON({!yes});
-		$.parseJSON({!yes});
 	</script>
 </apex:page>
 ]]></code>

--- a/pmd-visualforce/src/test/resources/net/sourceforge/pmd/lang/vf/rule/security/xml/VfUnescapeEl.xml
+++ b/pmd-visualforce/src/test/resources/net/sourceforge/pmd/lang/vf/rule/security/xml/VfUnescapeEl.xml
@@ -557,5 +557,20 @@ Safe unquoted followed by safe quoted
 ]]></code>
 		<source-type>vf</source-type>
 	</test-code>
+	<test-code>
+		<description><![CDATA[
+NOT method evaluates to safe boolean
+     ]]></description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+<apex:page>
+	<script>
+		if({!NOT(yes)}) { maskFormEls(); }
+	</script>
+</apex:page>
+]]></code>
+		<source-type>vf</source-type>
+	</test-code>
+
 
 </test-data>


### PR DESCRIPTION
{! NOT(booleanParam) } is a non-XSS vector since the resulting type is a boolean.
JSON.parse('{!someJSON}') is also safe from XSS as well as JSON.parse({!JSENCODE(someJSON)}).