### PR TITLE
[java] Make Excessive*Length consider all type declarations and constructors

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -26,6 +26,8 @@ This is a minor release.
     *   [#569](https://github.com/pmd/pmd/issues/569): \[core] XPath support requires specific toString implementations
 *   doc
     *   [#791](https://github.com/pmd/pmd/issues/791): \[doc] Documentation site reorganisation
+*   java
+    *   [#825](https://github.com/pmd/pmd/issues/825): \[java] Excessive*Length ignores too much
 
 ### API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveClassLengthRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveClassLengthRule.java
@@ -4,7 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.design;
 
-import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
 
 /**
  * This rule detects when a class exceeds a certain threshold. i.e. if a class
@@ -12,7 +12,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
  */
 public class ExcessiveClassLengthRule extends ExcessiveLengthRule {
     public ExcessiveClassLengthRule() {
-        super(ASTClassOrInterfaceDeclaration.class);
+        super(ASTAnyTypeDeclaration.class);
         setProperty(MINIMUM_DESCRIPTOR, 1000d);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveMethodLengthRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveMethodLengthRule.java
@@ -4,7 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.design;
 
-import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodOrConstructorDeclaration;
+
 
 /**
  * This rule detects when a method exceeds a certain threshold. i.e. if a method
@@ -12,7 +13,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
  */
 public class ExcessiveMethodLengthRule extends ExcessiveLengthRule {
     public ExcessiveMethodLengthRule() {
-        super(ASTMethodDeclaration.class);
+        super(ASTMethodOrConstructorDeclaration.class);
         setProperty(MINIMUM_DESCRIPTOR, 100d);
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ExcessiveClassLength.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ExcessiveClassLength.xml
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <test-data
-    xmlns="http://pmd.sourceforge.net/rule-tests"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
     <test-code>
-        <description><![CDATA[
-short
-     ]]></description>
+        <description>short</description>
         <rule-property name="minimum">10</rule-property>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
@@ -34,19 +32,47 @@ public class Foo {
 }
  ]]></code-fragment>
     <test-code>
-        <description><![CDATA[
-long
-     ]]></description>
+        <description>long</description>
         <rule-property name="minimum">10</rule-property>
         <expected-problems>1</expected-problems>
         <code-ref id="long"/>
     </test-code>
     <test-code>
-        <description><![CDATA[
-long class - changed minimum
-     ]]></description>
+        <description>long class - changed minimum</description>
         <rule-property name="minimum">2000</rule-property>
         <expected-problems>0</expected-problems>
         <code-ref id="long"/>
     </test-code>
+
+
+    <test-code>
+        <description>Consider enum types, refs #825</description>
+        <rule-property name="minimum">4</rule-property>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+        public enum Foo {
+             CONST;
+            // foo
+            // foo
+            // foo
+            // foo
+        }
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Consider annotation types, refs #825</description>
+        <rule-property name="minimum">4</rule-property>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+        public @interface Foo {
+            String name();
+            // foo
+            // foo
+            // foo
+            // foo
+        }
+     ]]></code>
+    </test-code>
+
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ExcessiveMethodLength.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ExcessiveMethodLength.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <test-data
-    xmlns="http://pmd.sourceforge.net/rule-tests"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
     <test-code>
         <description><![CDATA[
 short
@@ -43,17 +43,13 @@ long, normal range
         <code-ref id="long"/>
     </test-code>
     <test-code>
-        <description><![CDATA[
-long, minimum with longer range
-     ]]></description>
+        <description>long, minimum with longer range</description>
         <rule-property name="minimum">20</rule-property>
         <expected-problems>0</expected-problems>
         <code-ref id="long"/>
     </test-code>
     <test-code>
-        <description><![CDATA[
-not quite long
-     ]]></description>
+        <description>not quite long</description>
         <rule-property name="minimum">10</rule-property>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
@@ -72,14 +68,12 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-long
-     ]]></description>
+        <description>Consider constructors, refs #825</description>
         <rule-property name="minimum">10</rule-property>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Foo {
-    public static void main(String args[]) {
+    public Foo(String args[]) {
 	  bar();
 	  bar();
 	  bar();
@@ -95,7 +89,11 @@ public class Foo {
 	  bar();
 	  bar();
 	  bar();
-    } // > 10 lines - Not a violation
+	  bar();
+	  bar();
+	  bar();
+	  bar();
+    }
 }
      ]]></code>
     </test-code>


### PR DESCRIPTION
Resolves #825. 

I'll do another PR for the new rule replacing ExcessiveClassLength and ExcessiveMethodLength

