### PR TITLE
[core] Fix broken link in the site's doc

### DIFF
--- a/src/site/markdown/overview/products.md
+++ b/src/site/markdown/overview/products.md
@@ -51,6 +51,6 @@
 
 ## Articles
 
-*   <a href="http://www.unixgarden.com/index.php/gnu-linux-magazine/verifier-votre-code-java-avec-pmd">An introduction
+*   <a href="http://connect.ed-diamond.com/GNU-Linux-Magazine/GLMF-105/Verifier-votre-code-Java-avec-PMD">An introduction
     to PMD (in French)</a>
 


### PR DESCRIPTION
The link surprisingly pointed to an Italian blog about sex ^^