### PR TITLE
[core] Fix #725: numeric property descriptors now check their default value

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/AbstractMultiNumericProperty.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/AbstractMultiNumericProperty.java
@@ -20,7 +20,7 @@ import net.sourceforge.pmd.properties.modules.NumericPropertyModule;
  * @version Refactored June 2017 (6.0.0)
  */
 /* default */ abstract class AbstractMultiNumericProperty<T extends Number> extends AbstractMultiValueProperty<T>
-        implements NumericPropertyDescriptor<List<T>> {
+    implements NumericPropertyDescriptor<List<T>> {
 
     private final NumericPropertyModule<T> module;
 
@@ -43,6 +43,9 @@ import net.sourceforge.pmd.properties.modules.NumericPropertyModule;
         super(theName, theDescription, theDefault, theUIOrder, isDefinedExternally);
 
         module = new NumericPropertyModule<>(lower, upper);
+        for (T num : theDefault) {
+            module.checkNumber(num);
+        }
     }
 
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/AbstractNumericProperty.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/AbstractNumericProperty.java
@@ -43,7 +43,7 @@ import net.sourceforge.pmd.properties.modules.NumericPropertyModule;
         super(theName, theDescription, theDefault, theUIOrder, isDefinedExternally);
 
         module = new NumericPropertyModule<>(lower, upper);
-
+        module.checkNumber(theDefault);
 
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/LongMultiProperty.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/LongMultiProperty.java
@@ -90,7 +90,7 @@ public final class LongMultiProperty extends AbstractMultiNumericProperty<Long> 
     }
 
 
-    private static final class LongMultiPBuilder
+    public static final class LongMultiPBuilder
         extends MultiNumericPropertyBuilder<Long, LongMultiPBuilder> {
 
         protected LongMultiPBuilder(String name) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/modules/NumericPropertyModule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/modules/NumericPropertyModule.java
@@ -38,7 +38,7 @@ public class NumericPropertyModule<T extends Number> {
     }
 
 
-    private void checkNumber(T number) {
+    public void checkNumber(T number) {
         String error = valueErrorFor(number);
         if (error != null) {
             throw new IllegalArgumentException(error);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/modules/NumericPropertyModule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/modules/NumericPropertyModule.java
@@ -39,6 +39,9 @@ public class NumericPropertyModule<T extends Number> {
 
 
     public void checkNumber(T number) {
+        if (number == null) {
+            return; // TODO: remove me when you scrap StatisticalRule (see pull #727)
+        }
         String error = valueErrorFor(number);
         if (error != null) {
             throw new IllegalArgumentException(error);

--- a/pmd-core/src/test/java/net/sourceforge/pmd/properties/AbstractNumericPropertyDescriptorTester.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/properties/AbstractNumericPropertyDescriptorTester.java
@@ -10,6 +10,10 @@ import java.util.Map;
 
 import org.junit.Test;
 
+import net.sourceforge.pmd.properties.builders.MultiNumericPropertyBuilder;
+import net.sourceforge.pmd.properties.builders.SingleNumericPropertyBuilder;
+
+
 /**
  * @author Clément Fournier
  */
@@ -40,8 +44,8 @@ public abstract class AbstractNumericPropertyDescriptorTester<T> extends Abstrac
     @Override
     protected Map<PropertyDescriptorField, String> getPropertyDescriptorValues() {
         Map<PropertyDescriptorField, String> attributes = super.getPropertyDescriptorValues();
-        attributes.put(PropertyDescriptorField.MIN, "0");
-        attributes.put(PropertyDescriptorField.MAX, "10");
+        attributes.put(PropertyDescriptorField.MIN, min().toString());
+        attributes.put(PropertyDescriptorField.MAX, max().toString());
         return attributes;
     }
 
@@ -53,4 +57,27 @@ public abstract class AbstractNumericPropertyDescriptorTester<T> extends Abstrac
         getSingleFactory().build(attributes);
 
     }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBadDefaultValue() {
+        singleBuilder().defaultValue(createBadValue()).build();
+    }
+
+
+    @Test(expected = IllegalArgumentException.class)
+    @SuppressWarnings("unchecked")
+    public void testMultiBadDefaultValue() {
+        multiBuilder().defaultValues(createValue(), createBadValue()).build();
+    }
+
+
+    protected abstract SingleNumericPropertyBuilder<T, ?> singleBuilder();
+
+    protected abstract MultiNumericPropertyBuilder<T, ?> multiBuilder();
+
+
+    protected abstract T min();
+
+    protected abstract T max();
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/properties/DoublePropertyTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/properties/DoublePropertyTest.java
@@ -39,6 +39,18 @@ public class DoublePropertyTest extends AbstractNumericPropertyDescriptorTester<
     }
 
 
+    protected DoubleProperty.DoublePBuilder singleBuilder() {
+        return DoubleProperty.named("test").desc("foo")
+                             .range(MIN, MAX).defaultValue(createValue()).uiOrder(1.0f);
+    }
+
+
+    protected DoubleMultiProperty.DoubleMultiPBuilder multiBuilder() {
+        return DoubleMultiProperty.named("test").desc("foo")
+                                  .range(MIN, MAX).defaultValues(createValue(), createValue()).uiOrder(1.0f);
+    }
+
+
     @Override
     protected PropertyDescriptor<Double> createProperty() {
         return new DoubleProperty("testDouble", "Test double property", MIN, MAX, 9.0, 1.0f);
@@ -62,5 +74,17 @@ public class DoublePropertyTest extends AbstractNumericPropertyDescriptorTester<
     protected PropertyDescriptor<List<Double>> createBadMultiProperty() {
         return new DoubleMultiProperty("testDouble", "Test double property", MIN, MAX,
                                        new Double[] {MIN - SHIFT, MIN, MIN + SHIFT, MAX + SHIFT}, 1.0f);
+    }
+
+
+    @Override
+    protected Double min() {
+        return MIN;
+    }
+
+
+    @Override
+    protected Double max() {
+        return MAX;
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/properties/FloatPropertyTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/properties/FloatPropertyTest.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.properties;
 
 import java.util.List;
 
+
 /**
  * Evaluates the functionality of the FloatProperty descriptor by testing its
  * ability to catch creation errors (illegal args), flag out-of-range test
@@ -38,6 +39,18 @@ public class FloatPropertyTest extends AbstractNumericPropertyDescriptorTester<F
     }
 
 
+    protected FloatProperty.FloatPBuilder singleBuilder() {
+        return FloatProperty.named("test").desc("foo")
+                            .range(MIN, MAX).defaultValue(createValue()).uiOrder(1.0f);
+    }
+
+
+    protected FloatMultiProperty.FloatMultiPBuilder multiBuilder() {
+        return FloatMultiProperty.named("test").desc("foo")
+                                 .range(MIN, MAX).defaultValues(createValue(), createValue()).uiOrder(1.0f);
+    }
+
+
     @Override
     protected PropertyDescriptor<Float> createProperty() {
         return new FloatProperty("testFloat", "Test float property", MIN, MAX, 9.0f, 1.0f);
@@ -47,7 +60,7 @@ public class FloatPropertyTest extends AbstractNumericPropertyDescriptorTester<F
     @Override
     protected PropertyDescriptor<List<Float>> createMultiProperty() {
         return new FloatMultiProperty("testFloat", "Test float property", MIN, MAX,
-                                      new Float[] {-1f, 0f, 1f, 2f}, 1.0f);
+            new Float[]{6f, 9f, 1f, 2f}, 1.0f);
     }
 
 
@@ -60,7 +73,19 @@ public class FloatPropertyTest extends AbstractNumericPropertyDescriptorTester<F
     @Override
     protected PropertyDescriptor<List<Float>> createBadMultiProperty() {
         return new FloatMultiProperty("testFloat", "Test float property", 0f, 5f,
-                                      new Float[] {-1f, 0f, 1f, 2f}, 1.0f);
+            new Float[]{-1f, 0f, 1f, 2f}, 1.0f);
+    }
+
+
+    @Override
+    protected Float min() {
+        return MIN;
+    }
+
+
+    @Override
+    protected Float max() {
+        return MAX;
     }
 
 
@@ -69,6 +94,6 @@ public class FloatPropertyTest extends AbstractNumericPropertyDescriptorTester<F
         float defalt = randomFloat(0, 1000f);
 
         return new FloatProperty(randomString(nameLength), randomString(descLength), defalt - 1000f, defalt + 1000,
-                                 defalt, 0f);
+            defalt, 0f);
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/properties/IntegerPropertyTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/properties/IntegerPropertyTest.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.properties;
 
 import java.util.List;
 
+
 /**
  * Evaluates the functionality of the IntegerProperty descriptor by testing its
  * ability to catch creation errors (illegal args), flag out-of-range test
@@ -49,6 +50,18 @@ public class IntegerPropertyTest extends AbstractNumericPropertyDescriptorTester
     }
 
 
+    protected IntegerProperty.IntegerPBuilder singleBuilder() {
+        return IntegerProperty.named("test").desc("foo")
+                              .range(MIN, MAX).defaultValue(createValue()).uiOrder(1.0f);
+    }
+
+
+    protected IntegerMultiProperty.IntegerMultiPBuilder multiBuilder() {
+        return IntegerMultiProperty.named("test").desc("foo")
+                                   .range(MIN, MAX).defaultValues(createValue(), createValue()).uiOrder(1.0f);
+    }
+
+
     @Override
     protected PropertyDescriptor<Integer> createProperty() {
         return new IntegerProperty("testInteger", "Test integer property", MIN, MAX, MAX - 1, 1.0f);
@@ -72,5 +85,17 @@ public class IntegerPropertyTest extends AbstractNumericPropertyDescriptorTester
     @Override
     protected PropertyDescriptor<List<Integer>> createBadMultiProperty() {
         return new IntegerMultiProperty("testInteger", "", MIN, MAX, new Integer[] {MIN - 1, MAX}, 1.0f);
+    }
+
+
+    @Override
+    protected Integer min() {
+        return MIN;
+    }
+
+
+    @Override
+    protected Integer max() {
+        return MAX;
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/properties/LongPropertyTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/properties/LongPropertyTest.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.properties;
 
 import java.util.List;
 
+
 /**
  * @author Clément Fournier
  */
@@ -33,6 +34,18 @@ public class LongPropertyTest extends AbstractNumericPropertyDescriptorTester<Lo
     }
 
 
+    protected LongProperty.LongPBuilder singleBuilder() {
+        return LongProperty.named("test").desc("foo")
+                           .range(MIN, MAX).defaultValue(createValue()).uiOrder(1.0f);
+    }
+
+
+    protected LongMultiProperty.LongMultiPBuilder multiBuilder() {
+        return LongMultiProperty.named("test").desc("foo")
+                                .range(MIN, MAX).defaultValues(createValue(), createValue()).uiOrder(1.0f);
+    }
+
+
     @Override
     protected PropertyDescriptor<Long> createProperty() {
         return new LongProperty("testFloat", "Test float property", MIN, MAX, 90L, 1.0f);
@@ -42,7 +55,7 @@ public class LongPropertyTest extends AbstractNumericPropertyDescriptorTester<Lo
     @Override
     protected PropertyDescriptor<List<Long>> createMultiProperty() {
         return new LongMultiProperty("testFloat", "Test float property", MIN, MAX,
-                                     new Long[] {-1000L, 0L, 100L, 20L}, 1.0f);
+            new Long[]{1000L, 10L, 100L, 20L}, 1.0f);
     }
 
 
@@ -55,7 +68,18 @@ public class LongPropertyTest extends AbstractNumericPropertyDescriptorTester<Lo
     @Override
     protected PropertyDescriptor<List<Long>> createBadMultiProperty() {
         return new LongMultiProperty("testFloat", "Test float property", 0L, 5L,
-                                     new Long[] {-1000L, 0L, 100L, 20L}, 1.0f);
+            new Long[]{-1000L, 0L, 100L, 20L}, 1.0f);
     }
 
+
+    @Override
+    protected Long min() {
+        return MIN;
+    }
+
+
+    @Override
+    protected Long max() {
+        return MAX;
+    }
 }


### PR DESCRIPTION
This straightforward fix also shows that builders could help mocking properties for tests. Though I wonder if it's worth refactoring the entire properties testing framework. It's unlikely to change often, and already yields good coverage for most properties. Builders are not tested though.

Resolves #725 