### PR TITLE
[java] Relax UncommentedEmptyConstructor when @Inject is applied on the constructor.

### DIFF
--- a/pmd-java/src/main/resources/rulesets/java/design.xml
+++ b/pmd-java/src/main/resources/rulesets/java/design.xml
@@ -1426,7 +1426,7 @@ and unintentional empty constructors.
           <property name="xpath">
               <value>
     <![CDATA[
-//ConstructorDeclaration[@Private='false'][count(BlockStatement) = 0 and ($ignoreExplicitConstructorInvocation = 'true' or not(ExplicitConstructorInvocation)) and @containsComment = 'false']
+    //ConstructorDeclaration[@Private='false'][count(BlockStatement) = 0 and ($ignoreExplicitConstructorInvocation = 'true' or not(ExplicitConstructorInvocation)) and @containsComment = 'false' and (ancestor::MethodDeclaration/preceding-sibling::Annotation/*/Name[@Image='Inject']) = 'false']
  ]]>
              </value>
           </property>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UncommentedEmptyConstructor.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UncommentedEmptyConstructor.xml
@@ -2,6 +2,19 @@
 <test-data>
     <test-code>
         <description><![CDATA[
+@Inject is okay
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <rule-property name="ignoreExplicitConstructorInvocation">true</rule-property>
+        <code><![CDATA[
+public class Foo {
+ @Inject Foo() {
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
 simple failure
      ]]></description>
         <expected-problems>1</expected-problems>


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [X] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [ ] `mvn test` passes.
 - [X] `mvn checkstyle:check` passes. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

I added a test to verify the new behavior although I'm not sure if I'm at the right place for adding the check regarding the `@Inject` annotation. Could you help me there?

Fixes #357 