### PR TITLE
[core] improve error message

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
@@ -139,28 +139,36 @@ public class Report implements Iterable<RuleViolation> {
      * Represents a processing error, such as a parse error.
      */
     public static class ProcessingError {
-        private final String msg;
+        private final Throwable error;
         private final String file;
 
         /**
          * Creates a new processing error
          *
-         * @param msg
-         *            the error message
+         * @param error
+         *            the error
          * @param file
          *            the file during which the error occurred
          */
-        public ProcessingError(String msg, String file) {
-            this.msg = msg;
+        public ProcessingError(Throwable error, String file) {
+            this.error = error;
             this.file = file;
         }
 
         public String getMsg() {
-            return msg;
+            if (error != null) {
+                return error.getMessage();
+            } else {
+                return null;
+            }
         }
 
         public String getFile() {
             return file;
+        }
+
+        public Throwable getError() {
+            return error;
         }
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
@@ -230,7 +230,7 @@ public class PMDTaskImpl {
         if (failOnError) {
             throw new BuildException(pmde);
         }
-        errorReport.addError(new Report.ProcessingError(pmde.getMessage(), ctx.getSourceCodeFilename()));
+        errorReport.addError(new Report.ProcessingError(pmde, ctx.getSourceCodeFilename()));
     }
 
     private void setupClassLoader() {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/processor/PmdRunnable.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/processor/PmdRunnable.java
@@ -57,7 +57,7 @@ public class PmdRunnable implements Callable<Report> {
     private void addError(Report report, Exception e, String errorMessage) {
         // unexpected exception: log and stop executor service
         LOG.log(Level.FINE, errorMessage, e);
-        report.addError(new Report.ProcessingError(e.getMessage(), fileName));
+        report.addError(new Report.ProcessingError(e, fileName));
     }
 
     @Override

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/AbstractRendererTst.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/AbstractRendererTst.java
@@ -122,7 +122,7 @@ public abstract class AbstractRendererTst {
     @Test
     public void testError() throws Exception {
         Report rep = new Report();
-        Report.ProcessingError err = new Report.ProcessingError("Error", "file");
+        Report.ProcessingError err = new Report.ProcessingError(new RuntimeException("Error"), "file");
         rep.addError(err);
         String actual = ReportTest.render(getRenderer(), rep);
         assertEquals(filter(getExpectedError(err)), filter(actual));


### PR DESCRIPTION
 - [X] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [X] `mvn test` passes.
 - [X] `mvn checkstyle:check` passes. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
Report.ProcessingError should contain more details about the root cause of the issue. This fixes e.g. that maven-pmd-plugin currently only shows "Error while parsing" in case of errors.