### PR TITLE
[core] Add operations to manipulate a document

### DIFF
--- a/pmd-core/pom.xml
+++ b/pmd-core/pom.xml
@@ -64,14 +64,6 @@
                     <suppressionsLocation>pmd-core-checkstyle-suppressions.xml</suppressionsLocation>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>9</source>
-                    <target>9</target>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/pmd-core/pom.xml
+++ b/pmd-core/pom.xml
@@ -64,6 +64,14 @@
                     <suppressionsLocation>pmd-core-checkstyle-suppressions.xml</suppressionsLocation>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>9</source>
+                    <target>9</target>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/document/DeleteDocumentOperation.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/document/DeleteDocumentOperation.java
@@ -1,0 +1,17 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.document;
+
+public class DeleteDocumentOperation extends DocumentOperation {
+
+    public DeleteDocumentOperation(final int beginLine, final int endLine, final int beginColumn, final int endColumn) {
+        super(beginLine, endLine, beginColumn, endColumn);
+    }
+
+    @Override
+    public void apply(final Document document) {
+        document.delete(getRegionByLine());
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/document/Document.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/document/Document.java
@@ -1,0 +1,35 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.document;
+
+/**
+ * Represents a file which contains programming code that will be fixed.
+ */
+public interface Document {
+
+    /**
+     * Insert a text at a line at the position/column specified. If there is any text to the right of the insertion,
+     * that text is shifted by the length of the text to insert, which means that it is not replaced.
+     * @param beginLine the line in which to insert the text
+     * @param beginColumn the position in the line in which to insert the text
+     * @param textToInsert the text to be added
+     */
+    void insert(int beginLine, int beginColumn, String textToInsert);
+
+    /**
+     * Replace a specific region in the document which contains text by another text, which not necessarily is the same
+     * length as the region's one.
+     * @param regionByOffset the region in which a text will be inserted to replace the current document's contents
+     * @param textToReplace the text to insert
+     */
+    void replace(RegionByLine regionByOffset, String textToReplace);
+
+    /**
+     * Delete a region in the document, removing all text which contains it. If there is any text to the right of this
+     * region, it will be shifted to the left by the length of the region to delete.
+     * @param regionByOffset the region in which to erase all the text
+     */
+    void delete(RegionByLine regionByOffset);
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/document/DocumentFile.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/document/DocumentFile.java
@@ -30,7 +30,7 @@ public class DocumentFile implements Document, Closeable {
 
     private List<Integer> lineToOffset = new ArrayList<>();
 
-    private final String filePath;
+    private final Path filePath;
     private final BufferedReader reader;
     private int currentPosition = 0;
 
@@ -39,12 +39,12 @@ public class DocumentFile implements Document, Closeable {
 
     public DocumentFile(final File file) throws IOException {
         reader = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8);
-        this.filePath = file.getAbsolutePath();
+        this.filePath = file.toPath();
         mapLinesToOffsets();
     }
 
     private void mapLinesToOffsets() throws IOException {
-        try (Scanner scanner = new Scanner(Paths.get(filePath))) {
+        try (Scanner scanner = new Scanner(filePath)) {
             int currentGlobalOffset = 0;
 
             while (scanner.hasNextLine()) {
@@ -109,7 +109,7 @@ public class DocumentFile implements Document, Closeable {
         try {
             tryToReplaceInFile(mapToRegionByOffset(regionByLine), textToReplace);
         } catch (final IOException e) {
-            LOG.log(Level.WARNING, "An exception occurred when replacing in file " + filePath);
+            LOG.log(Level.WARNING, "An exception occurred when replacing in file " + filePath.toAbsolutePath());
         }
     }
 
@@ -132,7 +132,7 @@ public class DocumentFile implements Document, Closeable {
         try {
             tryToDeleteFromFile(mapToRegionByOffset(regionByOffset));
         } catch (final IOException e) {
-            LOG.log(Level.WARNING, "An exception occurred when deleting from file " + filePath);
+            LOG.log(Level.WARNING, "An exception occurred when deleting from file " + filePath.toAbsolutePath());
         }
     }
 
@@ -150,8 +150,8 @@ public class DocumentFile implements Document, Closeable {
         reader.close();
         writer.close();
 
-        if (!temporaryPath.toFile().renameTo(new File(filePath))) {
-            throw new IOException("Fixed file could not be renamed. Original path = " + filePath);
+        if (!temporaryPath.toFile().renameTo(filePath.toFile())) {
+            throw new IOException("Fixed file could not be renamed. Original path = " + filePath.toAbsolutePath());
         }
         temporaryPath.toFile().delete();
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/document/DocumentFile.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/document/DocumentFile.java
@@ -1,0 +1,148 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.document;
+
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Scanner;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+/**
+ * Implementation that handles a Document as a file in the filesystem and receives operations in a sorted manner
+ * (i.e. the regions are sorted). This improves the efficiency of reading the file by only scanning it once while
+ * operations are applied, until an instance of this document is closed.
+ */
+public class DocumentFile implements Document, Closeable {
+
+    private static final Logger LOG = Logger.getLogger(DocumentFile.class.getName());
+
+    private List<Integer> lineToOffset = new ArrayList<>();
+
+    private final String filePath;
+    private final BufferedReader reader;
+    private int currentPosition = 0;
+
+    private final Path temporaryPath = Files.createTempFile("pmd-", null);
+    private final Writer writer = new FileWriter(temporaryPath.toFile());
+
+    public DocumentFile(final File file) throws IOException {
+        reader = new BufferedReader(new FileReader(file));
+        this.filePath = file.getAbsolutePath();
+        mapLinesToOffsets();
+    }
+
+    private void mapLinesToOffsets() throws IOException {
+        try (Scanner scanner = new Scanner(filePath)) {
+            int currentGlobalOffset = 0;
+
+            while (scanner.hasNextLine()) {
+                lineToOffset.add(currentGlobalOffset);
+                currentGlobalOffset += scanner.nextLine().length();
+            }
+        }
+    }
+
+    @Override
+    public void insert(int beginLine, int beginColumn, final String textToInsert) {
+        try {
+            tryToInsertIntoFile(beginLine, beginColumn, textToInsert);
+        } catch (final IOException e) {
+            LOG.log(Level.WARNING, "An exception occurred when inserting into file " + filePath);
+        }
+    }
+
+    private void tryToInsertIntoFile(int beginLine, int beginColumn, final String textToInsert) throws IOException {
+        final int offset = mapToOffset(beginLine, beginColumn);
+        writeUntilOffsetReached(offset);
+        writer.write(textToInsert);
+    }
+
+    private int mapToOffset(final int line, final int column) {
+        return lineToOffset.get(line) + column;
+    }
+
+    /**
+     * Write characters between the current offset until the next offset to be read
+     * @param nextOffsetToRead the position in which the reader will stop reading
+     * @throws IOException if an I/O error occurs
+     */
+    private void writeUntilOffsetReached(final int nextOffsetToRead) throws IOException {
+        if (nextOffsetToRead < currentPosition) {
+            throw new IllegalStateException();
+        }
+        final char[] bufferToCopy = new char[nextOffsetToRead - currentPosition];
+        reader.read(bufferToCopy);
+        writer.write(bufferToCopy);
+        currentPosition = nextOffsetToRead;
+    }
+
+    @Override
+    public void replace(final RegionByLine regionByLine, final String textToReplace) {
+        try {
+            tryToReplaceInFile(mapToRegionByOffset(regionByLine), textToReplace);
+        } catch (final IOException e) {
+            LOG.log(Level.WARNING, "An exception occurred when replacing in file " + filePath);
+        }
+    }
+
+    private RegionByOffset mapToRegionByOffset(final RegionByLine regionByLine) {
+        final int startOffset = mapToOffset(regionByLine.getBeginLine(), regionByLine.getBeginColumn());
+        final int endOffset = mapToOffset(regionByLine.getEndLine(), regionByLine.getEndColumn());
+
+        return new RegionByOffsetImp(startOffset, endOffset - startOffset);
+    }
+
+    private void tryToReplaceInFile(final RegionByOffset regionByOffset, final String textToReplace) throws IOException {
+        writeUntilOffsetReached(regionByOffset.getOffset());
+        reader.skip(regionByOffset.getLength());
+        currentPosition = regionByOffset.getOffsetAfterEnding();
+        writer.write(textToReplace);
+    }
+
+    @Override
+    public void delete(final RegionByLine regionByOffset) {
+        try {
+            tryToDeleteFromFile(mapToRegionByOffset(regionByOffset));
+        } catch (final IOException e) {
+            LOG.log(Level.WARNING, "An exception occurred when deleting from file " + filePath);
+        }
+    }
+
+    private void tryToDeleteFromFile(final RegionByOffset regionByOffset) throws IOException {
+        writeUntilOffsetReached(regionByOffset.getOffset());
+        reader.skip(regionByOffset.getLength());
+        currentPosition = regionByOffset.getOffsetAfterEnding();
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (reader.ready()) {
+            writeUntilEOF();
+        }
+        reader.close();
+        writer.close();
+        Files.copy(temporaryPath, Paths.get(filePath), StandardCopyOption.REPLACE_EXISTING);
+        temporaryPath.toFile().delete();
+    }
+
+    private void writeUntilEOF() throws IOException {
+        for (final String line : reader.lines().collect(Collectors.toList())) {
+            writer.write(line);
+        }
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/document/DocumentFile.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/document/DocumentFile.java
@@ -4,15 +4,16 @@
 
 package net.sourceforge.pmd.util.document;
 
+import static java.util.Objects.requireNonNull;
+
 import java.io.BufferedReader;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
-import java.nio.charset.StandardCharsets;
+import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
@@ -35,10 +36,11 @@ public class DocumentFile implements Document, Closeable {
     private int currentPosition = 0;
 
     private final Path temporaryPath = Files.createTempFile("pmd-", ".tmp");
-    private final Writer writer = Files.newBufferedWriter(temporaryPath, StandardCharsets.UTF_8);
+    private final Writer writer;
 
-    public DocumentFile(final File file) throws IOException {
-        reader = Files.newBufferedReader(file.toPath(), StandardCharsets.UTF_8);
+    public DocumentFile(final File file, final Charset charset) throws IOException {
+        reader = Files.newBufferedReader(requireNonNull(file).toPath(), requireNonNull(charset));
+        writer = Files.newBufferedWriter(temporaryPath, charset);
         this.filePath = file.toPath();
         mapLinesToOffsets();
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/document/DocumentFile.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/document/DocumentFile.java
@@ -164,7 +164,7 @@ public class DocumentFile implements Document, Closeable {
         }
     }
 
-    public List<Integer> getLineToOffset() {
+    /* package-private */ List<Integer> getLineToOffset() {
         return lineToOffset;
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/document/DocumentFile.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/document/DocumentFile.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Scanner;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 /**
  * Implementation that handles a Document as a file in the filesystem and receives operations in a sorted manner
@@ -141,7 +140,9 @@ public class DocumentFile implements Document, Closeable {
     }
 
     private void writeUntilEOF() throws IOException {
-        for (final String line : reader.lines().collect(Collectors.toList())) {
+        String line;
+
+        while ((line = reader.readLine()) != null) {
             writer.write(line);
         }
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/document/DocumentOperation.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/document/DocumentOperation.java
@@ -1,0 +1,31 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.document;
+
+/**
+ * Represents an operation in a document which will be managed by
+ * {@link DocumentOperationsApplierForNonOverlappingRegions}.
+ */
+public abstract class DocumentOperation {
+
+    /**
+     * The region to which this operations belongs
+     */
+    private final RegionByLine regionByLine;
+
+    public DocumentOperation(final int beginLine, final int endLine, final int beginColumn, final int endColumn) {
+        regionByLine = new RegionByLineImp(beginLine, endLine, beginColumn, endColumn);
+    }
+
+    /**
+     * Apply this operation to the specified document
+     * @param document the document to which apply the operation
+     */
+    public abstract void apply(Document document);
+
+    public RegionByLine getRegionByLine() {
+        return regionByLine;
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/document/DocumentOperationsApplierForNonOverlappingRegions.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/document/DocumentOperationsApplierForNonOverlappingRegions.java
@@ -12,15 +12,15 @@ import java.util.Objects;
 
 public class DocumentOperationsApplierForNonOverlappingRegions {
 
+    private static final Comparator<DocumentOperation> COMPARATOR = new DocumentOperationNonOverlappingRegionsComparator();
+
     private final Document document;
     private final List<DocumentOperation> operations;
-    private final Comparator<DocumentOperation> comparator;
 
     private boolean applied;
 
     public DocumentOperationsApplierForNonOverlappingRegions(final Document document) {
         this.document = Objects.requireNonNull(document);
-        comparator = new DocumentOperationNonOverlappingRegionsComparator();
         operations = new ArrayList<>();
         applied = false;
     }
@@ -39,7 +39,7 @@ public class DocumentOperationsApplierForNonOverlappingRegions {
     }
 
     private int getIndexForDocumentOperation(final DocumentOperation documentOperation) {
-        int potentialIndex = Collections.binarySearch(operations, documentOperation, comparator);
+        int potentialIndex = Collections.binarySearch(operations, documentOperation, COMPARATOR);
 
         if (potentialIndex < 0) {
             return ~potentialIndex;
@@ -53,7 +53,7 @@ public class DocumentOperationsApplierForNonOverlappingRegions {
     }
 
     private boolean areSiblingsEqual(final int index) {
-        return comparator.compare(operations.get(index), operations.get(index + 1)) == 0;
+        return COMPARATOR.compare(operations.get(index), operations.get(index + 1)) == 0;
     }
 
     public void apply() {
@@ -65,7 +65,7 @@ public class DocumentOperationsApplierForNonOverlappingRegions {
         }
     }
 
-    private class DocumentOperationNonOverlappingRegionsComparator implements Comparator<DocumentOperation> {
+    private static class DocumentOperationNonOverlappingRegionsComparator implements Comparator<DocumentOperation> {
 
         @Override
         public int compare(final DocumentOperation o1, final DocumentOperation o2) {
@@ -73,7 +73,7 @@ public class DocumentOperationsApplierForNonOverlappingRegions {
             final RegionByLine r2 = Objects.requireNonNull(o2).getRegionByLine();
 
             final int comparison;
-            if (areInsertOperations(r1, r2)) {
+            if (areInsertOperationsAtTheSameOffset(r1, r2)) {
                 comparison = 0;
             } else if (doesFirstRegionEndBeforeSecondRegionBegins(r1, r2)) {
                 comparison = -1;
@@ -85,7 +85,7 @@ public class DocumentOperationsApplierForNonOverlappingRegions {
             return comparison;
         }
 
-        private boolean areInsertOperations(final RegionByLine r1, final RegionByLine r2) {
+        private boolean areInsertOperationsAtTheSameOffset(final RegionByLine r1, final RegionByLine r2) {
             return r1.getBeginLine() == r2.getBeginLine() && r1.getBeginColumn() == r2.getBeginColumn()
                     && r1.getBeginLine() == r1.getEndLine() && r1.getBeginColumn() == r1.getEndColumn();
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/document/DocumentOperationsApplierForNonOverlappingRegions.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/document/DocumentOperationsApplierForNonOverlappingRegions.java
@@ -73,7 +73,7 @@ public class DocumentOperationsApplierForNonOverlappingRegions {
             final RegionByLine r2 = Objects.requireNonNull(o2).getRegionByLine();
 
             final int comparison;
-            if (areInsertOperationsAtTheSameOffset(r1, r2)) {
+            if (operationsStartAtTheSameOffsetAndHaveZeroLength(r1, r2)) {
                 comparison = 0;
             } else if (doesFirstRegionEndBeforeSecondRegionBegins(r1, r2)) {
                 comparison = -1;
@@ -85,7 +85,7 @@ public class DocumentOperationsApplierForNonOverlappingRegions {
             return comparison;
         }
 
-        private boolean areInsertOperationsAtTheSameOffset(final RegionByLine r1, final RegionByLine r2) {
+        private boolean operationsStartAtTheSameOffsetAndHaveZeroLength(final RegionByLine r1, final RegionByLine r2) {
             return r1.getBeginLine() == r2.getBeginLine() && r1.getBeginColumn() == r2.getBeginColumn()
                     && r1.getBeginLine() == r1.getEndLine() && r1.getBeginColumn() == r1.getEndColumn();
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/document/DocumentOperationsApplierForNonOverlappingRegions.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/document/DocumentOperationsApplierForNonOverlappingRegions.java
@@ -59,11 +59,10 @@ public class DocumentOperationsApplierForNonOverlappingRegions {
     public void apply() {
         assertOperationsHaveNotBeenApplied();
         applied = true;
-        applyInReverseOrder();
-    }
 
-    private void applyInReverseOrder() {
-        operations.forEach(op -> op.apply(document));
+        for (final DocumentOperation operation : operations) {
+            operation.apply(document);
+        }
     }
 
     private class DocumentOperationNonOverlappingRegionsComparator implements Comparator<DocumentOperation> {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/document/DocumentOperationsApplierForNonOverlappingRegions.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/document/DocumentOperationsApplierForNonOverlappingRegions.java
@@ -1,0 +1,103 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.document;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+
+public class DocumentOperationsApplierForNonOverlappingRegions {
+
+    private final Document document;
+    private final List<DocumentOperation> operations;
+    private final Comparator<DocumentOperation> comparator;
+
+    private boolean applied;
+
+    public DocumentOperationsApplierForNonOverlappingRegions(final Document document) {
+        this.document = Objects.requireNonNull(document);
+        comparator = new DocumentOperationNonOverlappingRegionsComparator();
+        operations = new ArrayList<>();
+        applied = false;
+    }
+
+    public void addDocumentOperation(DocumentOperation documentOperation) {
+        assertOperationsHaveNotBeenApplied();
+
+        final int index = getIndexForDocumentOperation(Objects.requireNonNull(documentOperation));
+        operations.add(index, documentOperation);
+    }
+
+    private void assertOperationsHaveNotBeenApplied() {
+        if (applied) {
+            throw new IllegalStateException("Document operations have already been applied to the document");
+        }
+    }
+
+    private int getIndexForDocumentOperation(final DocumentOperation documentOperation) {
+        int potentialIndex = Collections.binarySearch(operations, documentOperation, comparator);
+
+        if (potentialIndex < 0) {
+            return ~potentialIndex;
+        }
+
+        final int lastIndex = operations.size() - 1;
+        while (potentialIndex < lastIndex && areSiblingsEqual(potentialIndex)) {
+            potentialIndex++;
+        }
+        return potentialIndex + 1;
+    }
+
+    private boolean areSiblingsEqual(final int index) {
+        return comparator.compare(operations.get(index), operations.get(index + 1)) == 0;
+    }
+
+    public void apply() {
+        assertOperationsHaveNotBeenApplied();
+        applied = true;
+        applyInReverseOrder();
+    }
+
+    private void applyInReverseOrder() {
+        operations.forEach(op -> op.apply(document));
+    }
+
+    private class DocumentOperationNonOverlappingRegionsComparator implements Comparator<DocumentOperation> {
+
+        @Override
+        public int compare(final DocumentOperation o1, final DocumentOperation o2) {
+            final RegionByLine r1 = Objects.requireNonNull(o1).getRegionByLine();
+            final RegionByLine r2 = Objects.requireNonNull(o2).getRegionByLine();
+
+            final int comparison;
+            if (areInsertOperations(r1, r2)) {
+                comparison = 0;
+            } else if (doesFirstRegionEndBeforeSecondRegionBegins(r1, r2)) {
+                comparison = -1;
+            } else if (doesFirstRegionEndBeforeSecondRegionBegins(r2, r1)) {
+                comparison = 1;
+            } else {
+                throw new IllegalArgumentException("Regions between document operations overlap, " + r1.toString() + "\n" + r2.toString());
+            }
+            return comparison;
+        }
+
+        private boolean areInsertOperations(final RegionByLine r1, final RegionByLine r2) {
+            return r1.getBeginLine() == r2.getBeginLine() && r1.getBeginColumn() == r2.getBeginColumn()
+                    && r1.getBeginLine() == r1.getEndLine() && r1.getBeginColumn() == r1.getEndColumn();
+        }
+
+        private boolean doesFirstRegionEndBeforeSecondRegionBegins(final RegionByLine r1, final RegionByLine r2) {
+            if (r1.getEndLine() < r2.getBeginLine()) {
+                return true;
+            } else if (r1.getEndLine() == r2.getBeginLine()) {
+                return r1.getEndColumn() <= r2.getBeginColumn();
+            }
+            return false;
+        }
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/document/InsertDocumentOperation.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/document/InsertDocumentOperation.java
@@ -1,0 +1,26 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.document;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Represents an insert operation in a {@link Document}.
+ */
+public class InsertDocumentOperation extends DocumentOperation {
+
+    private final String textToInsert;
+
+    public InsertDocumentOperation(final int beginLine, final int beginColumn, final String textToInsert) {
+        super(beginLine, beginLine, beginColumn, beginColumn);
+        this.textToInsert = requireNonNull(textToInsert);
+    }
+
+    @Override
+    public void apply(final Document document) {
+        final RegionByLine regionByLine = getRegionByLine();
+        document.insert(regionByLine.getBeginLine(), regionByLine.getBeginColumn(), textToInsert);
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/document/RegionByLine.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/document/RegionByLine.java
@@ -1,0 +1,19 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.document;
+
+/**
+ * Represents a region in a {@link Document} with the tuple (beginLine, endLine, beginColumn, endColumn).
+ */
+public interface RegionByLine {
+
+    int getBeginLine();
+
+    int getEndLine();
+
+    int getBeginColumn();
+
+    int getEndColumn();
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/document/RegionByLineImp.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/document/RegionByLineImp.java
@@ -1,0 +1,68 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.document;
+
+/**
+ * Immutable implementation of the {@link RegionByLine} interface.
+ */
+public class RegionByLineImp implements RegionByLine {
+
+    private final int beginLine;
+    private final int endLine;
+    private final int beginColumn;
+    private final int endColumn;
+
+    public RegionByLineImp(final int beginLine, final int endLine, final int beginColumn, final int endColumn) {
+        this.beginLine = requireNonNegative(beginLine);
+        this.endLine = requireNonNegative(endLine);
+        this.beginColumn = requireNonNegative(beginColumn);
+        this.endColumn = requireNonNegative(endColumn);
+
+        requireLinesCorrectlyOrdered();
+    }
+
+    private void requireLinesCorrectlyOrdered() {
+        if (beginLine > endLine) {
+            throw new IllegalArgumentException("endLine must be equal or greater than beginLine");
+        }
+    }
+
+    private static int requireNonNegative(final int value) {
+        if (value < 0) {
+            throw new IllegalArgumentException("parameter must be non-negative");
+        }
+        return value;
+    }
+
+    @Override
+    public int getBeginLine() {
+        return beginLine;
+    }
+
+    @Override
+    public int getEndLine() {
+        return endLine;
+    }
+
+    @Override
+    public int getBeginColumn() {
+        return beginColumn;
+    }
+
+    @Override
+    public int getEndColumn() {
+        return endColumn;
+    }
+
+    @Override
+    public String toString() {
+        return "RegionByLineImp{"
+                + "beginLine=" + beginLine
+                + ", endLine=" + endLine
+                + ", beginColumn=" + beginColumn
+                + ", endColumn=" + endColumn
+                + '}';
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/document/RegionByOffset.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/document/RegionByOffset.java
@@ -1,0 +1,17 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.document;
+
+/**
+ * Represents a region in a {@link Document} with the tuple (offset, length).
+ */
+public interface RegionByOffset {
+
+    int getOffset();
+
+    int getLength();
+
+    int getOffsetAfterEnding();
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/document/RegionByOffsetImp.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/document/RegionByOffsetImp.java
@@ -1,0 +1,42 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.document;
+
+/**
+ * Immutable implementation of the {@link RegionByOffset} interface.
+ */
+public class RegionByOffsetImp implements RegionByOffset {
+    private final int offset;
+    private final int length;
+    private final int offsetAfterEnding;
+
+    public RegionByOffsetImp(final int offset, final int length) {
+        this.offset = requireNonNegative(offset);
+        this.length = requireNonNegative(length);
+        offsetAfterEnding = offset + length;
+    }
+
+    private static int requireNonNegative(final int value) {
+        if (value < 0) {
+            throw new IllegalArgumentException();
+        }
+        return value;
+    }
+
+    @Override
+    public int getOffset() {
+        return offset;
+    }
+
+    @Override
+    public int getLength() {
+        return length;
+    }
+
+    @Override
+    public int getOffsetAfterEnding() {
+        return offsetAfterEnding;
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/document/ReplaceDocumentOperation.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/document/ReplaceDocumentOperation.java
@@ -1,0 +1,22 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.document;
+
+import static java.util.Objects.requireNonNull;
+
+public class ReplaceDocumentOperation extends DocumentOperation {
+
+    private final String textToReplace;
+
+    public ReplaceDocumentOperation(final int beginLine, final int endLine, final int beginColumn, final int endColumn, final String textToReplace) {
+        super(beginLine, endLine, beginColumn, endColumn);
+        this.textToReplace = requireNonNull(textToReplace);
+    }
+
+    @Override
+    public void apply(final Document document) {
+        document.replace(getRegionByLine(), textToReplace);
+    }
+}

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/document/DocumentFileTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/document/DocumentFileTest.java
@@ -1,0 +1,192 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.document;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+
+
+
+
+public class DocumentFileTest {
+
+    private static final String FILE_PATH = "psvm.java";
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    private File temporaryFile;
+
+    @Before
+    public void setUpTemporaryFiles() throws IOException {
+        temporaryFile = temporaryFolder.newFile(FILE_PATH);
+    }
+
+    @After
+    public void deleteTemporaryFiles() {
+        temporaryFile.delete();
+    }
+
+    @Test
+    public void insertAtStartOfTheFileShouldSucceed() throws IOException {
+        writeContentToTemporaryFile("static void main(String[] args) {}");
+
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+            documentFile.insert(0, 0, "public ");
+        }
+
+        try (FileInputStream stream = new FileInputStream(temporaryFile)) {
+            final String actualContent = new String(stream.readAllBytes());
+            assertEquals("public static void main(String[] args) {}", actualContent);
+        }
+    }
+
+    @Test
+    public void insertVariousTokensIntoTheFileShouldSucceed() throws IOException {
+        writeContentToTemporaryFile("static void main(String[] args) {}");
+
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+            documentFile.insert(0, 0, "public ");
+            documentFile.insert(0, 17, "final ");
+        }
+
+        try (FileInputStream stream = new FileInputStream(temporaryFile)) {
+            final String actualContent = new String(stream.readAllBytes());
+            assertEquals("public static void main(final String[] args) {}", actualContent);
+        }
+    }
+
+    @Test
+    public void insertAtTheEndOfTheFileShouldSucceed() throws IOException {
+        final String code = "public static void main(String[] args)";
+        writeContentToTemporaryFile(code);
+
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+            documentFile.insert(0, code.length(), "{}");
+        }
+
+        try (FileInputStream stream = new FileInputStream(temporaryFile)) {
+            final String actualContent = new String(stream.readAllBytes());
+            assertEquals("public static void main(String[] args){}", actualContent);
+        }
+    }
+
+    @Test
+    public void removeTokenShouldSucceed() throws IOException {
+        final String code = "public static void main(final String[] args) {}";
+        writeContentToTemporaryFile(code);
+
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+            documentFile.delete(new RegionByLineImp(0, 0, 24, 30));
+        }
+
+        try (FileInputStream stream = new FileInputStream(temporaryFile)) {
+            final String actualContent = new String(stream.readAllBytes());
+            assertEquals("public static void main(String[] args) {}", actualContent);
+        }
+    }
+
+    @Test
+    public void insertAndRemoveTokensShouldSucceed() throws IOException {
+        final String code = "static void main(final String[] args) {}";
+        writeContentToTemporaryFile(code);
+
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+            documentFile.insert(0, 0, "public ");
+            documentFile.delete(new RegionByLineImp(0, 0, 17, 23));
+        }
+
+        try (FileInputStream stream = new FileInputStream(temporaryFile)) {
+            final String actualContent = new String(stream.readAllBytes());
+            assertEquals("public static void main(String[] args) {}", actualContent);
+        }
+    }
+
+    @Test
+    public void insertAndDeleteVariousTokensShouldSucceed() throws IOException {
+        final String code = "void main(String[] args) {}";
+        writeContentToTemporaryFile(code);
+
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+            documentFile.insert(0, 0, "public ");
+            documentFile.insert(0, 0, "static ");
+            documentFile.delete(new RegionByLineImp(0, 0, 0, 4));
+            documentFile.insert(0, 10, "final ");
+            documentFile.delete(new RegionByLineImp(0, 0, 25, 28));
+        }
+
+        try (FileInputStream stream = new FileInputStream(temporaryFile)) {
+            final String actualContent = new String(stream.readAllBytes());
+            assertEquals("public static  main(final String[] args) ", actualContent);
+        }
+    }
+
+    @Test
+    public void replaceATokenShouldSucceed() throws IOException {
+        final String code = "int main(String[] args) {}";
+        writeContentToTemporaryFile(code);
+
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+            documentFile.replace(new RegionByLineImp(0, 0, 0, 3), "void");
+        }
+
+        try (FileInputStream stream = new FileInputStream(temporaryFile)) {
+            final String actualContent = new String(stream.readAllBytes());
+            assertEquals("void main(String[] args) {}", actualContent);
+        }
+    }
+
+    @Test
+    public void replaceVariousTokensShouldSucceed() throws IOException {
+        final String code = "int main(String[] args) {}";
+        writeContentToTemporaryFile(code);
+
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+            documentFile.replace(new RegionByLineImp(0, 0, 0, "int".length()), "void");
+            documentFile.replace(new RegionByLineImp(0, 0, 4, 4 + "main".length()), "foo");
+            documentFile.replace(new RegionByLineImp(0, 0, 9, 9 + "String".length()), "CharSequence");
+        }
+
+        try (FileInputStream stream = new FileInputStream(temporaryFile)) {
+            final String actualContent = new String(stream.readAllBytes());
+            assertEquals("void foo(CharSequence[] args) {}", actualContent);
+        }
+    }
+
+    @Test
+    public void insertDeleteAndReplaceVariousTokensShouldSucceed() throws IOException {
+        final String code = "static int main(CharSequence[] args) {}";
+        writeContentToTemporaryFile(code);
+
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+            documentFile.insert(0, 0, "public");
+            documentFile.delete(new RegionByLineImp(0, 0, 0, 6));
+            documentFile.replace(new RegionByLineImp(0, 0, 7, 7 + "int".length()), "void");
+            documentFile.insert(0, 16, "final ");
+            documentFile.replace(new RegionByLineImp(0, 0, 16, 16 + "CharSequence".length()), "String");
+        }
+
+        try (FileInputStream stream = new FileInputStream(temporaryFile)) {
+            final String actualContent = new String(stream.readAllBytes());
+            assertEquals("public void main(final String[] args) {}", actualContent);
+        }
+    }
+
+    private void writeContentToTemporaryFile(final String content) throws IOException {
+        try (FileWriter writer = new FileWriter(temporaryFile)) {
+            writer.write(content);
+        }
+    }
+}

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/document/DocumentFileTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/document/DocumentFileTest.java
@@ -38,7 +38,7 @@ public class DocumentFileTest {
     public void insertAtStartOfTheFileShouldSucceed() throws IOException {
         writeContentToTemporaryFile("static void main(String[] args) {}");
 
-        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile, StandardCharsets.UTF_8)) {
             documentFile.insert(0, 0, "public ");
         }
 
@@ -85,7 +85,7 @@ public class DocumentFileTest {
     public void insertVariousTokensIntoTheFileShouldSucceed() throws IOException {
         writeContentToTemporaryFile("static void main(String[] args) {}");
 
-        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile, StandardCharsets.UTF_8)) {
             documentFile.insert(0, 0, "public ");
             documentFile.insert(0, 17, "final ");
         }
@@ -101,7 +101,7 @@ public class DocumentFileTest {
         final String code = "public static void main(String[] args)";
         writeContentToTemporaryFile(code);
 
-        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile, StandardCharsets.UTF_8)) {
             documentFile.insert(0, code.length(), "{}");
         }
 
@@ -116,7 +116,7 @@ public class DocumentFileTest {
         final String code = "public static void main(final String[] args) {}";
         writeContentToTemporaryFile(code);
 
-        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile, StandardCharsets.UTF_8)) {
             documentFile.delete(new RegionByLineImp(0, 0, 24, 30));
         }
 
@@ -131,7 +131,7 @@ public class DocumentFileTest {
         final String code = "static void main(final String[] args) {}";
         writeContentToTemporaryFile(code);
 
-        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile, StandardCharsets.UTF_8)) {
             documentFile.insert(0, 0, "public ");
             documentFile.delete(new RegionByLineImp(0, 0, 17, 23));
         }
@@ -147,7 +147,7 @@ public class DocumentFileTest {
         final String code = "void main(String[] args) {}";
         writeContentToTemporaryFile(code);
 
-        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile, StandardCharsets.UTF_8)) {
             documentFile.insert(0, 0, "public ");
             documentFile.insert(0, 0, "static ");
             documentFile.delete(new RegionByLineImp(0, 0, 0, 4));
@@ -166,7 +166,7 @@ public class DocumentFileTest {
         final String code = "int main(String[] args) {}";
         writeContentToTemporaryFile(code);
 
-        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile, StandardCharsets.UTF_8)) {
             documentFile.replace(new RegionByLineImp(0, 0, 0, 3), "void");
         }
 
@@ -181,7 +181,7 @@ public class DocumentFileTest {
         final String code = "int main(String[] args) {}";
         writeContentToTemporaryFile(code);
 
-        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile, StandardCharsets.UTF_8)) {
             documentFile.replace(new RegionByLineImp(0, 0, 0, "int".length()), "void");
             documentFile.replace(new RegionByLineImp(0, 0, 4, 4 + "main".length()), "foo");
             documentFile.replace(new RegionByLineImp(0, 0, 9, 9 + "String".length()), "CharSequence");
@@ -198,7 +198,7 @@ public class DocumentFileTest {
         final String code = "static int main(CharSequence[] args) {}";
         writeContentToTemporaryFile(code);
 
-        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile, StandardCharsets.UTF_8)) {
             documentFile.insert(0, 0, "public");
             documentFile.delete(new RegionByLineImp(0, 0, 0, 6));
             documentFile.replace(new RegionByLineImp(0, 0, 7, 7 + "int".length()), "void");
@@ -224,7 +224,7 @@ public class DocumentFileTest {
         expectedLineToOffset.add(40);
         expectedLineToOffset.add(49);
 
-        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile, StandardCharsets.UTF_8)) {
             assertEquals(expectedLineToOffset, documentFile.getLineToOffset());
         }
     }
@@ -241,7 +241,7 @@ public class DocumentFileTest {
         expectedLineToOffset.add(41);
         expectedLineToOffset.add(51);
 
-        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile, StandardCharsets.UTF_8)) {
             assertEquals(expectedLineToOffset, documentFile.getLineToOffset());
         }
     }
@@ -258,7 +258,7 @@ public class DocumentFileTest {
         expectedLineToOffset.add(41);
         expectedLineToOffset.add(50);
 
-        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile, StandardCharsets.UTF_8)) {
             assertEquals(expectedLineToOffset, documentFile.getLineToOffset());
         }
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/document/DocumentFileTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/document/DocumentFileTest.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.Arrays;
 
 import org.junit.After;
 import org.junit.Before;
@@ -48,9 +49,42 @@ public class DocumentFileTest {
         }
 
         try (FileInputStream stream = new FileInputStream(temporaryFile)) {
-            final String actualContent = new String(stream.readAllBytes());
+            final String actualContent = new String(readAllBytes(stream));
             assertEquals("public static void main(String[] args) {}", actualContent);
         }
+    }
+
+    private byte[] readAllBytes(final FileInputStream stream) throws IOException {
+        final int defaultBufferSize = 8192;
+        final int maxBufferSize = Integer.MAX_VALUE - 8;
+
+        byte[] buf = new byte[defaultBufferSize];
+        int capacity = buf.length;
+        int nread = 0;
+        int n;
+        while (true) {
+            // read to EOF which may read more or less than initial buffer size
+            while ((n = stream.read(buf, nread, capacity - nread)) > 0) {
+                nread += n;
+            }
+
+            // if the last call to read returned -1, then we're done
+            if (n < 0) {
+                break;
+            }
+
+            // need to allocate a larger buffer
+            if (capacity <= maxBufferSize - capacity) {
+                capacity = capacity << 1;
+            } else {
+                if (capacity == maxBufferSize) {
+                    throw new OutOfMemoryError("Required array size too large");
+                }
+                capacity = maxBufferSize;
+            }
+            buf = Arrays.copyOf(buf, capacity);
+        }
+        return (capacity == nread) ? buf : Arrays.copyOf(buf, nread);
     }
 
     @Test
@@ -63,7 +97,7 @@ public class DocumentFileTest {
         }
 
         try (FileInputStream stream = new FileInputStream(temporaryFile)) {
-            final String actualContent = new String(stream.readAllBytes());
+            final String actualContent = new String(readAllBytes(stream));
             assertEquals("public static void main(final String[] args) {}", actualContent);
         }
     }
@@ -78,7 +112,7 @@ public class DocumentFileTest {
         }
 
         try (FileInputStream stream = new FileInputStream(temporaryFile)) {
-            final String actualContent = new String(stream.readAllBytes());
+            final String actualContent = new String(readAllBytes(stream));
             assertEquals("public static void main(String[] args){}", actualContent);
         }
     }
@@ -93,7 +127,7 @@ public class DocumentFileTest {
         }
 
         try (FileInputStream stream = new FileInputStream(temporaryFile)) {
-            final String actualContent = new String(stream.readAllBytes());
+            final String actualContent = new String(readAllBytes(stream));
             assertEquals("public static void main(String[] args) {}", actualContent);
         }
     }
@@ -109,7 +143,7 @@ public class DocumentFileTest {
         }
 
         try (FileInputStream stream = new FileInputStream(temporaryFile)) {
-            final String actualContent = new String(stream.readAllBytes());
+            final String actualContent = new String(readAllBytes(stream));
             assertEquals("public static void main(String[] args) {}", actualContent);
         }
     }
@@ -128,7 +162,7 @@ public class DocumentFileTest {
         }
 
         try (FileInputStream stream = new FileInputStream(temporaryFile)) {
-            final String actualContent = new String(stream.readAllBytes());
+            final String actualContent = new String(readAllBytes(stream));
             assertEquals("public static  main(final String[] args) ", actualContent);
         }
     }
@@ -143,7 +177,7 @@ public class DocumentFileTest {
         }
 
         try (FileInputStream stream = new FileInputStream(temporaryFile)) {
-            final String actualContent = new String(stream.readAllBytes());
+            final String actualContent = new String(readAllBytes(stream));
             assertEquals("void main(String[] args) {}", actualContent);
         }
     }
@@ -160,7 +194,7 @@ public class DocumentFileTest {
         }
 
         try (FileInputStream stream = new FileInputStream(temporaryFile)) {
-            final String actualContent = new String(stream.readAllBytes());
+            final String actualContent = new String(readAllBytes(stream));
             assertEquals("void foo(CharSequence[] args) {}", actualContent);
         }
     }
@@ -179,7 +213,7 @@ public class DocumentFileTest {
         }
 
         try (FileInputStream stream = new FileInputStream(temporaryFile)) {
-            final String actualContent = new String(stream.readAllBytes());
+            final String actualContent = new String(readAllBytes(stream));
             assertEquals("public void main(final String[] args) {}", actualContent);
         }
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/document/DocumentOperationsApplierForNonOverlappingRegionsWithDocumentFileTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/document/DocumentOperationsApplierForNonOverlappingRegionsWithDocumentFileTest.java
@@ -1,0 +1,192 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.document;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class DocumentOperationsApplierForNonOverlappingRegionsWithDocumentFileTest {
+
+    private static final String FILE_PATH = "psvm.java";
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    private File temporaryFile;
+
+    private DocumentOperationsApplierForNonOverlappingRegions applier;
+
+    @Before
+    public void setUpTemporaryFiles() throws IOException {
+        temporaryFile = temporaryFolder.newFile(FILE_PATH);
+    }
+
+    @After
+    public void deleteTemporaryFiles() {
+        temporaryFile.delete();
+    }
+
+    @Test
+    public void insertAtStartOfTheDocumentShouldSucceed() throws IOException {
+        writeContentToTemporaryFile("static void main(String[] args) {}");
+
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+            applier = new DocumentOperationsApplierForNonOverlappingRegions(documentFile);
+            applier.addDocumentOperation(new InsertDocumentOperation(0, 0, "public "));
+
+            applier.apply();
+        }
+
+        try (FileInputStream stream = new FileInputStream(temporaryFile)) {
+            final String actualContent = new String(stream.readAllBytes());
+            assertEquals("public static void main(String[] args) {}", actualContent);
+        }
+    }
+
+    @Test
+    public void removeTokenShouldSucceed() throws IOException {
+        writeContentToTemporaryFile("public static void main(String[] args) {}");
+
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+            applier = new DocumentOperationsApplierForNonOverlappingRegions(documentFile);
+            applier.addDocumentOperation(new DeleteDocumentOperation(0, 0, 7, 13));
+
+            applier.apply();
+        }
+
+        try (FileInputStream stream = new FileInputStream(temporaryFile)) {
+            final String actualContent = new String(stream.readAllBytes());
+            assertEquals("public  void main(String[] args) {}", actualContent);
+        }
+    }
+
+    @Test
+    public void insertAndRemoveTokensShouldSucceed() throws IOException {
+        final String code = "static void main(final String[] args) {}";
+        writeContentToTemporaryFile(code);
+
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+            applier = new DocumentOperationsApplierForNonOverlappingRegions(documentFile);
+            applier.addDocumentOperation(new InsertDocumentOperation(0, 0, "public "));
+            applier.addDocumentOperation(new DeleteDocumentOperation(0, 0, 17, 23));
+
+            applier.apply();
+        }
+
+        try (FileInputStream stream = new FileInputStream(temporaryFile)) {
+            final String actualContent = new String(stream.readAllBytes());
+            assertEquals("public static void main(String[] args) {}", actualContent);
+        }
+    }
+
+    @Test
+    public void insertAndDeleteVariousTokensShouldSucceed() throws IOException {
+        final String code = "void main(String[] args) {}";
+        writeContentToTemporaryFile(code);
+
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+            applier = new DocumentOperationsApplierForNonOverlappingRegions(documentFile);
+
+            applier.addDocumentOperation(new InsertDocumentOperation(0, 0, "public "));
+            applier.addDocumentOperation(new InsertDocumentOperation(0, 0, "static "));
+            applier.addDocumentOperation(new DeleteDocumentOperation(0, 0, 0, 4));
+            applier.addDocumentOperation(new InsertDocumentOperation(0, 10, "final "));
+            applier.addDocumentOperation(new DeleteDocumentOperation(0, 0, 25, 27));
+
+            applier.apply();
+        }
+
+        try (FileInputStream stream = new FileInputStream(temporaryFile)) {
+            final String actualContent = new String(stream.readAllBytes());
+            assertEquals("public static  main(final String[] args) ", actualContent);
+        }
+    }
+
+    @Test
+    public void replaceATokenShouldSucceed() throws IOException {
+        final String code = "int main(String[] args) {}";
+        writeContentToTemporaryFile(code);
+
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+            applier = new DocumentOperationsApplierForNonOverlappingRegions(documentFile);
+
+            applier.addDocumentOperation(new ReplaceDocumentOperation(0, 0, 0, "int".length(), "void"));
+
+            applier.apply();
+        }
+
+        try (FileInputStream stream = new FileInputStream(temporaryFile)) {
+            final String actualContent = new String(stream.readAllBytes());
+            assertEquals("void main(String[] args) {}", actualContent);
+        }
+    }
+
+    @Test
+    public void replaceVariousTokensShouldSucceed() throws IOException {
+        final String code = "int main(String[] args) {}";
+        writeContentToTemporaryFile(code);
+
+        final List<DocumentOperation> documentOperations = new LinkedList<>();
+        documentOperations.add(new ReplaceDocumentOperation(0, 0, 0, "int".length(), "void"));
+        documentOperations.add(new ReplaceDocumentOperation(0, 0, 4, 4 + "main".length(), "foo"));
+        documentOperations.add(new ReplaceDocumentOperation(0, 0, 9, 9 + "String".length(), "CharSequence"));
+
+        shuffleAndApplyOperations(documentOperations);
+
+        try (FileInputStream stream = new FileInputStream(temporaryFile)) {
+            final String actualContent = new String(stream.readAllBytes());
+            assertEquals("void foo(CharSequence[] args) {}", actualContent);
+        }
+    }
+
+    private void shuffleAndApplyOperations(List<DocumentOperation> documentOperations) throws IOException {
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+            applier = new DocumentOperationsApplierForNonOverlappingRegions(documentFile);
+
+            Collections.shuffle(documentOperations);
+            documentOperations.forEach(op -> applier.addDocumentOperation(op));
+
+            applier.apply();
+        }
+    }
+
+    @Test
+    public void insertDeleteAndReplaceVariousTokensShouldSucceed() throws IOException {
+        final String code = "static int main(CharSequence[] args) {}";
+        writeContentToTemporaryFile(code);
+
+        final List<DocumentOperation> documentOperations = new LinkedList<>();
+        documentOperations.add(new InsertDocumentOperation(0, 0, "public"));
+        documentOperations.add(new DeleteDocumentOperation(0, 0, 0, 6));
+        documentOperations.add(new ReplaceDocumentOperation(0, 0, 7, 7 + "int".length(), "void"));
+        documentOperations.add(new InsertDocumentOperation(0, 16, "final "));
+        documentOperations.add(new ReplaceDocumentOperation(0, 0, 16, 16 + "CharSequence".length(), "String"));
+
+        shuffleAndApplyOperations(documentOperations);
+
+        try (FileInputStream stream = new FileInputStream(temporaryFile)) {
+            final String actualContent = new String(stream.readAllBytes());
+            assertEquals("public void main(final String[] args) {}", actualContent);
+        }
+    }
+
+    private void writeContentToTemporaryFile(final String content) throws IOException {
+        try (FileWriter writer = new FileWriter(temporaryFile)) {
+            writer.write(content);
+        }
+    }
+}

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/document/DocumentOperationsApplierForNonOverlappingRegionsWithDocumentFileTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/document/DocumentOperationsApplierForNonOverlappingRegionsWithDocumentFileTest.java
@@ -15,7 +15,6 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,11 +33,6 @@ public class DocumentOperationsApplierForNonOverlappingRegionsWithDocumentFileTe
     @Before
     public void setUpTemporaryFiles() throws IOException {
         temporaryFile = temporaryFolder.newFile(FILE_PATH);
-    }
-
-    @After
-    public void deleteTemporaryFiles() {
-        temporaryFile.delete();
     }
 
     @Test

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/document/DocumentOperationsApplierForNonOverlappingRegionsWithDocumentFileTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/document/DocumentOperationsApplierForNonOverlappingRegionsWithDocumentFileTest.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -39,7 +40,7 @@ public class DocumentOperationsApplierForNonOverlappingRegionsWithDocumentFileTe
     public void insertAtStartOfTheDocumentShouldSucceed() throws IOException {
         writeContentToTemporaryFile("static void main(String[] args) {}");
 
-        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile, StandardCharsets.UTF_8)) {
             applier = new DocumentOperationsApplierForNonOverlappingRegions(documentFile);
             applier.addDocumentOperation(new InsertDocumentOperation(0, 0, "public "));
 
@@ -89,7 +90,7 @@ public class DocumentOperationsApplierForNonOverlappingRegionsWithDocumentFileTe
     public void removeTokenShouldSucceed() throws IOException {
         writeContentToTemporaryFile("public static void main(String[] args) {}");
 
-        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile, StandardCharsets.UTF_8)) {
             applier = new DocumentOperationsApplierForNonOverlappingRegions(documentFile);
             applier.addDocumentOperation(new DeleteDocumentOperation(0, 0, 7, 13));
 
@@ -107,7 +108,7 @@ public class DocumentOperationsApplierForNonOverlappingRegionsWithDocumentFileTe
         final String code = "static void main(final String[] args) {}";
         writeContentToTemporaryFile(code);
 
-        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile, StandardCharsets.UTF_8)) {
             applier = new DocumentOperationsApplierForNonOverlappingRegions(documentFile);
             applier.addDocumentOperation(new InsertDocumentOperation(0, 0, "public "));
             applier.addDocumentOperation(new DeleteDocumentOperation(0, 0, 17, 23));
@@ -126,7 +127,7 @@ public class DocumentOperationsApplierForNonOverlappingRegionsWithDocumentFileTe
         final String code = "void main(String[] args) {}";
         writeContentToTemporaryFile(code);
 
-        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile, StandardCharsets.UTF_8)) {
             applier = new DocumentOperationsApplierForNonOverlappingRegions(documentFile);
 
             applier.addDocumentOperation(new InsertDocumentOperation(0, 0, "public "));
@@ -149,7 +150,7 @@ public class DocumentOperationsApplierForNonOverlappingRegionsWithDocumentFileTe
         final String code = "int main(String[] args) {}";
         writeContentToTemporaryFile(code);
 
-        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile, StandardCharsets.UTF_8)) {
             applier = new DocumentOperationsApplierForNonOverlappingRegions(documentFile);
 
             applier.addDocumentOperation(new ReplaceDocumentOperation(0, 0, 0, "int".length(), "void"));
@@ -182,7 +183,7 @@ public class DocumentOperationsApplierForNonOverlappingRegionsWithDocumentFileTe
     }
 
     private void shuffleAndApplyOperations(List<DocumentOperation> documentOperations) throws IOException {
-        try (DocumentFile documentFile = new DocumentFile(temporaryFile)) {
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile, StandardCharsets.UTF_8)) {
             applier = new DocumentOperationsApplierForNonOverlappingRegions(documentFile);
 
             Collections.shuffle(documentOperations);


### PR DESCRIPTION
# Summary
To be able to make the fixes persist on the file on which the AST was created on, a new handler is needed that is able to manage all the operations (insert, delete and replace) and apply them in order to the original file.

# Additions
- **Document** interface to represent a file in which fixes can be applied.
- **DocumentOperation** represents one operation (insert, delete or replace) that will be managed by the **DocumentOperationsApplier** as to when or in what order to apply all of them.
- **RegionByLine** and **RegionByOffset** are both representations of regions in a document. The difference between them are, when one is used over the other. The RegionByLine is first used when an operation is created because the regions of the tokens are represented in this manner and there is no way to map it to (offset, length) until the operation has reached the document, which internally holds a map <LineNumber, Offset> to convert this type of region to a RegionByOffset.

# Additional notes
- **DocumentFile** which is an implementation of **Document** uses a reader and a writer to apply the fixes onto the file. The file is read only once, which improves efficiency, but it is expected to receive all the operations sorted.
  