### PR TITLE
[java] Detect more unnecessary finals

### DIFF
--- a/pmd-java/src/main/resources/rulesets/java/unnecessary.xml
+++ b/pmd-java/src/main/resources/rulesets/java/unnecessary.xml
@@ -62,7 +62,8 @@ public class Foo {
           externalInfoUrl="${pmd.website.baseurl}/rules/java/unnecessary.html#UnnecessaryFinalModifier">
       <description>
 When a class has the final modifier, all the methods are automatically final and do not need to be
-tagged as such. Similarly, private methods can't be overriden, and therefore do not need to be tagged either.
+tagged as such. Similarly, methods that can't be overridden (private methods, methods of anonymous classes,
+methods of enum instance) do not need to be tagged either.
       </description>
       <priority>3</priority>
       <properties>
@@ -73,7 +74,9 @@ tagged as such. Similarly, private methods can't be overriden, and therefore do 
     /ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration
         [count(./Annotation/MarkerAnnotation/Name[@Image='SafeVarargs' or @Image='java.lang.SafeVarargs']) = 0]
     /MethodDeclaration[@Final='true']
-    | //MethodDeclaration[@Final='true' and @Private='true']
+| //MethodDeclaration[@Final='true' and @Private='true']
+| //EnumConstant/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/MethodDeclaration[@Final='true']
+| //AllocationExpression/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/MethodDeclaration[@Final='true']
     ]]>
               </value>
           </property>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/unnecessary/xml/UnnecessaryFinalModifier.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/unnecessary/xml/UnnecessaryFinalModifier.xml
@@ -127,4 +127,32 @@ public class TestClass {
 }
         ]]></code>
     </test-code>
+    <test-code>
+    <description>Unnecessary final of enum method</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public enum Foo {
+    BAR {
+        @Override
+        public final void magic() {}
+    };
+
+    public void magic() {}
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+    <description>Unnecessary final of anonymous class method</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void stuff() {
+        Listener list = new Listener() {
+            @Override
+            public final void onEvent() {}
+        };
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/src/site/markdown/overview/changelog.md
+++ b/src/site/markdown/overview/changelog.md
@@ -9,12 +9,19 @@ This is a major release.
 ### Table Of Contents
 
 * [New and noteworthy](#New_and_noteworthy)
-    * [Removed Rules](#Removed_Rules)
+    *   [Modified Rules](#Modified_Rules)
+    *   [Removed Rules](#Removed_Rules)
 * [Fixed Issues](#Fixed_Issues)
 * [API Changes](#API_Changes)
 * [External Contributions](#External_Contributions)
 
 ### New and noteworthy
+
+#### Modified Rules
+
+*   The rule `UnnecessaryFinalModifier` (ruleset `java-unnecessarycode`) has been revamped to detect more cases.
+    It will now flag anonymous class' methods marked as final (can't be overriden, so it's pointless), along with
+    final methods overriden / defined within enum instances.
 
 #### Removed Rules
 
@@ -27,6 +34,8 @@ This is a major release.
     *   [#1513](https://sourceforge.net/p/pmd/bugs/1513/): \[java] Remove deprecated rule UseSingleton
 *   java-controversial
     *   [#408](https://github.com/pmd/pmd/issues/408): \[java] DFA not analyzing asserts
+*   java-unnecessarycode
+    *   [#412](https://github.com/pmd/pmd/issues/412): \[java] java-unnecessarycode/UnnecessaryFinalModifier missing cases
 
 ### API Changes
 


### PR DESCRIPTION
 - Mark unnecessary finals in anonymous class methods.
 - Mark unnecessary finals in enum instance methods.
 - Fixes #412

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `mvn test` passes.
 - [x] `mvn checkstyle:check` passes. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

