### PR TITLE
[core] Log all rules' movements to categories

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URISyntaxException;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -14,14 +13,11 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import org.apache.commons.io.IOUtils;
 
 import net.sourceforge.pmd.benchmark.Benchmark;
 import net.sourceforge.pmd.benchmark.Benchmarker;
@@ -79,8 +75,10 @@ public class PMD {
 
     /**
      * Constant that contains always the current version of PMD.
+     * @deprecated Use {@link PMDVersion#VERSION} instead.
      */
-    public static final String VERSION;
+    @Deprecated // to be removed with PMD 7.0.0.
+    public static final String VERSION = PMDVersion.VERSION;
 
     /**
      * Create a PMD instance using a default Configuration. Changes to the
@@ -475,29 +473,5 @@ public class PMD {
             }
         }
         return status;
-    }
-
-    /**
-     * Determines the version from maven's generated pom.properties file.
-     */
-    static {
-        String pmdVersion = null;
-        InputStream stream = PMD.class
-                .getResourceAsStream("/META-INF/maven/net.sourceforge.pmd/pmd-core/pom.properties");
-        if (stream != null) {
-            try {
-                Properties properties = new Properties();
-                properties.load(stream);
-                pmdVersion = properties.getProperty("version");
-            } catch (IOException e) {
-                LOG.log(Level.FINE, "Couldn't determine version of PMD", e);
-            } finally {
-                IOUtils.closeQuietly(stream);
-            }
-        }
-        if (pmdVersion == null) {
-            pmdVersion = "unknown";
-        }
-        VERSION = pmdVersion;
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMDVersion.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMDVersion.java
@@ -1,0 +1,57 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Stores the current PMD version and provides utility methods around it.
+ */
+public final class PMDVersion {
+
+    private static final Logger LOG = Logger.getLogger(PMDVersion.class.getName());
+    
+    /**
+     * Constant that contains always the current version of PMD.
+     */
+    public static final String VERSION;
+    
+    private static final String UNKNOWN_VERSION = "unknown";
+    
+    /**
+     * Determines the version from maven's generated pom.properties file.
+     */
+    static {
+        String pmdVersion = UNKNOWN_VERSION;
+        try (InputStream stream = PMDVersion.class.getResourceAsStream("/META-INF/maven/net.sourceforge.pmd/pmd-core/pom.properties")) {
+            if (stream != null) {
+                final Properties properties = new Properties();
+                properties.load(stream);
+                pmdVersion = properties.getProperty("version");
+            }   
+        } catch (final IOException e) {
+            LOG.log(Level.FINE, "Couldn't determine version of PMD", e);
+        }
+        
+        VERSION = pmdVersion;
+    }
+    
+    private PMDVersion() {
+        throw new AssertionError("Can't instantiate utility classes");
+    }
+    
+    public static String getNextMajorRelease() {
+        if (UNKNOWN_VERSION.equals(VERSION)) {
+            return UNKNOWN_VERSION;
+        }
+        
+        final int major = Integer.parseInt(VERSION.split("\\.")[0]);
+        return (major + 1) + ".0.0";
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
@@ -523,7 +523,7 @@ public class RuleSetFactory {
         if (!potentialRules.isEmpty() && potentialRules.size() == countDeprecated) {
             // all rules in the ruleset have been deprecated - the ruleset itself is considered to be deprecated
             rulesetDeprecated = true;
-            LOG.warning("The RuleSet " + ref + " has been deprecated.");
+            LOG.warning("The RuleSet " + ref + " has been deprecated and will be removed in PMD " + PMDVersion.getNextMajorRelease());
         }
 
         for (RuleReference r : potentialRules) {
@@ -623,19 +623,22 @@ public class RuleSetFactory {
                     LOG.warning("Use Rule name " + ruleReference.getRuleSetReference().getRuleSetFileName() + "/"
                             + ruleReference.getOriginalName() + " instead of the deprecated Rule name "
                             + otherRuleSetReferenceId
-                            + ". Future versions of PMD will remove support for this deprecated Rule name usage.");
+                            + ". PMD " + PMDVersion.getNextMajorRelease()
+                            + " will remove support for this deprecated Rule name usage.");
                 }
             } else if (referencedRule instanceof MockRule) {
                 if (LOG.isLoggable(Level.WARNING)) {
                     LOG.warning("Discontinue using Rule name " + otherRuleSetReferenceId
                             + " as it has been removed from PMD and no longer functions."
-                            + " Future versions of PMD will remove support for this Rule.");
+                            + " PMD " + PMDVersion.getNextMajorRelease()
+                            + " will remove support for this Rule.");
                 }
             } else {
                 if (LOG.isLoggable(Level.WARNING)) {
                     LOG.warning("Discontinue using Rule name " + otherRuleSetReferenceId
                             + " as it is scheduled for removal from PMD."
-                            + " Future versions of PMD will remove support for this Rule.");
+                            + " PMD " + PMDVersion.getNextMajorRelease()
+                            + " will remove support for this Rule.");
                 }
             }
         }
@@ -645,6 +648,15 @@ public class RuleSetFactory {
         RuleReference ruleReference = new RuleFactory().decorateRule(referencedRule, ruleElement);
         ruleReference.setRuleSetReference(ruleSetReference);
 
+        if (warnDeprecated && ruleReference.isDeprecated()) {
+            if (LOG.isLoggable(Level.WARNING)) {
+                LOG.warning("Use Rule name " + ruleReference.getRuleSetReference().getRuleSetFileName() + "/"
+                        + ruleReference.getOriginalName() + " instead of the deprecated Rule name "
+                        + ruleSetReferenceId.getRuleSetFileName() + "/" + ruleReference.getName()
+                        + ". PMD " + PMDVersion.getNextMajorRelease()
+                        + " will remove support for this deprecated Rule name usage.");
+            }
+        }
 
         if (withDeprecatedRuleReferences || !isSameRuleSet || !ruleReference.isDeprecated()) {
             ruleSetBuilder.addRuleReplaceIfExists(ruleReference);


### PR DESCRIPTION
 - All rules will log where they where moved to, even if the ruleset is referenced as a whole
 - All deprecation warnings now let's users know on which version support will be removed.

This may be a little noisier, but may help reduce anxiety caused in users, by letting them know when things will break; and how to reference each loaded rule under the new category system.