### PR TITLE
[core] RuleSetBuilder validation for name and description

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
@@ -67,8 +67,8 @@ public class RuleSet implements ChecksumAware {
     private RuleSet(final RuleSetBuilder builder) {
         checksum = builder.checksum;
         fileName = builder.fileName;
-        name = builder.name;
-        description = builder.description;
+        name = Objects.requireNonNull(builder.name, MISSING_RULESET_NAME);
+        description = Objects.requireNonNull(builder.description, MISSING_RULESET_DESCRIPTION);
         // TODO: ideally, the rules would be unmodifiable, too. But removeDysfunctionalRules might change the rules.
         rules = builder.rules;
         excludePatterns = Collections.unmodifiableList(builder.excludePatterns);
@@ -79,8 +79,8 @@ public class RuleSet implements ChecksumAware {
     }
 
     /* package */ static class RuleSetBuilder {
-        public String description = "";
-        public String name = "";
+        public String description;
+        public String name;
         public String fileName;
         private final List<Rule> rules = new ArrayList<>();
         private final List<String> excludePatterns = new ArrayList<>(0);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -38,6 +39,8 @@ public class RuleSet implements ChecksumAware {
 
     private static final Logger LOG = Logger.getLogger(RuleSet.class.getName());
     private static final String MISSING_RULE = "Missing rule";
+    private static final String MISSING_RULESET_DESCRIPTION = "RuleSet description must not be null";
+    private static final String MISSING_RULESET_NAME = "RuleSet name must not be null";
 
     private final long checksum;
 
@@ -347,12 +350,12 @@ public class RuleSet implements ChecksumAware {
         }
 
         public RuleSetBuilder withName(final String name) {
-            this.name = name;
+            this.name = Objects.requireNonNull(name, MISSING_RULESET_NAME);
             return this;
         }
 
         public RuleSetBuilder withDescription(final String description) {
-            this.description = description;
+            this.description = Objects.requireNonNull(description, MISSING_RULESET_DESCRIPTION);
             return this;
         }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
@@ -359,6 +359,10 @@ public class RuleSet implements ChecksumAware {
             return this;
         }
 
+        public boolean hasDescription() {
+            return this.description != null;
+        }
+
         public String getName() {
             return name;
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
@@ -345,6 +345,9 @@ public class RuleSetFactory {
 
             if (ruleSetElement.hasAttribute("name")) {
                 ruleSetBuilder.withName(ruleSetElement.getAttribute("name"));
+            } else {
+                LOG.warning("RuleSet name is missing. Future versions of PMD will require it.");
+                ruleSetBuilder.withName("Missing RuleSet Name");
             }
 
             NodeList nodeList = ruleSetElement.getChildNodes();
@@ -365,6 +368,11 @@ public class RuleSetFactory {
                                 + "> encountered as child of <ruleset> element.");
                     }
                 }
+            }
+
+            if (!ruleSetBuilder.hasDescription()) {
+                LOG.warning("RuleSet description is missing. Future versions of PMD will require it.");
+                ruleSetBuilder.withDescription("Missing description");
             }
 
             return ruleSetBuilder.build();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
@@ -278,7 +278,9 @@ public class RuleSetFactory {
             checksum = rule.getPropertiesByPropertyDescriptor().values().hashCode() * 31 + rule.getName().hashCode();
         }
 
-        final RuleSetBuilder builder = new RuleSetBuilder(checksum);
+        final RuleSetBuilder builder = new RuleSetBuilder(checksum)
+                .withName(rule.getName())
+                .withDescription("RuleSet for " + rule.getName());
         builder.addRule(rule);
         return builder.build();
     }
@@ -339,8 +341,11 @@ public class RuleSetFactory {
             Element ruleSetElement = document.getDocumentElement();
 
             RuleSetBuilder ruleSetBuilder = new RuleSetBuilder(inputStream.getChecksum().getValue())
-                    .withFileName(ruleSetReferenceId.getRuleSetFileName())
-                    .withName(ruleSetElement.getAttribute("name"));
+                    .withFileName(ruleSetReferenceId.getRuleSetFileName());
+
+            if (ruleSetElement.hasAttribute("name")) {
+                ruleSetBuilder.withName(ruleSetElement.getAttribute("name"));
+            }
 
             NodeList nodeList = ruleSetElement.getChildNodes();
             for (int i = 0; i < nodeList.getLength(); i++) {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryTest.java
@@ -13,14 +13,10 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.logging.Logger;
-import java.util.logging.StreamHandler;
 
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryTest.java
@@ -13,13 +13,18 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.logging.Logger;
+import java.util.logging.StreamHandler;
 
+import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.junit.Assert;
 import org.junit.Test;
 
+import net.sourceforge.pmd.junit.JavaUtilLoggingRule;
 import net.sourceforge.pmd.lang.DummyLanguageModule;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.rule.MockRule;
@@ -633,6 +638,39 @@ public class RuleSetFactoryTest {
         RuleSetFactory ruleSetFactory3 = new RuleSetFactory();
         RuleSet ruleset3 = ruleSetFactory3.createRuleSet(ref3);
         Assert.assertNotNull(ruleset3.getRuleByName("DummyBasicMockRule"));
+    }
+
+    @org.junit.Rule
+    public JavaUtilLoggingRule logging = new JavaUtilLoggingRule(RuleSetFactory.class.getName());
+
+    @Test
+    public void testMissingRuleSetNameIsWarning() throws Exception {
+        RuleSetReferenceId ref = createRuleSetReferenceId(
+                "<?xml version=\"1.0\"?>\n" + "<ruleset \n"
+                        + "    xmlns=\"http://pmd.sourceforge.net/ruleset/2.0.0\"\n"
+                        + "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+                        + "    xsi:schemaLocation=\"http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd\">\n"
+                        + "  <description>Custom ruleset for tests</description>\n"
+                        + "  <rule ref=\"rulesets/dummy/basic.xml\"/>\n"
+                        + "  </ruleset>\n");
+        RuleSetFactory ruleSetFactory = new RuleSetFactory();
+        ruleSetFactory.createRuleSet(ref);
+
+        assertTrue(logging.getLog().contains("RuleSet name is missing."));
+    }
+
+    @Test
+    public void testMissingRuleSetDescriptionIsWarning() throws Exception {
+        RuleSetReferenceId ref = createRuleSetReferenceId(
+                "<?xml version=\"1.0\"?>\n" + "<ruleset name=\"then name\"\n"
+                        + "    xmlns=\"http://pmd.sourceforge.net/ruleset/2.0.0\"\n"
+                        + "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
+                        + "    xsi:schemaLocation=\"http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd\">\n"
+                        + "  <rule ref=\"rulesets/dummy/basic.xml\"/>\n"
+                        + "  </ruleset>\n");
+        RuleSetFactory ruleSetFactory = new RuleSetFactory();
+        ruleSetFactory.createRuleSet(ref);
+        assertTrue(logging.getLog().contains("RuleSet description is missing."));
     }
 
     private static final String REF_OVERRIDE_ORIGINAL_NAME = "<?xml version=\"1.0\"?>" + PMD.EOL

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryTest.java
@@ -167,7 +167,8 @@ public class RuleSetFactoryTest {
 
     @Test
     public void testStringMultiPropertyDefaultDelimiter() throws Exception {
-        Rule r = loadFirstRule("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<ruleset>\n"
+        Rule r = loadFirstRule("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<ruleset name=\"the ruleset\">\n"
+                + "  <description>Desc</description>\n"
                 + "     <rule name=\"myRule\" message=\"Do not place to this package. Move to \n"
                 + "{0} package/s instead.\" \n" + "class=\"net.sourceforge.pmd.lang.rule.XPathRule\" "
                 + "language=\"dummy\">\n" + "         <description>Please move your class to the right folder(rest \n"
@@ -182,7 +183,8 @@ public class RuleSetFactoryTest {
 
     @Test
     public void testStringMultiPropertyDelimiter() throws Exception {
-        Rule r = loadFirstRule("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<ruleset>\n"
+        Rule r = loadFirstRule("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<ruleset name=\"test\">\n"
+                + "  <description>ruleset desc</description>\n"
                 + "     <rule name=\"myRule\" message=\"Do not place to this package. Move to \n"
                 + "{0} package/s instead.\" \n" + "class=\"net.sourceforge.pmd.lang.rule.XPathRule\" "
                 + "language=\"dummy\">\n" + "         <description>Please move your class to the right folder(rest \n"
@@ -197,7 +199,8 @@ public class RuleSetFactoryTest {
 
     @Test
     public void testRuleSetWithDeprecatedRule() throws Exception {
-        RuleSet rs = loadRuleSet("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<ruleset>\n"
+        RuleSet rs = loadRuleSet("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<ruleset name=\"ruleset\">\n"
+                + "  <description>ruleset desc</description>\n"
                 + "     <rule deprecated=\"true\" ref=\"rulesets/dummy/basic.xml/DummyBasicMockRule\"/>"
                 + "</ruleset>");
         Assert.assertEquals(1, rs.getRules().size());
@@ -207,7 +210,8 @@ public class RuleSetFactoryTest {
 
     @Test
     public void testRuleSetWithDeprecatedButRenamedRule() throws Exception {
-        RuleSet rs = loadRuleSet("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<ruleset>\n"
+        RuleSet rs = loadRuleSet("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<ruleset name=\"test\">\n"
+                + "  <description>ruleset desc</description>\n"
                 + "     <rule deprecated=\"true\" ref=\"NewName\" name=\"OldName\"/>"
                 + "     <rule name=\"NewName\" message=\"m\" class=\"net.sourceforge.pmd.lang.rule.XPathRule\" language=\"dummy\">"
                 + "         <description>d</description>\n" + "         <priority>2</priority>\n" + "     </rule>"
@@ -220,7 +224,8 @@ public class RuleSetFactoryTest {
 
     @Test
     public void testRuleSetReferencesADeprecatedRenamedRule() throws Exception {
-        RuleSet rs = loadRuleSet("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<ruleset>\n"
+        RuleSet rs = loadRuleSet("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<ruleset name=\"test\">\n"
+                + "  <description>ruleset desc</description>\n"
                 + "     <rule ref=\"rulesets/dummy/basic.xml/OldNameOfDummyBasicMockRule\"/>" + "</ruleset>");
         Assert.assertEquals(1, rs.getRules().size());
         Rule rule = rs.getRuleByName("OldNameOfDummyBasicMockRule");

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetTest.java
@@ -32,6 +32,19 @@ import net.sourceforge.pmd.lang.rule.RuleReference;
 
 public class RuleSetTest {
 
+    @Test(expected = NullPointerException.class)
+    public void testRuleSetRequiresName() {
+        new RuleSetBuilder(new Random().nextLong())
+            .withName(null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void testRuleSetRequiresDescription() {
+        new RuleSetBuilder(new Random().nextLong())
+            .withName("some name")
+            .withDescription(null);
+    }
+
     @Test
     public void testNoDFA() {
         MockRule mock = new MockRule("name", "desc", "msg", "rulesetname");

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetTest.java
@@ -45,6 +45,11 @@ public class RuleSetTest {
             .withDescription(null);
     }
 
+    @Test(expected = NullPointerException.class)
+    public void testRuleSetRequiresName2() {
+        new RuleSetBuilder(new Random().nextLong()).build();
+    }
+
     @Test
     public void testNoDFA() {
         MockRule mock = new MockRule("name", "desc", "msg", "rulesetname");
@@ -103,12 +108,18 @@ public class RuleSetTest {
         assertEquals("Rule isn't in ruleset.", rule, i.next());
     }
 
+    private RuleSetBuilder createRuleSetBuilder(String name) {
+        return new RuleSetBuilder(new Random().nextLong())
+                .withName(name)
+                .withDescription("Description for " + name);
+    }
+
     @Test
     public void testAddRuleSet() {
-        RuleSet set1 = new RuleSetBuilder(new Random().nextLong())
+        RuleSet set1 = createRuleSetBuilder("ruleset1")
                 .addRule(new MockRule("name", "desc", "msg", "rulesetname"))
                 .build();
-        RuleSet set2 = new RuleSetBuilder(new Random().nextLong())
+        RuleSet set2 = createRuleSetBuilder("ruleset2")
                 .addRule(new MockRule("name2", "desc", "msg", "rulesetname"))
                 .addRuleSet(set1)
                 .build();
@@ -117,10 +128,11 @@ public class RuleSetTest {
 
     @Test(expected = RuntimeException.class)
     public void testAddRuleSetByReferenceBad() {
-        RuleSet set1 = new RuleSetBuilder(new Random().nextLong())
+        RuleSet set1 = createRuleSetBuilder("ruleset1")
                 .addRule(new MockRule("name", "desc", "msg", "rulesetname"))
                 .build();
-        RuleSet set2 = new RuleSetBuilder(new Random().nextLong())
+
+        createRuleSetBuilder("ruleset2")
                 .addRule(new MockRule("name2", "desc", "msg", "rulesetname"))
                 .addRuleSetByReference(set1, false)
                 .build();
@@ -128,12 +140,12 @@ public class RuleSetTest {
 
     @Test
     public void testAddRuleSetByReferenceAllRule() {
-        RuleSet set2 = new RuleSetBuilder(new Random().nextLong())
+        RuleSet set2 = createRuleSetBuilder("ruleset2")
                 .withFileName("foo")
                 .addRule(new MockRule("name", "desc", "msg", "rulesetname"))
                 .addRule(new MockRule("name2", "desc", "msg", "rulesetname"))
                 .build();
-        RuleSet set1 = new RuleSetBuilder(new Random().nextLong())
+        RuleSet set1 = createRuleSetBuilder("ruleset1")
                 .addRuleSetByReference(set2, true)
                 .build();
         assertEquals("wrong rule size", 2, set1.getRules().size());
@@ -147,12 +159,12 @@ public class RuleSetTest {
 
     @Test
     public void testAddRuleSetByReferenceSingleRule() {
-        RuleSet set2 = new RuleSetBuilder(new Random().nextLong())
+        RuleSet set2 = createRuleSetBuilder("ruleset2")
                 .withFileName("foo")
                 .addRule(new MockRule("name", "desc", "msg", "rulesetname"))
                 .addRule(new MockRule("name2", "desc", "msg", "rulesetname"))
                 .build();
-        RuleSet set1 = new RuleSetBuilder(new Random().nextLong())
+        RuleSet set1 = createRuleSetBuilder("ruleset1")
                 .addRuleSetByReference(set2, false)
                 .build();
         assertEquals("wrong rule size", 2, set1.getRules().size());
@@ -166,20 +178,20 @@ public class RuleSetTest {
 
     @Test
     public void testApply0Rules() throws Exception {
-        RuleSet ruleset = new RuleSetBuilder(new Random().nextLong()).build();
+        RuleSet ruleset = createRuleSetBuilder("ruleset").build();
         verifyRuleSet(ruleset, 0, new HashSet<RuleViolation>());
     }
 
     @Test
     public void testEquals1() {
-        RuleSet s = new RuleSetBuilder(new Random().nextLong()).build();
+        RuleSet s = createRuleSetBuilder("ruleset").build();
         assertFalse("A ruleset cannot be equals to null", s.equals(null));
     }
 
     @Test
     @SuppressWarnings("PMD.UseAssertEqualsInsteadOfAssertTrue")
     public void testEquals2() {
-        RuleSet s = new RuleSetBuilder(new Random().nextLong()).build();
+        RuleSet s = createRuleSetBuilder("ruleset").build();
         assertTrue("A rulset must be equals to itself", s.equals(s));
     }
 
@@ -187,19 +199,18 @@ public class RuleSetTest {
     public void testEquals3() {
         RuleSet s = new RuleSetBuilder(new Random().nextLong())
                 .withName("basic rules")
+                .withDescription("desc")
                 .build();
         assertFalse("A ruleset cannot be equals to another kind of object", s.equals("basic rules"));
     }
 
     @Test
     public void testEquals4() {
-        RuleSet s1 = new RuleSetBuilder(new Random().nextLong())
-                .withName("my ruleset")
+        RuleSet s1 = createRuleSetBuilder("my ruleset")
                 .addRule(new MockRule("name", "desc", "msg", "rulesetname"))
                 .build();
 
-        RuleSet s2 = new RuleSetBuilder(new Random().nextLong())
-                .withName("my ruleset")
+        RuleSet s2 = createRuleSetBuilder("my ruleset")
                 .addRule(new MockRule("name", "desc", "msg", "rulesetname"))
                 .build();
 
@@ -209,13 +220,11 @@ public class RuleSetTest {
 
     @Test
     public void testEquals5() {
-        RuleSet s1 = new RuleSetBuilder(new Random().nextLong())
-                .withName("my ruleset")
+        RuleSet s1 = createRuleSetBuilder("my ruleset")
                 .addRule(new MockRule("name", "desc", "msg", "rulesetname"))
                 .build();
 
-        RuleSet s2 = new RuleSetBuilder(new Random().nextLong())
-                .withName("my other ruleset")
+        RuleSet s2 = createRuleSetBuilder("my other ruleset")
                 .addRule(new MockRule("name", "desc", "msg", "rulesetname"))
                 .build();
 
@@ -224,13 +233,11 @@ public class RuleSetTest {
 
     @Test
     public void testEquals6() {
-        RuleSet s1 = new RuleSetBuilder(new Random().nextLong())
-                .withName("my ruleset")
+        RuleSet s1 = createRuleSetBuilder("my ruleset")
                 .addRule(new MockRule("name", "desc", "msg", "rulesetname"))
                 .build();
 
-        RuleSet s2 = new RuleSetBuilder(new Random().nextLong())
-                .withName("my ruleset")
+        RuleSet s2 = createRuleSetBuilder("my ruleset")
                 .addRule(new MockRule("other rule", "desc", "msg", "rulesetname"))
                 .build();
 
@@ -265,13 +272,13 @@ public class RuleSetTest {
 
     @Test
     public void testAddExcludePattern() {
-        RuleSet ruleSet = new RuleSetBuilder(new Random().nextLong())
+        RuleSet ruleSet = createRuleSetBuilder("ruleset1")
                 .addExcludePattern("*")
                 .build();
         assertNotNull("Exclude patterns", ruleSet.getExcludePatterns());
         assertEquals("Invalid number of patterns", 1, ruleSet.getExcludePatterns().size());
         
-        RuleSet ruleSet2 = new RuleSetBuilder(new Random().nextLong())
+        RuleSet ruleSet2 = createRuleSetBuilder("ruleset2")
                 .addExcludePattern("*")
                 .addExcludePattern("*") // try to create a duplicate
                 .build();
@@ -283,17 +290,17 @@ public class RuleSetTest {
 
     @Test
     public void testAddExcludePatterns() {
-        RuleSet ruleSet = new RuleSetBuilder(new Random().nextLong())
+        RuleSet ruleSet = createRuleSetBuilder("ruleset1")
                 .addExcludePattern("*")
                 .addExcludePattern(".*")
                 .build();
-        RuleSet ruleSet2 = new RuleSetBuilder(new Random().nextLong())
+        RuleSet ruleSet2 = createRuleSetBuilder("ruleset2")
                 .addExcludePatterns(ruleSet.getExcludePatterns())
                 .build();
         assertNotNull("Exclude patterns", ruleSet2.getExcludePatterns());
         assertEquals("Invalid number of patterns", 2, ruleSet2.getExcludePatterns().size());
         
-        RuleSet ruleSet3 = new RuleSetBuilder(new Random().nextLong())
+        RuleSet ruleSet3 = createRuleSetBuilder("ruleset3")
                 .addExcludePattern("*")
                 .addExcludePattern(".*")
                 .addExcludePattern(".*") // try to create a duplicate
@@ -310,7 +317,7 @@ public class RuleSetTest {
         List<String> excludePatterns = new ArrayList<>();
         excludePatterns.add("*");
         excludePatterns.add(".*");
-        RuleSet ruleSet = new RuleSetBuilder(new Random().nextLong())
+        RuleSet ruleSet = createRuleSetBuilder("ruleset")
                 .setExcludePatterns(excludePatterns)
                 .build();
         assertNotNull("Exclude patterns", ruleSet.getExcludePatterns());
@@ -323,7 +330,7 @@ public class RuleSetTest {
 
     @Test
     public void testAddIncludePattern() {
-        RuleSet ruleSet = new RuleSetBuilder(new Random().nextLong())
+        RuleSet ruleSet = createRuleSetBuilder("ruleset")
                 .addIncludePattern("*")
                 .build();
         assertNotNull("Include patterns", ruleSet.getIncludePatterns());
@@ -335,11 +342,11 @@ public class RuleSetTest {
 
     @Test
     public void testAddIncludePatterns() {
-        RuleSet ruleSet = new RuleSetBuilder(new Random().nextLong())
+        RuleSet ruleSet = createRuleSetBuilder("ruleset1")
                 .addIncludePattern("*")
                 .addIncludePattern(".*")
                 .build();
-        RuleSet ruleSet2 = new RuleSetBuilder(new Random().nextLong())
+        RuleSet ruleSet2 = createRuleSetBuilder("ruleset1")
                 .addIncludePatterns(ruleSet.getIncludePatterns())
                 .build();
         assertNotNull("Include patterns", ruleSet2.getIncludePatterns());
@@ -355,7 +362,7 @@ public class RuleSetTest {
         List<String> includePatterns = new ArrayList<>();
         includePatterns.add("*");
         includePatterns.add(".*");
-        RuleSet ruleSet = new RuleSetBuilder(new Random().nextLong())
+        RuleSet ruleSet = createRuleSetBuilder("ruleset")
                 .setIncludePatterns(includePatterns)
                 .build();
         assertNotNull("Include patterns", ruleSet.getIncludePatterns());
@@ -370,28 +377,28 @@ public class RuleSetTest {
     public void testIncludeExcludeApplies() {
         File file = new File("C:\\myworkspace\\project\\some\\random\\package\\RandomClass.java");
 
-        RuleSet ruleSet = new RuleSetBuilder(new Random().nextLong()).build();
+        RuleSet ruleSet = createRuleSetBuilder("ruleset").build();
         assertTrue("No patterns", ruleSet.applies(file));
 
-        ruleSet = new RuleSetBuilder(new Random().nextLong())
+        ruleSet = createRuleSetBuilder("ruleset")
                 .addExcludePattern("nomatch")
                 .build();
         assertTrue("Non-matching exclude", ruleSet.applies(file));
 
-        ruleSet = new RuleSetBuilder(new Random().nextLong())
+        ruleSet = createRuleSetBuilder("ruleset")
                 .addExcludePattern("nomatch")
                 .addExcludePattern(".*/package/.*")
                 .build();
         assertFalse("Matching exclude", ruleSet.applies(file));
 
-        ruleSet = new RuleSetBuilder(new Random().nextLong())
+        ruleSet = createRuleSetBuilder("ruleset")
                 .addExcludePattern("nomatch")
                 .addExcludePattern(".*/package/.*")
                 .addIncludePattern(".*/randomX/.*")
                 .build();
         assertFalse("Non-matching include", ruleSet.applies(file));
 
-        ruleSet = new RuleSetBuilder(new Random().nextLong())
+        ruleSet = createRuleSetBuilder("ruleset")
                 .addExcludePattern("nomatch")
                 .addExcludePattern(".*/package/.*")
                 .addIncludePattern(".*/randomX/.*")
@@ -409,13 +416,11 @@ public class RuleSetTest {
         rule.setLanguage(LanguageRegistry.getLanguage(DummyLanguageModule.NAME));
         rule.addRuleChainVisit("dummyNode");
         assertTrue("RuleChain rule", rule.usesRuleChain());
-        RuleSet ruleSet1 = new RuleSetBuilder(new Random().nextLong())
-                .withName("RuleSet1")
+        RuleSet ruleSet1 = createRuleSetBuilder("RuleSet1")
                 .addRule(rule)
                 .build();
 
-        RuleSet ruleSet2 = new RuleSetBuilder(new Random().nextLong())
-                .withName("RuleSet2")
+        RuleSet ruleSet2 = createRuleSetBuilder("RuleSet2")
                 .addRule(rule)
                 .build();
 
@@ -435,8 +440,7 @@ public class RuleSetTest {
         assertEquals("Violations", 2, r.size());
 
         // One violation
-        ruleSet1 = new RuleSetBuilder(new Random().nextLong())
-                .withName("RuleSet1")
+        ruleSet1 = createRuleSetBuilder("RuleSet1")
                 .addExcludePattern(".*/package/.*")
                 .addRule(rule)
                 .build();

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetWriterTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetWriterTest.java
@@ -53,6 +53,8 @@ public class RuleSetWriterTest {
     public void testWrite() throws Exception {
         RuleSet braces = new RuleSetFactory().createRuleSet("net/sourceforge/pmd/TestRuleset1.xml");
         RuleSet ruleSet = new RuleSetBuilder(new Random().nextLong())
+                .withName("ruleset")
+                .withDescription("ruleset description")
                 .addRuleSetByReference(braces, true, "MockRule2")
                 .build();
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/junit/JavaUtilLoggingRule.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/junit/JavaUtilLoggingRule.java
@@ -1,0 +1,62 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.junit;
+
+import java.util.logging.Logger;
+import java.util.logging.StreamHandler;
+
+import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.junit.rules.ExternalResource;
+
+/**
+ * Junit Rule, to check for java util logging statements.
+ * 
+ * @author Andreas Dangel
+ * @see <a href="http://blog.diabol.se/?p=474">Testing the presence of log messages with java.util.logging</a>
+ */
+public class JavaUtilLoggingRule extends ExternalResource {
+    private final Logger logger;
+    private final ByteArrayOutputStream stream;
+    private final StreamHandler customLogHandler;
+
+
+    /**
+     * Creates a new rule, that attaches a custom log handler
+     * to the given logger.
+     * @param loggerName the name of the logger to check
+     */
+    public JavaUtilLoggingRule(String loggerName) {
+        this.logger = Logger.getLogger(loggerName);
+        this.stream = new ByteArrayOutputStream();
+        this.customLogHandler = new StreamHandler(stream, logger.getParent().getHandlers()[0].getFormatter());
+    }
+
+    @Override
+    protected void before() throws Throwable {
+        logger.addHandler(customLogHandler);
+    }
+
+    @Override
+    protected void after() {
+        logger.removeHandler(customLogHandler);
+    }
+
+    /**
+     * Gets the complete log.
+     * @return the log
+     */
+    public String getLog() {
+        customLogHandler.flush();
+        return stream.toString();
+    }
+
+    /**
+     * Clears the log.
+     */
+    public void clear() {
+        customLogHandler.flush();
+        stream.reset();
+    }
+}

--- a/pmd-test/src/test/java/net/sourceforge/pmd/testframework/RuleTstTest.java
+++ b/pmd-test/src/test/java/net/sourceforge/pmd/testframework/RuleTstTest.java
@@ -44,7 +44,7 @@ public class RuleTstTest {
         verify(rule).getMinimumLanguageVersion();
         verify(rule).getMaximumLanguageVersion();
         verify(rule).apply(anyList(), any(RuleContext.class));
-        verify(rule, times(2)).getName();
+        verify(rule, times(4)).getName();
         verify(rule).getPropertiesByPropertyDescriptor();
         verifyNoMoreInteractions(rule);
     }

--- a/src/site/markdown/overview/changelog.md
+++ b/src/site/markdown/overview/changelog.md
@@ -18,6 +18,7 @@ This is a minor release.
 ### Fixed Issues
 
 *   General
+    *   [#380](https://github.com/pmd/pmd/issues/380): \[core] NPE in RuleSet.hashCode
     *   [#407](https://github.com/pmd/pmd/issues/407): \[web] Release date is not properly formatted
 *   java
     *   [#414](https://github.com/pmd/pmd/issues/414): \[java] Java 8 parsing problem with annotations for wildcards


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `mvn test` passes.
 - [x] `mvn checkstyle:check` passes. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
This makes sure, we get early errors, if the ruleset being built is not valid - see #380 

I'm unsure about validation when actually building the ruleset (c3888ac). We obviously don't validate the XML against the schema at the moment and this change would make the name and description of a ruleset really required. So, there might be some ruleset.xml files, that worked before and would now fail to load.


