### PR TITLE
Add categories.properties files

### DIFF
--- a/pmd-apex/src/main/resources/category/apex/categories.properties
+++ b/pmd-apex/src/main/resources/category/apex/categories.properties
@@ -1,0 +1,17 @@
+#
+# BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+#
+
+rulesets.filenames=\
+    category/apex/bestpractices.xml,\
+    category/apex/codestyle.xml,\
+    category/apex/design.xml,\
+    category/apex/errorprone.xml,\
+    category/apex/performance.xml,\
+    category/apex/security.xml
+
+#
+# categories with no rules yet
+#
+#category/apex/documentation.xml
+#category/apex/multithreading.xml

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
@@ -113,7 +113,7 @@ public class RuleSetFactory {
 
     /**
      * Returns an Iterator of RuleSet objects loaded from descriptions from the
-     * "rulesets.properties" resource for each Language with Rule support.
+     * "categories.properties" resource for each Language with Rule support.
      *
      * @return An Iterator of RuleSet objects.
      *
@@ -125,7 +125,7 @@ public class RuleSetFactory {
             List<RuleSetReferenceId> ruleSetReferenceIds = new ArrayList<>();
             for (Language language : LanguageRegistry.findWithRuleSupport()) {
                 Properties props = new Properties();
-                rulesetsProperties = "rulesets/" + language.getTerseName() + "/rulesets.properties";
+                rulesetsProperties = "category/" + language.getTerseName() + "/categories.properties";
                 try (InputStream inputStream = resourceLoader.loadClassPathResourceAsStreamOrThrow(rulesetsProperties)) {
                     props.load(inputStream);
                 }
@@ -135,7 +135,7 @@ public class RuleSetFactory {
             return createRuleSets(ruleSetReferenceIds).getRuleSetsIterator();
         } catch (IOException ioe) {
             throw new RuntimeException("Couldn't find " + rulesetsProperties
-                    + "; please ensure that the rulesets directory is on the classpath. The current classpath is: "
+                    + "; please ensure that the directory is on the classpath. The current classpath is: "
                     + System.getProperty("java.class.path"));
         }
     }

--- a/pmd-java/src/main/resources/category/java/categories.properties
+++ b/pmd-java/src/main/resources/category/java/categories.properties
@@ -1,0 +1,15 @@
+#
+# BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+#
+
+rulesets.filenames=\
+    category/java/bestpractices.xml,\
+    category/java/codestyle.xml,\
+    category/java/design.xml,\
+    category/java/documentation.xml,\
+    category/java/errorprone.xml,\
+    category/java/multithreading.xml,\
+    category/java/performance.xml
+
+#   security doesn't contain any rules yet
+#    category/java/security.xml

--- a/pmd-javascript/src/main/resources/category/ecmascript/categories.properties
+++ b/pmd-javascript/src/main/resources/category/ecmascript/categories.properties
@@ -1,0 +1,17 @@
+#
+# BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+#
+
+rulesets.filenames=\
+    category/ecmascript/bestpractices.xml,\
+    category/ecmascript/codestyle.xml,\
+    category/ecmascript/errorprone.xml
+
+#
+#empty categories:
+#
+#category/ecmascript/design.xml,
+#category/ecmascript/documentation.xml,
+#category/ecmascript/multithreading.xml,
+#category/ecmascript/performance.xml,
+#category/ecmascript/security.xml,

--- a/pmd-jsp/src/main/resources/category/jsp/categories.properties
+++ b/pmd-jsp/src/main/resources/category/jsp/categories.properties
@@ -1,0 +1,17 @@
+#
+# BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+#
+
+rulesets.filenames=\
+    category/jsp/bestpractices.xml,\
+    category/jsp/codestyle.xml,\
+    category/jsp/design.xml,\
+    category/jsp/errorprone.xml,\
+    category/jsp/security.xml
+
+#
+# categories without rules
+#
+# category/jsp/documentation.xml
+# category/jsp/multithreading.xml
+# category/jsp/performance.xml

--- a/pmd-plsql/src/main/resources/category/plsql/categories.properties
+++ b/pmd-plsql/src/main/resources/category/plsql/categories.properties
@@ -1,0 +1,17 @@
+#
+# BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+#
+
+rulesets.filenames=\
+    category/plsql/bestpractices.xml,\
+    category/plsql/codestyle.xml,\
+    category/plsql/design.xml,\
+    category/plsql/errorprone.xml
+
+#
+# categories without rules
+#
+# category/plsql/documentation.xml
+# category/plsql/multithreading.xml
+# category/plsql/performance.xml
+# category/plsql/security.xml

--- a/pmd-visualforce/src/main/resources/category/vf/categories.properties
+++ b/pmd-visualforce/src/main/resources/category/vf/categories.properties
@@ -1,0 +1,17 @@
+#
+# BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+#
+
+rulesets.filenames=\
+    category/vf/security.xml
+
+#
+# categories without rules
+#
+# category/vf/bestpractices.xml
+# category/vf/codestyle.xml
+# category/vf/design.xml
+# category/vf/documentation.xml
+# category/vf/errorprone.xml
+# category/vf/multithreading.xml
+# category/vf/performance.xml

--- a/pmd-vm/src/main/resources/category/vm/categories.properties
+++ b/pmd-vm/src/main/resources/category/vm/categories.properties
@@ -1,0 +1,17 @@
+#
+# BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+#
+
+rulesets.filenames=\
+    category/vm/bestpractices.xml,\
+    category/vm/design.xml,\
+    category/vm/errorprone.xml
+
+#
+# categories without rules
+#
+# category/vm/codestyle.xml
+# category/vm/documentation.xml
+# category/vm/multithreading.xml
+# category/vm/performance.xml
+# category/vm/security.xml

--- a/pmd-xml/src/main/resources/category/pom/categories.properties
+++ b/pmd-xml/src/main/resources/category/pom/categories.properties
@@ -1,0 +1,18 @@
+#
+# BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+#
+
+rulesets.filenames=\
+    category/pom/errorprone.xml
+
+#
+# categories without rules
+#
+# category/pom/bestpractices.xml
+# category/pom/codestyle.xml
+# category/pom/design.xml
+# category/pom/documentation.xml
+# category/pom/multithreading.xml
+# category/pom/performance.xml
+# category/pom/security.xml
+

--- a/pmd-xml/src/main/resources/category/wsdl/categories.properties
+++ b/pmd-xml/src/main/resources/category/wsdl/categories.properties
@@ -1,0 +1,18 @@
+#
+# BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+#
+
+rulesets.filenames=
+
+#
+# categories without rules
+#
+# category/wsdl/bestpractices.xml
+# category/wsdl/codestyle.xml
+# category/wsdl/design.xml
+# category/wsdl/documentation.xml
+# category/wsdl/errorprone.xml
+# category/wsdl/multithreading.xml
+# category/wsdl/performance.xml
+# category/wsdl/security.xml
+

--- a/pmd-xml/src/main/resources/category/xml/categories.properties
+++ b/pmd-xml/src/main/resources/category/xml/categories.properties
@@ -1,0 +1,18 @@
+#
+# BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+#
+
+rulesets.filenames=\
+    category/xml/errorprone.xml
+
+#
+# categories without rules
+#
+# category/xml/bestpractices.xml
+# category/xml/codestyle.xml
+# category/xml/design.xml
+# category/xml/documentation.xml
+# category/xml/multithreading.xml
+# category/xml/performance.xml
+# category/xml/security.xml
+

--- a/pmd-xml/src/main/resources/category/xsl/categories.properties
+++ b/pmd-xml/src/main/resources/category/xsl/categories.properties
@@ -1,0 +1,18 @@
+#
+# BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+#
+
+rulesets.filenames=\
+    category/xsl/codestyle.xml,\
+    category/xsl/performance.xml
+
+#
+# categories without rules
+#
+# category/xsl/bestpractices.xml
+# category/xsl/design.xml
+# category/xsl/documentation.xml
+# category/xsl/errorprone.xml
+# category/xsl/multithreading.xml
+# category/xsl/security.xml
+


### PR DESCRIPTION
Add the `category/<language>/categories.properties` files for each language.

The rulesets.properties files are kept for backwards compatibility, if some tool used these properties files directly rather than the `RuleSetFactory.getRegisteredRuleSets()` method.

