### PR TITLE
[core] Dysfunctional rules are logged only once

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
@@ -169,54 +169,6 @@ public class PMD {
     }
 
     /**
-     * Create a report, filter out any defective rules, and keep a record of
-     * them.
-     *
-     * @param rs
-     *            the rules
-     * @param ctx
-     *            the rule context
-     * @param fileName
-     *            the filename of the source file, which should appear in the
-     *            report
-     * @return the Report
-     */
-    public static Report setupReport(RuleSets rs, RuleContext ctx, String fileName) {
-
-        Set<Rule> brokenRules = removeBrokenRules(rs);
-        Report report = Report.createReport(ctx, fileName);
-
-        for (Rule rule : brokenRules) {
-            report.addConfigError(new Report.ConfigurationError(rule, rule.dysfunctionReason()));
-        }
-
-        return report;
-    }
-
-    /**
-     * Remove and return the misconfigured rules from the rulesets and log them
-     * for good measure.
-     *
-     * @param ruleSets
-     *            RuleSets
-     * @return Set<Rule>
-     */
-    private static Set<Rule> removeBrokenRules(RuleSets ruleSets) {
-
-        Set<Rule> brokenRules = new HashSet<>();
-        ruleSets.removeDysfunctionalRules(brokenRules);
-
-        for (Rule rule : brokenRules) {
-            if (LOG.isLoggable(Level.WARNING)) {
-                LOG.log(Level.WARNING,
-                        "Removed misconfigured rule: " + rule.getName() + "  cause: " + rule.dysfunctionReason());
-            }
-        }
-
-        return brokenRules;
-    }
-
-    /**
      * Get the runtime configuration. The configuration can be modified to
      * affect how PMD behaves.
      *

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
@@ -48,6 +48,10 @@ public abstract class AbstractRule extends AbstractPropertySource implements Rul
         definePropertyDescriptor(Rule.VIOLATION_SUPPRESS_XPATH_DESCRIPTOR);
     }
 
+    /**
+     * @deprecated Use {@link #deepCopy()} to create verbatim copies of rules.
+     */
+    @Deprecated
     public void deepCopyValuesTo(AbstractRule otherRule) {
         otherRule.language = language;
         otherRule.minimumLanguageVersion = minimumLanguageVersion;
@@ -536,7 +540,7 @@ public abstract class AbstractRule extends AbstractPropertySource implements Rul
         }
         rule.setPriority(getPriority());
         for (final PropertyDescriptor<?> prop : getPropertyDescriptors()) {
-            if (!rule.hasDescriptor(prop)) {
+            if (rule.getPropertyDescriptor(prop.name()) == null) {
                 rule.definePropertyDescriptor(prop); // Property descriptors are immutable, and can be freely shared
             }
             

--- a/pmd-core/src/main/java/net/sourceforge/pmd/processor/AbstractPMDProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/processor/AbstractPMDProcessor.java
@@ -5,10 +5,15 @@
 package net.sourceforge.pmd.processor;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import net.sourceforge.pmd.PMDConfiguration;
 import net.sourceforge.pmd.Report;
+import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.RuleSetFactory;
 import net.sourceforge.pmd.RuleSets;
@@ -25,6 +30,8 @@ import net.sourceforge.pmd.util.datasource.DataSource;
  */
 public abstract class AbstractPMDProcessor {
 
+    private static final Logger LOG = Logger.getLogger(AbstractPMDProcessor.class.getName());
+    
     protected final PMDConfiguration configuration;
 
     public AbstractPMDProcessor(PMDConfiguration configuration) {
@@ -56,26 +63,58 @@ public abstract class AbstractPMDProcessor {
      * not</strong> be used by different threads. Each thread must create its
      * own copy of the rules.
      *
-     * @param factory
+     * @param factory The factory used to create the configured rule sets
+     * @param report The base report on which to report any configuration errors
      * @return the rules within a rulesets
      */
-    protected RuleSets createRuleSets(RuleSetFactory factory) {
-        return RulesetsFactoryUtils.getRuleSets(configuration.getRuleSets(), factory);
+    protected RuleSets createRuleSets(RuleSetFactory factory, Report report) {
+        final RuleSets rs = RulesetsFactoryUtils.getRuleSets(configuration.getRuleSets(), factory);
+        
+        final Set<Rule> brokenRules = removeBrokenRules(rs);
+        for (final Rule rule : brokenRules) {
+            report.addConfigError(new Report.ConfigurationError(rule, rule.dysfunctionReason()));
+        }
+        
+        return rs;
+    }
+    
+    /**
+     * Remove and return the misconfigured rules from the rulesets and log them
+     * for good measure.
+     *
+     * @param ruleSets RuleSets to prune of broken rules.
+     * @return Set<Rule>
+     */
+    private Set<Rule> removeBrokenRules(final RuleSets ruleSets) {
+        final Set<Rule> brokenRules = new HashSet<>();
+        ruleSets.removeDysfunctionalRules(brokenRules);
+
+        for (final Rule rule : brokenRules) {
+            if (LOG.isLoggable(Level.WARNING)) {
+                LOG.log(Level.WARNING,
+                        "Removed misconfigured rule: " + rule.getName() + "  cause: " + rule.dysfunctionReason());
+            }
+        }
+
+        return brokenRules;
     }
 
     public void processFiles(RuleSetFactory ruleSetFactory, List<DataSource> files, RuleContext ctx,
             List<Renderer> renderers) {
-        RuleSets rs = createRuleSets(ruleSetFactory);
+        RuleSets rs = createRuleSets(ruleSetFactory, ctx.getReport());
         configuration.getAnalysisCache().checkValidity(rs, configuration.getClassLoader());
         SourceCodeProcessor processor = new SourceCodeProcessor(configuration);
 
         for (DataSource dataSource : files) {
             String niceFileName = filenameFrom(dataSource);
 
-            runAnalysis(new PmdRunnable(configuration, dataSource, niceFileName, renderers,
-                    ctx, ruleSetFactory, processor));
+            runAnalysis(new PmdRunnable(dataSource, niceFileName, renderers, ctx, rs, processor));
         }
 
+        // render base report first - general errors
+        renderReports(renderers, ctx.getReport());
+        
+        // then add analysis results per file
         collectReports(renderers);
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/processor/PmdRunnable.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/processor/PmdRunnable.java
@@ -12,13 +12,9 @@ import java.util.concurrent.Callable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import net.sourceforge.pmd.PMD;
-import net.sourceforge.pmd.PMDConfiguration;
 import net.sourceforge.pmd.PMDException;
 import net.sourceforge.pmd.Report;
 import net.sourceforge.pmd.RuleContext;
-import net.sourceforge.pmd.RuleSetFactory;
-import net.sourceforge.pmd.RuleSetNotFoundException;
 import net.sourceforge.pmd.RuleSets;
 import net.sourceforge.pmd.SourceCodeProcessor;
 import net.sourceforge.pmd.renderers.Renderer;
@@ -30,23 +26,20 @@ public class PmdRunnable implements Callable<Report> {
 
     private static final ThreadLocal<ThreadContext> LOCAL_THREAD_CONTEXT = new ThreadLocal<>();
 
-    private final PMDConfiguration configuration;
     private final DataSource dataSource;
     private final String fileName;
     private final List<Renderer> renderers;
     private final RuleContext ruleContext;
-    private final RuleSetFactory ruleSetFactory;
+    private final RuleSets ruleSets;
     private final SourceCodeProcessor sourceCodeProcessor;
 
-    public PmdRunnable(PMDConfiguration configuration, DataSource dataSource, String fileName,
-            List<Renderer> renderers, RuleContext ruleContext, RuleSetFactory ruleSetFactory,
-            SourceCodeProcessor sourceCodeProcessor) {
-        this.configuration = configuration;
+    public PmdRunnable(DataSource dataSource, String fileName, List<Renderer> renderers,
+            RuleContext ruleContext, RuleSets ruleSets, SourceCodeProcessor sourceCodeProcessor) {
+        this.ruleSets = ruleSets;
         this.dataSource = dataSource;
         this.fileName = fileName;
         this.renderers = renderers;
         this.ruleContext = ruleContext;
-        this.ruleSetFactory = ruleSetFactory;
         this.sourceCodeProcessor = sourceCodeProcessor;
     }
 
@@ -64,21 +57,11 @@ public class PmdRunnable implements Callable<Report> {
     public Report call() {
         ThreadContext tc = LOCAL_THREAD_CONTEXT.get();
         if (tc == null) {
-            try {
-                tc = new ThreadContext(ruleSetFactory.createRuleSets(configuration.getRuleSets()),
-                        new RuleContext(ruleContext));
-            } catch (RuleSetNotFoundException e) {
-                throw new RuntimeException(e);
-            }
+            tc = new ThreadContext(new RuleSets(ruleSets), new RuleContext(ruleContext));
             LOCAL_THREAD_CONTEXT.set(tc);
         }
 
-        /*
-         * FIXME : This creates ConfigErrors for dysfunctional rules **per-thread**.
-         * We need rulesets to be copy-constructable and have them cleaned-up only once
-         * before analysis starts, reducing this to Report.createReport(tc.ruleContext, fileName);
-         */
-        Report report = PMD.setupReport(tc.ruleSets, tc.ruleContext, fileName);
+        Report report = Report.createReport(tc.ruleContext, fileName);
 
         if (LOG.isLoggable(Level.FINE)) {
             LOG.fine("Processing " + tc.ruleContext.getSourceCodeFilename());

--- a/pmd-core/src/test/java/net/sourceforge/pmd/AbstractRuleTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/AbstractRuleTest.java
@@ -25,12 +25,12 @@ import net.sourceforge.pmd.lang.rule.properties.StringProperty;
 
 public class AbstractRuleTest {
 
-    private static class MyRule extends AbstractRule {
+    public static class MyRule extends AbstractRule {
         private static final StringProperty FOO_PROPERTY = new StringProperty("foo", "foo property", "x", 1.0f);
 
         private static final StringProperty XPATH_PROPERTY = new StringProperty("xpath", "xpath property", "", 2.0f);
 
-        MyRule() {
+        public MyRule() {
             definePropertyDescriptor(FOO_PROPERTY);
             definePropertyDescriptor(XPATH_PROPERTY);
             setName("MyRule");
@@ -200,6 +200,26 @@ public class AbstractRuleTest {
         r2.setMessage("another message");
         assertEquals("Rules with different messages are still equal", r1, r2);
         assertEquals("Rules that are equal must have the an equal hashcode", r1.hashCode(), r2.hashCode());
+    }
+    
+    @Test
+    public void testDeepCopyRule() {
+        MyRule r1 = new MyRule();
+        MyRule r2 = (MyRule) r1.deepCopy();
+        assertEquals(r1.getDescription(), r2.getDescription());
+        assertEquals(r1.getExamples(), r2.getExamples());
+        assertEquals(r1.getExternalInfoUrl(), r2.getExternalInfoUrl());
+        assertEquals(r1.getLanguage(), r2.getLanguage());
+        assertEquals(r1.getMaximumLanguageVersion(), r2.getMaximumLanguageVersion());
+        assertEquals(r1.getMessage(), r2.getMessage());
+        assertEquals(r1.getMinimumLanguageVersion(), r2.getMinimumLanguageVersion());
+        assertEquals(r1.getName(), r2.getName());
+        assertEquals(r1.getPriority(), r2.getPriority());
+        assertEquals(r1.getPropertyDescriptors(), r2.getPropertyDescriptors());
+        assertEquals(r1.getRuleChainVisits(), r2.getRuleChainVisits());
+        assertEquals(r1.getRuleClass(), r2.getRuleClass());
+        assertEquals(r1.getRuleSetName(), r2.getRuleSetName());
+        assertEquals(r1.getSince(), r2.getSince());
     }
 
     public static junit.framework.Test suite() {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/processor/MultiThreadProcessorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/processor/MultiThreadProcessorTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -16,33 +17,64 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import net.sourceforge.pmd.PMDConfiguration;
+import net.sourceforge.pmd.Report;
+import net.sourceforge.pmd.Report.ConfigurationError;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.RuleSetFactory;
 import net.sourceforge.pmd.RuleViolation;
 import net.sourceforge.pmd.ThreadSafeReportListener;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.rule.AbstractRule;
+import net.sourceforge.pmd.renderers.AbstractAccumulatingRenderer;
 import net.sourceforge.pmd.renderers.Renderer;
 import net.sourceforge.pmd.stat.Metric;
 import net.sourceforge.pmd.util.datasource.DataSource;
 
 public class MultiThreadProcessorTest {
 
-    @Test
-    public void testRulesThreadSafety() {
+    private RuleContext ctx;
+    private MultiThreadProcessor processor;
+    private RuleSetFactory ruleSetFactory;
+    private List<DataSource> files;
+    private SimpleReportListener reportListener;
+    
+    public void setUpForTest(final String ruleset) {
         PMDConfiguration configuration = new PMDConfiguration();
-        configuration.setRuleSets("rulesets/MultiThreadProcessorTest/basic.xml");
+        configuration.setRuleSets(ruleset);
         configuration.setThreads(2);
-        List<DataSource> files = new ArrayList<>();
+        files = new ArrayList<>();
         files.add(new StringDataSource("file1-violation.dummy", "ABC"));
         files.add(new StringDataSource("file2-foo.dummy", "DEF"));
 
-        SimpleReportListener reportListener = new SimpleReportListener();
-        RuleContext ctx = new RuleContext();
+        reportListener = new SimpleReportListener();
+        ctx = new RuleContext();
         ctx.getReport().addListener(reportListener);
 
-        MultiThreadProcessor processor = new MultiThreadProcessor(configuration);
-        RuleSetFactory ruleSetFactory = new RuleSetFactory();
+        processor = new MultiThreadProcessor(configuration);
+        ruleSetFactory = new RuleSetFactory();
+    }
+    
+    @Test
+    public void testRulesDysnfunctionalLog() throws IOException {
+        setUpForTest("rulesets/MultiThreadProcessorTest/dysfunctional.xml");
+        final SimpleRenderer renderer = new SimpleRenderer(null, null);
+        renderer.start();
+        processor.processFiles(ruleSetFactory, files, ctx, Collections.<Renderer>singletonList(renderer));
+        renderer.end();
+
+        final Iterator<ConfigurationError> configErrors = renderer.getReport().configErrors();
+        final ConfigurationError error = configErrors.next();
+        
+        Assert.assertEquals("Dysfunctional rule message not present",
+                DysfunctionalRule.DYSFUNCTIONAL_RULE_REASON, error.issue());
+        Assert.assertEquals("Dysfunctional rule is wrong",
+                DysfunctionalRule.class, error.rule().getClass());
+        Assert.assertFalse("More configuration errors found than expected", configErrors.hasNext());
+    }
+    
+    @Test
+    public void testRulesThreadSafety() {
+        setUpForTest("rulesets/MultiThreadProcessorTest/basic.xml");
         processor.processFiles(ruleSetFactory, files, ctx, Collections.<Renderer>emptyList());
 
         // if the rule is not executed, then maybe a
@@ -104,6 +136,21 @@ public class MultiThreadProcessorTest {
             }
         }
     }
+    
+    public static class DysfunctionalRule extends AbstractRule {
+
+        public static final String DYSFUNCTIONAL_RULE_REASON = "dysfunctional rule is dysfunctional";
+
+        @Override
+        public void apply(List<? extends Node> nodes, RuleContext ctx) {
+            // noop
+        }
+        
+        @Override
+        public String dysfunctionReason() {
+            return DYSFUNCTIONAL_RULE_REASON;
+        }
+    }
 
     private static class SimpleReportListener implements ThreadSafeReportListener {
         public AtomicInteger violations = new AtomicInteger(0);
@@ -115,6 +162,26 @@ public class MultiThreadProcessorTest {
 
         @Override
         public void metricAdded(Metric metric) {
+        }
+    }
+    
+    private static class SimpleRenderer extends AbstractAccumulatingRenderer {
+
+        public SimpleRenderer(String name, String description) {
+            super(name, description);
+        }
+
+        @Override
+        public String defaultFileExtension() {
+            return null;
+        }
+
+        @Override
+        public void end() throws IOException {
+        }
+        
+        public Report getReport() {
+            return report;
         }
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/processor/MultiThreadProcessorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/processor/MultiThreadProcessorTest.java
@@ -167,7 +167,7 @@ public class MultiThreadProcessorTest {
     
     private static class SimpleRenderer extends AbstractAccumulatingRenderer {
 
-        public SimpleRenderer(String name, String description) {
+        /* default */ SimpleRenderer(String name, String description) {
             super(name, description);
         }
 

--- a/pmd-core/src/test/resources/rulesets/MultiThreadProcessorTest/dysfunctional.xml
+++ b/pmd-core/src/test/resources/rulesets/MultiThreadProcessorTest/dysfunctional.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ruleset name="Test Ruleset" xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+
+    <description>
+  Ruleset used by test MultiThreadProcessorTest
+  </description>
+
+    <rule name="DysfunctionalRule" language="dummy" since="1.0" message="dysfunctional rule" class="net.sourceforge.pmd.processor.MultiThreadProcessorTest$DysfunctionalRule"
+        externalInfoUrl="foo">
+        <description>Dysfunctional</description>
+        <priority>3</priority>
+        <example></example>
+    </rule>
+</ruleset>


### PR DESCRIPTION
  Under multi-thread runs, each thread parsed it's own copy of the ruleset, and removed dysfunctional rules. This meant 1 `ConfigError` per thread was being generated.

  Since #519, we now log `ConfigErrors`, meaning multiple identical logs in reports and noise for the user.

  Therefore, we change our approach. RuleSets are parsed only once. Dysfunctional rules are filtered and reported early on, before dispathing actual file analysis. Each analysis thread can then produce
their own copy of the ruleset by taking advantage of the `deepCopy` support for rules, ruleset and rulesets introduced in #464.

  The result is not only more concise reports, but the analysis thread actually perform less work. Rulesets XMLs are parsed exactly once, instead of 1 + 1 per thread as before, and rule configuration is validated only once.

  During this process an issue with how property descriptors where copied has arised and was fixed. A new unit test to validate this scenario has been introduced.

  This is part of #194 