### PR TITLE
[java] Handle properly reduction incompatibilities

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/MethodTypeResolution.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/MethodTypeResolution.java
@@ -140,8 +140,14 @@ public final class MethodTypeResolution {
                     }
 
                     methodType = parameterizeInvocation(context, methodType.getMethod(), argList);
+                    
+                    // May be null if the method call is not applicable
+                    if (methodType == null) {
+                        continue;
+                    }
                 }
 
+                // TODO : Is this needed? parameterizeInvocation already performs inference to check applicability...
                 // check subtypeability of each argument to the corresponding parameter
                 boolean methodIsApplicable = true;
 
@@ -166,7 +172,6 @@ public final class MethodTypeResolution {
         return selectedMethods;
     }
 
-
     public static MethodType parameterizeInvocation(JavaTypeDefinition context, Method method,
                                                     ASTArgumentList argList) {
 
@@ -177,6 +182,11 @@ public final class MethodTypeResolution {
 
         List<JavaTypeDefinition> resolvedTypeParameters = TypeInferenceResolver
                 .inferTypes(produceInitialConstraints(method, argList, variables), initialBounds, variables);
+
+        // Is the method applicable?
+        if (resolvedTypeParameters == null) {
+            return null;
+        }
 
         return getTypeDefOfMethod(context, method, resolvedTypeParameters);
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typeinference/InferenceRuleType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typeinference/InferenceRuleType.java
@@ -128,7 +128,8 @@ public enum InferenceRuleType {
 
             // Otherwise, the constraint is reduced according to the form of T: TODO
 
-            throw new IllegalStateException("Reduce method is flawed! " + val.toString());
+            return null;
+            //throw new IllegalStateException("Reduce method is flawed! " + val.toString());
         }
     },
 
@@ -257,7 +258,5 @@ public enum InferenceRuleType {
         }
     }
 
-    public List<BoundOrConstraint> reduce(BoundOrConstraint constraint) {
-        return null;
-    }
+    public abstract List<BoundOrConstraint> reduce(BoundOrConstraint constraint);
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typeinference/InferenceRuleType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typeinference/InferenceRuleType.java
@@ -83,7 +83,9 @@ public enum InferenceRuleType {
             // A constraint formula of the form ‹S = T›, where S and T are type arguments (§4.5.1), is reduced as
             // follows: TODO
 
-            throw new IllegalStateException("Reduce method is flawed! " + val.toString());
+            // TODO: Reduce to false for the time being, reduction is still incomplete
+            return null;
+            //throw new IllegalStateException("Reduce method is flawed! " + val.toString());
         }
     },
 
@@ -128,6 +130,7 @@ public enum InferenceRuleType {
 
             // Otherwise, the constraint is reduced according to the form of T: TODO
 
+            // TODO: Reduce to false for the time being, reduction is still incomplete
             return null;
             //throw new IllegalStateException("Reduce method is flawed! " + val.toString());
         }
@@ -221,7 +224,9 @@ public enum InferenceRuleType {
 
             // If T is a wildcard of the form ? super T': TODO
 
-            throw new IllegalStateException("Reduce method is flawed! " + val.toString());
+            // TODO: Reduce to false for the time being, reduction is still incomplete
+            return null;
+            //throw new IllegalStateException("Reduce method is flawed! " + val.toString());
         }
     };
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typeinference/TypeInferenceResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typeinference/TypeInferenceResolver.java
@@ -38,6 +38,11 @@ public final class TypeInferenceResolver {
         List<Bound> newBounds = new ArrayList<>();
         while (!constraints.isEmpty()) {
             List<BoundOrConstraint> reduceResult = constraints.remove(constraints.size() - 1).reduce();
+            
+            // If null, the types are incompatible
+            if (reduceResult == null) {
+                return null;
+            }
 
             for (BoundOrConstraint boundOrConstraint : reduceResult) {
                 if (boundOrConstraint instanceof Bound) {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
@@ -1328,7 +1328,7 @@ public class ClassTypeResolverTest {
 
         int index = 0;
 
-        // int a = subtype(10, 'a', null, new Integer[0]);
+        // int a = subtype(10, 'a', "");
         assertEquals(int.class, expressions.get(index).getType());
         assertEquals(int.class, getChildType(expressions.get(index), 0));
         assertEquals(int.class, getChildType(expressions.get(index++), 1));

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/TypeInferenceTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/TypeInferenceTest.java
@@ -10,6 +10,8 @@ import static net.sourceforge.pmd.lang.java.typeresolution.typeinference.Inferen
 import static net.sourceforge.pmd.lang.java.typeresolution.typeinference.InferenceRuleType.SUBTYPE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -41,15 +43,15 @@ public class TypeInferenceTest {
     private JavaTypeDefinition generic = JavaTypeDefinition.forClass(Map.class, number, integer);
     private Variable alpha = new Variable();
     private Variable beta = new Variable();
-    JavaTypeDefinition s = JavaTypeDefinition.forClass(int.class);
-    JavaTypeDefinition t = JavaTypeDefinition.forClass(double.class);
+    private JavaTypeDefinition s = JavaTypeDefinition.forClass(int.class);
+    private JavaTypeDefinition t = JavaTypeDefinition.forClass(double.class);
 
     @Test
     public void testEqualityReduceProperVsProper() {
         // If S and T are proper types, the constraint reduces to true if S is the same as T (§4.3.4), and false
         // otherwise.
         assertTrue(new Constraint(number, number, EQUALITY).reduce().isEmpty());
-        assertEquals(new Constraint(number, integer, EQUALITY).reduce(), null);
+        assertNull(new Constraint(number, integer, EQUALITY).reduce());
 
         // Otherwise, if S or T is the null type, the constraint reduces to false. TODO
     }
@@ -59,7 +61,7 @@ public class TypeInferenceTest {
         // Otherwise, if S is an inference variable, α, and T is not a primitive type, the constraint reduces to
         // the bound α = T.
         List<BoundOrConstraint> result = new Constraint(alpha, number, EQUALITY).reduce();
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), alpha, number, EQUALITY, Bound.class);
     }
 
@@ -68,11 +70,11 @@ public class TypeInferenceTest {
         // Otherwise, if T is an inference variable, α, and S is not a primitive type, the constraint reduces
         // to the bound S = α.
         List<BoundOrConstraint> result = new Constraint(number, alpha, EQUALITY).reduce();
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), number, alpha, EQUALITY, Bound.class);
 
         result = new Constraint(alpha, beta, EQUALITY).reduce();
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), alpha, beta, EQUALITY, Bound.class);
     }
 
@@ -82,7 +84,7 @@ public class TypeInferenceTest {
         // arguments B1, ..., Bn and T has type arguments A1, ..., An, the constraint reduces to the
         // following new constraints: for all i (1 ≤ i ≤ n), ‹Bi = Ai›.
         List<BoundOrConstraint> result = new Constraint(generic, generic, EQUALITY).reduce();
-        assertEquals(result.size(), 2);
+        assertEquals(2, result.size());
         testBoundOrConstraint(result.get(0), number, number, EQUALITY, Constraint.class);
         testBoundOrConstraint(result.get(1), integer, integer, EQUALITY, Constraint.class);
     }
@@ -93,7 +95,7 @@ public class TypeInferenceTest {
         List<BoundOrConstraint> result = new Constraint(JavaTypeDefinition.forClass(Number[].class),
                                                         JavaTypeDefinition.forClass(Integer[].class), EQUALITY)
                 .reduce();
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), number, integer, EQUALITY, Constraint.class);
     }
 
@@ -104,9 +106,9 @@ public class TypeInferenceTest {
         // If S and T are proper types, the constraint reduces to true if S is a subtype of T (§4.10),
         // and false otherwise.
         List<BoundOrConstraint> result = new Constraint(integer, number, SUBTYPE).reduce();
-        assertEquals(result.size(), 0);
+        assertEquals(0, result.size());
         result = new Constraint(number, integer, SUBTYPE).reduce();
-        assertEquals(result, null);
+        assertNull(result);
 
 
         // Otherwise, if S is the null type, the constraint reduces to true. TODO
@@ -118,7 +120,7 @@ public class TypeInferenceTest {
     public void testSubtypeReduceVariableVsAny() {
         // Otherwise, if S is an inference variable, α, the constraint reduces to the bound α <: T.
         List<BoundOrConstraint> result = new Constraint(alpha, integer, SUBTYPE).reduce();
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), alpha, integer, SUBTYPE, Bound.class);
     }
 
@@ -126,11 +128,11 @@ public class TypeInferenceTest {
     public void testSubtypeReduceAnyVsVariable() {
         // Otherwise, if T is an inference variable, α, the constraint reduces to the bound S <: α.
         List<BoundOrConstraint> result = new Constraint(integer, alpha, SUBTYPE).reduce();
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), integer, alpha, SUBTYPE, Bound.class);
 
         result = new Constraint(alpha, beta, SUBTYPE).reduce();
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), alpha, beta, SUBTYPE, Bound.class);
     }
 
@@ -142,10 +144,10 @@ public class TypeInferenceTest {
         // If S and T are proper types, the constraint reduces to true if S is compatible in a loose invocation
         // context with T (§5.3), and false otherwise.
         List<BoundOrConstraint> result = new Constraint(number, integer, LOOSE_INVOCATION).reduce();
-        assertEquals(result, null);
+        assertNull(result);
 
         result = new Constraint(integer, number, LOOSE_INVOCATION).reduce();
-        assertEquals(result.size(), 0);
+        assertEquals(0, result.size());
     }
 
     @Test
@@ -153,7 +155,7 @@ public class TypeInferenceTest {
         // Otherwise, if S is a primitive type, let S' be the result of applying boxing conversion (§5.1.7) to S.
         // Then the constraint reduces to ‹S' → T›.
         List<BoundOrConstraint> result = new Constraint(primitiveInt, number, LOOSE_INVOCATION).reduce();
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), integer, number, LOOSE_INVOCATION, Constraint.class);
 
     }
@@ -163,7 +165,7 @@ public class TypeInferenceTest {
         // Otherwise, if T is a primitive type, let T' be the result of applying boxing conversion (§5.1.7) to T.
         // Then the constraint reduces to ‹S = T'›.
         List<BoundOrConstraint> result = new Constraint(number, primitiveInt, LOOSE_INVOCATION).reduce();
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), number, integer, EQUALITY, Constraint.class);
 
         // Otherwise, if T is a parameterized type of the form G<T1, ..., Tn>, and there exists no type of the
@@ -180,11 +182,11 @@ public class TypeInferenceTest {
     public void testLooseInvocationAnythingElse() {
         // Otherwise, the constraint reduces to ‹S<:T›.
         List<BoundOrConstraint> result = new Constraint(number, alpha, LOOSE_INVOCATION).reduce();
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), number, alpha, SUBTYPE, Constraint.class);
 
         result = new Constraint(alpha, number, LOOSE_INVOCATION).reduce();
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), alpha, number, SUBTYPE, Constraint.class);
     }
 
@@ -195,7 +197,7 @@ public class TypeInferenceTest {
 
         // If T is a type: // If S is a type, the constraint reduces to ‹S = T›.
         List<BoundOrConstraint> result = new Constraint(number, integer, CONTAINS).reduce();
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), number, integer, EQUALITY, Constraint.class);
 
         // If T is a type: // If S is a wildcard, the constraint reduces to false. TODO
@@ -215,22 +217,22 @@ public class TypeInferenceTest {
 
         // ### Original rule 1. : α = S and α = T imply ‹S = T›
         result = incorporationResult(new Bound(alpha, s, EQUALITY), new Bound(alpha, t, EQUALITY));
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), s, t, EQUALITY, Constraint.class);
 
         // α = S and T = α imply ‹S = T›
         result = incorporationResult(new Bound(alpha, s, EQUALITY), new Bound(t, alpha, EQUALITY));
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), s, t, EQUALITY, Constraint.class);
 
         // S = α and α = T imply ‹S = T›
         result = incorporationResult(new Bound(s, alpha, EQUALITY), new Bound(alpha, t, EQUALITY));
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), s, t, EQUALITY, Constraint.class);
 
         // S = α and T = α imply ‹S = T›
         result = incorporationResult(new Bound(s, alpha, EQUALITY), new Bound(t, alpha, EQUALITY));
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), s, t, EQUALITY, Constraint.class);
     }
 
@@ -240,22 +242,22 @@ public class TypeInferenceTest {
 
         // ### Original rule 2. : α = S and α <: T imply ‹S <: T›
         result = incorporationResult(new Bound(alpha, s, EQUALITY), new Bound(alpha, t, SUBTYPE));
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), s, t, SUBTYPE, Constraint.class);
 
         // S = α and α <: T imply ‹S <: T›
         result = incorporationResult(new Bound(s, alpha, EQUALITY), new Bound(alpha, t, SUBTYPE));
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), s, t, SUBTYPE, Constraint.class);
 
         // α <: T and α = S imply ‹S <: T›
         result = incorporationResult(new Bound(alpha, t, SUBTYPE), new Bound(alpha, s, EQUALITY));
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), s, t, SUBTYPE, Constraint.class);
 
         // α <: T and S = α imply ‹S <: T›
         result = incorporationResult(new Bound(alpha, t, SUBTYPE), new Bound(s, alpha, EQUALITY));
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), s, t, SUBTYPE, Constraint.class);
     }
 
@@ -265,22 +267,22 @@ public class TypeInferenceTest {
 
         // ### Original rule 3. : α = S and T <: α imply ‹T <: S›
         result = incorporationResult(new Bound(alpha, s, EQUALITY), new Bound(t, alpha, SUBTYPE));
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), t, s, SUBTYPE, Constraint.class);
 
         // S = α and T <: α imply ‹T <: S›
         result = incorporationResult(new Bound(s, alpha, EQUALITY), new Bound(t, alpha, SUBTYPE));
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), t, s, SUBTYPE, Constraint.class);
 
         // T <: α and α = S imply ‹T <: S›
         result = incorporationResult(new Bound(t, alpha, SUBTYPE), new Bound(alpha, s, EQUALITY));
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), t, s, SUBTYPE, Constraint.class);
 
         // T <: α and S = α imply ‹T <: S›
         result = incorporationResult(new Bound(t, alpha, SUBTYPE), new Bound(s, alpha, EQUALITY));
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), t, s, SUBTYPE, Constraint.class);
     }
 
@@ -290,12 +292,12 @@ public class TypeInferenceTest {
 
         // ### Original rule 4. : S <: α and α <: T imply ‹S <: T›
         result = incorporationResult(new Bound(s, alpha, EQUALITY), new Bound(alpha, t, SUBTYPE));
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), s, t, SUBTYPE, Constraint.class);
 
         // α <: T and S <: α imply ‹S <: T›
         result = incorporationResult(new Bound(alpha, t, SUBTYPE), new Bound(s, alpha, EQUALITY));
-        assertEquals(result.size(), 1);
+        assertEquals(1, result.size());
         testBoundOrConstraint(result.get(0), s, t, SUBTYPE, Constraint.class);
 
     }
@@ -323,7 +325,7 @@ public class TypeInferenceTest {
         Set<Class<?>> minimalSet = TypeInferenceResolver.getMinimalErasedCandidateSet(
                 JavaTypeDefinition.forClass(List.class).getErasedSuperTypeSet());
 
-        assertEquals(minimalSet.size(), 1);
+        assertEquals(1, minimalSet.size());
         assertTrue(minimalSet.contains(List.class));
     }
 
@@ -334,7 +336,7 @@ public class TypeInferenceTest {
         lowerBounds.add(JavaTypeDefinition.forClass(SuperClassAOther.class));
         lowerBounds.add(JavaTypeDefinition.forClass(SuperClassAOther2.class));
 
-        assertEquals(TypeInferenceResolver.lub(lowerBounds), JavaTypeDefinition.forClass(SuperClassA2.class));
+        assertEquals(JavaTypeDefinition.forClass(SuperClassA2.class), TypeInferenceResolver.lub(lowerBounds));
     }
 
     @Test
@@ -343,8 +345,8 @@ public class TypeInferenceTest {
         bounds.add(new Bound(JavaTypeDefinition.forClass(SuperClassA.class), alpha, SUBTYPE));
         bounds.add(new Bound(JavaTypeDefinition.forClass(SuperClassAOther.class), alpha, SUBTYPE));
         Map<Variable, JavaTypeDefinition> result = TypeInferenceResolver.resolveVariables(bounds);
-        assertEquals(result.size(), 1);
-        assertEquals(result.get(alpha), JavaTypeDefinition.forClass(SuperClassA2.class));
+        assertEquals(1, result.size());
+        assertEquals(JavaTypeDefinition.forClass(SuperClassA2.class), result.get(alpha));
     }
 
     private List<Constraint> incorporationResult(Bound firstBound, Bound secondBound) {
@@ -358,34 +360,34 @@ public class TypeInferenceTest {
 
     private void testBoundOrConstraint(BoundOrConstraint val, JavaTypeDefinition left, JavaTypeDefinition right,
                                        InferenceRuleType rule, Class<? extends BoundOrConstraint> type) {
-        assertTrue(val.getClass() == type);
-        assertEquals(val.leftProper(), left);
-        assertEquals(val.rightProper(), right);
-        assertEquals(val.ruleType(), rule);
+        assertSame(type, val.getClass());
+        assertEquals(left, val.leftProper());
+        assertEquals(right, val.rightProper());
+        assertEquals(rule, val.ruleType());
     }
 
 
     private void testBoundOrConstraint(BoundOrConstraint val, JavaTypeDefinition left, Variable right,
                                        InferenceRuleType rule, Class<? extends BoundOrConstraint> type) {
-        assertTrue(val.getClass() == type);
-        assertEquals(val.leftProper(), left);
-        assertEquals(val.rightVariable(), right);
-        assertEquals(val.ruleType(), rule);
+        assertSame(type, val.getClass());
+        assertEquals(left, val.leftProper());
+        assertEquals(right, val.rightVariable());
+        assertEquals(rule, val.ruleType());
     }
 
     private void testBoundOrConstraint(BoundOrConstraint val, Variable left, JavaTypeDefinition right,
                                        InferenceRuleType rule, Class<? extends BoundOrConstraint> type) {
-        assertTrue(val.getClass() == type);
-        assertEquals(val.leftVariable(), left);
-        assertEquals(val.rightProper(), right);
-        assertEquals(val.ruleType(), rule);
+        assertSame(type, val.getClass());
+        assertEquals(left, val.leftVariable());
+        assertEquals(right, val.rightProper());
+        assertEquals(rule, val.ruleType());
     }
 
     private void testBoundOrConstraint(BoundOrConstraint val, Variable left, Variable right,
                                        InferenceRuleType rule, Class<? extends BoundOrConstraint> type) {
-        assertTrue(val.getClass() == type);
-        assertEquals(val.leftVariable(), left);
-        assertEquals(val.rightVariable(), right);
-        assertEquals(val.ruleType(), rule);
+        assertSame(type, val.getClass());
+        assertEquals(left, val.leftVariable());
+        assertEquals(right, val.rightVariable());
+        assertEquals(rule, val.ruleType());
     }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/MethodFirstPhase.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/MethodFirstPhase.java
@@ -14,7 +14,7 @@ import java.util.Set;
 public class MethodFirstPhase {
     void test() {
         //  primitive, char, simple
-        int a = subtype(10, 'a', "");
+        int a = subtype(Long.valueOf(10), 'a', "");
         // TODO: add null, array types
 
         Exception b = vararg((Number) null);
@@ -46,7 +46,11 @@ public class MethodFirstPhase {
         return null;
     }
 
-    int subtype(long a, int b, String c) {
+    <T extends CharSequence> int subtype(T a, int b, String c) {
+        return 0;
+    }
+    
+    int subtype(Long a, int b, String c) {
         return 0;
     }
 


### PR DESCRIPTION
 - When a reduce operation return null (it's incompatible), we should
handle it properly instead of producing a NPE.
 - This is not extensive, there are other scenarios still failing, but I'm addressing them separately
