### PR TITLE
[java] Fix boxing rules

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/MethodTypeResolution.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/MethodTypeResolution.java
@@ -13,7 +13,9 @@ import java.lang.reflect.Type;
 import java.lang.reflect.TypeVariable;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -38,9 +40,10 @@ public final class MethodTypeResolution {
 
     private static final List<Class<?>> PRIMITIVE_SUBTYPE_ORDER;
     private static final List<Class<?>> BOXED_PRIMITIVE_SUBTYPE_ORDER;
+    private static final Map<Class<?>, Class<?>> PRIMITIVE_BOXING_RULES;
 
     static {
-        List<Class<?>> primitiveList = new ArrayList<>();
+        final List<Class<?>> primitiveList = new ArrayList<>();
 
         primitiveList.add(double.class);
         primitiveList.add(float.class);
@@ -52,7 +55,7 @@ public final class MethodTypeResolution {
 
         PRIMITIVE_SUBTYPE_ORDER = Collections.unmodifiableList(primitiveList);
 
-        List<Class<?>> boxedList = new ArrayList<>();
+        final List<Class<?>> boxedList = new ArrayList<>();
 
         boxedList.add(Double.class);
         boxedList.add(Float.class);
@@ -63,6 +66,20 @@ public final class MethodTypeResolution {
         boxedList.add(Character.class);
 
         BOXED_PRIMITIVE_SUBTYPE_ORDER = Collections.unmodifiableList(boxedList);
+        
+        final Map<Class<?>, Class<?>> boxingRules = new HashMap<>();
+        
+        boxingRules.put(double.class, Double.class);
+        boxingRules.put(float.class, Float.class);
+        boxingRules.put(long.class, Long.class);
+        boxingRules.put(int.class, Integer.class);
+        boxingRules.put(short.class, Short.class);
+        boxingRules.put(byte.class, Byte.class);
+        boxingRules.put(char.class, Character.class);
+        boxingRules.put(boolean.class, Boolean.class);
+        boxingRules.put(void.class, Void.class);
+        
+        PRIMITIVE_BOXING_RULES = Collections.unmodifiableMap(boxingRules);
     }
 
     public static boolean checkSubtypeability(MethodType method, MethodType subtypeableMethod) {
@@ -686,11 +703,7 @@ public final class MethodTypeResolution {
     }
 
     public static JavaTypeDefinition boxPrimitive(JavaTypeDefinition def) {
-        if (!def.isPrimitive()) {
-            return null;
-        }
-
-        return JavaTypeDefinition.forClass(BOXED_PRIMITIVE_SUBTYPE_ORDER.get(PRIMITIVE_SUBTYPE_ORDER.indexOf(def.getType())));
+        return JavaTypeDefinition.forClass(PRIMITIVE_BOXING_RULES.get(def.getType()));
     }
 
     public static List<JavaTypeDefinition> getMethodExplicitTypeArugments(Node node) {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/MethodTypeResolutionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/MethodTypeResolutionTest.java
@@ -1,0 +1,24 @@
+package net.sourceforge.pmd.typeresolution;
+
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+
+import net.sourceforge.pmd.lang.java.typeresolution.MethodTypeResolution;
+import net.sourceforge.pmd.lang.java.typeresolution.typedefinition.JavaTypeDefinition;
+
+public class MethodTypeResolutionTest {
+
+    @Test
+    public void testBoxingRules() {
+        assertSame(Boolean.class, MethodTypeResolution.boxPrimitive(JavaTypeDefinition.forClass(boolean.class)).getType());
+        assertSame(Double.class, MethodTypeResolution.boxPrimitive(JavaTypeDefinition.forClass(double.class)).getType());
+        assertSame(Float.class, MethodTypeResolution.boxPrimitive(JavaTypeDefinition.forClass(float.class)).getType());
+        assertSame(Long.class, MethodTypeResolution.boxPrimitive(JavaTypeDefinition.forClass(long.class)).getType());
+        assertSame(Integer.class, MethodTypeResolution.boxPrimitive(JavaTypeDefinition.forClass(int.class)).getType());
+        assertSame(Character.class, MethodTypeResolution.boxPrimitive(JavaTypeDefinition.forClass(char.class)).getType());
+        assertSame(Short.class, MethodTypeResolution.boxPrimitive(JavaTypeDefinition.forClass(short.class)).getType());
+        assertSame(Byte.class, MethodTypeResolution.boxPrimitive(JavaTypeDefinition.forClass(byte.class)).getType());
+        assertSame(Void.class, MethodTypeResolution.boxPrimitive(JavaTypeDefinition.forClass(void.class)).getType());
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/MethodTypeResolutionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/MethodTypeResolutionTest.java
@@ -1,3 +1,7 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
 package net.sourceforge.pmd.typeresolution;
 
 import static org.junit.Assert.assertSame;


### PR DESCRIPTION
 - Boolean types were not considered since we were using the
subtypability set which deals exclusively with numeric types
 - Fixes #650
