### PR TITLE
[java] Fix in Java grammar: Try with final resource node error

### DIFF
--- a/pmd-java/etc/grammar/Java.jjt
+++ b/pmd-java/etc/grammar/Java.jjt
@@ -2253,7 +2253,7 @@ void Resources() :
 void Resource() :
 {}
 {
-   LOOKAHEAD(2) ( ( "final" | Annotation() )* Type() VariableDeclaratorId() "=" Expression() )
+   LOOKAHEAD(2) ( ( "final" {jjtThis.setFinal(true);} | Annotation() )* Type() VariableDeclaratorId() "=" Expression() )
    |
    Name() {checkForBadConciseTryWithResourcesUsage();}
 }


### PR DESCRIPTION
## Issue

When running the designer with the following code: https://pastebin.com/xGrHQ3QN I noticed that the **Resource** node contained in the **Resources** node has its _isFinal_ boolean value set to false. After checking the grammar, I noticed the issue here: https://github.com/pmd/pmd/blob/53210842c884bb91b58d2669a10e51d6d9611e53/pmd-java/etc/grammar/Java.jjt#L2256

## How I solved it
When a **final** token is found, the _isFinal_ value is currently not set to true. The solution is to invoke `{jjtThis.setFinal(true);}` to the right of `"final"` 