### PR TITLE
[java] Fix false positive in UnusedImport

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/imports/UnusedImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/imports/UnusedImportsRule.java
@@ -86,7 +86,14 @@ public class UnusedImportsRule extends AbstractJavaRule {
                         if (s != null) {
                             String[] params = s.split("\\s*,\\s*");
                             for (String param : params) {
-                                imports.remove(new ImportWrapper(param, param, new DummyJavaNode(-1)));
+                                final int firstDot = param.indexOf('.');
+                                final String expectedImportName;
+                                if (firstDot == -1) {
+                                    expectedImportName = param;
+                                } else {
+                                    expectedImportName = param.substring(0, firstDot);
+                                }
+                                imports.remove(new ImportWrapper(param, expectedImportName, new DummyJavaNode(-1)));
                             }
                         }
                     }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/typeresolution/xml/UnusedImports.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/typeresolution/xml/UnusedImports.xml
@@ -264,4 +264,19 @@ public interface Interface {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>#348 False Positive UnusedImports with javadoc for public static inner classes of imports</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.swing.GroupLayout;
+
+public class Foo {
+
+	/**
+	 * {@link Bar#doSomething(GroupLayout.Group)}
+	*/
+	void doSomething();
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/src/site/markdown/overview/changelog.md
+++ b/src/site/markdown/overview/changelog.md
@@ -57,6 +57,8 @@ Fields using generics are still Work in Progress, but we expect to fully support
     *   [#397](https://github.com/pmd/pmd/issues/397): \[java] ConstructorCallsOverridableMethodRule: false positive for method called from lambda expression
     *   [#410](https://github.com/pmd/pmd/issues/410): \[java] ImmutableField: False positive with lombok
     *   [#422](https://github.com/pmd/pmd/issues/422): \[java] PreserveStackTraceRule: false positive when using builder pattern
+*   java-imports:
+    *   [#348]((https://github.com/pmd/pmd/issues/348): \[java] imports/UnusedImport rule not considering static inner classes of imports
 *   java-junit
     *   [#428](https://github.com/pmd/pmd/issues/428): \[java] PMD requires public modifier on JUnit 5 test
 *   java-unnecessary


### PR DESCRIPTION
 - When referencing static inner members of imports, false positives
would be reported.
 - Fixes #348

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `mvn test` passes.
 - [x] `mvn checkstyle:check` passes. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)
