### PR TITLE
[java] Rewrite GuardLogStatementRule without XPath

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -28,6 +28,7 @@ This is a bug fixing release.
 *   doc
     *   [#794](https://github.com/pmd/pmd/issues/794): \[doc] Broken documentation links for 6.0.0
 *   java
+    *   [#783](https://github.com/pmd/pmd/issues/783): \[java] GuardLogStatement regression
     *   [#793](https://github.com/pmd/pmd/issues/793): \[java] Parser error with private method in nested classes in interfaces
 *   java-design
     *   [#785](https://github.com/pmd/pmd/issues/785): \[java] NPE in DataClass rule

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
@@ -280,4 +280,38 @@ public class GuardLogTest {
 }
 ]]></code>
     </test-code>
+    <test-code>
+        <description>#783 [java] GuardLogStatement regression</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.apache.log4j.Logger;
+
+public class GuardLogTest {
+    Logger LOG;
+    public void foo() {
+        if (!(exception instanceof IllegalArgumentException) && LOGGER.isErrorEnabled()) {
+            LOGGER.error("Some error " + someObject, exception);
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Wrong guard method for java util logging</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import java.util.logging.Logger;
+import java.util.logging.Level;
+
+public class Foo {
+    Logger LOGGER;
+
+    public void foo() {
+        if (LOGGER.isLoggable(Level.INFO)) { // should have been level FINE
+            LOGGER.log(Level.FINE, "This is a severe message" + " and concat");
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
- uses now a Java only implementation for the rule
- Fixes #783
