### PR TITLE
[java]  Fix ImmutableField false positive when lambda is in constructor 

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ImmutableFieldRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ImmutableFieldRule.java
@@ -40,7 +40,7 @@ public class ImmutableFieldRule extends AbstractLombokAwareRule {
         /** Variable is not changed outside the constructor. */
         IMMUTABLE,
         /** Variable is only written during declaration, if at all. */
-        CHECKDECL;
+        CHECKDECL
     }
 
     @Override
@@ -71,14 +71,14 @@ public class ImmutableFieldRule extends AbstractLombokAwareRule {
     }
 
     private boolean initializedWhenDeclared(VariableNameDeclaration field) {
-        return ((Node) field.getAccessNodeParent()).hasDescendantOfType(ASTVariableInitializer.class);
+        return field.getAccessNodeParent().hasDescendantOfType(ASTVariableInitializer.class);
     }
 
     private FieldImmutabilityType initializedInConstructor(List<NameOccurrence> usages, Set<ASTConstructorDeclaration> allConstructors) {
         FieldImmutabilityType result = FieldImmutabilityType.MUTABLE;
         int methodInitCount = 0;
         int lambdaUsage = 0;
-        Set<Node> consSet = new HashSet<>();
+        Set<ASTConstructorDeclaration> consSet = new HashSet<>(); // set of constructors accessing the field
         for (NameOccurrence occ : usages) {
             JavaNameOccurrence jocc = (JavaNameOccurrence) occ;
             if (jocc.isOnLeftHandSide() || jocc.isSelfAssignment()) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ImmutableFieldRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ImmutableFieldRule.java
@@ -98,6 +98,8 @@ public class ImmutableFieldRule extends AbstractLombokAwareRule {
                     }
                     if (inAnonymousInnerClass(node)) {
                         methodInitCount++;
+                    } else if (node.getFirstParentOfType(ASTLambdaExpression.class) != null) {
+                        lambdaUsage++;
                     } else {
                         consSet.add(constructor);
                     }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ImmutableField.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ImmutableField.xml
@@ -4,9 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
     <test-code>
-        <description><![CDATA[
-could be immutable, only assigned in constructor
-     ]]></description>
+        <description>Could be immutable, only assigned in constructor</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -18,9 +16,7 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-could be immutable, only assigned in decl
-     ]]></description>
+        <description>Could be immutable, only assigned in decl</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -29,9 +25,7 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-ok, assigned twice
-     ]]></description>
+        <description>Ok, assigned twice</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -46,9 +40,7 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-ok, static field 
-     ]]></description>
+        <description>Ok, static field </description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -62,9 +54,7 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-ok, one constructor assigns, one doesn't
-     ]]></description>
+        <description>Ok, one constructor assigns, one doesn't</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -77,9 +67,7 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-ok, assignment via postfix expression
-     ]]></description>
+        <description>Ok, assignment via postfix expression</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -90,9 +78,7 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-postfix expressions imply mutability
-     ]]></description>
+        <description>Postfix expressions imply mutability</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -104,9 +90,7 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-compound assignment
-     ]]></description>
+        <description>Compound assignment</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -123,9 +107,7 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-preincrement
-     ]]></description>
+        <description>Preincrement</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -137,9 +119,7 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-predecrement
-     ]]></description>
+        <description>Predecrement</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -151,9 +131,7 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-compound assignment 2
-     ]]></description>
+        <description>Compound assignment 2</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -165,9 +143,7 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-rhs 2
-     ]]></description>
+        <description>Rhs 2</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -179,9 +155,7 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-assignment in constructor is in try block
-     ]]></description>
+        <description>Assignment in constructor is in try block</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -195,9 +169,7 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-assignment in method is in try block
-     ]]></description>
+        <description>Assignment in method is in try block</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -211,9 +183,7 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-assignment in constructor in loop is ok
-     ]]></description>
+        <description>Assignment in constructor in loop is ok</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -225,9 +195,7 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-assignment in anonymous inner class method is OK
-     ]]></description>
+        <description>Assignment in anonymous inner class method is OK</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -244,9 +212,7 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-assignment through this
-     ]]></description>
+        <description>Assignment through this</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo{
@@ -265,9 +231,7 @@ public class Foo{
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-volatile variables can't be final
-     ]]></description>
+        <description>Volatile variables can't be final</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public final class Foo {
@@ -277,9 +241,7 @@ public final class Foo {
 }     ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-Bug 1740480, optional override of default value based on constructor argument check
-     ]]></description>
+        <description>Bug 1740480, optional override of default value based on constructor argument check</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class MyClass {
@@ -295,9 +257,7 @@ public class MyClass {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-Bug 1740480, assignment in single constructor based on constructor argument check
-     ]]></description>
+        <description>Bug 1740480, assignment in single constructor based on constructor argument check</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class MyClass {
@@ -314,9 +274,7 @@ public class MyClass {
      ]]></code>
     </test-code>
     <test-code>
-        <description>
-3526212, pmd-5.0.0: ImmutableField false positive on self-inc/dec
-        </description>
+        <description>3526212, pmd-5.0.0: ImmutableField false positive on self-inc/dec</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class pmd_inc {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ImmutableField.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ImmutableField.xml
@@ -409,4 +409,46 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#855 [java] ImmutableField: False positive within lambda</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            class Foo {
+                private Bar bar;
+
+                public Foo() {
+                    someMethod(() -> {
+                        bar = new Bar();
+                    });
+                }
+
+                private void someMethod(Runnable action) {
+                    action.run();
+                }
+
+                static class Bar {}
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#855 [java] ImmutableField: False positive within lambda (expression style)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            class Foo {
+                private Bar bar;
+
+                public Foo() {
+                    someMethod(() -> bar = new Bar());
+                }
+
+                private void someMethod(Runnable action) {
+                    action.run();
+                }
+
+                static class Bar {}
+            }
+            ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ImmutableField.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ImmutableField.xml
@@ -1,371 +1,426 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <test-data
-    xmlns="http://pmd.sourceforge.net/rule-tests"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
     <test-code>
         <description>Could be immutable, only assigned in constructor</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
-public class Foo {
- private int x;
- public Foo() {
-  x = 2;
- }
-}
-     ]]></code>
+            public class Foo {
+                private int x;
+
+                public Foo() {
+                    x = 2;
+                }
+            }
+            ]]></code>
     </test-code>
+
     <test-code>
         <description>Could be immutable, only assigned in decl</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
-public class Foo {
- private int x = 42;
-}
-     ]]></code>
+            public class Foo {
+                private int x = 42;
+            }
+            ]]></code>
     </test-code>
+
     <test-code>
         <description>Ok, assigned twice</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-public class Foo {
- private int x;
- public Foo() {
-  x = 41;
- }
- public void bar() {
-  x = 42;
- }
-}
-     ]]></code>
+            public class Foo {
+                private int x;
+
+                public Foo() {
+                    x = 41;
+                }
+
+                public void bar() {
+                    x = 42;
+                }
+            }
+            ]]></code>
     </test-code>
+
     <test-code>
-        <description>Ok, static field </description>
+        <description>Ok, static field</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-public class Foo {
- private static int x = 0;
- private final int y;
- public Foo() {
-  y = x;
-  x++;
- }
-}
-     ]]></code>
+            public class Foo {
+                private static int x = 0;
+                private final int y;
+
+                public Foo() {
+                    y = x;
+                    x++;
+                }
+            }
+            ]]></code>
     </test-code>
+
     <test-code>
         <description>Ok, one constructor assigns, one doesn't</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-public class Foo {
- private int x;
- public Foo(int y) {
-  x = y;
- }
- public Foo() {}
-}
-     ]]></code>
+            public class Foo {
+                private int x;
+
+                public Foo(int y) {
+                    x = y;
+                }
+
+                public Foo() {
+                }
+            }
+            ]]></code>
     </test-code>
+
     <test-code>
         <description>Ok, assignment via postfix expression</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-public class Foo {
- private int x;
- public Foo() {}
- private void bar() {x++;}
-}
-     ]]></code>
+            public class Foo {
+                private int x;
+
+                public Foo() {
+                }
+
+                private void bar() {
+                    x++;
+                }
+            }
+            ]]></code>
     </test-code>
+
     <test-code>
         <description>Postfix expressions imply mutability</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-public class Foo {
- private int x = 0;
- private void bar() {
-  x++;
- }
-}
-     ]]></code>
+            public class Foo {
+                private int x = 0;
+
+                private void bar() {
+                    x++;
+                }
+            }
+            ]]></code>
     </test-code>
+
     <test-code>
         <description>Compound assignment</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-public class Foo {
- private int w;
- private int z;
- private void bar() {
-  w = 2;
-  z = 4;
- }
- private void gaz() {
-  w += z++;
- }
-}
-     ]]></code>
+            public class Foo {
+                private int w;
+                private int z;
+
+                private void bar() {
+                    w = 2;
+                    z = 4;
+                }
+
+                private void gaz() {
+                    w += z++;
+                }
+            }
+            ]]></code>
     </test-code>
+
     <test-code>
         <description>Preincrement</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-public class Foo {
- private int x = 0;
- public void bar() {
-  ++x;
- }
-}
-     ]]></code>
+            public class Foo {
+                private int x = 0;
+
+                public void bar() {
+                    ++x;
+                }
+            }
+            ]]></code>
     </test-code>
+
     <test-code>
         <description>Predecrement</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-public class Foo {
- private int x = 0;
- public void bar() {
-  --x;
- }
-}
-     ]]></code>
+            public class Foo {
+                private int x = 0;
+
+                public void bar() {
+                    --x;
+                }
+            }
+            ]]></code>
     </test-code>
+
     <test-code>
         <description>Compound assignment 2</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-public class Foo {
- private int x = 0;
- public void bar() {
-  x += 1;
- }
-}
-     ]]></code>
+            public class Foo {
+                private int x = 0;
+
+                public void bar() {
+                    x += 1;
+                }
+            }
+            ]]></code>
     </test-code>
+
     <test-code>
         <description>Rhs 2</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-public class Foo {
- private int x = 0;
- public void bar() {
-  Object y = new Bar(x++);
- }
-}
-     ]]></code>
+            public class Foo {
+                private int x = 0;
+
+                public void bar() {
+                    Object y = new Bar(x++);
+                }
+            }
+            ]]></code>
     </test-code>
+
     <test-code>
         <description>Assignment in constructor is in try block</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-public class Foo {
- private int x;
- public Foo() {
-  try {
-   x = 2;
-  } catch (Exception e) {}
- }
-}
-     ]]></code>
+            public class Foo {
+                private int x;
+
+                public Foo() {
+                    try {
+                        x = 2;
+                    } catch (Exception e) {
+                    }
+                }
+            }
+            ]]></code>
     </test-code>
+
     <test-code>
         <description>Assignment in method is in try block</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-public class Foo {
- private int x;
- public void bar() {
-  try {
-   x = 2;
-  } catch (Exception e) {}
- }
-}
-     ]]></code>
+            public class Foo {
+                private int x;
+
+                public void bar() {
+                    try {
+                        x = 2;
+                    } catch (Exception e) {
+                    }
+                }
+            }
+            ]]></code>
     </test-code>
+
     <test-code>
         <description>Assignment in constructor in loop is ok</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-public class Foo {
- private int x;
- public Foo() {
-  for (int i=0; i<10; i++) { x += 5; }
- }
-}
-     ]]></code>
+            public class Foo {
+                private int x;
+
+                public Foo() {
+                    for (int i = 0; i < 10; i++) {
+                        x += 5;
+                    }
+                }
+            }
+            ]]></code>
     </test-code>
+
     <test-code>
         <description>Assignment in anonymous inner class method is OK</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-public class Foo {
- private int x = 2 ;
- public Foo() {
-   mouseListener = new MouseAdapter() {
-      public void mouseClicked(MouseEvent e) {
-        x = e.getSource();
-        super.mouseClicked(e);
-      }
-    };
- }
-}
-     ]]></code>
+            public class Foo {
+                private int x = 2;
+
+                public Foo() {
+                    mouseListener = new MouseAdapter() {
+                        public void mouseClicked(MouseEvent e) {
+                            x = e.getSource();
+                            super.mouseClicked(e);
+                        }
+                    };
+                }
+            }
+            ]]></code>
     </test-code>
+
     <test-code>
         <description>Assignment through this</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-public class Foo{
-    private int counter;
-    private Foo(){
-        counter = 0;
-    }
-    private int foo(){
-        if (++this.counter < 3) {
-            return 0;
-        }
-        return 1;
-    }
-}
+            public class Foo {
+                private int counter;
 
-     ]]></code>
+                private Foo() {
+                    counter = 0;
+                }
+
+                private int foo() {
+                    if (++this.counter < 3) {
+                        return 0;
+                    }
+                    return 1;
+                }
+            }
+            ]]></code>
     </test-code>
+
     <test-code>
         <description>Volatile variables can't be final</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-public final class Foo {
-    private volatile boolean bar = false;
-    public Foo() {
-    }
-}     ]]></code>
+            public final class Foo {
+                private volatile boolean bar = false;
+
+                public Foo() {
+                }
+            }
+            ]]></code>
     </test-code>
+
     <test-code>
         <description>Bug 1740480, optional override of default value based on constructor argument check</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-public class MyClass {
-  private int positive = 1;
+            public class MyClass {
+                private int positive = 1;
 
-  public MyClass (int value) {
-      // if negative keep default
-      if (value > 0) {
-          positive = value;
-      }
-  }
-}
-     ]]></code>
+                public MyClass(int value) {
+                    // if negative keep default
+                    if (value > 0) {
+                        positive = value;
+                    }
+                }
+            }
+            ]]></code>
     </test-code>
+
     <test-code>
         <description>Bug 1740480, assignment in single constructor based on constructor argument check</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-public class MyClass {
-  private int positive;
+            public class MyClass {
+                private int positive;
 
-  public MyClass (int value) {
-      if (value > 0) {
-          positive = value;
-      } else {
-          positive = 1;
-      }
-  }
-}
-     ]]></code>
+                public MyClass(int value) {
+                    if (value > 0) {
+                        positive = value;
+                    } else {
+                        positive = 1;
+                    }
+                }
+            }
+            ]]></code>
     </test-code>
+
     <test-code>
         <description>3526212, pmd-5.0.0: ImmutableField false positive on self-inc/dec</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-public class pmd_inc {
-    private int test;
+            public class pmd_inc {
+                private int test;
 
-    public pmd_inc() {
-        this.test = 2;
-    }
+                public pmd_inc() {
+                    this.test = 2;
+                }
 
-    public int get_test() {
-        return this.test;
-    }
+                public int get_test() {
+                    return this.test;
+                }
 
-    public void inc_test(int val) {
-        this.test += val;
-    }
-}
-        ]]></code>
+                public void inc_test(int val) {
+                    this.test += val;
+                }
+            }
+            ]]></code>
     </test-code>
+
     <test-code>
         <description>#946 ImmutableField false +</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-public class MyClass {
-    private long counter = 0;
-    public <E> void run(final E entity, final Class<? extends TemplatedClass<E>> m) throws MyException {
-        this.counter += 1;
-    }
-}
-]]></code>
+            public class MyClass {
+                private long counter = 0;
+
+                public <E> void run(final E entity, final Class<? extends TemplatedClass<E>> m) throws MyException {
+                    this.counter += 1;
+                }
+            }
+            ]]></code>
     </test-code>
+
     <test-code>
         <description>#1032 ImmutableField Rule: Private field in inner class gives false positive</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-public class Foo {
-    private static class Bar {
-        private int i;
-        Bar(final int i) {
-            this.i = i;
-        }
-    }
+            public class Foo {
+                private static class Bar {
+                    private int i;
 
-    public int foo() {
-        final Bar b = new Bar(1);
-        b.i=0;
-        return b.i;
-    }
-}
-        ]]></code>
+                    Bar(final int i) {
+                        this.i = i;
+                    }
+                }
+
+                public int foo() {
+                    final Bar b = new Bar(1);
+                    b.i = 0;
+                    return b.i;
+                }
+            }
+            ]]></code>
     </test-code>
 
     <test-code>
         <description>#1448 [java] ImmutableField: Private field in inner class gives false positive with lambdas</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-public class CombinersTest {
+            public class CombinersTest {
 
-private static final BinaryOperator<Purse> ADDITION = (p1, p2) -> {
-    p1.amount += p2.amount;
-    return p1;
-};
+                private static final BinaryOperator<Purse> ADDITION = (p1, p2) -> {
+                    p1.amount += p2.amount;
+                    return p1;
+                };
 
-private static class Purse {
-    private int amount;
+                private static class Purse {
+                    private int amount;
 
-    public Purse(final int amount) {
-        this.amount = amount;
-    }
-  }
+                    public Purse(final int amount) {
+                        this.amount = amount;
+                    }
+                }
 
-}
-        ]]></code>
+            }
+            ]]></code>
     </test-code>
 
     <test-code>
         <description>#410 [java] ImmutableField: False positive with lombok</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-import lombok.Getter;
-import lombok.Setter;
+            import lombok.Getter;
+            import lombok.Setter;
 
-@Getter
-@Setter
-public class Foo {
-    private String id;
-    public Foo(String id) {
-        this.id = id;
-    }
-}
-        ]]></code>
+            @Getter
+            @Setter
+            public class Foo {
+                private String id;
+
+                public Foo(String id) {
+                    this.id = id;
+                }
+            }
+            ]]></code>
     </test-code>
 
     <test-code>
@@ -385,7 +440,8 @@ public class Foo {
                     action.run();
                 }
 
-                static class Bar {}
+                static class Bar {
+                }
             }
             ]]></code>
     </test-code>
@@ -405,7 +461,8 @@ public class Foo {
                     action.run();
                 }
 
-                static class Bar {}
+                static class Bar {
+                }
             }
             ]]></code>
     </test-code>


### PR DESCRIPTION
The first commit fixes #855. The others are cleanups.
I ran a formatter on the test cases, hence the big diff. It could be nice to do that on all rule test files, to uniformize a bit