### PR TITLE
[java] Avoid errors upon resolving invalid classes

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -238,6 +238,7 @@ a warning will now be produced suggesting users to adopt it for better performan
     *   [#448](https://github.com/pmd/pmd/issues/448): \[cpp] Write custom CharStream to handle continuation characters
 *   java
     *   [#1513](https://sourceforge.net/p/pmd/bugs/1513/): \[java] Remove deprecated rule UseSingleton
+    *   [#328](https://github.com/pmd/pmd/issues/328): \[java] java.lang.ClassFormatError: Absent Code attribute in method that is not native or abstract in class file javax/servlet/jsp/PageContext
     *   [#487](https://github.com/pmd/pmd/pull/487): \[java] Fix typeresolution for anonymous extending object
     *   [#496](https://github.com/pmd/pmd/issues/496): \[java] processing error on generics inherited from enclosing class
     *   [#510](https://github.com/pmd/pmd/issues/510): \[java] Typeresolution fails on a simple primary when the source is loaded from a class literal

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/TypeSet.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/TypeSet.java
@@ -532,6 +532,9 @@ public class TypeSet {
                     return resolver.resolve(name);
                 } catch (ClassNotFoundException cnfe) {
                     // ignored, maybe another resolver will find the class
+                } catch (LinkageError le) {
+                    // we found the class, but there is a problem with it (see https://github.com/pmd/pmd/issues/328)
+                    return null;
                 }
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -1298,8 +1298,6 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
                     myType = pmdClassLoader.loadClass(qualifiedName);
                 } catch (ClassNotFoundException e) {
                     myType = processOnDemand(qualifiedName);
-                } catch (NoClassDefFoundError e) {
-                    myType = processOnDemand(qualifiedName);
                 } catch (LinkageError e) {
                     myType = processOnDemand(qualifiedName);
                 }
@@ -1430,7 +1428,7 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
                     String strName = anImportDeclaration.getImportedName();
                     String fieldName = strName.substring(strName.lastIndexOf('.') + 1);
 
-                    Class staticClassWithField = loadClass(strPackage);
+                    Class<?> staticClassWithField = loadClass(strPackage);
                     if (staticClassWithField != null) {
                         JavaTypeDefinition typeDef = getFieldType(JavaTypeDefinition.forClass(staticClassWithField),
                                                                   fieldName, currentAcu.getType());


### PR DESCRIPTION
 - Resolves #328
 - Take the chance to simplify some error handling (`NoClassDefFoundError` extends `LinkageError`)