### PR TITLE
[apex] int,id,boolean,ternary operator condition are not injection in Soql

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
@@ -13,12 +13,16 @@ import net.sourceforge.pmd.lang.apex.ast.ASTAssignmentExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTBinaryExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.apex.ast.ASTLiteralExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
 import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration;
 import net.sourceforge.pmd.lang.apex.ast.ASTVariableExpression;
 import net.sourceforge.pmd.lang.apex.ast.AbstractApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+
+import apex.jorje.semantic.ast.member.Parameter;
+import apex.jorje.semantic.ast.statement.VariableDeclaration;
 
 /**
  * Detects if variables in Database.query(variable) is escaped with
@@ -28,6 +32,9 @@ import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
  *
  */
 public class ApexSOQLInjectionRule extends AbstractApexRule {
+    private static final String BOOLEAN = "boolean";
+    private static final String ID = "id";
+    private static final String INTEGER = "integer";
     private static final String JOIN = "join";
     private static final String ESCAPE_SINGLE_QUOTES = "escapeSingleQuotes";
     private static final String STRING = "String";
@@ -48,6 +55,11 @@ public class ApexSOQLInjectionRule extends AbstractApexRule {
 
         if (Helper.isTestMethodOrClass(node) || Helper.isSystemLevelClass(node)) {
             return data; // stops all the rules
+        }
+
+        final List<ASTMethod> methodExpr = node.findDescendantsOfType(ASTMethod.class);
+        for (ASTMethod m : methodExpr) {
+            findSafeVariablesInSignature(m);
         }
 
         final List<ASTFieldDeclaration> fieldExpr = node.findDescendantsOfType(ASTFieldDeclaration.class);
@@ -87,6 +99,22 @@ public class ApexSOQLInjectionRule extends AbstractApexRule {
         return data;
     }
 
+    private void findSafeVariablesInSignature(ASTMethod m) {
+        List<Parameter> parameters = m.getNode().getMethodInfo().getParameters();
+        for (Parameter p : parameters) {
+            switch (p.getType().getApexName().toLowerCase()) {
+            case ID:
+            case INTEGER:
+            case BOOLEAN:
+                safeVariables.add(Helper.getFQVariableName(p));
+            default:
+                break;
+            }
+
+        }
+
+    }
+
     private void findSanitizedVariables(AbstractApexNode<?> node) {
         final ASTVariableExpression left = node.getFirstChildOfType(ASTVariableExpression.class);
         final ASTLiteralExpression literal = node.getFirstChildOfType(ASTLiteralExpression.class);
@@ -116,6 +144,18 @@ public class ApexSOQLInjectionRule extends AbstractApexRule {
                 if (left != null) {
                     safeVariables.add(Helper.getFQVariableName(left));
                 }
+            }
+        }
+
+        if (node instanceof ASTVariableDeclaration) {
+            VariableDeclaration o = (VariableDeclaration) node.getNode();
+            switch (o.getLocalInfo().getType().getApexName().toLowerCase()) {
+            case INTEGER:
+            case ID:
+            case BOOLEAN:
+                safeVariables.add(Helper.getFQVariableName(left));
+            default:
+                break;
             }
         }
     }
@@ -159,6 +199,8 @@ public class ApexSOQLInjectionRule extends AbstractApexRule {
                     if (!isSafeVariable) {
                         // select literal + other unsafe vars
                         selectContainingVariables.put(Helper.getFQVariableName(var), Boolean.FALSE);
+                    } else {
+                        safeVariables.add(Helper.getFQVariableName(var));
                     }
                 }
             }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
@@ -113,8 +113,8 @@ public class ApexSOQLInjectionRule extends AbstractApexRule {
             case DECIMAL:
             case LONG:
             case DOUBLE:
-
                 safeVariables.add(Helper.getFQVariableName(p));
+                break;
             default:
                 break;
             }
@@ -165,6 +165,7 @@ public class ApexSOQLInjectionRule extends AbstractApexRule {
             case LONG:
             case DOUBLE:
                 safeVariables.add(Helper.getFQVariableName(left));
+                break;
             default:
                 break;
             }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
@@ -35,6 +35,7 @@ import apex.jorje.semantic.ast.expression.MethodCallExpression;
 import apex.jorje.semantic.ast.expression.NewNameValueObjectExpression;
 import apex.jorje.semantic.ast.expression.VariableExpression;
 import apex.jorje.semantic.ast.member.Field;
+import apex.jorje.semantic.ast.member.Parameter;
 import apex.jorje.semantic.ast.statement.FieldDeclaration;
 import apex.jorje.semantic.ast.statement.VariableDeclaration;
 
@@ -261,6 +262,12 @@ public final class Helper {
             break;
         }
         return false;
+    }
+
+    public static String getFQVariableName(Parameter p) {
+        StringBuffer sb = new StringBuffer();        
+        sb.append(p.getDefiningType()).append(":").append(p.getName().value);        
+        return sb.toString();
     }
 
 }

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSOQLInjection.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSOQLInjection.xml
@@ -257,8 +257,7 @@ public class Foo {
 		<description>Literal concatenation in the query method is safe
 		</description>
 		<expected-problems>0</expected-problems>
-		<code><![CDATA[
-		
+		<code><![CDATA[		
 public class Foo {
 
 	public List<SObject> test1(String objName) {
@@ -272,8 +271,7 @@ public class Foo {
 	<test-code>
 		<description>Integer is safe in query</description>
 		<expected-problems>0</expected-problems>
-		<code><![CDATA[
-		
+		<code><![CDATA[		
 public class Foo {
 	public void test1(String objName, String limit) {
 		Integer nLimit = Integer.valueOf(limit);
@@ -286,8 +284,7 @@ public class Foo {
 	<test-code>
 		<description>ID var decl is safe in query</description>
 		<expected-problems>0</expected-problems>
-		<code><![CDATA[
-		
+		<code><![CDATA[		
 public class Foo {
 	public void test1() {
 		ID someId;
@@ -302,8 +299,7 @@ public class Foo {
 		<description>Safe ID and unsafe String from method signature
 		</description>
 		<expected-problems>1</expected-problems>
-		<code><![CDATA[
-		
+		<code><![CDATA[		
 public class Foo {
 	public void test1(ID someId, String name) {
 		List<SObject> res = Database.query('Select Id,' + name + ' From Account Where Id=' + someId);	
@@ -311,5 +307,20 @@ public class Foo {
 }
 		]]></code>
 	</test-code>
+
+	<test-code>
+		<description>Ternary operator condition var is safe but resulting type
+			isn't
+		</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[		
+public class Foo {
+	public void test1(String name) {
+		List<SObject> res = Database.query('Select Id,Name From ' + (name == 'Account' ? name : 'Cases');	
+	}
+}
+		]]></code>
+	</test-code>
+
 
 </test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSOQLInjection.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSOQLInjection.xml
@@ -236,7 +236,6 @@ public class Foo {
 		]]></code>
 	</test-code>
 
-
 	<test-code>
 		<description>Unsafe SOQL merged from many variables</description>
 		<expected-problems>1</expected-problems>
@@ -249,6 +248,65 @@ public class Foo {
 		String finalObjectQuery;
 		finalObjectQuery = baseQuery + fieldNameQuery + ' from ' + objName;
 		return Database.query(finalObjectQuery);	
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Literal concatenation in the query method is safe
+		</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+		
+public class Foo {
+
+	public List<SObject> test1(String objName) {
+		String baseQuery = 'Select Id, Name From ' + String.escapeSingleQuotes(objName);
+		return Database.query(baseQuery + ' LIMIT 1');	
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Integer is safe in query</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+		
+public class Foo {
+	public void test1(String objName, String limit) {
+		Integer nLimit = Integer.valueOf(limit);
+		List<SObject> res = Database.query('Select Id, Name From ' + String.escapeSingleQuotes(objName) + ' LIMIT ' + nLimit);	
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>ID var decl is safe in query</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+		
+public class Foo {
+	public void test1() {
+		ID someId;
+		someId = getId();
+		List<SObject> res = Database.query('Select Id, Name From Account Where Id=' + someId);	
+	}
+}
+		]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Safe ID and unsafe String from method signature
+		</description>
+		<expected-problems>1</expected-problems>
+		<code><![CDATA[
+		
+public class Foo {
+	public void test1(ID someId, String name) {
+		List<SObject> res = Database.query('Select Id,' + name + ' From Account Where Id=' + someId);	
 	}
 }
 		]]></code>


### PR DESCRIPTION
- Ids, integers and booleans passed to SOQL are not considered an injection.
- Ternary operator's condition variables are not contributing to SOQL and are considered safe too