### PR TITLE
[core] Use bootclasspath when building for java7

### DIFF
--- a/.travis/build-deploy.sh
+++ b/.travis/build-deploy.sh
@@ -25,8 +25,11 @@ function push_docs() {
 VERSION=$(./mvnw -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.5.0:exec | tail -1)
 echo "Building PMD ${VERSION} on branch ${TRAVIS_BRANCH}"
 
+# determine java 7 path
+JAVA7_HOME=$(jdk_switcher home openjdk7)
+
 # TODO : Once we release PMD 6.0.0 and have a compatible PMD plugin, enable PMD once again
-MVN_BUILD_FLAGS="-B -V -Djava7.home=/usr/lib/jvm/java-7-openjdk -Dpmd.skip=true"
+MVN_BUILD_FLAGS="-B -V -Djava7.home=${JAVA7_HOME} -Dpmd.skip=true"
 
 if travis_isPullRequest; then
 

--- a/.travis/build-deploy.sh
+++ b/.travis/build-deploy.sh
@@ -26,7 +26,7 @@ VERSION=$(./mvnw -q -Dexec.executable="echo" -Dexec.args='${project.version}' --
 echo "Building PMD ${VERSION} on branch ${TRAVIS_BRANCH}"
 
 # TODO : Once we release PMD 6.0.0 and have a compatible PMD plugin, enable PMD once again
-MVN_BUILD_FLAGS="-B -V -Djava7.home=/usr/lib/jvm/java-7-oracle -Dpmd.skip=true"
+MVN_BUILD_FLAGS="-B -V -Djava7.home=/usr/lib/jvm/java-7-openjdk -Dpmd.skip=true"
 
 if travis_isPullRequest; then
 

--- a/.travis/build-deploy.sh
+++ b/.travis/build-deploy.sh
@@ -26,7 +26,7 @@ VERSION=$(./mvnw -q -Dexec.executable="echo" -Dexec.args='${project.version}' --
 echo "Building PMD ${VERSION} on branch ${TRAVIS_BRANCH}"
 
 # TODO : Once we release PMD 6.0.0 and have a compatible PMD plugin, enable PMD once again
-MVN_BUILD_FLAGS="-B -V -Dpmd.skip=true"
+MVN_BUILD_FLAGS="-B -V -Djava7.home=/usr/lib/jvm/java-7-oracle -Dpmd.skip=true"
 
 if travis_isPullRequest; then
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -41,6 +41,8 @@ at <https://pmd.github.io/latest/>.
 
 ### Fixed Issues
 
+*   all
+    *   [#842](https://github.com/pmd/pmd/issues/842): \[core] Use correct java bootclasspath for compiling
 *   apex-errorprone
     *   [#792](https://github.com/pmd/pmd/issues/792): \[apex] AvoidDirectAccessTriggerMap incorrectly detects array access in classes
 *   apex-security

--- a/pmd-apex-jorje/pom.xml
+++ b/pmd-apex-jorje/pom.xml
@@ -14,6 +14,7 @@
   <properties>
     <config.basedir>${basedir}/../pmd-core</config.basedir>
     <java.version>8</java.version>
+    <java.home>${env.JAVA_HOME}</java.home>
     <apex.jorje.version>2017-11-17</apex.jorje.version>
   </properties>
 

--- a/pmd-apex/pom.xml
+++ b/pmd-apex/pom.xml
@@ -12,7 +12,9 @@
 
   <properties>
     <config.basedir>${basedir}/../pmd-core</config.basedir>
+
     <java.version>8</java.version>
+    <java.home>${env.JAVA_HOME}</java.home>
   </properties>
 
   <build>

--- a/pmd-java8/pom.xml
+++ b/pmd-java8/pom.xml
@@ -13,6 +13,7 @@
     <properties>
         <config.basedir>${basedir}/../pmd-core</config.basedir>
         <java.version>8</java.version>
+        <java.home>${env.JAVA_HOME}</java.home>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -255,11 +255,13 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
     </issueManagement>
 
     <properties>
+        <java.version>7</java.version>
+        <java.home>${env.JAVA_HOME}</java.home>
+
         <javacc.version>5.0</javacc.version>
         <surefire.version>2.20.1</surefire.version>
         <checkstyle.version>2.17</checkstyle.version>
         <pmd.plugin.version>3.8</pmd.plugin.version>
-        <java.version>7</java.version>
         <ant.version>1.10.1</ant.version>
         <javadoc.plugin.version>3.0.0-M1</javadoc.plugin.version>
         <antlr.version>4.7</antlr.version>
@@ -341,6 +343,9 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
                     <configuration>
                         <source>${java.version}</source>
                         <target>${java.version}</target>
+                        <compilerArguments>
+                            <bootclasspath>${java.home}/jre/lib/rt.jar</bootclasspath>
+                        </compilerArguments>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -922,6 +927,18 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+
+        <profile>
+            <id>jdk7-settings</id>
+            <activation>
+                <property>
+                    <name>java7.home</name>
+                </property>
+            </activation>
+            <properties>
+                <java.home>${java7.home}</java.home>
+            </properties>
         </profile>
 
         <profile>


### PR DESCRIPTION
This fixes #842 locally for me...
I hope, on travis there is still java7 available, but we would see this already in this PR build.

Note: I added a new property - if the new property (java7.home) is not set, the build will behave like before and won't fail, if non-java7 code is used.
When building locally, you'll need to execute for now:
`./mvnw clean install -Dpmd.skip=true -Djava7.home=/path/to/java7`

I've found out, it might be possible now, to combine scala and java9: https://groups.google.com/forum/#!topic/maven-and-scala/EDEmr6KIvcI - but this involves upgrading scala. I'd do this for 6.1.0 then.
