### PR TITLE
[ci] Fix coveralls integration: run a install first

### DIFF
--- a/.travis/build-coveralls.sh
+++ b/.travis/build-coveralls.sh
@@ -16,4 +16,5 @@ fi
 # coveralls plugin seems to need java.xml.bind module
 # echo "MAVEN_OPTS='-Xms1g -Xmx1g --add-modules java.se.ee'" > ${HOME}/.mavenrc
 
-./mvnw clean test jacoco:report coveralls:report -Pcoveralls -B -V
+./mvnw clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+./mvnw test jacoco:report coveralls:report -Pcoveralls -B -V


### PR DESCRIPTION
I *think*, this fixes the following issue: Whenever we release a new PMD version, the coveralls step is failing on travis: e.g. the [6.0.1 release build](https://travis-ci.org/pmd/pmd/builds/331484137).

The error message is this:
`[ERROR] Failed to execute goal on project pmd-apex: Could not resolve dependencies for project net.sourceforge.pmd:pmd-apex:jar:6.0.1: Could not find artifact net.sourceforge.pmd:pmd-apex-jorje:jar:lib:6.0.1 in central (https://repo.maven.apache.org/maven2) -> [Help 1]`

This fix now runs first a `mvn install` to install all modules into the local repository and then execute the tests with coveralls in a second step.
