### PR TITLE
[doc] Add build script for PMD documentation, disable old site build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
-sudo: false
-
+sudo: required
+services:
+  - docker
 addons:
   apt:
     packages:
@@ -23,7 +24,7 @@ env:
   - secure: "JIhuqaI0i+zvuqqXiQBHpuKr7AQ8jfk6Gbr8Qgiq4yJtdEWXZGxnAT9BmlbjkgT7ABXvLgxf2CIdUOMo1yYfBlxQL/y5+e89jaVpYF3tvNAzYQ1e12VzQRsd/jDb7qvm7tw3rDHEn3dSEot7Q6KbPcL6WzWJINVMCCmOgvq9gKHgE6Y5q5EgZ5rxiXyuO27ndzcbxaor4PIaiSzHO9+AJQ7p2zDLP+kG4nKVTBX0l9VoKiYFhIpIhpbigi3jyLDMDRiWpwTWZC6P8/RXfZg/lc5ADOuM2DM8oXPpZuqOa/g31LWQOSCuEnQ1G16vbLgipSPpgAc7jYWD5cywhG9dLkiKaZDh5x0meLM2RoAgz6eAnQfTTqJ68OM9o9yXjubEedsNpNRAr9/DXMd+fbh10W2vbvL5HCNB3lic3anehhR9le7PLuEKxg654wXt3KM2PZGVWbotIyBK0CvGzqGkppvwT23QdDDqSdkWuGQIhGQ0xBOdYkwebycxP5wwPUmObG+mymQ1Be2BXvmghttsiJdKlt4CVSYOJUMus6kU32G95hdTgKblsX4J1Of2i1nYsjyMKh3k945tqXwQrIsxOOQug0oIkz24zlLaOaQcorWtJ6Y1HPaZKpVIFUEF0y8Uq/O4oB2bOYC6WDUQfpj7nRG6xbi+BeBS84m1ttCEk4g="
   matrix:
   - BUILD=deploy
-  - BUILD=site
+  - BUILD=doc
   - BUILD=sonar
   - BUILD=coveralls
 

--- a/.travis/build-doc.sh
+++ b/.travis/build-doc.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+set -e
+
+source .travis/common-functions.sh
+
+VERSION=$(./mvnw -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.5.0:exec | tail -1)
+echo "Building PMD Documentation ${VERSION} on branch ${TRAVIS_BRANCH}"
+
+if ! travis_isPush; then
+    echo "Not building site, since this is not a push!"
+    exit 0
+fi
+
+cd docs
+
+# run jekyll
+echo -e "\n\nBuilding documentation using jekyll...\n\n"
+export JEKYLL_VERSION=3.5
+docker run --rm \
+  --volume=$PWD:/srv/jekyll \
+  -it jekyll/jekyll:$JEKYLL_VERSION \
+  jekyll build 
+
+# create pmd-doc archive
+echo -e "\n\nCreating pmd-doc archive...\n\n"
+mv _site pmd-doc-${VERSION}
+zip -qr pmd-doc-${VERSION}.zip pmd-doc-${VERSION}/
+
+
+# Uploading pmd doc distribution to sourceforge
+if [[ "$TRAVIS_TAG" != "" || "$VERSION" == *-SNAPSHOT ]]; then
+    echo -e "\n\nUploading pmd-doc archive to sourceforge...\n\n"
+    rsync -avh target/pmd-doc-${VERSION}.zip ${PMD_SF_USER}@web.sourceforge.net:/home/frs/project/pmd/pmd/${VERSION}/
+fi
+
+# rsync site to pmd.sourceforge.net/snapshot
+if [[ "$VERSION" == *-SNAPSHOT && "$TRAVIS_BRANCH" == "master" ]]; then
+    echo -e "\n\nUploading snapshot site...\n\n"
+    travis_wait rsync -ah --stats --delete target/pmd-doc-${VERSION}/ ${PMD_SF_USER}@web.sourceforge.net:/home/project-web/pmd/htdocs/snapshot/
+fi


### PR DESCRIPTION
Note: This PR depends on #507 

It uses a docker image for jekyll to build the site.
Once merged, it will rsync the documentation to http://pmd.sourceforge.net/snapshot/ - overriding the old one.

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `mvn test` passes.
 - [x] `mvn checkstyle:check` passes. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)
