### PR TITLE
[doc] Fix NPathComplexity documentation bad rendering

### DIFF
--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -1029,14 +1029,14 @@ public class Foo extends Bar {
           class="net.sourceforge.pmd.lang.java.rule.design.NPathComplexityRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#npathcomplexity">
         <description>
-            The NPath complexity of a method is the number of acyclic execution paths through that method.
-            While cyclomatic complexity counts the number of decision points in a method, NPath counts the number of
-            full paths from the beginning to the end of the block of the method. That metric grows exponentially, as
-            it multiplies the complexity of statements in the same block. For more details on the calculation, see the
-            documentation of the [NPath metric](/pmd_java_metrics_index.html#npath-complexity-npath).
+The NPath complexity of a method is the number of acyclic execution paths through that method.
+While cyclomatic complexity counts the number of decision points in a method, NPath counts the number of
+full paths from the beginning to the end of the block of the method. That metric grows exponentially, as
+it multiplies the complexity of statements in the same block. For more details on the calculation, see the
+documentation of the [NPath metric](/pmd_java_metrics_index.html#npath-complexity-npath).
 
-            A threshold of 200 is generally considered the point where measures should be taken to reduce
-            complexity and increase readability.
+A threshold of 200 is generally considered the point where measures should be taken to reduce
+complexity and increase readability.
         </description>
         <priority>3</priority>
         <example>


### PR DESCRIPTION
The second paragraph rendered as a fenced block of code.
