### PR TITLE
[java] Avoid runtime errors on incomplete classpath

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/MethodTypeResolution.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/MethodTypeResolution.java
@@ -450,10 +450,14 @@ public final class MethodTypeResolution {
         Class<?> contextClass = context.getType();
 
         // search the class
-        for (Method method : contextClass.getDeclaredMethods()) {
-            if (isMethodApplicable(method, methodName, argArity, accessingClass, typeArguments)) {
-                result.add(getTypeDefOfMethod(context, method, typeArguments));
+        try {
+            for (Method method : contextClass.getDeclaredMethods()) {
+                if (isMethodApplicable(method, methodName, argArity, accessingClass, typeArguments)) {
+                    result.add(getTypeDefOfMethod(context, method, typeArguments));
+                }
             }
+        } catch (final LinkageError ignored) {
+            // TODO : This is an incomplete classpath, report the missing class
         }
 
         // search it's supertype


### PR DESCRIPTION
When loading methods from a lib, which has a transitive dependency we don't have in the classpath, a `NoClassDefFoundError` arises. Similarly, a `LinkageError` can rise under circumstances similar to those of #328 

We therefore handle the `LinkageError` (`NoClassDefFoundError` is a subclass), and ignore it.