### PR TITLE
[java] Refactored ParserTst into a static utility class + add getSourceFromClass

### DIFF
--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ParserTst.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ParserTst.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.StringReader;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
@@ -15,6 +17,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.commons.io.IOUtils;
+
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.lang.LanguageVersionHandler;
@@ -25,7 +29,7 @@ import net.sourceforge.pmd.lang.java.symboltable.SymbolFacade;
 
 public abstract class ParserTst {
 
-    private class Collector<E> implements InvocationHandler {
+    private static class Collector<E> implements InvocationHandler {
         private Class<E> clazz = null;
         private Collection<E> collection;
 
@@ -46,13 +50,13 @@ public abstract class ParserTst {
                 SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
             if (method.getName().equals("visit")) {
                 if (clazz.isInstance(params[0])) {
-                    collection.add((E) params[0]);
+                    collection.add(clazz.cast(params[0]));
                 }
             }
 
             Method childrenAccept = params[0].getClass().getMethod("childrenAccept",
-                    new Class[] { JavaParserVisitor.class, Object.class });
-            childrenAccept.invoke(params[0], new Object[] { proxy, null });
+                                                                   JavaParserVisitor.class, Object.class);
+            childrenAccept.invoke(params[0], (JavaParserVisitor) proxy, null);
             return null;
         }
     }
@@ -61,7 +65,7 @@ public abstract class ParserTst {
         return getNodes(LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getDefaultVersion(), clazz, javaCode);
     }
 
-    public <E> Set<E> getNodes(LanguageVersion languageVersion, Class<E> clazz, String javaCode) {
+    protected <E> Set<E> getNodes(LanguageVersion languageVersion, Class<E> clazz, String javaCode) {
         Collector<E> coll = new Collector<>(clazz);
         LanguageVersionHandler languageVersionHandler = languageVersion.getLanguageVersionHandler();
         ASTCompilationUnit cu = (ASTCompilationUnit) languageVersionHandler
@@ -72,7 +76,7 @@ public abstract class ParserTst {
         return (Set<E>) coll.getCollection();
     }
 
-    public <E> List<E> getOrderedNodes(Class<E> clazz, String javaCode) {
+    protected <E> List<E> getOrderedNodes(Class<E> clazz, String javaCode) {
         Collector<E> coll = new Collector<>(clazz, new ArrayList<E>());
         LanguageVersionHandler languageVersionHandler = LanguageRegistry.getLanguage(JavaLanguageModule.NAME)
                 .getDefaultVersion().getLanguageVersionHandler();
@@ -99,7 +103,7 @@ public abstract class ParserTst {
         return sb.toString();
     }
 
-    public ASTCompilationUnit buildDFA(String javaCode) {
+    protected ASTCompilationUnit buildDFA(String javaCode) {
         LanguageVersionHandler languageVersionHandler = LanguageRegistry.getLanguage(JavaLanguageModule.NAME)
                 .getDefaultVersion().getLanguageVersionHandler();
         ASTCompilationUnit cu = (ASTCompilationUnit) languageVersionHandler
@@ -112,31 +116,87 @@ public abstract class ParserTst {
         return cu;
     }
 
-    public ASTCompilationUnit parseJava13(String code) {
-        return parseJava(LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.3"), code);
+    /** @see #parseJava(String, String)  */
+    protected ASTCompilationUnit parseJava13(String code) {
+        return parseJava("1.3", code);
     }
 
-    public ASTCompilationUnit parseJava14(String code) {
-        return parseJava(LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.4"), code);
+    /** @see #parseJava(String, String)  */
+    protected ASTCompilationUnit parseJava14(String code) {
+        return parseJava("1.4", code);
     }
 
-    public ASTCompilationUnit parseJava15(String code) {
-        return parseJava(LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"), code);
+    /** @see #parseJava(String, String)  */
+    protected ASTCompilationUnit parseJava15(String code) {
+        return parseJava("1.5", code);
     }
 
-    public ASTCompilationUnit parseJava17(String code) {
-        return parseJava(LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.7"), code);
+    /** @see #parseJava(String, String)  */
+    protected ASTCompilationUnit parseJava17(String code) {
+        return parseJava("1.7", code);
     }
 
-    public ASTCompilationUnit parseJava18(String code) {
-        return parseJava(LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.8"), code);
+    /** @see #parseJava(String, String)  */
+    protected ASTCompilationUnit parseJava18(String code) {
+        return parseJava("1.8", code);
     }
 
-    public ASTCompilationUnit parseJava(LanguageVersion languageVersion, String code) {
+    /** @see #parseJava(String, String)  */
+    protected ASTCompilationUnit parseJava13(Class<?> source) {
+        return parseJava13(getSourceFromClass(source));
+    }
+
+    /** @see #parseJava(String, String)  */
+    protected ASTCompilationUnit parseJava14(Class<?> source) {
+        return parseJava14(getSourceFromClass(source));
+    }
+
+    /** @see #parseJava(String, String)  */
+    protected ASTCompilationUnit parseJava15(Class<?> source) {
+        return parseJava15(getSourceFromClass(source));
+    }
+
+    /** @see #parseJava(String, String)  */
+    protected ASTCompilationUnit parseJava17(Class<?> source) {
+        return parseJava17(getSourceFromClass(source));
+    }
+
+    /** @see #parseJava(String, String)  */
+    protected ASTCompilationUnit parseJava18(Class<?> source) {
+        return parseJava18(getSourceFromClass(source));
+    }
+
+
+    /**
+     * Parses Java code and executes the symbol table visitor.
+     *
+     * @param version The Java version to use
+     * @param code    The source code
+     *
+     * @return The compilation unit
+     */
+    protected ASTCompilationUnit parseJava(String version, String code) {
+        LanguageVersion languageVersion = LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion(version);
         LanguageVersionHandler languageVersionHandler = languageVersion.getLanguageVersionHandler();
         ASTCompilationUnit rootNode = (ASTCompilationUnit) languageVersionHandler
                 .getParser(languageVersionHandler.getDefaultParserOptions()).parse(null, new StringReader(code));
         languageVersionHandler.getSymbolFacade().start(rootNode);
         return rootNode;
+    }
+
+    private String getSourceFromClass(Class<?> clazz) {
+        String sourceFile = clazz.getName().replace('.', '/') + ".java";
+        InputStream is = ParserTst.class.getClassLoader().getResourceAsStream(sourceFile);
+        if (is == null) {
+            throw new IllegalArgumentException(
+                "Unable to find source file " + sourceFile + " for " + clazz);
+        }
+        String source;
+        try {
+            source = IOUtils.toString(is);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        return source;
     }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ParserTstUtil.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ParserTstUtil.java
@@ -120,75 +120,92 @@ public class ParserTstUtil {
         return cu;
     }
 
-    /** @see #parseJava(String, String)  */
+    /** @see #parseJava(LanguageVersionHandler, String)  */
     public static ASTCompilationUnit parseJava13(String code) {
-        return parseJava("1.3", code);
+        return parseJava(getLanguageVersionHandler("1.3"), code);
     }
 
-    /** @see #parseJava(String, String)  */
+    /** @see #parseJava(LanguageVersionHandler, String)  */
     public static ASTCompilationUnit parseJava14(String code) {
-        return parseJava("1.4", code);
+        return parseJava(getLanguageVersionHandler("1.4"), code);
     }
 
-    /** @see #parseJava(String, String)  */
+    /** @see #parseJava(LanguageVersionHandler, String)  */
     public static ASTCompilationUnit parseJava15(String code) {
-        return parseJava("1.5", code);
+        return parseJava(getLanguageVersionHandler("1.5"), code);
     }
 
-    /** @see #parseJava(String, String)  */
+    /** @see #parseJava(LanguageVersionHandler, String)  */
     public static ASTCompilationUnit parseJava17(String code) {
-        return parseJava("1.7", code);
+        return parseJava(getLanguageVersionHandler("1.7"), code);
     }
 
-    /** @see #parseJava(String, String)  */
+    /** @see #parseJava(LanguageVersionHandler, String)  */
     public static ASTCompilationUnit parseJava18(String code) {
-        return parseJava("1.8", code);
+        return parseJava(getLanguageVersionHandler("1.8"), code);
     }
 
-    /** @see #parseJava(String, String)  */
+    /** @see #parseJava(LanguageVersionHandler, String)  */
     public static ASTCompilationUnit parseJava13(Class<?> source) {
         return parseJava13(getSourceFromClass(source));
     }
 
-    /** @see #parseJava(String, String)  */
+    /** @see #parseJava(LanguageVersionHandler, String)  */
     public static ASTCompilationUnit parseJava14(Class<?> source) {
         return parseJava14(getSourceFromClass(source));
     }
 
-    /** @see #parseJava(String, String)  */
+    /** @see #parseJava(LanguageVersionHandler, String)  */
     public static ASTCompilationUnit parseJava15(Class<?> source) {
         return parseJava15(getSourceFromClass(source));
     }
 
-    /** @see #parseJava(String, String)  */
+    /** @see #parseJava(LanguageVersionHandler, String)  */
     public static ASTCompilationUnit parseJava17(Class<?> source) {
         return parseJava17(getSourceFromClass(source));
     }
 
-    /** @see #parseJava(String, String)  */
+    /** @see #parseJava(LanguageVersionHandler, String)  */
     public static ASTCompilationUnit parseJava18(Class<?> source) {
         return parseJava18(getSourceFromClass(source));
+    }
+
+    /** @see #parseJava(LanguageVersionHandler, String) */
+    public static ASTCompilationUnit parseJavaDefaultVersion(String source) {
+        return parseJava(getDefaultLanguageVersionHandler(), source);
+    }
+
+    /** @see #parseJava(LanguageVersionHandler, String) */
+    public static ASTCompilationUnit parseJavaDefaultVersion(Class<?> source) {
+        return parseJavaDefaultVersion(getSourceFromClass(source));
+    }
+
+
+    public static LanguageVersionHandler getLanguageVersionHandler(String version) {
+        return LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion(version).getLanguageVersionHandler();
+    }
+
+    public static LanguageVersionHandler getDefaultLanguageVersionHandler() {
+        return LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getDefaultVersion().getLanguageVersionHandler();
     }
 
 
     /**
      * Parses Java code and executes the symbol table visitor.
      *
-     * @param version The Java version to use
-     * @param code    The source code
+     * @param languageVersionHandler The version handler for the wanted version
+     * @param code                   The source code
      *
      * @return The compilation unit
      */
-    public static ASTCompilationUnit parseJava(String version, String code) {
-        LanguageVersion languageVersion = LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion(version);
-        LanguageVersionHandler languageVersionHandler = languageVersion.getLanguageVersionHandler();
+    public static ASTCompilationUnit parseJava(LanguageVersionHandler languageVersionHandler, String code) {
         ASTCompilationUnit rootNode = (ASTCompilationUnit) languageVersionHandler
                 .getParser(languageVersionHandler.getDefaultParserOptions()).parse(null, new StringReader(code));
         languageVersionHandler.getSymbolFacade().start(rootNode);
         return rootNode;
     }
 
-    private static String getSourceFromClass(Class<?> clazz) {
+    public static String getSourceFromClass(Class<?> clazz) {
         String sourceFile = clazz.getName().replace('.', '/') + ".java";
         InputStream is = ParserTstUtil.class.getClassLoader().getResourceAsStream(sourceFile);
         if (is == null) {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ParserTstUtil.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ParserTstUtil.java
@@ -27,7 +27,11 @@ import net.sourceforge.pmd.lang.java.ast.JavaParserVisitor;
 import net.sourceforge.pmd.lang.java.dfa.DataFlowFacade;
 import net.sourceforge.pmd.lang.java.symboltable.SymbolFacade;
 
-public abstract class ParserTst {
+public class ParserTstUtil {
+
+    private ParserTstUtil() {
+
+    }
 
     private static class Collector<E> implements InvocationHandler {
         private Class<E> clazz = null;
@@ -61,11 +65,11 @@ public abstract class ParserTst {
         }
     }
 
-    public <E> Set<E> getNodes(Class<E> clazz, String javaCode) {
+    public static <E> Set<E> getNodes(Class<E> clazz, String javaCode) {
         return getNodes(LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getDefaultVersion(), clazz, javaCode);
     }
 
-    protected <E> Set<E> getNodes(LanguageVersion languageVersion, Class<E> clazz, String javaCode) {
+    public static <E> Set<E> getNodes(LanguageVersion languageVersion, Class<E> clazz, String javaCode) {
         Collector<E> coll = new Collector<>(clazz);
         LanguageVersionHandler languageVersionHandler = languageVersion.getLanguageVersionHandler();
         ASTCompilationUnit cu = (ASTCompilationUnit) languageVersionHandler
@@ -76,7 +80,7 @@ public abstract class ParserTst {
         return (Set<E>) coll.getCollection();
     }
 
-    protected <E> List<E> getOrderedNodes(Class<E> clazz, String javaCode) {
+    public static <E> List<E> getOrderedNodes(Class<E> clazz, String javaCode) {
         Collector<E> coll = new Collector<>(clazz, new ArrayList<E>());
         LanguageVersionHandler languageVersionHandler = LanguageRegistry.getLanguage(JavaLanguageModule.NAME)
                 .getDefaultVersion().getLanguageVersionHandler();
@@ -93,7 +97,7 @@ public abstract class ParserTst {
         return (List<E>) coll.getCollection();
     }
 
-    public <E> String dumpNodes(List<E> list) {
+    public static <E> String dumpNodes(List<E> list) {
         StringBuilder sb = new StringBuilder();
         int index = 0;
         for (E item : list) {
@@ -103,7 +107,7 @@ public abstract class ParserTst {
         return sb.toString();
     }
 
-    protected ASTCompilationUnit buildDFA(String javaCode) {
+    public static ASTCompilationUnit buildDFA(String javaCode) {
         LanguageVersionHandler languageVersionHandler = LanguageRegistry.getLanguage(JavaLanguageModule.NAME)
                 .getDefaultVersion().getLanguageVersionHandler();
         ASTCompilationUnit cu = (ASTCompilationUnit) languageVersionHandler
@@ -117,52 +121,52 @@ public abstract class ParserTst {
     }
 
     /** @see #parseJava(String, String)  */
-    protected ASTCompilationUnit parseJava13(String code) {
+    public static ASTCompilationUnit parseJava13(String code) {
         return parseJava("1.3", code);
     }
 
     /** @see #parseJava(String, String)  */
-    protected ASTCompilationUnit parseJava14(String code) {
+    public static ASTCompilationUnit parseJava14(String code) {
         return parseJava("1.4", code);
     }
 
     /** @see #parseJava(String, String)  */
-    protected ASTCompilationUnit parseJava15(String code) {
+    public static ASTCompilationUnit parseJava15(String code) {
         return parseJava("1.5", code);
     }
 
     /** @see #parseJava(String, String)  */
-    protected ASTCompilationUnit parseJava17(String code) {
+    public static ASTCompilationUnit parseJava17(String code) {
         return parseJava("1.7", code);
     }
 
     /** @see #parseJava(String, String)  */
-    protected ASTCompilationUnit parseJava18(String code) {
+    public static ASTCompilationUnit parseJava18(String code) {
         return parseJava("1.8", code);
     }
 
     /** @see #parseJava(String, String)  */
-    protected ASTCompilationUnit parseJava13(Class<?> source) {
+    public static ASTCompilationUnit parseJava13(Class<?> source) {
         return parseJava13(getSourceFromClass(source));
     }
 
     /** @see #parseJava(String, String)  */
-    protected ASTCompilationUnit parseJava14(Class<?> source) {
+    public static ASTCompilationUnit parseJava14(Class<?> source) {
         return parseJava14(getSourceFromClass(source));
     }
 
     /** @see #parseJava(String, String)  */
-    protected ASTCompilationUnit parseJava15(Class<?> source) {
+    public static ASTCompilationUnit parseJava15(Class<?> source) {
         return parseJava15(getSourceFromClass(source));
     }
 
     /** @see #parseJava(String, String)  */
-    protected ASTCompilationUnit parseJava17(Class<?> source) {
+    public static ASTCompilationUnit parseJava17(Class<?> source) {
         return parseJava17(getSourceFromClass(source));
     }
 
     /** @see #parseJava(String, String)  */
-    protected ASTCompilationUnit parseJava18(Class<?> source) {
+    public static ASTCompilationUnit parseJava18(Class<?> source) {
         return parseJava18(getSourceFromClass(source));
     }
 
@@ -175,7 +179,7 @@ public abstract class ParserTst {
      *
      * @return The compilation unit
      */
-    protected ASTCompilationUnit parseJava(String version, String code) {
+    public static ASTCompilationUnit parseJava(String version, String code) {
         LanguageVersion languageVersion = LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion(version);
         LanguageVersionHandler languageVersionHandler = languageVersion.getLanguageVersionHandler();
         ASTCompilationUnit rootNode = (ASTCompilationUnit) languageVersionHandler
@@ -184,9 +188,9 @@ public abstract class ParserTst {
         return rootNode;
     }
 
-    private String getSourceFromClass(Class<?> clazz) {
+    private static String getSourceFromClass(Class<?> clazz) {
         String sourceFile = clazz.getName().replace('.', '/') + ".java";
-        InputStream is = ParserTst.class.getClassLoader().getResourceAsStream(sourceFile);
+        InputStream is = ParserTstUtil.class.getClassLoader().getResourceAsStream(sourceFile);
         if (is == null) {
             throw new IllegalArgumentException(
                 "Unable to find source file " + sourceFile + " for " + clazz);

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotationTest.java
@@ -4,14 +4,15 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.getNodes;
+
 import org.junit.Test;
 
 import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.java.JavaLanguageModule;
-import net.sourceforge.pmd.lang.java.ParserTst;
 
-public class ASTAnnotationTest extends ParserTst {
+public class ASTAnnotationTest {
 
     @Test
     public void testAnnotationSucceedsWithDefaultMode() {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTAssignmentOperatorTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTAssignmentOperatorTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.getNodes;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -12,25 +13,24 @@ import java.util.Set;
 import org.junit.Test;
 
 import net.sourceforge.pmd.PMD;
-import net.sourceforge.pmd.lang.java.ParserTst;
 
-public class ASTAssignmentOperatorTest extends ParserTst {
+public class ASTAssignmentOperatorTest {
 
     @Test
     public void testSimpleAssignmentRecognized() {
-        Set<ASTAssignmentOperator> ops = super.getNodes(ASTAssignmentOperator.class, TEST1);
+        Set<ASTAssignmentOperator> ops = getNodes(ASTAssignmentOperator.class, TEST1);
         assertFalse((ops.iterator().next()).isCompound());
     }
 
     @Test
     public void testCompoundAssignmentPlusRecognized() {
-        Set<ASTAssignmentOperator> ops = super.getNodes(ASTAssignmentOperator.class, TEST2);
+        Set<ASTAssignmentOperator> ops = getNodes(ASTAssignmentOperator.class, TEST2);
         assertTrue((ops.iterator().next()).isCompound());
     }
 
     @Test
     public void testCompoundAssignmentMultRecognized() {
-        Set<ASTAssignmentOperator> ops = super.getNodes(ASTAssignmentOperator.class, TEST3);
+        Set<ASTAssignmentOperator> ops = getNodes(ASTAssignmentOperator.class, TEST3);
         assertTrue((ops.iterator().next()).isCompound());
     }
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTBlockStatementTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTBlockStatementTest.java
@@ -9,9 +9,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-import net.sourceforge.pmd.lang.java.ParserTst;
-
-public class ASTBlockStatementTest extends ParserTst {
+public class ASTBlockStatementTest {
 
     @Test
     public void testIsAllocation() {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTBooleanLiteralTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTBooleanLiteralTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.getNodes;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -12,9 +13,8 @@ import java.util.Set;
 import org.junit.Test;
 
 import net.sourceforge.pmd.PMD;
-import net.sourceforge.pmd.lang.java.ParserTst;
 
-public class ASTBooleanLiteralTest extends ParserTst {
+public class ASTBooleanLiteralTest {
 
     @Test
     public void testTrue() {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTFieldDeclarationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTFieldDeclarationTest.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.parseJava14;
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.parseJava15;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -11,9 +13,8 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 import net.sourceforge.pmd.PMD;
-import net.sourceforge.pmd.lang.java.ParserTst;
 
-public class ASTFieldDeclarationTest extends ParserTst {
+public class ASTFieldDeclarationTest {
 
     @Test
     public void testIsArray() {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTFormalParameterTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTFormalParameterTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.getNodes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -16,9 +17,8 @@ import org.junit.Test;
 import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.java.JavaLanguageModule;
-import net.sourceforge.pmd.lang.java.ParserTst;
 
-public class ASTFormalParameterTest extends ParserTst {
+public class ASTFormalParameterTest {
 
     @Test
     public void testVarargs() {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTImportDeclarationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTImportDeclarationTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.getNodes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -14,9 +15,8 @@ import org.junit.Test;
 import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.java.JavaLanguageModule;
-import net.sourceforge.pmd.lang.java.ParserTst;
 
-public class ASTImportDeclarationTest extends ParserTst {
+public class ASTImportDeclarationTest {
 
     @Test
     public void testImportOnDemand() {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTInitializerTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTInitializerTest.java
@@ -4,12 +4,13 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.getNodes;
+
 import org.junit.Test;
 
 import net.sourceforge.pmd.PMD;
-import net.sourceforge.pmd.lang.java.ParserTst;
 
-public class ASTInitializerTest extends ParserTst {
+public class ASTInitializerTest {
 
     @Test
     public void testDontCrashOnBlockStatement() {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTLiteralTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTLiteralTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.getNodes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -13,9 +14,8 @@ import java.util.Set;
 import org.junit.Test;
 
 import net.sourceforge.pmd.PMD;
-import net.sourceforge.pmd.lang.java.ParserTst;
 
-public class ASTLiteralTest extends ParserTst {
+public class ASTLiteralTest {
 
     @Test
     public void testIsStringLiteral() {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTLocalVariableDeclarationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTLocalVariableDeclarationTest.java
@@ -4,14 +4,14 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.parseJava14;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
 import net.sourceforge.pmd.PMD;
-import net.sourceforge.pmd.lang.java.ParserTst;
 
-public class ASTLocalVariableDeclarationTest extends ParserTst {
+public class ASTLocalVariableDeclarationTest {
 
     @Test
     public void testSingleDimArray() {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTPackageDeclarationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTPackageDeclarationTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.getNodes;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Set;
@@ -11,9 +12,8 @@ import java.util.Set;
 import org.junit.Test;
 
 import net.sourceforge.pmd.PMD;
-import net.sourceforge.pmd.lang.java.ParserTst;
 
-public class ASTPackageDeclarationTest extends ParserTst {
+public class ASTPackageDeclarationTest {
 
     private static final String PACKAGE_INFO_ANNOTATED = "@Deprecated" + PMD.EOL + "package net.sourceforge.pmd.foobar;"
             + PMD.EOL;

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTPrimarySuffixTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTPrimarySuffixTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.getNodes;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Set;
@@ -11,9 +12,8 @@ import java.util.Set;
 import org.junit.Test;
 
 import net.sourceforge.pmd.PMD;
-import net.sourceforge.pmd.lang.java.ParserTst;
 
-public class ASTPrimarySuffixTest extends ParserTst {
+public class ASTPrimarySuffixTest {
 
     @Test
     public void testArrayDereference() {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchLabelTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchLabelTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.getNodes;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -12,9 +13,8 @@ import java.util.Set;
 import org.junit.Test;
 
 import net.sourceforge.pmd.PMD;
-import net.sourceforge.pmd.lang.java.ParserTst;
 
-public class ASTSwitchLabelTest extends ParserTst {
+public class ASTSwitchLabelTest {
 
     @Test
     public void testDefaultOff() {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTThrowStatementTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTThrowStatementTest.java
@@ -4,19 +4,19 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.getNodes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
 
 import net.sourceforge.pmd.PMD;
-import net.sourceforge.pmd.lang.java.ParserTst;
 
 /**
  * Created on Jan 19, 2005 
  * @author mgriffa
  */
-public class ASTThrowStatementTest extends ParserTst {
+public class ASTThrowStatementTest {
 
     @Test
     public final void testGetFirstASTNameImageNull() {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclaratorIdTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclaratorIdTest.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.getNodes;
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.parseJava18;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -11,9 +13,8 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 import net.sourceforge.pmd.PMD;
-import net.sourceforge.pmd.lang.java.ParserTst;
 
-public class ASTVariableDeclaratorIdTest extends ParserTst {
+public class ASTVariableDeclaratorIdTest {
 
     @Test
     public void testIsExceptionBlockParameter() {
@@ -27,7 +28,7 @@ public class ASTVariableDeclaratorIdTest extends ParserTst {
 
     @Test
     public void testTypeNameNode() {
-        ASTCompilationUnit acu = super.getNodes(ASTCompilationUnit.class, TYPE_NAME_NODE).iterator().next();
+        ASTCompilationUnit acu = getNodes(ASTCompilationUnit.class, TYPE_NAME_NODE).iterator().next();
         ASTVariableDeclaratorId id = acu.findDescendantsOfType(ASTVariableDeclaratorId.class).get(0);
 
         ASTClassOrInterfaceType name = (ASTClassOrInterfaceType) id.getTypeNameNode().jjtGetChild(0);
@@ -36,7 +37,7 @@ public class ASTVariableDeclaratorIdTest extends ParserTst {
 
     @Test
     public void testAnnotations() {
-        ASTCompilationUnit acu = super.getNodes(ASTCompilationUnit.class, TEST_ANNOTATIONS).iterator().next();
+        ASTCompilationUnit acu = getNodes(ASTCompilationUnit.class, TEST_ANNOTATIONS).iterator().next();
         ASTVariableDeclaratorId id = acu.findDescendantsOfType(ASTVariableDeclaratorId.class).get(0);
 
         ASTClassOrInterfaceType name = (ASTClassOrInterfaceType) id.getTypeNameNode().jjtGetChild(0);

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/AccessNodeTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/AccessNodeTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.getNodes;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -11,9 +12,7 @@ import java.util.Set;
 
 import org.junit.Test;
 
-import net.sourceforge.pmd.lang.java.ParserTst;
-
-public class AccessNodeTest extends ParserTst {
+public class AccessNodeTest {
 
     public static class MyAccessNode extends AbstractJavaAccessNode {
         public MyAccessNode(int i) {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ClassDeclTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ClassDeclTest.java
@@ -4,15 +4,14 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.getNodes;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Set;
 
 import org.junit.Test;
 
-import net.sourceforge.pmd.lang.java.ParserTst;
-
-public class ClassDeclTest extends ParserTst {
+public class ClassDeclTest {
 
     @Test
     public void testPublic() {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/EncodingTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/EncodingTest.java
@@ -4,14 +4,14 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.parseJava14;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
 import net.sourceforge.pmd.PMD;
-import net.sourceforge.pmd.lang.java.ParserTst;
 
-public class EncodingTest extends ParserTst {
+public class EncodingTest {
 
     @Test
     public void testDecodingOfUTF8() throws Exception {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/FieldDeclTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/FieldDeclTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.getNodes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -11,9 +12,7 @@ import java.util.Set;
 
 import org.junit.Test;
 
-import net.sourceforge.pmd.lang.java.ParserTst;
-
-public class FieldDeclTest extends ParserTst {
+public class FieldDeclTest {
 
     public String makeAccessJavaCode(String[] access) {
         String result = "public class Test { ";

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/JDKVersionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/JDKVersionTest.java
@@ -4,15 +4,18 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.parseJava13;
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.parseJava14;
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.parseJava15;
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.parseJava17;
+
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
-import net.sourceforge.pmd.lang.java.ParserTst;
-
-public class JDKVersionTest extends ParserTst {
+public class JDKVersionTest {
 
     private static String loadSource(String name) {
         try {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/MethodDeclTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/MethodDeclTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.getNodes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -11,9 +12,7 @@ import java.util.Set;
 
 import org.junit.Test;
 
-import net.sourceforge.pmd.lang.java.ParserTst;
-
-public class MethodDeclTest extends ParserTst {
+public class MethodDeclTest {
 
     @Test
     public void testPublic() {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
@@ -4,6 +4,10 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.parseJava14;
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.parseJava15;
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.parseJava17;
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.parseJava18;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.fail;
@@ -16,9 +20,8 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import net.sourceforge.pmd.PMD;
-import net.sourceforge.pmd.lang.java.ParserTst;
 
-public class ParserCornersTest extends ParserTst {
+public class ParserCornersTest {
 
     /**
      * #1107 PMD 5.0.4 couldn't parse call of parent outer java class method

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/QualifiedNameTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/QualifiedNameTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.getNodes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -13,12 +14,10 @@ import java.util.Set;
 
 import org.junit.Test;
 
-import net.sourceforge.pmd.lang.java.ParserTst;
-
 /**
  * @author Clément Fournier
  */
-public class QualifiedNameTest extends ParserTst {
+public class QualifiedNameTest {
 
 
     @Test

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/SimpleNodeTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/SimpleNodeTest.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.getNodes;
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.parseJava14;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -22,9 +24,8 @@ import org.junit.Test;
 
 import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.java.ParserTst;
 
-public class SimpleNodeTest extends ParserTst {
+public class SimpleNodeTest {
 
     @Test
     public void testMethodDiffLines() {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/dfa/AcceptanceTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/dfa/AcceptanceTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.dfa;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.getOrderedNodes;
 import static org.junit.Assert.assertTrue;
 
 import java.util.List;
@@ -12,13 +13,12 @@ import org.junit.Test;
 
 import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.lang.dfa.DataFlowNode;
-import net.sourceforge.pmd.lang.java.ParserTst;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclarator;
 
 /*
  * Created on 18.08.2004
  */
-public class AcceptanceTest extends ParserTst {
+public class AcceptanceTest {
 
     @Test
     public void testbook() {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/dfa/DAAPathFinderTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/dfa/DAAPathFinderTest.java
@@ -4,16 +4,17 @@
 
 package net.sourceforge.pmd.lang.java.dfa;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.getOrderedNodes;
+
 import org.junit.Test;
 
 import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.lang.dfa.pathfinder.CurrentPath;
 import net.sourceforge.pmd.lang.dfa.pathfinder.DAAPathFinder;
 import net.sourceforge.pmd.lang.dfa.pathfinder.Executable;
-import net.sourceforge.pmd.lang.java.ParserTst;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclarator;
 
-public class DAAPathFinderTest extends ParserTst implements Executable {
+public class DAAPathFinderTest implements Executable {
 
     @Test
     public void testTwoUpdateDefs() {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/dfa/GeneralFiddlingTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/dfa/GeneralFiddlingTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.dfa;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.buildDFA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
@@ -13,11 +14,10 @@ import org.junit.Test;
 
 import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.lang.dfa.DataFlowNode;
-import net.sourceforge.pmd.lang.java.ParserTst;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclarator;
 
-public class GeneralFiddlingTest extends ParserTst {
+public class GeneralFiddlingTest {
 
     /**
      * Unit test for https://sourceforge.net/p/pmd/bugs/1325/

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/dfa/StatementAndBraceFinderTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/dfa/StatementAndBraceFinderTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.dfa;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.getOrderedNodes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -14,7 +15,6 @@ import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.dfa.DataFlowNode;
 import net.sourceforge.pmd.lang.dfa.NodeType;
 import net.sourceforge.pmd.lang.java.JavaLanguageModule;
-import net.sourceforge.pmd.lang.java.ParserTst;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
@@ -22,7 +22,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTStatementExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
 
-public class StatementAndBraceFinderTest extends ParserTst {
+public class StatementAndBraceFinderTest {
 
     @Test
     public void testStatementExpressionParentChildLinks() {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/JavaMetricsVisitorTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/JavaMetricsVisitorTest.java
@@ -8,16 +8,10 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringReader;
-
-import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
-import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersionHandler;
-import net.sourceforge.pmd.lang.java.JavaLanguageModule;
+import net.sourceforge.pmd.lang.java.ParserTstUtil;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.JavaParserVisitorAdapter;
@@ -27,7 +21,6 @@ import net.sourceforge.pmd.lang.java.metrics.signature.JavaOperationSigMask;
 import net.sourceforge.pmd.lang.java.metrics.signature.JavaOperationSignature.Role;
 import net.sourceforge.pmd.lang.java.metrics.signature.JavaSignature.Visibility;
 import net.sourceforge.pmd.lang.java.metrics.testdata.MetricsVisitorTestData;
-import net.sourceforge.pmd.typeresolution.ClassTypeResolverTest;
 
 /**
  * Tests of the metrics visitor.
@@ -45,7 +38,7 @@ public class JavaMetricsVisitorTest {
 
     @Test
     public void testOperationsAreThere() {
-        ASTCompilationUnit acu = parseAndVisitForClass15(MetricsVisitorTestData.class);
+        ASTCompilationUnit acu = parseAndVisitForClass(MetricsVisitorTestData.class);
 
         final JavaSignatureMatcher toplevel = JavaMetrics.getFacade().getTopLevelPackageStats();
 
@@ -64,7 +57,7 @@ public class JavaMetricsVisitorTest {
 
     @Test
     public void testFieldsAreThere() {
-        parseAndVisitForClass15(MetricsVisitorTestData.class);
+        parseAndVisitForClass(MetricsVisitorTestData.class);
 
 
         final JavaSignatureMatcher toplevel = JavaMetrics.getFacade().getTopLevelPackageStats();
@@ -88,7 +81,7 @@ public class JavaMetricsVisitorTest {
     // problem
     @Test
     public void testStaticOperationsSig() {
-        parseAndVisitForClass15(MetricsVisitorTestData.class);
+        parseAndVisitForClass(MetricsVisitorTestData.class);
 
         final JavaSignatureMatcher toplevel = JavaMetrics.getFacade().getTopLevelPackageStats();
 
@@ -108,42 +101,11 @@ public class JavaMetricsVisitorTest {
     }
 
 
-    /* default */
-    static ASTCompilationUnit parseAndVisitForClass15(Class<?> clazz) {
-        return parseAndVisitForClass(clazz, "1.5");
-    }
-
-
-    // Note: If you're using Eclipse or some other IDE to run this test, you
-    // _must_ have the src/test/java folder in
-    // the classpath. Normally the IDE doesn't put source directories themselves
-    // directly in the classpath, only
-    // the output directories are in the classpath.
-    private static ASTCompilationUnit parseAndVisitForClass(Class<?> clazz, String version) {
-        String sourceFile = clazz.getName().replace('.', '/') + ".java";
-        InputStream is = ClassTypeResolverTest.class.getClassLoader().getResourceAsStream(sourceFile);
-        if (is == null) {
-            throw new IllegalArgumentException(
-                "Unable to find source file " + sourceFile + " for " + clazz);
-        }
-        String source;
-        try {
-            source = IOUtils.toString(is);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        return parseAndVisitForString(source, version);
-    }
-
-
-    private static ASTCompilationUnit parseAndVisitForString(String source, String version) {
-        LanguageVersionHandler languageVersionHandler = LanguageRegistry.getLanguage(JavaLanguageModule.NAME)
-                                                                        .getVersion(version).getLanguageVersionHandler();
-        ASTCompilationUnit acu = (ASTCompilationUnit) languageVersionHandler
-            .getParser(languageVersionHandler.getDefaultParserOptions()).parse(null, new StringReader(source));
-        languageVersionHandler.getSymbolFacade().start(acu);
-        languageVersionHandler.getTypeResolutionFacade(JavaMetricsVisitorTest.class.getClassLoader()).start(acu);
-        languageVersionHandler.getMetricsVisitorFacade().start(acu);
+    static ASTCompilationUnit parseAndVisitForClass(Class<?> clazz) {
+        ASTCompilationUnit acu = ParserTstUtil.parseJavaDefaultVersion(clazz);
+        LanguageVersionHandler handler = ParserTstUtil.getDefaultLanguageVersionHandler();
+        handler.getTypeResolutionFacade(JavaMetricsVisitorTest.class.getClassLoader()).start(acu);
+        handler.getMetricsVisitorFacade().start(acu);
         return acu;
     }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/PackageStatsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/PackageStatsTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.metrics;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.getOrderedNodes;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -12,7 +13,6 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
 
-import net.sourceforge.pmd.lang.java.ParserTst;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodOrConstructorDeclaration;
@@ -27,7 +27,7 @@ import net.sourceforge.pmd.lang.java.metrics.signature.JavaOperationSignature;
  *
  * @author Clément Fournier
  */
-public class PackageStatsTest extends ParserTst {
+public class PackageStatsTest {
 
     private PackageStats pack;
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/ProjectMemoizerTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/ProjectMemoizerTest.java
@@ -4,7 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.metrics;
 
-import static net.sourceforge.pmd.lang.java.metrics.JavaMetricsVisitorTest.parseAndVisitForClass15;
+import static net.sourceforge.pmd.lang.java.metrics.JavaMetricsVisitorTest.parseAndVisitForClass;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -38,7 +38,7 @@ public class ProjectMemoizerTest {
 
     @Test
     public void memoizationTest() {
-        ASTCompilationUnit acu = parseAndVisitForClass15(MetricsVisitorTestData.class);
+        ASTCompilationUnit acu = parseAndVisitForClass(MetricsVisitorTestData.class);
 
         List<Integer> expected = visitWith(acu, true);
         List<Integer> real = visitWith(acu, false);
@@ -49,7 +49,7 @@ public class ProjectMemoizerTest {
 
     @Test
     public void forceMemoizationTest() {
-        ASTCompilationUnit acu = parseAndVisitForClass15(MetricsVisitorTestData.class);
+        ASTCompilationUnit acu = parseAndVisitForClass(MetricsVisitorTestData.class);
 
         List<Integer> reference = visitWith(acu, true);
         List<Integer> real = visitWith(acu, true);

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/SigMaskTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/SigMaskTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.metrics;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.getOrderedNodes;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -11,7 +12,6 @@ import java.util.List;
 
 import org.junit.Test;
 
-import net.sourceforge.pmd.lang.java.ParserTst;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
@@ -27,7 +27,7 @@ import net.sourceforge.pmd.lang.metrics.SigMask;
 /**
  * @author Clément Fournier
  */
-public class SigMaskTest extends ParserTst {
+public class SigMaskTest {
 
     private static final String TEST_FIELDS = "class Bzaz{"
         + "public String x;"

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/SignatureTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/SignatureTest.java
@@ -4,19 +4,17 @@
 
 package net.sourceforge.pmd.lang.java.metrics;
 
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.getOrderedNodes;
+import static net.sourceforge.pmd.lang.java.ParserTstUtil.parseJava17;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
-import net.sourceforge.pmd.lang.java.ParserTst;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
@@ -29,14 +27,13 @@ import net.sourceforge.pmd.lang.java.metrics.signature.JavaSignature;
 import net.sourceforge.pmd.lang.java.metrics.signature.JavaSignature.Visibility;
 import net.sourceforge.pmd.lang.java.metrics.testdata.GetterDetection;
 import net.sourceforge.pmd.lang.java.metrics.testdata.SetterDetection;
-import net.sourceforge.pmd.typeresolution.ClassTypeResolverTest;
 
 /**
  * Test class for {@link JavaSignature} and its subclasses.
  *
  * @author Clément Fournier
  */
-public class SignatureTest extends ParserTst {
+public class SignatureTest {
 
     // common to operation and field signatures
     @Test
@@ -106,7 +103,7 @@ public class SignatureTest extends ParserTst {
 
     @Test
     public void testGetterDetection() {
-        ASTCompilationUnit compilationUnit = parseClass(GetterDetection.class);
+        ASTCompilationUnit compilationUnit = parseJava17(GetterDetection.class);
 
         compilationUnit.jjtAccept(new JavaParserVisitorAdapter() {
             @Override
@@ -119,7 +116,7 @@ public class SignatureTest extends ParserTst {
 
     @Test
     public void testSetterDetection() {
-        ASTCompilationUnit compilationUnit = parseClass(SetterDetection.class);
+        ASTCompilationUnit compilationUnit = parseJava17(SetterDetection.class);
 
         compilationUnit.jjtAccept(new JavaParserVisitorAdapter() {
             @Override
@@ -269,22 +266,5 @@ public class SignatureTest extends ParserTst {
             assertTrue(sigs2.get(i) == sigs2.get(i + 1));
         }
     }
-
-    private ASTCompilationUnit parseClass(Class<?> clazz) {
-        String sourceFile = clazz.getName().replace('.', '/') + ".java";
-        InputStream is = ClassTypeResolverTest.class.getClassLoader().getResourceAsStream(sourceFile);
-        if (is == null) {
-            throw new IllegalArgumentException(
-                "Unable to find source file " + sourceFile + " for " + clazz);
-        }
-        String source;
-        try {
-            source = IOUtils.toString(is);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        return parseJava17(source);
-    }
-
 
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
@@ -8,17 +8,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.StringTokenizer;
 
-import org.apache.commons.io.IOUtils;
 import org.jaxen.JaxenException;
-
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -26,6 +22,7 @@ import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersionHandler;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.JavaLanguageModule;
+import net.sourceforge.pmd.lang.java.ParserTstUtil;
 import net.sourceforge.pmd.lang.java.ast.ASTAllocationExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTBooleanLiteral;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
@@ -1495,18 +1492,7 @@ public class ClassTypeResolverTest {
     // directly in the classpath, only
     // the output directories are in the classpath.
     private ASTCompilationUnit parseAndTypeResolveForClass(Class<?> clazz, String version) {
-        String sourceFile = clazz.getName().replace('.', '/') + ".java";
-        InputStream is = ClassTypeResolverTest.class.getClassLoader().getResourceAsStream(sourceFile);
-        if (is == null) {
-            throw new IllegalArgumentException("Unable to find source file " + sourceFile + " for " + clazz);
-        }
-        String source;
-        try {
-            source = IOUtils.toString(is);
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-        return parseAndTypeResolveForString(source, version);
+        return parseAndTypeResolveForString(ParserTstUtil.getSourceFromClass(clazz), version);
     }
 
     private ASTCompilationUnit parseAndTypeResolveForString(String source, String version) {


### PR DESCRIPTION
I added some functionality to ParserTst. That may reduce code duplication, e.g. [there](https://github.com/pmd/pmd/blob/52d78d2fa97913cf73814d0307a1c1ae6125a437/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java#L1488-L1521) and [there](https://github.com/pmd/pmd/blob/52d78d2fa97913cf73814d0307a1c1ae6125a437/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/JavaMetricsVisitorTest.java#L112-L149), and in the upcoming "multifile analysis" visitor. 

Now we can extend ParserTst and parse a class from a class literal out of the box, then apply the visitors we want. Maybe it would even make more sense to put all that in a static `JavaParserUtil` class, that way we need not extend ParserTst

