### PR TITLE
[core] java9 build updates

### DIFF
--- a/pmd-dist/pom.xml
+++ b/pmd-dist/pom.xml
@@ -189,7 +189,7 @@
         <profile>
             <id>jdk8-modules</id>
             <activation>
-                <jdk>1.8</jdk>
+                <jdk>[1.8,</jdk>
             </activation>
             <dependencies>
                 <dependency>
@@ -217,6 +217,7 @@
             </activation>
             <dependencies>
                 <!--
+                    https://github.com/scala/scala-dev/issues/139
                     https://issues.scala-lang.org/browse/SI-9103
                     https://sourceforge.net/p/pmd/bugs/1314/
                  -->

--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
         <pmd.plugin.version>3.8</pmd.plugin.version>
         <java.version>1.7</java.version>
         <ant.version>1.9.6</ant.version>
-        <javadoc.plugin.version>2.10.4</javadoc.plugin.version>
+        <javadoc.plugin.version>3.0.0-M1</javadoc.plugin.version>
         <antlr.version>4.5.2-1</antlr.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -904,7 +904,7 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
         <profile>
             <id>jdk8-modules</id>
             <activation>
-                <jdk>1.8</jdk>
+                <jdk>[1.8,</jdk>
             </activation>
             <modules>
                 <module>pmd-apex</module>
@@ -921,6 +921,7 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
             </activation>
             <modules>
                 <!--
+                    https://github.com/scala/scala-dev/issues/139
                     https://issues.scala-lang.org/browse/SI-9103
                     https://sourceforge.net/p/pmd/bugs/1314/
                  -->


### PR DESCRIPTION
Just some small updates, so that PMD can be built with a java9 environment.

* Updates the javadoc maven plugin, so that PMD can be built
  with a java9+mvn3.5.0 environment
* Makes sure, that the java8 modules are also enabled for java9
  and later

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `mvn test` passes.
 - [x] `mvn checkstyle:check` passes. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)



