### PR TITLE
[core] Custom rule reinitialization code

### DIFF
--- a/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
@@ -16,7 +16,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.FactoryConfigurationError;
@@ -75,7 +74,7 @@ public abstract class RuleTst {
         Rule rule = test.getRule();
 
         if (test.getReinitializeRule()) {
-            rule = findRule(rule.getRuleSetName(), rule.getName());
+            rule = reinitializeRule(rule);
         }
 
         Map<PropertyDescriptor<?>, Object> oldProperties = rule.getPropertiesByPropertyDescriptor();
@@ -118,6 +117,19 @@ public abstract class RuleTst {
             }
         }
     }
+
+
+    /**
+     * Code to be executed if the rule is reinitialised.
+     *
+     * @param rule The rule to reinitialise
+     *
+     * @return The rule once it has be reinitialised
+     */
+    protected Rule reinitializeRule(Rule rule) {
+        return findRule(rule.getRuleSetName(), rule.getName());
+    }
+
 
     private void assertMessages(Report report, TestDescriptor test) {
         if (report == null || test.getExpectedMessages().isEmpty()) {


### PR DESCRIPTION
**PR Description:** `test-code` elements can specify the `reinitializeRule` attribute in the xml. The only effect of this was until now to recreate the rule instance from its xml ruleset. This change allows a ruleset test (extending `RuleTst`) to override this behaviour in order to execute arbitrary rule reinitialisation code before a test.

This will enable us to fix one problem mentioned in the comments of #482, which is that the metrics framework must be reset between each test.

**Note:** By default rules are reinitialised even though they don't specify the attribute in the xml (see line 316 of `RuleTst`, as changed by this PR). Is that desirable behaviour?  