### PR TITLE
[java] Avoid crashes during type resolution when used JRE is older than dependencies' version

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -30,6 +30,7 @@ This is a bug fixing release.
 *   java
     *   [#783](https://github.com/pmd/pmd/issues/783): \[java] GuardLogStatement regression
     *   [#793](https://github.com/pmd/pmd/issues/793): \[java] Parser error with private method in nested classes in interfaces
+    *   [#814](https://github.com/pmd/pmd/issues/814): \[java] UnsupportedClassVersionError is failure instead of a warning
 *   java-design
     *   [#785](https://github.com/pmd/pmd/issues/785): \[java] NPE in DataClass rule
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -572,7 +572,10 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
                 }
             } catch (final NoSuchFieldException ignored) {
                 // swallow
-            } catch (final NoClassDefFoundError e) {
+            } catch (final LinkageError e) {
+                if (LOG.isLoggable(Level.WARNING)) {
+                    LOG.log(Level.WARNING, "Error during type resolution due to: " + e);
+                }
                 // TODO : report a missing class once we start doing that...
                 return null;
             }


### PR DESCRIPTION
 - Handle equally incomplete classpath, having a classpath which
   requires a different JRE version than the one used to run PMD and
   others.
 - Fixes #814