### PR TITLE
[core] Isolate classloaders for runtime and auxclasspath

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
@@ -42,6 +42,7 @@ import net.sourceforge.pmd.stat.Metric;
 import net.sourceforge.pmd.util.ClasspathClassLoader;
 import net.sourceforge.pmd.util.FileUtil;
 import net.sourceforge.pmd.util.IOUtil;
+import net.sourceforge.pmd.util.ResourceLoader;
 import net.sourceforge.pmd.util.database.DBMSMetadata;
 import net.sourceforge.pmd.util.database.DBURI;
 import net.sourceforge.pmd.util.database.SourceObject;
@@ -198,7 +199,7 @@ public class PMD {
     public static int doPMD(PMDConfiguration configuration) {
 
         // Load the RuleSets
-        RuleSetFactory ruleSetFactory = RulesetsFactoryUtils.getRulesetFactory(configuration);
+        RuleSetFactory ruleSetFactory = RulesetsFactoryUtils.getRulesetFactory(configuration, new ResourceLoader());
         RuleSets ruleSets = RulesetsFactoryUtils.getRuleSetsWithBenchmark(configuration.getRuleSets(), ruleSetFactory);
         if (ruleSets == null) {
             return 0;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
@@ -49,9 +49,9 @@ import net.sourceforge.pmd.util.ResourceLoader;
 
 /**
  * RuleSetFactory is responsible for creating RuleSet instances from XML
- * content. By default Rules will be loaded using the ClassLoader for this
- * class, using the {@link RulePriority#LOW} priority, with Rule deprecation
- * warnings off. By default, the ruleset compatibility filter is active, too.
+ * content. By default Rules will be loaded using the {@link RulePriority#LOW} priority,
+ * with Rule deprecation warnings off.
+ * By default, the ruleset compatibility filter is active, too.
  * See {@link RuleSetFactoryCompatibility}.
  */
 public class RuleSetFactory {
@@ -65,18 +65,18 @@ public class RuleSetFactory {
     private static final String MESSAGE = "message";
     private static final String EXTERNAL_INFO_URL = "externalInfoUrl";
 
-    private final ClassLoader classLoader;
+    private final ResourceLoader resourceLoader;
     private final RulePriority minimumPriority;
     private final boolean warnDeprecated;
     private final RuleSetFactoryCompatibility compatibilityFilter;
 
     public RuleSetFactory() {
-        this(RuleSetFactory.class.getClassLoader(), RulePriority.LOW, false, true);
+        this(new ResourceLoader(), RulePriority.LOW, false, true);
     }
 
-    public RuleSetFactory(final ClassLoader classLoader, final RulePriority minimumPriority,
+    public RuleSetFactory(final ResourceLoader resourceLoader, final RulePriority minimumPriority,
             final boolean warnDeprecated, final boolean enableCompatibility) {
-        this.classLoader = classLoader;
+        this.resourceLoader = resourceLoader;
         this.minimumPriority = minimumPriority;
         this.warnDeprecated = warnDeprecated;
 
@@ -97,7 +97,7 @@ public class RuleSetFactory {
      *            factory.
      */
     public RuleSetFactory(final RuleSetFactory factory, final boolean warnDeprecated) {
-        this(factory.classLoader, factory.minimumPriority, warnDeprecated, factory.compatibilityFilter != null);
+        this(factory.resourceLoader, factory.minimumPriority, warnDeprecated, factory.compatibilityFilter != null);
     }
 
     /**
@@ -125,7 +125,7 @@ public class RuleSetFactory {
             for (Language language : LanguageRegistry.findWithRuleSupport()) {
                 Properties props = new Properties();
                 rulesetsProperties = "rulesets/" + language.getTerseName() + "/rulesets.properties";
-                try (InputStream inputStream = ResourceLoader.loadResourceAsStream(rulesetsProperties);) {
+                try (InputStream inputStream = resourceLoader.loadClassPathResourceAsStreamOrThrow(rulesetsProperties)) {
                     props.load(inputStream);
                 }
                 String rulesetFilenames = props.getProperty("rulesets.filenames");
@@ -134,7 +134,7 @@ public class RuleSetFactory {
             return createRuleSets(ruleSetReferenceIds).getRuleSetsIterator();
         } catch (IOException ioe) {
             throw new RuntimeException("Couldn't find " + rulesetsProperties
-                    + "; please ensure that the rulesets directory is on the classpath.  The current classpath is: "
+                    + "; please ensure that the rulesets directory is on the classpath. The current classpath is: "
                     + System.getProperty("java.class.path"));
         }
     }
@@ -143,7 +143,7 @@ public class RuleSetFactory {
      * Create a RuleSets from a comma separated list of RuleSet reference IDs.
      * This is a convenience method which calls
      * {@link RuleSetReferenceId#parse(String)}, and then calls
-     * {@link #createRuleSets(List)}. The currently configured ClassLoader is
+     * {@link #createRuleSets(List)}. The currently configured ResourceLoader is
      * used.
      *
      * @param referenceString
@@ -158,7 +158,7 @@ public class RuleSetFactory {
 
     /**
      * Create a RuleSets from a list of RuleSetReferenceIds. The currently
-     * configured ClassLoader is used.
+     * configured ResourceLoader is used.
      *
      * @param ruleSetReferenceIds
      *            The List of RuleSetReferenceId of the RuleSets to create.
@@ -180,7 +180,7 @@ public class RuleSetFactory {
      * convenience method which calls {@link RuleSetReferenceId#parse(String)},
      * gets the first item in the List, and then calls
      * {@link #createRuleSet(RuleSetReferenceId)}. The currently configured
-     * ClassLoader is used.
+     * ResourceLoader is used.
      *
      * @param referenceString
      *            A comma separated list of RuleSet reference IDs.
@@ -199,7 +199,7 @@ public class RuleSetFactory {
 
     /**
      * Create a RuleSet from a RuleSetReferenceId. Priority filtering is ignored
-     * when loading a single Rule. The currently configured ClassLoader is used.
+     * when loading a single Rule. The currently configured ResourceLoader is used.
      *
      * @param ruleSetReferenceId
      *            The RuleSetReferenceId of the RuleSet to create.
@@ -291,7 +291,7 @@ public class RuleSetFactory {
 
     /**
      * Create a Rule from a RuleSet created from a file name resource. The
-     * currently configured ClassLoader is used.
+     * currently configured ResourceLoader is used.
      * <p>
      * Any Rules in the RuleSet other than the one being created, are _not_
      * created. Deprecated rules are _not_ ignored, so that they can be
@@ -329,7 +329,7 @@ public class RuleSetFactory {
     private RuleSet parseRuleSetNode(RuleSetReferenceId ruleSetReferenceId, boolean withDeprecatedRuleReferences)
             throws RuleSetNotFoundException {
         try (CheckedInputStream inputStream = new CheckedInputStream(
-                ruleSetReferenceId.getInputStream(this.classLoader), new Adler32());) {
+                ruleSetReferenceId.getInputStream(resourceLoader), new Adler32());) {
             if (!ruleSetReferenceId.isExternal()) {
                 throw new IllegalArgumentException(
                         "Cannot parse a RuleSet from a non-external reference: <" + ruleSetReferenceId + ">.");
@@ -543,7 +543,7 @@ public class RuleSetFactory {
         if (attribute == null || "".equals(attribute)) {
             throw new IllegalArgumentException("The 'class' field of rule can't be null, nor empty.");
         }
-        Rule rule = (Rule) RuleSetFactory.class.getClassLoader().loadClass(attribute).newInstance();
+        Rule rule = (Rule) Class.forName(attribute).newInstance();
         rule.setName(ruleElement.getAttribute("name"));
 
         if (ruleElement.hasAttribute("language")) {
@@ -774,7 +774,7 @@ public class RuleSetFactory {
      */
     private boolean containsRule(RuleSetReferenceId ruleSetReferenceId, String ruleName) {
         boolean found = false;
-        try (InputStream ruleSet = ruleSetReferenceId.getInputStream(classLoader)) {
+        try (InputStream ruleSet = ruleSetReferenceId.getInputStream(resourceLoader)) {
             DocumentBuilder builder = createDocumentBuilder();
             Document document = builder.parse(ruleSet);
             Element ruleSetElement = document.getDocumentElement();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
@@ -543,7 +543,7 @@ public class RuleSetFactory {
         if (attribute == null || "".equals(attribute)) {
             throw new IllegalArgumentException("The 'class' field of rule can't be null, nor empty.");
         }
-        Rule rule = (Rule) classLoader.loadClass(attribute).newInstance();
+        Rule rule = (Rule) RuleSetFactory.class.getClassLoader().loadClass(attribute).newInstance();
         rule.setName(ruleElement.getAttribute("name"));
 
         if (ruleElement.hasAttribute("language")) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RulesetsFactoryUtils.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RulesetsFactoryUtils.java
@@ -9,6 +9,7 @@ import java.util.logging.Logger;
 
 import net.sourceforge.pmd.benchmark.Benchmark;
 import net.sourceforge.pmd.benchmark.Benchmarker;
+import net.sourceforge.pmd.util.ResourceLoader;
 
 public final class RulesetsFactoryUtils {
 
@@ -72,8 +73,9 @@ public final class RulesetsFactoryUtils {
         return ruleSets;
     }
 
-    public static RuleSetFactory getRulesetFactory(final PMDConfiguration configuration) {
-        return new RuleSetFactory(configuration.getClassLoader(), configuration.getMinimumPriority(), true,
+    public static RuleSetFactory getRulesetFactory(final PMDConfiguration configuration,
+            final ResourceLoader resourceLoader) {
+        return new RuleSetFactory(resourceLoader, configuration.getMinimumPriority(), true,
                 configuration.isRuleSetFactoryCompatibilityEnabled());
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/ClasspathClassLoader.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/ClasspathClassLoader.java
@@ -102,15 +102,13 @@ public class ClasspathClassLoader extends URLClassLoader {
         // First, check if the class has already been loaded
         Class<?> c = findLoadedClass(name);
         if (c == null) {
-            if (c == null) {
-                try {
-                    // checking local
-                    c = findClass(name);
-                } catch (final ClassNotFoundException e) {
-                    // checking parent
-                    // This call to loadClass may eventually call findClass again, in case the parent doesn't find anything.
-                    c = super.loadClass(name, resolve);
-                }
+            try {
+                // checking local
+                c = findClass(name);
+            } catch (final ClassNotFoundException e) {
+                // checking parent
+                // This call to loadClass may eventually call findClass again, in case the parent doesn't find anything.
+                c = super.loadClass(name, resolve);
             }
         }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/ClasspathClassLoader.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/ClasspathClassLoader.java
@@ -34,7 +34,7 @@ public class ClasspathClassLoader extends URLClassLoader {
     static {
         registerAsParallelCapable();
     }
-
+    
     public ClasspathClassLoader(String classpath, ClassLoader parent) throws IOException {
         super(initURLs(classpath), parent);
     }
@@ -95,5 +95,28 @@ public class ClasspathClassLoader extends URLClassLoader {
                 .append("[[")
                 .append(StringUtils.join(getURLs(), ":"))
                 .append("] parent: ").append(getParent()).append(']').toString();
+    }
+    
+    @Override
+    protected Class<?> loadClass(final String name, final boolean resolve) throws ClassNotFoundException {
+        // First, check if the class has already been loaded
+        Class<?> c = findLoadedClass(name);
+        if (c == null) {
+            if (c == null) {
+                try {
+                    // checking local
+                    c = findClass(name);
+                } catch (final ClassNotFoundException e) {
+                    // checking parent
+                    // This call to loadClass may eventually call findClass again, in case the parent doesn't find anything.
+                    c = super.loadClass(name, resolve);
+                }
+            }
+        }
+
+        if (resolve) {
+            resolveClass(c);
+        }
+        return c;
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryCompatibilityTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryCompatibilityTest.java
@@ -13,6 +13,8 @@ import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
+import net.sourceforge.pmd.util.ResourceLoader;
+
 public class RuleSetFactoryCompatibilityTest {
     private static final Charset ISO_8859_1 = Charset.forName("ISO-8859-1");
     private static final Charset UTF_8 = Charset.forName("UTF-8");
@@ -136,7 +138,7 @@ public class RuleSetFactoryCompatibilityTest {
             throws RuleSetNotFoundException {
         return factory.createRuleSet(new RuleSetReferenceId(null) {
             @Override
-            public InputStream getInputStream(ClassLoader classLoader) throws RuleSetNotFoundException {
+            public InputStream getInputStream(ResourceLoader resourceLoader) throws RuleSetNotFoundException {
                 return new ByteArrayInputStream(ruleset.getBytes(UTF_8));
             }
         });

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryTest.java
@@ -55,8 +55,7 @@ public class RuleSetFactoryTest {
 
     @Test
     public void testExtendedReferences() throws Exception {
-        InputStream in = ResourceLoader.loadResourceAsStream("net/sourceforge/pmd/rulesets/reference-ruleset.xml",
-                this.getClass().getClassLoader());
+        InputStream in = new ResourceLoader().loadClassPathResourceAsStream("net/sourceforge/pmd/rulesets/reference-ruleset.xml");
         assertNotNull("Test ruleset not found - can't continue with test!", in);
         in.close();
 
@@ -325,7 +324,8 @@ public class RuleSetFactoryTest {
 
     @Test
     public void testReferencePriority() throws RuleSetNotFoundException {
-        RuleSetFactory rsf = new RuleSetFactory(getClass().getClassLoader(), RulePriority.LOW, false, true);
+        ResourceLoader rl = new ResourceLoader();
+        RuleSetFactory rsf = new RuleSetFactory(rl, RulePriority.LOW, false, true);
 
         RuleSet ruleSet = rsf.createRuleSet(createRuleSetReferenceId(REF_INTERNAL_TO_INTERNAL_CHAIN));
         assertEquals("Number of Rules", 3, ruleSet.getRules().size());
@@ -333,31 +333,31 @@ public class RuleSetFactoryTest {
         assertNotNull(ruleSet.getRuleByName("MockRuleNameRef"));
         assertNotNull(ruleSet.getRuleByName("MockRuleNameRefRef"));
 
-        rsf = new RuleSetFactory(getClass().getClassLoader(), RulePriority.MEDIUM_HIGH, false, true);
+        rsf = new RuleSetFactory(rl, RulePriority.MEDIUM_HIGH, false, true);
         ruleSet = rsf.createRuleSet(createRuleSetReferenceId(REF_INTERNAL_TO_INTERNAL_CHAIN));
         assertEquals("Number of Rules", 2, ruleSet.getRules().size());
         assertNotNull(ruleSet.getRuleByName("MockRuleNameRef"));
         assertNotNull(ruleSet.getRuleByName("MockRuleNameRefRef"));
 
-        rsf = new RuleSetFactory(getClass().getClassLoader(), RulePriority.HIGH, false, true);
+        rsf = new RuleSetFactory(rl, RulePriority.HIGH, false, true);
         ruleSet = rsf.createRuleSet(createRuleSetReferenceId(REF_INTERNAL_TO_INTERNAL_CHAIN));
         assertEquals("Number of Rules", 1, ruleSet.getRules().size());
         assertNotNull(ruleSet.getRuleByName("MockRuleNameRefRef"));
 
-        rsf = new RuleSetFactory(getClass().getClassLoader(), RulePriority.LOW, false, true);
+        rsf = new RuleSetFactory(rl, RulePriority.LOW, false, true);
         ruleSet = rsf.createRuleSet(createRuleSetReferenceId(REF_INTERNAL_TO_EXTERNAL_CHAIN));
         assertEquals("Number of Rules", 3, ruleSet.getRules().size());
         assertNotNull(ruleSet.getRuleByName("ExternalRefRuleName"));
         assertNotNull(ruleSet.getRuleByName("ExternalRefRuleNameRef"));
         assertNotNull(ruleSet.getRuleByName("ExternalRefRuleNameRefRef"));
 
-        rsf = new RuleSetFactory(getClass().getClassLoader(), RulePriority.MEDIUM_HIGH, false, true);
+        rsf = new RuleSetFactory(rl, RulePriority.MEDIUM_HIGH, false, true);
         ruleSet = rsf.createRuleSet(createRuleSetReferenceId(REF_INTERNAL_TO_EXTERNAL_CHAIN));
         assertEquals("Number of Rules", 2, ruleSet.getRules().size());
         assertNotNull(ruleSet.getRuleByName("ExternalRefRuleNameRef"));
         assertNotNull(ruleSet.getRuleByName("ExternalRefRuleNameRefRef"));
 
-        rsf = new RuleSetFactory(getClass().getClassLoader(), RulePriority.HIGH, false, true);
+        rsf = new RuleSetFactory(rl, RulePriority.HIGH, false, true);
         ruleSet = rsf.createRuleSet(createRuleSetReferenceId(REF_INTERNAL_TO_EXTERNAL_CHAIN));
         assertEquals("Number of Rules", 1, ruleSet.getRules().size());
         assertNotNull(ruleSet.getRuleByName("ExternalRefRuleNameRefRef"));
@@ -382,9 +382,10 @@ public class RuleSetFactoryTest {
 
     @Test
     public void testSetPriority() throws RuleSetNotFoundException {
-        RuleSetFactory rsf = new RuleSetFactory(getClass().getClassLoader(), RulePriority.MEDIUM_HIGH, false, true);
+        ResourceLoader rl = new ResourceLoader();
+        RuleSetFactory rsf = new RuleSetFactory(rl, RulePriority.MEDIUM_HIGH, false, true);
         assertEquals(0, rsf.createRuleSet(createRuleSetReferenceId(SINGLE_RULE)).size());
-        rsf = new RuleSetFactory(getClass().getClassLoader(), RulePriority.MEDIUM_LOW, false, true);
+        rsf = new RuleSetFactory(rl, RulePriority.MEDIUM_LOW, false, true);
         assertEquals(1, rsf.createRuleSet(createRuleSetReferenceId(SINGLE_RULE)).size());
     }
 
@@ -862,7 +863,7 @@ public class RuleSetFactoryTest {
     private static RuleSetReferenceId createRuleSetReferenceId(final String ruleSetXml) {
         return new RuleSetReferenceId(null) {
             @Override
-            public InputStream getInputStream(ClassLoader classLoader) throws RuleSetNotFoundException {
+            public InputStream getInputStream(ResourceLoader resourceLoader) throws RuleSetNotFoundException {
                 try {
                     return new ByteArrayInputStream(ruleSetXml.getBytes("UTF-8"));
                 } catch (UnsupportedEncodingException e) {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetReferenceIdTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetReferenceIdTest.java
@@ -24,6 +24,8 @@ import java.util.List;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
+import net.sourceforge.pmd.util.ResourceLoader;
+
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 
 public class RuleSetReferenceIdTest {
@@ -119,7 +121,7 @@ public class RuleSetReferenceIdTest {
         RuleSetReferenceId ruleSetReferenceId = new RuleSetReferenceId("  " + rulesetUrl + "  ");
         assertRuleSetReferenceId(true, rulesetUrl, true, null, rulesetUrl, ruleSetReferenceId);
 
-        try (InputStream inputStream = ruleSetReferenceId.getInputStream(RuleSetReferenceIdTest.class.getClassLoader());) {
+        try (InputStream inputStream = ruleSetReferenceId.getInputStream(new ResourceLoader())) {
             String loaded = IOUtils.toString(inputStream, "UTF-8");
             assertEquals("xyz", loaded);
         }
@@ -148,7 +150,7 @@ public class RuleSetReferenceIdTest {
         assertRuleSetReferenceId(true, hostpart + path, false, "DummyBasicMockRule", hostpart + completePath,
                 ruleSetReferenceId);
 
-        try (InputStream inputStream = ruleSetReferenceId.getInputStream(RuleSetReferenceIdTest.class.getClassLoader());) {
+        try (InputStream inputStream = ruleSetReferenceId.getInputStream(new ResourceLoader())) {
             String loaded = IOUtils.toString(inputStream, "UTF-8");
             assertEquals(basicRuleSet, loaded);
         }

--- a/pmd-test/src/main/java/net/sourceforge/pmd/AbstractLanguageVersionTest.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/AbstractLanguageVersionTest.java
@@ -115,9 +115,10 @@ public class AbstractLanguageVersionTest {
             return;
         }
 
+        ResourceLoader rl = new ResourceLoader();
         Properties props = new Properties();
         String rulesetsProperties = "rulesets/" + simpleTerseName + "/rulesets.properties";
-        try (InputStream inputStream = ResourceLoader.loadResourceAsStream(rulesetsProperties);) {
+        try (InputStream inputStream = rl.loadClassPathResourceAsStreamOrThrow(rulesetsProperties)) {
             props.load(inputStream);
         }
         String rulesetFilenames = props.getProperty("rulesets.filenames");
@@ -131,7 +132,7 @@ public class AbstractLanguageVersionTest {
 
         String[] rulesets = rulesetFilenames.split(",");
         for (String r : rulesets) {
-            InputStream stream = ResourceLoader.loadResourceAsStream(r);
+            InputStream stream = rl.loadClassPathResourceAsStream(r);
             assertNotNull(stream);
             stream.close();
             RuleSet ruleset = factory.createRuleSet(r);

--- a/pmd-test/src/main/java/net/sourceforge/pmd/AbstractRuleSetFactoryTest.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/AbstractRuleSetFactoryTest.java
@@ -243,7 +243,7 @@ public abstract class AbstractRuleSetFactoryTest {
         List<String> ruleSetFileNames = new ArrayList<>();
         try {
             Properties properties = new Properties();
-            try (InputStream is = ResourceLoader.loadResourceAsStream("rulesets/" + language + "/rulesets.properties")) {
+            try (InputStream is = new ResourceLoader().loadClassPathResourceAsStreamOrThrow("rulesets/" + language + "/rulesets.properties")) {
                 properties.load(is);
             }
             String fileNames = properties.getProperty("rulesets.filenames");
@@ -335,14 +335,7 @@ public abstract class AbstractRuleSetFactoryTest {
     }
 
     private static InputStream loadResourceAsStream(String resource) throws RuleSetNotFoundException {
-        InputStream inputStream = ResourceLoader.loadResourceAsStream(resource,
-                AbstractRuleSetFactoryTest.class.getClassLoader());
-        if (inputStream == null) {
-            throw new RuleSetNotFoundException("Can't find resource " + resource
-                    + "  Make sure the resource is a valid file or URL or is on the CLASSPATH.  Here's the current classpath: "
-                    + System.getProperty("java.class.path"));
-        }
-        return inputStream;
+        return new ResourceLoader().loadClassPathResourceAsStreamOrThrow(resource);
     }
 
     private void testRuleSet(String fileName)
@@ -477,7 +470,7 @@ public abstract class AbstractRuleSetFactoryTest {
     protected static RuleSetReferenceId createRuleSetReferenceId(final String ruleSetXml) {
         return new RuleSetReferenceId(null) {
             @Override
-            public InputStream getInputStream(ClassLoader classLoader) throws RuleSetNotFoundException {
+            public InputStream getInputStream(ResourceLoader resourceLoader) throws RuleSetNotFoundException {
                 try {
                     return new ByteArrayInputStream(ruleSetXml.getBytes("UTF-8"));
                 } catch (UnsupportedEncodingException e) {


### PR DESCRIPTION
 - We will now always load classes from auxclasspath during
typeresolution, even if we have a class with the same name in PMD's
classpath
 - This prevents conflicts when using different versions of the same
dependencies

