### PR TITLE
[vf] Adding proper AST support for negation expressions

### DIFF
--- a/pmd-visualforce/etc/grammar/VfParser.jjt
+++ b/pmd-visualforce/etc/grammar/VfParser.jjt
@@ -146,7 +146,7 @@ PARSER_END(VfParser)
 	| <GE: ">=" >
 	| <LT: "<" >
 	| <GT: ">" >
-	| <EXCL: ("!"|"~") >
+	| <EXCL: ("!"|"~"|"NOT") >
 	| <PIPE_PIPE: "||" >
 	| <STRING_LITERAL: <QUOTED_STRING> >
 	| <DIGITS: (<NUM_CHAR>)+ (<DOT> (<NUM_CHAR>)+)? >
@@ -496,14 +496,7 @@ void UnaryExpression()  #void :
 {}
 {
 	  ( <PLUS> | <MINUS> ) UnaryExpression()
-	|  NegationExpression()
-}
-
-void NegationExpression() #void :
-{}
-{
-  ( <EXCL> ) UnaryExpression()
-|  PrimaryExpression()
+	|  PrimaryExpression()
 }
 
 void PrimaryExpression() #void :
@@ -537,6 +530,7 @@ void PrimaryPrefix() #void :
 	| Identifier()	
 	| <LPAREN> Expression() <RPAREN>
 	| <LSQUARE> Expression() (<COMMA> Expression())*   <RSQUARE>
+	| NegationExpression()
 }
 
 void PrimarySuffix() #void :
@@ -546,6 +540,13 @@ void PrimarySuffix() #void :
 	| DotExpression()
 	| Arguments()
 }
+
+void NegationExpression() :
+{}
+{
+  ( <EXCL> ) Expression()
+}
+
 
 void DotExpression() :
 {}

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/ast/ASTNegationExpression.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/ast/ASTNegationExpression.java
@@ -1,0 +1,21 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.vf.ast;
+
+public class ASTNegationExpression extends AbstractVFNode {
+    public ASTNegationExpression(int id) {
+        super(id);
+    }
+
+    public ASTNegationExpression(VfParser p, int id) {
+        super(p, id);
+    }
+
+    /** Accept the visitor. **/
+    public Object jjtAccept(VfParserVisitor visitor, Object data) {
+
+        return visitor.visit(this, data);
+    }
+}

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/ast/VfParserVisitorAdapter.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/ast/VfParserVisitorAdapter.java
@@ -85,4 +85,9 @@ public class VfParserVisitorAdapter implements VfParserVisitor {
         return visit((VfNode) node, data);
     }
     
+    @Override
+    public Object visit(ASTNegationExpression node, Object data) {
+        return visit((VfNode) node, data);
+    }
+    
 }

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/rule/AbstractVfRule.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/rule/AbstractVfRule.java
@@ -28,6 +28,7 @@ import net.sourceforge.pmd.lang.vf.ast.ASTExpression;
 import net.sourceforge.pmd.lang.vf.ast.ASTHtmlScript;
 import net.sourceforge.pmd.lang.vf.ast.ASTIdentifier;
 import net.sourceforge.pmd.lang.vf.ast.ASTLiteral;
+import net.sourceforge.pmd.lang.vf.ast.ASTNegationExpression;
 import net.sourceforge.pmd.lang.vf.ast.ASTText;
 import net.sourceforge.pmd.lang.vf.ast.VfNode;
 import net.sourceforge.pmd.lang.vf.ast.VfParserVisitor;
@@ -124,6 +125,10 @@ public abstract class AbstractVfRule extends AbstractRule implements VfParserVis
     }
 
     public Object visit(ASTContent node, Object data) {
+        return visit((VfNode) node, data);
+    }
+
+    public Object visit(ASTNegationExpression node, Object data) {
         return visit((VfNode) node, data);
     }
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/rule/security/VfUnescapeElRule.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/rule/security/VfUnescapeElRule.java
@@ -21,6 +21,7 @@ import net.sourceforge.pmd.lang.vf.ast.ASTExpression;
 import net.sourceforge.pmd.lang.vf.ast.ASTHtmlScript;
 import net.sourceforge.pmd.lang.vf.ast.ASTIdentifier;
 import net.sourceforge.pmd.lang.vf.ast.ASTLiteral;
+import net.sourceforge.pmd.lang.vf.ast.ASTNegationExpression;
 import net.sourceforge.pmd.lang.vf.ast.ASTText;
 import net.sourceforge.pmd.lang.vf.ast.AbstractVFNode;
 import net.sourceforge.pmd.lang.vf.rule.AbstractVfRule;
@@ -245,6 +246,11 @@ public class VfUnescapeElRule extends AbstractVfRule {
     private boolean startsWithSafeResource(final ASTElExpression el) {
         final ASTExpression expression = el.getFirstChildOfType(ASTExpression.class);
         if (expression != null) {
+            final ASTNegationExpression negation = expression.getFirstChildOfType(ASTNegationExpression.class);
+            if (negation != null) {
+                return true;
+            }
+            
             final ASTIdentifier id = expression.getFirstChildOfType(ASTIdentifier.class);
             if (id != null) {
                 List<ASTArguments> args = expression.findChildrenOfType(ASTArguments.class);
@@ -254,8 +260,7 @@ public class VfUnescapeElRule extends AbstractVfRule {
                     case "casesafeid":
                     case "begins":
                     case "contains":
-                    case "len":
-                    case "not":
+                    case "len":                    
                     case "getrecordids":
                     case "linkto":
                     case "sqrt":

--- a/pmd-visualforce/src/test/resources/net/sourceforge/pmd/lang/vf/rule/security/xml/VfUnescapeEl.xml
+++ b/pmd-visualforce/src/test/resources/net/sourceforge/pmd/lang/vf/rule/security/xml/VfUnescapeEl.xml
@@ -567,6 +567,7 @@ NOT method evaluates to safe boolean
 <apex:page>
 	<script>
 		if({!NOT(yes)}) { maskFormEls(); }
+		if({!NOT foo(yes)}) { maskFormEls(); }
 	</script>
 </apex:page>
 ]]></code>


### PR DESCRIPTION
```!(expression)``` or ```NOT(expression)``` resolve to booleans; however, in VisualForce also the following works ```!expression``` and ```NOT expression```. Therefore, I added a new AST node to detect false positive cases and also handle both. 
