### PR TITLE
[java] Fix #388:  controversial.AvoidLiteralsInIfCondition 0.0 false positive

### DIFF
--- a/pmd-java/src/main/resources/rulesets/java/controversial.xml
+++ b/pmd-java/src/main/resources/rulesets/java/controversial.xml
@@ -681,7 +681,7 @@ More exceptions can be defined with the property "ignoreMagicNumbers".
 //IfStatement/Expression/*/PrimaryExpression/PrimaryPrefix/Literal
 [not(NullLiteral)]
 [not(BooleanLiteral)]
-[empty(index-of(tokenize($ignoreMagicNumbers, ','), @Image))]
+[empty(index-of(tokenize($ignoreMagicNumbers, '\s*,\s*'), @Image))]
 ]]>
         </value>
       </property>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/controversial/xml/AvoidLiteralsInIfCondition.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/controversial/xml/AvoidLiteralsInIfCondition.xml
@@ -74,4 +74,19 @@ public class Foo {
 }
       ]]></code>
   </test-code>
+  <test-code>
+    <description>#388 False positive due to space in property list</description>
+    <expected-problems>0</expected-problems>
+    <rule-property name="ignoreMagicNumbers"><![CDATA[-1,0,1, 0.0]]></rule-property>
+    <code><![CDATA[
+    class Foo {
+      void bar() {
+        if (num == 0.0) {
+	        return MathExtItg.sgn0raw(num) == 1 ? IEEEclass.PositiveZero : IEEEclass.NegativeZero;
+	      }
+      }
+    }
+    ]]></code>
+  </test-code>
+
 </test-data>


### PR DESCRIPTION
This has been pending for a while. The solution proposed by @adangel did the trick

Fixes #388 