### PR TITLE
[apex] Shade jorje into main jar for easier consumption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ bin/
 .idea
 *.patch
 */src/site/site.xml
+pmd-apex/dependency-reduced-pom.xml
+

--- a/pmd-apex/pom.xml
+++ b/pmd-apex/pom.xml
@@ -14,6 +14,7 @@
   <properties>
     <config.basedir>${basedir}/../pmd-core</config.basedir>
     <java.version>8</java.version>
+    <apex.jorje.version>1.0-sfdc-224-SNAPSHOT-3083815933</apex.jorje.version>
   </properties>
 
   <build>
@@ -59,6 +60,28 @@
           </execution>
         </executions>
       </plugin>
+
+      <!-- repackage main artifact to include apex-jorje directly -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <configuration>
+            <artifactSet>
+                <includes>
+                    <include>apex</include>
+                </includes>
+            </artifactSet>
+            <shadedArtifactAttached>false</shadedArtifactAttached>
+        </configuration>
+        <executions>
+            <execution>
+                <phase>package</phase>
+                <goals>
+                    <goal>shade</goal>
+                </goals>
+            </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <dependencies>
@@ -70,37 +93,37 @@
     <dependency>
       <groupId>apex</groupId>
       <artifactId>apex-jorje-data</artifactId>
-      <version>1.0-sfdc-224-SNAPSHOT-3083815933</version>
+      <version>${apex.jorje.version}</version>
     </dependency>
 
     <dependency>
       <groupId>apex</groupId>
       <artifactId>apex-jorje-ide</artifactId>
-      <version>1.0-sfdc-224-SNAPSHOT-3083815933</version>
+      <version>${apex.jorje.version}</version>
     </dependency>
 
     <dependency>
       <groupId>apex</groupId>
       <artifactId>apex-jorje-parser</artifactId>
-      <version>1.0-sfdc-224-SNAPSHOT-3083815933</version>
+      <version>${apex.jorje.version}</version>
     </dependency>
 
     <dependency>
       <groupId>apex</groupId>
       <artifactId>apex-jorje-semantic</artifactId>
-      <version>1.0-sfdc-224-SNAPSHOT-3083815933</version>
+      <version>${apex.jorje.version}</version>
     </dependency>
 
     <dependency>
       <groupId>apex</groupId>
       <artifactId>apex-jorje-services</artifactId>
-      <version>1.0-sfdc-224-SNAPSHOT-3083815933</version>
+      <version>${apex.jorje.version}</version>
     </dependency>
 
     <dependency>
       <groupId>apex</groupId>
       <artifactId>apex-jorje-tools</artifactId>
-      <version>1.0-sfdc-224-SNAPSHOT-3083815933</version>
+      <version>${apex.jorje.version}</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Shade jorje into main jar for easier consumption downstream e.g. eclipse plugin

pmd-apex.jar now contains everything needed for apex:
* our own classes
* all the class files from the apex-jorje jar files

Currently, the apex-jorje jar files (declared as dependencies for pmd-apex) are available only within the PMD maven project - so this means, that pmd-dist works fine with packaging the additional apex-jorje jars. But if you want to use pmd-apex from outside the PMD project (e.g. for the eclipse plugin), these apex-jorje jars are missing, because these dependencies are not in maven central...

Ideally I would like to separate our own pmd-apex.jar from the apex-jorje jars, but I don't know how (without creating an extra module for deploying apex-jorje under our groupId within the PMD project or a separate project).

Anyway, with this change, I can re-enable apex for the eclipse plugin again.

