### PR TITLE
[jsp] Fixed JspEncoding false positive

### DIFF
--- a/pmd-jsp/src/main/resources/rulesets/jsp/basic.xml
+++ b/pmd-jsp/src/main/resources/rulesets/jsp/basic.xml
@@ -239,7 +239,7 @@ A missing 'meta' tag or page directive will trigger this rule, as well as a non-
 			<property name="xpath">
 				<value>
 					<![CDATA[
-//Content[
+//CompilationUnit/Content[
 not(Element[@Name="meta"][
    Attribute[@Name="content"]/AttributeValue[contains(lower-case(@Image),"charset=utf-8")]
 ]) 

--- a/pmd-jsp/src/test/resources/net/sourceforge/pmd/lang/jsp/rule/basic/xml/JspEncoding.xml
+++ b/pmd-jsp/src/test/resources/net/sourceforge/pmd/lang/jsp/rule/basic/xml/JspEncoding.xml
@@ -64,4 +64,24 @@ Good meta header 2
      ]]></code>
         <source-type>jsp</source-type>
     </test-code>
+    <test-code>
+        <description><![CDATA[
+Issue #369
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+<%@ page contentType="text/html;charset=UTF-8" language="java" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jsp/jstl/fmt" %>
+<%@ taglib prefix="fn" uri="http://topjava.javawebinar.ru/functions" %>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+    <title>Meal list</title>
+    <link rel="stylesheet" href="css/style.css">
+</head>
+</html>
+     ]]></code>
+        <source-type>jsp</source-type>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Fix #369 

There were several nested content nodes in the code sample, which triggered the rule as the deep ones did not contain encoding specification.