### PR TITLE
[java] fix error with raw types, bug #471

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -381,7 +381,7 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
                     if (typeNode == null) {
                         return null;
                     }
-                    
+
                     if (typeNode.jjtGetChild(0) instanceof ASTReferenceType) {
                         return ((TypeNode) typeNode.jjtGetChild(0)).getTypeDefinition();
                     } else { // primitive type
@@ -425,6 +425,11 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
      * @return JavaTypeDefinition of the {@code genericType}.
      */
     private JavaTypeDefinition getNextTypeDefinition(JavaTypeDefinition context, Type genericType) {
+        return getNextTypeDefinition(context, genericType, null);
+    }
+
+    private JavaTypeDefinition getNextTypeDefinition(JavaTypeDefinition context, Type genericType,
+                                                     JavaTypeDefinitionBuilder buildTypeInAdvance) {
         if (genericType == null) {
             return null;
         }
@@ -435,6 +440,10 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
 
             ParameterizedType parameterizedType = (ParameterizedType) genericType;
             JavaTypeDefinitionBuilder typeDef = JavaTypeDefinition.builder((Class) parameterizedType.getRawType());
+
+            if (buildTypeInAdvance != null) {
+                buildTypeInAdvance.addTypeArg(typeDef.build());
+            }
 
             // recursively determine each type argument's type def.
             for (Type type : parameterizedType.getActualTypeArguments()) {
@@ -520,7 +529,13 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
 
             for (TypeVariable parameter : clazzWithDefBounds.getTypeParameters()) {
                 // TODO: fix self reference "< ... E extends Something<E> ... >"
-                typeDef.addTypeArg(getNextTypeDefinition(context, parameter.getBounds()[0]));
+                JavaTypeDefinition typeDefOfParameter = getNextTypeDefinition(context, parameter.getBounds()[0],
+                                                                              typeDef);
+
+                // if it isn't 0, then it has already been added
+                if (typeDefOfParameter.getGenericArgs().size() == 0) {
+                    typeDef.addTypeArg(getNextTypeDefinition(context, parameter.getBounds()[0]));
+                }
             }
         }
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
@@ -70,6 +70,7 @@ import net.sourceforge.pmd.typeresolution.testdata.Operators;
 import net.sourceforge.pmd.typeresolution.testdata.Promotion;
 import net.sourceforge.pmd.typeresolution.testdata.SuperExpression;
 import net.sourceforge.pmd.typeresolution.testdata.ThisExpression;
+import net.sourceforge.pmd.typeresolution.testdata.dummytypes.GenericClass;
 import net.sourceforge.pmd.typeresolution.testdata.dummytypes.SuperClassA;
 import net.sourceforge.pmd.typeresolution.testdata.dummytypes.SuperClassA2;
 import net.sourceforge.pmd.typeresolution.testdata.dummytypes.SuperClassB;
@@ -1040,6 +1041,16 @@ public class ClassTypeResolverTest {
         assertEquals(Integer.class, expressions.get(index).getType());
         assertEquals(Integer.class, getChildType(expressions.get(index++), 0));
 
+        // bug #471
+        // rawGeneric.fifth = new GenericClass();
+        assertEquals(GenericClass.class, expressions.get(index).getType());
+        assertEquals(GenericClass.class, getChildType(expressions.get(index++), 0));
+        // inheritedRawGeneric.fifth = new GenericClass();
+        assertEquals(GenericClass.class, expressions.get(index).getType());
+        assertEquals(GenericClass.class, getChildType(expressions.get(index++), 0));
+        // parameterRawGeneric.fifth = new GenericClass();
+        assertEquals(GenericClass.class, expressions.get(index).getType());
+        assertEquals(GenericClass.class, getChildType(expressions.get(index++), 0));
 
         // Make sure we got them all
         assertEquals("All expressions not tested", index, expressions.size());

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/FieldAccessGenericRaw.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/FieldAccessGenericRaw.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.typeresolution.testdata;
 
+import net.sourceforge.pmd.typeresolution.testdata.dummytypes.GenericClass;
 import net.sourceforge.pmd.typeresolution.testdata.dummytypes.GenericClass2;
 import net.sourceforge.pmd.typeresolution.testdata.dummytypes.GenericSuperClassA;
 
@@ -33,5 +34,10 @@ public class FieldAccessGenericRaw<T extends GenericClass2> extends GenericSuper
         parameterRawGeneric.third = new Object();
         parameterRawGeneric.fourth.second = "";
         parameterRawGeneric.rawGeneric.second = new Integer(0);
+
+        // Bug #471
+        rawGeneric.fifth = new GenericClass();
+        inheritedRawGeneric.fifth = new GenericClass();
+        parameterRawGeneric.fifth = new GenericClass();
     }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/dummytypes/GenericClass2.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/dummytypes/GenericClass2.java
@@ -7,13 +7,13 @@ package net.sourceforge.pmd.typeresolution.testdata.dummytypes;
 public class GenericClass2<A extends Integer, B extends A, C,
         S extends String,
         D extends GenericClass<A, S>,
-        //, E extends GenericClass<E, E>,
+        E extends GenericClass<E, E>,
         F extends GenericClass2> {
     public A first;
     public B second;
     public C third;
     public D fourth;
-    //public E fifth; // recursion
+    public E fifth; // recursion
     public F sixth; // recursion
     public GenericClass2 rawGeneric;
 }


### PR DESCRIPTION
Issue was with determining the upper bounds of raw types when they had type parameters
with circular references, example: GenericClass<E extends Foo<E>> #471 