### PR TITLE
Fixes #429 [core] Error when running PMD from folder with space

### DIFF
--- a/pmd-dist/src/main/scripts/bgastviewer.bat
+++ b/pmd-dist/src/main/scripts/bgastviewer.bat
@@ -3,4 +3,4 @@ set TOPDIR=%~dp0..
 set OPTS=
 set MAIN_CLASS=net.sourceforge.pmd.util.viewer.Viewer
 
-java -classpath %TOPDIR%\lib\* %OPTS% %MAIN_CLASS% %*
+java -classpath "%TOPDIR%\lib\*" %OPTS% %MAIN_CLASS% %*

--- a/pmd-dist/src/main/scripts/cpd.bat
+++ b/pmd-dist/src/main/scripts/cpd.bat
@@ -3,4 +3,4 @@ set TOPDIR=%~dp0..
 set OPTS=
 set MAIN_CLASS=net.sourceforge.pmd.cpd.CPD
 
-java -classpath %TOPDIR%\lib\* %OPTS% %MAIN_CLASS% %*
+java -classpath "%TOPDIR%\lib\*" %OPTS% %MAIN_CLASS% %*

--- a/pmd-dist/src/main/scripts/cpdgui.bat
+++ b/pmd-dist/src/main/scripts/cpdgui.bat
@@ -3,4 +3,4 @@ set TOPDIR=%~dp0..
 set OPTS=
 set MAIN_CLASS=net.sourceforge.pmd.cpd.GUI
 
-java -classpath %TOPDIR%\lib\* %OPTS% %MAIN_CLASS% %*
+java -classpath "%TOPDIR%\lib\*" %OPTS% %MAIN_CLASS% %*

--- a/pmd-dist/src/main/scripts/designer.bat
+++ b/pmd-dist/src/main/scripts/designer.bat
@@ -3,4 +3,4 @@ set TOPDIR=%~dp0..
 set OPTS=
 set MAIN_CLASS=net.sourceforge.pmd.util.designer.Designer
 
-java -classpath %TOPDIR%\lib\* %OPTS% %MAIN_CLASS% %*
+java -classpath "%TOPDIR%\lib\*" %OPTS% %MAIN_CLASS% %*

--- a/pmd-dist/src/main/scripts/pmd.bat
+++ b/pmd-dist/src/main/scripts/pmd.bat
@@ -3,4 +3,4 @@ set TOPDIR=%~dp0..
 set OPTS=
 set MAIN_CLASS=net.sourceforge.pmd.PMD
 
-java -classpath %TOPDIR%\lib\* %OPTS% %MAIN_CLASS% %*
+java -classpath "%TOPDIR%\lib\*" %OPTS% %MAIN_CLASS% %*

--- a/pmd-dist/src/main/scripts/run.sh
+++ b/pmd-dist/src/main/scripts/run.sh
@@ -59,7 +59,7 @@ java_heapsize_settings() {
 
 set_lib_dir() {
   if [ -z ${LIB_DIR} ]; then
-    local script_dir=$(dirname ${0})
+    local script_dir=$(dirname "${0}")
     local cwd="${PWD}"
 
     cd "${script_dir}/../lib"
@@ -113,7 +113,7 @@ classpath=$CLASSPATH
 
 cd "${CWD}"
 
-for jarfile in ${LIB_DIR}/*.jar; do
+for jarfile in "${LIB_DIR}"/*.jar; do
     if [ -n "$classpath" ]; then
         classpath=$classpath:$jarfile
     else

--- a/src/site/markdown/overview/changelog.md
+++ b/src/site/markdown/overview/changelog.md
@@ -19,6 +19,7 @@ This is a minor release.
 
 *   General
     *   [#407](https://github.com/pmd/pmd/issues/407): \[web] Release date is not properly formatted
+    *   [#429](https://github.com/pmd/pmd/issues/429): \[core] Error when running PMD from folder with space
 *   java
     *   [#414](https://github.com/pmd/pmd/issues/414): \[java] Java 8 parsing problem with annotations for wildcards
     *   [#415](https://github.com/pmd/pmd/issues/415): \[java] Parsing Error when having an Annotated Inner class


### PR DESCRIPTION
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `mvn test` passes.
 - [x] `mvn checkstyle:check` passes. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

Fixes the start scripts of PMD where at various places quotes were missing to correctly handle path names with spaces.

Fixes #429 
