### PR TITLE
[java] Simplify ForLoopShouldBeWhileLoop

### DIFF
--- a/pmd-java/src/main/resources/rulesets/java/basic.xml
+++ b/pmd-java/src/main/resources/rulesets/java/basic.xml
@@ -59,11 +59,10 @@ Some for loops can be simplified to while loops, this makes them more concise.
         <property name="xpath">
             <value><![CDATA[
 //ForStatement
-  [count(*) > 1]
   [not(LocalVariableDeclaration)]
   [not(ForInit)]
   [not(ForUpdate)]
-  [not(Type and Expression and Statement)]
+  [Expression]
 ]]></value>
         </property>
     </properties>


### PR DESCRIPTION
 - Remove checks that will always be true (a node can't be a Type and
a Statement and an Expression at the same time)
 - Simplify count(*) > 1 checks (expensive) for an Expression check (the one
node we actually care about)
