### PR TITLE
[core] Add getXPathNodeName to the Node interface

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -23,12 +23,25 @@ This is a minor release.
 
 *   all
     *   [#848](https://github.com/pmd/pmd/issues/848): \[doc] Test failures when building pmd-doc under Windows
+    *   [#569](https://github.com/pmd/pmd/issues/569): \[core] XPath support requires specific toString implementations
 *   doc
     *   [#791](https://github.com/pmd/pmd/issues/791): \[doc] Documentation site reorganisation
 
 ### API Changes
 
+#### Changes to the Node interface
+
+The method `getXPathNodeName` is added to the `Node` interface, which removes the
+use of the `toString` of a node to get its XPath element name (see [#569](https://github.com/pmd/pmd/issues/569)).
+A default implementation is provided in `AbstractNode`, to stay compatible
+with existing implementors.
+
+The `toString` method of a Node is not changed for the time being, and still produces
+the name of the XPath node. That behaviour may however change in future major releases,
+e.g. to produce a more useful message for debugging.
+
 ### External Contributions
+
 
 *   [#790](https://github.com/pmd/pmd/pull/790): \[java] Added some comments for JDK 9 - [Tobias Weimer](https://github.com/tweimer)
 *   [#803](https://github.com/pmd/pmd/pull/803): \[doc] Added SpotBugs as successor of FindBugs - [Tobias Weimer](https://github.com/tweimer)

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNode.java
@@ -135,7 +135,6 @@ public abstract class AbstractApexNode<T extends AstNode> extends AbstractNode i
 
     @Override
     public final String getXPathNodeName() {
-        new ASTMapEntryNode(null).toString();
         return this.getClass().getSimpleName().replaceFirst("^AST", "");
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNode.java
@@ -130,14 +130,12 @@ public abstract class AbstractApexNode<T extends AstNode> extends AbstractNode i
         }
     }
 
-    @Override
-    public String toString() {
-        return getXPathNodeName();
-    }
+
 
 
     @Override
     public final String getXPathNodeName() {
+        new ASTMapEntryNode(null).toString();
         return this.getClass().getSimpleName().replaceFirst("^AST", "");
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNode.java
@@ -132,8 +132,15 @@ public abstract class AbstractApexNode<T extends AstNode> extends AbstractNode i
 
     @Override
     public String toString() {
+        return getXPathNodeName();
+    }
+
+
+    @Override
+    public final String getXPathNodeName() {
         return this.getClass().getSimpleName().replaceFirst("^AST", "");
     }
+
 
     public String getLocation() {
         if (hasRealLoc()) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/DumpFacade.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/DumpFacade.java
@@ -49,7 +49,7 @@ public class DumpFacade {
         writer.print(prefix);
 
         // 2) JJT Name of the Node
-        writer.print(node.toString());
+        writer.print(node.getXPathNodeName());
 
         //
         // If there are any additional details, then:

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.ast;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-
+import java.util.logging.Logger;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -18,11 +18,15 @@ import org.jaxen.JaxenException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+import net.sourceforge.pmd.PMDVersion;
 import net.sourceforge.pmd.lang.ast.xpath.Attribute;
 import net.sourceforge.pmd.lang.ast.xpath.DocumentNavigator;
 import net.sourceforge.pmd.lang.dfa.DataFlowNode;
 
 public abstract class AbstractNode implements Node {
+
+    private static final Logger LOG = Logger.getLogger(AbstractNode.class.getName());
+
 
     protected Node parent;
     protected Node[] children;
@@ -448,6 +452,23 @@ public abstract class AbstractNode implements Node {
      */
     @Override
     public String getXPathNodeName() {
+        LOG.warning("getXPathNodeName should be overriden in classes derived from AbstractNode. " +
+                            "The implementation is provided for compatibility with existing implementors," +
+                            "but could be declared abstract as soon as release " + PMDVersion.getNextMajorRelease()
+                            + ".");
         return toString();
+    }
+
+
+    /**
+     * {@inheritDoc}
+     *
+     * @deprecated The equivalence between toString and a node's name could be broken as soon as release 7.0.0.
+     *  Use getXPathNodeName for that purpose. The use for debugging purposes is not deprecated.
+     */
+    @Deprecated
+    @Override
+    public String toString() {
+        return getXPathNodeName();
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
@@ -114,13 +114,6 @@ public abstract class AbstractNode implements Node {
         return id;
     }
 
-    /**
-     * Subclasses should implement this method to return a name usable with
-     * XPathRule for evaluating Element Names.
-     */
-    @Override
-    public abstract String toString();
-
     @Override
     public String getImage() {
         return image;
@@ -442,5 +435,19 @@ public abstract class AbstractNode implements Node {
                 jjtGetChild(i).jjtSetChildIndex(i);
             }
         }
+    }
+
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This default implementation adds compatibility with the previous
+     * way to get the xpath node name, which used {@link Object#toString()}.
+     *
+     * <p>Please override it. It may be removed in a future major version.
+     */
+    @Override
+    public String getXPathNodeName() {
+        return toString();
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
@@ -451,6 +451,7 @@ public abstract class AbstractNode implements Node {
      * <p>Please override it. It may be removed in a future major version.
      */
     @Override
+    // @Deprecated // FUTURE 7.0.0 make abstract
     public String getXPathNodeName() {
         LOG.warning("getXPathNodeName should be overriden in classes derived from AbstractNode. " +
                             "The implementation is provided for compatibility with existing implementors," +

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
@@ -453,9 +453,9 @@ public abstract class AbstractNode implements Node {
     @Override
     // @Deprecated // FUTURE 7.0.0 make abstract
     public String getXPathNodeName() {
-        LOG.warning("getXPathNodeName should be overriden in classes derived from AbstractNode. " +
-                            "The implementation is provided for compatibility with existing implementors," +
-                            "but could be declared abstract as soon as release " + PMDVersion.getNextMajorRelease()
+        LOG.warning("getXPathNodeName should be overriden in classes derived from AbstractNode. "
+                            + "The implementation is provided for compatibility with existing implementors,"
+                            + "but could be declared abstract as soon as release " + PMDVersion.getNextMajorRelease()
                             + ".");
         return toString();
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/Node.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/Node.java
@@ -281,4 +281,12 @@ public interface Node {
      *          The index of the child to be removed
      */
     void removeChildAtIndex(int childIndex);
+
+
+    /**
+     * Gets the name of the node that is used to match it with XPath queries.
+     *
+     * @return The XPath node name
+     */
+    String getXPathNodeName();
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/AttributeAxisIterator.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/AttributeAxisIterator.java
@@ -105,7 +105,7 @@ public class AttributeAxisIterator implements Iterator<Attribute> {
         = new HashSet<>(Arrays.<Class<?>>asList(Integer.TYPE, Boolean.TYPE, Double.TYPE, String.class, Long.TYPE, Character.TYPE, Float.TYPE));
     
     private static final Set<String> FILTERED_OUT_NAMES 
-        = new HashSet<>(Arrays.asList("toString", "getClass", "getTypeNameNode", "hashCode", "getImportedNameNode", "getScope"));
+        = new HashSet<>(Arrays.asList("toString", "getClass", "getXPathNodeName", "getTypeNameNode", "hashCode", "getImportedNameNode", "getScope"));
     
     protected boolean isAttributeAccessor(Method method) {
         String methodName = method.getName();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/DocumentNavigator.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/DocumentNavigator.java
@@ -48,7 +48,7 @@ public class DocumentNavigator extends DefaultNavigator {
 
     @Override
     public String getElementName(Object node) {
-        return node.toString();
+        return ((Node) node).getXPathNodeName();
     }
 
     @Override

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/saxon/ElementNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/saxon/ElementNode.java
@@ -83,7 +83,7 @@ public class ElementNode extends AbstractNodeInfo {
 
     @Override
     public String getLocalPart() {
-        return node.toString();
+        return node.getXPathNodeName();
     }
 
     @Override

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRuleChainVisitor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRuleChainVisitor.java
@@ -112,7 +112,7 @@ public abstract class AbstractRuleChainVisitor implements RuleChainVisitor {
      * Index a single node for visitation by rules.
      */
     protected void indexNode(Node node) {
-        List<Node> nodes = nodeNameToNodes.get(node.toString());
+        List<Node> nodes = nodeNameToNodes.get(node.getXPathNodeName());
         if (nodes != null) {
             nodes.add(node);
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/JaxenXPathRuleQuery.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/JaxenXPathRuleQuery.java
@@ -70,7 +70,7 @@ public class JaxenXPathRuleQuery extends AbstractXPathRuleQuery {
         try {
             initializeXPathExpression(
                     data.getLanguageVersion().getLanguageVersionHandler().getXPathHandler().getNavigator());
-            List<XPath> xpaths = nodeNameToXPaths.get(node.toString());
+            List<XPath> xpaths = nodeNameToXPaths.get(node.getXPathNodeName());
             if (xpaths == null) {
                 xpaths = nodeNameToXPaths.get(AST_ROOT);
             }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/jaxen/MatchesFunctionTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/jaxen/MatchesFunctionTest.java
@@ -26,7 +26,6 @@ public class MatchesFunctionTest {
             super(1);
         }
 
-        @Deprecated
         @Override
         public String toString() {
             return "MyNode";

--- a/pmd-core/src/test/java/net/sourceforge/pmd/jaxen/MatchesFunctionTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/jaxen/MatchesFunctionTest.java
@@ -26,6 +26,7 @@ public class MatchesFunctionTest {
             super(1);
         }
 
+        @Deprecated
         @Override
         public String toString() {
             return "MyNode";

--- a/pmd-core/src/test/java/net/sourceforge/pmd/jaxen/MatchesFunctionTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/jaxen/MatchesFunctionTest.java
@@ -38,6 +38,12 @@ public class MatchesFunctionTest {
         public String getClassName() {
             return className;
         }
+
+
+        @Override
+        public String getXPathNodeName() {
+            return "MyNode";
+        }
     }
 
     @Test

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNode.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNode.java
@@ -9,7 +9,6 @@ public class DummyNode extends AbstractNode {
         super(id);
     }
 
-    @Deprecated
     @Override
     public String toString() {
         return "dummyNode";

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNode.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNode.java
@@ -13,4 +13,9 @@ public class DummyNode extends AbstractNode {
     public String toString() {
         return "dummyNode";
     }
+
+    @Override
+    public String getXPathNodeName() {
+        return "dummyNode";
+    }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNode.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNode.java
@@ -9,6 +9,7 @@ public class DummyNode extends AbstractNode {
         super(id);
     }
 
+    @Deprecated
     @Override
     public String toString() {
         return "dummyNode";

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractJavaNode.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractJavaNode.java
@@ -78,10 +78,7 @@ public abstract class AbstractJavaNode extends AbstractNode implements JavaNode 
         return comment;
     }
 
-    @Override
-    public String toString() {
-        return getXPathNodeName();
-    }
+
 
     @Override
     public final String getXPathNodeName() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractJavaNode.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractJavaNode.java
@@ -78,7 +78,13 @@ public abstract class AbstractJavaNode extends AbstractNode implements JavaNode 
         return comment;
     }
 
+    @Override
     public String toString() {
+        return getXPathNodeName();
+    }
+
+    @Override
+    public final String getXPathNodeName() {
         return JavaParserTreeConstants.jjtNodeName[id];
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/Comment.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/Comment.java
@@ -23,7 +23,6 @@ public abstract class Comment extends AbstractNode {
         }
     }
 
-    @Deprecated
     public String toString() {
         return getImage();
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/Comment.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/Comment.java
@@ -23,6 +23,7 @@ public abstract class Comment extends AbstractNode {
         }
     }
 
+    @Deprecated
     public String toString() {
         return getImage();
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/DumpFacade.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/DumpFacade.java
@@ -45,7 +45,7 @@ public class DumpFacade extends JavaParserVisitorAdapter {
         writer.print(prefix);
 
         // 2) JJT Name of the Node
-        writer.print(node.toString());
+        writer.print(node.getXPathNodeName());
 
         //
         // If there are any additional details, then:

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/FormalComment.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/FormalComment.java
@@ -10,4 +10,9 @@ public class FormalComment extends Comment {
         super(t);
     }
 
+
+    @Override
+    public String getXPathNodeName() {
+        return "FormalComment";
+    }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavadocElement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavadocElement.java
@@ -21,10 +21,7 @@ public class JavadocElement extends AbstractNode {
         return tag;
     }
 
-    @Override
-    public String toString() {
-        return getXPathNodeName();
-    }
+
 
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavadocElement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavadocElement.java
@@ -23,6 +23,12 @@ public class JavadocElement extends AbstractNode {
 
     @Override
     public String toString() {
+        return getXPathNodeName();
+    }
+
+
+    @Override
+    public String getXPathNodeName() {
         return tag.label + " : " + tag.description;
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/MultiLineComment.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/MultiLineComment.java
@@ -10,4 +10,10 @@ public class MultiLineComment extends Comment {
         super(t);
     }
 
+
+    @Override
+    public String getXPathNodeName() {
+        return "MultiLineComment";
+    }
+
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/SingleLineComment.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/SingleLineComment.java
@@ -10,4 +10,9 @@ public class SingleLineComment extends Comment {
         super(t);
     }
 
+
+    @Override
+    public String getXPathNodeName() {
+        return "SingleLineComment";
+    }
 }

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/AbstractEcmascriptNode.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/AbstractEcmascriptNode.java
@@ -70,6 +70,12 @@ public abstract class AbstractEcmascriptNode<T extends AstNode> extends Abstract
 
     @Override
     public String toString() {
+        return getXPathNodeName();
+    }
+
+
+    @Override
+    public String getXPathNodeName() {
         return node.shortName();
     }
 }

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/AbstractEcmascriptNode.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/AbstractEcmascriptNode.java
@@ -68,10 +68,7 @@ public abstract class AbstractEcmascriptNode<T extends AstNode> extends Abstract
         return node.hasSideEffects();
     }
 
-    @Override
-    public String toString() {
-        return getXPathNodeName();
-    }
+
 
 
     @Override

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/DumpFacade.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/DumpFacade.java
@@ -49,7 +49,7 @@ public class DumpFacade {
         writer.print(prefix);
 
         // 2) JJT Name of the Node
-        writer.print(node.toString());
+        writer.print(node.getXPathNodeName());
 
         //
         // If there are any additional details, then:

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/AbstractJspNode.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/AbstractJspNode.java
@@ -56,9 +56,7 @@ public abstract class AbstractJspNode extends AbstractNode implements JspNode {
         return data;
     }
 
-    public String toString() {
-        return getXPathNodeName();
-    }
+
 
 
     @Override

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/AbstractJspNode.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/AbstractJspNode.java
@@ -6,7 +6,7 @@ package net.sourceforge.pmd.lang.jsp.ast;
 
 import net.sourceforge.pmd.lang.ast.AbstractNode;
 
-public class AbstractJspNode extends AbstractNode implements JspNode {
+public abstract class AbstractJspNode extends AbstractNode implements JspNode {
 
     protected JspParser parser;
 
@@ -57,6 +57,12 @@ public class AbstractJspNode extends AbstractNode implements JspNode {
     }
 
     public String toString() {
+        return getXPathNodeName();
+    }
+
+
+    @Override
+    public String getXPathNodeName() {
         return JspParserTreeConstants.jjtNodeName[id];
     }
 }

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/AbstractJspNode.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/AbstractJspNode.java
@@ -6,7 +6,7 @@ package net.sourceforge.pmd.lang.jsp.ast;
 
 import net.sourceforge.pmd.lang.ast.AbstractNode;
 
-public abstract class AbstractJspNode extends AbstractNode implements JspNode {
+public class AbstractJspNode extends AbstractNode implements JspNode {
 
     protected JspParser parser;
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/DumpFacade.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/DumpFacade.java
@@ -47,7 +47,7 @@ public class DumpFacade extends JspParserVisitorAdapter {
         writer.print(prefix);
 
         // 2) JJT Name of the Node
-        writer.print(node.toString());
+        writer.print(node.getXPathNodeName());
 
         //
         // If there are any additional details, then:

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/AbstractPLSQLNode.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/AbstractPLSQLNode.java
@@ -77,9 +77,7 @@ public abstract class AbstractPLSQLNode extends net.sourceforge.pmd.lang.ast.Abs
      * otherwise overriding toString() is probably all you need to do.
      */
 
-    public String toString() {
-        return getXPathNodeName();
-    }
+
 
     public String toString(String prefix) {
         return prefix + toString();

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/AbstractPLSQLNode.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/AbstractPLSQLNode.java
@@ -64,6 +64,12 @@ public abstract class AbstractPLSQLNode extends net.sourceforge.pmd.lang.ast.Abs
         return data;
     }
 
+
+    @Override
+    public String getXPathNodeName() {
+        return PLSQLParserTreeConstants.jjtNodeName[id];
+    }
+
     /*
      * You can override these two methods in subclasses of SimpleNode to
      * customize the way the node appears when the tree is dumped. If your
@@ -72,7 +78,7 @@ public abstract class AbstractPLSQLNode extends net.sourceforge.pmd.lang.ast.Abs
      */
 
     public String toString() {
-        return PLSQLParserTreeConstants.jjtNodeName[id];
+        return getXPathNodeName();
     }
 
     public String toString(String prefix) {

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/DumpFacade.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/DumpFacade.java
@@ -45,7 +45,7 @@ public class DumpFacade extends PLSQLParserVisitorAdapter {
         writer.print(prefix);
 
         // 2) JJT Name of the Node
-        writer.print(node.toString());
+        writer.print(node.getXPathNodeName());
 
         //
         // If there are any additional details, then:

--- a/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/ast/DummyNode.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/ast/DummyNode.java
@@ -15,4 +15,10 @@ public class DummyNode extends AbstractNode {
     public String toString() {
         return "dummyNode";
     }
+
+
+    @Override
+    public String getXPathNodeName() {
+        return "dummyNode";
+    }
 }

--- a/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/ast/DummyNode.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/ast/DummyNode.java
@@ -11,6 +11,7 @@ public class DummyNode extends AbstractNode {
         super(id);
     }
 
+    @Deprecated
     @Override
     public String toString() {
         return "dummyNode";

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/ast/AbstractVFNode.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/ast/AbstractVFNode.java
@@ -56,9 +56,7 @@ public abstract class AbstractVFNode extends AbstractNode implements VfNode {
         return data;
     }
 
-    public String toString() {
-        return getXPathNodeName();
-    }
+
 
 
     @Override

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/ast/AbstractVFNode.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/ast/AbstractVFNode.java
@@ -6,7 +6,7 @@ package net.sourceforge.pmd.lang.vf.ast;
 
 import net.sourceforge.pmd.lang.ast.AbstractNode;
 
-public class AbstractVFNode extends AbstractNode implements VfNode {
+public abstract class AbstractVFNode extends AbstractNode implements VfNode {
 
     protected VfParser parser;
 
@@ -57,6 +57,12 @@ public class AbstractVFNode extends AbstractNode implements VfNode {
     }
 
     public String toString() {
+        return getXPathNodeName();
+    }
+
+
+    @Override
+    public String getXPathNodeName() {
         return VfParserTreeConstants.jjtNodeName[id];
     }
 }

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/ast/AbstractVFNode.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/ast/AbstractVFNode.java
@@ -6,7 +6,7 @@ package net.sourceforge.pmd.lang.vf.ast;
 
 import net.sourceforge.pmd.lang.ast.AbstractNode;
 
-public abstract class AbstractVFNode extends AbstractNode implements VfNode {
+public class AbstractVFNode extends AbstractNode implements VfNode {
 
     protected VfParser parser;
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/ast/DumpFacade.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/ast/DumpFacade.java
@@ -47,7 +47,7 @@ public class DumpFacade extends VfParserVisitorAdapter {
         writer.print(prefix);
 
         // 2) JJT Name of the Node
-        writer.print(node.toString());
+        writer.print(node.getXPathNodeName());
 
         //
         // If there are any additional details, then:

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/ast/ASTDirective.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/ast/ASTDirective.java
@@ -81,6 +81,7 @@ public class ASTDirective extends AbstractVmNode {
     /**
      * @since 1.5
      */
+    @Deprecated
     @Override
     public String toString() {
         return new ToStringBuilder(this).appendSuper(super.toString()).append("directiveName", getDirectiveName())

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/ast/AbstractVmNode.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/ast/AbstractVmNode.java
@@ -121,6 +121,12 @@ public class AbstractVmNode extends AbstractNode implements VmNode {
         return data;
     }
 
+
+    @Override
+    public String getXPathNodeName() {
+        return VmParserTreeConstants.jjtNodeName[id];
+    }
+
     /*
      * You can override these two methods in subclasses of SimpleNode to
      * customize the way the node appears when the tree is dumped. If your
@@ -129,7 +135,7 @@ public class AbstractVmNode extends AbstractNode implements VmNode {
      */
 
     public String toString() {
-        return VmParserTreeConstants.jjtNodeName[id];
+        return getXPathNodeName();
     }
 
     /**

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/ast/AbstractVmNode.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/ast/AbstractVmNode.java
@@ -134,9 +134,7 @@ public class AbstractVmNode extends AbstractNode implements VmNode {
      * otherwise overriding toString() is probably all you need to do.
      */
 
-    public String toString() {
-        return getXPathNodeName();
-    }
+
 
     /**
      * @param prefix

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/DumpFacade.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/DumpFacade.java
@@ -51,7 +51,7 @@ public class DumpFacade {
         writer.print(prefix);
 
         // 2) JJT Name of the Node
-        writer.print(node.toString());
+        writer.print(node.getXPathNodeName());
 
         //
         // If there are any additional details, then:

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/XmlNodeInvocationHandler.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/XmlNodeInvocationHandler.java
@@ -121,17 +121,16 @@ public class XmlNodeInvocationHandler implements InvocationHandler {
                 return null;
             } else if ("isFindBoundary".equals(method.getName())) {
                 return false;
+            } else if ("getXPathNodeName".equals(method.getName())) {
+                return node.getNodeName().replace("#", "");
             }
             throw new UnsupportedOperationException("Method not supported for XmlNode: " + method);
         } else {
             if ("toString".equals(method.getName())) {
-                String s = node.getNodeName();
-                s = s.replace("#", "");
-                return s;
+                return node.getNodeName().replace("#", "");
             }
             // Delegate method
-            Object result = method.invoke(node, args);
-            return result;
+            return method.invoke(node, args);
         }
     }
 


### PR DESCRIPTION
A default implementation is available in AbstractNode to preserve compatibility with the previous way, which
used Object.toString.

Fixes #569