### PR TITLE
[java] Fix #885

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CompareObjectsWithEqualsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CompareObjectsWithEqualsRule.java
@@ -84,7 +84,9 @@ public class CompareObjectsWithEqualsRule extends AbstractJavaRule {
                 ASTReferenceType type1 = ((Node) nd1.getAccessNodeParent())
                         .getFirstDescendantOfType(ASTReferenceType.class);
                 // skip, if it is an enum
-                if (type0.getType() != null && type0.getType().equals(type1.getType()) && type0.getType().isEnum()) {
+                if (type0.getType() != null && type0.getType().equals(type1.getType())
+                    // It may be a custom enum class or an explicit Enum class usage
+                    && (type0.getType().isEnum() || type0.getType() == java.lang.Enum.class)) {
                     return data;
                 }
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CompareObjectsWithEquals.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CompareObjectsWithEquals.xml
@@ -204,4 +204,16 @@ public class CompareWithEqualsTest {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>#885 CompareObjectsWithEquals fails with Enum class</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class CompareWithEqualsTest {
+   public static boolean test(Enum<?> a, Enum<?> b)
+   {
+      return a == b;
+   }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
**PR Description:**
Fix #885: `CompareObjectsWithEqualsRule` Java rule should not be triggered by enums.
Enum class exlicit usage was not being considered an Enum type in the rule.