### PR TITLE
[core] Render config errors

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
@@ -188,7 +188,7 @@ public class PMD {
         Report report = Report.createReport(ctx, fileName);
 
         for (Rule rule : brokenRules) {
-            report.addConfigError(new Report.RuleConfigurationError(rule, rule.dysfunctionReason()));
+            report.addConfigError(new Report.ConfigurationError(rule, rule.dysfunctionReason()));
         }
 
         return report;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
@@ -42,7 +42,7 @@ public class Report implements Iterable<RuleViolation> {
     private final Set<Metric> metrics = new HashSet<>();
     private final List<ThreadSafeReportListener> listeners = new ArrayList<>();
     private List<ProcessingError> errors;
-    private List<RuleConfigurationError> configErrors;
+    private List<ConfigurationError> configErrors;
     private Map<Integer, String> linesToSuppress = new HashMap<>();
     private long start;
     private long end;
@@ -99,19 +99,19 @@ public class Report implements Iterable<RuleViolation> {
     /**
      * Represents a configuration error.
      */
-    public static class RuleConfigurationError {
+    public static class ConfigurationError {
         private final Rule rule;
         private final String issue;
 
         /**
-         * Creates a new configuration error.
+         * Creates a new configuration error for a specific rule.
          *
          * @param theRule
          *            the rule which is configured wrongly
          * @param theIssue
          *            the reason, why the configuration is wrong
          */
-        public RuleConfigurationError(Rule theRule, String theIssue) {
+        public ConfigurationError(Rule theRule, String theIssue) {
             rule = theRule;
             issue = theIssue;
         }
@@ -347,7 +347,7 @@ public class Report implements Iterable<RuleViolation> {
      * @param error
      *            the error to add
      */
-    public void addConfigError(RuleConfigurationError error) {
+    public void addConfigError(ConfigurationError error) {
         if (configErrors == null) {
             configErrors = new ArrayList<>();
         }
@@ -380,6 +380,10 @@ public class Report implements Iterable<RuleViolation> {
         Iterator<ProcessingError> i = r.errors();
         while (i.hasNext()) {
             addError(i.next());
+        }
+        Iterator<ConfigurationError> ce = r.configErrors();
+        while (ce.hasNext()) {
+            addConfigError(ce.next());
         }
         Iterator<Metric> m = r.metrics();
         while (m.hasNext()) {
@@ -479,8 +483,8 @@ public class Report implements Iterable<RuleViolation> {
      *
      * @return the iterator
      */
-    public Iterator<RuleConfigurationError> configErrors() {
-        return configErrors == null ? EmptyIterator.<RuleConfigurationError>instance() : configErrors.iterator();
+    public Iterator<ConfigurationError> configErrors() {
+        return configErrors == null ? EmptyIterator.<ConfigurationError>instance() : configErrors.iterator();
     }
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/AbstractIncrementingRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/AbstractIncrementingRenderer.java
@@ -30,6 +30,11 @@ public abstract class AbstractIncrementingRenderer extends AbstractRenderer {
      * Accumulated processing errors.
      */
     protected List<Report.ProcessingError> errors = new LinkedList<>();
+    
+    /**
+     * Accumulated configuration errors.
+     */
+    protected List<Report.ConfigurationError> configErrors = new LinkedList<>();
 
     /**
      * Accumulated suppressed violations.
@@ -67,6 +72,10 @@ public abstract class AbstractIncrementingRenderer extends AbstractRenderer {
 
         for (Iterator<Report.ProcessingError> i = report.errors(); i.hasNext();) {
             errors.add(i.next());
+        }
+        
+        for (Iterator<Report.ConfigurationError> i = report.configErrors(); i.hasNext();) {
+            configErrors.add(i.next());
         }
 
         if (showSuppressedViolations) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/HTMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/HTMLRenderer.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.StringEscapeUtils;
 
 import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.Report;
+import net.sourceforge.pmd.Report.ConfigurationError;
 import net.sourceforge.pmd.RuleViolation;
 import net.sourceforge.pmd.lang.rule.properties.StringProperty;
 import net.sourceforge.pmd.util.StringUtil;
@@ -71,6 +72,7 @@ public class HTMLRenderer extends AbstractIncrementingRenderer {
         if (showSuppressedViolations) {
             glomSuppressions(writer, suppressed);
         }
+        glomConfigurationErrors(writer, configErrors);
     }
 
     /**
@@ -106,6 +108,7 @@ public class HTMLRenderer extends AbstractIncrementingRenderer {
         if (showSuppressedViolations) {
             glomSuppressions(writer, suppressed);
         }
+        glomConfigurationErrors(writer, configErrors);
         writer.write("</body></html>" + PMD.EOL);
     }
 
@@ -197,6 +200,34 @@ public class HTMLRenderer extends AbstractIncrementingRenderer {
             buf.append("<td align=\"center\">" + (sv.suppressedByNOPMD() ? "NOPMD" : "Annotation") + "</td>" + PMD.EOL);
             buf.append("<td align=\"center\">" + (sv.getUserMessage() == null ? "" : sv.getUserMessage()) + "</td>"
                     + PMD.EOL);
+            buf.append("</tr>" + PMD.EOL);
+            writer.write(buf.toString());
+        }
+        writer.write("</table>");
+    }
+    
+    private void glomConfigurationErrors(final Writer writer, final List<ConfigurationError> configErrors) throws IOException {
+        if (configErrors.isEmpty()) {
+            return;
+        }
+
+        writer.write("<hr/>");
+        writer.write("<center><h3>Configuration errors</h3></center>");
+        writer.write("<table align=\"center\" cellspacing=\"0\" cellpadding=\"3\"><tr>" + PMD.EOL
+                + "<th>Rule</th><th>Problem</th></tr>" + PMD.EOL);
+
+        StringBuilder buf = new StringBuilder(500);
+        boolean colorize = true;
+        for (Report.ConfigurationError ce : configErrors) {
+            buf.setLength(0);
+            buf.append("<tr");
+            if (colorize) {
+                buf.append(" bgcolor=\"lightgrey\"");
+            }
+            colorize = !colorize;
+            buf.append("> " + PMD.EOL);
+            buf.append("<td>" + ce.rule().getName() + "</td>" + PMD.EOL);
+            buf.append("<td>" + ce.issue() + "</td>" + PMD.EOL);
             buf.append("</tr>" + PMD.EOL);
             writer.write(buf.toString());
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextColorRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextColorRenderer.java
@@ -112,7 +112,7 @@ public class TextColorRenderer extends AbstractAccumulatingRenderer {
      */
     @Override
     public void end() throws IOException {
-        StringBuffer buf = new StringBuffer(500);
+        StringBuilder buf = new StringBuilder(500);
         buf.append(PMD.EOL);
         initializeColorsIfSupported();
         String lastFile = null;
@@ -160,10 +160,20 @@ public class TextColorRenderer extends AbstractAccumulatingRenderer {
             buf.append(this.green + "    err:  " + this.cyan + error.getMsg() + this.colorReset + PMD.EOL + PMD.EOL);
             writer.write(buf.toString());
         }
+        
+        for (Iterator<Report.ConfigurationError> i = report.configErrors(); i.hasNext();) {
+            buf.setLength(0);
+            numberOfErrors++;
+            Report.ConfigurationError error = i.next();
+            buf.append(this.redBold + "*" + this.colorReset + " rule: " + this.whiteBold
+                    + error.rule().getName() + this.colorReset + PMD.EOL);
+            buf.append(this.green + "    err:  " + this.cyan + error.issue() + this.colorReset + PMD.EOL + PMD.EOL);
+            writer.write(buf.toString());
+        }
 
         // adding error message count, if any
         if (numberOfErrors > 0) {
-            writer.write(this.redBold + "*" + this.colorReset + " errors:   " + this.whiteBold + numberOfWarnings
+            writer.write(this.redBold + "*" + this.colorReset + " errors:   " + this.whiteBold + numberOfErrors
                     + this.colorReset + PMD.EOL);
         }
         writer.write(this.yellowBold + "*" + this.colorReset + " warnings: " + this.whiteBold + numberOfWarnings

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextRenderer.java
@@ -60,14 +60,12 @@ public class TextRenderer extends AbstractIncrementingRenderer {
     public void end() throws IOException {
         Writer writer = getWriter();
         StringBuilder buf = new StringBuilder(500);
-        if (!errors.isEmpty()) {
-
-            for (Report.ProcessingError error : errors) {
-                buf.setLength(0);
-                buf.append(error.getFile());
-                buf.append("\t-\t").append(error.getMsg()).append(PMD.EOL);
-                writer.write(buf.toString());
-            }
+        
+        for (Report.ProcessingError error : errors) {
+            buf.setLength(0);
+            buf.append(error.getFile());
+            buf.append("\t-\t").append(error.getMsg()).append(PMD.EOL);
+            writer.write(buf.toString());
         }
 
         for (Report.SuppressedViolation excluded : suppressed) {
@@ -76,6 +74,13 @@ public class TextRenderer extends AbstractIncrementingRenderer {
             buf.append(" rule violation suppressed by ");
             buf.append(excluded.suppressedByNOPMD() ? "//NOPMD" : "Annotation");
             buf.append(" in ").append(excluded.getRuleViolation().getFilename()).append(PMD.EOL);
+            writer.write(buf.toString());
+        }
+        
+        for (Report.ConfigurationError error : configErrors) {
+            buf.setLength(0);
+            buf.append(error.rule().getName());
+            buf.append("\t-\t").append(error.issue()).append(PMD.EOL);
             writer.write(buf.toString());
         }
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/VBHTMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/VBHTMLRenderer.java
@@ -101,7 +101,7 @@ public class VBHTMLRenderer extends AbstractIncrementingRenderer {
         if (!errors.isEmpty()) {
             sb.setLength(0);
             sb.append("<table border=\"0\" width=\"80%\">");
-            sb.append("<tr id=TableHeader><td><font class=title>&nbsp;Problems found</font></td></tr>");
+            sb.append("<tr id=TableHeader><td colspan=\"2\"><font class=title>&nbsp;Problems found</font></td></tr>");
             boolean colorize = false;
             for (Report.ProcessingError error : errors) {
                 if (colorize) {
@@ -110,7 +110,27 @@ public class VBHTMLRenderer extends AbstractIncrementingRenderer {
                     sb.append("<tr id=RowColor2>");
                 }
                 colorize = !colorize;
-                sb.append("<td><font class=body>").append(error).append("\"</font></td></tr>");
+                sb.append("<td><font class=body>").append(error.getFile()).append("</font></td>");
+                sb.append("<td><font class=body>").append(error.getMsg()).append("</font></td></tr>");
+            }
+            sb.append("</table>");
+            writer.write(sb.toString());
+        }
+        
+        if (!configErrors.isEmpty()) {
+            sb.setLength(0);
+            sb.append("<table border=\"0\" width=\"80%\">");
+            sb.append("<tr id=TableHeader><td colspan=\"2\"><font class=title>&nbsp;Configuration problems found</font></td></tr>");
+            boolean colorize = false;
+            for (Report.ConfigurationError error : configErrors) {
+                if (colorize) {
+                    sb.append("<tr id=RowColor1>");
+                } else {
+                    sb.append("<tr id=RowColor2>");
+                }
+                colorize = !colorize;
+                sb.append("<td><font class=body>").append(error.rule().getName()).append("</font></td>");
+                sb.append("<td><font class=body>").append(error.issue()).append("</font></td></tr>");
             }
             sb.append("</table>");
             writer.write(sb.toString());

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XMLRenderer.java
@@ -152,6 +152,17 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
                 writer.write(buf.toString());
             }
         }
+        
+        // config errors
+        for (final Report.ConfigurationError ce : configErrors) {
+            buf.setLength(0);
+            buf.append("<configerror ").append("rule=\"");
+            StringUtil.appendXmlEscaped(buf, ce.rule().getName(), useUTF8);
+            buf.append("\" msg=\"");
+            StringUtil.appendXmlEscaped(buf, ce.issue(), useUTF8);
+            buf.append("\"/>").append(PMD.EOL);
+            writer.write(buf.toString());
+        }
 
         writer.write("</pmd>" + PMD.EOL);
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/AbstractRendererTst.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/AbstractRendererTst.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 
 import net.sourceforge.pmd.FooRule;
 import net.sourceforge.pmd.Report;
+import net.sourceforge.pmd.Report.ConfigurationError;
 import net.sourceforge.pmd.Report.ProcessingError;
 import net.sourceforge.pmd.ReportTest;
 import net.sourceforge.pmd.RuleContext;
@@ -34,6 +35,10 @@ public abstract class AbstractRendererTst {
     public abstract String getExpectedMultiple();
 
     public String getExpectedError(ProcessingError error) {
+        return "";
+    }
+    
+    public String getExpectedError(ConfigurationError error) {
         return "";
     }
 
@@ -119,6 +124,15 @@ public abstract class AbstractRendererTst {
         Report rep = new Report();
         Report.ProcessingError err = new Report.ProcessingError("Error", "file");
         rep.addError(err);
+        String actual = ReportTest.render(getRenderer(), rep);
+        assertEquals(filter(getExpectedError(err)), filter(actual));
+    }
+    
+    @Test
+    public void testConfigError() throws Exception {
+        Report rep = new Report();
+        Report.ConfigurationError err = new Report.ConfigurationError(new FooRule(), "a configuration error");
+        rep.addConfigError(err);
         String actual = ReportTest.render(getRenderer(), rep);
         assertEquals(filter(getExpectedError(err)), filter(actual));
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/CSVRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/CSVRendererTest.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.renderers;
 
 import net.sourceforge.pmd.PMD;
+import net.sourceforge.pmd.Report.ConfigurationError;
 import net.sourceforge.pmd.Report.ProcessingError;
 
 public class CSVRendererTest extends AbstractRendererTst {
@@ -16,24 +17,33 @@ public class CSVRendererTest extends AbstractRendererTst {
 
     @Override
     public String getExpected() {
-        return "\"Problem\",\"Package\",\"File\",\"Priority\",\"Line\",\"Description\",\"Rule set\",\"Rule\"" + PMD.EOL
+        return getHeader()
                 + "\"1\",\"\",\"n/a\",\"5\",\"1\",\"blah\",\"RuleSet\",\"Foo\"" + PMD.EOL;
     }
 
     @Override
     public String getExpectedEmpty() {
-        return "\"Problem\",\"Package\",\"File\",\"Priority\",\"Line\",\"Description\",\"Rule set\",\"Rule\"" + PMD.EOL;
+        return getHeader();
     }
 
     @Override
     public String getExpectedMultiple() {
-        return "\"Problem\",\"Package\",\"File\",\"Priority\",\"Line\",\"Description\",\"Rule set\",\"Rule\"" + PMD.EOL
+        return getHeader()
                 + "\"1\",\"\",\"n/a\",\"5\",\"1\",\"blah\",\"RuleSet\",\"Foo\"" + PMD.EOL
                 + "\"2\",\"\",\"n/a\",\"5\",\"1\",\"blah\",\"RuleSet\",\"Foo\"" + PMD.EOL;
     }
 
     @Override
     public String getExpectedError(ProcessingError error) {
+        return getHeader();
+    }
+    
+    @Override
+    public String getExpectedError(ConfigurationError error) {
+        return getHeader();
+    }
+    
+    private String getHeader() {
         return "\"Problem\",\"Package\",\"File\",\"Priority\",\"Line\",\"Description\",\"Rule set\",\"Rule\"" + PMD.EOL;
     }
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/EmptyRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/EmptyRendererTest.java
@@ -6,8 +6,6 @@ package net.sourceforge.pmd.renderers;
 
 import org.junit.Test;
 
-import net.sourceforge.pmd.Report.ProcessingError;
-
 public class EmptyRendererTest extends AbstractRendererTst {
 
     @Override
@@ -34,11 +32,6 @@ public class EmptyRendererTest extends AbstractRendererTst {
 
     @Override
     public String getExpectedMultiple() {
-        return "";
-    }
-
-    @Override
-    public String getExpectedError(ProcessingError error) {
         return "";
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/HTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/HTMLRendererTest.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.renderers;
 
 import net.sourceforge.pmd.PMD;
+import net.sourceforge.pmd.Report.ConfigurationError;
 import net.sourceforge.pmd.Report.ProcessingError;
 
 public class HTMLRendererTest extends AbstractRendererTst {
@@ -21,9 +22,7 @@ public class HTMLRendererTest extends AbstractRendererTst {
 
     @Override
     public String getExpected() {
-        return "<html><head><title>PMD</title></head><body>" + PMD.EOL
-                + "<center><h3>PMD report</h3></center><center><h3>Problems found</h3></center><table align=\"center\" cellspacing=\"0\" cellpadding=\"3\"><tr>"
-                + PMD.EOL + "<th>#</th><th>File</th><th>Line</th><th>Problem</th></tr>" + PMD.EOL
+        return getHeader()
                 + "<tr bgcolor=\"lightgrey\"> " + PMD.EOL + "<td align=\"center\">1</td>" + PMD.EOL
                 + "<td width=\"*%\">filename/that/needs &lt;script&gt;alert(1)&lt;/script&gt; escaping.ext</td>" + PMD.EOL + "<td align=\"center\" width=\"5%\">1</td>" + PMD.EOL
                 + "<td width=\"*\">blah</td>" + PMD.EOL + "</tr>" + PMD.EOL + "</table></body></html>" + PMD.EOL;
@@ -31,17 +30,13 @@ public class HTMLRendererTest extends AbstractRendererTst {
 
     @Override
     public String getExpectedEmpty() {
-        return "<html><head><title>PMD</title></head><body>" + PMD.EOL
-                + "<center><h3>PMD report</h3></center><center><h3>Problems found</h3></center><table align=\"center\" cellspacing=\"0\" cellpadding=\"3\"><tr>"
-                + PMD.EOL + "<th>#</th><th>File</th><th>Line</th><th>Problem</th></tr>" + PMD.EOL
+        return getHeader()
                 + "</table></body></html>" + PMD.EOL;
     }
 
     @Override
     public String getExpectedMultiple() {
-        return "<html><head><title>PMD</title></head><body>" + PMD.EOL
-                + "<center><h3>PMD report</h3></center><center><h3>Problems found</h3></center><table align=\"center\" cellspacing=\"0\" cellpadding=\"3\"><tr>"
-                + PMD.EOL + "<th>#</th><th>File</th><th>Line</th><th>Problem</th></tr>" + PMD.EOL
+        return getHeader()
                 + "<tr bgcolor=\"lightgrey\"> " + PMD.EOL + "<td align=\"center\">1</td>" + PMD.EOL
                 + "<td width=\"*%\">filename/that/needs &lt;script&gt;alert(1)&lt;/script&gt; escaping.ext</td>" + PMD.EOL + "<td align=\"center\" width=\"5%\">1</td>" + PMD.EOL
                 + "<td width=\"*\">blah</td>" + PMD.EOL + "</tr>" + PMD.EOL + "<tr> " + PMD.EOL
@@ -52,12 +47,25 @@ public class HTMLRendererTest extends AbstractRendererTst {
 
     @Override
     public String getExpectedError(ProcessingError error) {
-        return "<html><head><title>PMD</title></head><body>" + PMD.EOL
-                + "<center><h3>PMD report</h3></center><center><h3>Problems found</h3></center><table align=\"center\" cellspacing=\"0\" cellpadding=\"3\"><tr>"
-                + PMD.EOL + "<th>#</th><th>File</th><th>Line</th><th>Problem</th></tr>" + PMD.EOL
+        return getHeader()
                 + "</table><hr/><center><h3>Processing errors</h3></center><table align=\"center\" cellspacing=\"0\" cellpadding=\"3\"><tr>"
                 + PMD.EOL + "<th>File</th><th>Problem</th></tr>" + PMD.EOL + "<tr bgcolor=\"lightgrey\"> " + PMD.EOL
                 + "<td>file</td>" + PMD.EOL + "<td>Error</td>" + PMD.EOL + "</tr>" + PMD.EOL + "</table></body></html>"
                 + PMD.EOL;
+    }
+    
+    @Override
+    public String getExpectedError(ConfigurationError error) {
+        return getHeader()
+                + "</table><hr/><center><h3>Configuration errors</h3></center><table align=\"center\" cellspacing=\"0\" cellpadding=\"3\"><tr>"
+                + PMD.EOL + "<th>Rule</th><th>Problem</th></tr>" + PMD.EOL + "<tr bgcolor=\"lightgrey\"> " + PMD.EOL
+                + "<td>Foo</td>" + PMD.EOL + "<td>a configuration error</td>" + PMD.EOL + "</tr>" + PMD.EOL + "</table></body></html>"
+                + PMD.EOL;
+    }
+
+    private String getHeader() {
+        return "<html><head><title>PMD</title></head><body>" + PMD.EOL
+                + "<center><h3>PMD report</h3></center><center><h3>Problems found</h3></center><table align=\"center\" cellspacing=\"0\" cellpadding=\"3\"><tr>"
+                + PMD.EOL + "<th>#</th><th>File</th><th>Line</th><th>Problem</th></tr>" + PMD.EOL;
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/PapariTextRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/PapariTextRendererTest.java
@@ -10,6 +10,7 @@ import java.io.Reader;
 import java.io.StringReader;
 
 import net.sourceforge.pmd.PMD;
+import net.sourceforge.pmd.Report.ConfigurationError;
 import net.sourceforge.pmd.Report.ProcessingError;
 
 public class PapariTextRendererTest extends AbstractRendererTst {
@@ -56,7 +57,14 @@ public class PapariTextRendererTest extends AbstractRendererTst {
     @Override
     public String getExpectedError(ProcessingError error) {
         return PMD.EOL + PMD.EOL + "Summary:" + PMD.EOL + PMD.EOL + "    err:  Error" + PMD.EOL + PMD.EOL
-                + "* errors:   0" + PMD.EOL + "* warnings: 0" + PMD.EOL;
+                + "* errors:   1" + PMD.EOL + "* warnings: 0" + PMD.EOL;
+    }
+
+    @Override
+    public String getExpectedError(ConfigurationError error) {
+        return PMD.EOL + PMD.EOL + "Summary:" + PMD.EOL + PMD.EOL + "* rule: Foo" + PMD.EOL
+                + "    err:  a configuration error" + PMD.EOL + PMD.EOL
+                + "* errors:   1" + PMD.EOL + "* warnings: 0" + PMD.EOL;
     }
 
     public static junit.framework.Test suite() {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/SummaryHTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/SummaryHTMLRendererTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import net.sourceforge.pmd.FooRule;
 import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.Report;
+import net.sourceforge.pmd.Report.ConfigurationError;
 import net.sourceforge.pmd.Report.ProcessingError;
 import net.sourceforge.pmd.ReportTest;
 import net.sourceforge.pmd.RuleContext;
@@ -90,6 +91,21 @@ public class SummaryHTMLRendererTest extends AbstractRendererTst {
                 + "</table><hr/><center><h3>Processing errors</h3></center><table align=\"center\" cellspacing=\"0\" cellpadding=\"3\"><tr>"
                 + PMD.EOL + "<th>File</th><th>Problem</th></tr>" + PMD.EOL + "<tr bgcolor=\"lightgrey\"> " + PMD.EOL
                 + "<td>file</td>" + PMD.EOL + "<td>Error</td>" + PMD.EOL + "</tr>" + PMD.EOL
+                + "</table></tr></table></body></html>" + PMD.EOL;
+    }
+    
+    @Override
+    public String getExpectedError(ConfigurationError error) {
+        return "<html><head><title>PMD</title></head><body>" + PMD.EOL + "<center><h2>Summary</h2></center>" + PMD.EOL
+                + "<table align=\"center\" cellspacing=\"0\" cellpadding=\"3\">" + PMD.EOL
+                + "<tr><th>Rule name</th><th>Number of violations</th></tr>" + PMD.EOL + "</table>" + PMD.EOL
+                + "<center><h2>Detail</h2></center><table align=\"center\" cellspacing=\"0\" cellpadding=\"3\"><tr>"
+                + PMD.EOL
+                + "<center><h3>PMD report</h3></center><center><h3>Problems found</h3></center><table align=\"center\" cellspacing=\"0\" cellpadding=\"3\"><tr>"
+                + PMD.EOL + "<th>#</th><th>File</th><th>Line</th><th>Problem</th></tr>" + PMD.EOL
+                + "</table><hr/><center><h3>Configuration errors</h3></center><table align=\"center\" cellspacing=\"0\" cellpadding=\"3\"><tr>"
+                + PMD.EOL + "<th>Rule</th><th>Problem</th></tr>" + PMD.EOL + "<tr bgcolor=\"lightgrey\"> " + PMD.EOL
+                + "<td>Foo</td>" + PMD.EOL + "<td>a configuration error</td>" + PMD.EOL + "</tr>" + PMD.EOL
                 + "</table></tr></table></body></html>" + PMD.EOL;
     }
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/TextRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/TextRendererTest.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.renderers;
 
 import net.sourceforge.pmd.PMD;
+import net.sourceforge.pmd.Report.ConfigurationError;
 import net.sourceforge.pmd.Report.ProcessingError;
 
 public class TextRendererTest extends AbstractRendererTst {
@@ -32,5 +33,10 @@ public class TextRendererTest extends AbstractRendererTst {
     @Override
     public String getExpectedError(ProcessingError error) {
         return "file\t-\tError" + PMD.EOL;
+    }
+
+    @Override
+    public String getExpectedError(ConfigurationError error) {
+        return "Foo\t-\ta configuration error" + PMD.EOL;
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/VBHTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/VBHTMLRendererTest.java
@@ -74,8 +74,8 @@ public class VBHTMLRendererTest extends AbstractRendererTst {
                 + PMD.EOL + "#TableHeader { background-color: #003366; }" + PMD.EOL
                 + "#RowColor1 { background-color: #eeeeee; }" + PMD.EOL + "#RowColor2 { background-color: white; }"
                 + PMD.EOL
-                + "--></style><body><center><br><table border=\"0\" width=\"80%\"><tr id=TableHeader><td><font class=title>&nbsp;Problems found</font></td></tr><tr id=RowColor2><td><font class=body>"
-                + error + "\"</font></td></tr></table></center></body></html>" + PMD.EOL;
+                + "--></style><body><center><br><table border=\"0\" width=\"80%\"><tr id=TableHeader><td colspan=\"2\"><font class=title>&nbsp;Problems found</font></td></tr><tr id=RowColor2><td><font class=body>"
+                + error.getFile() + "</font></td><td><font class=body>" + error.getMsg() + "</font></td></tr></table></center></body></html>" + PMD.EOL;
     }
 
     public static junit.framework.Test suite() {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/VBHTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/VBHTMLRendererTest.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.renderers;
 
 import net.sourceforge.pmd.PMD;
+import net.sourceforge.pmd.Report.ConfigurationError;
 import net.sourceforge.pmd.Report.ProcessingError;
 
 public class VBHTMLRendererTest extends AbstractRendererTst {
@@ -76,6 +77,21 @@ public class VBHTMLRendererTest extends AbstractRendererTst {
                 + PMD.EOL
                 + "--></style><body><center><br><table border=\"0\" width=\"80%\"><tr id=TableHeader><td colspan=\"2\"><font class=title>&nbsp;Problems found</font></td></tr><tr id=RowColor2><td><font class=body>"
                 + error.getFile() + "</font></td><td><font class=body>" + error.getMsg() + "</font></td></tr></table></center></body></html>" + PMD.EOL;
+    }
+    
+    @Override
+    public String getExpectedError(ConfigurationError error) {
+        return "<html><head><title>PMD</title></head><style type=\"text/css\"><!--" + PMD.EOL
+                + "body { background-color: white; font-family:verdana, arial, helvetica, geneva; font-size: 16px; font-style: italic; color: black; }"
+                + PMD.EOL
+                + ".title { font-family: verdana, arial, helvetica,geneva; font-size: 12px; font-weight:bold; color: white; }"
+                + PMD.EOL
+                + ".body { font-family: verdana, arial, helvetica, geneva; font-size: 12px; font-weight:plain; color: black; }"
+                + PMD.EOL + "#TableHeader { background-color: #003366; }" + PMD.EOL
+                + "#RowColor1 { background-color: #eeeeee; }" + PMD.EOL + "#RowColor2 { background-color: white; }"
+                + PMD.EOL
+                + "--></style><body><center><br><table border=\"0\" width=\"80%\"><tr id=TableHeader><td colspan=\"2\"><font class=title>&nbsp;Configuration problems found</font></td></tr><tr id=RowColor2><td><font class=body>"
+                + error.rule().getName() + "</font></td><td><font class=body>" + error.issue() + "</font></td></tr></table></center></body></html>" + PMD.EOL;
     }
 
     public static junit.framework.Test suite() {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
@@ -17,6 +17,7 @@ import org.xml.sax.InputSource;
 import net.sourceforge.pmd.FooRule;
 import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.Report;
+import net.sourceforge.pmd.Report.ConfigurationError;
 import net.sourceforge.pmd.Report.ProcessingError;
 import net.sourceforge.pmd.ReportTest;
 import net.sourceforge.pmd.RuleContext;
@@ -60,6 +61,13 @@ public class XMLRendererTest extends AbstractRendererTst {
     public String getExpectedError(ProcessingError error) {
         return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + PMD.EOL + "<pmd version=\"" + PMD.VERSION
                 + "\" timestamp=\"2014-10-06T19:30:51.222\">" + PMD.EOL + "<error filename=\"file\" msg=\"Error\"/>"
+                + PMD.EOL + "</pmd>" + PMD.EOL;
+    }
+
+    @Override
+    public String getExpectedError(ConfigurationError error) {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + PMD.EOL + "<pmd version=\"" + PMD.VERSION
+                + "\" timestamp=\"2014-10-06T19:30:51.222\">" + PMD.EOL + "<configerror rule=\"Foo\" msg=\"a configuration error\"/>"
                 + PMD.EOL + "</pmd>" + PMD.EOL;
     }
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/YAHTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/YAHTMLRendererTest.java
@@ -11,6 +11,7 @@ import org.junit.After;
 import org.junit.Before;
 
 import net.sourceforge.pmd.PMD;
+import net.sourceforge.pmd.Report.ConfigurationError;
 import net.sourceforge.pmd.Report.ProcessingError;
 
 public class YAHTMLRendererTest extends AbstractRendererTst {
@@ -74,6 +75,11 @@ public class YAHTMLRendererTest extends AbstractRendererTst {
 
     @Override
     public String getExpectedError(ProcessingError error) {
+        return getExpected();
+    }
+
+    @Override
+    public String getExpectedError(ConfigurationError error) {
         return getExpected();
     }
 }

--- a/src/site/markdown/overview/changelog.md
+++ b/src/site/markdown/overview/changelog.md
@@ -12,6 +12,7 @@ This is a major release.
     *   [Revamped Apex CPD](#Revamped_Apex_CPD)
     *   [Java Type Resolution](#Java_Type_Resolution)
     *   [Metrics Framework](#Metrics_Framework)
+    *   [Configuration Error Reporting](#Configuration_Error_Reporting)
     *   [Modified Rules](#Modified_Rules)
     *   [Removed Rules](#Removed_Rules)
 * [Fixed Issues](#Fixed_Issues)
@@ -47,6 +48,25 @@ on the new metrics framework for object-oriented metrics.
 There are already a couple of metrics (e.g. ATFD, WMC, Cyclo, LoC) implemented. More metrics are planned.
 Based on those metrics, rules like "GodClass" detection can be implemented more easily.
 
+#### Configuration Error Reporting
+
+For a long time reports have been notified of configuration errors on rules, but they have remained hidden.
+On a push to make these more evident to users, and help them get the best results out of PMD, we have started
+to include them on the reports.
+
+So far, only reports that include processing errors are showing configuration errors. In other words, the report formats
+providing configuration error reporting are:
+
+*   csv
+*   html
+*   summaryhtml
+*   text
+*   textcolor
+*   vbhtml
+*   xml
+
+As we move forward we will be able to detect and report more configuration errors (ie: incomplete `auxclasspath`)
+and include them to such reports.
 
 #### Modified Rules
 


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `mvn test` passes.
 - [x] `mvn checkstyle:check` passes. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

- All renderers previously including processing errors now also include configuration errors.
- I take the chance to fix a couple of issues with `VBHTMLRenderer`, that was rendering processing errors using `toString()` (which has a default implementation)
- Notice that renderers that didn't previously include processing errors are unmodified
- This resolves part 1 of #194 