### PR TITLE
[core] Use jetbrains' @NotNull and @Nullable annotations to ease null checking

### DIFF
--- a/pmd-java/pom.xml
+++ b/pmd-java/pom.xml
@@ -159,5 +159,10 @@
             <artifactId>system-rules</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>13.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -887,6 +887,11 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
                 <artifactId>system-rules</artifactId>
                 <version>1.8.0</version>
             </dependency>
+            <dependency>
+                <groupId>org.jetbrains</groupId>
+                <artifactId>annotations</artifactId>
+                <version>13.0</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
It would be nice to be able to use [Jetbrains' `@NotNull` and `@Nullable`](https://www.jetbrains.com/help/idea/nullable-and-notnull-annotations.html) annotations to ease null checking in future code. It wouldn't change much anyway, as these annotations are not retained at runtime and the jar is *very* lightweight.

(This PR only adds them to pmd-java)