### PR TITLE
[apex] Avoid FPs on non-existing else block

### DIFF
--- a/pmd-apex/src/main/resources/category/apex/errorprone.xml
+++ b/pmd-apex/src/main/resources/category/apex/errorprone.xml
@@ -150,7 +150,7 @@ Empty block statements serve no purpose and should be removed.
                 <value>
 <![CDATA[
 //Method/ModifierNode[@Abstract!='true' and ../BlockStatement[count(*) = 0]]
-| //Method/BlockStatement//BlockStatement[count(*) = 0]
+| //Method/BlockStatement//BlockStatement[count(*) = 0 and @Location != parent::*/@Location]
 ]]>
                 </value>
             </property>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/xml/EmptyStatementBlock.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/xml/EmptyStatementBlock.xml
@@ -10,10 +10,10 @@ Failure case: Empty Statement Block
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Foo {
- public void foo() {
- }
+  public void foo() {
+  }
 
- public abstract void bar() {}
+  public abstract void bar() {}
 }
      ]]></code>
     </test-code>
@@ -24,11 +24,41 @@ Success case: Empty Statement Block
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
- public void foo() {
+  public void foo() {
     system.debug(1);
- }
+  }
+  public abstract void bar() {}
 }
- public abstract void bar() {}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+#760 - false positive on non existing else block
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+  public void foo() {
+    if (something) {
+      system.debug(1);
+    }
+  }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+#760 - is reported on existing else block
+     ]]></description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+  public void foo() {
+    if (something) {
+      system.debug(1);
+    } else {
+    }
+  }
 }
      ]]></code>
     </test-code>


### PR DESCRIPTION
 - IfElseStatement always has 2 BlockStatements, for the if and the
   else, even if not present on the code. When that happens, the phantom
   block is given the same location the parent has.
 - Fixes #760