### PR TITLE
[java] Remove deprecated rule UseSingleton (fixes #1513)

### DIFF
--- a/pmd-java/src/main/resources/rulesets/java/design.xml
+++ b/pmd-java/src/main/resources/rulesets/java/design.xml
@@ -10,7 +10,6 @@ The Design ruleset contains rules that flag suboptimal code implementations. Alt
 are suggested.
   </description>
 
-  <rule deprecated="true" name="UseSingleton" ref="UseUtilityClass"/>
   <rule name="UseUtilityClass"
   		  since="0.3"
         message="All methods are static.  Consider using a utility class instead. Alternatively, you could add a private constructor or make the class abstract to silence this warning."

--- a/src/site/markdown/overview/changelog.md
+++ b/src/site/markdown/overview/changelog.md
@@ -28,11 +28,18 @@ This is a minor release.
         </properties>
     </rule>
 
+#### Removed Rules
+
+*   The deprecated rule "UseSingleton" has been removed from the ruleset "java-design". The rule has been renamed
+    long time ago to "UseUtilityClass".
+
 
 ### Fixed Issues
 
 *   General
     *   [#377](https://github.com/pmd/pmd/issues/377): \[core] Use maven wrapper and upgrade to maven 3.5.0
+*   java
+    *   [#1513](https://sourceforge.net/p/pmd/bugs/1513/): \[java] Remove deprecated rule UseSingleton
 *   java-design
     *   [#345](https://github.com/pmd/pmd/issues/345): \[java] FieldDeclarationsShouldBeAtStartOfClass: Add ability to ignore interfaces
 


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `mvn test` passes.
 - [x] `mvn checkstyle:check` passes. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

This is a fix for https://sourceforge.net/p/pmd/bugs/1513/

There is another commit in there, that fixes rulecompatibility for UnusedModifier - this should definitely go into 5.7.0

However, since we want to move to [semantic versioning](http://semver.org/), is removing are rule valid for a 5.7.0 release or should we do such changes in general in a next 6.0.0 release?
This was the last rule marked as `deprecated` - all other deprecated rules have already been removed.

There are a few other deprecated methods in the Java code, too.

