### PR TITLE
[core] Revamp charset / stream management

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/AbstractConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/AbstractConfiguration.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd;
 
+import java.nio.charset.Charset;
+
 /**
  * Base configuration class for both PMD and CPD.
  *
@@ -11,7 +13,7 @@ package net.sourceforge.pmd;
  */
 public abstract class AbstractConfiguration {
 
-    private String sourceEncoding = System.getProperty("file.encoding");
+    private Charset sourceEncoding = Charset.forName(System.getProperty("file.encoding"));
     private boolean debug;
 
     /**
@@ -26,7 +28,7 @@ public abstract class AbstractConfiguration {
      *
      * @return The character encoding.
      */
-    public String getSourceEncoding() {
+    public Charset getSourceEncoding() {
         return sourceEncoding;
     }
 
@@ -37,7 +39,7 @@ public abstract class AbstractConfiguration {
      *            The character encoding.
      */
     public void setSourceEncoding(String sourceEncoding) {
-        this.sourceEncoding = sourceEncoding;
+        this.sourceEncoding = Charset.forName(sourceEncoding);
     }
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/SourceCodeProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/SourceCodeProcessor.java
@@ -4,14 +4,12 @@
 
 package net.sourceforge.pmd;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
-import java.io.UnsupportedEncodingException;
 import java.util.Collections;
 import java.util.List;
-
-import org.apache.commons.io.IOUtils;
 
 import net.sourceforge.pmd.benchmark.Benchmark;
 import net.sourceforge.pmd.benchmark.Benchmarker;
@@ -48,10 +46,10 @@ public class SourceCodeProcessor {
      * @see #processSourceCode(Reader, RuleSets, RuleContext)
      */
     public void processSourceCode(InputStream sourceCode, RuleSets ruleSets, RuleContext ctx) throws PMDException {
-        try {
-            processSourceCode(new InputStreamReader(sourceCode, configuration.getSourceEncoding()), ruleSets, ctx);
-        } catch (UnsupportedEncodingException uee) {
-            throw new PMDException("Unsupported encoding exception: " + uee.getMessage());
+        try (Reader streamReader = new InputStreamReader(sourceCode, configuration.getSourceEncoding())) {
+            processSourceCode(streamReader, ruleSets, ctx);
+        } catch (IOException e) {
+            throw new PMDException("IO exception: " + e.getMessage(), e);
         }
     }
 
@@ -102,7 +100,6 @@ public class SourceCodeProcessor {
                 configuration.getAnalysisCache().analysisFailed(ctx.getSourceCodeFile());
                 throw new PMDException("Error while processing " + ctx.getSourceCodeFilename(), e);
             } finally {
-                IOUtils.closeQuietly(sourceCode);
                 ruleSets.end(ctx);
             }
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/Benchmarker.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/Benchmarker.java
@@ -4,9 +4,10 @@
 
 package net.sourceforge.pmd.benchmark;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.Reader;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -191,12 +192,9 @@ public class Benchmarker {
             RuleContext ctx = new RuleContext();
             long start = System.currentTimeMillis();
             for (DataSource dataSource : dataSources) {
-                Reader reader = new InputStreamReader(dataSource.getInputStream());
-                try {
+                try (InputStream stream = new BufferedInputStream(dataSource.getInputStream())) {
                     ctx.setSourceCodeFilename(dataSource.getNiceFileName(false, null));
-                    new SourceCodeProcessor(config).processSourceCode(reader, ruleSets, ctx);
-                } finally {
-                    IOUtils.closeQuietly(reader);
+                    new SourceCodeProcessor(config).processSourceCode(stream, ruleSets, ctx);
                 }
             }
             long end = System.currentTimeMillis();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
@@ -143,7 +143,7 @@ public class CPDConfiguration extends AbstractConfiguration {
     }
 
     public SourceCode sourceCodeFor(File file) {
-        return new SourceCode(new SourceCode.FileCodeLoader(file, getSourceEncoding()));
+        return new SourceCode(new SourceCode.FileCodeLoader(file, getSourceEncoding().name()));
     }
 
     public SourceCode sourceCodeFor(Reader reader, String sourceCodeName) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/processor/PmdRunnable.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/processor/PmdRunnable.java
@@ -87,8 +87,7 @@ public class PmdRunnable implements Callable<Report> {
             r.startFileAnalysis(dataSource);
         }
 
-        try {
-            InputStream stream = new BufferedInputStream(dataSource.getInputStream());
+        try (InputStream stream = new BufferedInputStream(dataSource.getInputStream())) {
             tc.ruleContext.setLanguageVersion(null);
             sourceCodeProcessor.processSourceCode(stream, tc.ruleSets, tc.ruleContext);
         } catch (PMDException pmde) {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/ConfigurationTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/ConfigurationTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
 import org.junit.Test;
@@ -76,9 +77,9 @@ public class ConfigurationTest {
     @Test
     public void testSourceEncoding() {
         PMDConfiguration configuration = new PMDConfiguration();
-        assertEquals("Default source encoding", System.getProperty("file.encoding"), configuration.getSourceEncoding());
-        configuration.setSourceEncoding("some_other_encoding");
-        assertEquals("Changed source encoding", "some_other_encoding", configuration.getSourceEncoding());
+        assertEquals("Default source encoding", System.getProperty("file.encoding"), configuration.getSourceEncoding().name());
+        configuration.setSourceEncoding(StandardCharsets.UTF_16LE.name());
+        assertEquals("Changed source encoding", StandardCharsets.UTF_16LE, configuration.getSourceEncoding());
     }
 
     @Test


### PR DESCRIPTION
 - File encoding is converted to Charset only once. Errors in it's setup
will fail the run immediately instead of producing one error per file.
 - We make sure to close the source stream from the same place we create
it, by using try-with-resources
 - When wrapping the stream to a reader, we use try-with-resources
again, just in case
 - The bechmark code now takes into account charset setup, and more
closely resembles the normal execution path
 - This fixes #618
