### PR TITLE
[java] java-basic/DontCallThreadRun false negative

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -150,6 +150,8 @@ All existing rules have been updated to reflect these changes. If you have custo
     *   [#487](https://github.com/pmd/pmd/pull/487): \[java] Fix typeresolution for anonymous extending object
     *   [#496](https://github.com/pmd/pmd/issues/496): \[java] processing error on generics inherited from enclosing class
     *   [#527](https://github.com/pmd/pmd/issues/527): \[java] Lombok getter annotation on enum is not recognized correctly
+*   java-basic
+    *   [#565](https://github.com/pmd/pmd/pull/565): \[java] False negative on DontCallThreadRun when extending Thread
 *   java-comments
     *   [#536](https://github.com/pmd/pmd/issues/536): \[java] CommentDefaultAccessModifierRule ignores constructors
 *   java-controversial

--- a/pmd-java/src/main/resources/rulesets/java/basic.xml
+++ b/pmd-java/src/main/resources/rulesets/java/basic.xml
@@ -720,7 +720,8 @@ for (int i = 0; i < 10; i++) {
            since="4.3"
            message="Don't call Thread.run() explicitly, use Thread.start()"
            class="net.sourceforge.pmd.lang.rule.XPathRule"
-           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_basic.html#dontcallthreadrun">
+           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_basic.html#dontcallthreadrun"
+           typeResolution="true">
       <description>
 Explicitly calling Thread.run() method will execute in the caller's thread of control.  Instead, call Thread.start() for the intended behavior.
       </description>
@@ -735,9 +736,8 @@ Explicitly calling Thread.run() method will execute in the caller's thread of co
     [
         ./Name[ends-with(@Image, '.run') or @Image = 'run']
         and substring-before(Name/@Image, '.') =//VariableDeclarator/VariableDeclaratorId/@Image
-        [../../../Type/ReferenceType[ClassOrInterfaceType/@Image = 'Thread']]
-        or (
-        ./AllocationExpression/ClassOrInterfaceType[@Image = 'Thread']
+            [../../../Type/ReferenceType/ClassOrInterfaceType[typeof(@Image, 'java.lang.Thread', 'Thread')]]
+        or (./AllocationExpression/ClassOrInterfaceType[typeof(@Image, 'java.lang.Thread', 'Thread')]
         and ../PrimarySuffix[@Image = 'run'])
     ]
 ]

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/basic/BasicRulesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/basic/BasicRulesTest.java
@@ -40,4 +40,11 @@ public class BasicRulesTest extends SimpleAggregatorTst {
         addRule(RULESET, "DontUseFloatTypeForLoopIndices");
         addRule(RULESET, "SimplifiedTernary");
     }
+    // Used by DontCallThreadRun test cases
+    public static class TestThread extends Thread {
+        @Override
+        public void run() {
+            System.out.println("test");
+        }
+    }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/basic/BasicRulesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/basic/BasicRulesTest.java
@@ -40,6 +40,7 @@ public class BasicRulesTest extends SimpleAggregatorTst {
         addRule(RULESET, "DontUseFloatTypeForLoopIndices");
         addRule(RULESET, "SimplifiedTernary");
     }
+
     // Used by DontCallThreadRun test cases
     public static class TestThread extends Thread {
         @Override

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/basic/xml/DontCallThreadRun.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/basic/xml/DontCallThreadRun.xml
@@ -27,4 +27,19 @@ public class Foo {
 }
      ]]></code>
     </test-code>
+    <test-code>
+        <description><![CDATA[
+#565 - inheritance use case - call to Thread().run()
+     ]]></description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import net.sourceforge.pmd.lang.java.rule.basic.BasicRulesTest.TestThread;
+
+public class Foo {
+  public void bar() {
+    new TestThread().run();
+  }
+}
+     ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
 - Use type resolution to determine when we are using a `Thread`
 - Fixes #565
