### PR TITLE
[java] False positive with builder pattern in java-design/PreserveStackTrace

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/PreserveStackTraceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/PreserveStackTraceRule.java
@@ -58,7 +58,8 @@ public class PreserveStackTraceRule extends AbstractJavaRule {
                     // maybe it is used inside a anonymous class
                     ck(data, target, throwStatement, parent);
                 } else {
-                    ck(data, target, throwStatement, args);
+                    // Check all arguments used in the throw statement 
+                    ck(data, target, throwStatement, throwStatement);
                 }
             } else {
                 Node child = throwStatement.jjtGetChild(0);

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/PreserveStackTrace.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/PreserveStackTrace.xml
@@ -515,4 +515,25 @@ public class Bug {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#422 False positive when using builder pattern</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.IOException;
+
+public class Bug {
+    void test() throws IOException {
+        try {
+            // do something
+        } catch (final IOException e) {
+            throw uncheckedException(ErrorCodeCommon.DIRECTORY_NOT_FOUND)
+                    .withField("dirname", dirname)
+                    .causedBy(e)
+                    .build();
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Fixed it by checking all arguments in the throw statement, rather than just those in the first argument list.

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `mvn test` passes.
 - [x] `mvn checkstyle:check` passes. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
Fixes https://github.com/pmd/pmd/issues/422
