### PR TITLE
[java] Properly handle 0-arg calls

### DIFF
--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
@@ -105,6 +105,7 @@ import net.sourceforge.pmd.typeresolution.testdata.SubTypeUsage;
 import net.sourceforge.pmd.typeresolution.testdata.SuperExpression;
 import net.sourceforge.pmd.typeresolution.testdata.ThisExpression;
 import net.sourceforge.pmd.typeresolution.testdata.VarArgsMethodUseCase;
+import net.sourceforge.pmd.typeresolution.testdata.VarargsAsFixedArity;
 import net.sourceforge.pmd.typeresolution.testdata.VarargsZeroArity;
 import net.sourceforge.pmd.typeresolution.testdata.dummytypes.Converter;
 import net.sourceforge.pmd.typeresolution.testdata.dummytypes.GenericClass;
@@ -1538,6 +1539,35 @@ public class ClassTypeResolverTest {
 
         //String var2 = aMethod("");
         assertEquals(String.class, expressions.get(index++).getType());
+        
+        // Make sure we got them all
+        assertEquals("All expressions not tested", index, expressions.size());
+    }
+    
+    @Test
+    public void testMethodTypeInferenceVarargsAsFixedArity() throws JaxenException {
+        ASTCompilationUnit acu = parseAndTypeResolveForClass15(VarargsAsFixedArity.class);
+
+        List<AbstractJavaTypeNode> expressions = convertList(
+                acu.findChildNodesWithXPath("//VariableInitializer/Expression/PrimaryExpression"),
+                AbstractJavaTypeNode.class);
+
+        int index = 0;
+
+        // int var = aMethod("");
+        assertEquals(int.class, expressions.get(index++).getType());
+
+        // String var2 = aMethod();
+        assertEquals(String.class, expressions.get(index++).getType());
+        
+        // String var3 = aMethod("", "");
+        assertEquals(String.class, expressions.get(index++).getType());
+        
+        // String var4 = aMethod(new Object[] { null });
+        assertEquals(String.class, expressions.get(index++).getType());
+        
+        // null literal has null type
+        assertNull(expressions.get(index++).getType());
         
         // Make sure we got them all
         assertEquals("All expressions not tested", index, expressions.size());

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
@@ -105,6 +105,7 @@ import net.sourceforge.pmd.typeresolution.testdata.SubTypeUsage;
 import net.sourceforge.pmd.typeresolution.testdata.SuperExpression;
 import net.sourceforge.pmd.typeresolution.testdata.ThisExpression;
 import net.sourceforge.pmd.typeresolution.testdata.VarArgsMethodUseCase;
+import net.sourceforge.pmd.typeresolution.testdata.VarargsZeroArity;
 import net.sourceforge.pmd.typeresolution.testdata.dummytypes.Converter;
 import net.sourceforge.pmd.typeresolution.testdata.dummytypes.GenericClass;
 import net.sourceforge.pmd.typeresolution.testdata.dummytypes.JavaTypeDefinitionEquals;
@@ -1518,6 +1519,26 @@ public class ClassTypeResolverTest {
         assertEquals(SuperClassA2.class, getChildType(expressions.get(index), 0));
         assertEquals(SuperClassA2.class, getChildType(expressions.get(index++), 1));
 
+        // Make sure we got them all
+        assertEquals("All expressions not tested", index, expressions.size());
+    }
+    
+    @Test
+    public void testMethodTypeInferenceVarargsZeroArity() throws JaxenException {
+        ASTCompilationUnit acu = parseAndTypeResolveForClass15(VarargsZeroArity.class);
+
+        List<AbstractJavaTypeNode> expressions = convertList(
+                acu.findChildNodesWithXPath("//VariableInitializer/Expression/PrimaryExpression"),
+                AbstractJavaTypeNode.class);
+
+        int index = 0;
+
+        // int var = aMethod();
+        assertEquals(int.class, expressions.get(index++).getType());
+
+        //String var2 = aMethod("");
+        assertEquals(String.class, expressions.get(index++).getType());
+        
         // Make sure we got them all
         assertEquals("All expressions not tested", index, expressions.size());
     }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/VarargsAsFixedArity.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/VarargsAsFixedArity.java
@@ -1,0 +1,23 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.typeresolution.testdata;
+
+public class VarargsAsFixedArity {
+
+    public void tester() {
+        int var = aMethod("");
+        String var2 = aMethod();
+        String var3 = aMethod("", "");
+        String var4 = aMethod(new Object[] { null });
+    }
+    
+    public int aMethod(Object s) {
+        return 0;
+    }
+    
+    public String aMethod(Object... s) {
+        return null;
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/VarargsZeroArity.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/VarargsZeroArity.java
@@ -1,3 +1,7 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
 package net.sourceforge.pmd.typeresolution.testdata;
 
 public class VarargsZeroArity {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/VarargsZeroArity.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/VarargsZeroArity.java
@@ -1,0 +1,17 @@
+package net.sourceforge.pmd.typeresolution.testdata;
+
+public class VarargsZeroArity {
+
+    public void tester() {
+        int var = aMethod();
+        String var2 = aMethod("");
+    }
+    
+    public int aMethod() {
+        return 0;
+    }
+    
+    public String aMethod(String... args) {
+        return null;
+    }
+}


### PR DESCRIPTION
 - We no longer take all methods as applicable for a 0-arg method call
during type resolution.

This resolves the issue

```
Caused by: java.lang.IllegalStateException: These methods can only be vararg at the same time:
MethodType [method=public org.apache.solr.common.params.ModifiableSolrParams org.apache.solr.common.params.ModifiableSolrParams.set(java.lang.String,int), returnType=JavaTypeDefinition [clazz=class org.apache.solr.common.params.ModifiableSolrParams, definitionType=EXACT, genericArgs=[], isGeneric=false]
, argTypes=[JavaTypeDefinition [clazz=class java.lang.String, definitionType=EXACT, genericArgs=[], isGeneric=false]
, JavaTypeDefinition [clazz=int, definitionType=EXACT, genericArgs=[], isGeneric=false]
]]
MethodType [method=public org.apache.solr.common.params.ModifiableSolrParams org.apache.solr.common.params.ModifiableSolrParams.set(java.lang.String,java.lang.String[]), returnType=JavaTypeDefinition [clazz=class org.apache.solr.common.params.ModifiableSolrParams, definitionType=EXACT, genericArgs=[], isGeneric=false]
, argTypes=[JavaTypeDefinition [clazz=class java.lang.String, definitionType=EXACT, genericArgs=[], isGeneric=false]
, JavaTypeDefinition [clazz=class [Ljava.lang.String;, definitionType=EXACT, genericArgs=[], isGeneric=false]
]]
        at net.sourceforge.pmd.lang.java.typeresolution.MethodTypeResolution.checkSubtypeability(MethodTypeResolution.java:99)
        at net.sourceforge.pmd.lang.java.typeresolution.MethodTypeResolution.selectMostSpecificMethod(MethodTypeResolution.java:394)
        at net.sourceforge.pmd.lang.java.typeresolution.MethodTypeResolution.getBestMethodReturnType(MethodTypeResolution.java:364)
        at net.sourceforge.pmd.lang.java.typeresolution.ClassTypeResolver.visit(ClassTypeResolver.java:467)
```