### PR TITLE
[java] SignatureDeclareThrowsException ignores @Override

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/strictexception/SignatureDeclareThrowsExceptionRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/strictexception/SignatureDeclareThrowsExceptionRule.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.List;
 
 import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
@@ -50,6 +51,15 @@ public class SignatureDeclareThrowsExceptionRule extends AbstractJavaRule {
 
         if (methodDeclaration.getMethodName().startsWith("test")) {
             return super.visit(methodDeclaration, o);
+        }
+        
+        // Ignore overridden methods, the issue should be marked on the method definition
+        final List<ASTAnnotation> methodAnnotations = methodDeclaration.jjtGetParent().findChildrenOfType(ASTAnnotation.class);
+        for (final ASTAnnotation annotation : methodAnnotations) {
+            final ASTName annotationName = annotation.getFirstDescendantOfType(ASTName.class);
+            if (annotationName.hasImageEqualTo("Override") || annotationName.hasImageEqualTo("java.lang.Override")) {
+                return super.visit(methodDeclaration, o);
+            }
         }
 
         List<ASTName> exceptionList = Collections.emptyList();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/rules/SignatureDeclareThrowsException.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/rules/SignatureDeclareThrowsException.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.java.typeresolution.rules;
 import java.util.List;
 
 import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
@@ -112,6 +113,15 @@ public class SignatureDeclareThrowsException extends AbstractJavaRule {
     public Object visit(ASTMethodDeclaration methodDeclaration, Object o) {
         if (junitImported && isAllowedMethod(methodDeclaration)) {
             return super.visit(methodDeclaration, o);
+        }
+        
+        // Ignore overridden methods, the issue should be marked on the method definition
+        final List<ASTAnnotation> methodAnnotations = methodDeclaration.jjtGetParent().findChildrenOfType(ASTAnnotation.class);
+        for (final ASTAnnotation annotation : methodAnnotations) {
+            final ASTName annotationName = annotation.getFirstDescendantOfType(ASTName.class);
+            if (annotationName.hasImageEqualTo("Override") || annotationName.hasImageEqualTo("java.lang.Override")) {
+                return super.visit(methodDeclaration, o);
+            }
         }
 
         checkExceptions(methodDeclaration, o);

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/strictexception/xml/SignatureDeclareThrowsException.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/strictexception/xml/SignatureDeclareThrowsException.xml
@@ -103,4 +103,16 @@ public class BugSignature {
 public class UnmodifiableList<T> implements @Readonly List<@Readonly T> {}
         ]]></code>
     </test-code>
+    
+    <test-code>
+        <description>#350 allow throws exception when overriding a method defined elsewhere</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class BugSignature implements LousyInterface {
+  @Override
+  public void record() throws Exception {
+  }
+}
+]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/typeresolution/xml/SignatureDeclareThrowsException.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/typeresolution/xml/SignatureDeclareThrowsException.xml
@@ -151,4 +151,16 @@ public class Foo {
 public class UnmodifiableList<T> implements @Readonly List<@Readonly T> {}
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#350 allow throws exception when overriding a method defined elsewhere</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class BugSignature implements LousyInterface {
+  @Override
+  public void record() throws Exception {
+  }
+}
+]]></code>
+    </test-code>
 </test-data>

--- a/src/site/markdown/overview/changelog.md
+++ b/src/site/markdown/overview/changelog.md
@@ -61,6 +61,10 @@ Fields using generics are still Work in Progress, but we expect to fully support
     *   [#348]((https://github.com/pmd/pmd/issues/348): \[java] imports/UnusedImport rule not considering static inner classes of imports
 *   java-junit
     *   [#428](https://github.com/pmd/pmd/issues/428): \[java] PMD requires public modifier on JUnit 5 test
+*   java-strictexceptions
+    *   [#350](https://github.com/pmd/pmd/issues/350): \[java] Throwing Exception in method signature is fine if the method is overriding or implementing something
+*   java-typeresolution
+    *   [#350](https://github.com/pmd/pmd/issues/350): \[java] Throwing Exception in method signature is fine if the method is overriding or implementing something
 *   java-unnecessary
     *   [#421](https://github.com/pmd/pmd/issues/421): \[java] UnnecessaryFinalModifier final in private method
 


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `mvn test` passes.
 - [x] `mvn checkstyle:check` passes. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
 - Avoid reporting on @Overrides, since we have no control of the
interface.
 - The original definition is still reported if it's part of our
application's code.
 - Fixes #350