### PR TITLE
[apex] AvoidDirectAccessTriggerMap incorrectly detects array access in classes

### DIFF
--- a/pmd-apex/src/main/resources/category/apex/errorprone.xml
+++ b/pmd-apex/src/main/resources/category/apex/errorprone.xml
@@ -22,7 +22,7 @@ Avoid directly accessing Trigger.old and Trigger.new as it can lead to a bug. Tr
             <property name="xpath">
                 <value>
 <![CDATA[
-//ArrayLoadExpression/TriggerVariableExpression | //ArrayLoadExpression/LiteralExpression
+//ArrayLoadExpression[TriggerVariableExpression and LiteralExpression]
 ]]>
                 </value>
             </property>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/xml/AvoidDirectAccessTriggerMap.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/xml/AvoidDirectAccessTriggerMap.xml
@@ -7,15 +7,15 @@
 
     <test-code>
         <description>Directly accessing the Trigger.old map.</description>
-        <expected-problems>2</expected-problems>
+        <expected-problems>1</expected-problems>
         <code><![CDATA[
 trigger AccountTrigger on Account (before insert, before update) {
    Account a = Trigger.new[0]; //Bad: Accessing the trigger array directly is not recommended.
 }
 		]]></code>
 	</test-code>
-    
-	<test-code>
+
+    <test-code>
         <description>Looping through map, best practice</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
@@ -25,6 +25,19 @@ trigger AccountTrigger on Account (before insert, before update) {
         system.debug(a);
    }
 }
+		]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Regression issue #792</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class NotATrigger {
+   void foo(){
+        Account[] accounts = opportunity.Accounts[0];
+   }
+}
+
 		]]></code>
     </test-code>
     


### PR DESCRIPTION
Fixes #792 