### PR TITLE
[core] Expose the full mapping from property type id to property extractor  

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyDescriptorUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyDescriptorUtil.java
@@ -56,6 +56,16 @@ public class PropertyDescriptorUtil {
     private PropertyDescriptorUtil() {
     }
 
+    
+    /**
+     * Returns the full mappings from type ids to extractors.
+     *
+     * @return The full mapping.
+     */
+    public static Map<String, PropertyDescriptorExternalBuilder<?>> typeIdsToExtractors() {
+        return DESCRIPTOR_FACTORIES_BY_TYPE;
+    }
+
 
     /**
      * Gets the factory for the descriptor identified by the string id.


### PR DESCRIPTION
While working on the designer, it occurred to me that we need a way to list the different (type id -> property extractor) mappings, if we want to make a GUI to define properties.