### PR TITLE
[apex] Fix documentation typo

### DIFF
--- a/pmd-apex/src/main/resources/rulesets/apex/style.xml
+++ b/pmd-apex/src/main/resources/rulesets/apex/style.xml
@@ -119,7 +119,7 @@ See more here: https://developer.salesforce.com/page/Trigger_Frameworks_and_Apex
           externalInfoUrl="${pmd.website.baseurl}/rules/apex/style.html#AvoidGlobalModifier">
     <description>
 Global classes should be avoided (especially in managed packages) as they can never be deleted or changed in signature. Always check twice if something needs to be global.
-Many interfaces (e.g. Batch) required global modifiers in the past but don't require this anymore. Don't look yourself in.
+Many interfaces (e.g. Batch) required global modifiers in the past but don't require this anymore. Don't lock yourself in.
     </description>
       <priority>3</priority>
     <example>


### PR DESCRIPTION
Fix typo in apex ruleset documentation.

