### PR TITLE
[java] EmptyCatchBlock may ignore blocks based on exception name

### DIFF
--- a/pmd-java/src/main/resources/rulesets/java/empty.xml
+++ b/pmd-java/src/main/resources/rulesets/java/empty.xml
@@ -30,10 +30,12 @@ or reported.
  [FormalParameter/Type/ReferenceType
    /ClassOrInterfaceType[@Image != 'InterruptedException' and @Image != 'CloneNotSupportedException']
  ]
+ [FormalParameter/VariableDeclaratorId[not(matches(@Image, $allowExceptionNameRegex))]]
  ]]>
              </value>
           </property>
           <property name="allowCommentedBlocks" type="Boolean" description="Empty blocks containing comments will be skipped" value="false"/>
+          <property name="allowExceptionNameRegex" type="String" description="Empty blocks catching exceptions with names matching this regular expression will be skipped" value="^$"/>
       </properties>
       <example>
   <![CDATA[

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/empty/xml/EmptyCatchBlock.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/empty/xml/EmptyCatchBlock.xml
@@ -167,4 +167,21 @@ Javadoc comment is not OK
     </test-code>
  
     <!-- END Commented blocks -->
+    <test-code>
+        <description><![CDATA[
+Allow to ignore exceptions by name
+     ]]></description>
+        <rule-property name="allowExceptionNameRegex">^(ignored|expected)$</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ void foo() {
+  try {
+  } catch (NullPointerException expected) {
+  } catch (IllegalArgumentException ignored) {
+  }
+ }
+}
+     ]]></code>
+    </test-code>
 </test-data>

--- a/src/site/markdown/overview/changelog.md
+++ b/src/site/markdown/overview/changelog.md
@@ -39,6 +39,11 @@ Fields using generics are still Work in Progress, but we expect to fully support
 *   The ruleset java-junit now properly detects JUnit5, and rules are being adapted to the changes on it's API.
     This support is, however, still incomplete. Let us know of any uses we are still missing on the [issue tracker](https://github.com/pmd/pmd/issues)
 
+*   The Java rule `EmptyCatchBlock` (ruleset java-empty) now exposes a new property called `allowExceptionNameRegex`.
+    This allow to setup a regular expression for names of exceptions you wish to ignore for this rule. For instance,
+    setting it to `^(ignored|expected)$` would ignore all empty catch blocks where the catched exception is named
+    either `ignored` or `expected`. The default ignores no exceptions, being backwards compatible.
+
 ### Fixed Issues
 
 *   General
@@ -57,7 +62,9 @@ Fields using generics are still Work in Progress, but we expect to fully support
     *   [#397](https://github.com/pmd/pmd/issues/397): \[java] ConstructorCallsOverridableMethodRule: false positive for method called from lambda expression
     *   [#410](https://github.com/pmd/pmd/issues/410): \[java] ImmutableField: False positive with lombok
     *   [#422](https://github.com/pmd/pmd/issues/422): \[java] PreserveStackTraceRule: false positive when using builder pattern
-*   java-imports:
+*   java-empty
+    *   [#413](https://github.com/pmd/pmd/issues/413): \[java] EmptyCatchBlock don't fail when exception is named ignore / expected
+*   java-imports
     *   [#348]((https://github.com/pmd/pmd/issues/348): \[java] imports/UnusedImport rule not considering static inner classes of imports
 *   java-junit
     *   [#428](https://github.com/pmd/pmd/issues/428): \[java] PMD requires public modifier on JUnit 5 test


### PR DESCRIPTION
 - Allow the developer to setup a regular expression for exception names
to be ignored by the rule.
 - Fixes #413

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `mvn test` passes.
 - [x] `mvn checkstyle:check` passes. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

