### PR TITLE
[java] EmptyCatchBlock ignore expected by default

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -237,6 +237,9 @@ The rule reference documentation has been updated to reflect these changes.
     *   `accessorCommentRequirement` to specify documentation requirements for getters and setters (default to `ignored`)
     *   `methodWithOverrideCommentRequirement` to specify documentation requirements for methods annotated with `@Override` (default to `ignored`)
 
+*   The Java rule `EmptyCatchBlock` (category `errorprone`, former ruleset `java-empty`) has been changed to ignore
+    exceptions named `ignore` or `expected` by default. You can still override this behaviour by setting the `allowExceptionNameRegex` property.
+
 #### Deprecated Rules
 
 *   The Java rules `NcssConstructorCount`, `NcssMethodCount`, and `NcssTypeCount` (ruleset `java-codesize`) have been

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -1379,7 +1379,7 @@ or reported.
                 </value>
             </property>
             <property name="allowCommentedBlocks" type="Boolean" description="Empty blocks containing comments will be skipped" value="false"/>
-            <property name="allowExceptionNameRegex" type="String" description="Empty blocks catching exceptions with names matching this regular expression will be skipped" value="^$"/>
+            <property name="allowExceptionNameRegex" type="String" description="Empty blocks catching exceptions with names matching this regular expression will be skipped" value="^(ignored|expected)$"/>
         </properties>
         <example>
 <![CDATA[

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/EmptyCatchBlock.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/EmptyCatchBlock.xml
@@ -172,9 +172,8 @@ Javadoc comment is not OK
     <!-- END Commented blocks -->
     <test-code>
         <description><![CDATA[
-Allow to ignore exceptions by name
+Exceptions named "ignored" and "expected" are ignored by default
      ]]></description>
-        <rule-property name="allowExceptionNameRegex">^(ignored|expected)$</rule-property>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -182,6 +181,22 @@ public class Foo {
   try {
   } catch (NullPointerException expected) {
   } catch (IllegalArgumentException ignored) {
+  }
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+Allow to ignore exceptions by name
+     ]]></description>
+        <rule-property name="allowExceptionNameRegex">^idontcare$</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ void foo() {
+  try {
+  } catch (NullPointerException idontcare) {
   }
  }
 }


### PR DESCRIPTION
 - We change the default to ignore exceptions named `ignore` or
   `expected`, users can still override this behavior.
 - Part of #709 
