### PR TITLE
[java] Add property to ignore interfaces in FieldDeclarationsShouldBeAtStartOfClassRule

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/FieldDeclarationsShouldBeAtStartOfClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/FieldDeclarationsShouldBeAtStartOfClassRule.java
@@ -40,6 +40,8 @@ public class FieldDeclarationsShouldBeAtStartOfClassRule extends AbstractJavaRul
             "Ignore Enum Declarations that precede fields.", true, 1.0f);
     private BooleanProperty ignoreAnonymousClassDeclarations = new BooleanProperty("ignoreAnonymousClassDeclarations",
             "Ignore Field Declarations, that are initialized with anonymous class declarations", true, 2.0f);
+    private BooleanProperty ignoreInterfaceDeclarations = new BooleanProperty("ignoreInterfaceDeclarations",
+            "Ignore Interface Declarations that precede fields.", false, 3.0f);
 
     /**
      * Initializes the rule {@link FieldDeclarationsShouldBeAtStartOfClassRule}.
@@ -67,10 +69,19 @@ public class FieldDeclarationsShouldBeAtStartOfClassRule extends AbstractJavaRul
                     && getProperty(ignoreAnonymousClassDeclarations).booleanValue()) {
                 continue;
             }
-            if (child instanceof ASTClassOrInterfaceDeclaration || child instanceof ASTMethodDeclaration
-                    || child instanceof ASTConstructorDeclaration || child instanceof ASTAnnotationTypeDeclaration) {
+            if (child instanceof ASTMethodDeclaration || child instanceof ASTConstructorDeclaration
+                    || child instanceof ASTAnnotationTypeDeclaration) {
                 addViolation(data, node);
                 break;
+            }
+            if (child instanceof ASTClassOrInterfaceDeclaration) {
+                ASTClassOrInterfaceDeclaration declaration = (ASTClassOrInterfaceDeclaration) child;
+                if (declaration.isInterface() && getProperty(ignoreInterfaceDeclarations).booleanValue()) {
+                    continue;
+                } else {
+                    addViolation(data, node);
+                    break;
+                }
             }
             if (child instanceof ASTEnumDeclaration && !getProperty(ignoreEnumDeclarations).booleanValue()) {
                 addViolation(data, node);


### PR DESCRIPTION
fixes #345

@jsotuyod My code looks like this right now which is 😢:
```java
public interface StartCaptureListener {
    void onStartCapture(boolean shouldUploadMediaToTba);
}

private static final int TAKE_PHOTO_RC = 334; // NOPMD https://github.com/pmd/pmd/issues/345
private static final List<String> PERMS; // NOPMD https://github.com/pmd/pmd/issues/345
private static final String MEDIA_CREATOR_KEY = "media_creator"; // NOPMD https://github.com/pmd/pmd/issues/345

private WeakReference<Fragment> mFragment; // NOPMD https://github.com/pmd/pmd/issues/345
private TeamHelper mTeamHelper; // NOPMD https://github.com/pmd/pmd/issues/345
private PermissionRequestHandler mPermHandler; // NOPMD https://github.com/pmd/pmd/issues/345
private WeakReference<OnSuccessListener<TeamHelper>> mListener; // NOPMD https://github.com/pmd/pmd/issues/345
private String mPhotoPath; // NOPMD https://github.com/pmd/pmd/issues/345
private boolean mShouldUploadMediaToTba; // NOPMD https://github.com/pmd/pmd/issues/345
```

I'm trying to add that property you mentioned, but I'm not sure how to test my code or build pmd for that matter. (I don't even know if what I wrote compiles 😄)