### PR TITLE
[java] Mockito verify method is not taken into account in JUnitTestsShouldIncludeAssert rule

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/junit/JUnitTestsShouldIncludeAssertRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/junit/JUnitTestsShouldIncludeAssertRule.java
@@ -52,7 +52,8 @@ public class JUnitTestsShouldIncludeAssertRule extends AbstractJUnitRule {
     private boolean containsExpectOrAssert(Node n, Map<String, List<NameOccurrence>> expectables) {
         if (n instanceof ASTStatementExpression) {
             if (isExpectStatement((ASTStatementExpression) n, expectables)
-                    || isAssertOrFailStatement((ASTStatementExpression) n)) {
+                    || isAssertOrFailStatement((ASTStatementExpression) n)
+                    || isVerifyStatement((ASTStatementExpression) n)) {
                 return true;
             }
         } else {
@@ -129,6 +130,25 @@ public class JUnitTestsShouldIncludeAssertRule extends AbstractJUnitRule {
                     String img = name.getImage();
                     if (img != null && (img.startsWith("assert") || img.startsWith("fail")
                             || img.startsWith("Assert.assert") || img.startsWith("Assert.fail"))) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Tells if the expression is verify statement or not
+     */
+    private boolean isVerifyStatement(ASTStatementExpression expression) {
+        if (expression != null) {
+            ASTPrimaryExpression pe = expression.getFirstChildOfType(ASTPrimaryExpression.class);
+            if (pe != null) {
+                Node name = pe.getFirstDescendantOfType(ASTName.class);
+                if (name != null) {
+                    String img = name.getImage();
+                    if (img != null && (img.startsWith("verify") || img.startsWith("Mockito.verify"))) {
                         return true;
                     }
                 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/junit/xml/JUnitTestsShouldIncludeAssert.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/junit/xml/JUnitTestsShouldIncludeAssert.xml
@@ -340,4 +340,57 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>#358 Treat Mockito's verify as assert expressions</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class FooTest {
+
+    @Mock
+    private Bar bar;
+
+    @Test
+    public void testFooCallsBar() {
+        Foo foo = new Foo(bar);
+        foo.doTask();
+
+        verify(bar, times(1)).actuallyDoTask();
+    }
+}]]></code>
+    </test-code>
+    <test-code>
+        <description>#358 Treat Mockito's Mockito.verify as assert expressions</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class FooTest {
+
+    @Mock
+    private Bar bar;
+
+    @Test
+    public void testFooCallsBar() {
+        Foo foo = new Foo(bar);
+        foo.doTask();
+
+        Mockito.verify(bar, Mockito.times(1)).actuallyDoTask();
+    }
+}]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
**PR Description:**
Fixes #358 by treating Mockito's verify as assert statement
