### PR TITLE
[apex] Use Apex lexer for CPD

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/cpd/ApexLanguage.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/cpd/ApexLanguage.java
@@ -4,8 +4,21 @@
 
 package net.sourceforge.pmd.cpd;
 
+import java.util.Properties;
+
 public class ApexLanguage extends AbstractLanguage {
+
     public ApexLanguage() {
+        this(new Properties());
+    }
+
+    public ApexLanguage(Properties properties) {
         super("Apex", "apex", new ApexTokenizer(), ".cls");
+        setProperties(properties);
+    }
+
+    public final void setProperties(Properties properties) {
+        ApexTokenizer tokenizer = (ApexTokenizer) getTokenizer();
+        tokenizer.setProperties(properties);
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/cpd/ApexTokenizer.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/cpd/ApexTokenizer.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.cpd;
 
 import java.util.Locale;
+import java.util.Properties;
 
 import org.antlr.runtime.ANTLRStringStream;
 import org.antlr.runtime.Lexer;
@@ -15,6 +16,18 @@ import net.sourceforge.pmd.lang.ast.TokenMgrError;
 import apex.jorje.parser.impl.ApexLexer;
 
 public class ApexTokenizer implements Tokenizer {
+
+    /**
+     * If the properties is <code>false</code> (default), then the case of any token
+     * is ignored.
+     */
+    public static final String CASE_SENSITIVE = "net.sourceforge.pmd.cpd.ApexTokenizer.caseSensitive";
+
+    private boolean caseSensitive;
+
+    public void setProperties(Properties properties) {
+        caseSensitive = Boolean.parseBoolean(properties.getProperty(CASE_SENSITIVE, "false"));
+    }
 
     @Override
     public void tokenize(SourceCode sourceCode, Tokens tokenEntries) {
@@ -33,8 +46,9 @@ public class ApexTokenizer implements Tokenizer {
             while (token.getType() != Token.EOF) {
                 if (token.getChannel() != Lexer.HIDDEN) {
                     String tokenText = token.getText();
-                    // note: old behavior of AbstractTokenizer was, to consider only lowercase
-                    tokenText = tokenText.toLowerCase(Locale.ROOT);
+                    if (!caseSensitive) {
+                        tokenText = tokenText.toLowerCase(Locale.ROOT);
+                    }
                     TokenEntry tokenEntry = new TokenEntry(tokenText, sourceCode.getFileName(), token.getLine());
                     tokenEntries.add(tokenEntry);
                 }

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/cpd/ApexCpdTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/cpd/ApexCpdTest.java
@@ -15,6 +15,8 @@ import org.apache.commons.io.FilenameUtils;
 import org.junit.Before;
 import org.junit.Test;
 
+import net.sourceforge.pmd.lang.apex.ApexLanguageModule;
+
 public class ApexCpdTest {
     private File testdir;
 
@@ -27,8 +29,8 @@ public class ApexCpdTest {
     @Test
     public void testIssue427() throws IOException {
         CPDConfiguration configuration = new CPDConfiguration();
-        configuration.setMinimumTileSize(50);
-        configuration.setLanguage(LanguageFactory.createLanguage("apex"));
+        configuration.setMinimumTileSize(10);
+        configuration.setLanguage(LanguageFactory.createLanguage(ApexLanguageModule.TERSE_NAME));
         CPD cpd = new CPD(configuration);
         cpd.add(new File(testdir, "SFDCEncoder.cls"));
         cpd.add(new File(testdir, "SFDCEncoderConstants.cls"));
@@ -38,10 +40,11 @@ public class ApexCpdTest {
         Iterator<Match> matches = cpd.getMatches();
         int duplications = 0;
         while (matches.hasNext()) {
-            Match match = matches.next();
+            matches.next();
             duplications++;
-            assertTrue(match.getSourceCodeSlice().startsWith("/*"));
         }
         assertEquals(1, duplications);
+        Match firstDuplication = cpd.getMatches().next();
+        assertTrue(firstDuplication.getSourceCodeSlice().startsWith("global with sharing class SFDCEncoder"));
     }
 }

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/cpd/ApexTokenizerTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/cpd/ApexTokenizerTest.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Properties;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
@@ -28,6 +29,16 @@ public class ApexTokenizerTest {
         }
         assertEquals(28, tokens.size());
         assertEquals("someparam", findTokensByLine(8, tokens).get(0).toString());
+    }
+
+    @Test
+    public void testTokenizeCaseSensitive() throws IOException {
+        Tokens tokens = tokenize(load("Simple.cls"), true);
+        if (tokens.size() != 28) {
+            printTokens(tokens);
+        }
+        assertEquals(28, tokens.size());
+        assertEquals("someParam", findTokensByLine(8, tokens).get(0).toString());
     }
 
     /**
@@ -56,7 +67,14 @@ public class ApexTokenizerTest {
     }
 
     private Tokens tokenize(String code) {
+        return tokenize(code, false);
+    }
+
+    private Tokens tokenize(String code, boolean caseSensitive) {
         ApexTokenizer tokenizer = new ApexTokenizer();
+        Properties properties = new Properties();
+        properties.setProperty(ApexTokenizer.CASE_SENSITIVE, Boolean.toString(caseSensitive));
+        tokenizer.setProperties(properties);
         Tokens tokens = new Tokens();
         tokenizer.tokenize(new SourceCode(new StringCodeLoader(code)), tokens);
         return tokens;

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/cpd/ApexTokenizerTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/cpd/ApexTokenizerTest.java
@@ -30,6 +30,18 @@ public class ApexTokenizerTest {
         assertEquals("someparam", findTokensByLine(8, tokens).get(0).toString());
     }
 
+    /**
+     * Comments are ignored since using ApexLexer.
+     */
+    @Test
+    public void testTokenizeWithComments() throws IOException {
+        Tokens tokens = tokenize(load("issue427/SFDCEncoder.cls"));
+        assertEquals(17, tokens.size());
+
+        Tokens tokens2 = tokenize(load("issue427/SFDCEncoderConstants.cls"));
+        assertEquals(17, tokens2.size());
+    }
+
     private List<TokenEntry> findTokensByLine(int line, Tokens tokens) {
         List<TokenEntry> result = new ArrayList<>();
         for (TokenEntry entry : tokens.getTokens()) {

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/cpd/issue427/SFDCEncoder.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/cpd/issue427/SFDCEncoder.cls
@@ -25,5 +25,7 @@ global with sharing class SFDCEncoder {
 	/* Note - the order of these encoding strings is very important so we don't end up with double encoding.
 	      Each string we search for, must not be found as a result of a previous encoded string replacement */
 	/************ CLASS CODE HERE *************/
+
+	public String someParam { get; set; }
 }
 

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/cpd/issue427/SFDCEncoderConstants.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/cpd/issue427/SFDCEncoderConstants.cls
@@ -22,5 +22,6 @@
 public with sharing class SFDCEncoderConstants {
 
 	/************ CLASS CODE HERE *************/
+	public String someParam { get; set; }
 }
 

--- a/src/site/markdown/overview/changelog.md
+++ b/src/site/markdown/overview/changelog.md
@@ -23,6 +23,8 @@ This is a major release.
 
 ### Fixed Issues
 
+*   apex
+    *   [#488](https://github.com/pmd/pmd/pull/488): \[apex] Use Apex lexer for CPD
 *   java
     *   [#1513](https://sourceforge.net/p/pmd/bugs/1513/): \[java] Remove deprecated rule UseSingleton
 *   java-controversial


### PR DESCRIPTION
I noticed, that the Apex Jorje parser/compiler is actually based on ANTLR and provides a lexer. Before this change, the Apex CPD used the simple AbstractTokenizer. I expect, that with using the ApexLexer directly to tokenize the source code, the CPD matches should be more accurate, although I don't have a concrete example. It uses a similar integration of the ANTLR based lexer as we use for Swift.

To stay backwards compatible, the tokens are all lowercased. I prepared a property for the ApexTokenizer, to switch this behavior, but the option is not passed through via CPDConfiguration from commandline or CPD GUI (or any other integration).


Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `mvn test` passes.
 - [x] `mvn checkstyle:check` passes. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)


