### PR TITLE
[doc] Fix build under Windows

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -43,6 +43,7 @@ at <https://pmd.github.io/latest/>.
 
 *   all
     *   [#842](https://github.com/pmd/pmd/issues/842): \[core] Use correct java bootclasspath for compiling
+    *   [#848](https://github.com/pmd/pmd/issues/848): \[doc] Test failures when building pmd-doc under Windows
 *   apex-errorprone
     *   [#792](https://github.com/pmd/pmd/issues/792): \[apex] AvoidDirectAccessTriggerMap incorrectly detects array access in classes
 *   apex-security

--- a/pmd-doc/pom.xml
+++ b/pmd-doc/pom.xml
@@ -13,6 +13,7 @@
 
     <properties>
         <java.version>8</java.version>
+        <java.home>${env.JAVA_HOME}</java.home>
         <config.basedir>${basedir}/../pmd-core</config.basedir>
     </properties>
 

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/docs/GenerateRuleDocsCmd.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/docs/GenerateRuleDocsCmd.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.docs;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
@@ -15,6 +16,8 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Pattern;
+
+import org.apache.commons.io.FilenameUtils;
 
 import net.sourceforge.pmd.RuleSet;
 import net.sourceforge.pmd.RuleSetFactory;
@@ -43,7 +46,9 @@ public class GenerateRuleDocsCmd {
     public static List<String> findAdditionalRulesets(Path basePath) {
         try {
             List<String> additionalRulesets = new ArrayList<>();
-            Pattern rulesetPattern = Pattern.compile("^.+/pmd-\\w+/src/main/resources/rulesets/\\w+/\\w+.xml$");
+            Pattern rulesetPattern = Pattern.compile("^.+" + Pattern.quote(File.separator) + "pmd-\\w+"
+                    + Pattern.quote(FilenameUtils.normalize("/src/main/resources/rulesets/"))
+                    + "\\w+" + Pattern.quote(File.separator) + "\\w+.xml$");
             Files.walkFileTree(basePath, new SimpleFileVisitor<Path>() {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleDocGenerator.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleDocGenerator.java
@@ -109,7 +109,7 @@ public class RuleDocGenerator {
         for (String filename : additionalRulesets) {
             try {
                 // do not take rulesets from pmd-test or pmd-core
-                if (!filename.contains("pmd-test/") && !filename.contains("pmd-core/")) {
+                if (!filename.contains("pmd-test") && !filename.contains("pmd-core")) {
                     rulesets.add(ruleSetFactory.createRuleSet(filename));
                 } else {
                     LOG.fine("Ignoring ruleset " + filename);
@@ -539,7 +539,9 @@ public class RuleDocGenerator {
         if (!foundPathResult.isEmpty()) {
             Path foundPath = foundPathResult.get(0);
             foundPath = root.relativize(foundPath);
-            return foundPath.toString();
+            // Note: the path is normalized to unix path separators, so that the editme link
+            // uses forward slashes
+            return FilenameUtils.normalize(foundPath.toString(), true);
         }
 
         return StringUtils.chomp(ruleset.getFileName());

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleDocGenerator.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleDocGenerator.java
@@ -12,6 +12,7 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -26,6 +27,7 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import java.util.regex.Matcher;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -300,6 +302,10 @@ public class RuleDocGenerator {
         return description;
     }
 
+    private static List<String> toLines(String s) {
+        return Arrays.asList(s.split("\r\n|\n"));
+    }
+
     /**
      * Generates for each ruleset a page. The page contains the details for each rule.
      *
@@ -375,12 +381,12 @@ public class RuleDocGenerator {
                         lines.add("");
                     }
 
-                    lines.add(stripIndentation(rule.getDescription()));
+                    lines.addAll(toLines(stripIndentation(rule.getDescription())));
                     lines.add("");
 
                     if (rule instanceof XPathRule || rule instanceof RuleReference && ((RuleReference) rule).getRule() instanceof XPathRule) {
                         lines.add("```");
-                        lines.add(StringUtils.stripToEmpty(rule.getProperty(XPathRule.XPATH_DESCRIPTOR)));
+                        lines.addAll(toLines(StringUtils.stripToEmpty(rule.getProperty(XPathRule.XPATH_DESCRIPTOR))));
                         lines.add("```");
                         lines.add("");
                     } else {
@@ -396,7 +402,7 @@ public class RuleDocGenerator {
                         lines.add("");
                         for (String example : rule.getExamples()) {
                             lines.add("``` " + mapLanguageForHighlighting(languageTersename));
-                            lines.add(StringUtils.stripToEmpty(example));
+                            lines.addAll(toLines(StringUtils.stripToEmpty(example)));
                             lines.add("```");
                             lines.add("");
                         }
@@ -540,7 +546,8 @@ public class RuleDocGenerator {
     }
 
     private String getRuleClassSourceFilepath(String ruleClass) throws IOException {
-        final String relativeSourceFilename = ruleClass.replaceAll("\\.", File.separator) + ".java";
+        final String relativeSourceFilename = ruleClass.replaceAll("\\.", Matcher.quoteReplacement(File.separator))
+                + ".java";
         final List<Path> foundPathResult = new LinkedList<>();
 
         Files.walkFileTree(root, new SimpleFileVisitor<Path>() {

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleSetUtils.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleSetUtils.java
@@ -51,7 +51,7 @@ public final class RuleSetUtils {
 
     public static String getRuleSetClasspath(RuleSet ruleset) {
         final String RESOURCES_PATH = "/resources/";
-        String filename = StringUtils.chomp(ruleset.getFileName());
+        String filename = FilenameUtils.normalize(StringUtils.chomp(ruleset.getFileName()), true);
         int startIndex = filename.lastIndexOf(RESOURCES_PATH);
         if (startIndex > -1) {
             return filename.substring(startIndex + RESOURCES_PATH.length());

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/docs/SidebarGenerator.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/docs/SidebarGenerator.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.docs;
 
 import java.io.IOException;
+import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -85,10 +86,12 @@ public class SidebarGenerator {
     }
 
     public Map<String, Object> loadSidebar() throws IOException {
-        Yaml yaml = new Yaml();
-        @SuppressWarnings("unchecked")
-        Map<String, Object> sidebar = (Map<String, Object>) yaml.load(Files.newBufferedReader(sidebarPath, StandardCharsets.UTF_8));
-        return sidebar;
+        try (Reader reader = Files.newBufferedReader(sidebarPath, StandardCharsets.UTF_8)) {
+            Yaml yaml = new Yaml();
+            @SuppressWarnings("unchecked")
+            Map<String, Object> sidebar = (Map<String, Object>) yaml.load(reader);
+            return sidebar;
+        }
     }
 
     public void writeSidebar(Map<String, Object> sidebar) throws IOException {

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/docs/SidebarGenerator.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/docs/SidebarGenerator.java
@@ -15,8 +15,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import org.apache.commons.lang3.SystemUtils;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.DumperOptions.FlowStyle;
+import org.yaml.snakeyaml.DumperOptions.LineBreak;
 import org.yaml.snakeyaml.Yaml;
 
 import net.sourceforge.pmd.RuleSet;
@@ -92,6 +94,9 @@ public class SidebarGenerator {
     public void writeSidebar(Map<String, Object> sidebar) throws IOException {
         DumperOptions options = new DumperOptions();
         options.setDefaultFlowStyle(FlowStyle.BLOCK);
+        if (SystemUtils.IS_OS_WINDOWS) {
+            options.setLineBreak(LineBreak.WIN);
+        }
         Yaml yaml = new Yaml(options);
         writer.write(sidebarPath, Arrays.asList(yaml.dump(sidebar)));
         System.out.println("Generated " + sidebarPath);

--- a/pmd-doc/src/test/java/net/sourceforge/pmd/docs/RuleDocGeneratorTest.java
+++ b/pmd-doc/src/test/java/net/sourceforge/pmd/docs/RuleDocGeneratorTest.java
@@ -8,15 +8,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
-import java.io.Writer;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
+import java.util.List;
 
+import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -38,9 +38,14 @@ public class RuleDocGeneratorTest {
 
         root = Files.createTempDirectory("pmd-ruledocgenerator-test");
         Files.createDirectories(root.resolve("docs/_data/sidebars"));
-        try (Writer out = Files.newBufferedWriter(root.resolve("docs/_data/sidebars/pmd_sidebar.yml"), StandardCharsets.UTF_8)) {
-            IOUtils.write("entries:\n- title: sidebar\n  folders:\n  - title: 1\n  - title: 2\n  - title: Rules\n", out);
-        }
+        List<String> mockedSidebar = Arrays.asList(
+                "entries:",
+                "- title: sidebar",
+                "  folders:",
+                "  - title: 1",
+                "  - title: 2",
+                "  - title: Rules");
+        Files.write(root.resolve("docs/_data/sidebars/pmd_sidebar.yml"), mockedSidebar);
     }
 
     @After
@@ -74,17 +79,17 @@ public class RuleDocGeneratorTest {
 
         assertEquals(3, writer.getData().size());
         FileEntry languageIndex = writer.getData().get(0);
-        assertTrue(languageIndex.getFilename().endsWith("docs/pages/pmd/rules/java.md"));
+        assertTrue(FilenameUtils.normalize(languageIndex.getFilename(), true).endsWith("docs/pages/pmd/rules/java.md"));
         assertEquals(IOUtils.toString(RuleDocGeneratorTest.class.getResourceAsStream("/expected/java.md")),
                 languageIndex.getContent());
 
         FileEntry ruleSetIndex = writer.getData().get(1);
-        assertTrue(ruleSetIndex.getFilename().endsWith("docs/pages/pmd/rules/java/sample.md"));
+        assertTrue(FilenameUtils.normalize(ruleSetIndex.getFilename(), true).endsWith("docs/pages/pmd/rules/java/sample.md"));
         assertEquals(IOUtils.toString(RuleDocGeneratorTest.class.getResourceAsStream("/expected/sample.md")),
                 ruleSetIndex.getContent());
 
         FileEntry sidebar = writer.getData().get(2);
-        assertTrue(sidebar.getFilename().endsWith("docs/_data/sidebars/pmd_sidebar.yml"));
+        assertTrue(FilenameUtils.normalize(sidebar.getFilename(), true).endsWith("docs/_data/sidebars/pmd_sidebar.yml"));
         assertEquals(IOUtils.toString(RuleDocGeneratorTest.class.getResourceAsStream("/expected/pmd_sidebar.yml")),
                 sidebar.getContent());
     }

--- a/pmd-doc/src/test/java/net/sourceforge/pmd/docs/RuleSetResolverTest.java
+++ b/pmd-doc/src/test/java/net/sourceforge/pmd/docs/RuleSetResolverTest.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
+import org.apache.commons.io.FilenameUtils;
 import org.junit.Test;
 
 import net.sourceforge.pmd.RuleSetFactory;
@@ -22,7 +23,7 @@ public class RuleSetResolverTest {
     private static List<String> excludedRulesets = new ArrayList<>();
 
     static {
-        excludedRulesets.add("pmd-test/src/main/resources/rulesets/dummy/basic.xml");
+        excludedRulesets.add(FilenameUtils.normalize("pmd-test/src/main/resources/rulesets/dummy/basic.xml"));
     }
 
     @Test

--- a/pmd-doc/src/test/java/net/sourceforge/pmd/docs/SidebarGeneratorTest.java
+++ b/pmd-doc/src/test/java/net/sourceforge/pmd/docs/SidebarGeneratorTest.java
@@ -15,10 +15,12 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.SystemUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.DumperOptions.FlowStyle;
+import org.yaml.snakeyaml.DumperOptions.LineBreak;
 import org.yaml.snakeyaml.Yaml;
 
 import net.sourceforge.pmd.RuleSet;
@@ -47,6 +49,9 @@ public class SidebarGeneratorTest {
 
         DumperOptions options = new DumperOptions();
         options.setDefaultFlowStyle(FlowStyle.BLOCK);
+        if (SystemUtils.IS_OS_WINDOWS) {
+            options.setLineBreak(LineBreak.WIN);
+        }
         String yaml = new Yaml(options).dump(result);
 
         assertEquals(IOUtils.toString(SidebarGeneratorTest.class.getResourceAsStream("sidebar.yml")), yaml);


### PR DESCRIPTION
This fixes #848 
There were several issues:
* line endings
* path names (filtering the names for the rulesets, generating the editme-links, etc.)
* a file handle leak

I've verified the build now under Windows. Currently, the generated documentation (under `docs/...`) is exactly the same as it is being generated under Linux.

This PR is not strictly required for 6.0.1, since it fixes the build under Windows and doesn't change anything else. But I think, it also wouldn't do any harm.

For now, I've selected milestone 6.1.0.
