### PR TITLE
[java] Fix TCC metric crashing on local class

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -52,7 +52,6 @@ at <https://pmd.github.io/latest/>.
     *   [#794](https://github.com/pmd/pmd/issues/794): \[doc] Broken documentation links for 6.0.0
 *   java
     *   [#793](https://github.com/pmd/pmd/issues/793): \[java] Parser error with private method in nested classes in interfaces
-    *   [#812](https://github.com/pmd/pmd/issues/812): \[java] Exception applying rule DataClass
     *   [#814](https://github.com/pmd/pmd/issues/814): \[java] UnsupportedClassVersionError is failure instead of a warning
     *   [#831](https://github.com/pmd/pmd/issues/831): \[java] StackOverflow in JavaTypeDefinitionSimple.toString
 *   java-bestpractices
@@ -62,6 +61,8 @@ at <https://pmd.github.io/latest/>.
     *   [#817](https://github.com/pmd/pmd/issues/817): \[java] UnnecessaryModifierRule crashes on valid code
 *   java-design
     *   [#785](https://github.com/pmd/pmd/issues/785): \[java] NPE in DataClass rule
+    *   [#812](https://github.com/pmd/pmd/issues/812): \[java] Exception applying rule DataClass
+    *   [#827](https://github.com/pmd/pmd/issues/827): \[java] GodClass crashes with java.lang.NullPointerException
 *   java-performance
     *   [#841](https://github.com/pmd/pmd/issues/841): \[java] InsufficientStringBufferDeclaration NumberFormatException
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassOrInterfaceDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassOrInterfaceDeclaration.java
@@ -7,7 +7,13 @@ package net.sourceforge.pmd.lang.java.ast;
 
 import java.util.List;
 
+import net.sourceforge.pmd.lang.ast.Node;
+
+
 public class ASTClassOrInterfaceDeclaration extends AbstractJavaAccessTypeNode implements ASTAnyTypeDeclaration {
+
+    private boolean isLocal;
+    private boolean isLocalComputed; // guard for lazy evaluation of isLocal()
 
     private boolean isInterface;
     private JavaQualifiedName qualifiedName;
@@ -36,6 +42,33 @@ public class ASTClassOrInterfaceDeclaration extends AbstractJavaAccessTypeNode i
     public boolean isNested() {
         return jjtGetParent() instanceof ASTClassOrInterfaceBodyDeclaration
             || jjtGetParent() instanceof ASTAnnotationTypeMemberDeclaration;
+    }
+
+
+    /**
+     * Returns true if the class is declared inside a block other
+     * than the body of another class, or the top level.
+     */
+    public boolean isLocal() {
+        if (!isLocalComputed) {
+            Node current = jjtGetParent();
+            while (current != null) {
+                if (current instanceof ASTAnyTypeDeclaration) {
+                    isLocal = false;
+                    break;
+                } else if (current instanceof ASTMethodOrConstructorDeclaration
+                        || current instanceof ASTInitializer) {
+                    isLocal = true;
+                    break;
+                }
+                current = current.jjtGetParent();
+            }
+            if (current == null) {
+                isLocal = false;
+            }
+            isLocalComputed = true;
+        }
+        return isLocal;
     }
 
     public boolean isInterface() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassOrInterfaceDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassOrInterfaceDeclaration.java
@@ -82,10 +82,13 @@ public class ASTClassOrInterfaceDeclaration extends AbstractJavaAccessTypeNode i
     @Override
     public JavaQualifiedName getQualifiedName() {
         if (qualifiedName == null) {
-            if (isNested()) {
+            if (isNested() || isLocal()) {
                 ASTAnyTypeDeclaration parent = this.getFirstParentOfType(ASTAnyTypeDeclaration.class);
                 JavaQualifiedName parentQN = parent.getQualifiedName();
-                qualifiedName = JavaQualifiedName.ofNestedClass(parentQN, this.getImage());
+
+                qualifiedName = isLocal()
+                        ? JavaQualifiedName.ofLocalClass(parentQN, this.getImage())
+                        : JavaQualifiedName.ofNestedClass(parentQN, this.getImage());
                 return qualifiedName;
             }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaQualifiedName.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaQualifiedName.java
@@ -95,6 +95,12 @@ public final class JavaQualifiedName implements QualifiedName {
         localIndices[0] = NOTLOCAL_PLACEHOLDER;
     }
 
+
+    /* default, test only */ static void resetLocalIndicesCounter() {
+        LOCAL_INDICES.clear();
+    }
+
+
     /**
      * Builds the qualified name of a method declaration.
      *

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaQualifiedName.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaQualifiedName.java
@@ -76,6 +76,7 @@ public final class JavaQualifiedName implements QualifiedName {
 
     // maps class names to the names of their local classes, to the count of local classes with the same name
     private static final Map<JavaQualifiedName, Map<String, Integer>> LOCAL_INDICES = new WeakHashMap<>();
+    private static final Pattern LOCAL_INDEX_PATTERN = Pattern.compile("(\\d+)(\\w+)");
 
     private String[] packages = null; // unnamed package
     private String[] classes = new String[1];
@@ -292,10 +293,9 @@ public final class JavaQualifiedName implements QualifiedName {
 
         qname.classes = matcher.group(CLASSES_GROUP_INDEX).split("\\$");
         qname.localIndices = new int[qname.classes.length];
-        Pattern localIndexPattern = Pattern.compile("(\\d+)(\\w+)");
 
         for (int i = 0; i < qname.classes.length; i++) {
-            Matcher localIndexMatcher = localIndexPattern.matcher(qname.classes[i]);
+            Matcher localIndexMatcher = LOCAL_INDEX_PATTERN.matcher(qname.classes[i]);
             if (localIndexMatcher.matches()) {
                 qname.localIndices[i] = Integer.parseInt(localIndexMatcher.group(1));
                 qname.classes[i] = localIndexMatcher.group(2);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaQualifiedName.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaQualifiedName.java
@@ -5,10 +5,15 @@
 package net.sourceforge.pmd.lang.java.ast;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.WeakHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import net.sourceforge.pmd.lang.ast.QualifiedName;
+
 
 /**
  * Represents Qualified Names for use within the java metrics framework.
@@ -18,16 +23,76 @@ public final class JavaQualifiedName implements QualifiedName {
     /**
      * Pattern specifying the format.
      *
-     * <p>{@code ((\w+\.)+|\.)((\w+)(\$\w+)*)(#(\w+)\(((\w+)(, \w+)*)?\))?}
+     * <pre>
+     *    ((\w+\.)+|\.)             # packages
+     *    (                         # classes
+     *       (\w+)                  # primary class
+     *       (
+     *         \$                   # separator
+     *         (\d+)?               # optional local class index
+     *         \w+
+     *       )*
+     *     )
+     *     (                        # optional operation suffix
+     *       \#
+     *       (\w+)                  # method name
+     *       \(
+     *       (                      # parameters
+     *         (\w+)
+     *         (,\040\w+)*          # \040 is a space
+     *       )?
+     *       \)
+     *     )?
+     * </pre>
      */
-    public static final Pattern FORMAT = Pattern.compile("((\\w+\\.)+|\\.)((\\w+)(\\$\\w+)*)(#(\\w+)\\(((\\w+)(, \\w+)*)?\\))?");
+    private static final Pattern FORMAT = Pattern.compile("((\\w+\\.)+|\\.)              # packages\n"
+                                                                  + "(                         # classes\n"
+                                                                  + "  (\\w+)                  # primary class\n"
+                                                                  + "  ("
+                                                                  + "    \\$                   # separator\n"
+                                                                  + "    (\\d+)?               # optional local class index\n"
+                                                                  + "    \\w+"
+                                                                  + "  )*"
+                                                                  + ")"
+                                                                  + "(                         # optional operation suffix\n"
+                                                                  + "  \\#"
+                                                                  + "  (\\w+)                  # method name\n"
+                                                                  + "  \\("
+                                                                  + "    (                     # parameters\n"
+                                                                  + "      (\\w+)"
+                                                                  + "      (,\\040\\w+)*        # \040 is a space\n"
+                                                                  + "    )?"
+                                                                  + "  \\)"
+                                                                  + ")?", Pattern.COMMENTS);
+    // indices of interesting groups in the regex
+    private static final int PACKAGES_GROUP_INDEX = 1;
+    private static final int CLASSES_GROUP_INDEX = 3;
+    private static final int OPERATION_GROUP_INDEX = 7;
+    private static final int PARAMETERS_GROUP_INDEX = 9;
+
+
+    /** Local index value for when the class is not local. */
+    private static final int NOTLOCAL_PLACEHOLDER = -1;
+
+    // maps class names to the names of their local classes, to the count of local classes with the same name
+    private static final Map<JavaQualifiedName, Map<String, Integer>> LOCAL_INDICES = new WeakHashMap<>();
 
     private String[] packages = null; // unnamed package
     private String[] classes = new String[1];
     private String operation = null;
 
-    private JavaQualifiedName() {
 
+    /**
+     * Local indices of the parents and of this class, in order.
+     * They can be zipped with the {@link #classes} array.
+     *
+     * <p>If a class is not local, its local index is {@link #NOTLOCAL_PLACEHOLDER}.
+     */
+    private int[] localIndices = new int[1];
+
+
+    private JavaQualifiedName() {
+        localIndices[0] = NOTLOCAL_PLACEHOLDER;
     }
 
     /**
@@ -63,7 +128,7 @@ public final class JavaQualifiedName implements QualifiedName {
     }
 
 
-    /** Factorises the functionality of makeOperationof() */
+    /** Factorises the functionality of ofOperation() */
     private static JavaQualifiedName ofOperation(JavaQualifiedName parent, String opName, ASTFormalParameters params) {
         JavaQualifiedName qname = new JavaQualifiedName();
 
@@ -84,17 +149,61 @@ public final class JavaQualifiedName implements QualifiedName {
      * @return The qualified name of the nested class
      */
     /* default */ static JavaQualifiedName ofNestedClass(JavaQualifiedName parent, String className) {
-        JavaQualifiedName qname = new JavaQualifiedName();
-        qname.packages = parent.packages;
-        if (parent.classes[0] != null) {
-            qname.classes = Arrays.copyOf(parent.classes, parent.classes.length + 1);
-            qname.classes[parent.classes.length] = className;
-        } else {
-            qname.classes[0] = className;
-        }
-
-        return qname;
+        return nestedOrLocalClassQualifiedNameHelper(parent, className, NOTLOCAL_PLACEHOLDER);
     }
+
+
+    /**
+     * Builds the qualified name of a local class using the qualified name of its immediate parent.
+     * Local classes use a random suffix to prevent qualified name collisions.
+     *
+     * @param parent    The qname of the immediate parent
+     * @param className The name of the class
+     *
+     * @return The qualified name of the local class
+     */
+    /* default */ static JavaQualifiedName ofLocalClass(JavaQualifiedName parent, String className) {
+        return nestedOrLocalClassQualifiedNameHelper(parent, className, addLocal(parent, className));
+    }
+
+
+    // works from the parent class qualified name to create a nested or local class name
+    // use NOTLOCAL_PLACEHOLDER if the class is not local
+    private static JavaQualifiedName nestedOrLocalClassQualifiedNameHelper(JavaQualifiedName parent, String className, int localIndex) {
+        JavaQualifiedName toBuild = new JavaQualifiedName();
+
+        toBuild.packages = parent.packages;
+        toBuild.classes = Arrays.copyOf(parent.classes, parent.classes.length + 1);
+        toBuild.classes[parent.classes.length] = className;
+
+        // copy the local indices of the parents
+        toBuild.localIndices = Arrays.copyOf(parent.localIndices, parent.localIndices.length + 1);
+        toBuild.localIndices[parent.localIndices.length] = localIndex;
+
+        return toBuild;
+    }
+
+
+    // Registers a class as local to the parent qualified name, and gives back its index.
+    // The index identifies the local class in the scope of its parent.
+    private static int addLocal(JavaQualifiedName parent, String localClassName) {
+        Map<String, Integer> siblings = LOCAL_INDICES.get(parent);
+        if (siblings == null) {
+            LOCAL_INDICES.put(parent, new HashMap<String, Integer>());
+            LOCAL_INDICES.get(parent).put(localClassName, 1);
+            return 1;
+        } else {
+            Integer count = siblings.get(localClassName);
+            if (count == null) {
+                siblings.put(localClassName, 1);
+                return 1;
+            } else {
+                siblings.put(localClassName, count + 1);
+                return count + 1;
+            }
+        }
+    }
+
 
     /**
      * Builds the qualified name of an outer (not nested) class.
@@ -135,6 +244,7 @@ public final class JavaQualifiedName implements QualifiedName {
         return ofString(name);
     }
 
+
     /**
      * Parses a qualified name given in the format defined for this implementation. The format
      * is specified by a regex pattern (see {@link JavaQualifiedName#FORMAT}). Examples:
@@ -152,6 +262,12 @@ public final class JavaQualifiedName implements QualifiedName {
      * <li> A class in the unnamed package is preceded by a single full stop.
      * </ul>
      *
+     * <p>{@code com.foo.Class$1LocalClass}
+     * <ul>
+     * <li> A local class' qualified name is assigned an index which identifies it within the scope
+     * of its enclosing class. The index is displayed after the separating dollar symbol.
+     * </ul>
+     *
      * @param name The name to parse.
      *
      * @return A qualified name instance corresponding to the parsed string.
@@ -165,12 +281,26 @@ public final class JavaQualifiedName implements QualifiedName {
             return null;
         }
 
-        qname.packages = ".".equals(matcher.group(1)) ? null : matcher.group(1).split("\\.");
-        qname.classes = matcher.group(3).split("\\$");
-        qname.operation = matcher.group(6) == null ? null : matcher.group(6).substring(1);
+        qname.packages = ".".equals(matcher.group(PACKAGES_GROUP_INDEX)) ? null : matcher.group(PACKAGES_GROUP_INDEX).split("\\.");
+        qname.operation = matcher.group(OPERATION_GROUP_INDEX) == null ? null : matcher.group(OPERATION_GROUP_INDEX).substring(1);
+
+        qname.classes = matcher.group(CLASSES_GROUP_INDEX).split("\\$");
+        qname.localIndices = new int[qname.classes.length];
+        Pattern localIndexPattern = Pattern.compile("(\\d+)(\\w+)");
+
+        for (int i = 0; i < qname.classes.length; i++) {
+            Matcher localIndexMatcher = localIndexPattern.matcher(qname.classes[i]);
+            if (localIndexMatcher.matches()) {
+                qname.localIndices[i] = Integer.parseInt(localIndexMatcher.group(1));
+                qname.classes[i] = localIndexMatcher.group(2);
+            } else {
+                qname.localIndices[i] = NOTLOCAL_PLACEHOLDER;
+            }
+        }
 
         return qname;
     }
+
 
     /** Returns a normalized method name (not Java-canonical!). */
     private static String getOperationName(String methodName, ASTFormalParameters params) {
@@ -209,12 +339,20 @@ public final class JavaQualifiedName implements QualifiedName {
 
 
     /**
+     * Returns true if this qname identifies a local class.
+     */
+    public boolean isLocalClass() {
+        return localIndices[localIndices.length - 1] != NOTLOCAL_PLACEHOLDER;
+    }
+
+
+    /**
      * Returns the packages. This is specific to Java's package structure.
      *
      * @return The packages.
      */
     public String[] getPackages() {
-        return packages;
+        return packages == null ? null : Arrays.copyOf(packages, packages.length);
     }
 
 
@@ -225,7 +363,7 @@ public final class JavaQualifiedName implements QualifiedName {
      * @return The class names array.
      */
     public String[] getClasses() {
-        return classes;
+        return Arrays.copyOf(classes, classes.length);
     }
 
 
@@ -260,27 +398,23 @@ public final class JavaQualifiedName implements QualifiedName {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-
         JavaQualifiedName that = (JavaQualifiedName) o;
-
-        // Probably incorrect - comparing Object[] arrays with Arrays.equals
-        if (!Arrays.equals(packages, that.packages)) {
-            return false;
-        }
-        // Probably incorrect - comparing Object[] arrays with Arrays.equals
-        if (!Arrays.equals(classes, that.classes)) {
-            return false;
-        }
-        return operation != null ? operation.equals(that.operation) : that.operation == null;
+        return Arrays.equals(packages, that.packages)
+                && Arrays.equals(classes, that.classes)
+                && Objects.equals(operation, that.operation)
+                && Arrays.equals(localIndices, that.localIndices);
     }
+
 
     @Override
     public int hashCode() {
-        int result = Arrays.hashCode(packages);
+        int result = Objects.hash(operation);
+        result = 31 * result + Arrays.hashCode(packages);
         result = 31 * result + Arrays.hashCode(classes);
-        result = 31 * result + (operation != null ? operation.hashCode() : 0);
+        result = 31 * result + Arrays.hashCode(localIndices);
         return result;
     }
+
 
     @Override
     public String toString() {
@@ -289,25 +423,27 @@ public final class JavaQualifiedName implements QualifiedName {
         if (packages != null) {
             int last = packages.length - 1;
             for (int i = 0; i < last; i++) {
-                sb.append(packages[i]);
-                sb.append('.');
+                sb.append(packages[i]).append('.');
             }
 
             sb.append(packages[last]);
         }
         sb.append('.'); // this dot is there even if package is null
 
-        int last = classes.length - 1;
-        for (int i = 0; i < last; i++) {
-            sb.append(classes[i]);
+        sb.append(classes[0]);
+
+        for (int i = 1; i < classes.length; i++) {
             sb.append('$');
+
+            if (localIndices[i] != NOTLOCAL_PLACEHOLDER) {
+                sb.append(localIndices[i]);
+            }
+
+            sb.append(classes[i]);
         }
 
-        sb.append(classes[last]);
-
         if (operation != null) {
-            sb.append('#');
-            sb.append(operation);
+            sb.append('#').append(operation);
         }
 
         return sb.toString();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/impl/TccMetric.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/impl/TccMetric.java
@@ -11,7 +11,7 @@ import java.util.Map;
 import java.util.Set;
 
 import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
-import net.sourceforge.pmd.lang.java.metrics.impl.visitors.TccMethodPairVisitor;
+import net.sourceforge.pmd.lang.java.metrics.impl.visitors.TccAttributeAccessCollector;
 import net.sourceforge.pmd.lang.metrics.MetricOptions;
 
 /**
@@ -25,8 +25,7 @@ public class TccMetric extends AbstractJavaClassMetric {
 
     @Override
     public double computeFor(ASTAnyTypeDeclaration node, MetricOptions options) {
-        @SuppressWarnings("unchecked")
-        Map<String, Set<String>> usagesByMethod = (Map<String, Set<String>>) node.jjtAccept(new TccMethodPairVisitor(), null);
+        Map<String, Set<String>> usagesByMethod = new TccAttributeAccessCollector(node).start();
 
         int numPairs = numMethodsRelatedByAttributeAccess(usagesByMethod);
         int maxPairs = maxMethodPairs(usagesByMethod.size());

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/impl/visitors/TccAttributeAccessCollector.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/impl/visitors/TccAttributeAccessCollector.java
@@ -6,44 +6,65 @@ package net.sourceforge.pmd.lang.java.metrics.impl.visitors;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
 
 import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
 import net.sourceforge.pmd.lang.java.ast.JavaParserVisitorReducedAdapter;
 import net.sourceforge.pmd.lang.java.symboltable.ClassScope;
 import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
 import net.sourceforge.pmd.lang.symboltable.Scope;
 
+
 /**
- * Returns the map of method names to the set local attributes accessed when visiting a class.
+ * Returns the map of method names to the set of local attributes accessed when visiting a class.
  *
  * @author Clément Fournier
  * @since 6.0.0
  */
-public class TccMethodPairVisitor extends JavaParserVisitorReducedAdapter {
+public class TccAttributeAccessCollector extends JavaParserVisitorReducedAdapter {
 
-    /**
-     * Collects for each method of the current class, which local attributes are accessed.
-     */
-    Stack<Map<String, Set<String>>> methodAttributeAccess = new Stack<>();
+    private final ASTAnyTypeDeclaration exploredClass;
+
 
     /** The name of the current method. */
     private String currentMethodName;
 
+    private Map<String, Set<String>> methodAttributeAccess;
+
+
+    public TccAttributeAccessCollector(ASTAnyTypeDeclaration exploredClass) {
+        this.exploredClass = exploredClass;
+    }
+
+
+    /**
+     * Collects the attribute accesses by method into a map.
+     */
+    @SuppressWarnings("unchecked")
+    public Map<String, Set<String>> start() {
+        return (Map<String, Set<String>>) this.visit(exploredClass, new HashMap<String, Set<String>>());
+    }
+
 
     @Override
     public Object visit(ASTAnyTypeDeclaration node, Object data) {
-        methodAttributeAccess.push(new HashMap<String, Set<String>>());
-        super.visit(node, data);
-
-        methodAttributeAccess.peek().remove(null);
-        return methodAttributeAccess.pop();
+        if (node == exploredClass) {
+            methodAttributeAccess = new HashMap<>();
+            super.visit(node, data);
+        } else if (node instanceof ASTClassOrInterfaceDeclaration
+                && ((ASTClassOrInterfaceDeclaration) node).isLocal()) {
+            super.visit(node, data);
+        }
+        return methodAttributeAccess;
     }
 
 
@@ -51,26 +72,37 @@ public class TccMethodPairVisitor extends JavaParserVisitorReducedAdapter {
     public Object visit(ASTMethodDeclaration node, Object data) {
 
         if (!node.isAbstract()) {
-            currentMethodName = node.getQualifiedName().getOperation();
-            methodAttributeAccess.peek().put(currentMethodName, new HashSet<String>());
+            if (node.getFirstParentOfType(ASTAnyTypeDeclaration.class) == exploredClass) {
+                currentMethodName = node.getQualifiedName().getOperation();
+                methodAttributeAccess.put(currentMethodName, new HashSet<String>());
 
-            super.visit(node, data);
-
-            currentMethodName = null;
+                super.visit(node, data);
+                currentMethodName = null;
+            } else {
+                super.visit(node, data);
+            }
         }
 
         return null;
     }
 
 
+    @Override
+    public Object visit(ASTConstructorDeclaration node, Object data) {
+        return data; // we're only looking for method pairs
+    }
+
+
     /**
-     * The primary expression node is used to detect access to attributes and method calls. If the access is not for a
-     * foreign class, then the {@link #methodAttributeAccess} map is updated for the current method.
+     * The primary expression node is used to detect access
+     * to attributes and method calls. If the access is not for a
+     * foreign class, then the {@link #methodAttributeAccess}
+     * map is updated for the current method.
      */
     @Override
     public Object visit(ASTPrimaryExpression node, Object data) {
         if (currentMethodName != null) {
-            Set<String> methodAccess = methodAttributeAccess.peek().get(currentMethodName);
+            Set<String> methodAccess = methodAttributeAccess.get(currentMethodName);
             String variableName = getVariableName(node);
             if (isLocalAttributeAccess(variableName, node.getScope())) {
                 methodAccess.add(variableName);
@@ -81,9 +113,18 @@ public class TccMethodPairVisitor extends JavaParserVisitorReducedAdapter {
         return super.visit(node, data);
     }
 
-
     private String getVariableName(ASTPrimaryExpression node) {
         ASTPrimaryPrefix prefix = node.getFirstDescendantOfType(ASTPrimaryPrefix.class);
+
+        if (prefix.usesThisModifier()) {
+            List<ASTPrimarySuffix> suffixes = node.findChildrenOfType(ASTPrimarySuffix.class);
+            if (suffixes.size() > 1) {
+                if (!suffixes.get(1).isArguments()) { // not a method call
+                    return suffixes.get(0).getImage();
+                }
+            }
+        }
+
         ASTName name = prefix.getFirstDescendantOfType(ASTName.class);
 
         String variableName = null;
@@ -107,7 +148,8 @@ public class TccMethodPairVisitor extends JavaParserVisitorReducedAdapter {
         while (currentScope != null) {
             for (VariableNameDeclaration decl : currentScope.getDeclarations(VariableNameDeclaration.class).keySet()) {
                 if (decl.getImage().equals(varName)) {
-                    if (currentScope instanceof ClassScope) {
+                    if (currentScope instanceof ClassScope
+                            && ((ClassScope) currentScope).getClassDeclaration().getNode() == exploredClass) {
                         return true;
                     }
                 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTClassOrInterfaceDeclarationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTClassOrInterfaceDeclarationTest.java
@@ -1,0 +1,76 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.ast;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import net.sourceforge.pmd.lang.java.ParserTstUtil;
+
+
+/**
+ * @author Clément Fournier
+ * @since 6.1.0
+ */
+public class ASTClassOrInterfaceDeclarationTest {
+
+    private static final String LOCAL_CLASS_IN_METHOD
+            = "class Foo { void bar() { class Local {}}}";
+
+    private static final String NESTED_CLASS_IS_NOT_LOCAL
+            = "class Foo { class Nested {} void bar() {}}";
+
+    private static final String LOCAL_CLASS_IN_INITIALIZER
+            = "class Foo { { class Local {} } }";
+
+    private static final String LOCAL_CHILDREN_ARE_NOT_ALWAYS_LOCAL
+            = "class Foo { { class Local { class Nested {} void bar() {class Local2 {}}}}}";
+
+
+    @Test
+    public void testLocalInMethod() {
+        List<ASTClassOrInterfaceDeclaration> classes = ParserTstUtil.getOrderedNodes(ASTClassOrInterfaceDeclaration.class, LOCAL_CLASS_IN_METHOD);
+        assertTrue(classes.size() == 2);
+
+        assertFalse("Local class false-positive", classes.get(0).isLocal());
+        assertTrue("Local class false-negative", classes.get(1).isLocal());
+    }
+
+
+    @Test
+    public void testLocalInInitializer() {
+        List<ASTClassOrInterfaceDeclaration> classes = ParserTstUtil.getOrderedNodes(ASTClassOrInterfaceDeclaration.class, LOCAL_CLASS_IN_INITIALIZER);
+        assertTrue(classes.size() == 2);
+
+        assertFalse("Local class false-positive", classes.get(0).isLocal());
+        assertTrue("Local class false-negative", classes.get(1).isLocal());
+    }
+
+
+    @Test
+    public void testNestedClassIsNotLocal() {
+        List<ASTClassOrInterfaceDeclaration> classes = ParserTstUtil.getOrderedNodes(ASTClassOrInterfaceDeclaration.class, NESTED_CLASS_IS_NOT_LOCAL);
+        assertTrue(classes.size() == 2);
+
+        assertFalse("Local class false-positive", classes.get(0).isLocal());
+        assertFalse("Local class false-positive", classes.get(1).isLocal());
+    }
+
+
+    @Test
+    public void testLocalChildrenAreNotAlwaysLocal() {
+        List<ASTClassOrInterfaceDeclaration> classes = ParserTstUtil.getOrderedNodes(ASTClassOrInterfaceDeclaration.class, LOCAL_CHILDREN_ARE_NOT_ALWAYS_LOCAL);
+        assertTrue(classes.size() == 4);
+
+        assertFalse("Local class false-positive", classes.get(0).isLocal()); // class Foo
+        assertTrue("Local class false-negative", classes.get(1).isLocal());  // class Local
+        assertFalse("Local class false-positive", classes.get(2).isLocal()); // class Nested
+        assertTrue("Local class false-negative", classes.get(3).isLocal());  // class Local2
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/QualifiedNameTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/QualifiedNameTest.java
@@ -25,6 +25,11 @@ import net.sourceforge.pmd.lang.java.ParserTstUtil;
  */
 public class QualifiedNameTest {
 
+    /** Provides a hook into the package-private reset method for the local indices counter. */
+    public static void resetLocalIndicesCounterHook() {
+        JavaQualifiedName.resetLocalIndicesCounter();
+    }
+
 
     @Test
     public void testEmptyPackage() {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/QualifiedNameTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/QualifiedNameTest.java
@@ -6,13 +6,19 @@ package net.sourceforge.pmd.lang.java.ast;
 
 import static net.sourceforge.pmd.lang.java.ParserTstUtil.getNodes;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
+import java.util.List;
 import java.util.Set;
 
 import org.junit.Test;
+
+import net.sourceforge.pmd.lang.java.ParserTstUtil;
+
 
 /**
  * @author Clément Fournier
@@ -251,6 +257,23 @@ public class QualifiedNameTest {
     }
 
     @Test
+    public void testParseLocalClasses() {
+        final String SIMPLE = "foo.bar.Bzaz$1Local";
+        final String NESTED = "foo.Bar$1Local$Nested";
+        JavaQualifiedName simple = JavaQualifiedName.ofString(SIMPLE);
+        JavaQualifiedName nested = JavaQualifiedName.ofString(NESTED);
+
+        assertNotNull(simple);
+        assertTrue(simple.isLocalClass());
+        assertNotNull(nested);
+        assertFalse(nested.isLocalClass());
+
+        assertEquals(SIMPLE, simple.toString());
+        assertEquals(NESTED, nested.toString());
+
+    }
+
+    @Test
     public void testParseMalformed() {
         assertNull(JavaQualifiedName.ofString(".foo.bar.Bzaz"));
         assertNull(JavaQualifiedName.ofString("foo.bar."));
@@ -260,6 +283,57 @@ public class QualifiedNameTest {
         assertNull(JavaQualifiedName.ofString("foo.bar.Bzaz#foo(String , int)"));
     }
 
+
+
+    @Test
+    public void testSimpleLocalClass() {
+        final String TEST = "package bar; class Boron { public void foo(String j) { class Local {} } }";
+
+        List<ASTClassOrInterfaceDeclaration> classes
+                = ParserTstUtil.getOrderedNodes(ASTClassOrInterfaceDeclaration.class, TEST);
+
+        JavaQualifiedName qname = JavaQualifiedName.ofString("bar.Boron$1Local");
+
+        assertEquals(qname, classes.get(1).getQualifiedName());
+    }
+
+    @Test
+    public void testLocalClassNameClash() {
+        final String TEST = "package bar; class Bzaz{ void foo() { class Local {} } {// initializer\n class Local {}}}";
+
+        List<ASTClassOrInterfaceDeclaration> classes
+                = ParserTstUtil.getOrderedNodes(ASTClassOrInterfaceDeclaration.class, TEST);
+
+        assertNotEquals(classes.get(1).getQualifiedName(), classes.get(2).getQualifiedName());
+
+        assertEquals(JavaQualifiedName.ofString("bar.Bzaz$1Local"), classes.get(1).getQualifiedName());
+        assertEquals(JavaQualifiedName.ofString("bar.Bzaz$2Local"), classes.get(2).getQualifiedName());
+    }
+
+
+    @Test
+    public void testLocalClassDeepNesting() {
+        final String TEST
+                = "class Bzaz{ void foo() { "
+                + "  class Local { "
+                + "    class Nested {"
+                + "      {"
+                + "        class InnerLocal{}"
+                + "      }"
+                + "    }"
+                + "  }"
+                + "}}";
+
+
+        List<ASTClassOrInterfaceDeclaration> classes
+                = ParserTstUtil.getOrderedNodes(ASTClassOrInterfaceDeclaration.class, TEST);
+
+        assertNotEquals(classes.get(1).getQualifiedName(), classes.get(2).getQualifiedName());
+
+        assertEquals(JavaQualifiedName.ofString(".Bzaz$1Local"), classes.get(1).getQualifiedName());
+        assertEquals(JavaQualifiedName.ofString(".Bzaz$1Local$Nested"), classes.get(2).getQualifiedName());
+        assertEquals(JavaQualifiedName.ofString(".Bzaz$1Local$Nested$1InnerLocal"), classes.get(3).getQualifiedName());
+    }
 
 }
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/AbstractMetricTestRule.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/AbstractMetricTestRule.java
@@ -132,7 +132,7 @@ public abstract class AbstractMetricTestRule extends AbstractJavaMetricsRule {
         if (val == (int) val) {
             return String.valueOf((int) val);
         } else {
-            return String.format(Locale.ROOT, "%." + 4 + "f", val);
+            return String.format(Locale.ROOT, "%.4f", val);
         }
     }
 
@@ -165,6 +165,6 @@ public abstract class AbstractMetricTestRule extends AbstractJavaMetricsRule {
                                                        "" + niceDoubleString(methodValue), });
             }
         }
-        return data;
+        return super.visit(node, data);
     }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/AllMetricsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/AllMetricsTest.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.java.metrics.impl;
 
 import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.lang.java.ast.QualifiedNameTest;
 import net.sourceforge.pmd.lang.java.metrics.MetricsHook;
 import net.sourceforge.pmd.testframework.SimpleAggregatorTst;
 
@@ -22,6 +23,7 @@ public class AllMetricsTest extends SimpleAggregatorTst {
     @Override
     protected Rule reinitializeRule(Rule rule) {
         MetricsHook.reset();
+        QualifiedNameTest.resetLocalIndicesCounterHook();
         return rule;
     }
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/DesignRulesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/DesignRulesTest.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.java.rule.design;
 
 import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.lang.java.ast.QualifiedNameTest;
 import net.sourceforge.pmd.lang.java.metrics.MetricsHook;
 import net.sourceforge.pmd.testframework.SimpleAggregatorTst;
 
@@ -18,6 +19,7 @@ public class DesignRulesTest extends SimpleAggregatorTst {
     @Override
     protected Rule reinitializeRule(Rule rule) {
         MetricsHook.reset();
+        QualifiedNameTest.resetLocalIndicesCounterHook();
         return rule;
     }
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/metrics/impl/xml/TccTest.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/metrics/impl/xml/TccTest.xml
@@ -26,11 +26,11 @@ this(name, valueType, initialValue, null);
 
 
 public Property(String name, Class valueType, Object initialValue, Object[] values) {
-_name = name;
-_valueType = valueType;
-_initialValue = initialValue;
-_availableValues = values;
-_currentValue = _initialValue;
+    _name = name;
+    _valueType = valueType;
+    _initialValue = initialValue;
+    _availableValues = values;
+    _currentValue = _initialValue;
 }
 
 public String getName() {
@@ -96,5 +96,100 @@ return _name.compareTo(((Property) o)._name);
         }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Do not crash on local class, refs #827</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>'com.pack.Pack$1Inner' has value 0.</message>
+        </expected-messages>
+        <code><![CDATA[
+        package com.pack;
+
+        import java.util.ArrayList;
+        import java.util.Arrays;
+        import java.util.Date;
+        import java.util.HashMap;
+        import java.util.List;
+        import java.util.Map;
+
+        public class Pack implements IPack {
+
+
+            @Override
+            public Map<String, String> get() {
+
+                class Inner implements IInner {
+
+                    private Map<String, String> results;
+
+                    public Inner(Map<String, String> results) {
+                        this.results = results;
+                    }
+
+                    public void method() {
+                        this.results = new HashMap<String, String>();
+                    }
+
+                    private void otherMethod() {
+                        this.results.clear();
+                    }
+                }
+                return null;
+            }
+        }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Attribute accesses in local class count as accesses of the method</description>
+        <expected-problems>2</expected-problems>
+        <expected-messages>
+            <message>'com.pack.Pack' has value 1.</message>
+            <message>'com.pack.Pack$1Inner' has value 0.</message>
+        </expected-messages>
+        <code><![CDATA[
+        package com.pack;
+
+        import java.util.ArrayList;
+        import java.util.Arrays;
+        import java.util.Date;
+        import java.util.HashMap;
+        import java.util.List;
+        import java.util.Map;
+
+        public class Pack implements IPack {
+
+            // the attribute is in the outer class
+            private Map<String, String> results;
+
+            public void paired() {
+                results.clear();
+            }
+
+            @Override
+            public Map<String, String> get() {
+
+                class Inner implements IInner {
+
+
+                    public Inner(Map<String, String> results) {
+                        this.results = results;
+                    }
+
+                    public void method() {
+                        this.results = new HashMap<String, String>();
+                    }
+
+                    private void otherMethod() {
+                        this.results.clear();
+                    }
+                }
+                return null;
+            }
+        }
+        ]]></code>
+    </test-code>
+
 
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/GodClass.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/GodClass.xml
@@ -133,15 +133,52 @@ public class Foo {
         <description>#1085 NullPointerException by at net.sourceforge.pmd.lang.java.rule.design.GodClassRule.visit(GodClassRule.java:313)</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-public enum Color {
-  BLUE,
-  RED;
-  
-  public int toHex() {
-    return 0;
-  }
-}
+        public enum Color {
+          BLUE,
+          RED;
+
+          public int toHex() {
+            return 0;
+          }
+        }
         ]]>
+        </code>
+    </test-code>
+
+
+    <test-code>
+        <description>GodClass crashes with java.lang.NullPointerException, refs #827</description>
+        <expected-problems>0</expected-problems>
+        <code>
+            <![CDATA[
+            package com.pack;
+
+            import java.util.ArrayList;
+            import java.util.Arrays;
+            import java.util.Date;
+            import java.util.HashMap;
+            import java.util.List;
+            import java.util.Map;
+
+            public class Pack implements IPack {
+
+
+                @Override
+                public Map<String, String> get() {
+
+                    class Inner implements IInner {
+
+                        private Map<String, String> results;
+
+                        public Inner(Map<String, String> results) {
+                            this.results = results;
+                        }
+                    }
+                    return null;
+                }
+
+            }
+            ]]>
         </code>
     </test-code>
 </test-data>

--- a/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
@@ -163,7 +163,7 @@ public abstract class RuleTst {
      *
      * @param rule The rule to reinitialise
      *
-     * @return The rule once it has be reinitialised
+     * @return The rule once it has been reinitialised
      */
     protected Rule reinitializeRule(Rule rule) {
         return findRule(rule.getRuleSetName(), rule.getName());


### PR DESCRIPTION
Fixes #827. This change needed  a bit of work around JavaQualifiedName to handle local classes in a sensible manner. In this implementation, the qualified name of a local class is determined in the following way:
* The qualified name is identical to the qualified name of the innermost enclosing class (not the method), up until the local classe's own name
* The local classe's name is written after a dollar symbol, like for nested classes, but we add an integer index to differentiate between local classes with an identical name.

eg with: 

```java
package pack;
class Outer {
  void foo() {
    class Inner {}
  }

  void bar() {
    class Inner {}
  }
}
``` 
the two local classes will have different qualified names, respectively `pack.Outer$1Inner` and `pack.Outer$2Inner`. The text representation of the qnames are similar to what the java compiler produces, which you can check with a stack trace. 

This implementation uses a static map to keep track of the indices... which is awkward because we must reset it between tests.

