### PR TITLE
[java] Fix #357: UncommentedEmptyConstructor consider annotations on Constructor

### DIFF
--- a/pmd-java/src/main/resources/rulesets/java/design.xml
+++ b/pmd-java/src/main/resources/rulesets/java/design.xml
@@ -1413,6 +1413,7 @@ public void doSomething() {
           since="3.4"
           message="Document empty constructor"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
+          typeResolution="true"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/design.html#UncommentedEmptyConstructor">
       <description>
 Uncommented Empty Constructor finds instances where a constructor does not
@@ -1427,7 +1428,7 @@ and unintentional empty constructors.
     <![CDATA[
 //ConstructorDeclaration[@Private='false']
                         [count(BlockStatement) = 0 and ($ignoreExplicitConstructorInvocation = 'true' or not(ExplicitConstructorInvocation)) and @containsComment = 'false']
-                        [not(../Annotation/MarkerAnnotation/Name[@Image='Inject'])]
+                        [not(../Annotation/MarkerAnnotation/Name[typeof(@Image, 'javax.inject.Inject', 'Inject')])]
 ]]>
              </value>
           </property>

--- a/pmd-java/src/main/resources/rulesets/java/design.xml
+++ b/pmd-java/src/main/resources/rulesets/java/design.xml
@@ -1425,8 +1425,10 @@ and unintentional empty constructors.
           <property name="xpath">
               <value>
     <![CDATA[
-//ConstructorDeclaration[@Private='false'][count(BlockStatement) = 0 and ($ignoreExplicitConstructorInvocation = 'true' or not(ExplicitConstructorInvocation)) and @containsComment = 'false']
- ]]>
+//ConstructorDeclaration[@Private='false']
+                        [count(BlockStatement) = 0 and ($ignoreExplicitConstructorInvocation = 'true' or not(ExplicitConstructorInvocation)) and @containsComment = 'false']
+                        [not(../Annotation/MarkerAnnotation/Name[@Image='Inject'])]
+]]>
              </value>
           </property>
           <property name="ignoreExplicitConstructorInvocation" type="Boolean" description="Ignore explicit constructor invocation when deciding whether constructor is empty or not" value="false"/>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UncommentedEmptyConstructor.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UncommentedEmptyConstructor.xml
@@ -170,4 +170,19 @@ public class WebAgent {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#357 UncommentedEmptyConstructor consider annotations on Constructor</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+        import javax.inject.Inject;
+
+        public class MyClass {
+          @Inject MyClass() {
+
+          }
+        }
+        ]]>
+        </code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
This whitelists annotations called `Inject`, but not specifically `javax.inject.Inject`
