### PR TITLE
[java] Fix 521: UnusedPrivateMethod returns false positives with primitive data type in map argument

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTType.java
@@ -23,11 +23,11 @@ public class ASTType extends AbstractJavaTypeNode {
     }
 
     public String getTypeImage() {
-        ASTPrimitiveType prim = getFirstDescendantOfType(ASTPrimitiveType.class);
-        if (prim != null) {
-            return prim.getImage();
+        ASTClassOrInterfaceType refType = getFirstDescendantOfType(ASTClassOrInterfaceType.class);
+        if (refType != null) {
+            return refType.getImage();
         }
-        return getFirstDescendantOfType(ASTClassOrInterfaceType.class).getImage();
+        return getFirstDescendantOfType(ASTPrimitiveType.class).getImage();
     }
 
     public int getArrayDepth() {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/unusedcode/xml/UnusedPrivateMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/unusedcode/xml/UnusedPrivateMethod.xml
@@ -1531,4 +1531,22 @@ public class Something {
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#521 UnusedPrivateMethod returns false positives with primitive data type in map argument</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+        public class Foo {
+          public Foo() {
+            Map<String, double[]> map = new LinkedHashMap<>();
+            addToMap(map);
+          }
+
+          private void addToMap(Map<String, double[]> map) {
+            map.put("foo", new double[]{0., 1.});
+          }
+        }
+        ]]></code>
+    </test-code>
+
 </test-data>


### PR DESCRIPTION
Fixes #521

The problem was caused by the method `ASTType.getTypeImage`, which looked greedily for a primitive type before looking for a reference type. That made `addToMap`'s formal parameter (of type `Map<String, double[]>`), which is parameterized with a primitive type, have a type image of `"double"`, which made the comparison fail when [comparing](https://github.com/pmd/pmd/blob/585a555ba5ccafc1c152f89e3d362f2a8a779b57/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/ClassScope.java#L244-L249) the name occurence with the name declaration.