### PR TITLE
[core] Allow deep copying of RuleSets

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/Rule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/Rule.java
@@ -21,7 +21,6 @@ import net.sourceforge.pmd.lang.rule.properties.StringProperty;
  * single rule instance is reused for analyzing multiple files.
  * </p>
  */
-// FUTURE Implement Cloneable and clone()
 public interface Rule extends PropertySource {
 
     /**
@@ -355,4 +354,10 @@ public interface Rule extends PropertySource {
      *            the rule context
      */
     void end(RuleContext ctx);
+    
+    /**
+     * Creates a new copy of this rule.
+     * @return A new exact copy of this rule
+     */
+    Rule deepCopy();
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
@@ -9,8 +9,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.logging.Level;
@@ -206,8 +206,7 @@ public class RuleSet implements ChecksumAware {
             if (rule instanceof RuleReference) {
                 ruleReference = (RuleReference) rule;
             } else {
-                final RuleSetReference ruleSetReference = new RuleSetReference();
-                ruleSetReference.setRuleSetFileName(ruleSetFileName);
+                final RuleSetReference ruleSetReference = new RuleSetReference(ruleSetFileName);
                 ruleReference = new RuleReference();
                 ruleReference.setRule(rule);
                 ruleReference.setRuleSetReference(ruleSetReference);
@@ -266,11 +265,13 @@ public class RuleSet implements ChecksumAware {
                 throw new RuntimeException(
                         "Adding a rule by reference is not allowed with an empty rule set file name.");
             }
-            final RuleSetReference ruleSetReference = new RuleSetReference(ruleSet.getFileName());
-            ruleSetReference.setAllRules(allRules);
-            if (excludes != null) {
-                ruleSetReference.setExcludes(new HashSet<>(Arrays.asList(excludes)));
+            final RuleSetReference ruleSetReference;
+            if (excludes == null) {
+                ruleSetReference = new RuleSetReference(ruleSet.getFileName(), allRules);
+            } else {
+                ruleSetReference = new RuleSetReference(ruleSet.getFileName(), allRules, new LinkedHashSet<>(Arrays.asList(excludes)));
             }
+
             for (final Rule rule : ruleSet.getRules()) {
                 final RuleReference ruleReference = new RuleReference(rule, ruleSetReference);
                 rules.add(ruleReference);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
@@ -35,7 +35,6 @@ import net.sourceforge.pmd.util.filter.Filters;
  *
  * @see Rule
  */
-// FUTURE Implement Cloneable and clone()
 public class RuleSet implements ChecksumAware {
 
     private static final Logger LOG = Logger.getLogger(RuleSet.class.getName());
@@ -77,6 +76,22 @@ public class RuleSet implements ChecksumAware {
 
         final Filter<String> regexFilter = Filters.buildRegexFilterIncludeOverExclude(includePatterns, excludePatterns);
         filter = Filters.toNormalizedFileFilter(regexFilter);
+    }
+    
+    public RuleSet(final RuleSet rs) {
+        checksum = rs.checksum;
+        fileName = rs.fileName;
+        name = rs.name;
+        description = rs.description;
+        
+        rules = new ArrayList<>(rs.rules.size());
+        for (final Rule rule : rs.rules) {
+            rules.add(rule.deepCopy());
+        }
+        
+        excludePatterns = rs.excludePatterns; // we can share immutable lists of immutable elements
+        includePatterns = rs.includePatterns;
+        filter = rs.filter; // filters are immutable, can be shared
     }
 
     /* package */ static class RuleSetBuilder {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
@@ -441,9 +441,6 @@ public class RuleSetFactory {
      */
     private void parseRuleSetReferenceNode(RuleSetReferenceId ruleSetReferenceId, RuleSetBuilder ruleSetBuilder,
             Element ruleElement, String ref) throws RuleSetNotFoundException {
-        RuleSetReference ruleSetReference = new RuleSetReference();
-        ruleSetReference.setAllRules(true);
-        ruleSetReference.setRuleSetFileName(ref);
         String priority = null;
         NodeList childNodes = ruleElement.getChildNodes();
         Set<String> excludedRulesCheck = new HashSet<>();
@@ -452,12 +449,12 @@ public class RuleSetFactory {
             if (isElementNode(child, "exclude")) {
                 Element excludeElement = (Element) child;
                 String excludedRuleName = excludeElement.getAttribute("name");
-                ruleSetReference.addExclude(excludedRuleName);
                 excludedRulesCheck.add(excludedRuleName);
             } else if (isElementNode(child, PRIORITY)) {
                 priority = parseTextNode(child).trim();
             }
         }
+        final RuleSetReference ruleSetReference = new RuleSetReference(ref, true, excludedRulesCheck);
 
         RuleSetFactory ruleSetFactory = new RuleSetFactory(this, warnDeprecated);
         RuleSet otherRuleSet = ruleSetFactory.createRuleSet(RuleSetReferenceId.parse(ref).get(0));
@@ -679,9 +676,7 @@ public class RuleSetFactory {
             }
         }
 
-        RuleSetReference ruleSetReference = new RuleSetReference();
-        ruleSetReference.setAllRules(false);
-        ruleSetReference.setRuleSetFileName(otherRuleSetReferenceId.getRuleSetFileName());
+        RuleSetReference ruleSetReference = new RuleSetReference(otherRuleSetReferenceId.getRuleSetFileName(), false);
 
         RuleReference ruleReference = new RuleReference();
         ruleReference.setRuleSetReference(ruleSetReference);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetReference.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetReference.java
@@ -4,50 +4,43 @@
 
 package net.sourceforge.pmd;
 
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
 /**
  * This class represents a reference to RuleSet.
  */
-// TODO : Make this class immutable
 public class RuleSetReference {
-    private String ruleSetFileName;
-    private boolean allRules;
-    private Set<String> excludes = new LinkedHashSet<>(0);
+    private final String ruleSetFileName;
+    private final boolean allRules;
+    private final Set<String> excludes;
 
-    public RuleSetReference() {
+    public RuleSetReference(final String theFilename, final boolean allRules, final Set<String> excludes) {
+        ruleSetFileName = theFilename;
+        this.allRules = allRules;
+        this.excludes = Collections.unmodifiableSet(new LinkedHashSet<>(excludes));
     }
 
-    public RuleSetReference(String theFilename) {
+    public RuleSetReference(final String theFilename, final boolean allRules) {
         ruleSetFileName = theFilename;
+        this.allRules = allRules;
+        this.excludes = Collections.<String>emptySet();
+    }
+
+    public RuleSetReference(final String theFilename) {
+        this(theFilename, false);
     }
 
     public String getRuleSetFileName() {
         return ruleSetFileName;
     }
 
-    public void setRuleSetFileName(String ruleSetFileName) {
-        this.ruleSetFileName = ruleSetFileName;
-    }
-
     public boolean isAllRules() {
         return allRules;
     }
 
-    public void setAllRules(boolean allRules) {
-        this.allRules = allRules;
-    }
-
     public Set<String> getExcludes() {
         return excludes;
-    }
-
-    public void setExcludes(Set<String> excludes) {
-        this.excludes = excludes;
-    }
-
-    public void addExclude(String name) {
-        this.excludes.add(name);
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetReference.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetReference.java
@@ -10,6 +10,7 @@ import java.util.Set;
 /**
  * This class represents a reference to RuleSet.
  */
+// TODO : Make this class immutable
 public class RuleSetReference {
     private String ruleSetFileName;
     private boolean allRules;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSets.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSets.java
@@ -36,6 +36,16 @@ public class RuleSets {
      */
     public RuleSets() {
     }
+    
+    /**
+     * Copy constructor. Deep copies RuleSets.
+     * @param ruleSets The RuleSets to copy.
+     */
+    public RuleSets(final RuleSets ruleSets) {
+        for (final RuleSet rs : ruleSets.ruleSets) {
+            addRuleSet(new RuleSet(rs));
+        }
+    }
 
     /**
      * Public constructor. Add the given rule set.

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
@@ -536,10 +536,8 @@ public abstract class AbstractRule extends AbstractPropertySource implements Rul
         }
         rule.setPriority(getPriority());
         for (final PropertyDescriptor<?> prop : getPropertyDescriptors()) {
-            final PropertyDescriptor<?> existingProp = rule.getPropertyDescriptor(prop.name());
-            
-            if (existingProp == null) {
-                rule.definePropertyDescriptor(prop); // Property descriptors are immutable, an can be freely shared
+            if (!rule.hasDescriptor(prop)) {
+                rule.definePropertyDescriptor(prop); // Property descriptors are immutable, and can be freely shared
             }
             
             rule.setProperty((PropertyDescriptor<Object>) prop, getProperty((PropertyDescriptor<Object>) prop));

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import net.sourceforge.pmd.AbstractPropertySource;
+import net.sourceforge.pmd.PropertyDescriptor;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.RulePriority;
@@ -22,7 +23,6 @@ import net.sourceforge.pmd.lang.ast.Node;
  *
  * @author pieter_van_raemdonck - Application Engineers NV/SA - www.ae.be
  */
-// FUTURE Implement Cloneable and clone()?
 public abstract class AbstractRule extends AbstractPropertySource implements Rule {
 
     private Language language;
@@ -502,5 +502,49 @@ public abstract class AbstractRule extends AbstractPropertySource implements Rul
         Object propertyValues = getPropertiesByPropertyDescriptor();
         return getClass().getName().hashCode() + (getName() != null ? getName().hashCode() : 0)
                 + getPriority().hashCode() + (propertyValues != null ? propertyValues.hashCode() : 0);
+    }
+    
+    @SuppressWarnings("unchecked")
+    @Override
+    public Rule deepCopy() {
+        Rule rule = null;
+        try {
+            rule = getClass().newInstance();
+        } catch (InstantiationException | IllegalAccessException e) {
+            // Can't happen... we already have an instance
+        }
+        rule.setName(getName());
+        rule.setLanguage(getLanguage());
+        rule.setMinimumLanguageVersion(getMinimumLanguageVersion());
+        rule.setMaximumLanguageVersion(getMaximumLanguageVersion());
+        rule.setSince(getSince());
+        rule.setMessage(getMessage());
+        rule.setRuleSetName(getRuleSetName());
+        rule.setExternalInfoUrl(getExternalInfoUrl());
+        if (usesDFA()) {
+            rule.setUsesDFA();
+        }
+        if (usesTypeResolution()) {
+            rule.setUsesTypeResolution();
+        }
+        if (usesMetrics()) {
+            rule.setUsesMetrics();
+        }
+        rule.setDescription(getDescription());
+        for (final String example : getExamples()) {
+            rule.addExample(example);
+        }
+        rule.setPriority(getPriority());
+        for (final PropertyDescriptor<?> prop : getPropertyDescriptors()) {
+            final PropertyDescriptor<?> existingProp = rule.getPropertyDescriptor(prop.name());
+            
+            if (existingProp == null) {
+                rule.definePropertyDescriptor(prop); // Property descriptors are immutable, an can be freely shared
+            }
+            
+            rule.setProperty((PropertyDescriptor<Object>) prop, getProperty((PropertyDescriptor<Object>) prop));
+        }
+        
+        return rule;
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleReference.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleReference.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.rule;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,7 +43,7 @@ public class RuleReference extends AbstractDelegateRule {
     private RulePriority priority;
     private RuleSetReference ruleSetReference;
 
-    private static final List<PropertyDescriptor<?>> EMPTY_DESCRIPTORS = new ArrayList<>(0);
+    private static final List<PropertyDescriptor<?>> EMPTY_DESCRIPTORS = Collections.emptyList();
 
     public RuleReference() {
     }
@@ -338,5 +339,32 @@ public class RuleReference extends AbstractDelegateRule {
         if (propertyDescriptors != null) {
             propertyDescriptors.remove(desc);
         }
+    }
+    
+    @Override
+    public Rule deepCopy() {
+        RuleReference rule = null;
+        try {
+            rule = getClass().newInstance();
+        } catch (InstantiationException | IllegalAccessException e) {
+            // Can't happen... we already have an instance
+        }
+        rule.setRule(this.getRule().deepCopy());
+        
+        rule.language = language;
+        rule.minimumLanguageVersion = minimumLanguageVersion;
+        rule.maximumLanguageVersion = maximumLanguageVersion;
+        rule.deprecated = deprecated;
+        rule.name = name;
+        rule.propertyDescriptors = propertyDescriptors;
+        rule.propertyValues = propertyValues == null ? null : new HashMap<>(propertyValues);
+        rule.message = message;
+        rule.description = description;
+        rule.examples = examples == null ? null : new ArrayList<>(examples);
+        rule.externalInfoUrl = externalInfoUrl;
+        rule.priority = priority;
+        rule.ruleSetReference = ruleSetReference;
+        
+        return rule;
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/processor/PmdRunnable.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/processor/PmdRunnable.java
@@ -73,6 +73,11 @@ public class PmdRunnable implements Callable<Report> {
             LOCAL_THREAD_CONTEXT.set(tc);
         }
 
+        /*
+         * FIXME : This creates ConfigErrors for dysfunctional rules **per-thread**.
+         * We need rulesets to be copy-constructable and have them cleaned-up only once
+         * before analysis starts, reducing this to Report.createReport(tc.ruleContext, fileName);
+         */
         Report report = PMD.setupReport(tc.ruleSets, tc.ruleContext, fileName);
 
         if (LOG.isLoggable(Level.FINE)) {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/FooRule.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/FooRule.java
@@ -17,16 +17,12 @@ import net.sourceforge.pmd.lang.rule.AbstractRule;
 public class FooRule extends AbstractRule {
     public FooRule() {
         setLanguage(LanguageRegistry.getLanguage(DummyLanguageModule.NAME));
+        setName("Foo");
     }
 
     @Override
     public String getMessage() {
         return "blah";
-    }
-
-    @Override
-    public String getName() {
-        return "Foo";
     }
 
     @Override

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleReferenceTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleReferenceTest.java
@@ -61,6 +61,47 @@ public class RuleReferenceTest {
         ruleReference.setExternalInfoUrl("externalInfoUrl2");
         ruleReference.setPriority(RulePriority.MEDIUM_HIGH);
 
+        validateOverridenValues(PROPERTY1_DESCRIPTOR, PROPERTY2_DESCRIPTOR, ruleReference);
+    }
+    
+    @Test
+    public void testDeepCopyOverride() {
+        final StringProperty PROPERTY1_DESCRIPTOR = new StringProperty("property1", "Test property", null, 0f);
+        MockRule rule = new MockRule();
+        rule.definePropertyDescriptor(PROPERTY1_DESCRIPTOR);
+        rule.setLanguage(LanguageRegistry.getLanguage(Dummy2LanguageModule.NAME));
+        rule.setName("name1");
+        rule.setProperty(PROPERTY1_DESCRIPTOR, "value1");
+        rule.setMessage("message1");
+        rule.setDescription("description1");
+        rule.addExample("example1");
+        rule.setExternalInfoUrl("externalInfoUrl1");
+        rule.setPriority(RulePriority.HIGH);
+
+        final StringProperty PROPERTY2_DESCRIPTOR = new StringProperty("property2", "Test property", null, 0f);
+        RuleReference ruleReference = new RuleReference();
+        ruleReference.setRule(rule);
+        ruleReference.definePropertyDescriptor(PROPERTY2_DESCRIPTOR);
+        ruleReference.setLanguage(LanguageRegistry.getLanguage(DummyLanguageModule.NAME));
+        ruleReference
+                .setMinimumLanguageVersion(LanguageRegistry.getLanguage(DummyLanguageModule.NAME).getVersion("1.3"));
+        ruleReference
+                .setMaximumLanguageVersion(LanguageRegistry.getLanguage(DummyLanguageModule.NAME).getVersion("1.7"));
+        ruleReference.setDeprecated(true);
+        ruleReference.setName("name2");
+        ruleReference.setProperty(PROPERTY1_DESCRIPTOR, "value2");
+        ruleReference.setProperty(PROPERTY2_DESCRIPTOR, "value3");
+        ruleReference.setMessage("message2");
+        ruleReference.setDescription("description2");
+        ruleReference.addExample("example2");
+        ruleReference.setExternalInfoUrl("externalInfoUrl2");
+        ruleReference.setPriority(RulePriority.MEDIUM_HIGH);
+
+        validateOverridenValues(PROPERTY1_DESCRIPTOR, PROPERTY2_DESCRIPTOR, (RuleReference) ruleReference.deepCopy());
+    }
+
+    private void validateOverridenValues(final StringProperty propertyDescriptor1,
+            final StringProperty propertyDescriptor2, RuleReference ruleReference) {
         assertEquals("Override failed", LanguageRegistry.getLanguage(DummyLanguageModule.NAME),
                 ruleReference.getLanguage());
         assertEquals("Override failed", LanguageRegistry.getLanguage(DummyLanguageModule.NAME),
@@ -83,20 +124,20 @@ public class RuleReferenceTest {
         assertEquals("Override failed", "name2", ruleReference.getName());
         assertEquals("Override failed", "name2", ruleReference.getOverriddenName());
 
-        assertEquals("Override failed", "value2", ruleReference.getProperty(PROPERTY1_DESCRIPTOR));
-        assertEquals("Override failed", "value3", ruleReference.getProperty(PROPERTY2_DESCRIPTOR));
-        assertTrue("Override failed", ruleReference.getPropertyDescriptors().contains(PROPERTY1_DESCRIPTOR));
-        assertTrue("Override failed", ruleReference.getPropertyDescriptors().contains(PROPERTY2_DESCRIPTOR));
-        assertFalse("Override failed", ruleReference.getOverriddenPropertyDescriptors().contains(PROPERTY1_DESCRIPTOR));
-        assertTrue("Override failed", ruleReference.getOverriddenPropertyDescriptors().contains(PROPERTY2_DESCRIPTOR));
+        assertEquals("Override failed", "value2", ruleReference.getProperty(propertyDescriptor1));
+        assertEquals("Override failed", "value3", ruleReference.getProperty(propertyDescriptor2));
+        assertTrue("Override failed", ruleReference.getPropertyDescriptors().contains(propertyDescriptor1));
+        assertTrue("Override failed", ruleReference.getPropertyDescriptors().contains(propertyDescriptor2));
+        assertFalse("Override failed", ruleReference.getOverriddenPropertyDescriptors().contains(propertyDescriptor1));
+        assertTrue("Override failed", ruleReference.getOverriddenPropertyDescriptors().contains(propertyDescriptor2));
         assertTrue("Override failed",
-                ruleReference.getPropertiesByPropertyDescriptor().containsKey(PROPERTY1_DESCRIPTOR));
+                ruleReference.getPropertiesByPropertyDescriptor().containsKey(propertyDescriptor1));
         assertTrue("Override failed",
-                ruleReference.getPropertiesByPropertyDescriptor().containsKey(PROPERTY2_DESCRIPTOR));
+                ruleReference.getPropertiesByPropertyDescriptor().containsKey(propertyDescriptor2));
         assertTrue("Override failed",
-                ruleReference.getOverriddenPropertiesByPropertyDescriptor().containsKey(PROPERTY1_DESCRIPTOR));
+                ruleReference.getOverriddenPropertiesByPropertyDescriptor().containsKey(propertyDescriptor1));
         assertTrue("Override failed",
-                ruleReference.getOverriddenPropertiesByPropertyDescriptor().containsKey(PROPERTY2_DESCRIPTOR));
+                ruleReference.getOverriddenPropertiesByPropertyDescriptor().containsKey(propertyDescriptor2));
 
         assertEquals("Override failed", "message2", ruleReference.getMessage());
         assertEquals("Override failed", "message2", ruleReference.getOverriddenMessage());

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleReferenceTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleReferenceTest.java
@@ -23,7 +23,7 @@ public class RuleReferenceTest {
     @Test
     public void testRuleSetReference() {
         RuleReference ruleReference = new RuleReference();
-        RuleSetReference ruleSetReference = new RuleSetReference();
+        RuleSetReference ruleSetReference = new RuleSetReference("somename");
         ruleReference.setRuleSetReference(ruleSetReference);
         assertEquals("Not same rule set reference", ruleSetReference, ruleReference.getRuleSetReference());
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetTest.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
@@ -453,6 +454,24 @@ public class RuleSetTest {
         ctx.setReport(r);
         ruleSets.apply(makeCompilationUnits(), ctx, LanguageRegistry.getLanguage(DummyLanguageModule.NAME));
         assertEquals("Violations", 1, r.size());
+    }
+    
+    @Test
+    public void copyConstructorDeepCopies() {
+        Rule rule = new FooRule();
+        rule.setName("FooRule1");
+        rule.setLanguage(LanguageRegistry.getLanguage(DummyLanguageModule.NAME));
+        rule.addRuleChainVisit("dummyNode");
+        RuleSet ruleSet1 = createRuleSetBuilder("RuleSet1")
+                .addRule(rule)
+                .build();
+        RuleSet ruleSet2 = new RuleSet(ruleSet1);
+        
+        assertEquals(ruleSet1, ruleSet2);
+        assertNotSame(ruleSet1, ruleSet2);
+        
+        assertEquals(rule, ruleSet2.getRuleByName("FooRule1"));
+        assertNotSame(rule, ruleSet2.getRuleByName("FooRule1"));
     }
 
     private void verifyRuleSet(RuleSet ruleset, int size, Set<RuleViolation> values) {


### PR DESCRIPTION
 - Copy constructor for RuleSets
 - Copy constructor for RuleSet
 - Copy method for Rules
 - I'm still sharing a few objects that are not strictly immutables, but
treated as them

This would allow to start resolving the issue commented on https://github.com/pmd/pmd/issues/194#issuecomment-310428462

This change adds new methods, but doesn't modify existing APIs, so it would be safe for 5.8.0.

However, I'd still want a second opinion as to wether the classes that I allow to share are really to be treated / converted to immutables, or I should extend deep copying to them.


 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `mvn test` passes.
 - [x] `mvn checkstyle:check` passes. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

