### PR TITLE
[doc] Render old/deprecated rulesets

### DIFF
--- a/docs/_data/sidebars/pmd_sidebar.yml
+++ b/docs/_data/sidebars/pmd_sidebar.yml
@@ -45,6 +45,8 @@ entries:
     - title: Suppressing
       url: /pmd_userdocs_suppressing.html
       output: web, pdf
+    - title: null
+      output: web, pdf
       subfolders:
       - title: Tools / Integrations
         output: web, pdf

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -14,33 +14,44 @@
         <ul>
             {% for folderitem in folder.folderitems %}
             {% if folderitem.output contains "web" %}
-            {% if folderitem.external_url %}
-            <li><a href="{{folderitem.external_url}}" target="_blank">{{folderitem.title}}</a></li>
-            {% elsif page.url == folderitem.url or page.sidebaractiveurl == folderitem.url %}
-            <li class="active"><a href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
+
+            {% unless folderitem.subfolders %}
+
+                {% if folderitem.external_url %}
+                <li><a href="{{folderitem.external_url}}" target="_blank">{{folderitem.title}}</a></li>
+                {% elsif folderitem.url and page.url == folderitem.url or page.sidebaractiveurl == folderitem.url %}
+                <li class="active"><a href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
+                {% elsif folderitem.url %}
+                <li><a href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
+                {% else %}
+                <li><a href="#">{{folderitem.title}}</a></li>
+                {% endif %}
+
             {% else %}
-            <li><a href="{{folderitem.url | remove: "/"}}">{{folderitem.title}}</a></li>
-            {% endif %}
-            {% for subfolders in folderitem.subfolders %}
-            {% if subfolders.output contains "web" %}
-            <li class="subfolders">
-                <a href="#">{{ subfolders.title }}</a>
-                <ul>
-                    {% for subfolderitem in subfolders.subfolderitems %}
-                    {% if subfolderitem.output contains "web" %}
-                    {% if subfolderitem.external_url %}
-                    <li><a href="{{subfolderitem.external_url}}" target="_blank">{{subfolderitem.title}}</a></li>
-                    {% elsif page.url == subfolderitem.url %}
-                    <li class="active"><a href="{{subfolderitem.url | remove: "/"}}">{{subfolderitem.title}}</a></li>
-                    {% else %}
-                    <li><a href="{{subfolderitem.url | remove: "/"}}">{{subfolderitem.title}}</a></li>
-                    {% endif %}
-                    {% endif %}
-                    {% endfor %}
-                </ul>
-            </li>
-            {% endif %}
-            {% endfor %}
+
+                {% for subfolders in folderitem.subfolders %}
+                {% if subfolders.output contains "web" %}
+                <li class="subfolders">
+                    <a href="#">{{ subfolders.title }}</a>
+                    <ul>
+                        {% for subfolderitem in subfolders.subfolderitems %}
+                        {% if subfolderitem.output contains "web" %}
+                        {% if subfolderitem.external_url %}
+                        <li><a href="{{subfolderitem.external_url}}" target="_blank">{{subfolderitem.title}}</a></li>
+                        {% elsif page.url == subfolderitem.url %}
+                        <li class="active"><a href="{{subfolderitem.url | remove: "/"}}">{{subfolderitem.title}}</a></li>
+                        {% else %}
+                        <li><a href="{{subfolderitem.url | remove: "/"}}">{{subfolderitem.title}}</a></li>
+                        {% endif %}
+                        {% endif %}
+                        {% endfor %}
+                    </ul>
+                </li>
+                {% endif %}
+                {% endfor %}
+
+            {% endunless %}
+
             {% endif %}
             {% endfor %}
         </ul>

--- a/pmd-core/src/main/resources/rulesets/releases/510.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/510.xml
@@ -31,14 +31,14 @@ This ruleset contains links to rules that are new in PMD v5.1.0
     <rule ref="rulesets/plsql/dates.xml/TO_TIMESTAMPWithoutDateFormat"/>
     <rule ref="rulesets/plsql/TomKytesDespair.xml/TomKytesDespair"/>
 
-    <rule ref="rulestes/vm/basic.xml/AvoidDeeplyNestedIfStmts"/>
-    <rule ref="rulestes/vm/basic.xml/CollapsibleIfStatements"/>
-    <rule ref="rulestes/vm/basic.xml/ExcessiveTemplateLength"/>
-    <rule ref="rulestes/vm/basic.xml/AvoidReassigningParameters"/>
-    <rule ref="rulestes/vm/basic.xml/EmptyIfStmt"/>
-    <rule ref="rulestes/vm/basic.xml/EmptyForeachStmt"/>
-    <rule ref="rulestes/vm/basic.xml/UnusedMacroParameter"/>
-    <rule ref="rulestes/vm/basic.xml/NoInlineJavaScript"/>
-    <rule ref="rulestes/vm/basic.xml/NoInlineStyles"/>
+    <rule ref="rulesets/vm/basic.xml/AvoidDeeplyNestedIfStmts"/>
+    <rule ref="rulesets/vm/basic.xml/CollapsibleIfStatements"/>
+    <rule ref="rulesets/vm/basic.xml/ExcessiveTemplateLength"/>
+    <rule ref="rulesets/vm/basic.xml/AvoidReassigningParameters"/>
+    <rule ref="rulesets/vm/basic.xml/EmptyIfStmt"/>
+    <rule ref="rulesets/vm/basic.xml/EmptyForeachStmt"/>
+    <rule ref="rulesets/vm/basic.xml/UnusedMacroParameter"/>
+    <rule ref="rulesets/vm/basic.xml/NoInlineJavaScript"/>
+    <rule ref="rulesets/vm/basic.xml/NoInlineStyles"/>
 </ruleset>
 

--- a/pmd-core/src/main/resources/rulesets/releases/550.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/550.xml
@@ -20,7 +20,7 @@ This ruleset contains links to rules that are new in PMD v5.5.0
     <rule ref="rulesets/apex/complexity.xml/StdCyclomaticComplexity" />
     <rule ref="rulesets/apex/complexity.xml/TooManyFields" />
     <rule ref="rulesets/apex/complexity.xml/ExcessivePublicCount" />
-    <rule ref="rulesets/apex/complexity.xml/AvoidDmlStatementsInLoops" />
+    <rule ref="rulesets/apex/performance.xml/AvoidDmlStatementsInLoops" />
     <rule ref="rulesets/apex/performance.xml/AvoidSoqlInLoops" />
     <rule ref="rulesets/apex/style.xml/VariableNamingConventions" />
     <rule ref="rulesets/apex/style.xml/MethodNamingConventions" />

--- a/pmd-core/src/main/resources/rulesets/releases/600.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/600.xml
@@ -8,7 +8,7 @@
 This ruleset contains links to rules that are new in PMD v6.0.0
   </description>
 
-    <rule ref="category/java/errorprone.xml/ForLoopCanBeForeach"/>
+    <rule ref="category/java/bestpractices.xml/ForLoopCanBeForeach"/>
     <rule ref="category/java/errorprone.xml/DoNotExtendJavaLangThrowable"/>
     <rule ref="category/java/design.xml/DataClass"/>
     <rule ref="category/java/design.xml/NcssCount"/>

--- a/pmd-doc/pom.xml
+++ b/pmd-doc/pom.xml
@@ -60,6 +60,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.19</version>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleDocGenerator.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleDocGenerator.java
@@ -305,7 +305,7 @@ public class RuleDocGenerator {
                         lines.add("");
                     }
 
-                    lines.add(StringUtils.stripToEmpty(rule.getDescription()));
+                    lines.add(stripIndentation(rule.getDescription()));
                     lines.add("");
 
                     if (rule instanceof XPathRule || rule instanceof RuleReference && ((RuleReference) rule).getRule() instanceof XPathRule) {
@@ -369,6 +369,38 @@ public class RuleDocGenerator {
                 System.out.println("Generated " + path);
             }
         }
+    }
+
+    private static String stripIndentation(String description) {
+        if (description == null || description.isEmpty()) {
+            return "";
+        }
+
+        String stripped = StringUtils.stripStart(description, "\n\r");
+        stripped = StringUtils.stripEnd(stripped, "\n\r ");
+
+        int indentation = 0;
+        int strLen = stripped.length();
+        while (Character.isWhitespace(stripped.charAt(indentation)) && indentation < strLen) {
+            indentation++;
+        }
+
+        String[] lines = stripped.split("\\n");
+        String prefix = StringUtils.repeat(' ', indentation);
+        StringBuilder result = new StringBuilder(stripped.length());
+
+        if (StringUtils.isNotEmpty(prefix)) {
+            for (int i = 0; i < lines.length; i++) {
+                String line = lines[i];
+                if (i > 0) {
+                    result.append(StringUtils.LF);
+                }
+                result.append(StringUtils.removeStart(line, prefix));
+            }
+        } else {
+            result.append(stripped);
+        }
+        return result.toString();
     }
 
     /**

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleDocGenerator.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleDocGenerator.java
@@ -42,13 +42,11 @@ public class RuleDocGenerator {
 
     private static final String DEPRECATION_LABEL_SMALL = "<span style=\"border-radius: 0.25em; color: #fff; padding: 0.2em 0.6em 0.3em; display: inline; background-color: #d9534f; font-size: 75%;\">Deprecated</span> ";
     private static final String DEPRECATION_LABEL = "<span style=\"border-radius: 0.25em; color: #fff; padding: 0.2em 0.6em 0.3em; display: inline; background-color: #d9534f;\">Deprecated</span> ";
+    private static final String DEPRECATED_RULE_PROPERTY_MARKER = "deprecated!";
 
     private static final String GITHUB_SOURCE_LINK = "https://github.com/pmd/pmd/blob/master/";
 
-    private final Path root;
-    private final FileWriter writer;
-
-    /** Maintains mapping from pmd terse language name to rouge highlighter language */
+    /** Maintains mapping from pmd terse language name to rouge highlighter language. */
     private static final Map<String, String> LANGUAGE_HIGHLIGHT_MAPPER = new HashMap<>();
 
     static {
@@ -57,6 +55,9 @@ public class RuleDocGenerator {
         LANGUAGE_HIGHLIGHT_MAPPER.put("apex", "java");
         LANGUAGE_HIGHLIGHT_MAPPER.put("plsql", "sql");
     }
+
+    private final Path root;
+    private final FileWriter writer;
 
     public RuleDocGenerator(FileWriter writer, Path root) {
         this.root = Objects.requireNonNull(root, "Root directory must be provided");
@@ -344,9 +345,14 @@ public class RuleDocGenerator {
                         lines.add("|Name|Default Value|Description|");
                         lines.add("|----|-------------|-----------|");
                         for (PropertyDescriptor<?> propertyDescriptor : properties) {
+                            String description = propertyDescriptor.description();
+                            if (description != null && description.toLowerCase(Locale.ROOT).startsWith(DEPRECATED_RULE_PROPERTY_MARKER)) {
+                                description = DEPRECATION_LABEL_SMALL
+                                        + description.substring(DEPRECATED_RULE_PROPERTY_MARKER.length());
+                            }
                             lines.add("|" + propertyDescriptor.name()
                                 + "|" + (propertyDescriptor.defaultValue() != null ? String.valueOf(propertyDescriptor.defaultValue()) : "")
-                                + "|" + propertyDescriptor.description()
+                                + "|" + description
                                 + "|");
                         }
                         lines.add("");

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleDocGenerator.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleDocGenerator.java
@@ -184,31 +184,11 @@ public class RuleDocGenerator {
             lines.add("folder: pmd/rules");
             lines.add("---");
 
-            lines.add("List of rulesets and rules contained in each ruleset.");
-            lines.add("");
-
-            for (RuleSet ruleset : entry.getValue()) {
-                String link = RULESET_INDEX_PERMALINK_PATTERN
-                        .replace("${language.tersename}", languageTersename)
-                        .replace("${ruleset.name}", RuleSetUtils.getRuleSetFilename(ruleset));
-                lines.add("*   [" + ruleset.getName() + "](" + link + "): " + getRuleSetDescriptionSingleLine(ruleset));
-            }
-            lines.add("");
-
-            List<RuleSet> additionalRulesetsForLanguage = sortedAdditionalRulesets.get(entry.getKey());
-            if (additionalRulesetsForLanguage != null) {
-                lines.add("List of additional rulesets");
-                for (RuleSet ruleset : additionalRulesetsForLanguage) {
-                    String deprecation = isRuleSetDeprecated(ruleset) ? DEPRECATION_LABEL_SMALL : "";
-                    lines.add("*    " + ruleset.getName() + ": "
-                            + deprecation
-                            + getRuleSetDescriptionSingleLine(ruleset));
-                }
-                lines.add("");
-            }
-
             for (RuleSet ruleset : entry.getValue()) {
                 lines.add("## " + ruleset.getName());
+                lines.add("");
+                lines.add("{% include callout.html content=\"" + getRuleSetDescriptionSingleLine(ruleset).replaceAll("\"", "'") + "\" %}");
+                lines.add("");
 
                 for (Rule rule : getSortedRules(ruleset)) {
                     String link = RULESET_INDEX_PERMALINK_PATTERN
@@ -238,6 +218,20 @@ public class RuleDocGenerator {
                                 + (rule.isDeprecated() ? DEPRECATION_LABEL_SMALL : "")
                                 + getShortRuleDescription(rule));
                     }
+                }
+                lines.add("");
+            }
+
+            List<RuleSet> additionalRulesetsForLanguage = sortedAdditionalRulesets.get(entry.getKey());
+            if (additionalRulesetsForLanguage != null) {
+                lines.add("## Additional rulesets");
+                lines.add("");
+
+                for (RuleSet ruleset : additionalRulesetsForLanguage) {
+                    String deprecation = isRuleSetDeprecated(ruleset) ? DEPRECATION_LABEL_SMALL : "";
+                    lines.add("*    " + ruleset.getName() + ": "
+                            + deprecation
+                            + getRuleSetDescriptionSingleLine(ruleset));
                 }
                 lines.add("");
             }

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleSetUtils.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleSetUtils.java
@@ -7,7 +7,9 @@ package net.sourceforge.pmd.docs;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
 
+import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleSet;
+import net.sourceforge.pmd.lang.rule.RuleReference;
 
 public final class RuleSetUtils {
 
@@ -29,4 +31,51 @@ public final class RuleSetUtils {
         return FilenameUtils.getBaseName(StringUtils.chomp(rulesetFileName));
     }
 
+    /**
+     * A ruleset is considered deprecated, if it only contains rule references
+     * and all rule references are deprecated.
+     *
+     * @param ruleset
+     * @return
+     */
+    public static boolean isRuleSetDeprecated(RuleSet ruleset) {
+        boolean result = true;
+        for (Rule rule : ruleset.getRules()) {
+            if (!(rule instanceof RuleReference) || !rule.isDeprecated()) {
+                result = false;
+                break;
+            }
+        }
+        return result;
+    }
+
+    public static String getRuleSetClasspath(RuleSet ruleset) {
+        final String RESOURCES_PATH = "/resources/";
+        String filename = StringUtils.chomp(ruleset.getFileName());
+        int startIndex = filename.lastIndexOf(RESOURCES_PATH);
+        if (startIndex > -1) {
+            return filename.substring(startIndex + RESOURCES_PATH.length());
+        } else {
+            return filename;
+        }
+    }
+
+    /**
+     * Recursively resolves rule references until the last reference.
+     * The last reference is returned.
+     * If the given rule not a reference, the rule is returned.
+     *
+     * @param rule
+     * @return
+     */
+    public static Rule resolveRuleReferences(Rule rule) {
+        Rule result = rule;
+        Rule ref = rule;
+        while (ref instanceof RuleReference) {
+            // remember the last reference
+            result = ref;
+            ref = ((RuleReference) ref).getRule();
+        }
+        return result;
+    }
 }

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleSetUtils.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleSetUtils.java
@@ -1,0 +1,32 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.docs;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import net.sourceforge.pmd.RuleSet;
+
+public final class RuleSetUtils {
+
+    private RuleSetUtils() {
+        // Utility class
+    }
+
+    /**
+     * Gets the sanitized base name of the ruleset.
+     * For some reason, the filename might contain some newlines, which are removed.
+     * @param ruleset
+     * @return
+     */
+    public static String getRuleSetFilename(RuleSet ruleset) {
+        return getRuleSetFilename(ruleset.getFileName());
+    }
+
+    public static String getRuleSetFilename(String rulesetFileName) {
+        return FilenameUtils.getBaseName(StringUtils.chomp(rulesetFileName));
+    }
+
+}

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/docs/SidebarGenerator.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/docs/SidebarGenerator.java
@@ -1,0 +1,99 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.docs;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.DumperOptions.FlowStyle;
+import org.yaml.snakeyaml.Yaml;
+
+import net.sourceforge.pmd.RuleSet;
+import net.sourceforge.pmd.lang.Language;
+
+public class SidebarGenerator {
+    private static final String SIDEBAR_YML = "docs/_data/sidebars/pmd_sidebar.yml";
+
+    private final FileWriter writer;
+    private final Path sidebarPath;
+
+    public SidebarGenerator(FileWriter writer, Path basePath) {
+        this.writer = Objects.requireNonNull(writer, "A file writer must be provided");
+        this.sidebarPath = Objects.requireNonNull(basePath, "A base directory must be provided").resolve(SIDEBAR_YML);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> extractRuleReference(Map<String, Object> sidebar) {
+        List<Map<String, Object>> entries = (List<Map<String, Object>>) sidebar.get("entries");
+        Map<String, Object> entry = entries.get(0);
+        List<Map<String, Object>> folders = (List<Map<String, Object>>) entry.get("folders");
+        return folders.get(2);
+    }
+
+    public void generateSidebar(Map<Language, List<RuleSet>> sortedRulesets) throws IOException {
+        Map<String, Object> sidebar = loadSidebar();
+        Map<String, Object> ruleReference = extractRuleReference(sidebar);
+        ruleReference.put("folderitems", generateRuleReferenceSection(sortedRulesets));
+        writeSidebar(sidebar);
+    }
+
+    List<Map<String, Object>> generateRuleReferenceSection(Map<Language, List<RuleSet>> sortedRulesets) {
+        List<Map<String, Object>> newFolderItems = new ArrayList<>();
+        for (Map.Entry<Language, List<RuleSet>> entry : sortedRulesets.entrySet()) {
+            Map<String, Object> newFolderItem = new LinkedHashMap<>();
+            newFolderItem.put("title", null);
+            newFolderItem.put("output", "web, pdf");
+
+            Map<String, Object> subfolder = new LinkedHashMap<>();
+            newFolderItem.put("subfolders", Arrays.asList(subfolder));
+
+            subfolder.put("title", entry.getKey().getName() + " Rules");
+            subfolder.put("output", "web, pdf");
+            List<Map<String, Object>> subfolderitems = new ArrayList<>();
+            subfolder.put("subfolderitems", subfolderitems);
+
+            Map<String, Object> ruleIndexSubfolderItem = new LinkedHashMap<>();
+            ruleIndexSubfolderItem.put("title", "Index");
+            ruleIndexSubfolderItem.put("output", "web, pdf");
+            ruleIndexSubfolderItem.put("url", "/pmd_rules_" + entry.getKey().getTerseName() + ".html");
+            subfolderitems.add(ruleIndexSubfolderItem);
+
+            for (RuleSet ruleset : entry.getValue()) {
+                Map<String, Object> subfolderitem = new LinkedHashMap<>();
+                subfolderitem.put("title", ruleset.getName());
+                subfolderitem.put("output", "web, pdf");
+                subfolderitem.put("url", "/pmd_rules_" + entry.getKey().getTerseName() + "_" + RuleSetUtils.getRuleSetFilename(ruleset) + ".html");
+                subfolderitems.add(subfolderitem);
+            }
+
+            newFolderItems.add(newFolderItem);
+        }
+        return newFolderItems;
+    }
+
+    public Map<String, Object> loadSidebar() throws IOException {
+        Yaml yaml = new Yaml();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> sidebar = (Map<String, Object>) yaml.load(Files.newBufferedReader(sidebarPath, StandardCharsets.UTF_8));
+        return sidebar;
+    }
+
+    public void writeSidebar(Map<String, Object> sidebar) throws IOException {
+        DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(FlowStyle.BLOCK);
+        Yaml yaml = new Yaml(options);
+        writer.write(sidebarPath, Arrays.asList(yaml.dump(sidebar)));
+        System.out.println("Generated " + sidebarPath);
+    }
+}

--- a/pmd-doc/src/test/java/net/sourceforge/pmd/docs/RuleDocGeneratorTest.java
+++ b/pmd-doc/src/test/java/net/sourceforge/pmd/docs/RuleDocGeneratorTest.java
@@ -44,11 +44,11 @@ public class RuleDocGeneratorTest {
     @Test
     public void testSingleRuleset() throws RuleSetNotFoundException, IOException {
         RuleDocGenerator generator = new RuleDocGenerator(writer, root);
-        
+
         RuleSetFactory rsf = new RuleSetFactory();
         RuleSet ruleset = rsf.createRuleSet("rulesets/ruledoctest/sample.xml");
-        
-        generator.generate(Arrays.asList(ruleset).iterator());
+
+        generator.generate(Arrays.asList(ruleset).iterator(), Arrays.asList("rulesets/ruledoctest/sample-deprecated.xml"));
 
         assertEquals(2, writer.getData().size());
         FileEntry languageIndex = writer.getData().get(0);

--- a/pmd-doc/src/test/java/net/sourceforge/pmd/docs/RuleDocGeneratorTest.java
+++ b/pmd-doc/src/test/java/net/sourceforge/pmd/docs/RuleDocGeneratorTest.java
@@ -67,7 +67,10 @@ public class RuleDocGeneratorTest {
         RuleSetFactory rsf = new RuleSetFactory();
         RuleSet ruleset = rsf.createRuleSet("rulesets/ruledoctest/sample.xml");
 
-        generator.generate(Arrays.asList(ruleset).iterator(), Arrays.asList("rulesets/ruledoctest/sample-deprecated.xml"));
+        generator.generate(Arrays.asList(ruleset).iterator(),
+                Arrays.asList(
+                        "rulesets/ruledoctest/sample-deprecated.xml",
+                        "rulesets/ruledoctest/other-ruleset.xml"));
 
         assertEquals(3, writer.getData().size());
         FileEntry languageIndex = writer.getData().get(0);

--- a/pmd-doc/src/test/java/net/sourceforge/pmd/docs/RuleSetResolverTest.java
+++ b/pmd-doc/src/test/java/net/sourceforge/pmd/docs/RuleSetResolverTest.java
@@ -1,0 +1,57 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.docs;
+
+import static org.junit.Assert.fail;
+
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.junit.Test;
+
+import net.sourceforge.pmd.RuleSetFactory;
+import net.sourceforge.pmd.RuleSetNotFoundException;
+
+public class RuleSetResolverTest {
+
+    private static List<String> excludedRulesets = new ArrayList<>();
+
+    static {
+        excludedRulesets.add("pmd-test/src/main/resources/rulesets/dummy/basic.xml");
+    }
+
+    @Test
+    public void resolveAllRulesets() {
+        Path basePath = FileSystems.getDefault().getPath(".").resolve("..").toAbsolutePath().normalize();
+        List<String> additionalRulesets = GenerateRuleDocsCmd.findAdditionalRulesets(basePath);
+    
+        filterRuleSets(additionalRulesets);
+
+        RuleSetFactory ruleSetFactory = new RuleSetFactory();
+        for (String filename : additionalRulesets) {
+            try {
+                ruleSetFactory.createRuleSet(filename);
+            } catch (RuntimeException | RuleSetNotFoundException e) {
+                fail("Couldn't load ruleset " + filename + ": " + e.getMessage());
+            }
+        }
+    }
+
+    private void filterRuleSets(List<String> additionalRulesets) {
+        Iterator<String> it = additionalRulesets.iterator();
+        while (it.hasNext()) {
+            String filename = it.next();
+            for (String exclusion : excludedRulesets) {
+                if (filename.endsWith(exclusion)) {
+                    it.remove();
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/pmd-doc/src/test/java/net/sourceforge/pmd/docs/SidebarGeneratorTest.java
+++ b/pmd-doc/src/test/java/net/sourceforge/pmd/docs/SidebarGeneratorTest.java
@@ -1,0 +1,54 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.docs;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Before;
+import org.junit.Test;
+import org.yaml.snakeyaml.DumperOptions;
+import org.yaml.snakeyaml.DumperOptions.FlowStyle;
+import org.yaml.snakeyaml.Yaml;
+
+import net.sourceforge.pmd.RuleSet;
+import net.sourceforge.pmd.RuleSetFactory;
+import net.sourceforge.pmd.lang.Language;
+import net.sourceforge.pmd.lang.LanguageRegistry;
+
+public class SidebarGeneratorTest {
+    private MockedFileWriter writer = new MockedFileWriter();
+
+    @Before
+    public void setup() {
+        writer.reset();
+    }
+
+    @Test
+    public void testSidebar() throws IOException {
+        Map<Language, List<RuleSet>> rulesets = new HashMap<>();
+        RuleSet ruleSet1 = new RuleSetFactory().createNewRuleSet("test", "test", "bestpractices.xml", Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        RuleSet ruleSet2 = new RuleSetFactory().createNewRuleSet("test2", "test", "codestyle.xml", Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        rulesets.put(LanguageRegistry.findLanguageByTerseName("java"), Arrays.asList(ruleSet1, ruleSet2));
+        rulesets.put(LanguageRegistry.findLanguageByTerseName("ecmascript"), Arrays.asList(ruleSet1));
+
+        SidebarGenerator generator = new SidebarGenerator(writer, FileSystems.getDefault().getPath(".."));
+        List<Map<String, Object>> result = generator.generateRuleReferenceSection(rulesets);
+
+        DumperOptions options = new DumperOptions();
+        options.setDefaultFlowStyle(FlowStyle.BLOCK);
+        String yaml = new Yaml(options).dump(result);
+
+        assertEquals(IOUtils.toString(SidebarGeneratorTest.class.getResourceAsStream("sidebar.yml")), yaml);
+    }
+}

--- a/pmd-doc/src/test/resources/expected/java.md
+++ b/pmd-doc/src/test/resources/expected/java.md
@@ -7,6 +7,9 @@ List of rulesets and rules contained in each ruleset.
 
 *   [Sample](pmd_rules_java_sample.html): Sample ruleset to test rule doc generation.
 
+List of additional rulesets
+*    Sample Deprecated: <span style="border-radius: 0.25em; color: #fff; padding: 0.2em 0.6em 0.3em; display: inline; background-color: #d9534f; font-size: 75%;">Deprecated</span> Sample ruleset which only contains deprecated rule references.
+
 ## Sample
 *   [DeprecatedSample](pmd_rules_java_sample.html#deprecatedsample): <span style="border-radius: 0.25em; color: #fff; padding: 0.2em 0.6em 0.3em; display: inline; background-color: #d9534f; font-size: 75%;">Deprecated</span> Just some description of a deprecated rule.
 *   [JumbledIncrementer](pmd_rules_java_sample.html#jumbledincrementer): Avoid jumbled loop incrementers - its usually a mistake, and is confusing even if intentional.

--- a/pmd-doc/src/test/resources/expected/java.md
+++ b/pmd-doc/src/test/resources/expected/java.md
@@ -3,16 +3,16 @@ title: Java Rules
 permalink: pmd_rules_java.html
 folder: pmd/rules
 ---
-List of rulesets and rules contained in each ruleset.
-
-*   [Sample](pmd_rules_java_sample.html): Sample ruleset to test rule doc generation.
-
-List of additional rulesets
-*    Sample Deprecated: <span style="border-radius: 0.25em; color: #fff; padding: 0.2em 0.6em 0.3em; display: inline; background-color: #d9534f; font-size: 75%;">Deprecated</span> Sample ruleset which only contains deprecated rule references.
-
 ## Sample
+
+{% include callout.html content="Sample ruleset to test rule doc generation." %}
+
 *   [DeprecatedSample](pmd_rules_java_sample.html#deprecatedsample): <span style="border-radius: 0.25em; color: #fff; padding: 0.2em 0.6em 0.3em; display: inline; background-color: #d9534f; font-size: 75%;">Deprecated</span> Just some description of a deprecated rule.
 *   [JumbledIncrementer](pmd_rules_java_sample.html#jumbledincrementer): Avoid jumbled loop incrementers - its usually a mistake, and is confusing even if intentional.
 *   [MovedRule](pmd_rules_java_sample.html#movedrule): <span style="border-radius: 0.25em; color: #fff; padding: 0.2em 0.6em 0.3em; display: inline; background-color: #d9534f; font-size: 75%;">Deprecated</span> The rule has been moved to another ruleset. Use instead [JumbledIncrementer](pmd_rules_java_sample2.html#jumbledincrementer).
 *   [OverrideBothEqualsAndHashcode](pmd_rules_java_sample.html#overridebothequalsandhashcode): Override both 'public boolean Object.equals(Object other)', and 'public int Object.hashCode()', o...
 *   [RenamedRule](pmd_rules_java_sample.html#renamedrule): <span style="border-radius: 0.25em; color: #fff; padding: 0.2em 0.6em 0.3em; display: inline; background-color: #d9534f; font-size: 75%;">Deprecated</span> The rule has been renamed. Use instead [JumbledIncrementer](pmd_rules_java_sample.html#jumbledincrementer).
+
+## Additional rulesets
+
+*    Sample Deprecated: <span style="border-radius: 0.25em; color: #fff; padding: 0.2em 0.6em 0.3em; display: inline; background-color: #d9534f; font-size: 75%;">Deprecated</span> Sample ruleset which only contains deprecated rule references.

--- a/pmd-doc/src/test/resources/expected/java.md
+++ b/pmd-doc/src/test/resources/expected/java.md
@@ -15,4 +15,19 @@ folder: pmd/rules
 
 ## Additional rulesets
 
-*    Sample Deprecated: <span style="border-radius: 0.25em; color: #fff; padding: 0.2em 0.6em 0.3em; display: inline; background-color: #d9534f; font-size: 75%;">Deprecated</span> Sample ruleset which only contains deprecated rule references.
+*   Other ruleset (`rulesets/ruledoctest/other-ruleset.xml`):
+
+    Ruleset which serves a specific use case, such as Getting Started.
+
+    It contains the following rules:
+
+    [JumbledIncrementer](pmd_rules_java_sample.html#jumbledincrementer), [OverrideBothEqualsAndHashcode](pmd_rules_java_sample.html#overridebothequalsandhashcode)
+
+*   Sample Deprecated (`rulesets/ruledoctest/sample-deprecated.xml`):
+
+    <span style="border-radius: 0.25em; color: #fff; padding: 0.2em 0.6em 0.3em; display: inline; background-color: #d9534f; font-size: 75%;">Deprecated</span>  This ruleset is for backwards compatibility.
+
+    It contains the following rules:
+
+    [JumbledIncrementer](pmd_rules_java_sample.html#jumbledincrementer), [OverrideBothEqualsAndHashcode](pmd_rules_java_sample.html#overridebothequalsandhashcode)
+

--- a/pmd-doc/src/test/resources/expected/pmd_sidebar.yml
+++ b/pmd-doc/src/test/resources/expected/pmd_sidebar.yml
@@ -1,0 +1,19 @@
+entries:
+- title: sidebar
+  folders:
+  - title: 1
+  - title: 2
+  - title: Rules
+    folderitems:
+    - title: null
+      output: web, pdf
+      subfolders:
+      - title: Java Rules
+        output: web, pdf
+        subfolderitems:
+        - title: Index
+          output: web, pdf
+          url: /pmd_rules_java.html
+        - title: Sample
+          output: web, pdf
+          url: /pmd_rules_java_sample.html

--- a/pmd-doc/src/test/resources/expected/sample.md
+++ b/pmd-doc/src/test/resources/expected/sample.md
@@ -121,6 +121,12 @@ Override both `public boolean Object.equals(Object other)`, and `public int Obje
 Even if you are inheriting a `hashCode()` from a parent class, consider implementing hashCode and explicitly
 delegating to your superclass.
 
+Second paragraph.
+
+    Code sample
+
+Third paragraph.
+
 **This rule is defined by the following Java class:** [net.sourceforge.pmd.lang.java.rule.errorprone.OverrideBothEqualsAndHashcodeRule](https://github.com/pmd/pmd/blob/master/net/sourceforge/pmd/lang/java/rule/errorprone/OverrideBothEqualsAndHashcodeRule.java)
 
 **Example(s):**

--- a/pmd-doc/src/test/resources/expected/sample.md
+++ b/pmd-doc/src/test/resources/expected/sample.md
@@ -62,6 +62,7 @@ public class JumbledIncrementerRule1 {
 |Name|Default Value|Description|
 |----|-------------|-----------|
 |sampleAdditionalProperty|the value|This is a additional property for tests|
+|sampleDeprecatedProperty|test|<span style="border-radius: 0.25em; color: #fff; padding: 0.2em 0.6em 0.3em; display: inline; background-color: #d9534f; font-size: 75%;">Deprecated</span>  This is a sample deprecated property for tests|
 
 **Use this rule by referencing it:**
 ``` xml
@@ -192,6 +193,7 @@ public class JumbledIncrementerRule1 {
 |Name|Default Value|Description|
 |----|-------------|-----------|
 |sampleAdditionalProperty|the value|This is a additional property for tests|
+|sampleDeprecatedProperty|test|<span style="border-radius: 0.25em; color: #fff; padding: 0.2em 0.6em 0.3em; display: inline; background-color: #d9534f; font-size: 75%;">Deprecated</span>  This is a sample deprecated property for tests|
 
 **Use this rule by referencing it:**
 ``` xml

--- a/pmd-doc/src/test/resources/net/sourceforge/pmd/docs/sidebar.yml
+++ b/pmd-doc/src/test/resources/net/sourceforge/pmd/docs/sidebar.yml
@@ -1,0 +1,27 @@
+- title: null
+  output: web, pdf
+  subfolders:
+  - title: Java Rules
+    output: web, pdf
+    subfolderitems:
+    - title: Index
+      output: web, pdf
+      url: /pmd_rules_java.html
+    - title: test
+      output: web, pdf
+      url: /pmd_rules_java_bestpractices.html
+    - title: test2
+      output: web, pdf
+      url: /pmd_rules_java_codestyle.html
+- title: null
+  output: web, pdf
+  subfolders:
+  - title: Ecmascript Rules
+    output: web, pdf
+    subfolderitems:
+    - title: Index
+      output: web, pdf
+      url: /pmd_rules_ecmascript.html
+    - title: test
+      output: web, pdf
+      url: /pmd_rules_ecmascript_bestpractices.html

--- a/pmd-doc/src/test/resources/rulesets/ruledoctest/other-ruleset.xml
+++ b/pmd-doc/src/test/resources/rulesets/ruledoctest/other-ruleset.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+
+<ruleset name="Other ruleset"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+  <description>
+Ruleset which serves a specific use case, such as Getting Started.
+  </description>
+
+    <rule ref="rulesets/ruledoctest/sample.xml/OverrideBothEqualsAndHashcode" />
+    <rule ref="rulesets/ruledoctest/sample.xml/JumbledIncrementer" />
+
+</ruleset>

--- a/pmd-doc/src/test/resources/rulesets/ruledoctest/sample-deprecated.xml
+++ b/pmd-doc/src/test/resources/rulesets/ruledoctest/sample-deprecated.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+
+<ruleset name="Sample Deprecated"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+  <description>
+Sample ruleset which only contains deprecated rule references.
+  </description>
+
+    <rule ref="rulesets/ruledoctest/sample.xml/OverrideBothEqualsAndHashcode" deprecated="true" />
+    <rule ref="rulesets/ruledoctest/sample.xml/JumbledIncrementer" deprecated="true" />
+
+</ruleset>

--- a/pmd-doc/src/test/resources/rulesets/ruledoctest/sample.xml
+++ b/pmd-doc/src/test/resources/rulesets/ruledoctest/sample.xml
@@ -16,9 +16,15 @@ Sample ruleset to test rule doc generation.
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_sample.html#overridebothequalsandhashcode"
           minimumLanguageVersion="1.5">
       <description>
-Override both `public boolean Object.equals(Object other)`, and `public int Object.hashCode()`, or override neither.
-Even if you are inheriting a `hashCode()` from a parent class, consider implementing hashCode and explicitly
-delegating to your superclass.
+            Override both `public boolean Object.equals(Object other)`, and `public int Object.hashCode()`, or override neither.
+            Even if you are inheriting a `hashCode()` from a parent class, consider implementing hashCode and explicitly
+            delegating to your superclass.
+
+            Second paragraph.
+
+                Code sample
+
+            Third paragraph.
       </description>
       <priority>3</priority>
       <example>

--- a/pmd-doc/src/test/resources/rulesets/ruledoctest/sample.xml
+++ b/pmd-doc/src/test/resources/rulesets/ruledoctest/sample.xml
@@ -71,6 +71,7 @@ Avoid jumbled loop incrementers - its usually a mistake, and is confusing even i
              </value>
          </property>
          <property name="sampleAdditionalProperty" type="String" description="This is a additional property for tests" value="the value" />
+         <property name="sampleDeprecatedProperty" type="String" description="Deprecated! This is a sample deprecated property for tests" value="test" />
      </properties>
      <example>
  <![CDATA[

--- a/pmd-java/src/main/resources/rulesets/java/naming.xml
+++ b/pmd-java/src/main/resources/rulesets/java/naming.xml
@@ -23,6 +23,8 @@ The Naming Ruleset contains rules regarding preferred usage of names and identif
     <rule ref="category/java/codestyle.xml/LongVariable" deprecated="true" />
     <rule ref="category/java/codestyle.xml/MethodNamingConventions" deprecated="true" />
     <rule ref="category/java/codestyle.xml/MIsLeadingVariableName" name="MisleadingVariableName" deprecated="true" /> <!-- also renamed -->
+    <!-- providing also the new name, since RuleSetFactoryCompatibility will change existing rulesets to use the new rulename -->
+    <rule ref="category/java/codestyle.xml/MIsLeadingVariableName" deprecated="true" />
     <rule ref="category/java/codestyle.xml/NoPackage" deprecated="true" />
     <rule ref="category/java/codestyle.xml/PackageCase" deprecated="true" />
     <rule ref="category/java/codestyle.xml/ShortClassName" deprecated="true" />

--- a/pmd-visualforce/src/main/resources/rulesets/vf/security.xml
+++ b/pmd-visualforce/src/main/resources/rulesets/vf/security.xml
@@ -8,7 +8,7 @@
 Rules concerning basic VF guidelines.
   </description>
 
-    <rule ref="category/vf/VfCsrf" deprecated="true" />
-    <rule ref="category/vf/VfUnescapeEl" deprecated="true" />
+    <rule ref="category/vf/security.xml/VfCsrf" deprecated="true" />
+    <rule ref="category/vf/security.xml/VfUnescapeEl" deprecated="true" />
 
 </ruleset>


### PR DESCRIPTION
This is about "Documentation: Should we also generate pages about the "old" rulesets" from #709 

Preview available at: http://adangel.github.io/pmd/index.html

Changes:
*   Ruleset Properties are marked as deprecated, e.g. http://adangel.github.io/pmd/pmd_rules_java_design.html#npathcomplexity
    Technically, I just check whether the description starts with "Deprecated!".
*   The sidebar part for the rule references is now generated, too, and contains subentries for the new categories/rulesets: http://adangel.github.io/pmd/pmd_rules_java.html
*   On the ruleset index page (per language), I added the other rulesets, that are existing in our source code: http://adangel.github.io/pmd/pmd_rules_java.html#additional-rulesets
    If the ruleset only contains rule references and all rule references are marked as deprecated, then I display the "Deprecated" label.
*   New unit test in pmd-doc, which tries to load all available rulesets... I found some problems and fixed these, see https://github.com/pmd/pmd/commit/06a1244e15407f3be75e8d54fd036203acad81ad
*   Add/Generate text "This ruleset is for backwards compatibility for XXX, it includes the following rules".

