### PR TITLE
[apex] Fix Apex metrics framework failing on triggers, refs #768

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexQualifiedName.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexQualifiedName.java
@@ -119,15 +119,15 @@ public class ApexQualifiedName implements QualifiedName {
      *
      * <p>Here are some examples of the format:
      * <ul>
-     * <li> {@code namespace::OuterClass.InnerClass}: name of an inner class
-     * <li> {@code namespace::Class#method(String, int)}: name of an operation
+     * <li> {@code namespace__OuterClass.InnerClass}: name of an inner class
+     * <li> {@code namespace__Class#method(String, int)}: name of an operation
      * </ul>
      *
      * @param toParse The string to parse
      *
      * @return An ApexQualifiedName, or null if the string couldn't be parsed
      */
-    // private static final Pattern FORMAT = Pattern.compile("(\\w+)::(\\w+)(.(\\w+))?(#(\\w+))?"); // TODO
+    // private static final Pattern FORMAT = Pattern.compile("(\\w+)__(\\w+)(.(\\w+))?(#(\\w+))?"); // TODO
     public static ApexQualifiedName ofString(String toParse) {
         throw new UnsupportedOperationException();
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexQualifiedName.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexQualifiedName.java
@@ -70,7 +70,7 @@ public class ApexQualifiedName implements QualifiedName {
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append(nameSpace).append("::");
+        sb.append(nameSpace).append("__");
         sb.append(classes[0]);
 
         if (classes.length > 1) {

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexQualifiedNameTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexQualifiedNameTest.java
@@ -26,7 +26,7 @@ public class ApexQualifiedNameTest {
         ApexNode<Compilation> root = ApexParserTestHelpers.parse("public class Foo {}");
 
         ApexQualifiedName qname = ASTUserClass.class.cast(root).getQualifiedName();
-        assertEquals("c::Foo", qname.toString());
+        assertEquals("c__Foo", qname.toString());
         assertEquals(1, qname.getClasses().length);
         assertNotNull(qname.getNameSpace());
         assertNull(qname.getOperation());
@@ -38,7 +38,7 @@ public class ApexQualifiedNameTest {
         ApexNode<Compilation> root = ApexParserTestHelpers.parse("public class Foo { class Bar {}}");
 
         ApexQualifiedName qname = root.getFirstDescendantOfType(ASTUserClass.class).getQualifiedName();
-        assertEquals("c::Foo.Bar", qname.toString());
+        assertEquals("c__Foo.Bar", qname.toString());
         assertEquals(2, qname.getClasses().length);
         assertNotNull(qname.getNameSpace());
         assertNull(qname.getOperation());
@@ -49,7 +49,7 @@ public class ApexQualifiedNameTest {
     public void testSimpleMethod() {
         ApexNode<Compilation> root = ApexParserTestHelpers.parse("public class Foo { String foo() {}}");
         ApexQualifiedName qname = root.getFirstDescendantOfType(ASTMethod.class).getQualifiedName();
-        assertEquals("c::Foo#foo()", qname.toString());
+        assertEquals("c__Foo#foo()", qname.toString());
         assertEquals(1, qname.getClasses().length);
         assertNotNull(qname.getNameSpace());
         assertEquals("foo()", qname.getOperation());
@@ -60,7 +60,7 @@ public class ApexQualifiedNameTest {
     public void testMethodWithArguments() {
         ApexNode<Compilation> root = ApexParserTestHelpers.parse("public class Foo { String foo(String h, Foo g) {}}");
         ApexQualifiedName qname = root.getFirstDescendantOfType(ASTMethod.class).getQualifiedName();
-        assertEquals("c::Foo#foo(String,Foo)", qname.toString());
+        assertEquals("c__Foo#foo(String,Foo)", qname.toString());
         assertEquals(1, qname.getClasses().length);
         assertNotNull(qname.getNameSpace());
         assertEquals("foo(String,Foo)", qname.getOperation());
@@ -94,7 +94,7 @@ public class ApexQualifiedNameTest {
         List<ASTMethod> methods = root.findDescendantsOfType(ASTMethod.class);
 
         for (ASTMethod m : methods) {
-            assertEquals("c::trigger.Account#myAccountTrigger", m.getQualifiedName().toString());
+            assertEquals("c__trigger.Account#myAccountTrigger", m.getQualifiedName().toString());
         }
     }
 }

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexQualifiedNameTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexQualifiedNameTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 
 import apex.jorje.semantic.ast.compilation.Compilation;
 
+
 /**
  * @author Clément Fournier
  */
@@ -25,7 +26,7 @@ public class ApexQualifiedNameTest {
         ApexNode<Compilation> root = ApexParserTestHelpers.parse("public class Foo {}");
 
         ApexQualifiedName qname = ASTUserClass.class.cast(root).getQualifiedName();
-        assertEquals("c__Foo", qname.toString());
+        assertEquals("c::Foo", qname.toString());
         assertEquals(1, qname.getClasses().length);
         assertNotNull(qname.getNameSpace());
         assertNull(qname.getOperation());
@@ -37,7 +38,7 @@ public class ApexQualifiedNameTest {
         ApexNode<Compilation> root = ApexParserTestHelpers.parse("public class Foo { class Bar {}}");
 
         ApexQualifiedName qname = root.getFirstDescendantOfType(ASTUserClass.class).getQualifiedName();
-        assertEquals("c__Foo.Bar", qname.toString());
+        assertEquals("c::Foo.Bar", qname.toString());
         assertEquals(2, qname.getClasses().length);
         assertNotNull(qname.getNameSpace());
         assertNull(qname.getOperation());
@@ -48,7 +49,7 @@ public class ApexQualifiedNameTest {
     public void testSimpleMethod() {
         ApexNode<Compilation> root = ApexParserTestHelpers.parse("public class Foo { String foo() {}}");
         ApexQualifiedName qname = root.getFirstDescendantOfType(ASTMethod.class).getQualifiedName();
-        assertEquals("c__Foo#foo()", qname.toString());
+        assertEquals("c::Foo#foo()", qname.toString());
         assertEquals(1, qname.getClasses().length);
         assertNotNull(qname.getNameSpace());
         assertEquals("foo()", qname.getOperation());
@@ -59,7 +60,7 @@ public class ApexQualifiedNameTest {
     public void testMethodWithArguments() {
         ApexNode<Compilation> root = ApexParserTestHelpers.parse("public class Foo { String foo(String h, Foo g) {}}");
         ApexQualifiedName qname = root.getFirstDescendantOfType(ASTMethod.class).getQualifiedName();
-        assertEquals("c__Foo#foo(String,Foo)", qname.toString());
+        assertEquals("c::Foo#foo(String,Foo)", qname.toString());
         assertEquals(1, qname.getClasses().length);
         assertNotNull(qname.getNameSpace());
         assertEquals("foo(String,Foo)", qname.getOperation());
@@ -69,9 +70,9 @@ public class ApexQualifiedNameTest {
     @Test
     public void testOverLoads() {
         ApexNode<Compilation> root = ApexParserTestHelpers.parse("public class Foo { "
-                                                                     + "String foo(String h) {} "
-                                                                     + "String foo(int c) {}"
-                                                                     + "String foo(Foo c) {}}");
+                                                                 + "String foo(String h) {} "
+                                                                 + "String foo(int c) {}"
+                                                                 + "String foo(Foo c) {}}");
 
         List<ASTMethod> methods = root.findDescendantsOfType(ASTMethod.class);
 
@@ -81,6 +82,19 @@ public class ApexQualifiedNameTest {
                     assertNotEquals(m1.getQualifiedName(), m2.getQualifiedName());
                 }
             }
+        }
+    }
+
+
+    @Test
+    public void testTrigger() {
+        ApexNode<Compilation> root = ApexParserTestHelpers.parse("trigger myAccountTrigger on Account (before insert, before update) {}");
+
+
+        List<ASTMethod> methods = root.findDescendantsOfType(ASTMethod.class);
+
+        for (ASTMethod m : methods) {
+            assertEquals("c::trigger.Account#myAccountTrigger", m.getQualifiedName().toString());
         }
     }
 }

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/xml/CyclomaticComplexity.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/xml/CyclomaticComplexity.xml
@@ -251,5 +251,52 @@
         </expected-messages>
         <code-ref id="many-small-methods"/>
     </test-code>
+    
+    
+    <code-fragment id="trigger">
+        <![CDATA[
+            trigger CaseAssignLevel on CaseAssignLevel__c (after delete, after insert, after undelete, after update, before delete, before insert, before update) {
+            
+            if(Trigger.isBefore) {
+                if(Trigger.isInsert || Trigger.isUpdate) {
+                    CaseAssignLevel_tr.doIsNotTrigger(Trigger.new);
+                }
+            }
+            
+            
+            
+            if(Trigger.isBefore && !CaseAssignLevel_tr.isNotTrigger) {
+                if(Trigger.isInsert || Trigger.isUpdate) {
+                    CaseAssignLevel_tr.doCreateKeyValue(Trigger.new, Trigger.oldMap);	
+                }
+            }
+            
+            
+            else if(Trigger.isAfter && !CaseAssignLevel_tr.isNotTrigger) {
+                if(Trigger.isInsert || Trigger.isUpdate) {
+                    
+                }
+            }
+            
+            }
+        ]]>
+    </code-fragment>
+    
+    <test-code>
+        <description>#768 NPE caused by exception in ApexQualifiedName.ofMethod because of trigger</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>The trigger 'CaseAssignLevel' has a cyclomatic complexity of 12.</message>
+        </expected-messages>
+        <code-ref id="trigger"/>
+    </test-code>
+
+    <test-code>
+        <description>#768 NPE caused by exception in ApexQualifiedName.ofMethod because of trigger</description>
+        <rule-property name="methodReportLevel">13</rule-property>
+        <expected-problems>0</expected-problems>
+        <code-ref id="trigger"/>
+    </test-code>
+
 
 </test-data>


### PR DESCRIPTION
The Apex metrics framework was previously oblivious to triggers... Our parser parses them as an ASTUserTrigger with an ASTMethod node inside, which contains the actual code. So there wasn't much to change, except assign a special qualified name to the method. I'm no Apex developer though, and I couldn't find a detailed syntax spec for Apex, so I made a few assumptions:
* A trigger is never contained in a class
* There are never two triggers with the same name in a project (except maybe if they're applied to different objects)
* A trigger cannot contain another trigger

Could an experienced Apex developer confirm these hold for the projects PMD analyses? @up2go-rsoesemann maybe?

Based on these, the qualified name of an apex trigger (well the method of the trigger) is of the form `namespace::trigger.targetObject#triggerName`. I also changed the `__` namespace separator to `::` because I believe `__` can actually be used in identifiers (?), like the target of the trigger in #768's example