### PR TITLE
[core] Provide an XML Schema for XML reports

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -61,6 +61,8 @@ PMD release, the metrics framework is supported for both Java and Apex.
 
 A number of improvements on error reporting have taken place, meaning changes to some of the report formats.
 
+Also of note, the xml report now provides a XML Schema definition, allowing easier parsing and validation.
+
 ##### Processing Errors
 
 Processing errors can now provide not only the message previously included on some reports, but also a full stacktrace.
@@ -139,6 +141,8 @@ All existing rules have been updated to reflect these changes. If you have custo
 
 ### Fixed Issues
 
+*   all
+    *   [#538](https://github.com/pmd/pmd/issues/538): \[core] Provide an XML Schema for XML reports
 *   apex
     *   [#488](https://github.com/pmd/pmd/pull/488): \[apex] Use Apex lexer for CPD
     *   [#489](https://github.com/pmd/pmd/pull/489): \[apex] Update Apex compiler

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XMLRenderer.java
@@ -178,7 +178,10 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
     }
 
     private void createVersionAttr(StringBuilder buffer) {
-        buffer.append("<pmd version=\"").append(PMD.VERSION).append('"');
+        buffer.append("<pmd xmlns=\"http://pmd.sourceforge.net/report/2.0.0\"").append(PMD.EOL)
+            .append("    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"").append(PMD.EOL)
+            .append("    xsi:schemaLocation=\"http://pmd.sourceforge.net/report/2.0.0 http://pmd.sourceforge.net/report_2_0_0.xsd\"").append(PMD.EOL)
+            .append("    version=\"").append(PMD.VERSION).append('"');
     }
 
     private void createTimestampAttr(StringBuilder buffer) {

--- a/pmd-core/src/main/resources/pmd-nicerhtml.xsl
+++ b/pmd-core/src/main/resources/pmd-nicerhtml.xsl
@@ -1,26 +1,26 @@
-<xsl:stylesheet	version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+<xsl:stylesheet	version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+	xmlns:pmd="http://pmd.sourceforge.net/report/2.0.0">
 <xsl:output method="xml" indent="yes" doctype-public="-//W3C//DTD XHTML 1.0 Transitional//EN"
-doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" />
+	doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" />
 <xsl:decimal-format decimal-separator="." grouping-separator="," />
 
 <!-- keys for violations list -->
-<xsl:key name="violations" match="violation" use="@rule" />
+<xsl:key name="violations" match="pmd:violation" use="@rule" />
 
 <!-- XSL for PMD report. Author : Fabien Bancharel. -->
 <!-- Inspired by Checkstyle -->
 
 <xsl:template name="timestamp">
 	<!--** Timestamp processing to display date -->
-	<xsl:value-of select="substring-before(//pmd/@timestamp, 'T')"/> - <xsl:value-of select="substring-before(substring-after(//pmd/@timestamp, 'T'), '.')"/>
+	<xsl:value-of select="substring-before(//pmd:pmd/@timestamp, 'T')"/> - <xsl:value-of select="substring-before(substring-after(//pmd:pmd/@timestamp, 'T'), '.')"/>
 </xsl:template>
 
 
-
-<xsl:template match="pmd">
+<xsl:template match="pmd:pmd">
 	<!--** Process root node pmd : html header, style, call templates -->
 	<html>
 		<head>
-		<title>PMD <xsl:value-of select="//pmd/@version"/> Report</title>
+		<title>PMD <xsl:value-of select="//pmd:pmd/@version"/> Report</title>
 		<style type="text/css">
     .bannercell {
       border: 0px;
@@ -85,7 +85,7 @@ doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" />
       <tr>
         <td class="bannercell" rowspan="2">
         </td>
-    	<td class="text-align:right"><h2>PMD <xsl:value-of select="//pmd/@version"/> Report. Generated on <xsl:call-template name="timestamp"/></h2></td>
+    	<td class="text-align:right"><h2>PMD <xsl:value-of select="//pmd:pmd/@version"/> Report. Generated on <xsl:call-template name="timestamp"/></h2></td>
       </tr>
       </table>
     	<hr size="1"/>
@@ -103,7 +103,7 @@ doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" />
 			<hr size="1" width="100%" align="left"/>
 
 			<!-- For each file create its part -->
-            <xsl:apply-templates select="file" />
+            <xsl:apply-templates select="pmd:file" />
 
 			<hr size="1" width="100%" align="left"/>
 
@@ -113,7 +113,7 @@ doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" />
 </xsl:template>
 
 
-	<xsl:template match="pmd" mode="rulelist">
+	<xsl:template match="pmd:pmd" mode="rulelist">
 	<!--** Process root node pmd, for mode 'rulelist' : violated rules -->
 	<h3>Rules</h3>
 	<table class="log" border="0" cellpadding="5" cellspacing="2"
@@ -125,7 +125,7 @@ doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" />
 		</tr>
 
 		<xsl:for-each
-			select="file/violation[@rule and generate-id(.) = generate-id(key('violations', @rule))]">
+			select="pmd:file/pmd:violation[@rule and generate-id(.) = generate-id(key('violations', @rule))]">
 			<!-- Sort by number of violations -->
 			<xsl:sort data-type="number" order="descending"
 				select="count(key('violations', @rule))" />
@@ -133,7 +133,7 @@ doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" />
 			<xsl:variable name="currentRule" select="@rule" />
 			<xsl:variable name="currentSeverity" select="@priority" />
 			<xsl:variable name="violationCount"
-				select="count(../../file/violation[@rule=$currentRule])" />
+				select="count(../../pmd:file/pmd:violation[@rule=$currentRule])" />
 
 			<tr>
 				<xsl:call-template name="alternated-row" />
@@ -154,7 +154,7 @@ doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" />
 	</xsl:template>
 
 
-	<xsl:template match="pmd" mode="filelist">
+	<xsl:template match="pmd:pmd" mode="filelist">
 	<!--** Process root node pmd, for mode 'filelist' : number of violations for each file -->
 	<h3>Files</h3>
 	<table class="log" border="0" cellpadding="5" cellspacing="2"
@@ -169,10 +169,10 @@ doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" />
 		</tr>
 
 		<xsl:for-each
-			select="file">
+			select="pmd:file">
 			<!-- Sort by number of violations -->
 			<xsl:sort data-type="number" order="descending"
-				select="count(violation)" />
+				select="count(pmd:violation)" />
 
 			<xsl:variable name="currentSource" select="@name" />
 
@@ -182,11 +182,11 @@ doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" />
 						<xsl:variable name="anchor" select="translate(@name, '\/', '__')"></xsl:variable>
 						<a href="#f-{$anchor}"><xsl:value-of select="@name" /></a>
 					</td>
-					<td><xsl:value-of select="count(violation[@priority = 5])" /></td>
-					<td><xsl:value-of select="count(violation[@priority = 4])" /></td>
-					<td><xsl:value-of select="count(violation[@priority = 3])" /></td>
-					<td><xsl:value-of select="count(violation[@priority = 2])" /></td>
-					<td><xsl:value-of select="count(violation[@priority = 1])" /></td>
+					<td><xsl:value-of select="count(pmd:violation[@priority = 5])" /></td>
+					<td><xsl:value-of select="count(pmd:violation[@priority = 4])" /></td>
+					<td><xsl:value-of select="count(pmd:violation[@priority = 3])" /></td>
+					<td><xsl:value-of select="count(pmd:violation[@priority = 2])" /></td>
+					<td><xsl:value-of select="count(pmd:violation[@priority = 1])" /></td>
 				</tr>
 
 		</xsl:for-each>
@@ -194,7 +194,7 @@ doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" />
 	</xsl:template>
 
 
-	<xsl:template match="file">
+	<xsl:template match="pmd:file">
 		<!--** Process node 'file' : violations details -->
 		<xsl:variable name="anchor" select="translate(@name, '\/', '__')"></xsl:variable>
 		<a name="f-{$anchor}"></a>
@@ -207,7 +207,7 @@ doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" />
 				<th>Error Description</th>
 				<th style="width:40px;">Line</th>
 			</tr>
-			<xsl:for-each select="violation">
+			<xsl:for-each select="pmd:violation">
 				<xsl:variable name="currentSeverity" select="@priority" />
 				<tr>
 					<xsl:call-template name="alternated-row" />
@@ -219,9 +219,9 @@ doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" />
 						 -
 						 <xsl:choose>
 						 <xsl:when test="@externalInfoUrl">
-						 <a href="{@externalInfoUrl}"><xsl:value-of select="." disable-output-escaping="yes" /></a>
+						 <a href="{@externalInfoUrl}"><xsl:value-of select="text()" disable-output-escaping="yes" /></a>
 						 </xsl:when>
-						 <xsl:otherwise><xsl:value-of select="." disable-output-escaping="yes" /></xsl:otherwise>
+						 <xsl:otherwise><xsl:value-of select="text()" disable-output-escaping="yes" /></xsl:otherwise>
 						 </xsl:choose>
 					</td>
 					<td>
@@ -234,7 +234,7 @@ doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" />
 	</xsl:template>
 
 
-	<xsl:template match="pmd" mode="summary">
+	<xsl:template match="pmd:pmd" mode="summary">
 		<!--** Process root node 'pmd',  for mode 'summary' : number of files, number of violations by severity -->
 		<h3>Summary</h3>
 		<table class="log" border="0" cellpadding="5" cellspacing="2"
@@ -250,13 +250,13 @@ doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" />
 			</tr>
 			<tr>
 				<xsl:call-template name="alternated-row" />
-		        <td><xsl:value-of select="count(//file)"/></td>
-		        <td><xsl:value-of select="count(//violation)"/></td>
-		        <td><xsl:value-of select="count(//violation[@priority = 1])"/></td>
-		        <td><xsl:value-of select="count(//violation[@priority = 2])"/></td>
-		        <td><xsl:value-of select="count(//violation[@priority = 3])"/></td>
-		        <td><xsl:value-of select="count(//violation[@priority = 4])"/></td>
-		        <td><xsl:value-of select="count(//violation[@priority = 5])"/></td>
+		        <td><xsl:value-of select="count(//pmd:file)"/></td>
+		        <td><xsl:value-of select="count(//pmd:violation)"/></td>
+		        <td><xsl:value-of select="count(//pmd:violation[@priority = 1])"/></td>
+		        <td><xsl:value-of select="count(//pmd:violation[@priority = 2])"/></td>
+		        <td><xsl:value-of select="count(//pmd:violation[@priority = 3])"/></td>
+		        <td><xsl:value-of select="count(//pmd:violation[@priority = 4])"/></td>
+		        <td><xsl:value-of select="count(//pmd:violation[@priority = 5])"/></td>
 			</tr>
 		</table>
 	</xsl:template>
@@ -269,7 +269,3 @@ doctype-system="http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd" />
 		</xsl:attribute>
 	</xsl:template>
 </xsl:stylesheet>
-
-
-
-

--- a/pmd-core/src/main/resources/report_2_0_0.xsd
+++ b/pmd-core/src/main/resources/report_2_0_0.xsd
@@ -1,0 +1,73 @@
+<?xml version="1.0"?>
+<xs:schema
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
+  xmlns="http://pmd.sourceforge.net/report/2.0.0"
+  targetNamespace="http://pmd.sourceforge.net/report/2.0.0"
+  elementFormDefault="qualified">
+
+  <xs:element name="pmd">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="file" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element name="error" type="error" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element ref="suppressedviolation" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element ref="configerror" minOccurs="0" maxOccurs="unbounded" />
+      </xs:sequence>
+      <xs:attribute name="version" type="xs:string" use="required" />
+      <xs:attribute name="timestamp" type="xs:string" use="required" />
+    </xs:complexType>
+  </xs:element>
+
+  <xs:element name="file">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="violation" type="violation" minOccurs="1" maxOccurs="unbounded" />
+      </xs:sequence>
+      <xs:attribute name="name" type="xs:string" use="required"/>
+    </xs:complexType>
+  </xs:element>
+  
+  <xs:complexType name="violation">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+	    <xs:attribute name="beginline" type="xs:integer" use="required" />
+	    <xs:attribute name="endline" type="xs:integer" use="required" />
+	    <xs:attribute name="begincolumn" type="xs:integer" use="required" />
+	    <xs:attribute name="endcolumn" type="xs:integer" use="required" />
+	    <xs:attribute name="rule" type="xs:string" use="required" />
+	    <xs:attribute name="ruleset" type="xs:string" use="required" />
+	    <xs:attribute name="package" type="xs:string" use="optional" />
+	    <xs:attribute name="class" type="xs:string" use="optional" />
+	    <xs:attribute name="method" type="xs:string" use="optional" />
+	    <xs:attribute name="variable" type="xs:string" use="optional" />
+	    <xs:attribute name="externalInfoUrl" type="xs:string" use="optional" />
+	    <xs:attribute name="priority" type="xs:string" use="required" />
+	  </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  
+  <xs:complexType name="error">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+        <xs:attribute name="filename" type="xs:string" use="required"/>
+        <xs:attribute name="msg" type="xs:string" use="required"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  
+  <xs:element name="suppressedviolation">
+    <xs:complexType>
+      <xs:attribute name="filename" type="xs:string" use="required" />
+      <xs:attribute name="suppressiontype" type="xs:string" use="required" />
+      <xs:attribute name="msg" type="xs:string" use="required" />
+      <xs:attribute name="usermsg" type="xs:string" use="required" />
+    </xs:complexType>
+  </xs:element>
+  
+  <xs:element name="configerror">
+    <xs:complexType>
+      <xs:attribute name="rule" type="xs:string" use="required" />
+      <xs:attribute name="msg" type="xs:string" use="required" />
+    </xs:complexType>
+  </xs:element>
+</xs:schema>

--- a/pmd-core/src/main/resources/report_2_0_0.xsd
+++ b/pmd-core/src/main/resources/report_2_0_0.xsd
@@ -8,24 +8,22 @@
   <xs:element name="pmd">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="file" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element name="file" type="file" minOccurs="0" maxOccurs="unbounded" />
         <xs:element name="error" type="error" minOccurs="0" maxOccurs="unbounded" />
-        <xs:element ref="suppressedviolation" minOccurs="0" maxOccurs="unbounded"/>
-        <xs:element ref="configerror" minOccurs="0" maxOccurs="unbounded" />
+        <xs:element name="suppressedviolation" type="suppressedviolation" minOccurs="0" maxOccurs="unbounded"/>
+        <xs:element name="configerror" type="configerror" minOccurs="0" maxOccurs="unbounded" />
       </xs:sequence>
       <xs:attribute name="version" type="xs:string" use="required" />
       <xs:attribute name="timestamp" type="xs:string" use="required" />
     </xs:complexType>
   </xs:element>
 
-  <xs:element name="file">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element name="violation" type="violation" minOccurs="1" maxOccurs="unbounded" />
-      </xs:sequence>
-      <xs:attribute name="name" type="xs:string" use="required"/>
-    </xs:complexType>
-  </xs:element>
+  <xs:complexType name="file">
+    <xs:sequence>
+      <xs:element name="violation" type="violation" minOccurs="1" maxOccurs="unbounded" />
+    </xs:sequence>
+    <xs:attribute name="name" type="xs:string" use="required"/>
+  </xs:complexType>
   
   <xs:complexType name="violation">
     <xs:simpleContent>
@@ -55,19 +53,15 @@
     </xs:simpleContent>
   </xs:complexType>
   
-  <xs:element name="suppressedviolation">
-    <xs:complexType>
-      <xs:attribute name="filename" type="xs:string" use="required" />
-      <xs:attribute name="suppressiontype" type="xs:string" use="required" />
-      <xs:attribute name="msg" type="xs:string" use="required" />
-      <xs:attribute name="usermsg" type="xs:string" use="required" />
-    </xs:complexType>
-  </xs:element>
+  <xs:complexType name="suppressedviolation">
+    <xs:attribute name="filename" type="xs:string" use="required" />
+    <xs:attribute name="suppressiontype" type="xs:string" use="required" />
+    <xs:attribute name="msg" type="xs:string" use="required" />
+    <xs:attribute name="usermsg" type="xs:string" use="required" />
+  </xs:complexType>
   
-  <xs:element name="configerror">
-    <xs:complexType>
-      <xs:attribute name="rule" type="xs:string" use="required" />
-      <xs:attribute name="msg" type="xs:string" use="required" />
-    </xs:complexType>
-  </xs:element>
+   <xs:complexType name="configerror">
+     <xs:attribute name="rule" type="xs:string" use="required" />
+     <xs:attribute name="msg" type="xs:string" use="required" />
+   </xs:complexType>
 </xs:schema>

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
@@ -35,22 +35,19 @@ public class XMLRendererTest extends AbstractRendererTst {
 
     @Override
     public String getExpected() {
-        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + PMD.EOL + "<pmd version=\"" + PMD.VERSION
-                + "\" timestamp=\"2014-10-06T19:30:51.262\">" + PMD.EOL + "<file name=\"n/a\">" + PMD.EOL
+        return getHeader() + "<file name=\"n/a\">" + PMD.EOL
                 + "<violation beginline=\"1\" endline=\"1\" begincolumn=\"1\" endcolumn=\"1\" rule=\"Foo\" ruleset=\"RuleSet\" priority=\"5\">"
                 + PMD.EOL + "blah" + PMD.EOL + "</violation>" + PMD.EOL + "</file>" + PMD.EOL + "</pmd>" + PMD.EOL;
     }
 
     @Override
     public String getExpectedEmpty() {
-        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + PMD.EOL + "<pmd version=\"" + PMD.VERSION
-                + "\" timestamp=\"2014-10-06T19:30:51.262\">" + PMD.EOL + "</pmd>" + PMD.EOL;
+        return getHeader() + "</pmd>" + PMD.EOL;
     }
 
     @Override
     public String getExpectedMultiple() {
-        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + PMD.EOL + "<pmd version=\"" + PMD.VERSION
-                + "\" timestamp=\"2014-10-06T19:30:51.239\">" + PMD.EOL + "<file name=\"n/a\">" + PMD.EOL
+        return getHeader() + "<file name=\"n/a\">" + PMD.EOL
                 + "<violation beginline=\"1\" endline=\"1\" begincolumn=\"1\" endcolumn=\"1\" rule=\"Foo\" ruleset=\"RuleSet\" priority=\"5\">"
                 + PMD.EOL + "blah" + PMD.EOL + "</violation>" + PMD.EOL
                 + "<violation beginline=\"1\" endline=\"1\" begincolumn=\"1\" endcolumn=\"2\" rule=\"Foo\" ruleset=\"RuleSet\" priority=\"5\">"
@@ -59,15 +56,13 @@ public class XMLRendererTest extends AbstractRendererTst {
 
     @Override
     public String getExpectedError(ProcessingError error) {
-        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + PMD.EOL + "<pmd version=\"" + PMD.VERSION
-                + "\" timestamp=\"2014-10-06T19:30:51.222\">" + PMD.EOL + "<error filename=\"file\" msg=\"Error\">"
+        return getHeader() + "<error filename=\"file\" msg=\"Error\">"
                 + PMD.EOL + "<![CDATA[" + error.getDetail() + "]]>" + PMD.EOL + "</error>" + PMD.EOL + "</pmd>" + PMD.EOL;
     }
 
     @Override
     public String getExpectedError(ConfigurationError error) {
-        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + PMD.EOL + "<pmd version=\"" + PMD.VERSION
-                + "\" timestamp=\"2014-10-06T19:30:51.222\">" + PMD.EOL + "<configerror rule=\"Foo\" msg=\"a configuration error\"/>"
+        return getHeader() + "<configerror rule=\"Foo\" msg=\"a configuration error\"/>"
                 + PMD.EOL + "</pmd>" + PMD.EOL;
     }
 
@@ -114,5 +109,13 @@ public class XMLRendererTest extends AbstractRendererTst {
         Renderer renderer = getRenderer();
         renderer.setProperty(XMLRenderer.ENCODING, "ISO-8859-1");
         verifyXmlEscaping(renderer, "&#x1041c;");
+    }
+    
+    public String getHeader() {
+        return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + PMD.EOL
+                + "<pmd xmlns=\"http://pmd.sourceforge.net/report/2.0.0\"" + PMD.EOL
+                + "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + PMD.EOL
+                + "    xsi:schemaLocation=\"http://pmd.sourceforge.net/report/2.0.0 http://pmd.sourceforge.net/report_2_0_0.xsd\"" + PMD.EOL
+                + "    version=\"" + PMD.VERSION + "\" timestamp=\"2014-10-06T19:30:51.262\">" + PMD.EOL;
     }
 }


### PR DESCRIPTION
 - Fixes #538
 - The schema is named as version 2.0.0, since technically, this is the second iteration of the XML report given the recent changes (the first one never having a formal schema)
 - Once this is merged, the file should be published on the site