### PR TITLE
[apex] Remove shading for the apex modules - not needed anymore

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -233,6 +233,7 @@ a warning will now be produced suggesting users to adopt it for better performan
     *   [#488](https://github.com/pmd/pmd/pull/488): \[apex] Use Apex lexer for CPD
     *   [#489](https://github.com/pmd/pmd/pull/489): \[apex] Update Apex compiler
     *   [#500](https://github.com/pmd/pmd/issues/500): \[apex] Running through CLI shows jorje optimization messages
+    *   [#605](https://github.com/pmd/pmd/issues/605): \[apex] java.lang.NoClassDefFoundError in the latest build
     *   [#637](https://github.com/pmd/pmd/issues/637): \[apex] Avoid SOSL in loops
 *   cpp
     *   [#448](https://github.com/pmd/pmd/issues/448): \[cpp] Write custom CharStream to handle continuation characters

--- a/pmd-apex/pom.xml
+++ b/pmd-apex/pom.xml
@@ -59,43 +59,6 @@
           </execution>
         </executions>
       </plugin>
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-            <configuration>
-              <artifactSet>
-                <includes>
-                  <include>apex</include>
-                </includes>
-                <excludes>
-                  <exclude>${project.groupId}</exclude>
-                </excludes>
-              </artifactSet>
-              <relocations>
-                <!-- apex uses an older version of asm, hence we need to shaded it away -->
-                <relocation>
-                  <pattern>org.objectweb.asm</pattern>
-                  <shadedPattern>shaded.org.objectweb.asm</shadedPattern>
-                </relocation>
-                <!-- apex uses an older version of jackson, hence we need to shaded it away -->
-                <relocation>
-                  <pattern>com.fasterxml.jackson</pattern>
-                  <shadedPattern>shaded.com.fasterxml.jackson</shadedPattern>
-                </relocation>
-              </relocations>
-              <shadedArtifactAttached>true</shadedArtifactAttached>
-              <shadedClassifierName>apex-jorje-shaded</shadedClassifierName>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
   </build>
   <dependencies>
@@ -165,6 +128,12 @@
     <dependency>
       <groupId>net.sourceforge.saxon</groupId>
       <artifactId>saxon</artifactId>
+    </dependency>
+
+    <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm</artifactId>
+        <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/pmd-dist/pom.xml
+++ b/pmd-dist/pom.xml
@@ -209,12 +209,6 @@
                 </dependency>
                 <dependency>
                     <groupId>net.sourceforge.pmd</groupId>
-                    <artifactId>pmd-apex</artifactId>
-                    <version>${project.version}</version>
-                    <classifier>apex-jorje-shaded</classifier>
-                </dependency>
-                <dependency>
-                    <groupId>net.sourceforge.pmd</groupId>
                     <artifactId>pmd-ui</artifactId>
                     <version>${project.version}</version>
                 </dependency>

--- a/pmd-dist/src/main/assembly/bin.xml
+++ b/pmd-dist/src/main/assembly/bin.xml
@@ -52,10 +52,6 @@
             <directoryMode>0755</directoryMode>
             <fileMode>0644</fileMode>
             <useProjectArtifact>false</useProjectArtifact>
-            <!-- exclude the apex (transitive) dependencies - we use the shaded version instead -->
-            <excludes>
-                <exclude>apex:*</exclude>
-            </excludes>
         </dependencySet>
     </dependencySets>
 </assembly>


### PR DESCRIPTION
[apex] Remove shading for the apex modules - not needed anymore

Fixes #605. The apex modules do not contain any non-apex code anymore
(not an uber-jar anymore).

Explicitely defining asm as runtime dependency.
