### PR TITLE
[core] Fix XSS in HTML renderer

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/HTMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/HTMLRenderer.java
@@ -9,7 +9,7 @@ import java.io.Writer;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.commons.lang.StringEscapeUtils;
+import org.apache.commons.lang3.StringEscapeUtils;
 
 import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.Report;
@@ -124,7 +124,7 @@ public class HTMLRenderer extends AbstractIncrementingRenderer {
             buf.append("> " + PMD.EOL);
             buf.append("<td align=\"center\">" + violationCount + "</td>" + PMD.EOL);
             buf.append("<td width=\"*%\">"
-                    + maybeWrap(StringEscapeUtils.escapeHtml(rv.getFilename()),
+                    + maybeWrap(StringEscapeUtils.escapeHtml4(rv.getFilename()),
                             linePrefix == null ? "" : linePrefix + Integer.toString(rv.getBeginLine()))
                     + "</td>" + PMD.EOL);
             buf.append("<td align=\"center\" width=\"5%\">" + Integer.toString(rv.getBeginLine()) + "</td>" + PMD.EOL);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/HTMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/HTMLRenderer.java
@@ -9,6 +9,8 @@ import java.io.Writer;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.commons.lang.StringEscapeUtils;
+
 import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.Report;
 import net.sourceforge.pmd.RuleViolation;
@@ -122,7 +124,7 @@ public class HTMLRenderer extends AbstractIncrementingRenderer {
             buf.append("> " + PMD.EOL);
             buf.append("<td align=\"center\">" + violationCount + "</td>" + PMD.EOL);
             buf.append("<td width=\"*%\">"
-                    + maybeWrap(rv.getFilename(),
+                    + maybeWrap(StringEscapeUtils.escapeHtml(rv.getFilename()),
                             linePrefix == null ? "" : linePrefix + Integer.toString(rv.getBeginLine()))
                     + "</td>" + PMD.EOL);
             buf.append("<td align=\"center\" width=\"5%\">" + Integer.toString(rv.getBeginLine()) + "</td>" + PMD.EOL);


### PR DESCRIPTION
XSS in the HTML renderer when file name contains markup.
E.g. ```<td width="*%">/tmp/pmd3186397825114149840/src/classes<script>alert(1)</script>AccountMergingController.cls</td>```