### PR TITLE
[java] Type resolution: super and this keywords

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPrimarySuffix.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPrimarySuffix.java
@@ -5,7 +5,7 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
-public class ASTPrimarySuffix extends AbstractJavaNode {
+public class ASTPrimarySuffix extends AbstractJavaTypeNode {
 
     private boolean isArguments;
     private boolean isArrayDereference;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -14,55 +14,8 @@ import java.util.logging.Logger;
 
 import net.sourceforge.pmd.lang.ast.AbstractNode;
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.java.ast.ASTAdditiveExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTAllocationExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTAndExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTAnnotationTypeDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTArrayDimsAndInits;
-import net.sourceforge.pmd.lang.java.ast.ASTBooleanLiteral;
-import net.sourceforge.pmd.lang.java.ast.ASTCastExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBody;
-import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
-import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
-import net.sourceforge.pmd.lang.java.ast.ASTConditionalAndExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTConditionalExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTConditionalOrExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTEnumDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTEqualityExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTExclusiveOrExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTInclusiveOrExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTInstanceOfExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTLiteral;
-import net.sourceforge.pmd.lang.java.ast.ASTMarkerAnnotation;
-import net.sourceforge.pmd.lang.java.ast.ASTMultiplicativeExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTName;
-import net.sourceforge.pmd.lang.java.ast.ASTNormalAnnotation;
-import net.sourceforge.pmd.lang.java.ast.ASTNullLiteral;
-import net.sourceforge.pmd.lang.java.ast.ASTPackageDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTPostfixExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTPreDecrementExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTPreIncrementExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
-import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
-import net.sourceforge.pmd.lang.java.ast.ASTPrimitiveType;
-import net.sourceforge.pmd.lang.java.ast.ASTReferenceType;
-import net.sourceforge.pmd.lang.java.ast.ASTRelationalExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTShiftExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTSingleMemberAnnotation;
-import net.sourceforge.pmd.lang.java.ast.ASTStatementExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTType;
-import net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTUnaryExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTUnaryExpressionNotPlusMinus;
-import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
-import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
-import net.sourceforge.pmd.lang.java.ast.JavaParserVisitorAdapter;
-import net.sourceforge.pmd.lang.java.ast.TypeNode;
+import net.sourceforge.pmd.lang.java.ast.*;
+import net.sourceforge.pmd.lang.symboltable.Scope;
 
 //
 // Helpful reading:
@@ -442,40 +395,52 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
     }
 
     @Override
-    public Object visit(ASTPrimaryExpression node, Object data) {
-        super.visit(node, data);
-        if (node.jjtGetNumChildren() == 1) {
-            rollupTypeUnary(node);
-        } else {
-            // TODO OMG, this is complicated. PrimaryExpression, PrimaryPrefix
-            // and PrimarySuffix are all related.
+    public Object visit(ASTPrimaryExpression primaryNode, Object data) {
+        super.visit(primaryNode, data);
+
+        Class<?> primaryNodeType = null;
+        AbstractJavaTypeNode previousChild = null;
+
+        for (int childIndex = 0; childIndex < primaryNode.jjtGetNumChildren(); ++childIndex) {
+            AbstractJavaTypeNode currentChild = (AbstractJavaTypeNode) primaryNode.jjtGetChild(childIndex);
+
+            // skip children which already have their type assigned
+            if(currentChild.getType() == null) {
+                // Last token, because if 'this' is a Suffix, it'll have tokens '.' and 'this'
+                if (currentChild.jjtGetLastToken().toString().equals("this")) {
+                    if (previousChild != null) { // Qualified 'this' expression
+                        currentChild.setType(previousChild.getType());
+                    } else { // simple 'this' expression
+                        ASTClassOrInterfaceDeclaration typeDeclaration
+                                = currentChild.getFirstParentOfType(ASTClassOrInterfaceDeclaration.class);
+                        if (typeDeclaration != null)
+                            currentChild.setType(typeDeclaration.getType());
+                    }
+                }
+            }
+
+            if(currentChild.getType() != null)
+                primaryNodeType = currentChild.getType();
+
+            previousChild = currentChild;
         }
+
+        primaryNode.setType(primaryNodeType);
+
         return data;
     }
 
     @Override
     public Object visit(ASTPrimaryPrefix node, Object data) {
         super.visit(node, data);
+        rollupTypeUnary(node);
 
-        if(node.jjtGetFirstToken().toString().equals("this")) {
-            ASTClassOrInterfaceDeclaration typeDeclaration
-                    = node.getFirstParentOfType(ASTClassOrInterfaceDeclaration.class);
-            if(typeDeclaration != null)
-                node.setType(typeDeclaration.getType());
-        } else if (node.getImage() == null) {
-            rollupTypeUnary(node);
-        } else {
-            // TODO OMG, this is complicated. PrimaryExpression, PrimaryPrefix
-            // and PrimarySuffix are all related.
-        }
         return data;
     }
 
     @Override
     public Object visit(ASTPrimarySuffix node, Object data) {
         super.visit(node, data);
-        // TODO OMG, this is complicated. PrimaryExpression, PrimaryPrefix and
-        // PrimarySuffix are all related.
         return data;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -14,8 +14,56 @@ import java.util.logging.Logger;
 
 import net.sourceforge.pmd.lang.ast.AbstractNode;
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.java.ast.*;
-import net.sourceforge.pmd.lang.symboltable.Scope;
+import net.sourceforge.pmd.lang.java.ast.ASTAdditiveExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTAllocationExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTAndExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTAnnotationTypeDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTArrayDimsAndInits;
+import net.sourceforge.pmd.lang.java.ast.ASTBooleanLiteral;
+import net.sourceforge.pmd.lang.java.ast.ASTCastExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBody;
+import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.lang.java.ast.ASTConditionalAndExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTConditionalExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTConditionalOrExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTEnumDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTEqualityExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTExclusiveOrExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTInclusiveOrExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTInstanceOfExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTLiteral;
+import net.sourceforge.pmd.lang.java.ast.ASTMarkerAnnotation;
+import net.sourceforge.pmd.lang.java.ast.ASTMultiplicativeExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTName;
+import net.sourceforge.pmd.lang.java.ast.ASTNormalAnnotation;
+import net.sourceforge.pmd.lang.java.ast.ASTNullLiteral;
+import net.sourceforge.pmd.lang.java.ast.ASTPackageDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTPostfixExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTPreDecrementExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTPreIncrementExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimitiveType;
+import net.sourceforge.pmd.lang.java.ast.ASTReferenceType;
+import net.sourceforge.pmd.lang.java.ast.ASTRelationalExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTShiftExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTSingleMemberAnnotation;
+import net.sourceforge.pmd.lang.java.ast.ASTStatementExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTType;
+import net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTUnaryExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTUnaryExpressionNotPlusMinus;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
+import net.sourceforge.pmd.lang.java.ast.AbstractJavaTypeNode;
+import net.sourceforge.pmd.lang.java.ast.JavaParserVisitorAdapter;
+import net.sourceforge.pmd.lang.java.ast.TypeNode;
 
 //
 // Helpful reading:
@@ -413,8 +461,9 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
                     } else { // simple 'this' expression
                         ASTClassOrInterfaceDeclaration typeDeclaration
                                 = currentChild.getFirstParentOfType(ASTClassOrInterfaceDeclaration.class);
-                        if (typeDeclaration != null)
+                        if (typeDeclaration != null) {
                             currentChild.setType(typeDeclaration.getType());
+                        }
                     }
 
                     // Last token, because if 'super' is a Suffix, it'll have tokens '.' and 'super'
@@ -424,8 +473,9 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
                     } else { // simple 'super' expression
                         ASTClassOrInterfaceDeclaration typeDeclaration
                                 = currentChild.getFirstParentOfType(ASTClassOrInterfaceDeclaration.class);
-                        if (typeDeclaration != null && typeDeclaration.getType() != null)
+                        if (typeDeclaration != null && typeDeclaration.getType() != null) {
                             currentChild.setType(typeDeclaration.getType().getSuperclass());
+                        }
                     }
                 }
             }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -405,7 +405,7 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
             AbstractJavaTypeNode currentChild = (AbstractJavaTypeNode) primaryNode.jjtGetChild(childIndex);
 
             // skip children which already have their type assigned
-            if(currentChild.getType() == null) {
+            if (currentChild.getType() == null) {
                 // Last token, because if 'this' is a Suffix, it'll have tokens '.' and 'this'
                 if (currentChild.jjtGetLastToken().toString().equals("this")) {
                     if (previousChild != null) { // Qualified 'this' expression
@@ -416,11 +416,22 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
                         if (typeDeclaration != null)
                             currentChild.setType(typeDeclaration.getType());
                     }
+
+                    // Last token, because if 'super' is a Suffix, it'll have tokens '.' and 'super'
+                } else if (currentChild.jjtGetLastToken().toString().equals("super")) {
+                    if (previousChild != null) { // Qualified 'super' expression
+                        currentChild.setType(previousChild.getType().getSuperclass());
+                    } else { // simple 'super' expression
+                        ASTClassOrInterfaceDeclaration typeDeclaration
+                                = currentChild.getFirstParentOfType(ASTClassOrInterfaceDeclaration.class);
+                        if (typeDeclaration != null && typeDeclaration.getType() != null)
+                            currentChild.setType(typeDeclaration.getType().getSuperclass());
+                    }
                 }
             }
 
-            if(currentChild.getType() != null)
-                primaryNodeType = currentChild.getType();
+            //if (currentChild.getType() != null)
+            primaryNodeType = currentChild.getType();
 
             previousChild = currentChild;
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -456,7 +456,13 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
     @Override
     public Object visit(ASTPrimaryPrefix node, Object data) {
         super.visit(node, data);
-        if (node.getImage() == null) {
+
+        if(node.jjtGetFirstToken().toString().equals("this")) {
+            ASTClassOrInterfaceDeclaration typeDeclaration
+                    = node.getFirstParentOfType(ASTClassOrInterfaceDeclaration.class);
+            if(typeDeclaration != null)
+                node.setType(typeDeclaration.getType());
+        } else if (node.getImage() == null) {
             rollupTypeUnary(node);
         } else {
             // TODO OMG, this is complicated. PrimaryExpression, PrimaryPrefix

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
@@ -585,6 +585,11 @@ public class ClassTypeResolverTest {
 
         assertEquals(ThisExprNested.class, expressions.get(index).getType());
         assertEquals(ThisExprNested.class, prefixes.get(index++).getType());
+
+        // Qualified this
+        assertEquals(ThisExpression.class, expressions.get(index).getType());
+        assertEquals(ThisExpression.class, prefixes.get(index++).getType());
+
         assertEquals(ThisExprStaticNested.class, expressions.get(index).getType());
         assertEquals(ThisExprStaticNested.class, prefixes.get(index++).getType());
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
@@ -598,6 +598,31 @@ public class ClassTypeResolverTest {
         assertEquals("All expressions not tested", index, prefixes.size());
     }
 
+    @Test
+    public void testSuperExpression() throws JaxenException {
+        ASTCompilationUnit acu = parseAndTypeResolveForClass15(SuperExpression.class);
+
+        List<AbstractJavaTypeNode> expressions = convertList(
+                acu.findChildNodesWithXPath("//VariableInitializer/Expression/PrimaryExpression/PrimaryPrefix"),
+                AbstractJavaTypeNode.class);
+
+        int index = 0;
+
+        assertEquals(SuperClass.class, expressions.get(index++).getType());
+        assertEquals(SuperClass.class, expressions.get(index++).getType());
+        assertEquals(SuperClass.class, expressions.get(index++).getType());
+        assertEquals(SuperClass.class, expressions.get(index++).getType());
+        assertEquals(SuperClass.class, ((TypeNode)expressions.get(index++).jjtGetParent().jjtGetChild(1)).getType());
+
+        assertEquals(SuperExpression.class, expressions.get(index++).getType());
+        assertEquals(SuperExpression.class, expressions.get(index++).getType());
+        
+
+        // Make sure we got them all
+        assertEquals("All expressions not tested", index, expressions.size());
+    }
+
+
 
     private ASTCompilationUnit parseAndTypeResolveForClass15(Class<?> clazz) {
         return parseAndTypeResolveForClass(clazz, "1.5");

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
@@ -14,20 +14,55 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
 
-import net.sourceforge.pmd.lang.java.ast.*;
-import net.sourceforge.pmd.typeresolution.testdata.*;
-import net.sourceforge.pmd.typeresolution.testdata.ThisExpression.*;
+
 import org.apache.commons.io.IOUtils;
 import org.jaxen.JaxenException;
 import org.junit.Assert;
 import org.junit.Test;
 
+
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersionHandler;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.JavaLanguageModule;
+import net.sourceforge.pmd.lang.java.ast.ASTAllocationExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTBooleanLiteral;
+import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.lang.java.ast.ASTExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
+import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTLiteral;
+import net.sourceforge.pmd.lang.java.ast.ASTName;
+import net.sourceforge.pmd.lang.java.ast.ASTNullLiteral;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
+import net.sourceforge.pmd.lang.java.ast.ASTReferenceType;
+import net.sourceforge.pmd.lang.java.ast.ASTStatementExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTType;
+import net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
+import net.sourceforge.pmd.lang.java.ast.AbstractJavaTypeNode;
+import net.sourceforge.pmd.lang.java.ast.TypeNode;
+
 import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
 import net.sourceforge.pmd.lang.java.typeresolution.ClassTypeResolver;
+import net.sourceforge.pmd.typeresolution.testdata.AnonymousInnerClass;
+import net.sourceforge.pmd.typeresolution.testdata.ArrayListFound;
+import net.sourceforge.pmd.typeresolution.testdata.DefaultJavaLangImport;
+import net.sourceforge.pmd.typeresolution.testdata.EnumWithAnonymousInnerClass;
+import net.sourceforge.pmd.typeresolution.testdata.ExtraTopLevelClass;
+import net.sourceforge.pmd.typeresolution.testdata.InnerClass;
+import net.sourceforge.pmd.typeresolution.testdata.Literals;
+import net.sourceforge.pmd.typeresolution.testdata.Operators;
+import net.sourceforge.pmd.typeresolution.testdata.Promotion;
+import net.sourceforge.pmd.typeresolution.testdata.SuperClass;
+import net.sourceforge.pmd.typeresolution.testdata.SuperExpression;
+import net.sourceforge.pmd.typeresolution.testdata.ThisExpression;
+
 
 public class ClassTypeResolverTest {
 
@@ -583,15 +618,15 @@ public class ClassTypeResolverTest {
         assertEquals(ThisExpression.class, expressions.get(index).getType());
         assertEquals(ThisExpression.class, prefixes.get(index++).getType());
 
-        assertEquals(ThisExprNested.class, expressions.get(index).getType());
-        assertEquals(ThisExprNested.class, prefixes.get(index++).getType());
+        assertEquals(ThisExpression.ThisExprNested.class, expressions.get(index).getType());
+        assertEquals(ThisExpression.ThisExprNested.class, prefixes.get(index++).getType());
 
         // Qualified this
         assertEquals(ThisExpression.class, expressions.get(index).getType());
         assertEquals(ThisExpression.class, prefixes.get(index++).getType());
 
-        assertEquals(ThisExprStaticNested.class, expressions.get(index).getType());
-        assertEquals(ThisExprStaticNested.class, prefixes.get(index++).getType());
+        assertEquals(ThisExpression.ThisExprStaticNested.class, expressions.get(index).getType());
+        assertEquals(ThisExpression.ThisExprStaticNested.class, prefixes.get(index++).getType());
 
         // Make sure we got them all
         assertEquals("All expressions not tested", index, expressions.size());
@@ -612,7 +647,7 @@ public class ClassTypeResolverTest {
         assertEquals(SuperClass.class, expressions.get(index++).getType());
         assertEquals(SuperClass.class, expressions.get(index++).getType());
         assertEquals(SuperClass.class, expressions.get(index++).getType());
-        assertEquals(SuperClass.class, ((TypeNode)expressions.get(index++).jjtGetParent().jjtGetChild(1)).getType());
+        assertEquals(SuperClass.class, ((TypeNode) expressions.get(index++).jjtGetParent().jjtGetChild(1)).getType());
 
         assertEquals(SuperExpression.class, expressions.get(index++).getType());
         assertEquals(SuperExpression.class, expressions.get(index++).getType());

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
@@ -623,7 +623,8 @@ public class ClassTypeResolverTest {
 
         // Qualified this
         assertEquals(ThisExpression.class, expressions.get(index).getType());
-        assertEquals(ThisExpression.class, prefixes.get(index++).getType());
+        assertEquals(ThisExpression.class, prefixes.get(index).getType());
+        assertEquals(ThisExpression.class, ((TypeNode) expressions.get(index++).jjtGetChild(1)).getType());
 
         assertEquals(ThisExpression.ThisExprStaticNested.class, expressions.get(index).getType());
         assertEquals(ThisExpression.ThisExprStaticNested.class, prefixes.get(index++).getType());
@@ -647,6 +648,7 @@ public class ClassTypeResolverTest {
         assertEquals(SuperClass.class, expressions.get(index++).getType());
         assertEquals(SuperClass.class, expressions.get(index++).getType());
         assertEquals(SuperClass.class, expressions.get(index++).getType());
+        assertEquals(SuperExpression.class, ((TypeNode) expressions.get(index).jjtGetParent().jjtGetChild(0)).getType());
         assertEquals(SuperClass.class, ((TypeNode) expressions.get(index++).jjtGetParent().jjtGetChild(1)).getType());
 
         assertEquals(SuperExpression.class, expressions.get(index++).getType());

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
@@ -14,6 +14,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
 
+import net.sourceforge.pmd.lang.java.ast.*;
+import net.sourceforge.pmd.typeresolution.testdata.*;
+import net.sourceforge.pmd.typeresolution.testdata.ThisExpression.*;
 import org.apache.commons.io.IOUtils;
 import org.jaxen.JaxenException;
 import org.junit.Assert;
@@ -23,36 +26,8 @@ import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersionHandler;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.JavaLanguageModule;
-import net.sourceforge.pmd.lang.java.ast.ASTAllocationExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTBooleanLiteral;
-import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
-import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
-import net.sourceforge.pmd.lang.java.ast.ASTExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
-import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTLiteral;
-import net.sourceforge.pmd.lang.java.ast.ASTName;
-import net.sourceforge.pmd.lang.java.ast.ASTNullLiteral;
-import net.sourceforge.pmd.lang.java.ast.ASTReferenceType;
-import net.sourceforge.pmd.lang.java.ast.ASTStatementExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTType;
-import net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
-import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
-import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
 import net.sourceforge.pmd.lang.java.typeresolution.ClassTypeResolver;
-import net.sourceforge.pmd.typeresolution.testdata.AnonymousInnerClass;
-import net.sourceforge.pmd.typeresolution.testdata.ArrayListFound;
-import net.sourceforge.pmd.typeresolution.testdata.DefaultJavaLangImport;
-import net.sourceforge.pmd.typeresolution.testdata.EnumWithAnonymousInnerClass;
-import net.sourceforge.pmd.typeresolution.testdata.ExtraTopLevelClass;
-import net.sourceforge.pmd.typeresolution.testdata.InnerClass;
-import net.sourceforge.pmd.typeresolution.testdata.Literals;
-import net.sourceforge.pmd.typeresolution.testdata.Operators;
-import net.sourceforge.pmd.typeresolution.testdata.Promotion;
 
 public class ClassTypeResolverTest {
 
@@ -134,7 +109,7 @@ public class ClassTypeResolverTest {
     /**
      * If we don't have the auxclasspath, we might not find the inner class. In
      * that case, we'll need to search by name for a match.
-     * 
+     *
      * @throws Exception
      */
     @Test
@@ -583,6 +558,41 @@ public class ClassTypeResolverTest {
         Assert.assertNotNull(id.getType());
         Assert.assertSame(StringTokenizer.class, id.getType());
     }
+
+
+    @Test
+    public void testThisExpression() throws JaxenException {
+        ASTCompilationUnit acu = parseAndTypeResolveForClass15(ThisExpression.class);
+
+        List<ASTPrimaryExpression> expressions = convertList(
+                acu.findChildNodesWithXPath("//PrimaryExpression"),
+                ASTPrimaryExpression.class);
+        List<ASTPrimaryPrefix> prefixes = convertList(
+                acu.findChildNodesWithXPath("//PrimaryPrefix"),
+                ASTPrimaryPrefix.class);
+
+        int index = 0;
+
+
+        assertEquals(ThisExpression.class, expressions.get(index).getType());
+        assertEquals(ThisExpression.class, prefixes.get(index++).getType());
+        assertEquals(ThisExpression.class, expressions.get(index).getType());
+        assertEquals(ThisExpression.class, prefixes.get(index++).getType());
+        assertEquals(ThisExpression.class, expressions.get(index).getType());
+        assertEquals(ThisExpression.class, prefixes.get(index++).getType());
+        assertEquals(ThisExpression.class, expressions.get(index).getType());
+        assertEquals(ThisExpression.class, prefixes.get(index++).getType());
+
+        assertEquals(ThisExprNested.class, expressions.get(index).getType());
+        assertEquals(ThisExprNested.class, prefixes.get(index++).getType());
+        assertEquals(ThisExprStaticNested.class, expressions.get(index).getType());
+        assertEquals(ThisExprStaticNested.class, prefixes.get(index++).getType());
+
+        // Make sure we got them all
+        assertEquals("All expressions not tested", index, expressions.size());
+        assertEquals("All expressions not tested", index, prefixes.size());
+    }
+
 
     private ASTCompilationUnit parseAndTypeResolveForClass15(Class<?> clazz) {
         return parseAndTypeResolveForClass(clazz, "1.5");

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/SuperClass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/SuperClass.java
@@ -1,3 +1,8 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+
 package net.sourceforge.pmd.typeresolution.testdata;
 
 public class SuperClass {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/SuperClass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/SuperClass.java
@@ -1,0 +1,5 @@
+package net.sourceforge.pmd.typeresolution.testdata;
+
+public class SuperClass {
+    protected SuperClass s;
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/SuperExpression.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/SuperExpression.java
@@ -1,7 +1,14 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+
 package net.sourceforge.pmd.typeresolution.testdata;
 
 public class SuperExpression extends SuperClass {
-    public SuperExpression() { SuperClass a = super.s; }
+    public SuperExpression() {
+        SuperClass a = super.s;
+    }
 
     protected SuperExpression b;
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/SuperExpression.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/SuperExpression.java
@@ -1,0 +1,25 @@
+package net.sourceforge.pmd.typeresolution.testdata;
+
+public class SuperExpression extends SuperClass {
+    public SuperExpression() { SuperClass a = super.s; }
+
+    protected SuperExpression b;
+
+    { SuperClass s = super.s; }
+
+    public void foo() {
+        SuperClass a = super.s;
+    }
+
+    SuperClass a = super.s;
+
+    public class SuperExprNested extends SuperExpression {
+        SuperClass a = SuperExpression.super.s;
+        SuperExpression b = super.b;
+    }
+
+    public static class ThisExprStaticNested extends SuperExpression {
+        SuperExpression a = super.b;
+    }
+}
+

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/ThisExpression.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/ThisExpression.java
@@ -1,9 +1,18 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+
 package net.sourceforge.pmd.typeresolution.testdata;
 
 public class ThisExpression {
-    public ThisExpression() { ThisExpression a = this; }
+    public ThisExpression() {
+        ThisExpression a = this;
+    }
 
-    { ThisExpression a = this; }
+    {
+        ThisExpression a = this;
+    }
 
     public void foo() {
         ThisExpression a = this;

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/ThisExpression.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/ThisExpression.java
@@ -13,6 +13,7 @@ public class ThisExpression {
 
     public class ThisExprNested {
         ThisExprNested a = this;
+        ThisExpression b = ThisExpression.this;
     }
 
     public static class ThisExprStaticNested {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/ThisExpression.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/ThisExpression.java
@@ -1,0 +1,22 @@
+package net.sourceforge.pmd.typeresolution.testdata;
+
+public class ThisExpression {
+    public ThisExpression() { ThisExpression a = this; }
+
+    { ThisExpression a = this; }
+
+    public void foo() {
+        ThisExpression a = this;
+    }
+
+    ThisExpression a = this;
+
+    public class ThisExprNested {
+        ThisExprNested a = this;
+    }
+
+    public static class ThisExprStaticNested {
+        ThisExprStaticNested a = this;
+    }
+}
+

--- a/pmd-java8/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverJava8Test.java
+++ b/pmd-java8/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverJava8Test.java
@@ -4,22 +4,31 @@
 
 package net.sourceforge.pmd.typeresolution;
 
+import static org.junit.Assert.assertEquals;
+
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.List;
 
-import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.java.ast.*;
-import net.sourceforge.pmd.typeresolution.testdata.*;
 import org.jaxen.JaxenException;
 import org.junit.Test;
 
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersionHandler;
+import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.JavaLanguageModule;
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
+import net.sourceforge.pmd.lang.java.ast.AbstractJavaTypeNode;
+import net.sourceforge.pmd.typeresolution.testdata.SuperClass;
+import net.sourceforge.pmd.typeresolution.testdata.SuperExpression;
+import net.sourceforge.pmd.typeresolution.testdata.ThisExpression;
+import net.sourceforge.pmd.typeresolution.testdata.UsesJavaStreams;
+import net.sourceforge.pmd.typeresolution.testdata.UsesRepeatableAnnotations;
 
-import static org.junit.Assert.assertEquals;
+
 
 public class ClassTypeResolverJava8Test {
 

--- a/pmd-java8/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverJava8Test.java
+++ b/pmd-java8/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverJava8Test.java
@@ -10,18 +10,14 @@ import java.util.ArrayList;
 import java.util.List;
 
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
-import net.sourceforge.pmd.typeresolution.testdata.ThisExpression;
+import net.sourceforge.pmd.lang.java.ast.*;
+import net.sourceforge.pmd.typeresolution.testdata.*;
 import org.jaxen.JaxenException;
 import org.junit.Test;
 
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersionHandler;
 import net.sourceforge.pmd.lang.java.JavaLanguageModule;
-import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
-import net.sourceforge.pmd.typeresolution.testdata.UsesJavaStreams;
-import net.sourceforge.pmd.typeresolution.testdata.UsesRepeatableAnnotations;
 
 import static org.junit.Assert.assertEquals;
 
@@ -58,6 +54,22 @@ public class ClassTypeResolverJava8Test {
         // Make sure we got them all
         assertEquals("All expressions not tested", index, expressions.size());
         assertEquals("All expressions not tested", index, prefixes.size());
+    }
+
+    @Test
+    public void testSuperExpression() throws JaxenException {
+        ASTCompilationUnit acu = parseAndTypeResolveForClass18(SuperExpression.class);
+
+        List<AbstractJavaTypeNode> expressions = convertList(
+                acu.findChildNodesWithXPath("//VariableInitializer/Expression/PrimaryExpression/PrimaryPrefix"),
+                AbstractJavaTypeNode.class);
+
+        int index = 0;
+
+        assertEquals(SuperClass.class, expressions.get(index++).getType());
+
+        // Make sure we got them all
+        assertEquals("All expressions not tested", index, expressions.size());
     }
 
     private static <T> List<T> convertList(List<Node> nodes, Class<T> target) {

--- a/pmd-java8/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverJava8Test.java
+++ b/pmd-java8/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverJava8Test.java
@@ -6,7 +6,14 @@ package net.sourceforge.pmd.typeresolution;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
 
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
+import net.sourceforge.pmd.typeresolution.testdata.ThisExpression;
+import org.jaxen.JaxenException;
 import org.junit.Test;
 
 import net.sourceforge.pmd.lang.LanguageRegistry;
@@ -15,6 +22,8 @@ import net.sourceforge.pmd.lang.java.JavaLanguageModule;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.typeresolution.testdata.UsesJavaStreams;
 import net.sourceforge.pmd.typeresolution.testdata.UsesRepeatableAnnotations;
+
+import static org.junit.Assert.assertEquals;
 
 public class ClassTypeResolverJava8Test {
 
@@ -26,6 +35,37 @@ public class ClassTypeResolverJava8Test {
     @Test
     public void repeatableAnnotationsMethodShouldBeParseable() {
         ASTCompilationUnit acu = parseAndTypeResolveForClass18(UsesRepeatableAnnotations.class);
+    }
+
+    @Test
+    public void testThisExpression() throws JaxenException {
+        ASTCompilationUnit acu = parseAndTypeResolveForClass18(ThisExpression.class);
+
+        List<ASTPrimaryExpression> expressions = convertList(
+                acu.findChildNodesWithXPath("//VariableInitializer/Expression/PrimaryExpression"),
+                ASTPrimaryExpression.class);
+        List<ASTPrimaryPrefix> prefixes = convertList(
+                acu.findChildNodesWithXPath("//VariableInitializer/Expression/PrimaryExpression/PrimaryPrefix"),
+                ASTPrimaryPrefix.class);
+
+        int index = 0;
+
+        assertEquals(ThisExpression.class, expressions.get(index).getType());
+        assertEquals(ThisExpression.class, prefixes.get(index++).getType());
+        assertEquals(ThisExpression.PrimaryThisInterface.class, expressions.get(index).getType());
+        assertEquals(ThisExpression.PrimaryThisInterface.class, prefixes.get(index++).getType());
+
+        // Make sure we got them all
+        assertEquals("All expressions not tested", index, expressions.size());
+        assertEquals("All expressions not tested", index, prefixes.size());
+    }
+
+    private static <T> List<T> convertList(List<Node> nodes, Class<T> target) {
+        List<T> converted = new ArrayList<>();
+        for (Node n : nodes) {
+            converted.add(target.cast(n));
+        }
+        return converted;
     }
 
     private ASTCompilationUnit parseAndTypeResolveForClass18(Class<?> clazz) {

--- a/pmd-java8/src/test/java/net/sourceforge/pmd/typeresolution/testdata/SuperClass.java
+++ b/pmd-java8/src/test/java/net/sourceforge/pmd/typeresolution/testdata/SuperClass.java
@@ -1,3 +1,8 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+
 package net.sourceforge.pmd.typeresolution.testdata;
 
 public class SuperClass {

--- a/pmd-java8/src/test/java/net/sourceforge/pmd/typeresolution/testdata/SuperClass.java
+++ b/pmd-java8/src/test/java/net/sourceforge/pmd/typeresolution/testdata/SuperClass.java
@@ -1,0 +1,5 @@
+package net.sourceforge.pmd.typeresolution.testdata;
+
+public class SuperClass {
+    protected SuperClass s;
+}

--- a/pmd-java8/src/test/java/net/sourceforge/pmd/typeresolution/testdata/SuperExpression.java
+++ b/pmd-java8/src/test/java/net/sourceforge/pmd/typeresolution/testdata/SuperExpression.java
@@ -1,8 +1,15 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+
 package net.sourceforge.pmd.typeresolution.testdata;
 
 public class SuperExpression extends SuperClass {
     public void foo() {
-        ((Runnable) (() -> { SuperClass a = super.s; })).run();
+        ((Runnable) (() -> {
+                        SuperClass a = super.s; }))
+                .run();
     }
 }
 

--- a/pmd-java8/src/test/java/net/sourceforge/pmd/typeresolution/testdata/SuperExpression.java
+++ b/pmd-java8/src/test/java/net/sourceforge/pmd/typeresolution/testdata/SuperExpression.java
@@ -1,0 +1,8 @@
+package net.sourceforge.pmd.typeresolution.testdata;
+
+public class SuperExpression extends SuperClass {
+    public void foo() {
+        ((Runnable) (() -> { SuperClass a = super.s; })).run();
+    }
+}
+

--- a/pmd-java8/src/test/java/net/sourceforge/pmd/typeresolution/testdata/ThisExpression.java
+++ b/pmd-java8/src/test/java/net/sourceforge/pmd/typeresolution/testdata/ThisExpression.java
@@ -1,9 +1,16 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+
 package net.sourceforge.pmd.typeresolution.testdata;
 
 public class ThisExpression {
 
     public void foo() {
-        ((Runnable) (() -> { ThisExpression b = this; })).run();
+        ((Runnable) (() -> {
+                        ThisExpression b = this; }))
+                .run();
     }
 
     public interface PrimaryThisInterface {

--- a/pmd-java8/src/test/java/net/sourceforge/pmd/typeresolution/testdata/ThisExpression.java
+++ b/pmd-java8/src/test/java/net/sourceforge/pmd/typeresolution/testdata/ThisExpression.java
@@ -1,0 +1,15 @@
+package net.sourceforge.pmd.typeresolution.testdata;
+
+public class ThisExpression {
+
+    public void foo() {
+        ((Runnable) (() -> { ThisExpression b = this; })).run();
+    }
+
+    public interface PrimaryThisInterface {
+        default void foo() {
+            PrimaryThisInterface a = this;
+        }
+    }
+}
+


### PR DESCRIPTION
Add support for resolving the types of 'this' and 'super' keywords in Java. PrimaryPrefix and PrimarySuffix nodes containing 'this' or 'super' and PrimaryExpressions containing only qualified or unqualified 'this' now have their types assigned.