### PR TITLE
[java] Fix NPE in type resolution

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -419,7 +419,7 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
         if (node.getType() != null) { // static field or method
             // node.getType() has been set by the call to searchNodeNameForClass above
             // node.getType() will have the value equal to the Class found by that method
-            previousType = JavaTypeDefinition.forClass(node.getType());
+            previousType = node.getTypeDefinition();
         } else { // non-static field or method
             if (dotSplitImage.length == 1 && astArguments != null) { // method
                 List<MethodType> methods = getLocalApplicableMethods(node, dotSplitImage[0],

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typedefinition/JavaTypeDefinitionSimple.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typedefinition/JavaTypeDefinitionSimple.java
@@ -85,11 +85,11 @@ import java.util.logging.Logger;
     }
 
     private JavaTypeDefinition getGenericType(final String parameterName, Method method,
-                                              List<JavaTypeDefinition> methodTypeArgumens) {
-        if (method != null && methodTypeArgumens != null) {
+                                              List<JavaTypeDefinition> methodTypeArguments) {
+        if (method != null && methodTypeArguments != null) {
             int paramIndex = getGenericTypeIndex(method.getTypeParameters(), parameterName);
             if (paramIndex != -1) {
-                return methodTypeArgumens.get(paramIndex);
+                return methodTypeArguments.get(paramIndex);
             }
         }
 
@@ -190,7 +190,7 @@ import java.util.logging.Logger;
                 return forClass(UPPER_WILDCARD, resolveTypeDefinition(wildcardUpperBounds[0], method, methodTypeArgs));
             }
         } else if (type instanceof GenericArrayType) {
-            JavaTypeDefinition component = resolveTypeDefinition(((GenericArrayType) type).getGenericComponentType());
+            JavaTypeDefinition component = resolveTypeDefinition(((GenericArrayType) type).getGenericComponentType(), method, methodTypeArgs);
             // TODO: retain the generic types of the array component...
             return forClass(Array.newInstance(component.getType(), 0).getClass());
         }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
@@ -86,6 +86,7 @@ import net.sourceforge.pmd.typeresolution.testdata.FieldAccessShadow;
 import net.sourceforge.pmd.typeresolution.testdata.FieldAccessStatic;
 import net.sourceforge.pmd.typeresolution.testdata.FieldAccessSuper;
 import net.sourceforge.pmd.typeresolution.testdata.GenericMethodsImplicit;
+import net.sourceforge.pmd.typeresolution.testdata.GenericsArrays;
 import net.sourceforge.pmd.typeresolution.testdata.InnerClass;
 import net.sourceforge.pmd.typeresolution.testdata.Literals;
 import net.sourceforge.pmd.typeresolution.testdata.MethodAccessibility;
@@ -1502,6 +1503,36 @@ public class ClassTypeResolverTest {
         assertEquals("All expressions not tested", index, expressions.size());
     }
 
+
+    @Test
+    public void testGenericArrays() throws JaxenException {
+        ASTCompilationUnit acu = parseAndTypeResolveForClass15(GenericsArrays.class);
+
+        List<AbstractJavaTypeNode> expressions = convertList(
+                acu.findChildNodesWithXPath("//VariableInitializer/Expression/PrimaryExpression"),
+                AbstractJavaTypeNode.class);
+        
+        int index = 0;
+
+        // List<String> var = Arrays.asList(params);
+        AbstractJavaTypeNode expression = expressions.get(index++);
+        // TODO : Type inference is still incomplete, we fail to detect the return type of the method
+        //assertEquals(List.class, expression.getTypeDefinition().getType());
+        //assertEquals(String.class, expression.getTypeDefinition().getGenericType(0).getType());
+        
+        // List<String> var2 = Arrays.<String>asList(params);
+        AbstractJavaTypeNode expression2 = expressions.get(index++);
+        assertEquals(List.class, expression2.getTypeDefinition().getType());
+        assertEquals(String.class, expression2.getTypeDefinition().getGenericType(0).getType());
+        
+        // List<String[]> var3 = Arrays.<String[]>asList(params);
+        AbstractJavaTypeNode expression3 = expressions.get(index++);
+        assertEquals(List.class, expression3.getTypeDefinition().getType());
+        assertEquals(String[].class, expression3.getTypeDefinition().getGenericType(0).getType());
+        
+        // Make sure we got them all
+        assertEquals("All expressions not tested", index, expressions.size());
+    }
 
     @Test
     public void testMethodTypeInference() throws JaxenException {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/GenericsArrays.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/GenericsArrays.java
@@ -1,0 +1,18 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.typeresolution.testdata;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class GenericsArrays {
+
+    @SuppressWarnings("unused")
+    public void test(String[] params) {
+        List<String> var = Arrays.asList(params);
+        List<String> var2 = Arrays.<String>asList(params);
+        List<String[]> var3 = Arrays.<String[]>asList(params);
+    }
+}


### PR DESCRIPTION
 - The resolution of `GenericArrayType` was broken, so we caused NPEs.
 - Those types are now properly resolved, but the test case is still
incomplete due to missing pieces in type inference
