### PR TITLE
[core] Support shortnames when using filelist

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/datasource/FileDataSource.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/datasource/FileDataSource.java
@@ -37,14 +37,19 @@ public class FileDataSource implements DataSource {
     }
 
     private String glomName(boolean shortNames, String inputFileName, File file) {
-        if (shortNames && inputFileName.indexOf(',') == -1) {
-            if (new File(inputFileName).isDirectory()) {
-                return trimAnyPathSep(file.getPath().substring(inputFileName.length()));
-            } else {
-                if (inputFileName.indexOf(FILE_SEPARATOR.charAt(0)) == -1) {
-                    return inputFileName;
+        if (shortNames) {
+            if (inputFileName != null && inputFileName.indexOf(',') == -1) {
+                if (new File(inputFileName).isDirectory()) {
+                    return trimAnyPathSep(file.getPath().substring(inputFileName.length()));
+                } else {
+                    if (inputFileName.indexOf(FILE_SEPARATOR.charAt(0)) == -1) {
+                        return inputFileName;
+                    }
+                    return trimAnyPathSep(inputFileName.substring(inputFileName.lastIndexOf(FILE_SEPARATOR)));
                 }
-                return trimAnyPathSep(inputFileName.substring(inputFileName.lastIndexOf(FILE_SEPARATOR)));
+            } else {
+                // if the 'master' file is not specified, just use the file name
+                return file.getName();
             }
         }
 


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `mvn test` passes.
 - [x] `mvn checkstyle:check` passes. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
This pull request attempts a fix to issue #872.
The `inputFileName` ('master' file) parameter may be null,
in which case the `getNiceFileName` function should return just the file name if short name is required.

