### PR TITLE
[java] Fix false negative PreserveStackTrace on string concatenation

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PreserveStackTraceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PreserveStackTraceRule.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.java.ast.ASTAdditiveExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTAllocationExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTCastExpression;
@@ -140,8 +141,12 @@ public class PreserveStackTraceRule extends AbstractJavaRule {
             List<ASTName> nameNodes = baseNode.findDescendantsOfType(ASTName.class);
             for (ASTName nameNode : nameNodes) {
                 if (target.equals(nameNode.getImage())) {
-                    match = true;
-                    break;
+                	boolean isPartOfStringConcatenation = 
+                		(nameNode.jjtGetParent().jjtGetParent().jjtGetParent() instanceof ASTAdditiveExpression);
+                	if (!isPartOfStringConcatenation) {
+	                    match = true;
+	                    break;
+                	}
                 }
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PreserveStackTraceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PreserveStackTraceRule.java
@@ -160,8 +160,7 @@ public class PreserveStackTraceRule extends AbstractJavaRule {
      */
     private boolean isStringConcat(Node childNode, Node baseNode) {
         Node currentNode = childNode;
-        // limit to 10 levels
-        for (int i = 0; i < 10 && currentNode != null && currentNode != baseNode; i++) {
+        while (currentNode != baseNode) {
             currentNode = currentNode.jjtGetParent();
             if (currentNode instanceof ASTAdditiveExpression) {
                 return true;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PreserveStackTraceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PreserveStackTraceRule.java
@@ -140,8 +140,8 @@ public class PreserveStackTraceRule extends AbstractJavaRule {
         if (target != null && baseNode != null) {
             List<ASTName> nameNodes = baseNode.findDescendantsOfType(ASTName.class);
             for (ASTName nameNode : nameNodes) {
-                if (target.equals(nameNode.getImage())) {                	
-                    boolean isPartOfStringConcatenation = isStringConcat(nameNode, baseNode);                        
+                if (target.equals(nameNode.getImage())) {
+                    boolean isPartOfStringConcatenation = isStringConcat(nameNode, baseNode);
                     if (!isPartOfStringConcatenation) {
                         match = true;
                         break;
@@ -151,6 +151,7 @@ public class PreserveStackTraceRule extends AbstractJavaRule {
         }
         return match;
     }
+    
     /**
      * Checks whether the given childNode is part of an additive expression (String concatenation) limiting search to base Node.
      * @param childNode
@@ -158,15 +159,15 @@ public class PreserveStackTraceRule extends AbstractJavaRule {
      * @return
      */
     private boolean isStringConcat(Node childNode, Node baseNode) {
-    	Node currentNode = childNode;
-    	// limit to 10 levels
-    	for (int i = 0; i < 10 && currentNode != null && currentNode != baseNode; i++) {
-    		currentNode = currentNode.jjtGetParent();
-    		if (currentNode instanceof ASTAdditiveExpression) {
-    			return true;
-    		}
-    	}
-    	return false;
+        Node currentNode = childNode;
+        // limit to 10 levels
+        for (int i = 0; i < 10 && currentNode != null && currentNode != baseNode; i++) {
+            currentNode = currentNode.jjtGetParent();
+            if (currentNode instanceof ASTAdditiveExpression) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private void ck(Object data, String target, ASTThrowStatement throwStatement, Node baseNode) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PreserveStackTraceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PreserveStackTraceRule.java
@@ -141,12 +141,12 @@ public class PreserveStackTraceRule extends AbstractJavaRule {
             List<ASTName> nameNodes = baseNode.findDescendantsOfType(ASTName.class);
             for (ASTName nameNode : nameNodes) {
                 if (target.equals(nameNode.getImage())) {
-                	boolean isPartOfStringConcatenation = 
-                		(nameNode.jjtGetParent().jjtGetParent().jjtGetParent() instanceof ASTAdditiveExpression);
-                	if (!isPartOfStringConcatenation) {
-	                    match = true;
-	                    break;
-                	}
+                    boolean isPartOfStringConcatenation = 
+                        (nameNode.jjtGetParent().jjtGetParent().jjtGetParent() instanceof ASTAdditiveExpression);
+                    if (!isPartOfStringConcatenation) {
+                        match = true;
+                        break;
+                    }
                 }
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PreserveStackTraceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PreserveStackTraceRule.java
@@ -140,9 +140,8 @@ public class PreserveStackTraceRule extends AbstractJavaRule {
         if (target != null && baseNode != null) {
             List<ASTName> nameNodes = baseNode.findDescendantsOfType(ASTName.class);
             for (ASTName nameNode : nameNodes) {
-                if (target.equals(nameNode.getImage())) {
-                    boolean isPartOfStringConcatenation = 
-                        (nameNode.jjtGetParent().jjtGetParent().jjtGetParent() instanceof ASTAdditiveExpression);
+                if (target.equals(nameNode.getImage())) {                	
+                    boolean isPartOfStringConcatenation = isStringConcat(nameNode, baseNode);                        
                     if (!isPartOfStringConcatenation) {
                         match = true;
                         break;
@@ -151,6 +150,23 @@ public class PreserveStackTraceRule extends AbstractJavaRule {
             }
         }
         return match;
+    }
+    /**
+     * Checks whether the given childNode is part of an additive expression (String concatenation) limiting search to base Node.
+     * @param childNode
+     * @param baseNode
+     * @return
+     */
+    private boolean isStringConcat(Node childNode, Node baseNode) {
+    	Node currentNode = childNode;
+    	// limit to 10 levels
+    	for (int i = 0; i < 10 && currentNode != null && currentNode != baseNode; i++) {
+    		currentNode = currentNode.jjtGetParent();
+    		if (currentNode instanceof ASTAdditiveExpression) {
+    			return true;
+    		}
+    	}
+    	return false;
     }
 
     private void ck(Object data, String target, ASTThrowStatement throwStatement, Node baseNode) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/PreserveStackTrace.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/PreserveStackTrace.xml
@@ -539,4 +539,20 @@ public class Bug {
 }
         ]]></code>
     </test-code>
+    
+    <test-code>
+    <description>#543 False negative with String concatenation</description>
+    <expected-problems>1</expected-problems>
+    <code><![CDATA[
+public class Foo {
+    public void foo(String a) throws Exception {
+        try {
+            int i = Integer.parseInt(a);
+        } catch(Exception e){
+            throw new Exception("something bad:" + e);
+        }
+    }
+}
+    ]]></code>
+</test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/PreserveStackTrace.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/PreserveStackTrace.xml
@@ -542,14 +542,18 @@ public class Bug {
     
     <test-code>
     <description>#543 False negative with String concatenation</description>
-    <expected-problems>1</expected-problems>
+    <expected-problems>3</expected-problems>
     <code><![CDATA[
 public class Foo {
     public void foo(String a) throws Exception {
         try {
             int i = Integer.parseInt(a);
-        } catch(Exception e){
-            throw new Exception("something bad:" + e);
+        } catch(java.io.FileNotFoundException e) {
+            throw new Exception("file not found:" + e.toString());
+        } catch(java.io.IOException e) {
+            throw new Exception("I/O error:" + e);
+        } catch(Exception e) {
+            throw new Exception("something bad:" + (e));
         }
     }
 }


### PR DESCRIPTION
PMD should fire PreserveStackTrace in the following code

public void foo(String a) throws Exception {
    try {
        int i = Integer.parseInt(a);
    } catch(Exception e){
        throw new Exception("something bad:" + e);
        // Stack trace is lost, but no violation was reported!
    }
}

Closes pmd/pmd#543

