### PR TITLE
[java] CommentDefaultAccessModifierRule should consider constructors too

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/comments/CommentDefaultAccessModifierRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/comments/CommentDefaultAccessModifierRule.java
@@ -12,6 +12,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBodyDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclarator;
@@ -82,6 +83,14 @@ public class CommentDefaultAccessModifierRule extends AbstractCommentRule {
         // check for nested classes
         if (decl.isNested() && shouldReport(decl)) {
             addViolationWithMessage(data, decl, String.format(MESSAGE, decl.getImage(), "nested class"));
+        }
+        return super.visit(decl, data);
+    }
+
+    @Override
+    public Object visit(final ASTConstructorDeclaration decl, Object data) {
+        if (shouldReport(decl)) {
+            addViolationWithMessage(data, decl, String.format(MESSAGE, decl.getImage(), "constructor"));
         }
         return super.visit(decl, data);
     }

--- a/pmd-java/src/main/resources/rulesets/java/comments.xml
+++ b/pmd-java/src/main/resources/rulesets/java/comments.xml
@@ -82,9 +82,9 @@ A rule for the politically correct... we don't want to offend anyone.
       message="Missing commented default access modifier"
       externalInfoUrl="${pmd.website.baseurl}/rules/java/comments.html#CommentDefaultAccessModifier">
     <description>
-        To avoid mistakes if we want that a Method, Field or Nested class have a default access modifier
-        we must add a comment at the beginning of the Method, Field or Nested class.
-        By default the comment must be /* default */, if you want another, you have to provide a regex.
+        To avoid mistakes if we want that a Method, Constructor, Field or Nested class have a default access modifier
+        we must add a comment at the beginning of it's declaration.
+        By default the comment must be /* default */, if you want another, you have to provide a regexp.
     </description>
     <priority>3</priority>
     <properties>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/comments/xml/CommentDefaultAccessModifier.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/comments/xml/CommentDefaultAccessModifier.xml
@@ -158,4 +158,26 @@ public class CommentDefaultAccessModifier {
 }
         ]]></code>
     </test-code>
+    
+    <test-code>
+        <description>#536 Constructor with default access modifier should trigger</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    Foo() {}
+}
+        ]]></code>
+    </test-code>
+    
+    <test-code>
+        <description>#536 Enum constructor with implicit private modifier should not trigger</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public enum Bar {
+    ONE, TWO;
+    
+    Bar() {}
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/src/site/markdown/overview/changelog.md
+++ b/src/site/markdown/overview/changelog.md
@@ -91,6 +91,8 @@ and include them to such reports.
     *   [#487](https://github.com/pmd/pmd/pull/487): \[java] Fix typeresolution for anonymous extending object
     *   [#496](https://github.com/pmd/pmd/issues/496): \[java] processing error on generics inherited from enclosing class
     *   [#527](https://github.com/pmd/pmd/issues/527): \[java] Lombok getter annotation on enum is not recognized correctly
+*   java-comments
+    *   [#536](https://github.com/pmd/pmd/issues/536): \[java] CommentDefaultAccessModifierRule ignores constructors
 *   java-controversial
     *   [#408](https://github.com/pmd/pmd/issues/408): \[java] DFA not analyzing asserts
 *   java-sunsecure


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `mvn test` passes.
 - [x] `mvn checkstyle:check` passes. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
 - Resolves #536
