### PR TITLE
[core] Enable dogfood

### DIFF
--- a/docs/pages/pmd/rules/java/documentation.md
+++ b/docs/pages/pmd/rules/java/documentation.md
@@ -29,7 +29,6 @@ A rule for the politically correct... we don't want to offend anyone.
 |----|-------------|-----------|
 |disallowedTerms|[idiot, jerk]|Illegal terms or phrases|
 |caseSensitive|false|Case sensitive|
-|wordsAreRegex|false|Use regular expressions|
 
 **Use this rule by referencing it:**
 ``` xml

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -12,10 +12,12 @@ This is a bug fixing release.
 
 ### Table Of Contents
 
-* [New and noteworthy](#new-and-noteworthy)
-* [Fixed Issues](#fixed-issues)
-* [API Changes](#api-changes)
-* [External Contributions](#external-contributions)
+*   [New and noteworthy](#new-and-noteworthy)
+*   [Fixed Issues](#fixed-issues)
+    *   [Ecmascript (JavaScript)](#ecmascript-javascript)
+    *   [Modified Rules](#modified-rules)
+*   [API Changes](#api-changes)
+*   [External Contributions](#external-contributions)
 
 ### New and noteworthy
 
@@ -28,6 +30,11 @@ Detailed changes for changed in Rhino can be found:
 * [For 1.7.7.1](https://github.com/mozilla/rhino/blob/master/RELEASE-NOTES.md#rhino-1771)
 
 Both are bugfixing releases.
+
+#### Modified Rules
+
+*   The rule "CommentContentRule" (java-documentation) previously had the property `wordsAreRegex`. But this 
+    property never had been implemented and is removed now.
 
 ### Fixed Issues
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ApexHandler.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ApexHandler.java
@@ -15,10 +15,8 @@ import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.ast.DumpFacade;
 import net.sourceforge.pmd.lang.apex.multifile.ApexMultifileVisitorFacade;
 import net.sourceforge.pmd.lang.apex.rule.ApexRuleViolationFactory;
-import net.sourceforge.pmd.lang.ast.xpath.AbstractASTXPathHandler;
+import net.sourceforge.pmd.lang.ast.xpath.DefaultASTXPathHandler;
 import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
-
-import net.sf.saxon.sxpath.IndependentContext;
 
 public class ApexHandler extends AbstractLanguageVersionHandler {
 
@@ -30,13 +28,7 @@ public class ApexHandler extends AbstractLanguageVersionHandler {
 
     @Override
     public XPathHandler getXPathHandler() {
-        return new AbstractASTXPathHandler() {
-            public void initialize() {
-            }
-
-            public void initialize(IndependentContext context) {
-            }
-        };
+        return new DefaultASTXPathHandler();
     }
 
     public RuleViolationFactory getRuleViolationFactory() {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ApexParserOptions.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ApexParserOptions.java
@@ -5,29 +5,10 @@
 package net.sourceforge.pmd.lang.apex;
 
 import net.sourceforge.pmd.lang.ParserOptions;
-import net.sourceforge.pmd.util.StringUtil;
 
 public class ApexParserOptions extends ParserOptions {
 
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = super.hashCode();
-        result = prime * result + (1237);
-        result = prime * result + (1237);
-        result = prime * result;
-        return result;
-    }
+    // empty class for now, since we don't have extra options for Apex
+    // Once you add something here, make sure to override hashCode and equals
 
-    @Override
-    public boolean equals(Object obj) {
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null || getClass() != obj.getClass()) {
-            return false;
-        }
-        final ApexParserOptions that = (ApexParserOptions) obj;
-        return StringUtil.isSame(this.suppressMarker, that.suppressMarker, false, false, false);
-    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexParser.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexParser.java
@@ -28,15 +28,10 @@ public class ApexParser {
     protected final ApexParserOptions parserOptions;
 
     private Map<Integer, String> suppressMap;
-    private String suppressMarker = "NOPMD";
 
     public ApexParser(ApexParserOptions parserOptions) {
         ApexJorjeLogging.disableLogging();
         this.parserOptions = parserOptions;
-
-        if (parserOptions.getSuppressMarker() != null) {
-            suppressMarker = parserOptions.getSuppressMarker();
-        }
     }
 
     public Compilation parseApex(final String sourceCode) throws ParseException {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexParser.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexParser.java
@@ -40,8 +40,7 @@ public class ApexParser {
         Locations.useIndexFactory();
         CompilerService.INSTANCE.visitAstFromString(sourceCode, visitor);
 
-        Compilation astRoot = visitor.getTopLevel();
-        return astRoot;
+        return visitor.getTopLevel();
     }
 
     public ApexNode<Compilation> parse(final Reader reader) {
@@ -55,8 +54,7 @@ public class ApexParser {
                 throw new ParseException("Couldn't parse the source - there is not root node - Syntax Error??");
             }
 
-            ApexNode<Compilation> tree = treeBuilder.build(astRoot);
-            return tree;
+            return treeBuilder.build(astRoot);
         } catch (IOException e) {
             throw new ParseException(e);
         }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexQualifiedName.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexQualifiedName.java
@@ -20,7 +20,7 @@ import apex.jorje.semantic.symbol.type.TypeInfo;
  *
  * @author Clément Fournier
  */
-public class ApexQualifiedName implements QualifiedName {
+public final class ApexQualifiedName implements QualifiedName {
 
 
     private final String nameSpace;
@@ -155,7 +155,7 @@ public class ApexQualifiedName implements QualifiedName {
 
         List<TypeInfo> paramTypes = node.getNode().getMethodInfo().getParameterTypes();
 
-        if (paramTypes.size() > 0) {
+        if (!paramTypes.isEmpty()) {
             sb.append(paramTypes.get(0).getApexName());
 
             for (int i = 1; i < paramTypes.size(); i++) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/CompilerService.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/CompilerService.java
@@ -84,11 +84,10 @@ public class CompilerService {
         List<SourceFile> sourceFiles = sources.stream().map(s -> SourceFile.builder().setBody(s).build())
                 .collect(Collectors.toList());
         CompilationInput compilationUnit = createCompilationInput(sourceFiles, visitor);
-        return compile(compilationUnit, visitor, compilerStage);
+        return compile(compilationUnit, compilerStage);
     }
 
-    private ApexCompiler compile(CompilationInput compilationInput, AstVisitor<AdditionalPassScope> visitor,
-            CompilerStage compilerStage) {
+    private ApexCompiler compile(CompilationInput compilationInput, CompilerStage compilerStage) {
         ApexCompiler compiler = ApexCompiler.builder().setInput(compilationInput).build();
         compiler.compile(compilerStage);
         callAdditionalPassVisitor(compiler);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/EmptySymbolProvider.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/EmptySymbolProvider.java
@@ -29,11 +29,11 @@ import apex.jorje.semantic.symbol.type.TypeInfo;
 /**
  * @author jspagnola
  */
-public class EmptySymbolProvider implements SymbolProvider {
+public final class EmptySymbolProvider implements SymbolProvider {
 
     private static final EmptySymbolProvider INSTANCE = new EmptySymbolProvider();
 
-    EmptySymbolProvider() {
+    private EmptySymbolProvider() {
     }
 
     public static EmptySymbolProvider get() {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/TestQueryValidators.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/TestQueryValidators.java
@@ -34,6 +34,7 @@ import apex.jorje.semantic.symbol.resolver.SymbolResolver;
  *
  * @author jspagnola
  */
+@SuppressWarnings("PMD.MissingStaticMethodInNonInstantiatableClass") // this class provides utility classes
 public final class TestQueryValidators {
 
     private TestQueryValidators() {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/signature/ApexOperationSigMask.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/signature/ApexOperationSigMask.java
@@ -18,10 +18,6 @@ public class ApexOperationSigMask {
     private Set<Visibility> visMask = EnumSet.allOf(Visibility.class);
 
 
-    public ApexOperationSigMask() {
-    }
-
-
     /**
      * Sets the mask to cover all visibilities.
      */

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/multifile/ApexProjectMirror.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/multifile/ApexProjectMirror.java
@@ -16,14 +16,13 @@ import net.sourceforge.pmd.lang.apex.metrics.signature.ApexOperationSigMask;
  *
  * @author Clément Fournier
  */
-class ApexProjectMirror implements ApexSignatureMatcher {
+final class ApexProjectMirror implements ApexSignatureMatcher {
 
     static final ApexProjectMirror INSTANCE = new ApexProjectMirror();
 
     private final Map<ApexQualifiedName, ApexClassStats> classes = new HashMap<>();
 
-    ApexProjectMirror() {
-
+    private ApexProjectMirror() {
     }
 
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/AbstractStatisticalApexRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/AbstractStatisticalApexRule.java
@@ -21,7 +21,7 @@ public abstract class AbstractStatisticalApexRule extends AbstractApexRule imple
     }
 
     public Object[] getViolationParameters(DataPoint point) {
-        return null;
+        return new Object[0];
     }
 
     @Override

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/ApexRuleViolation.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/ApexRuleViolation.java
@@ -22,6 +22,7 @@ import net.sourceforge.pmd.lang.rule.ParametricRuleViolation;
  * </ul>
  * @param <T>
  */
+@SuppressWarnings("PMD.UseUtilityClass") // we inherit non-static methods...
 public class ApexRuleViolation<T> extends ParametricRuleViolation<Node> {
 
     public ApexRuleViolation(Rule rule, RuleContext ctx, Node node, String message, int beginLine, int endLine) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveAssertsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveAssertsRule.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.apex.rule.bestpractices;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTBlockStatement;
@@ -51,7 +52,7 @@ public class ApexUnitTestClassShouldHaveAssertsRule extends AbstractApexUnitTest
         boolean isAssertFound = false;
 
         for (final ASTMethodCallExpression methodCallExpression : methodCalls) {
-            if (ASSERT_METHODS.contains(methodCallExpression.getFullMethodName().toLowerCase())) {
+            if (ASSERT_METHODS.contains(methodCallExpression.getFullMethodName().toLowerCase(Locale.ROOT))) {
                 isAssertFound = true;
                 break;
             }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/MethodNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/MethodNamingConventionsRule.java
@@ -45,10 +45,10 @@ public class MethodNamingConventionsRule extends AbstractApexRule {
     }
 
     private boolean isPropertyAccessor(ASTMethod node) {
-        return (node.getParentsOfType(ASTProperty.class).size() > 0);
+        return !node.getParentsOfType(ASTProperty.class).isEmpty();
     }
 
     private boolean isConstructor(ASTMethod node) {
-        return (node.getNode().getMethodInfo().isConstructor());
+        return node.getNode().getMethodInfo().isConstructor();
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/VariableNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/VariableNamingConventionsRule.java
@@ -8,6 +8,7 @@ import static apex.jorje.semantic.symbol.type.ModifierTypeInfos.FINAL;
 import static apex.jorje.semantic.symbol.type.ModifierTypeInfos.STATIC;
 
 import java.util.List;
+import java.util.Locale;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTField;
 import net.sourceforge.pmd.lang.apex.ast.ASTParameter;
@@ -152,7 +153,7 @@ public class VariableNamingConventionsRule extends AbstractApexRule {
 
         // Static finals should be uppercase
         if (isStatic && isFinal) {
-            if (!varName.equals(varName.toUpperCase())) {
+            if (!varName.equals(varName.toUpperCase(Locale.ROOT))) {
                 addViolationWithMessage(data, node,
                         "Variables that are final and static should be all capitals, ''{0}'' is not all capitals.",
                         new Object[] { varName });

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/AbstractNcssCountRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/AbstractNcssCountRule.java
@@ -108,9 +108,7 @@ public abstract class AbstractNcssCountRule extends AbstractStatisticalApexRule 
 
     @Override
     public Object visit(ASTIfBlockStatement node, Object data) {
-
-        Integer lineCount = countNodeChildren(node, data);
-        return lineCount;
+        return countNodeChildren(node, data);
     }
 
     @Override

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/StdCyclomaticComplexityRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/StdCyclomaticComplexityRule.java
@@ -20,7 +20,6 @@ import net.sourceforge.pmd.lang.apex.ast.ASTUserInterface;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserTrigger;
 import net.sourceforge.pmd.lang.apex.ast.ASTWhileLoopStatement;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
-import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.properties.BooleanProperty;
 import net.sourceforge.pmd.properties.IntegerProperty;
 
@@ -57,7 +56,7 @@ public class StdCyclomaticComplexityRule extends AbstractApexRule {
         public int highestDecisionPoints;
         public int methodCount;
 
-        private Entry(Node node) {
+        private Entry() {
         }
 
         public void bumpDecisionPoints() {
@@ -90,7 +89,7 @@ public class StdCyclomaticComplexityRule extends AbstractApexRule {
         reportLevel = getProperty(REPORT_LEVEL_DESCRIPTOR);
         showClassesComplexity = getProperty(SHOW_CLASSES_COMPLEXITY_DESCRIPTOR);
         showMethodsComplexity = getProperty(SHOW_METHODS_COMPLEXITY_DESCRIPTOR);
-        entryStack.push(new Entry(node));
+        entryStack.push(new Entry());
         super.visit(node, data);
         Entry classEntry = entryStack.pop();
         if (showClassesComplexity) {
@@ -107,7 +106,7 @@ public class StdCyclomaticComplexityRule extends AbstractApexRule {
         reportLevel = getProperty(REPORT_LEVEL_DESCRIPTOR);
         showClassesComplexity = getProperty(SHOW_CLASSES_COMPLEXITY_DESCRIPTOR);
         showMethodsComplexity = getProperty(SHOW_METHODS_COMPLEXITY_DESCRIPTOR);
-        entryStack.push(new Entry(node));
+        entryStack.push(new Entry());
         super.visit(node, data);
         Entry classEntry = entryStack.pop();
         if (showClassesComplexity) {
@@ -126,7 +125,7 @@ public class StdCyclomaticComplexityRule extends AbstractApexRule {
 
     @Override
     public Object visit(ASTUserEnum node, Object data) {
-        entryStack.push(new Entry(node));
+        entryStack.push(new Entry());
         super.visit(node, data);
         Entry classEntry = entryStack.pop();
         if (classEntry.getComplexityAverage() >= reportLevel || classEntry.highestDecisionPoints >= reportLevel) {
@@ -139,7 +138,7 @@ public class StdCyclomaticComplexityRule extends AbstractApexRule {
     @Override
     public Object visit(ASTMethod node, Object data) {
         if (!node.getImage().matches("<clinit>|<init>|clone")) {
-            entryStack.push(new Entry(node));
+            entryStack.push(new Entry());
             super.visit(node, data);
             Entry methodEntry = entryStack.pop();
             int methodDecisionPoints = methodEntry.decisionPoints;
@@ -152,7 +151,7 @@ public class StdCyclomaticComplexityRule extends AbstractApexRule {
             }
 
             if (showMethodsComplexity && methodEntry.decisionPoints >= reportLevel) {
-                String methodType = (node.getNode().getMethodInfo().isConstructor()) ? "constructor" : "method";
+                String methodType = node.getNode().getMethodInfo().isConstructor() ? "constructor" : "method";
                 addViolation(data, node,
                         new String[] { methodType, node.getImage(), String.valueOf(methodEntry.decisionPoints) });
             }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
@@ -47,6 +48,7 @@ import apex.jorje.data.Identifier;
 import apex.jorje.data.ast.TypeRef;
 import apex.jorje.data.ast.TypeRefs.ArrayTypeRef;
 import apex.jorje.data.ast.TypeRefs.ClassTypeRef;
+import com.google.common.base.Objects;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
 
@@ -188,7 +190,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
                 }
                 sb.deleteCharAt(sb.length() - 1);
 
-                switch (sb.toString().toLowerCase()) {
+                switch (sb.toString().toLowerCase(Locale.ROOT)) {
                 case "list":
                 case "map":
                     addParametersToMapping(node, typeArgs);
@@ -244,12 +246,13 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     }
 
     private void addVariableToMapping(final String variableName, final String type) {
-        switch (type.toLowerCase()) {
+        switch (type.toLowerCase(Locale.ROOT)) {
         case "list":
         case "map":
-            return;
+            break;
         default:
             varToTypeMapping.put(variableName, getSimpleType(type));
+            break;
         }
     }
 
@@ -421,7 +424,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
                 }
 
                 AbstractApexNode<?> match = n.getFirstDescendantOfType(self.getClass());
-                if (match == self) {
+                if (Objects.equal(match, self)) {
                     break;
                 }
                 ASTMethodCallExpression methodCall = n.getFirstDescendantOfType(ASTMethodCallExpression.class);
@@ -436,7 +439,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     private void mapCallToMethodDecl(final AbstractApexNode<?> self,
             final Set<ASTMethodCallExpression> innerMethodCalls, final List<ASTMethodCallExpression> nodes) {
         for (ASTMethodCallExpression node : nodes) {
-            if (node == self) {
+            if (Objects.equal(node, self)) {
                 break;
             }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
@@ -363,8 +363,8 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
         final ASTMethod wrappingMethod = node.getFirstParentOfType(ASTMethod.class);
         final ASTUserClass wrappingClass = node.getFirstParentOfType(ASTUserClass.class);
 
-        if ((wrappingClass != null && Helper.isTestMethodOrClass(wrappingClass))
-                || (wrappingMethod != null && Helper.isTestMethodOrClass(wrappingMethod))) {
+        if (wrappingClass != null && Helper.isTestMethodOrClass(wrappingClass)
+                || wrappingMethod != null && Helper.isTestMethodOrClass(wrappingMethod)) {
             return;
         }
 
@@ -393,7 +393,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
             final ASTBlockStatement blockStatement = outerMethod.getFirstChildOfType(ASTBlockStatement.class);
             recursivelyEvaluateCRUDMethodCalls(self, innerMethodCalls, blockStatement);
 
-            final List<ASTMethod> constructorMethods = findConstructorlMethods(self);
+            final List<ASTMethod> constructorMethods = findConstructorlMethods();
             for (ASTMethod method : constructorMethods) {
                 innerMethodCalls.addAll(method.findDescendantsOfType(ASTMethodCallExpression.class));
             }
@@ -447,11 +447,11 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
         }
     }
 
-    private List<ASTMethod> findConstructorlMethods(final AbstractApexNode<?> node) {
+    private List<ASTMethod> findConstructorlMethods() {
         final ArrayList<ASTMethod> ret = new ArrayList<>();
         final Set<String> constructors = classMethods.keySet().stream()
-                .filter(p -> (p.contains("<init>") || p.contains("<clinit>")
-                        || p.startsWith(className + ":" + className + ":"))).collect(Collectors.toSet());
+                .filter(p -> p.contains("<init>") || p.contains("<clinit>")
+                        || p.startsWith(className + ":" + className + ":")).collect(Collectors.toSet());
 
         for (String c : constructors) {
             ret.add(classMethods.get(c));
@@ -539,8 +539,9 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
         final ASTMethod wrappingMethod = node.getFirstParentOfType(ASTMethod.class);
         final ASTUserClass wrappingClass = node.getFirstParentOfType(ASTUserClass.class);
 
-        if (isCount || (wrappingClass != null && Helper.isTestMethodOrClass(wrappingClass))
-                || (wrappingMethod != null && Helper.isTestMethodOrClass(wrappingMethod))) {
+        if (isCount
+                || wrappingClass != null && Helper.isTestMethodOrClass(wrappingClass)
+                || wrappingMethod != null && Helper.isTestMethodOrClass(wrappingMethod)) {
             return;
         }
 
@@ -627,6 +628,6 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
                 .matcher(method.getNode().getMethodInfo().getEmitSignature().getReturnType().getApexName()).matches();
         final boolean noParams = method.findChildrenOfType(ASTParameter.class).isEmpty();
 
-        return (startsWithGet && noParams && !voidOrString);
+        return startsWithGet && noParams && !voidOrString;
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.regex.Matcher;
@@ -60,10 +61,10 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     private static final Pattern SELECT_FROM_PATTERN = Pattern.compile("[\\S|\\s]+?FROM[\\s]+?(\\w+)",
             Pattern.CASE_INSENSITIVE);
 
-    private final HashMap<String, String> varToTypeMapping = new HashMap<>();
+    private final Map<String, String> varToTypeMapping = new HashMap<>();
     private final ListMultimap<String, String> typeToDMLOperationMapping = ArrayListMultimap.create();
-    private final HashMap<String, String> checkedTypeToDMLOperationViaESAPI = new HashMap<>();
-    private final WeakHashMap<String, ASTMethod> classMethods = new WeakHashMap<>();
+    private final Map<String, String> checkedTypeToDMLOperationViaESAPI = new HashMap<>();
+    private final Map<String, ASTMethod> classMethods = new WeakHashMap<>();
     private String className;
 
     private static final String IS_CREATEABLE = "isCreateable";
@@ -355,7 +356,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     }
 
     private void checkForCRUD(final AbstractApexNode<?> node, final Object data, final String crudMethod) {
-        final HashSet<ASTMethodCallExpression> prevCalls = getPreviousMethodCalls(node);
+        final Set<ASTMethodCallExpression> prevCalls = getPreviousMethodCalls(node);
         for (ASTMethodCallExpression prevCall : prevCalls) {
             collectCRUDMethodLevelChecks(prevCall);
         }
@@ -386,8 +387,8 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
         }
     }
 
-    private HashSet<ASTMethodCallExpression> getPreviousMethodCalls(final AbstractApexNode<?> self) {
-        final HashSet<ASTMethodCallExpression> innerMethodCalls = new HashSet<>();
+    private Set<ASTMethodCallExpression> getPreviousMethodCalls(final AbstractApexNode<?> self) {
+        final Set<ASTMethodCallExpression> innerMethodCalls = new HashSet<>();
         final ASTMethod outerMethod = self.getFirstParentOfType(ASTMethod.class);
         if (outerMethod != null) {
             final ASTBlockStatement blockStatement = outerMethod.getFirstChildOfType(ASTBlockStatement.class);
@@ -406,7 +407,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     }
 
     private void recursivelyEvaluateCRUDMethodCalls(final AbstractApexNode<?> self,
-            final HashSet<ASTMethodCallExpression> innerMethodCalls, final ASTBlockStatement blockStatement) {
+            final Set<ASTMethodCallExpression> innerMethodCalls, final ASTBlockStatement blockStatement) {
         if (blockStatement != null) {
             int numberOfStatements = blockStatement.jjtGetNumChildren();
             for (int i = 0; i < numberOfStatements; i++) {
@@ -433,7 +434,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     }
 
     private void mapCallToMethodDecl(final AbstractApexNode<?> self,
-            final HashSet<ASTMethodCallExpression> innerMethodCalls, final List<ASTMethodCallExpression> nodes) {
+            final Set<ASTMethodCallExpression> innerMethodCalls, final List<ASTMethodCallExpression> nodes) {
         for (ASTMethodCallExpression node : nodes) {
             if (node == self) {
                 break;
@@ -528,7 +529,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
         final boolean isCount = node.getNode().getCanonicalQuery().startsWith("SELECT COUNT()");
         final Set<String> typesFromSOQL = getTypesFromSOQLQuery(node);
 
-        final HashSet<ASTMethodCallExpression> prevCalls = getPreviousMethodCalls(node);
+        final Set<ASTMethodCallExpression> prevCalls = getPreviousMethodCalls(node);
         for (ASTMethodCallExpression prevCall : prevCalls) {
             collectCRUDMethodLevelChecks(prevCall);
         }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexDangerousMethodsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexDangerousMethodsRule.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.apex.rule.security;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTField;
@@ -35,7 +36,7 @@ public class ApexDangerousMethodsRule extends AbstractApexRule {
     private static final String SYSTEM = "System";
     private static final String DEBUG = "debug";
 
-    private final HashSet<String> whiteListedVariables = new HashSet<>();
+    private final Set<String> whiteListedVariables = new HashSet<>();
 
     public ApexDangerousMethodsRule() {
         super.addRuleChainVisit(ASTUserClass.class);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexInsecureEndpointRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexInsecureEndpointRule.java
@@ -39,23 +39,23 @@ public class ApexInsecureEndpointRule extends AbstractApexRule {
 
     @Override
     public Object visit(ASTAssignmentExpression node, Object data) {
-        findInsecureEndpoints(node, data);
+        findInsecureEndpoints(node);
         return data;
     }
 
     @Override
     public Object visit(ASTVariableDeclaration node, Object data) {
-        findInsecureEndpoints(node, data);
+        findInsecureEndpoints(node);
         return data;
     }
 
     @Override
     public Object visit(ASTFieldDeclaration node, Object data) {
-        findInsecureEndpoints(node, data);
+        findInsecureEndpoints(node);
         return data;
     }
 
-    private void findInsecureEndpoints(AbstractApexNode<?> node, Object data) {
+    private void findInsecureEndpoints(AbstractApexNode<?> node) {
         ASTVariableExpression variableNode = node.getFirstChildOfType(ASTVariableExpression.class);
         findInnerInsecureEndpoints(node, variableNode);
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.apex.rule.security;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -108,7 +109,7 @@ public class ApexSOQLInjectionRule extends AbstractApexRule {
     private void findSafeVariablesInSignature(ASTMethod m) {
         List<Parameter> parameters = m.getNode().getMethodInfo().getParameters();
         for (Parameter p : parameters) {
-            switch (p.getType().getApexName().toLowerCase()) {
+            switch (p.getType().getApexName().toLowerCase(Locale.ROOT)) {
             case ID:
             case INTEGER:
             case BOOLEAN:
@@ -159,7 +160,7 @@ public class ApexSOQLInjectionRule extends AbstractApexRule {
 
         if (node instanceof ASTVariableDeclaration) {
             VariableDeclaration o = (VariableDeclaration) node.getNode();
-            switch (o.getLocalInfo().getType().getApexName().toLowerCase()) {
+            switch (o.getLocalInfo().getType().getApexName().toLowerCase(Locale.ROOT)) {
             case INTEGER:
             case ID:
             case BOOLEAN:

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
@@ -7,6 +7,8 @@ package net.sourceforge.pmd.lang.apex.rule.security;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTAssignmentExpression;
@@ -45,8 +47,8 @@ public class ApexSOQLInjectionRule extends AbstractApexRule {
     private static final String DATABASE = "Database";
     private static final String QUERY = "query";
     private static final Pattern SELECT_PATTERN = Pattern.compile("^select[\\s]+?.*?$", Pattern.CASE_INSENSITIVE);
-    private final HashSet<String> safeVariables = new HashSet<>();
-    private final HashMap<String, Boolean> selectContainingVariables = new HashMap<>();
+    private final Set<String> safeVariables = new HashSet<>();
+    private final Map<String, Boolean> selectContainingVariables = new HashMap<>();
 
     public ApexSOQLInjectionRule() {
         setProperty(CODECLIMATE_CATEGORIES, "Security");

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSuggestUsingNamedCredRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSuggestUsingNamedCredRule.java
@@ -67,7 +67,7 @@ public class ApexSuggestUsingNamedCredRule extends AbstractApexRule {
 
     private void findFieldLiterals(final ASTField fDecl) {
         Object f = fDecl.getNode().getFieldInfo().getValue();
-        if (f != null && f instanceof String) {
+        if (f instanceof String) {
             final String fieldValue = (String) f;
             if (AUTHORIZATION.equalsIgnoreCase(fieldValue)) {
                 listOfAuthorizationVariables.add(Helper.getFQVariableName(fDecl));

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.apex.rule.security;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTDmlDeleteStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTDmlInsertStatement;
@@ -43,7 +44,7 @@ import apex.jorje.semantic.ast.statement.VariableDeclaration;
  *
  */
 public final class Helper {
-    protected static final String ANY_METHOD = "*";
+    static final String ANY_METHOD = "*";
 
     private Helper() {
         throw new AssertionError("Can't instantiate helper classes");
@@ -58,22 +59,14 @@ public final class Helper {
         }
 
         final String className = node.getNode().getDefiningType().getApexName();
-        if (className.endsWith("Test")) {
-            return true;
-        }
-
-        return false;
+        return className.endsWith("Test");
     }
 
     static boolean foundAnySOQLorSOSL(final ApexNode<?> node) {
         final List<ASTSoqlExpression> dmlSoqlExpression = node.findDescendantsOfType(ASTSoqlExpression.class);
         final List<ASTSoslExpression> dmlSoslExpression = node.findDescendantsOfType(ASTSoslExpression.class);
 
-        if (dmlSoqlExpression.isEmpty() && dmlSoslExpression.isEmpty()) {
-            return false;
-        }
-
-        return true;
+        return !dmlSoqlExpression.isEmpty() || !dmlSoslExpression.isEmpty();
     }
 
     /**
@@ -93,27 +86,17 @@ public final class Helper {
         final List<ASTDmlInsertStatement> dmlInsertStatement = node.findDescendantsOfType(ASTDmlInsertStatement.class);
         final List<ASTDmlDeleteStatement> dmlDeleteStatement = node.findDescendantsOfType(ASTDmlDeleteStatement.class);
 
-        if (dmlUpsertStatement.isEmpty() && dmlUpdateStatement.isEmpty() && dmlUndeleteStatement.isEmpty()
-                && dmlMergeStatement.isEmpty() && dmlInsertStatement.isEmpty() && dmlDeleteStatement.isEmpty()) {
-            return false;
-        }
-
-        return true;
+        return !dmlUpsertStatement.isEmpty() || !dmlUpdateStatement.isEmpty() || !dmlUndeleteStatement.isEmpty()
+                || !dmlMergeStatement.isEmpty() || !dmlInsertStatement.isEmpty() || !dmlDeleteStatement.isEmpty();
     }
 
     static boolean isMethodName(final ASTMethodCallExpression methodNode, final String className,
             final String methodName) {
         final ASTReferenceExpression reference = methodNode.getFirstChildOfType(ASTReferenceExpression.class);
-        if (reference != null && reference.getNode().getNames().size() == 1) {
-            if (reference.getNode().getNames().get(0).getValue().equalsIgnoreCase(className)) {
-                if (methodName.equals(ANY_METHOD) || isMethodName(methodNode, methodName)) {
-                    return true;
-                }
-            }
-        }
 
-        return false;
-
+        return reference != null && reference.getNode().getNames().size() == 1
+                && reference.getNode().getNames().get(0).getValue().equalsIgnoreCase(className)
+                && (methodName.equals(ANY_METHOD) || isMethodName(methodNode, methodName));
     }
 
     static boolean isMethodName(final ASTMethodCallExpression m, final String methodName) {
@@ -234,7 +217,7 @@ public final class Helper {
             }
         }
 
-        switch (sb.toString().toLowerCase()) {
+        switch (sb.toString().toLowerCase(Locale.ROOT)) {
         case "queueable":
         case "database.batchable":
         case "installhandler":

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
@@ -229,7 +229,7 @@ public final class Helper {
         for (int i = 0; i < ids.size(); i++) {
             sb.append(ids.get(i).getValue());
 
-            if (i != (ids.size() - 1)) {
+            if (i != ids.size() - 1) {
                 sb.append(".");
             }
         }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
@@ -195,15 +195,13 @@ public final class Helper {
     static boolean isSystemLevelClass(ASTUserClass node) {
         List<TypeRef> interfaces = node.getNode().getDefiningType().getCodeUnitDetails().getInterfaceTypeRefs();
 
-        boolean hasWhitelistedInterfaces = false;
         for (TypeRef intObject : interfaces) {
             if (isWhitelisted(intObject.getNames())) {
-                hasWhitelistedInterfaces = true;
-                break;
+                return true;
             }
         }
 
-        return hasWhitelistedInterfaces;
+        return false;
     }
 
     private static boolean isWhitelisted(List<Identifier> ids) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
@@ -211,11 +211,16 @@ public final class Helper {
 
     static boolean isSystemLevelClass(ASTUserClass node) {
         List<TypeRef> interfaces = node.getNode().getDefiningType().getCodeUnitDetails().getInterfaceTypeRefs();
+
+        boolean hasWhitelistedInterfaces = false;
         for (TypeRef intObject : interfaces) {
-            return isWhitelisted(intObject.getNames());
+            if (isWhitelisted(intObject.getNames())) {
+                hasWhitelistedInterfaces = true;
+                break;
+            }
         }
 
-        return false;
+        return hasWhitelistedInterfaces;
     }
 
     private static boolean isWhitelisted(List<Identifier> ids) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
@@ -226,6 +226,7 @@ public class PMD {
 
                 @Override
                 public void metricAdded(Metric metric) {
+                    // ignored - not needed for counting violations
                 }
             });
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
@@ -169,10 +169,9 @@ public class Report implements Iterable<RuleViolation> {
                 error.printStackTrace(writer);
                 return stringWriter.toString();
             } catch (IOException e) {
-                // can never happen when using StringWriter
+                // IOException on close - should never happen when using StringWriter
+                throw new RuntimeException(e);
             }
-            
-            return null;
         }
 
         public String getFile() {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
@@ -470,7 +470,7 @@ public class RuleSet implements ChecksumAware {
      *         <code>false</code> otherwise
      */
     public boolean applies(File file) {
-        return file != null ? filter.filter(file) : true;
+        return file == null || filter.filter(file);
     }
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
@@ -225,9 +225,7 @@ public class RuleSet implements ChecksumAware {
                 ruleReference = (RuleReference) rule;
             } else {
                 final RuleSetReference ruleSetReference = new RuleSetReference(ruleSetFileName);
-                ruleReference = new RuleReference();
-                ruleReference.setRule(rule);
-                ruleReference.setRuleSetReference(ruleSetReference);
+                ruleReference = new RuleReference(rule, ruleSetReference);
             }
             rules.add(ruleReference);
             return this;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
@@ -456,7 +456,7 @@ public class RuleSetFactory {
         Element ruleElement = (Element) ruleNode;
         String ref = ruleElement.getAttribute("ref");
         if (ref.endsWith("xml")) {
-            parseRuleSetReferenceNode(ruleSetReferenceId, ruleSetBuilder, ruleElement, ref);
+            parseRuleSetReferenceNode(ruleSetBuilder, ruleElement, ref);
         } else if (StringUtils.isBlank(ref)) {
             parseSingleRuleNode(ruleSetReferenceId, ruleSetBuilder, ruleNode);
         } else {
@@ -470,8 +470,6 @@ public class RuleSetFactory {
      * explicitly excluded, below the minimum priority threshold for this
      * RuleSetFactory, or which are deprecated.
      *
-     * @param ruleSetReferenceId
-     *            The RuleSetReferenceId of the RuleSet being parsed.
      * @param ruleSetBuilder
      *            The RuleSet being constructed.
      * @param ruleElement
@@ -479,8 +477,8 @@ public class RuleSetFactory {
      * @param ref
      *            The RuleSet reference.
      */
-    private void parseRuleSetReferenceNode(RuleSetReferenceId ruleSetReferenceId, RuleSetBuilder ruleSetBuilder,
-            Element ruleElement, String ref) throws RuleSetNotFoundException {
+    private void parseRuleSetReferenceNode(RuleSetBuilder ruleSetBuilder, Element ruleElement, String ref)
+            throws RuleSetNotFoundException {
         String priority = null;
         NodeList childNodes = ruleElement.getChildNodes();
         Set<String> excludedRulesCheck = new HashSet<>();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
@@ -503,9 +503,7 @@ public class RuleSetFactory {
         for (Rule rule : otherRuleSet.getRules()) {
             excludedRulesCheck.remove(rule.getName());
             if (!ruleSetReference.getExcludes().contains(rule.getName())) {
-                RuleReference ruleReference = new RuleReference();
-                ruleReference.setRuleSetReference(ruleSetReference);
-                ruleReference.setRule(rule);
+                RuleReference ruleReference = new RuleReference(rule, ruleSetReference);
                 // override the priority
                 if (priority != null) {
                     ruleReference.setPriority(RulePriority.valueOf(Integer.parseInt(priority)));
@@ -644,8 +642,7 @@ public class RuleSetFactory {
 
         RuleSetReference ruleSetReference = new RuleSetReference(otherRuleSetReferenceId.getRuleSetFileName(), false);
 
-        RuleReference ruleReference = new RuleFactory().decorateRule(referencedRule, ruleElement);
-        ruleReference.setRuleSetReference(ruleSetReference);
+        RuleReference ruleReference = new RuleFactory().decorateRule(referencedRule, ruleSetReference, ruleElement);
 
         if (warnDeprecated && ruleReference.isDeprecated()) {
             if (LOG.isLoggable(Level.WARNING)) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
@@ -426,6 +426,7 @@ public class RuleSetFactory {
             dbf.setExpandEntityReferences(false);
         } catch (final ParserConfigurationException e) {
             // an unsupported feature... too bad, but won't fail execution due to this
+            LOG.log(Level.WARNING, "Ignored unsupported XML Parser Feature for parsing rulesets", e);
         }
         
         return dbf.newDocumentBuilder();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactoryCompatibility.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactoryCompatibility.java
@@ -115,8 +115,8 @@ public class RuleSetFactoryCompatibility {
         return new StringReader(ruleset);
     }
 
-    private String applyAllFilters(String in) {
-        String result = in;
+    private String applyAllFilters(String ruleset) {
+        String result = ruleset;
         for (RuleSetFilter filter : filters) {
             result = filter.apply(result);
         }
@@ -194,9 +194,9 @@ public class RuleSetFactoryCompatibility {
             return filter;
         }
 
-        String apply(String in) {
-            String result = in;
-            Matcher matcher = refPattern.matcher(in);
+        String apply(String ruleset) {
+            String result = ruleset;
+            Matcher matcher = refPattern.matcher(ruleset);
 
             if (matcher.find()) {
                 result = matcher.replaceAll(replacement);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetReferenceId.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetReferenceId.java
@@ -228,7 +228,7 @@ public class RuleSetReferenceId {
         if (name != null) {
             try (InputStream resource = new ResourceLoader().loadClassPathResourceAsStreamOrThrow(name)) {
                 resourceFound = true;
-            } catch (Exception e) {
+            } catch (Exception ignored) {
                 // ignored
             }
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetReferenceId.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetReferenceId.java
@@ -198,7 +198,7 @@ public class RuleSetReferenceId {
                         ruleName = null;
                         allRules = true;
                     } else {
-                        external = externalRuleSetReferenceId != null ? externalRuleSetReferenceId.isExternal() : false;
+                        external = externalRuleSetReferenceId != null && externalRuleSetReferenceId.isExternal();
                         ruleSetFileName = externalRuleSetReferenceId != null
                                 ? externalRuleSetReferenceId.getRuleSetFileName() : null;
                         ruleName = id;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetReferenceId.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetReferenceId.java
@@ -293,11 +293,7 @@ public class RuleSetReferenceId {
             return false;
         }
 
-        if (stripped.startsWith("http://") || stripped.startsWith("https://")) {
-            return true;
-        }
-
-        return false;
+        return stripped.startsWith("http://") || stripped.startsWith("https://");
     }
 
     private static boolean isValidUrl(String name) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetWriter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetWriter.java
@@ -11,7 +11,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.FactoryConfigurationError;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetWriter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetWriter.java
@@ -216,7 +216,7 @@ public class RuleSetWriter {
     private Element createSingleRuleElement(Language language, LanguageVersion minimumLanguageVersion,
             LanguageVersion maximumLanguageVersion, Boolean deprecated, String name, String since, String ref,
             String message, String externalInfoUrl, String clazz, Boolean dfa, Boolean typeResolution,
-            Boolean multifile,
+            Boolean multifile, // NOPMD: TODO multifile
             String description, RulePriority priority, List<PropertyDescriptor<?>> propertyDescriptors,
             Map<PropertyDescriptor<?>, Object> propertiesByPropertyDescriptor, List<String> examples) {
         Element ruleElement = createRuleElement();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetWriter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetWriter.java
@@ -9,6 +9,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.FactoryConfigurationError;
@@ -41,6 +44,7 @@ import net.sourceforge.pmd.properties.PropertyTypeId;
  * file.
  */
 public class RuleSetWriter {
+    private static final Logger LOG = Logger.getLogger(RuleSetWriter.class.getName());
 
     public static final String RULESET_2_0_0_NS_URI = "http://pmd.sourceforge.net/ruleset/2.0.0";
 
@@ -78,6 +82,7 @@ public class RuleSetWriter {
                 transformerFactory.setAttribute("indent-number", 3);
             } catch (IllegalArgumentException iae) {
                 // ignore it, specific to one parser
+                LOG.log(Level.FINE, "Couldn't set indentation", iae);
             }
             Transformer transformer = transformerFactory.newTransformer();
             transformer.setOutputProperty(OutputKeys.METHOD, "xml");

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetWriter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetWriter.java
@@ -170,8 +170,7 @@ public class RuleSetWriter {
             if (ruleSetReference.isAllRules()) {
                 if (!ruleSetFileNames.contains(ruleSetReference.getRuleSetFileName())) {
                     ruleSetFileNames.add(ruleSetReference.getRuleSetFileName());
-                    Element ruleSetReferenceElement = createRuleSetReferenceElement(ruleSetReference);
-                    return ruleSetReferenceElement;
+                    return createRuleSetReferenceElement(ruleSetReference);
                 } else {
                     return null;
                 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSets.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSets.java
@@ -35,8 +35,9 @@ public class RuleSets {
      * Public constructor.
      */
     public RuleSets() {
+        // default constructor
     }
-    
+
     /**
      * Copy constructor. Deep copies RuleSets.
      * @param ruleSets The RuleSets to copy.
@@ -54,7 +55,6 @@ public class RuleSets {
      *            the RuleSet
      */
     public RuleSets(RuleSet ruleSet) {
-        this();
         addRuleSet(ruleSet);
     }
 
@@ -77,7 +77,7 @@ public class RuleSets {
      * @return RuleSet[]
      */
     public RuleSet[] getAllRuleSets() {
-        return ruleSets.toArray(new RuleSet[ruleSets.size()]);
+        return ruleSets.toArray(new RuleSet[0]);
     }
 
     public Iterator<RuleSet> getRuleSetsIterator() {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/Formatter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/Formatter.java
@@ -206,9 +206,9 @@ public class Formatter {
                 if (res instanceof Charset) {
                     return ((Charset) res).name();
                 }
-            } catch (NoSuchFieldException e) {
+            } catch (NoSuchFieldException ignored) {
                 // fall-through
-            } catch (IllegalAccessException e) {
+            } catch (IllegalAccessException ignored) {
                 // fall-through
             }
             return getNativeConsoleEncoding();
@@ -224,11 +224,11 @@ public class Formatter {
             if (res instanceof String) {
                 return (String) res;
             }
-        } catch (NoSuchMethodException e) {
+        } catch (NoSuchMethodException ignored) {
             // fall-through
-        } catch (InvocationTargetException e) {
+        } catch (InvocationTargetException ignored) {
             // fall-through
-        } catch (IllegalAccessException e) {
+        } catch (IllegalAccessException ignored) {
             // fall-through
         }
         return null;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/BenchmarkReport.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/BenchmarkReport.java
@@ -16,15 +16,15 @@ public interface BenchmarkReport {
 
     /**
      *
-     * @param stressResults
-     * @param out
+     * @param stressResults the durations from the stress test run
+     * @param stream the report is written into this stream
      */
-    void generate(Set<RuleDuration> stressResults, PrintStream out);
+    void generate(Set<RuleDuration> stressResults, PrintStream stream);
 
     /**
      *
      * @param benchmarksByName
-     * @param out
+     * @param stream the report is written into this stream
      */
-    void generate(Map<String, BenchmarkResult> benchmarksByName, PrintStream out);
+    void generate(Map<String, BenchmarkResult> benchmarksByName, PrintStream stream);
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/BenchmarkResult.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/BenchmarkResult.java
@@ -40,7 +40,13 @@ class BenchmarkResult implements Comparable<BenchmarkResult> {
         int cmp = type.index - benchmarkResult.type.index;
         if (cmp == 0) {
             long delta = this.time - benchmarkResult.time;
-            cmp = delta > 0 ? 1 : (delta < 0 ? -1 : 0);
+            if (delta > 0) {
+                cmp = 1;
+            } else if (delta < 0) {
+                cmp = -1;
+            } else {
+                cmp = 0;
+            }
         }
         return cmp;
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/BenchmarkResult.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/BenchmarkResult.java
@@ -37,16 +37,9 @@ class BenchmarkResult implements Comparable<BenchmarkResult> {
 
     @Override
     public int compareTo(BenchmarkResult benchmarkResult) {
-        int cmp = type.index - benchmarkResult.type.index;
+        int cmp = Integer.compare(type.index, benchmarkResult.type.index);
         if (cmp == 0) {
-            long delta = this.time - benchmarkResult.time;
-            if (delta > 0) {
-                cmp = 1;
-            } else if (delta < 0) {
-                cmp = -1;
-            } else {
-                cmp = 0;
-            }
+            cmp = Long.compare(this.time, benchmarkResult.time);
         }
         return cmp;
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/Benchmarker.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/Benchmarker.java
@@ -40,7 +40,7 @@ import net.sourceforge.pmd.util.datasource.DataSource;
  *
  *
  */
-public class Benchmarker {
+public final class Benchmarker {
 
     private static final Map<String, BenchmarkResult> BENCHMARKS_BY_NAME = new HashMap<>();
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TextReport.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TextReport.java
@@ -26,19 +26,12 @@ public class TextReport implements BenchmarkReport {
     private static final int NAME_COLUMN_WIDTH = 50;
     private static final int VALUE_COLUMN_WIDTH = 8;
 
-    /**
-     *
-     * @param stressResults the durations from the stress test run
-     * @param out
-     *            PrintStream
-     * @see BenchmarkReport#generate(Set, PrintStream)
-     */
     @Override
-    public void generate(Set<RuleDuration> stressResults, PrintStream out) {
+    public void generate(Set<RuleDuration> stressResults, PrintStream stream) {
 
-        out.println("=========================================================");
-        out.println("Rule\t\t\t\t\t\tTime in ms");
-        out.println("=========================================================");
+        stream.println("=========================================================");
+        stream.println("Rule\t\t\t\t\t\tTime in ms");
+        stream.println("=========================================================");
 
         for (RuleDuration result : stressResults) {
             StringBuilder buffer = new StringBuilder(result.rule.getName());
@@ -46,25 +39,18 @@ public class TextReport implements BenchmarkReport {
                 buffer.append(' ');
             }
             buffer.append(result.time);
-            out.println(out.toString());
+            stream.println(stream.toString());
         }
 
-        out.println("=========================================================");
+        stream.println("=========================================================");
     }
 
     public void report(Map<String, BenchmarkResult> benchmarksByName) {
         generate(benchmarksByName, System.out);
     }
 
-    /**
-     *
-     * @param benchmarksByName
-     * @param out
-     *            PrintStream
-     * @see BenchmarkReport#generate(Map, PrintStream)
-     */
     @Override
-    public void generate(Map<String, BenchmarkResult> benchmarksByName, PrintStream out) {
+    public void generate(Map<String, BenchmarkResult> benchmarksByName, PrintStream stream) {
 
         List<BenchmarkResult> results = new ArrayList<>(benchmarksByName.values());
 
@@ -153,7 +139,7 @@ public class TextReport implements BenchmarkReport {
             buf.appendLn(buf2.toString());
         }
 
-        out.print(buf.toString());
+        stream.print(buf.toString());
     }
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/AnalysisResult.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/AnalysisResult.java
@@ -44,9 +44,9 @@ public class AnalysisResult {
             IOUtils.skipFully(stream, sourceFile.length());
 
             return stream.getChecksum().getValue();
-        } catch (final IOException e) {
+        } catch (final IOException ignored) {
             // We don't really care, if it's unreadable
-            // the analysis will fail and report the error on it's own
+            // the analysis will fail and report the error on it's own since the checksum won't match
         }
 
         return 0;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cli/PMDCommandLineInterface.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cli/PMDCommandLineInterface.java
@@ -20,7 +20,7 @@ import com.beust.jcommander.ParameterException;
  * @author Romain Pelisse &lt;belaran@gmail.com&gt;
  *
  */
-public class PMDCommandLineInterface {
+public final class PMDCommandLineInterface {
 
     public static final String PROG_NAME = "pmd";
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cli/PMDCommandLineInterface.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cli/PMDCommandLineInterface.java
@@ -184,7 +184,7 @@ public class PMDCommandLineInterface {
         if (noExit == null) {
             noExit = System.getProperty(NO_EXIT_AFTER_RUN);
         }
-        return (noExit == null ? true : false);
+        return noExit == null;
     }
 
     private static void setStatusCode(int statusCode) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/AbstractTokenizer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/AbstractTokenizer.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.cpd;
 
 import java.util.List;
+import java.util.Locale;
 
 /**
  *
@@ -51,7 +52,7 @@ public abstract class AbstractTokenizer implements Tokenizer {
                 loc = getTokenFromLine(token, loc);
                 if (token.length() > 0 && !isIgnorableString(token.toString())) {
                     if (downcaseString) {
-                        token = new StringBuilder(token.toString().toLowerCase());
+                        token = new StringBuilder(token.toString().toLowerCase(Locale.ROOT));
                     }
                     // need to re-think how to link this
                     // if ( CPD.debugEnable ) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/AnyTokenizer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/AnyTokenizer.java
@@ -6,7 +6,7 @@ package net.sourceforge.pmd.cpd;
 
 import java.io.BufferedReader;
 import java.io.CharArrayReader;
-import java.util.NoSuchElementException;
+import java.io.IOException;
 import java.util.StringTokenizer;
 
 import org.apache.commons.io.IOUtils;
@@ -28,23 +28,18 @@ public class AnyTokenizer implements Tokenizer {
             String line = reader.readLine();
             while (line != null) {
                 StringTokenizer tokenizer = new StringTokenizer(line, TOKENS, true);
-                try {
+                while (tokenizer.hasMoreTokens()) {
                     String token = tokenizer.nextToken();
-                    while (token != null) {
-                        if (!" ".equals(token) && !"\t".equals(token)) {
-                            tokenEntries.add(new TokenEntry(token, sourceCode.getFileName(), lineNumber));
-                        }
-                        token = tokenizer.nextToken();
+                    if (!" ".equals(token) && !"\t".equals(token)) {
+                        tokenEntries.add(new TokenEntry(token, sourceCode.getFileName(), lineNumber));
                     }
-                } catch (NoSuchElementException ex) {
-                    // done with tokens
                 }
                 // advance iteration variables
                 line = reader.readLine();
                 lineNumber++;
             }
-        } catch (Exception ex) {
-            ex.printStackTrace();
+        } catch (IOException ignored) {
+            ignored.printStackTrace();
         } finally {
             IOUtils.closeQuietly(reader);
             tokenEntries.add(TokenEntry.getEOF());

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDCommandLineInterface.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDCommandLineInterface.java
@@ -49,7 +49,7 @@ public class CPDCommandLineInterface {
         if (noExit == null) {
             noExit = System.getProperty(NO_EXIT_AFTER_RUN);
         }
-        return (noExit == null ? true : false);
+        return noExit == null;
     }
 
     private static void setStatusCode(int statusCode) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDCommandLineInterface.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDCommandLineInterface.java
@@ -23,7 +23,7 @@ import net.sourceforge.pmd.util.database.DBURI;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
 
-public class CPDCommandLineInterface {
+public final class CPDCommandLineInterface {
     private static final Logger LOGGER = Logger.getLogger(CPDCommandLineInterface.class.getName());
 
     private static final int DUPLICATE_CODE_FOUND = 4;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
@@ -144,9 +144,6 @@ public class CPDConfiguration extends AbstractConfiguration {
         }
     }
 
-    public CPDConfiguration() {
-    }
-
     @Parameter(names = "--encoding", description = "Character encoding to use when processing files", required = false)
     public void setEncoding(String encoding) {
         this.encoding = encoding;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
@@ -239,7 +239,7 @@ public class CPDConfiguration extends AbstractConfiguration {
             if (method != null) {
                 method.invoke(renderer, encoding);
             }
-        } catch (IntrospectionException e) {
+        } catch (IntrospectionException ignored) {
             // ignored - maybe this renderer doesn't have a encoding property
         }
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDNullListener.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDNullListener.java
@@ -9,9 +9,11 @@ import java.io.File;
 public class CPDNullListener implements CPDListener {
     @Override
     public void addedFile(int fileCount, File file) {
+        // does nothing - override it if necessary
     }
 
     @Override
     public void phaseUpdate(int phase) {
+        // does nothing - override it if necessary
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/GUI.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/GUI.java
@@ -58,7 +58,7 @@ import javax.swing.SwingConstants;
 import javax.swing.Timer;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
-import javax.swing.event.TableModelListener;
+import javax.swing.table.AbstractTableModel;
 import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.JTableHeader;
 import javax.swing.table.TableColumn;
@@ -138,7 +138,7 @@ public class GUI implements CPDListener {
                 @Override
                 public String[] extensions() {
                     List<String> exts = lang.getExtensions();
-                    return exts.toArray(new String[exts.size()]);
+                    return exts.toArray(new String[0]);
                 }
 
                 @Override
@@ -748,16 +748,16 @@ public class GUI implements CPDListener {
         return sb.toString();
     }
 
-    private interface SortingTableModel<E> extends TableModel {
-        int sortColumn();
+    private abstract class SortingTableModel<E> extends AbstractTableModel {
+        abstract int sortColumn();
 
-        void sortColumn(int column);
+        abstract void sortColumn(int column);
 
-        boolean sortDescending();
+        abstract boolean sortDescending();
 
-        void sortDescending(boolean flag);
+        abstract void sortDescending(boolean flag);
 
-        void sort(Comparator<E> comparator);
+        abstract void sort(Comparator<E> comparator);
     }
 
     private TableModel tableModelFrom(final List<Match> items) {
@@ -805,20 +805,8 @@ public class GUI implements CPDListener {
             }
 
             @Override
-            public void setValueAt(Object aValue, int rowIndex, int columnIndex) {
-            }
-
-            @Override
             public String getColumnName(int i) {
                 return matchColumns[i].label();
-            }
-
-            @Override
-            public void addTableModelListener(TableModelListener l) {
-            }
-
-            @Override
-            public void removeTableModelListener(TableModelListener l) {
             }
 
             @Override

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/LanguageFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/LanguageFactory.java
@@ -72,7 +72,7 @@ public final class LanguageFactory {
         if (BY_EXTENSION.equals(language)) {
             implementation = instance.getLanguageByExtension(properties.getProperty(EXTENSION));
         } else {
-            implementation = instance.languages.get(instance.languageAliases(language).toLowerCase());
+            implementation = instance.languages.get(instance.languageAliases(language).toLowerCase(Locale.ROOT));
         }
         if (implementation == null) {
             // No proper implementation

--- a/pmd-core/src/main/java/net/sourceforge/pmd/dcd/ClassLoaderUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/dcd/ClassLoaderUtil.java
@@ -56,8 +56,8 @@ public class ClassLoaderUtil {
             for (Class<?> superInterface : type.getInterfaces()) {
                 try {
                     return myGetField(superInterface, name);
-                } catch (NoSuchFieldException e2) {
-                    // Okay
+                } catch (NoSuchFieldException ignored) {
+                    // Ignored, we'll try the super class next
                 }
             }
             // Try the super classes
@@ -99,8 +99,8 @@ public class ClassLoaderUtil {
                     // + type.getSuperclass());
                     return myGetMethod(type.getSuperclass(), name, parameterTypes);
                 }
-            } catch (NoSuchMethodException e2) {
-                // Okay
+            } catch (NoSuchMethodException ignored) {
+                // Ignored, we'll try the interfaces next
             }
             // Try the super interfaces
             for (Class<?> superInterface : type.getInterfaces()) {
@@ -108,8 +108,8 @@ public class ClassLoaderUtil {
                     // System.out.println("Checking super interface: "
                     // + superInterface);
                     return myGetMethod(superInterface, name, parameterTypes);
-                } catch (NoSuchMethodException e3) {
-                    // Okay
+                } catch (NoSuchMethodException ignored) {
+                    // Ignored, fall through to the last line, were we throw
                 }
             }
             throw new NoSuchMethodException(type.getName() + '.' + getMethodSignature(name, parameterTypes));
@@ -153,7 +153,8 @@ public class ClassLoaderUtil {
                 clazz.getDeclaredMethod(method.getName(), method.getParameterTypes());
                 return true;
             }
-        } catch (NoSuchMethodException e) {
+        } catch (NoSuchMethodException ignored) {
+            // Ignored, checking super class and interfaces next
         }
         // Check super class
         if (clazz.getSuperclass() != null) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/dcd/ClassLoaderUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/dcd/ClassLoaderUtil.java
@@ -12,7 +12,7 @@ import java.lang.reflect.Method;
  * ClassLoader utilities. Useful for extracting additional details from a class
  * hierarchy beyond the basic standard Java Reflection APIs.
  */
-public class ClassLoaderUtil {
+public final class ClassLoaderUtil {
 
     public static final String CLINIT = "<clinit>";
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/dcd/DCD.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/dcd/DCD.java
@@ -46,7 +46,7 @@ import net.sourceforge.pmd.util.filter.Filters;
  *
  * @author Ryan Gustafson &lt;ryan.gustafson@gmail.com&gt;
  */
-public class DCD {
+public final class DCD {
     //
     // TODO Implement the direct users, indirect users, and dead code
     // candidate sets. Use the pmd.util.filter.Filter APIs. Need to come up

--- a/pmd-core/src/main/java/net/sourceforge/pmd/dcd/asm/TypeSignatureVisitor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/dcd/asm/TypeSignatureVisitor.java
@@ -94,7 +94,7 @@ public class TypeSignatureVisitor extends SignatureVisitor {
             throw new RuntimeException();
         }
         if (parameterTypes != null) {
-            return parameterTypes.toArray(new Class<?>[parameterTypes.size()]);
+            return parameterTypes.toArray(new Class<?>[0]);
         } else {
             return null;
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/dcd/graph/ConstructorNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/dcd/graph/ConstructorNode.java
@@ -15,7 +15,6 @@ import net.sourceforge.pmd.dcd.asm.TypeSignatureVisitor;
 /**
  * Represents a Class Constructor in a UsageGraph.
  */
-@SuppressWarnings("PMD.OverrideBothEqualsAndHashcode")
 public class ConstructorNode extends MemberNode<ConstructorNode, Constructor<?>> {
 
     private WeakReference<Constructor<?>> constructorReference;
@@ -79,22 +78,5 @@ public class ConstructorNode extends MemberNode<ConstructorNode, Constructor<?>>
             }
         }
         return cmp;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj instanceof ConstructorNode) {
-            ConstructorNode that = (ConstructorNode) obj;
-            return super.equals(that);
-        }
-        return false;
-    }
-
-    /* (non-Javadoc)
-     * @see net.sourceforge.pmd.dcd.graph.MemberNode#hashCode()
-     */
-    @Override
-    public int hashCode() {
-        return super.hashCode();
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/dcd/graph/FieldNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/dcd/graph/FieldNode.java
@@ -12,7 +12,6 @@ import net.sourceforge.pmd.dcd.ClassLoaderUtil;
 /**
  * Represents a Class Field in a UsageGraph.
  */
-@SuppressWarnings("PMD.OverrideBothEqualsAndHashcode")
 public class FieldNode extends MemberNode<FieldNode, Field> {
 
     private WeakReference<Field> fieldReference;
@@ -35,22 +34,5 @@ public class FieldNode extends MemberNode<FieldNode, Field> {
     @Override
     public int compareTo(FieldNode that) {
         return this.name.compareTo(that.name);
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj instanceof FieldNode) {
-            FieldNode that = (FieldNode) obj;
-            return super.equals(that);
-        }
-        return false;
-    }
-
-    /* (non-Javadoc)
-     * @see net.sourceforge.pmd.dcd.graph.MemberNode#hashCode()
-     */
-    @Override
-    public int hashCode() {
-        return super.hashCode();
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/dcd/graph/MemberNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/dcd/graph/MemberNode.java
@@ -24,8 +24,6 @@ public abstract class MemberNode<S extends MemberNode<S, T>, T extends Member>
 
     private List<MemberNode> users;
 
-    private Object decoration;
-
     public MemberNode(ClassNode classNode, String name, String desc) {
         this.classNode = classNode;
         this.name = name;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/dcd/graph/MemberNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/dcd/graph/MemberNode.java
@@ -87,6 +87,7 @@ public abstract class MemberNode<S extends MemberNode<S, T>, T extends Member>
     }
 
     @SuppressWarnings("PMD.SuspiciousEqualsMethodName")
+    @Deprecated // To be removed with PMD 7.0.0
     public boolean equals(S that) {
         return equals(that.name, that.desc);
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/dcd/graph/MethodNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/dcd/graph/MethodNode.java
@@ -15,7 +15,6 @@ import net.sourceforge.pmd.dcd.asm.TypeSignatureVisitor;
 /**
  * Represents a Class Method in a UsageGraph.
  */
-@SuppressWarnings("PMD.OverrideBothEqualsAndHashcode")
 public class MethodNode extends MemberNode<MethodNode, Method> {
 
     private WeakReference<Method> methodReference;
@@ -57,22 +56,5 @@ public class MethodNode extends MemberNode<MethodNode, Method> {
             }
         }
         return cmp;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj instanceof MethodNode) {
-            MethodNode that = (MethodNode) obj;
-            return super.equals(that);
-        }
-        return false;
-    }
-
-    /* (non-Javadoc)
-     * @see net.sourceforge.pmd.dcd.graph.MemberNode#hashCode()
-     */
-    @Override
-    public int hashCode() {
-        return super.hashCode();
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageFilenameFilter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageFilenameFilter.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.FilenameFilter;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -52,7 +53,7 @@ public class LanguageFilenameFilter implements FilenameFilter {
             return false;
         }
 
-        String extension = name.substring(1 + lastDotIndex).toUpperCase();
+        String extension = name.substring(1 + lastDotIndex).toUpperCase(Locale.ROOT);
         for (Language language : languages) {
             for (String ext : language.getExtensions()) {
                 if (extension.equalsIgnoreCase(ext)) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/XPathHandler.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/XPathHandler.java
@@ -19,10 +19,12 @@ public interface XPathHandler {
     XPathHandler DUMMY = new XPathHandler() {
         @Override
         public void initialize() {
+            // empty handler - does nothing
         }
 
         @Override
         public void initialize(IndependentContext context) {
+            // empty handler - does nothing
         }
 
         @Override

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/AttributeAxisIterator.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/AttributeAxisIterator.java
@@ -65,7 +65,7 @@ public class AttributeAxisIterator implements Iterator<Attribute> {
                     postFilter.add(new MethodWrapper(element));
                 }
             }
-            methodCache.putIfAbsent(contextNode.getClass(), postFilter.toArray(new MethodWrapper[postFilter.size()]));
+            methodCache.putIfAbsent(contextNode.getClass(), postFilter.toArray(new MethodWrapper[0]));
         }
         this.methodWrappers = methodCache.get(contextNode.getClass());
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/DefaultASTXPathHandler.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/DefaultASTXPathHandler.java
@@ -1,0 +1,19 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.ast.xpath;
+
+import net.sf.saxon.sxpath.IndependentContext;
+
+public class DefaultASTXPathHandler extends AbstractASTXPathHandler {
+    @Override
+    public void initialize() {
+        // override if needed
+    }
+
+    @Override
+    public void initialize(IndependentContext context) {
+        // override if needed
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/dfa/StackObject.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/dfa/StackObject.java
@@ -24,7 +24,6 @@ public class StackObject {
 
     @Override
     public String toString() {
-        return ("StackObject: type=" + type + ", node=" + node.toString());
-
+        return "StackObject: type=" + type + ", node=" + node.toString();
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/metrics/MetricKeyUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/metrics/MetricKeyUtil.java
@@ -14,7 +14,7 @@ import net.sourceforge.pmd.lang.ast.Node;
  * @author Clément Fournier
  * @since 6.0.0
  */
-public class MetricKeyUtil {
+public final class MetricKeyUtil {
 
     private MetricKeyUtil() {
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/metrics/ParameterizedMetricKey.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/metrics/ParameterizedMetricKey.java
@@ -63,6 +63,7 @@ public final class ParameterizedMetricKey<N extends Node> {
      *
      * @return An instance of parameterized metric key corresponding to the parameters
      */
+    @SuppressWarnings("PMD.SingletonClassReturningNewInstance")
     public static <N extends Node> ParameterizedMetricKey<N> getInstance(MetricKey<N> key, MetricOptions options) {
         ParameterizedMetricKey<N> tmp = new ParameterizedMetricKey<>(key, options);
         if (!POOL.containsKey(tmp)) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
@@ -438,8 +438,9 @@ public abstract class AbstractRule extends AbstractPropertySource implements Rul
         Rule rule = null;
         try {
             rule = getClass().newInstance();
-        } catch (InstantiationException | IllegalAccessException e) {
+        } catch (InstantiationException | IllegalAccessException ignored) {
             // Can't happen... we already have an instance
+            throw new RuntimeException(ignored); // in case it happens anyway, something is really wrong...
         }
         rule.setName(getName());
         rule.setLanguage(getLanguage());

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/MockRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/MockRule.java
@@ -41,5 +41,6 @@ public class MockRule extends AbstractRule {
 
     @Override
     public void apply(List<? extends Node> nodes, RuleContext ctx) {
+        // the mock rule does nothing. Usually you would start here to analyze the AST.
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleReference.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleReference.java
@@ -45,9 +45,18 @@ public class RuleReference extends AbstractDelegateRule {
 
     private static final List<PropertyDescriptor<?>> EMPTY_DESCRIPTORS = Collections.emptyList();
 
+    @Deprecated // to be removed with PMD 7.0.0
+    // when creating a rule reference, always provide the rule and the ruleset, see
+    // the constructor RuleReference(Rule, RuleSetReference)
     public RuleReference() {
+        // default constructor
     }
 
+    /**
+     * 
+     * @param theRule the referenced rule
+     * @param theRuleSetReference the rule set, where the rule is defined
+     */
     public RuleReference(Rule theRule, RuleSetReference theRuleSetReference) {
         setRule(theRule);
         ruleSetReference = theRuleSetReference;
@@ -317,11 +326,7 @@ public class RuleReference extends AbstractDelegateRule {
             }
         }
 
-        if (!getRule().usesDefaultValues()) {
-            return false;
-        }
-
-        return true;
+        return getRule().usesDefaultValues();
     }
 
     @Override

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleReference.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleReference.java
@@ -346,8 +346,9 @@ public class RuleReference extends AbstractDelegateRule {
         RuleReference rule = null;
         try {
             rule = getClass().newInstance();
-        } catch (InstantiationException | IllegalAccessException e) {
+        } catch (InstantiationException | IllegalAccessException ignored) {
             // Can't happen... we already have an instance
+            throw new RuntimeException(ignored); // in case it happens anyway, then something is really wrong...
         }
         rule.setRule(this.getRule().deepCopy());
         

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/xpath/Initializer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/xpath/Initializer.java
@@ -17,7 +17,7 @@ import net.sf.saxon.sxpath.IndependentContext;
  * Initialization should be performed before any XPath related operations are
  * performed.
  */
-public class Initializer {
+public final class Initializer {
 
     private Initializer() { }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/xpath/PMDFunctions.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/xpath/PMDFunctions.java
@@ -4,7 +4,7 @@
 
 package net.sourceforge.pmd.lang.xpath;
 
-public class PMDFunctions {
+public final class PMDFunctions {
     private PMDFunctions() { }
 
     public static boolean matches(String s, String pattern1) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/processor/AbstractPMDProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/processor/AbstractPMDProcessor.java
@@ -49,7 +49,7 @@ public abstract class AbstractPMDProcessor {
             long end = System.nanoTime();
             Benchmarker.mark(Benchmark.Reporting, end - start, 1);
         } catch (IOException ioe) {
-
+            throw new RuntimeException(ioe);
         }
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/processor/MultiThreadProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/processor/MultiThreadProcessor.java
@@ -12,7 +12,6 @@ import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.ThreadFactory;
 
 import net.sourceforge.pmd.PMDConfiguration;
 import net.sourceforge.pmd.Report;
@@ -24,7 +23,6 @@ import net.sourceforge.pmd.renderers.Renderer;
  */
 public class MultiThreadProcessor extends AbstractPMDProcessor {
 
-    private ThreadFactory factory;
     private ExecutorService executor;
     private CompletionService<Report> completionService;
     private List<Future<Report>> tasks = new ArrayList<>();
@@ -32,8 +30,7 @@ public class MultiThreadProcessor extends AbstractPMDProcessor {
     public MultiThreadProcessor(final PMDConfiguration configuration) {
         super(configuration);
 
-        factory = new PmdThreadFactory();
-        executor = Executors.newFixedThreadPool(configuration.getThreads(), factory);
+        executor = Executors.newFixedThreadPool(configuration.getThreads(), new PmdThreadFactory());
         completionService = new ExecutorCompletionService<>(executor);
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/AbstractAccumulatingRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/AbstractAccumulatingRenderer.java
@@ -39,6 +39,7 @@ public abstract class AbstractAccumulatingRenderer extends AbstractRenderer {
 
     @Override
     public void startFileAnalysis(DataSource dataSource) {
+        // does nothing - override if necessary
     }
 
     @Override

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/AbstractIncrementingRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/AbstractIncrementingRenderer.java
@@ -47,10 +47,12 @@ public abstract class AbstractIncrementingRenderer extends AbstractRenderer {
 
     @Override
     public void start() throws IOException {
+        // does nothing - override if necessary
     }
 
     @Override
     public void startFileAnalysis(DataSource dataSource) {
+        // does nothing - override if necessary
     }
 
     @Override
@@ -85,5 +87,6 @@ public abstract class AbstractIncrementingRenderer extends AbstractRenderer {
 
     @Override
     public void end() throws IOException {
+        // does nothing - override if necessary
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/CodeClimateIssue.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/CodeClimateIssue.java
@@ -11,7 +11,7 @@ import net.sourceforge.pmd.PMD;
  * (https://github.com/codeclimate/spec/blob/master/SPEC.md#issues)
  */
 public class CodeClimateIssue {
-    public final String type = "issue";
+    public String type;
     public String check_name; // SUPPRESS CHECKSTYLE underscore is required per codeclimate format
     public String description;
     public Content content;
@@ -19,6 +19,10 @@ public class CodeClimateIssue {
     public Location location;
     public String severity;
     public int remediation_points; // SUPPRESS CHECKSTYLE underscore is required per codeclimate format
+
+    public CodeClimateIssue() {
+        type = "issue"; // the default type for PMD violations when reporting as code climate
+    }
 
     /**
      * Location structure

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/EmptyRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/EmptyRenderer.java
@@ -26,17 +26,21 @@ public class EmptyRenderer extends AbstractRenderer {
 
     @Override
     public void start() throws IOException {
+        // deliberately does nothing
     }
 
     @Override
     public void startFileAnalysis(DataSource dataSource) {
+        // deliberately does nothing
     }
 
     @Override
     public void renderFileReport(Report report) throws IOException {
+        // deliberately does nothing
     }
 
     @Override
     public void end() throws IOException {
+        // deliberately does nothing
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/RendererFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/RendererFactory.java
@@ -129,8 +129,8 @@ public class RendererFactory {
             if (!Modifier.isPublic(constructor.getModifiers())) {
                 constructor = null;
             }
-        } catch (NoSuchMethodException e) {
-            // Ok
+        } catch (NoSuchMethodException ignored) {
+            // Ignored, we'll check default constructor next
         }
 
         // 2) No-arg constructor?
@@ -139,8 +139,8 @@ public class RendererFactory {
             if (!Modifier.isPublic(constructor.getModifiers())) {
                 constructor = null;
             }
-        } catch (NoSuchMethodException e2) {
-            // Ok
+        } catch (NoSuchMethodException ignored) {
+            // Ignored, we'll eventually throw an exception, if there is no constructor
         }
 
         if (constructor == null) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/RendererFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/RendererFactory.java
@@ -21,7 +21,7 @@ import net.sourceforge.pmd.properties.PropertyDescriptor;
  *
  * @see Renderer
  */
-public class RendererFactory {
+public final class RendererFactory {
 
     private static final Logger LOG = Logger.getLogger(RendererFactory.class.getName());
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextRenderer.java
@@ -29,10 +29,6 @@ public class TextRenderer extends AbstractIncrementingRenderer {
     }
 
     @Override
-    public void start() throws IOException {
-    }
-
-    @Override
     public void renderFileViolations(Iterator<RuleViolation> violations) throws IOException {
         Writer writer = getWriter();
         StringBuilder buf = new StringBuilder();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/rules/RuleFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/rules/RuleFactory.java
@@ -25,6 +25,7 @@ import org.w3c.dom.NodeList;
 
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RulePriority;
+import net.sourceforge.pmd.RuleSetReference;
 import net.sourceforge.pmd.lang.rule.RuleReference;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyDescriptorField;
@@ -59,19 +60,19 @@ public class RuleFactory {
     private static final List<String> REQUIRED_ATTRIBUTES = Collections.unmodifiableList(Arrays.asList(NAME, CLASS));
 
     /**
-     * Decorates a referenced rule with the metadata that are overriden in the given rule element.
+     * Decorates a referenced rule with the metadata that are overridden in the given rule element.
      *
      * <p>Declaring a property in the overriding element throws an exception (the property must exist in the referenced
      * rule).
      *
      * @param referencedRule Referenced rule
+     * @param ruleSetReference the ruleset, where the referenced rule is defined
      * @param ruleElement    Element overriding some metadata about the rule
      *
      * @return A rule reference to the referenced rule
      */
-    public RuleReference decorateRule(Rule referencedRule, Element ruleElement) {
-        RuleReference ruleReference = new RuleReference();
-        ruleReference.setRule(referencedRule);
+    public RuleReference decorateRule(Rule referencedRule, RuleSetReference ruleSetReference, Element ruleElement) {
+        RuleReference ruleReference = new RuleReference(referencedRule, ruleSetReference);
 
         if (ruleElement.hasAttribute(DEPRECATED)) {
             ruleReference.setDeprecated(Boolean.parseBoolean(ruleElement.getAttribute(DEPRECATED)));

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/ClasspathClassLoader.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/ClasspathClassLoader.java
@@ -50,7 +50,7 @@ public class ClasspathClassLoader extends URLClassLoader {
             // Treat as classpath
             addClasspathURLs(urls, classpath);
         }
-        return urls.toArray(new URL[urls.size()]);
+        return urls.toArray(new URL[0]);
     }
 
     private static void addClasspathURLs(final List<URL> urls, final String classpath) throws MalformedURLException {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/NumericConstants.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/NumericConstants.java
@@ -4,7 +4,7 @@
 
 package net.sourceforge.pmd.util;
 
-public class NumericConstants {
+public final class NumericConstants {
 
     public static final Integer ZERO = 0;
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/ResourceLoader.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/ResourceLoader.java
@@ -63,6 +63,7 @@ public class ResourceLoader {
                 return new FileInputStream(file);
             } catch (final FileNotFoundException e) {
                 // if the file didn't exist, we wouldn't be here
+                throw new RuntimeException(e); // somehow the file vanished between checking for existence and opening
             }
         }
 
@@ -76,7 +77,7 @@ public class ResourceLoader {
             try {
                 return loadClassPathResourceAsStream(name);
             } catch (final IOException ignored) {
-                // We will throw out own exception, with a different message
+                // We will throw our own exception, with a different message
             }
         }
         

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/StringUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/StringUtil.java
@@ -370,7 +370,7 @@ public final class StringUtil {
             index = str.indexOf(separator, currPos);
         }
         list.add(str.substring(currPos));
-        return list.toArray(new String[list.size()]);
+        return list.toArray(new String[0]);
     }
 
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/database/SourceObject.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/database/SourceObject.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.util.database;
 
+import java.util.Locale;
 import java.util.logging.Logger;
 
 import net.sourceforge.pmd.cpd.SourceCode;
@@ -130,21 +131,21 @@ public class SourceObject {
         LOG.entering(CLASS_NAME, "getSuffixFromType", this);
         if (null == type || type.isEmpty()) {
             return "";
-        } else if (type.toUpperCase().indexOf("JAVA") >= 0) {
+        } else if (type.toUpperCase(Locale.ROOT).indexOf("JAVA") >= 0) {
             return ".java";
-        } else if (type.toUpperCase().indexOf("TRIGGER") >= 0) {
+        } else if (type.toUpperCase(Locale.ROOT).indexOf("TRIGGER") >= 0) {
             return ".trg";
-        } else if (type.toUpperCase().indexOf("FUNCTION") >= 0) {
+        } else if (type.toUpperCase(Locale.ROOT).indexOf("FUNCTION") >= 0) {
             return ".fnc";
-        } else if (type.toUpperCase().indexOf("PROCEDURE") >= 0) {
+        } else if (type.toUpperCase(Locale.ROOT).indexOf("PROCEDURE") >= 0) {
             return ".prc";
-        } else if (type.toUpperCase().indexOf("PACKAGE_BODY") >= 0) {
+        } else if (type.toUpperCase(Locale.ROOT).indexOf("PACKAGE_BODY") >= 0) {
             return ".pkb";
-        } else if (type.toUpperCase().indexOf("PACKAGE") >= 0) {
+        } else if (type.toUpperCase(Locale.ROOT).indexOf("PACKAGE") >= 0) {
             return ".pks";
-        } else if (type.toUpperCase().indexOf("TYPE_BODY") >= 0) {
+        } else if (type.toUpperCase(Locale.ROOT).indexOf("TYPE_BODY") >= 0) {
             return ".tpb";
-        } else if (type.toUpperCase().indexOf("TYPE") >= 0) {
+        } else if (type.toUpperCase(Locale.ROOT).indexOf("TYPE") >= 0) {
             return ".tps";
         } else {
             return "";
@@ -157,8 +158,7 @@ public class SourceObject {
      * parser is used.
      */
     public String getPseudoFileName() {
-        String falseFilePath = String.format("/Database/%s/%s/%s%s", getSchema(), getType(), getName(),
+        return String.format("/Database/%s/%s/%s%s", getSchema(), getType(), getName(),
                 getSuffixFromType());
-        return falseFilePath;
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/designer/Designer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/designer/Designer.java
@@ -912,6 +912,7 @@ public class Designer implements ClipboardOwner {
                         undoManager.undo();
                     }
                 } catch (CannotUndoException e) {
+                    throw new RuntimeException(e);
                 }
             }
         });
@@ -925,6 +926,7 @@ public class Designer implements ClipboardOwner {
                         undoManager.redo();
                     }
                 } catch (CannotRedoException e) {
+                    throw new RuntimeException(e);
                 }
             }
         });

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/designer/Designer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/designer/Designer.java
@@ -222,7 +222,7 @@ public class Designer implements ClipboardOwner {
                 }
             }
         }
-        return languageVersions.toArray(new LanguageVersion[languageVersions.size()]);
+        return languageVersions.toArray(new LanguageVersion[0]);
     }
 
     private LanguageVersion getLanguageVersion() {
@@ -990,6 +990,7 @@ public class Designer implements ClipboardOwner {
 
     @Override
     public void lostOwnership(Clipboard clipboard, Transferable contents) {
+        // ignored
     }
 
     private void loadSettings() {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/filter/AbstractDelegateFilter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/filter/AbstractDelegateFilter.java
@@ -15,6 +15,7 @@ public abstract class AbstractDelegateFilter<T> implements Filter<T> {
     protected Filter<T> filter;
 
     public AbstractDelegateFilter() {
+        // default constructor
     }
 
     public AbstractDelegateFilter(Filter<T> filter) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/filter/FileExtensionFilter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/filter/FileExtensionFilter.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.util.filter;
 
 import java.io.File;
+import java.util.Locale;
 
 public class FileExtensionFilter implements Filter<File> {
     protected final String[] extensions;
@@ -25,7 +26,7 @@ public class FileExtensionFilter implements Filter<File> {
         this.ignoreCase = ignoreCase;
         if (ignoreCase) {
             for (int i = 0; i < this.extensions.length; i++) {
-                this.extensions[i] = this.extensions[i].toUpperCase();
+                this.extensions[i] = this.extensions[i].toUpperCase(Locale.ROOT);
             }
         }
     }
@@ -36,7 +37,7 @@ public class FileExtensionFilter implements Filter<File> {
         if (!accept) {
             for (String extension : extensions) {
                 String name = file.getName();
-                if (ignoreCase ? name.toUpperCase().endsWith(extension) : name.endsWith(extension)) {
+                if (ignoreCase ? name.toUpperCase(Locale.ROOT).endsWith(extension) : name.endsWith(extension)) {
                     accept = true;
                     break;
                 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/filter/Filters.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/filter/Filters.java
@@ -14,7 +14,7 @@ import java.util.List;
  * Utility class for working with Filters. Contains builder style methods, apply
  * methods, as well as mechanisms for adapting Filters and FilenameFilters.
  */
-public class Filters {
+public final class Filters {
 
     private Filters() { }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/filter/RegexStringFilter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/filter/RegexStringFilter.java
@@ -67,7 +67,7 @@ public class RegexStringFilter implements Filter<String> {
         } else {
             try {
                 this.pattern = Pattern.compile(this.regex);
-            } catch (PatternSyntaxException e) {
+            } catch (PatternSyntaxException ignored) {
                 // If the regular expression is invalid, then pattern will be
                 // null.
             }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/log/AntLogHandler.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/log/AntLogHandler.java
@@ -62,9 +62,11 @@ public class AntLogHandler extends Handler {
 
     @Override
     public void close() throws SecurityException {
+        // nothing to do
     }
 
     @Override
     public void flush() {
+        // nothing to do
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/log/ConsoleLogHandler.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/log/ConsoleLogHandler.java
@@ -35,9 +35,11 @@ public class ConsoleLogHandler extends Handler {
 
     @Override
     public void close() throws SecurityException {
+        // nothing to do
     }
 
     @Override
     public void flush() {
+        System.out.flush();
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/Viewer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/Viewer.java
@@ -14,7 +14,7 @@ import net.sourceforge.pmd.util.viewer.gui.MainFrame;
  * @version $Id$
  */
 @Deprecated // to be removed with PMD 7.0.0
-public class Viewer {
+public final class Viewer {
 
     private Viewer() { }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/model/AttributeToolkit.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/model/AttributeToolkit.java
@@ -13,7 +13,7 @@ import net.sourceforge.pmd.lang.ast.xpath.Attribute;
  * @version $Id$
  */
 @Deprecated // to be removed with PMD 7.0.0
-public class AttributeToolkit {
+public final class AttributeToolkit {
 
     private AttributeToolkit() { }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/util/NLS.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/util/NLS.java
@@ -13,7 +13,7 @@ import java.util.ResourceBundle;
  * @version $Id$
  */
 @Deprecated // to be removed with PMD 7.0.0
-public class NLS {
+public final class NLS {
     private static final ResourceBundle BUNDLE;
 
     static {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageModule.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageModule.java
@@ -107,9 +107,9 @@ public class DummyLanguageModule extends BaseLanguageModule {
         protected RuleViolation createRuleViolation(Rule rule, RuleContext ruleContext, Node node, String message,
                 int beginLine, int endLine) {
             ParametricRuleViolation<Node> rv = new ParametricRuleViolation<Node>(rule, ruleContext, node, message) {
-                {
-                    this.packageName = "foo"; // just for testing variable
-                    // expansion
+                public String getPackageName() {
+                    this.packageName = "foo"; // just for testing variable expansion
+                    return super.getPackageName();
                 }
             };
             rv.setLines(beginLine, endLine);

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/docs/GenerateRuleDocsCmd.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/docs/GenerateRuleDocsCmd.java
@@ -23,7 +23,7 @@ import net.sourceforge.pmd.RuleSet;
 import net.sourceforge.pmd.RuleSetFactory;
 import net.sourceforge.pmd.RuleSetNotFoundException;
 
-public class GenerateRuleDocsCmd {
+public final class GenerateRuleDocsCmd {
     private GenerateRuleDocsCmd() {
         // Utility class
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/cpd/JavaTokenizer.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/cpd/JavaTokenizer.java
@@ -179,9 +179,8 @@ public class JavaTokenizer implements Tokenizer {
         }
 
         public boolean isDiscarding() {
-            boolean result = discardingSemicolon || discardingKeywords || discardingAnnotations
+            return discardingSemicolon || discardingKeywords || discardingAnnotations
                     || discardingSuppressing;
-            return result;
         }
 
         private void detectAnnotations(Token currentToken) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/AbstractJavaHandler.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/AbstractJavaHandler.java
@@ -12,7 +12,7 @@ import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.VisitorStarter;
 import net.sourceforge.pmd.lang.XPathHandler;
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.ast.xpath.AbstractASTXPathHandler;
+import net.sourceforge.pmd.lang.ast.xpath.DefaultASTXPathHandler;
 import net.sourceforge.pmd.lang.dfa.DFAGraphRule;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.DumpFacade;
@@ -46,13 +46,15 @@ public abstract class AbstractJavaHandler extends AbstractLanguageVersionHandler
 
     @Override
     public XPathHandler getXPathHandler() {
-        return new AbstractASTXPathHandler() {
+        return new DefaultASTXPathHandler() {
+            @Override
             public void initialize() {
                 TypeOfFunction.registerSelfInSimpleContext();
                 GetCommentOnFunction.registerSelfInSimpleContext();
                 MetricFunction.registerSelfInSimpleContext();
             }
 
+            @Override
             public void initialize(IndependentContext context) {
                 super.initialize(context, LanguageRegistry.getLanguage(JavaLanguageModule.NAME), JavaFunctions.class);
             }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAllocationExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAllocationExpression.java
@@ -5,8 +5,6 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
-import net.sourceforge.pmd.lang.ast.Node;
-
 public class ASTAllocationExpression extends AbstractJavaTypeNode {
     public ASTAllocationExpression(int id) {
         super(id);
@@ -25,8 +23,8 @@ public class ASTAllocationExpression extends AbstractJavaTypeNode {
 
     public boolean isAnonymousClass() {
         if (jjtGetNumChildren() > 1) {
-            Node lastChild = jjtGetChild(jjtGetNumChildren() - 1);
-            return lastChild instanceof ASTClassOrInterfaceBody;
+            // check the last child
+            return jjtGetChild(jjtGetNumChildren() - 1) instanceof ASTClassOrInterfaceBody;
         }
         return false;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExpression.java
@@ -41,7 +41,7 @@ public class ASTExpression extends AbstractJavaTypeNode {
         ASTLiteral literal = primaryPrefix.getFirstChildOfType(ASTLiteral.class);
 
         if (literal == null || literal.isStringLiteral()
-                || (literal.jjtGetNumChildren() != 0 && literal.jjtGetChild(0) instanceof ASTNullLiteral)) {
+                || literal.jjtGetNumChildren() != 0 && literal.jjtGetChild(0) instanceof ASTNullLiteral) {
             return false;
         }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExpression.java
@@ -40,12 +40,9 @@ public class ASTExpression extends AbstractJavaTypeNode {
 
         ASTLiteral literal = primaryPrefix.getFirstChildOfType(ASTLiteral.class);
 
-        if (literal == null || literal.isStringLiteral()
-                || literal.jjtGetNumChildren() != 0 && literal.jjtGetChild(0) instanceof ASTNullLiteral) {
-            return false;
-        }
-
+        // if it is not a string literal and not a null, then it is one of
         // byte, short, char, int, long, float, double, boolean
-        return true;
+        return literal != null && !literal.isStringLiteral()
+                && (literal.jjtGetNumChildren() == 0 || !(literal.jjtGetChild(0) instanceof ASTNullLiteral));
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFieldDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFieldDeclaration.java
@@ -90,14 +90,11 @@ public class ASTFieldDeclaration extends AbstractJavaAccessTypeNode implements D
     }
 
     public boolean isAnnotationMember() {
-        if (jjtGetParent().jjtGetParent() instanceof ASTAnnotationTypeBody) {
-            return true;
-        }
-        return false;
+        return getNthParent(2) instanceof ASTAnnotationTypeBody;
     }
 
     public boolean isInterfaceMember() {
-        if (jjtGetParent().jjtGetParent() instanceof ASTEnumBody) {
+        if (getNthParent(2) instanceof ASTEnumBody) {
             return false;
         }
         ASTClassOrInterfaceDeclaration n = getFirstParentOfType(ASTClassOrInterfaceDeclaration.class);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLiteral.java
@@ -5,6 +5,7 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import java.util.Locale;
 import java.util.regex.Pattern;
 
 public class ASTLiteral extends AbstractJavaTypeNode {
@@ -98,7 +99,7 @@ public class ASTLiteral extends AbstractJavaTypeNode {
     }
     
     private String stripIntValue() {
-        String image = getImage().toLowerCase().replaceAll("_", "");
+        String image = getImage().toLowerCase(Locale.ROOT).replaceAll("_", "");
         
         boolean isNegative = false;
         if (image.charAt(0) == '-') {
@@ -126,11 +127,11 @@ public class ASTLiteral extends AbstractJavaTypeNode {
     }
     
     private String stripFloatValue() {
-        return getImage().toLowerCase().replaceAll("_", "");
+        return getImage().toLowerCase(Locale.ROOT).replaceAll("_", "");
     }
     
     private int getIntBase() {
-        final String image = getImage().toLowerCase();
+        final String image = getImage().toLowerCase(Locale.ROOT);
         final int offset = image.charAt(0) == '-' ? 1 : 0;
         if (image.startsWith("0x", offset)) {
             return 16;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/Comment.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/Comment.java
@@ -42,7 +42,7 @@ public abstract class Comment extends AbstractNode {
                     entry.getValue() + 1, entry.getValue() + tag.label.length() + 1, tag));
         }
 
-        children = kids.toArray(new Node[kids.size()]);
+        children = kids.toArray(new Node[0]);
     }
 
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaParserVisitorDecorator.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaParserVisitorDecorator.java
@@ -14,11 +14,6 @@ public class JavaParserVisitorDecorator implements JavaParserControllessVisitor 
 
     private JavaParserVisitor visitor;
 
-
-    public JavaParserVisitorDecorator() {
-    }
-
-
     public void setBase(JavaParserControllessVisitor base) {
         visitor = base;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaQualifiedName.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaQualifiedName.java
@@ -68,7 +68,6 @@ public final class JavaQualifiedName implements QualifiedName {
     private static final int PACKAGES_GROUP_INDEX = 1;
     private static final int CLASSES_GROUP_INDEX = 3;
     private static final int OPERATION_GROUP_INDEX = 7;
-    private static final int PARAMETERS_GROUP_INDEX = 9;
 
 
     /** Local index value for when the class is not local. */

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/JavaMetricsComputer.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/JavaMetricsComputer.java
@@ -17,13 +17,12 @@ import net.sourceforge.pmd.lang.metrics.AbstractMetricsComputer;
  *
  * @author Clément Fournier
  */
-public class JavaMetricsComputer extends AbstractMetricsComputer<ASTAnyTypeDeclaration, ASTMethodOrConstructorDeclaration> {
+public final class JavaMetricsComputer extends AbstractMetricsComputer<ASTAnyTypeDeclaration, ASTMethodOrConstructorDeclaration> {
 
     static final JavaMetricsComputer INSTANCE = new JavaMetricsComputer();
 
 
     private JavaMetricsComputer() {
-
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/impl/visitors/AtfdBaseVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/impl/visitors/AtfdBaseVisitor.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.java.metrics.impl.visitors;
 
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableInt;
 
 import net.sourceforge.pmd.lang.java.ast.ASTAllocationExpression;
@@ -15,7 +16,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
 import net.sourceforge.pmd.lang.java.ast.JavaParserVisitorAdapter;
-import net.sourceforge.pmd.util.StringUtil;
 
 /**
  * Computes Atfd.
@@ -41,7 +41,7 @@ public class AtfdBaseVisitor extends JavaParserVisitorAdapter {
 
         String methodOrAttributeName = getMethodOrAttributeName(node);
 
-        return methodOrAttributeName != null && StringUtil.startsWithAny(methodOrAttributeName, "get", "is", "set");
+        return methodOrAttributeName != null && StringUtils.startsWithAny(methodOrAttributeName, "get", "is", "set");
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/impl/visitors/CycloBaseVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/impl/visitors/CycloBaseVisitor.java
@@ -25,12 +25,12 @@ import net.sourceforge.pmd.lang.java.ast.JavaParserControllessVisitorAdapter;
  * @author Clément Fournier
  * @see net.sourceforge.pmd.lang.java.metrics.impl.CycloMetric
  */
-public class CycloBaseVisitor extends JavaParserControllessVisitorAdapter {
+public final class CycloBaseVisitor extends JavaParserControllessVisitorAdapter {
 
     /** Instance. */
     public static final CycloBaseVisitor INSTANCE = new CycloBaseVisitor();
 
-    protected CycloBaseVisitor() {
+    private CycloBaseVisitor() {
 
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/impl/visitors/CycloBaseVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/impl/visitors/CycloBaseVisitor.java
@@ -25,14 +25,10 @@ import net.sourceforge.pmd.lang.java.ast.JavaParserControllessVisitorAdapter;
  * @author Clément Fournier
  * @see net.sourceforge.pmd.lang.java.metrics.impl.CycloMetric
  */
-public final class CycloBaseVisitor extends JavaParserControllessVisitorAdapter {
+public class CycloBaseVisitor extends JavaParserControllessVisitorAdapter {
 
     /** Instance. */
     public static final CycloBaseVisitor INSTANCE = new CycloBaseVisitor();
-
-    private CycloBaseVisitor() {
-
-    }
 
     @Override
     public Object visit(ASTSwitchStatement node, Object data) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/impl/visitors/NcssBaseVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/impl/visitors/NcssBaseVisitor.java
@@ -41,15 +41,10 @@ import net.sourceforge.pmd.lang.java.ast.JavaParserControllessVisitorAdapter;
  * @author Clément Fournier
  * @see net.sourceforge.pmd.lang.java.metrics.impl.NcssMetric
  */
-public final class NcssBaseVisitor extends JavaParserControllessVisitorAdapter {
+public class NcssBaseVisitor extends JavaParserControllessVisitorAdapter {
 
     /** Instance. */
     public static final NcssBaseVisitor INSTANCE = new NcssBaseVisitor();
-
-
-    private NcssBaseVisitor() {
-    }
-
 
     @Override
     public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/impl/visitors/NcssBaseVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/impl/visitors/NcssBaseVisitor.java
@@ -41,14 +41,13 @@ import net.sourceforge.pmd.lang.java.ast.JavaParserControllessVisitorAdapter;
  * @author Clément Fournier
  * @see net.sourceforge.pmd.lang.java.metrics.impl.NcssMetric
  */
-public class NcssBaseVisitor extends JavaParserControllessVisitorAdapter {
+public final class NcssBaseVisitor extends JavaParserControllessVisitorAdapter {
 
     /** Instance. */
     public static final NcssBaseVisitor INSTANCE = new NcssBaseVisitor();
 
 
-    protected NcssBaseVisitor() {
-
+    private NcssBaseVisitor() {
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/impl/visitors/NpathBaseVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/impl/visitors/NpathBaseVisitor.java
@@ -146,7 +146,7 @@ public class NpathBaseVisitor extends JavaParserVisitorReducedAdapter {
             boolCompReturn += conditionalExpressionComplexity;
         }
 
-        return (boolCompReturn > 0) ? boolCompReturn : 1;
+        return boolCompReturn > 0 ? boolCompReturn : 1;
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/impl/visitors/NpathBaseVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/impl/visitors/NpathBaseVisitor.java
@@ -28,13 +28,10 @@ import net.sourceforge.pmd.lang.java.metrics.impl.CycloMetric;
  * @author Clément Fournier
  * @author Jason Bennett
  */
-public final class NpathBaseVisitor extends JavaParserVisitorReducedAdapter {
+public class NpathBaseVisitor extends JavaParserVisitorReducedAdapter {
 
     /** Instance. */
     public static final NpathBaseVisitor INSTANCE = new NpathBaseVisitor();
-
-    private NpathBaseVisitor() {
-    }
 
     /* Multiplies the complexity of the children of this node. */
     private int multiplyChildrenComplexities(JavaNode node, Object data) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/impl/visitors/NpathBaseVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/impl/visitors/NpathBaseVisitor.java
@@ -28,13 +28,12 @@ import net.sourceforge.pmd.lang.java.metrics.impl.CycloMetric;
  * @author Clément Fournier
  * @author Jason Bennett
  */
-public class NpathBaseVisitor extends JavaParserVisitorReducedAdapter {
+public final class NpathBaseVisitor extends JavaParserVisitorReducedAdapter {
 
     /** Instance. */
     public static final NpathBaseVisitor INSTANCE = new NpathBaseVisitor();
 
-    protected NpathBaseVisitor() {
-
+    private NpathBaseVisitor() {
     }
 
     /* Multiplies the complexity of the children of this node. */

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/impl/visitors/TccAttributeAccessCollector.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/impl/visitors/TccAttributeAccessCollector.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
@@ -57,7 +58,7 @@ public class TccAttributeAccessCollector extends JavaParserVisitorReducedAdapter
 
     @Override
     public Object visit(ASTAnyTypeDeclaration node, Object data) {
-        if (node == exploredClass) {
+        if (Objects.equals(node, exploredClass)) {
             methodAttributeAccess = new HashMap<>();
             super.visit(node, data);
         } else if (node instanceof ASTClassOrInterfaceDeclaration

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/multifile/PackageStats.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/multifile/PackageStats.java
@@ -32,8 +32,7 @@ final class PackageStats implements ProjectMirror {
     /**
      * Default constructor.
      */
-    /* default */ PackageStats() {
-
+    private PackageStats() {
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/multifile/signature/JavaFieldSigMask.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/multifile/signature/JavaFieldSigMask.java
@@ -14,12 +14,6 @@ public final class JavaFieldSigMask extends JavaSigMask<JavaFieldSignature> {
     private boolean coverFinal = true;
     private boolean coverStatic = true;
 
-
-    public JavaFieldSigMask() {
-        super();
-    }
-
-
     /** Include final fields?. */
     public void coverFinal(boolean coverFinal) {
         this.coverFinal = coverFinal;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJUnitRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJUnitRule.java
@@ -15,8 +15,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTExtendsList;
 import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
-import net.sourceforge.pmd.lang.java.ast.ASTResultType;
-import net.sourceforge.pmd.lang.java.ast.ASTTypeParameters;
 import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.typeresolution.TypeHelper;
 
@@ -38,10 +36,9 @@ public abstract class AbstractJUnitRule extends AbstractJavaRule {
         isJUnit5Class = false;
 
         isJUnit3Class = isJUnit3Class(node);
-        if (!isJUnit3Class) {
-            isJUnit4Class = isJUnit4Class(node);
-            isJUnit5Class = isJUnit5Class(node);
-        }
+        isJUnit4Class = isJUnit4Class(node);
+        isJUnit5Class = isJUnit5Class(node);
+
         if (isJUnit4Class && isJUnit5Class) {
             isJUnit4Class &= hasImports(node, JUNIT4_CLASS_NAME);
             isJUnit5Class &= hasImports(node, JUNIT5_CLASS_NAME);
@@ -74,29 +71,22 @@ public abstract class AbstractJUnitRule extends AbstractJavaRule {
         }
 
         boolean result = false;
-        if (isJUnit3Class) {
-            result = isJUnit3Method(method);
-        }
-
+        result |= isJUnit3Method(method);
         result |= isJUnit4Method(method);
         result |= isJUnit5Method(method);
         return result;
     }
 
     private boolean isJUnit4Method(ASTMethodDeclaration method) {
-        return doesNodeContainJUnitAnnotation(method.jjtGetParent(), JUNIT4_CLASS_NAME);
+        return isJUnit4Class && doesNodeContainJUnitAnnotation(method.jjtGetParent(), JUNIT4_CLASS_NAME);
     }
 
     private boolean isJUnit5Method(ASTMethodDeclaration method) {
-        return doesNodeContainJUnitAnnotation(method.jjtGetParent(), JUNIT5_CLASS_NAME);
+        return isJUnit5Class && doesNodeContainJUnitAnnotation(method.jjtGetParent(), JUNIT5_CLASS_NAME);
     }
 
     private boolean isJUnit3Method(ASTMethodDeclaration method) {
-        Node node = method.jjtGetChild(0);
-        if (node instanceof ASTTypeParameters) {
-            node = method.jjtGetChild(1);
-        }
-        return ((ASTResultType) node).isVoid() && method.getMethodName().startsWith("test");
+        return isJUnit3Class && method.isVoid() && method.getMethodName().startsWith("test");
     }
 
     private boolean isJUnit3Class(ASTCompilationUnit node) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractStatisticalJavaRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractStatisticalJavaRule.java
@@ -21,7 +21,7 @@ public abstract class AbstractStatisticalJavaRule extends AbstractJavaRule imple
     }
 
     public Object[] getViolationParameters(DataPoint point) {
-        return null;
+        return new Object[0];
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ArrayIsStoredDirectlyRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ArrayIsStoredDirectlyRule.java
@@ -44,12 +44,10 @@ public class ArrayIsStoredDirectlyRule extends AbstractSunSecureRule {
     @Override
     public Object visit(ASTConstructorDeclaration node, Object data) {
         ASTFormalParameter[] arrs = getArrays(node.getParameters());
-        if (arrs != null) {
-            // TODO check if one of these arrays is stored in a non local
-            // variable
-            List<ASTBlockStatement> bs = node.findDescendantsOfType(ASTBlockStatement.class);
-            checkAll(data, arrs, bs);
-        }
+        // TODO check if one of these arrays is stored in a non local
+        // variable
+        List<ASTBlockStatement> bs = node.findDescendantsOfType(ASTBlockStatement.class);
+        checkAll(data, arrs, bs);
         return data;
     }
 
@@ -57,9 +55,7 @@ public class ArrayIsStoredDirectlyRule extends AbstractSunSecureRule {
     public Object visit(ASTMethodDeclaration node, Object data) {
         final ASTFormalParameters params = node.getFirstDescendantOfType(ASTFormalParameters.class);
         ASTFormalParameter[] arrs = getArrays(params);
-        if (arrs != null) {
-            checkAll(data, arrs, node.findDescendantsOfType(ASTBlockStatement.class));
-        }
+        checkAll(data, arrs, node.findDescendantsOfType(ASTBlockStatement.class));
         return data;
     }
 
@@ -160,9 +156,9 @@ public class ArrayIsStoredDirectlyRule extends AbstractSunSecureRule {
                     l2.add(fp);
                 }
             }
-            return l2.toArray(new ASTFormalParameter[l2.size()]);
+            return l2.toArray(new ASTFormalParameter[0]);
         }
-        return null;
+        return new ASTFormalParameter[0];
     }
 
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ForLoopCanBeForeachRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ForLoopCanBeForeachRule.java
@@ -29,6 +29,7 @@ import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
 import net.sourceforge.pmd.lang.java.typeresolution.TypeHelper;
 import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
 import net.sourceforge.pmd.lang.symboltable.Scope;
+import net.sourceforge.pmd.lang.symboltable.ScopedNode;
 
 /**
  * @author Clément Fournier
@@ -395,16 +396,19 @@ public class ForLoopCanBeForeachRule extends AbstractJavaRule {
             return false;
         }
 
+        boolean onlyCallingNext = true;
         for (NameOccurrence occ : indexInfo.getValue()) {
-            String image = occ.getLocation().getImage();
+            ScopedNode location = occ.getLocation();
+            boolean isCallingNext = location instanceof ASTName
+                    && (location.hasImageEqualTo(indexName + ".hasNext")
+                            || location.hasImageEqualTo(indexName + ".next"));
 
-            if (occ.getLocation() instanceof ASTName
-                && ((indexName + ".hasNext").equals(image) || (indexName + ".next").equals(image))) {
-                continue;
+            if (!isCallingNext) {
+                onlyCallingNext = false;
+                break;
             }
-            return false;
         }
-        return true;
+        return onlyCallingNext;
     }
 
     private boolean isIterableModifiedInsideLoop(Entry<VariableNameDeclaration, List<NameOccurrence>> iterableInfo,

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ForLoopCanBeForeachRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ForLoopCanBeForeachRule.java
@@ -8,6 +8,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 
 import org.jaxen.JaxenException;
 
@@ -126,7 +127,7 @@ public class ForLoopCanBeForeachRule extends AbstractJavaRule {
         for (Entry<VariableNameDeclaration, List<NameOccurrence>> e : decls.entrySet()) {
 
             ASTForInit declInit = e.getKey().getNode().getFirstParentOfType(ASTForInit.class);
-            if (declInit == init) {
+            if (Objects.equals(declInit, init)) {
                 indexVarAndOccurrences = e;
                 break;
             }
@@ -417,7 +418,7 @@ public class ForLoopCanBeForeachRule extends AbstractJavaRule {
         String iterableName = iterableInfo.getKey().getName();
         for (NameOccurrence occ : iterableInfo.getValue()) {
             ASTForStatement forParent = occ.getLocation().getFirstParentOfType(ASTForStatement.class);
-            if (forParent == stmt) {
+            if (Objects.equals(forParent, stmt)) {
                 String image = occ.getLocation().getImage();
                 if (image.startsWith(iterableName + ".remove")) {
                     return true;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ForLoopCanBeForeachRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ForLoopCanBeForeachRule.java
@@ -173,7 +173,7 @@ public class ForLoopCanBeForeachRule extends AbstractJavaRule {
             + "/PrimaryExpression"
             + "/PrimaryPrefix"
             + "/Name"
-            + (itName == null ? "" : ("[@Image='" + itName + "']"));
+            + (itName == null ? "" : "[@Image='" + itName + "']");
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ForLoopCanBeForeachRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ForLoopCanBeForeachRule.java
@@ -397,7 +397,6 @@ public class ForLoopCanBeForeachRule extends AbstractJavaRule {
             return false;
         }
 
-        boolean onlyCallingNext = true;
         for (NameOccurrence occ : indexInfo.getValue()) {
             ScopedNode location = occ.getLocation();
             boolean isCallingNext = location instanceof ASTName
@@ -405,11 +404,10 @@ public class ForLoopCanBeForeachRule extends AbstractJavaRule {
                             || location.hasImageEqualTo(indexName + ".next"));
 
             if (!isCallingNext) {
-                onlyCallingNext = false;
-                break;
+                return false;
             }
         }
-        return onlyCallingNext;
+        return true;
     }
 
     private boolean isIterableModifiedInsideLoop(Entry<VariableNameDeclaration, List<NameOccurrence>> iterableInfo,

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PreserveStackTraceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PreserveStackTraceRule.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.ast.Node;
@@ -160,7 +161,7 @@ public class PreserveStackTraceRule extends AbstractJavaRule {
      */
     private boolean isStringConcat(Node childNode, Node baseNode) {
         Node currentNode = childNode;
-        while (currentNode != baseNode) {
+        while (!Objects.equals(currentNode, baseNode)) {
             currentNode = currentNode.jjtGetParent();
             if (currentNode instanceof ASTAdditiveExpression) {
                 return true;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
@@ -172,7 +172,6 @@ public class UnusedImportsRule extends AbstractJavaRule {
         } else {
             name = node.getImage().substring(0, node.getImage().indexOf('.'));
         }
-        ImportWrapper candidate = new ImportWrapper(node.getImage(), name);
-        return candidate;
+        return new ImportWrapper(node.getImage(), name);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/CommentDefaultAccessModifierRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/CommentDefaultAccessModifierRule.java
@@ -100,7 +100,7 @@ public class CommentDefaultAccessModifierRule extends AbstractCommentRule {
         List<ASTClassOrInterfaceDeclaration> parentClassOrInterface = decl
                 .getParentsOfType(ASTClassOrInterfaceDeclaration.class);
         // ignore if is a Interface
-        return (!parentClassOrInterface.isEmpty() && !parentClassOrInterface.get(0).isInterface())
+        return !parentClassOrInterface.isEmpty() && !parentClassOrInterface.get(0).isInterface()
                 // check if the field/method/nested class has a default access
                 // modifier
                 && decl.isPackagePrivate()

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/DuplicateImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/DuplicateImportsRule.java
@@ -79,11 +79,8 @@ public class DuplicateImportsRule extends AbstractJavaRule {
         }
 
         String fullyQualifiedClassName = "java.lang." + singleTypeName;
-        if (node.getClassTypeResolver().classNameExists(fullyQualifiedClassName)) {
-            return true; // Class exists in another imported package
-        }
-
-        return false; // This really is a duplicate import
+        // Class might exist in another imported package
+        return node.getClassTypeResolver().classNameExists(fullyQualifiedClassName);
     }
 
     public Object visit(ASTImportDeclaration node, Object data) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryFullyQualifiedNameRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryFullyQualifiedNameRule.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.java.rule.codestyle;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
@@ -141,7 +142,7 @@ public class UnnecessaryFullyQualifiedNameRule extends AbstractJavaRule {
 
             // Is there any other static import conflictive?
             for (final ASTImportDeclaration importDeclaration : imports) {
-                if (importDeclaration != firstMatch && importDeclaration.isStatic()) {
+                if (!Objects.equals(importDeclaration, firstMatch) && importDeclaration.isStatic()) {
                     if (importDeclaration.getImportedName().startsWith(firstMatch.getImportedName())
                             && importDeclaration.getImportedName().lastIndexOf('.') == firstMatch.getImportedName()
                                     .length()) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/VariableNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/VariableNamingConventionsRule.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
 import java.util.List;
+import java.util.Locale;
 
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotationTypeDeclaration;
@@ -177,7 +178,7 @@ public class VariableNamingConventionsRule extends AbstractJavaRule {
 
         // Static finals should be uppercase
         if (isStatic && isFinal) {
-            if (!varName.equals(varName.toUpperCase())) {
+            if (!varName.equals(varName.toUpperCase(Locale.ROOT))) {
                 addViolationWithMessage(data, variableDeclaratorId,
                         "Variables that are final and static should be all capitals, ''{0}'' is not all capitals.",
                         new Object[] { varName });

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/VariableNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/VariableNamingConventionsRule.java
@@ -146,7 +146,7 @@ public class VariableNamingConventionsRule extends AbstractJavaRule {
         for (ASTFormalParameter formalParameter : node.findChildrenOfType(ASTFormalParameter.class)) {
             for (ASTVariableDeclaratorId variableDeclaratorId : formalParameter
                     .findChildrenOfType(ASTVariableDeclaratorId.class)) {
-                checkVariableDeclaratorId(parameterPrefixes, parameterSuffixes, node, false, formalParameter.isFinal(),
+                checkVariableDeclaratorId(parameterPrefixes, parameterSuffixes, false, formalParameter.isFinal(),
                         variableDeclaratorId, data);
             }
         }
@@ -158,13 +158,13 @@ public class VariableNamingConventionsRule extends AbstractJavaRule {
         for (ASTVariableDeclarator variableDeclarator : root.findChildrenOfType(ASTVariableDeclarator.class)) {
             for (ASTVariableDeclaratorId variableDeclaratorId : variableDeclarator
                     .findChildrenOfType(ASTVariableDeclaratorId.class)) {
-                checkVariableDeclaratorId(prefixes, suffixes, root, isStatic, isFinal, variableDeclaratorId, data);
+                checkVariableDeclaratorId(prefixes, suffixes, isStatic, isFinal, variableDeclaratorId, data);
             }
         }
         return data;
     }
 
-    private Object checkVariableDeclaratorId(List<String> prefixes, List<String> suffixes, Node root, boolean isStatic,
+    private Object checkVariableDeclaratorId(List<String> prefixes, List<String> suffixes, boolean isStatic,
             boolean isFinal, ASTVariableDeclaratorId variableDeclaratorId, Object data) {
 
         // Get the variable name

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CyclomaticComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CyclomaticComplexityRule.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.java.rule.design;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.logging.Logger;
 
@@ -125,7 +126,7 @@ public class CyclomaticComplexityRule extends AbstractJavaMetricsRule {
             if (classWmc >= classReportLevel) {
                 int classHighest = (int) JavaMetrics.get(JavaOperationMetricKey.CYCLO, node, cycloOptions, ResultOption.HIGHEST);
 
-                String[] messageParams = {node.getTypeKind().name().toLowerCase(),
+                String[] messageParams = {node.getTypeKind().name().toLowerCase(Locale.ROOT),
                                           node.getImage(),
                                           " total",
                                           classWmc + " (highest " + classHighest + ")", };

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LawOfDemeterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LawOfDemeterRule.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import net.sourceforge.pmd.RuleContext;
@@ -383,7 +384,7 @@ public class LawOfDemeterRule extends AbstractJavaRule {
             boolean factory = false;
             List<ASTName> names = declarator.findDescendantsOfType(ASTName.class);
             for (ASTName name : names) {
-                if (name.getImage().toLowerCase().contains("factory")) {
+                if (name.getImage().toLowerCase(Locale.ROOT).contains("factory")) {
                     factory = true;
                     break;
                 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NcssCountRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NcssCountRule.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.java.rule.design;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
@@ -83,7 +84,7 @@ public final class NcssCountRule extends AbstractJavaMetricsRule {
             int classHighest = (int) JavaMetrics.get(JavaOperationMetricKey.NCSS, node, ncssOptions, ResultOption.HIGHEST);
 
             if (classSize >= classReportLevel) {
-                String[] messageParams = {node.getTypeKind().name().toLowerCase(),
+                String[] messageParams = {node.getTypeKind().name().toLowerCase(Locale.ROOT),
                                           node.getImage(),
                                           classSize + " (Highest = " + classHighest + ")", };
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/AbstractCommentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/AbstractCommentRule.java
@@ -35,9 +35,6 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
  */
 public abstract class AbstractCommentRule extends AbstractJavaRule {
 
-    protected AbstractCommentRule() {
-    }
-
     protected List<Integer> tagsIndicesIn(String comments) {
 
         int atPos = comments.indexOf('@');

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/AbstractCommentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/AbstractCommentRule.java
@@ -188,8 +188,8 @@ public abstract class AbstractCommentRule extends AbstractJavaRule {
                 || n1.getEndLine() == n2.getEndLine() && n1.getEndColumn() < n2.getEndColumn());
         boolean isNotSameClass = node.getFirstParentOfType(ASTClassOrInterfaceBody.class) != n2
                 .getFirstParentOfType(ASTClassOrInterfaceBody.class);
-        boolean isNodeWithinNode2 = (node.getEndLine() < n2.getEndLine()
-                || node.getEndLine() == n2.getEndLine() && node.getEndColumn() < n2.getEndColumn());
+        boolean isNodeWithinNode2 = node.getEndLine() < n2.getEndLine()
+                || node.getEndLine() == n2.getEndLine() && node.getEndColumn() < n2.getEndColumn();
         return isNotWithinNode2 || isNotSameClass || isNodeWithinNode2;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentContentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentContentRule.java
@@ -31,15 +31,11 @@ import net.sourceforge.pmd.properties.StringMultiProperty;
 public class CommentContentRule extends AbstractCommentRule {
 
     private boolean caseSensitive;
-    private boolean wordsAreRegex;
     private List<String> originalBadWords;
     private List<String> currentBadWords;
 
     // FIXME need some better defaults (or none?)
     private static final String[] BAD_WORDS = {"idiot", "jerk" };
-
-    public static final BooleanProperty WORDS_ARE_REGEX_DESCRIPTOR = new BooleanProperty("wordsAreRegex",
-            "Use regular expressions", false, 1.0f);
 
     // ignored when property above == True
     public static final BooleanProperty CASE_SENSITIVE_DESCRIPTOR = new BooleanProperty("caseSensitive",
@@ -56,7 +52,6 @@ public class CommentContentRule extends AbstractCommentRule {
     }
 
     public CommentContentRule() {
-        definePropertyDescriptor(WORDS_ARE_REGEX_DESCRIPTOR);
         definePropertyDescriptor(CASE_SENSITIVE_DESCRIPTOR);
         definePropertyDescriptor(DISSALLOWED_TERMS_DESCRIPTOR);
     }
@@ -66,7 +61,6 @@ public class CommentContentRule extends AbstractCommentRule {
      */
     @Override
     public void start(RuleContext ctx) {
-        wordsAreRegex = getProperty(WORDS_ARE_REGEX_DESCRIPTOR);
         originalBadWords = getProperty(DISSALLOWED_TERMS_DESCRIPTOR);
         caseSensitive = getProperty(CASE_SENSITIVE_DESCRIPTOR);
         if (caseSensitive) {
@@ -77,12 +71,6 @@ public class CommentContentRule extends AbstractCommentRule {
                 currentBadWords.add(badWord.toUpperCase());
             }
         }
-    }
-
-    @Override
-    public Set<PropertyDescriptor<?>> ignoredProperties() {
-        return getProperty(WORDS_ARE_REGEX_DESCRIPTOR) ? NON_REGEX_PROPERTIES
-                                                       : Collections.<PropertyDescriptor<?>>emptySet();
     }
 
     /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentContentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentContentRule.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
@@ -68,7 +69,7 @@ public class CommentContentRule extends AbstractCommentRule {
         } else {
             currentBadWords = new ArrayList<>();
             for (String badWord : originalBadWords) {
-                currentBadWords.add(badWord.toUpperCase());
+                currentBadWords.add(badWord.toUpperCase(Locale.ROOT));
             }
         }
     }
@@ -94,7 +95,7 @@ public class CommentContentRule extends AbstractCommentRule {
         }
 
         if (!caseSensitive) {
-            commentText = commentText.toUpperCase();
+            commentText = commentText.toUpperCase(Locale.ROOT);
         }
 
         List<String> foundWords = new ArrayList<>();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentRequiredRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentRequiredRule.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
@@ -97,7 +98,9 @@ public class CommentRequiredRule extends AbstractCommentRule {
 
 
         addViolationWithMessage(data, node,
-            DESCRIPTOR_NAME_TO_COMMENT_TYPE.get(descriptor.name()) + " are " + getProperty(descriptor).label.toLowerCase());
+            DESCRIPTOR_NAME_TO_COMMENT_TYPE.get(descriptor.name())
+            + " are "
+            + getProperty(descriptor).label.toLowerCase(Locale.ROOT));
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidFieldNameMatchingMethodNameRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidFieldNameMatchingMethodNameRule.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.java.rule.errorprone;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 
 import net.sourceforge.pmd.lang.ast.Node;
@@ -40,11 +41,11 @@ public class AvoidFieldNameMatchingMethodNameRule extends AbstractJavaRule {
             if (child instanceof ASTFieldDeclaration) {
                 fields.add((ASTFieldDeclaration) child);
             } else if (child instanceof ASTMethodDeclaration) {
-                methodNames.add(((ASTMethodDeclaration) child).getMethodName().toLowerCase());
+                methodNames.add(((ASTMethodDeclaration) child).getMethodName().toLowerCase(Locale.ROOT));
             }
         }
         for (ASTFieldDeclaration field : fields) {
-            String varName = field.getVariableName().toLowerCase();
+            String varName = field.getVariableName().toLowerCase(Locale.ROOT);
             if (methodNames.contains(varName)) {
                 addViolation(data, field, field.getVariableName());
             }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/BeanMembersShouldSerializeRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/BeanMembersShouldSerializeRule.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.java.rule.errorprone;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import net.sourceforge.pmd.lang.ast.Node;
@@ -80,7 +81,7 @@ public class BeanMembersShouldSerializeRule extends AbstractJavaRule {
                 continue;
             }
             String varName = trimIfPrefix(decl.getImage());
-            varName = varName.substring(0, 1).toUpperCase() + varName.substring(1, varName.length());
+            varName = varName.substring(0, 1).toUpperCase(Locale.ROOT) + varName.substring(1, varName.length());
             boolean hasGetMethod = Arrays.binarySearch(methNameArray, "get" + varName) >= 0
                     || Arrays.binarySearch(methNameArray, "is" + varName) >= 0;
             boolean hasSetMethod = Arrays.binarySearch(methNameArray, "set" + varName) >= 0;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloneMethodMustImplementCloneableRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloneMethodMustImplementCloneableRule.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.java.rule.errorprone;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import net.sourceforge.pmd.lang.ast.Node;
@@ -15,7 +16,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTExtendsList;
-import net.sourceforge.pmd.lang.java.ast.ASTFormalParameters;
 import net.sourceforge.pmd.lang.java.ast.ASTImplementsList;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclarator;
@@ -152,21 +152,17 @@ public class CloneMethodMustImplementCloneableRule extends AbstractJavaRule {
                 .findDescendantsOfType(ASTClassOrInterfaceDeclaration.class);
         final Set<String> classesNames = new HashSet<String>();
         for (final ASTClassOrInterfaceDeclaration c : classes) {
-            if (c != currentClass && extendsOrImplementsCloneable(c)) {
+            if (!Objects.equals(c, currentClass) && extendsOrImplementsCloneable(c)) {
                 classesNames.add(c.getImage());
             }
         }
         return classesNames;
     }
 
-    public boolean isCloneMethod(final ASTMethodDeclarator node) {
-        if (!"clone".equals(node.getImage())) {
+    public boolean isCloneMethod(final ASTMethodDeclarator method) {
+        if (!"clone".equals(method.getImage())) {
             return false;
         }
-        final int countParams = ((ASTFormalParameters) node.jjtGetChild(0)).jjtGetNumChildren();
-        if (countParams != 0) {
-            return false;
-        }
-        return true;
+        return method.getParameterCount() == 0;
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
@@ -367,7 +367,7 @@ public class CloseResourceRule extends AbstractJavaRule {
                         + "  [PrimaryExpression/PrimaryPrefix/Literal/NullLiteral]");
                 return !nodes.isEmpty();
             } catch (JaxenException e) {
-                // no boolean literals or other condition
+                throw new RuntimeException(e);
             }
         }
         return true;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConstructorCallsOverridableMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConstructorCallsOverridableMethodRule.java
@@ -596,7 +596,7 @@ public final class ConstructorCallsOverridableMethodRule extends AbstractJavaRul
         public List<ConstructorInvocation> calledConstructors;
         public Map<ConstructorHolder, List<MethodInvocation>> allPrivateConstructorsOfClass;
 
-        EvalPackage() {
+        private EvalPackage() {
         }
 
         EvalPackage(String className) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidSlf4jMessageFormatRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidSlf4jMessageFormatRule.java
@@ -29,6 +29,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 import net.sourceforge.pmd.lang.java.ast.AbstractJavaTypeNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
+import net.sourceforge.pmd.lang.java.typeresolution.TypeHelper;
 import net.sourceforge.pmd.lang.symboltable.NameDeclaration;
 
 public class InvalidSlf4jMessageFormatRule extends AbstractJavaRule {
@@ -45,7 +46,7 @@ public class InvalidSlf4jMessageFormatRule extends AbstractJavaRule {
     public Object visit(final ASTName node, final Object data) {
         final NameDeclaration nameDeclaration = node.getNameDeclaration();
         // ignore imports or methods
-        if (nameDeclaration == null || !(nameDeclaration instanceof VariableNameDeclaration)) {
+        if (!(nameDeclaration instanceof VariableNameDeclaration)) {
             return super.visit(node, data);
         }
 
@@ -100,19 +101,13 @@ public class InvalidSlf4jMessageFormatRule extends AbstractJavaRule {
         // in case a new exception is created or the exception class is
         // mentioned.
         ASTClassOrInterfaceType classOrInterface = last.getFirstDescendantOfType(ASTClassOrInterfaceType.class);
-        if (classOrInterface != null && classOrInterface.getType() != null
-                && Throwable.class.isAssignableFrom(classOrInterface.getType())) {
-            return true;
-        }
-        return false;
+        return classOrInterface != null && classOrInterface.getType() != null
+                && TypeHelper.isA(classOrInterface, Throwable.class);
     }
 
     private boolean hasTypeThrowable(ASTPrimaryExpression last) {
         // if the type could be determined already
-        if (last.getType() != null && Throwable.class.isAssignableFrom(last.getType())) {
-            return true;
-        }
-        return false;
+        return last.getType() != null && TypeHelper.isA(last, Throwable.class);
     }
 
     private boolean isReferencingThrowable(ASTPrimaryExpression last) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/SingletonClassReturningNewInstanceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/SingletonClassReturningNewInstanceRule.java
@@ -62,7 +62,7 @@ public class SingletonClassReturningNewInstanceRule extends AbstractJavaRule {
 
             List<ASTBlockStatement> astBlockStatements = node.findDescendantsOfType(ASTBlockStatement.class);
             returnVariableName = getReturnVariableName(node);
-            if (astBlockStatements.size() != 0) {
+            if (!astBlockStatements.isEmpty()) {
                 for (ASTBlockStatement blockStatement : astBlockStatements) {
                     if (blockStatement.hasDescendantOfType(ASTLocalVariableDeclaration.class)) {
                         List<ASTLocalVariableDeclaration> lVarList = blockStatement

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/SingletonClassReturningNewInstanceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/SingletonClassReturningNewInstanceRule.java
@@ -106,7 +106,7 @@ public class SingletonClassReturningNewInstanceRule extends AbstractJavaRule {
     }
 
     private String getNameFromPrimaryPrefix(ASTPrimaryPrefix pp) {
-        if ((pp.jjtGetNumChildren() == 1) && (pp.jjtGetChild(0) instanceof ASTName)) {
+        if (pp.jjtGetNumChildren() == 1 && pp.jjtGetChild(0) instanceof ASTName) {
             return ((ASTName) pp.jjtGetChild(0)).getImage();
         }
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveAppendsShouldReuseRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveAppendsShouldReuseRule.java
@@ -165,9 +165,6 @@ public class ConsecutiveAppendsShouldReuseRule extends AbstractJavaRule {
     }
 
     private boolean isFirstChild(Node node, Class<?> clazz) {
-        if (node.jjtGetNumChildren() == 1 && clazz.isAssignableFrom(node.jjtGetChild(0).getClass())) {
-            return true;
-        }
-        return false;
+        return node.jjtGetNumChildren() == 1 && clazz.isAssignableFrom(node.jjtGetChild(0).getClass());
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientStringBufferingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientStringBufferingRule.java
@@ -121,10 +121,7 @@ public class InefficientStringBufferingRule extends AbstractJavaRule {
 
     private boolean isPrimitiveType(ASTName name) {
         ASTType type = getTypeNode(name);
-        if (type != null && !type.findChildrenOfType(ASTPrimitiveType.class).isEmpty()) {
-            return true;
-        }
-        return false;
+        return type != null && !type.findChildrenOfType(ASTPrimitiveType.class).isEmpty();
     }
 
     private ASTType getTypeNode(ASTName name) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/UseStringBufferForStringAppendsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/UseStringBufferForStringAppendsRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.performance;
 
+import java.util.Objects;
+
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignmentOperator;
@@ -48,8 +50,9 @@ public class UseStringBufferForStringAppendsRule extends AbstractJavaRule {
             ASTConditionalExpression conditional = name.getFirstParentOfType(ASTConditionalExpression.class);
 
             if (conditional != null) {
-                Node thirdParent = name.jjtGetParent().jjtGetParent().jjtGetParent();
-                if ((thirdParent == conditional || thirdParent.jjtGetParent() == conditional)
+                Node thirdParent = name.getNthParent(3);
+                Node fourthParent = name.getNthParent(4);
+                if ((Objects.equals(thirdParent, conditional) || Objects.equals(fourthParent, conditional))
                         && conditional.getFirstParentOfType(ASTStatementExpression.class) == statement) {
                     // is used in ternary as only option (not appended to other
                     // string)

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/JavaNameOccurrence.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/JavaNameOccurrence.java
@@ -109,11 +109,7 @@ public class JavaNameOccurrence implements NameOccurrence {
             return false;
         }
 
-        if (isCompoundAssignment(primaryExpression)) {
-            return false;
-        }
-
-        return true;
+        return !isCompoundAssignment(primaryExpression);
     }
 
     private boolean isCompoundAssignment(Node primaryExpression) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/SimpleTypedNameDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/SimpleTypedNameDeclaration.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.java.symboltable;
 
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 
 /**
@@ -150,8 +151,8 @@ public class SimpleTypedNameDeclaration implements TypedNameDeclaration {
         } else if (!typeImage.equals(other.typeImage)) {
             // consider auto-boxing
             if (other.typeImage != null) {
-                String lcType = typeImage.toLowerCase();
-                String otherLcType = other.typeImage.toLowerCase();
+                String lcType = typeImage.toLowerCase(Locale.ROOT);
+                String otherLcType = other.typeImage.toLowerCase(Locale.ROOT);
                 if (primitiveTypes.contains(lcType) && primitiveTypes.contains(otherLcType)) {
                     if (lcType.equals(otherLcType)) {
                         return true;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/TypeSet.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/TypeSet.java
@@ -406,7 +406,11 @@ public class TypeSet {
             types.put("long", long.class);
             types.put("boolean", boolean.class);
             types.put("byte", byte.class);
-            types.put("short", short.class);
+
+            @SuppressWarnings("PMD.AvoidUsingShortType") // scoping the suppression just for the following statement
+            Class<?> shortType = short.class;
+            types.put("short", shortType);
+
             types.put("char", char.class);
             PRIMITIVE_TYPES = Collections.unmodifiableMap(types);
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/TypeSet.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/TypeSet.java
@@ -128,7 +128,8 @@ public class TypeSet {
                 try {
                     return pmdClassLoader.loadClass(className);
                 } catch (final ClassNotFoundException e) {
-                    // Ignored, can never actually happen
+                    // Ignored, can never actually happen, since we loaded the class at least once before...
+                    throw new RuntimeException(e); // in case it happens anyway
                 }
             }
 
@@ -144,8 +145,8 @@ public class TypeSet {
                             // Update the mapping
                             classNames.put(name, actualClassName);
                             return c;
-                        } catch (final ClassNotFoundException e) {
-                            // Ignored
+                        } catch (final ClassNotFoundException ignored) {
+                            // Ignored, we'll try again with a different class name, assuming inner classes
                         }
                     }
 
@@ -366,8 +367,8 @@ public class TypeSet {
                 if (pmdClassLoader.couldResolve(fqClassName)) {
                     try {
                         return pmdClassLoader.loadClass(fqClassName);
-                    } catch (ClassNotFoundException e) {
-                        // ignored
+                    } catch (ClassNotFoundException ignored) {
+                        // ignored, we'll throw a custom exception later
                     }
                 }
             }
@@ -530,7 +531,7 @@ public class TypeSet {
             if (resolver.couldResolve(name)) {
                 try {
                     return resolver.resolve(name);
-                } catch (ClassNotFoundException cnfe) {
+                } catch (ClassNotFoundException ignored) {
                     // ignored, maybe another resolver will find the class
                 } catch (LinkageError le) {
                     // we found the class, but there is a problem with it (see https://github.com/pmd/pmd/issues/328)

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -633,7 +633,7 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
                     if (foundTypeDef != null) { // if null, then it's not an inherited field
                         return foundTypeDef;
                     }
-                } catch (ClassCastException e) {
+                } catch (ClassCastException ignored) {
                     // if there is an anonymous class, getClassDeclaration().getType() will throw
                     // TODO: maybe there is a better way to handle this, maybe this hides bugs
                 }
@@ -1280,16 +1280,16 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
                     + qualifiedName.substring(qualifiedName.lastIndexOf('.') + 1);
             try {
                 myType = pmdClassLoader.loadClass(qualifiedNameInner);
-            } catch (Exception e) {
-                // ignored
+            } catch (Exception ignored) {
+                // ignored, we'll try again with a different package name/fqcn
             }
         }
         if (myType == null && qualifiedName != null && !qualifiedName.contains(".")) {
             // try again with java.lang....
             try {
                 myType = pmdClassLoader.loadClass("java.lang." + qualifiedName);
-            } catch (Exception e) {
-                // ignored
+            } catch (Exception ignored) {
+                // ignored, we'll try again with generics
             }
         }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -1355,9 +1355,19 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
 
     private Class<?> processOnDemand(String qualifiedName) {
         for (String entry : importedOnDemand) {
+            String fullClassName = entry + "." + qualifiedName;
             try {
-                return pmdClassLoader.loadClass(entry + "." + qualifiedName);
-            } catch (Throwable e) {
+                return pmdClassLoader.loadClass(fullClassName);
+            } catch (ClassNotFoundException ignored) {
+                if (LOG.isLoggable(Level.FINE)) {
+                    LOG.log(Level.FINE, "Tried to load class " + fullClassName + " from on demand import, "
+                            + "which apparently doesn't exist.", ignored);
+                }
+            } catch (LinkageError ignored) {
+                if (LOG.isLoggable(Level.FINE)) {
+                    LOG.log(Level.FINE, "Tried to load class " + fullClassName + " from on demand import, "
+                            + "which apparently doesn't exist.", ignored);
+                }
             }
         }
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/MethodType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/MethodType.java
@@ -14,7 +14,7 @@ import net.sourceforge.pmd.lang.java.typeresolution.typedefinition.JavaTypeDefin
 /**
  * This is really just a POJO.
  */
-public class MethodType {
+public final class MethodType {
     private final JavaTypeDefinition returnType;
     private final List<JavaTypeDefinition> argTypes;
     private final Method method;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/MethodTypeResolution.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/MethodTypeResolution.java
@@ -525,9 +525,9 @@ public final class MethodTypeResolution {
                 // is visible
                 && isMemberVisibleFromClass(method.getDeclaringClass(), method.getModifiers(), accessingClass)
                 // if method is vararg with arity n, then the invocation's arity >= n - 1
-                && (!method.isVarArgs() || (argArity >= getArity(method) - 1))
+                && (!method.isVarArgs() || argArity >= getArity(method) - 1)
                 // if the method isn't vararg, then arity matches
-                && (method.isVarArgs() || (argArity == getArity(method)))
+                && (method.isVarArgs() || argArity == getArity(method))
                 // isn't generic or arity of type arguments matches that of parameters
                 && (!isGeneric(method) || typeArguments.isEmpty()
                 || method.getTypeParameters().length == typeArguments.size())) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/MethodTypeResolution.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/MethodTypeResolution.java
@@ -45,11 +45,15 @@ public final class MethodTypeResolution {
     static {
         final List<Class<?>> primitiveList = new ArrayList<>();
 
+        @SuppressWarnings("PMD.AvoidUsingShortType") // defining a local variable to suppress warnings only for
+        // the following statement
+        Class<?> shortType = short.class;
+
         primitiveList.add(double.class);
         primitiveList.add(float.class);
         primitiveList.add(long.class);
         primitiveList.add(int.class);
-        primitiveList.add(short.class);
+        primitiveList.add(shortType);
         primitiveList.add(byte.class);
         primitiveList.add(char.class); // this is here for convenience, not really in order
 
@@ -73,7 +77,7 @@ public final class MethodTypeResolution {
         boxingRules.put(float.class, Float.class);
         boxingRules.put(long.class, Long.class);
         boxingRules.put(int.class, Integer.class);
-        boxingRules.put(short.class, Short.class);
+        boxingRules.put(shortType, Short.class);
         boxingRules.put(byte.class, Byte.class);
         boxingRules.put(char.class, Character.class);
         boxingRules.put(boolean.class, Boolean.class);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/MethodTypeResolution.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/MethodTypeResolution.java
@@ -525,7 +525,7 @@ public final class MethodTypeResolution {
     public static boolean isMethodApplicable(Method method, String methodName, int argArity,
                                              Class<?> accessingClass, List<JavaTypeDefinition> typeArguments) {
 
-        if (method.getName().equals(methodName) // name matches
+        return method.getName().equals(methodName) // name matches
                 // is visible
                 && isMemberVisibleFromClass(method.getDeclaringClass(), method.getModifiers(), accessingClass)
                 // if method is vararg with arity n, then the invocation's arity >= n - 1
@@ -534,12 +534,7 @@ public final class MethodTypeResolution {
                 && (method.isVarArgs() || argArity == getArity(method))
                 // isn't generic or arity of type arguments matches that of parameters
                 && (!isGeneric(method) || typeArguments.isEmpty()
-                || method.getTypeParameters().length == typeArguments.size())) {
-
-            return true;
-        }
-
-        return false;
+                || method.getTypeParameters().length == typeArguments.size());
     }
 
 
@@ -631,15 +626,10 @@ public final class MethodTypeResolution {
         // covers unboxing
         int indexInBoxed = BOXED_PRIMITIVE_SUBTYPE_ORDER.indexOf(argument.getType());
 
-        if (indexInBoxed != -1 // arg is boxed primitive
+        return indexInBoxed != -1 // arg is boxed primitive
                 && isSubtypeable(parameter,
-                                 JavaTypeDefinition.forClass(PRIMITIVE_SUBTYPE_ORDER.get(indexInBoxed)))) {
-            return true;
-        }
-
+                                 JavaTypeDefinition.forClass(PRIMITIVE_SUBTYPE_ORDER.get(indexInBoxed)));
         // TODO: add raw unchecked conversion part
-
-        return false;
     }
 
     public static boolean isSubtypeable(JavaTypeDefinition parameter, ASTExpression argument) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelper.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelper.java
@@ -4,11 +4,15 @@
 
 package net.sourceforge.pmd.lang.java.typeresolution;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.symboltable.TypedNameDeclaration;
 
 public final class TypeHelper {
+    private static final Logger LOG = Logger.getLogger(TypeHelper.class.getName());
 
     private TypeHelper() {
         // utility class
@@ -31,6 +35,7 @@ public final class TypeHelper {
                 }
             } catch (final ClassNotFoundException e) {
                 // The requested type is not on the auxclasspath
+                LOG.log(Level.WARNING, "Incomplete auxclasspath: The class " + clazzName + " was not found");
             }
         }
         

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelper.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelper.java
@@ -4,20 +4,25 @@
 
 package net.sourceforge.pmd.lang.java.typeresolution;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.symboltable.TypedNameDeclaration;
 
 public final class TypeHelper {
-    private static final Logger LOG = Logger.getLogger(TypeHelper.class.getName());
 
     private TypeHelper() {
         // utility class
     }
 
+    /**
+     * Checks whether the resolved type of the given {@link TypeNode} n is of the type
+     * given by the clazzName. If the clazzName is on the auxclasspath, then also subclasses
+     * are considered.
+     *
+     * @param n the type node to check
+     * @param clazzName the class name to compare to
+     * @return <code>true</code> if type node n is of type clazzName or a subtype of clazzName
+     */
     public static boolean isA(final TypeNode n, final String clazzName) {
         if (n.getType() != null) {
             try {
@@ -33,12 +38,13 @@ public final class TypeHelper {
                 if (clazz != null) {
                     return isA(n, clazz);
                 }
-            } catch (final ClassNotFoundException e) {
-                // The requested type is not on the auxclasspath
-                LOG.log(Level.WARNING, "Incomplete auxclasspath: The class " + clazzName + " was not found");
+            } catch (final ClassNotFoundException ignored) {
+                // The requested type is not on the auxclasspath. This might happen, if the type node
+                // is probed for a specific type (e.g. is is a JUnit5 Test Annotation class).
+                // Failing to resolve clazzName does not necessarily indicate an incomplete auxclasspath.
             }
         }
-        
+
         return clazzName.equals(n.getImage()) || clazzName.endsWith("." + n.getImage());
     }
     

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typedefinition/JavaTypeDefinitionSimple.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typedefinition/JavaTypeDefinitionSimple.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -264,7 +265,7 @@ import java.util.logging.Logger;
 
     @Override
     public boolean equals(Object obj) {
-        if (obj == null || !(obj instanceof JavaTypeDefinitionSimple)) {
+        if (!(obj instanceof JavaTypeDefinitionSimple)) {
             return false;
         }
 
@@ -341,7 +342,7 @@ import java.util.logging.Logger;
     }
 
     public JavaTypeDefinition getAsSuper(Class<?> superClazz) {
-        if (clazz == superClazz) { // optimize for same class calls
+        if (Objects.equals(clazz, superClazz)) { // optimize for same class calls
             return this;
         }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typedefinition/JavaTypeDefinitionUpper.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typedefinition/JavaTypeDefinitionUpper.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.java.typeresolution.typedefinition;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 
@@ -144,14 +145,7 @@ import java.util.Set;
         }
 
         // we assume that the typeList list cannot contain duplicates, then indeed, this will prove equality
-        outer:
-        for (JavaTypeDefinition intersectionTypeDef : typeList) {
-            for (JavaTypeDefinition otherIntersectionTypeDef : otherTypeDef.typeList) {
-                if (intersectionTypeDef.equals(otherIntersectionTypeDef)) {
-                    continue outer;
-                }
-            }
-
+        if (!Arrays.deepEquals(typeList, otherTypeDef.typeList)) {
             return false;
         }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typedefinition/JavaTypeDefinitionUpper.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typedefinition/JavaTypeDefinitionUpper.java
@@ -145,11 +145,7 @@ import java.util.Set;
         }
 
         // we assume that the typeList list cannot contain duplicates, then indeed, this will prove equality
-        if (!Arrays.deepEquals(typeList, otherTypeDef.typeList)) {
-            return false;
-        }
-
-        return true;
+        return Arrays.deepEquals(typeList, otherTypeDef.typeList);
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typeinference/TypeInferenceResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typeinference/TypeInferenceResolver.java
@@ -337,7 +337,8 @@ public final class TypeInferenceResolver {
                 }
 
                 private void advanceToNextK() {
-                    if (++k > n) {
+                    k++;
+                    if (k > n) {
                         nextBitSet = null;
                     } else {
                         nextBitSet.clear();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typeinference/TypeInferenceResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typeinference/TypeInferenceResolver.java
@@ -293,8 +293,8 @@ public final class TypeInferenceResolver {
         for (Bound bound : bounds) {
             for (Variable first : firstList) {
                 if (bound.ruleType == EQUALITY
-                        && ((bound.leftVariable() == first && bound.rightVariable() == second)
-                        || (bound.leftVariable() == second && bound.rightVariable() == first))) {
+                        && (bound.leftVariable() == first && bound.rightVariable() == second
+                        || bound.leftVariable() == second && bound.rightVariable() == first)) {
                     return true;
                 }
             }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typeinference/TypeInferenceResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typeinference/TypeInferenceResolver.java
@@ -15,6 +15,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import net.sourceforge.pmd.lang.java.typeresolution.MethodTypeResolution;
@@ -184,7 +185,7 @@ public final class TypeInferenceResolver {
         outter:
         for (Class<?> candidate : erasedSet) {
             for (Class<?> erasedSetMember : erasedSet) {
-                if (candidate != erasedSetMember
+                if (!Objects.equals(candidate, erasedSetMember)
                         && MethodTypeResolution.isSubtypeable(candidate, erasedSetMember)) {
                     continue outter; // skip candidate from result set
                 }
@@ -276,7 +277,7 @@ public final class TypeInferenceResolver {
         for (Variable unresolvedVariable : variables) {
             for (Variable dependency : dependencies.get(unresolvedVariable)) {
                 if (!instantiations.containsKey(dependency)
-                        && unresolvedVariable != dependency
+                        && !Objects.equals(unresolvedVariable, dependency)
                         && !boundsHaveAnEqualityBetween(variables, dependency, bounds)) {
                     return false;
                 }
@@ -324,58 +325,60 @@ public final class TypeInferenceResolver {
 
         @Override
         public Iterator<List<Variable>> iterator() {
-            return new Iterator<List<Variable>>() {
-                private BitSet nextBitSet = new BitSet(n);
+            return new CombinationsIterator();
+        }
 
-                {
+        private class CombinationsIterator implements Iterator<List<Variable>> {
+            private BitSet nextBitSet = new BitSet(n);
+
+            private CombinationsIterator() {
+                advanceToNextK();
+            }
+
+            private void advanceToNextK() {
+                k++;
+                if (k > n) {
+                    nextBitSet = null;
+                } else {
+                    nextBitSet.clear();
+                    nextBitSet.set(0, k);
+                }
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException("remove");
+            }
+
+            @Override
+            public boolean hasNext() {
+                return nextBitSet != null;
+            }
+
+            @Override
+            public List<Variable> next() {
+                BitSet resultBitSet = (BitSet) nextBitSet.clone();
+
+                int b = nextBitSet.previousClearBit(n - 1);
+                int b1 = nextBitSet.previousSetBit(b);
+
+                if (b1 == -1) {
                     advanceToNextK();
+                } else {
+                    nextBitSet.clear(b1);
+                    nextBitSet.set(b1 + 1, b1 + (n - b) + 1);
+                    nextBitSet.clear(b1 + (n - b) + 1, n);
                 }
 
-                @Override
-                public void remove() {
-
-                }
-
-                private void advanceToNextK() {
-                    k++;
-                    if (k > n) {
-                        nextBitSet = null;
-                    } else {
-                        nextBitSet.clear();
-                        nextBitSet.set(0, k);
+                resultList.clear();
+                for (int i = 0; i < n; ++i) {
+                    if (resultBitSet.get(i)) {
+                        resultList.add(permuteThis.get(i));
                     }
                 }
 
-                @Override
-                public boolean hasNext() {
-                    return nextBitSet != null;
-                }
-
-                @Override
-                public List<Variable> next() {
-                    BitSet resultBitSet = (BitSet) nextBitSet.clone();
-
-                    int b = nextBitSet.previousClearBit(n - 1);
-                    int b1 = nextBitSet.previousSetBit(b);
-
-                    if (b1 == -1) {
-                        advanceToNextK();
-                    } else {
-                        nextBitSet.clear(b1);
-                        nextBitSet.set(b1 + 1, b1 + (n - b) + 1);
-                        nextBitSet.clear(b1 + (n - b) + 1, n);
-                    }
-
-                    resultList.clear();
-                    for (int i = 0; i < n; ++i) {
-                        if (resultBitSet.get(i)) {
-                            resultList.add(permuteThis.get(i));
-                        }
-                    }
-
-                    return unmodifyableViewOfResult;
-                }
-            };
+                return unmodifyableViewOfResult;
+            }
         }
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/visitors/PMDASMVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/visitors/PMDASMVisitor.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.objectweb.asm.AnnotationVisitor;
-import org.objectweb.asm.Attribute;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.Label;
@@ -127,10 +126,6 @@ public class PMDASMVisitor extends ClassVisitor {
     }
 
     @Override
-    public void visitSource(String source, String debug) {
-    }
-
-    @Override
     public void visitInnerClass(String name, String outerName, String innerName, int access) {
         if (!this.outerName.replace('.', '/').equals(outerName)) {
             // do not consider the inner class if it is not a member of our
@@ -145,14 +140,6 @@ public class PMDASMVisitor extends ClassVisitor {
             innerClasses.add(name.replace('/', '.'));
         }
         packages.put(innerName, name.replace('/', '.'));
-    }
-
-    @Override
-    public void visitOuterClass(String owner, String name, String desc) {
-    }
-
-    @Override
-    public void visitEnd() {
     }
 
     private void addMethodDesc(String desc) {
@@ -181,10 +168,6 @@ public class PMDASMVisitor extends ClassVisitor {
         }
     }
 
-    @Override
-    public void visitAttribute(Attribute attr) {
-    }
-
     /*
      * Start visitors
      */
@@ -202,14 +185,6 @@ public class PMDASMVisitor extends ClassVisitor {
         public AnnotationVisitor visitAnnotation(String desc, boolean visible) {
             parent.addType(Type.getType(desc));
             return parent.annotationVisitor;
-        }
-
-        @Override
-        public void visitAttribute(Attribute attr) {
-        }
-
-        @Override
-        public void visitEnd() {
         }
     }
 
@@ -238,10 +213,6 @@ public class PMDASMVisitor extends ClassVisitor {
         }
 
         @Override
-        public void visitEnd() {
-        }
-
-        @Override
         public void visit(String name, Object value) {
             if (value instanceof Type) {
                 parent.addType((Type) value);
@@ -255,10 +226,6 @@ public class PMDASMVisitor extends ClassVisitor {
         PMDSignatureVisitor(PMDASMVisitor visitor) {
             super(Opcodes.ASM5);
             this.parent = visitor;
-        }
-
-        @Override
-        public void visitFormalTypeParameter(String name) {
         }
 
         @Override
@@ -297,14 +264,6 @@ public class PMDASMVisitor extends ClassVisitor {
         }
 
         @Override
-        public void visitBaseType(char descriptor) {
-        }
-
-        @Override
-        public void visitTypeVariable(String name) {
-        }
-
-        @Override
         public SignatureVisitor visitArrayType() {
             return this;
         }
@@ -320,16 +279,8 @@ public class PMDASMVisitor extends ClassVisitor {
         }
 
         @Override
-        public void visitTypeArgument() {
-        }
-
-        @Override
         public SignatureVisitor visitTypeArgument(char wildcard) {
             return this;
-        }
-
-        @Override
-        public void visitEnd() {
         }
     }
 
@@ -343,11 +294,6 @@ public class PMDASMVisitor extends ClassVisitor {
 
         @Override
         public AnnotationVisitor visitParameterAnnotation(int parameter, String desc, boolean visible) {
-            parent.addType(Type.getType(desc));
-            return parent.annotationVisitor;
-        }
-
-        public AnnotationVisitor visitAnnotation(String name, String desc) {
             parent.addType(Type.getType(desc));
             return parent.annotationVisitor;
         }
@@ -400,56 +346,8 @@ public class PMDASMVisitor extends ClassVisitor {
         }
 
         @Override
-        public void visitCode() {
-        }
-
-        @Override
-        public void visitFrame(int type, int nLocal, Object[] local, int nStack, Object[] stack) {
-        }
-
-        @Override
-        public void visitInsn(int opcode) {
-        }
-
-        @Override
-        public void visitIntInsn(int opcode, int operand) {
-        }
-
-        @Override
-        public void visitVarInsn(int opcode, int var) {
-        }
-
-        @Override
-        public void visitJumpInsn(int opcode, Label label) {
-        }
-
-        @Override
-        public void visitLabel(Label label) {
-        }
-
-        @Override
-        public void visitIincInsn(int var, int increment) {
-        }
-
-        @Override
-        public void visitTableSwitchInsn(int min, int max, Label dflt, Label... labels) {
-        }
-
-        @Override
-        public void visitLookupSwitchInsn(Label dflt, int[] keys, Label[] labels) {
-        }
-
-        @Override
         public void visitTryCatchBlock(Label start, Label end, Label handler, String type) {
             parent.parseClassName(type);
-        }
-
-        @Override
-        public void visitLineNumber(int line, Label start) {
-        }
-
-        @Override
-        public void visitMaxs(int maxStack, int maxLocals) {
         }
 
         @Override
@@ -462,14 +360,5 @@ public class PMDASMVisitor extends ClassVisitor {
             parent.addType(Type.getType(desc));
             return parent.annotationVisitor;
         }
-
-        @Override
-        public void visitEnd() {
-        }
-
-        @Override
-        public void visitAttribute(Attribute attr) {
-        }
-
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/xpath/MetricFunction.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/xpath/MetricFunction.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.java.xpath;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 
 import org.apache.commons.lang3.EnumUtils;
@@ -82,7 +83,7 @@ public class MetricFunction implements Function {
 
 
     private static JavaClassMetricKey getClassMetricKey(String s) {
-        String constantName = s.toUpperCase();
+        String constantName = s.toUpperCase(Locale.ROOT);
         if (!CLASS_METRIC_KEY_MAP.containsKey(constantName)) {
             throw new IllegalArgumentException(badClassMetricKeyMessage());
         }
@@ -91,7 +92,7 @@ public class MetricFunction implements Function {
 
 
     private static JavaOperationMetricKey getOperationMetricKey(String s) {
-        String constantName = s.toUpperCase();
+        String constantName = s.toUpperCase(Locale.ROOT);
         if (!OPERATION_METRIC_KEY_MAP.containsKey(constantName)) {
             throw new IllegalArgumentException(badOperationMetricKeyMessage());
         }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/multifile/PackageStatsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/multifile/PackageStatsTest.java
@@ -34,7 +34,8 @@ public class PackageStatsTest {
 
     @Before
     public void setUp() {
-        pack = new PackageStats();
+        pack = PackageStats.INSTANCE;
+        pack.reset();
     }
 
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/Ecmascript3Handler.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/Ecmascript3Handler.java
@@ -12,13 +12,11 @@ import net.sourceforge.pmd.lang.ParserOptions;
 import net.sourceforge.pmd.lang.VisitorStarter;
 import net.sourceforge.pmd.lang.XPathHandler;
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.ast.xpath.AbstractASTXPathHandler;
+import net.sourceforge.pmd.lang.ast.xpath.DefaultASTXPathHandler;
 import net.sourceforge.pmd.lang.ecmascript.ast.DumpFacade;
 import net.sourceforge.pmd.lang.ecmascript.ast.EcmascriptNode;
 import net.sourceforge.pmd.lang.ecmascript.rule.EcmascriptRuleViolationFactory;
 import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
-
-import net.sf.saxon.sxpath.IndependentContext;
 
 /**
  * Implementation of LanguageVersionHandler for the ECMAScript Version 3.
@@ -27,13 +25,7 @@ public class Ecmascript3Handler extends AbstractLanguageVersionHandler {
 
     @Override
     public XPathHandler getXPathHandler() {
-        return new AbstractASTXPathHandler() {
-            public void initialize() {
-            }
-
-            public void initialize(IndependentContext context) {
-            }
-        };
+        return new DefaultASTXPathHandler();
     }
 
     public RuleViolationFactory getRuleViolationFactory() {

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTKeywordLiteral.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTKeywordLiteral.java
@@ -4,13 +4,15 @@
 
 package net.sourceforge.pmd.lang.ecmascript.ast;
 
+import java.util.Locale;
+
 import org.mozilla.javascript.Token;
 import org.mozilla.javascript.ast.KeywordLiteral;
 
 public class ASTKeywordLiteral extends AbstractEcmascriptNode<KeywordLiteral> {
     public ASTKeywordLiteral(KeywordLiteral keywordLiteral) {
         super(keywordLiteral);
-        super.setImage(Token.typeToName(keywordLiteral.getType()).toLowerCase());
+        super.setImage(Token.typeToName(keywordLiteral.getType()).toLowerCase(Locale.ROOT));
     }
 
     /**

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTVariableDeclaration.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTVariableDeclaration.java
@@ -4,13 +4,15 @@
 
 package net.sourceforge.pmd.lang.ecmascript.ast;
 
+import java.util.Locale;
+
 import org.mozilla.javascript.Token;
 import org.mozilla.javascript.ast.VariableDeclaration;
 
 public class ASTVariableDeclaration extends AbstractEcmascriptNode<VariableDeclaration> {
     public ASTVariableDeclaration(VariableDeclaration variableDeclaration) {
         super(variableDeclaration);
-        super.setImage(Token.typeToName(variableDeclaration.getType()).toLowerCase());
+        super.setImage(Token.typeToName(variableDeclaration.getType()).toLowerCase(Locale.ROOT));
     }
 
     /**

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/JspHandler.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/JspHandler.java
@@ -12,13 +12,11 @@ import net.sourceforge.pmd.lang.ParserOptions;
 import net.sourceforge.pmd.lang.VisitorStarter;
 import net.sourceforge.pmd.lang.XPathHandler;
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.ast.xpath.AbstractASTXPathHandler;
+import net.sourceforge.pmd.lang.ast.xpath.DefaultASTXPathHandler;
 import net.sourceforge.pmd.lang.jsp.ast.DumpFacade;
 import net.sourceforge.pmd.lang.jsp.ast.JspNode;
 import net.sourceforge.pmd.lang.jsp.rule.JspRuleViolationFactory;
 import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
-
-import net.sf.saxon.sxpath.IndependentContext;
 
 /**
  * Implementation of LanguageVersionHandler for the JSP parser.
@@ -29,13 +27,7 @@ public class JspHandler extends AbstractLanguageVersionHandler {
 
     @Override
     public XPathHandler getXPathHandler() {
-        return new AbstractASTXPathHandler() {
-            public void initialize() {
-            }
-
-            public void initialize(IndependentContext context) {
-            }
-        };
+        return new DefaultASTXPathHandler();
     }
 
     public RuleViolationFactory getRuleViolationFactory() {

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/design/NoInlineStyleInformationRule.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/design/NoInlineStyleInformationRule.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.jsp.rule.design;
 
+import java.util.Locale;
 import java.util.Set;
 
 import net.sourceforge.pmd.lang.jsp.ast.ASTAttribute;
@@ -64,7 +65,7 @@ public class NoInlineStyleInformationRule extends AbstractJspRule {
      * @return boolean
      */
     private boolean isStyleElement(ASTElement elementNode) {
-        return STYLE_ELEMENT_NAMES.contains(elementNode.getName().toUpperCase());
+        return STYLE_ELEMENT_NAMES.contains(elementNode.getName().toUpperCase(Locale.ROOT));
     }
 
     /**
@@ -77,10 +78,10 @@ public class NoInlineStyleInformationRule extends AbstractJspRule {
      *         otherwise.
      */
     private boolean isStyleAttribute(ASTAttribute attributeNode) {
-        if (STYLE_ATTRIBUTES.contains(attributeNode.getName().toUpperCase())) {
+        if (STYLE_ATTRIBUTES.contains(attributeNode.getName().toUpperCase(Locale.ROOT))) {
             if (attributeNode.jjtGetParent() instanceof ASTElement) {
                 ASTElement parent = (ASTElement) attributeNode.jjtGetParent();
-                if (ELEMENT_NAMES_THAT_CAN_HAVE_STYLE_ATTRIBUTES.contains(parent.getName().toUpperCase())) {
+                if (ELEMENT_NAMES_THAT_CAN_HAVE_STYLE_ATTRIBUTES.contains(parent.getName().toUpperCase(Locale.ROOT))) {
                     return true;
                 }
             }

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/PLSQLHandler.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/PLSQLHandler.java
@@ -6,8 +6,6 @@ package net.sourceforge.pmd.lang.plsql;
 
 import java.io.Writer;
 
-import org.jaxen.Navigator;
-
 import net.sourceforge.pmd.lang.AbstractLanguageVersionHandler;
 import net.sourceforge.pmd.lang.DataFlowHandler;
 import net.sourceforge.pmd.lang.Parser;
@@ -15,7 +13,7 @@ import net.sourceforge.pmd.lang.ParserOptions;
 import net.sourceforge.pmd.lang.VisitorStarter;
 import net.sourceforge.pmd.lang.XPathHandler;
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.ast.xpath.DocumentNavigator;
+import net.sourceforge.pmd.lang.ast.xpath.DefaultASTXPathHandler;
 import net.sourceforge.pmd.lang.dfa.DFAGraphRule;
 import net.sourceforge.pmd.lang.plsql.ast.ASTInput;
 import net.sourceforge.pmd.lang.plsql.ast.DumpFacade;
@@ -25,8 +23,6 @@ import net.sourceforge.pmd.lang.plsql.dfa.DataFlowFacade;
 import net.sourceforge.pmd.lang.plsql.rule.PLSQLRuleViolationFactory;
 import net.sourceforge.pmd.lang.plsql.symboltable.SymbolFacade;
 import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
-
-import net.sf.saxon.sxpath.IndependentContext;
 
 /**
  * Implementation of LanguageVersionHandler for the PLSQL AST. It uses anonymous
@@ -81,21 +77,11 @@ public class PLSQLHandler extends AbstractLanguageVersionHandler {
         };
     }
 
-    @Override
     /**
      * Return minimal XPathHandler to cope with Jaxen XPath Rules.
      */
+    @Override
     public XPathHandler getXPathHandler() {
-        return new XPathHandler() {
-            public void initialize() {
-            }
-
-            public void initialize(IndependentContext context) {
-            }
-
-            public Navigator getNavigator() {
-                return new DocumentNavigator();
-            }
-        };
+        return new DefaultASTXPathHandler();
     }
 }

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/PLSQLParser.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/PLSQLParser.java
@@ -35,8 +35,7 @@ public class PLSQLParser extends AbstractParser {
     protected net.sourceforge.pmd.lang.plsql.ast.PLSQLParser createPLSQLParser(Reader source) throws ParseException {
         Reader in = IOUtil.skipBOM(source);
         // Wrapped PLSQL AST Parser
-        net.sourceforge.pmd.lang.plsql.ast.PLSQLParser parser = new net.sourceforge.pmd.lang.plsql.ast.PLSQLParser(in);
-        return parser;
+        return new net.sourceforge.pmd.lang.plsql.ast.PLSQLParser(in);
     }
 
     public boolean canParse() {

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/dfa/StatementAndBraceFinder.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/dfa/StatementAndBraceFinder.java
@@ -767,6 +767,7 @@ public class StatementAndBraceFinder extends PLSQLParserVisitorAdapter {
      * The method handles the special "for" loop. It creates always an
      * expression node even if the loop looks like for(;;).
      */
+    @SuppressWarnings("PMD.UnusedFormalParameter") // TODO: dfa implementation in plsql is incomplete
     private void addForExpressionNode(Node node, Structure dataFlow) {
         ASTForStatement parent = (ASTForStatement) node.jjtGetParent();
         boolean hasExpressionChild = false;

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractStatisticalPLSQLRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractStatisticalPLSQLRule.java
@@ -21,7 +21,7 @@ public abstract class AbstractStatisticalPLSQLRule extends AbstractPLSQLRule imp
     }
 
     public Object[] getViolationParameters(DataPoint point) {
-        return null;
+        return new Object[0];
     }
 
     @Override

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/AbstractNcssCountRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/AbstractNcssCountRule.java
@@ -119,26 +119,17 @@ public abstract class AbstractNcssCountRule extends AbstractStatisticalPLSQLRule
 
     @Override
     public Object visit(ASTIfStatement node, Object data) {
-
-        Integer lineCount = countNodeChildren(node, data);
-
-        return lineCount;
+        return countNodeChildren(node, data);
     }
 
     @Override
     public Object visit(ASTElsifClause node, Object data) {
-
-        Integer lineCount = countNodeChildren(node, data);
-
-        return lineCount;
+        return countNodeChildren(node, data);
     }
 
     @Override
     public Object visit(ASTElseClause node, Object data) {
-
-        Integer lineCount = countNodeChildren(node, data);
-
-        return lineCount;
+        return countNodeChildren(node, data);
     }
 
     @Override

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/NPathComplexityRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/NPathComplexityRule.java
@@ -364,7 +364,7 @@ public class NPathComplexityRule extends AbstractStatisticalPLSQLRule {
         }
         // add in npath of last label
         npath += caseRange;
-        LOGGER.exiting(CLASS_NAME, "visit(ASTCaseWhenClause)", (boolCompSwitch + npath));
+        LOGGER.exiting(CLASS_NAME, "visit(ASTCaseWhenClause)", boolCompSwitch + npath);
         return Integer.valueOf(boolCompSwitch + npath);
     }
 
@@ -386,7 +386,7 @@ public class NPathComplexityRule extends AbstractStatisticalPLSQLRule {
         }
         // add in npath of last label
         npath += caseRange;
-        LOGGER.exiting(CLASS_NAME, "visit(ASTCaseStatement)", (boolCompSwitch + npath));
+        LOGGER.exiting(CLASS_NAME, "visit(ASTCaseStatement)", boolCompSwitch + npath);
         return Integer.valueOf(boolCompSwitch + npath);
     }
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/PLSQLNameOccurrence.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/PLSQLNameOccurrence.java
@@ -94,15 +94,11 @@ public class PLSQLNameOccurrence implements NameOccurrence {
          * ASTAssignmentOperator)) { return false; }
          */
 
-        if (isPartOfQualifiedName() /* or is an array type */) {
-            return false;
-        }
-
         /*
          * if (isCompoundAssignment(primaryExpression)) { return false; }
          */
 
-        return true;
+        return !isPartOfQualifiedName() /* and not is an array type */;
     }
 
     /*

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/TypeSet.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/TypeSet.java
@@ -74,7 +74,9 @@ public class TypeSet {
                     try {
                         String importPkg = importStmt.substring(0, importStmt.indexOf('*') - 1);
                         return Class.forName(importPkg + '.' + name);
-                    } catch (ClassNotFoundException cnfe) {
+                    } catch (ClassNotFoundException ignored) {
+                        // Ignored, we'll throw a custom exception later, after all import possibilities have
+                        // been checked
                     }
                 }
             }
@@ -150,7 +152,8 @@ public class TypeSet {
         for (Resolver resolver : resolvers) {
             try {
                 return resolver.resolve(name);
-            } catch (ClassNotFoundException cnfe) {
+            } catch (ClassNotFoundException ignored) {
+                // Ignored, maybe another resolver might find the class
             }
         }
 

--- a/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/DummyLanguageModule.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/DummyLanguageModule.java
@@ -113,9 +113,9 @@ public class DummyLanguageModule extends BaseLanguageModule {
         protected RuleViolation createRuleViolation(Rule rule, RuleContext ruleContext, Node node, String message,
                 int beginLine, int endLine) {
             ParametricRuleViolation<Node> rv = new ParametricRuleViolation<Node>(rule, ruleContext, node, message) {
-                {
-                    // just for testing variable expansion
-                    this.packageName = "foo"; 
+                public String getPackageName() {
+                    this.packageName = "foo"; // just for testing variable expansion
+                    return super.getPackageName();
                 }
             };
             rv.setLines(beginLine, endLine);

--- a/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTestRunner.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTestRunner.java
@@ -116,18 +116,18 @@ public class RuleTestRunner extends ParentRunner<TestDescriptor> {
                 instance.runTest(testCase);
             }
         };
-        statement = withBefores(testCase, statement);
-        statement = withAfters(testCase, statement);
+        statement = withBefores(statement);
+        statement = withAfters(statement);
         statement = withRules(testCase, statement);
         return statement;
     }
 
-    private Statement withBefores(final TestDescriptor testCase, Statement statement) {
+    private Statement withBefores(Statement statement) {
         List<FrameworkMethod> befores = getTestClass().getAnnotatedMethods(Before.class);
         return befores.isEmpty() ? statement : new RunBefores(statement, befores, instance);
     }
 
-    private Statement withAfters(final TestDescriptor testCase, Statement statement) {
+    private Statement withAfters(Statement statement) {
         List<FrameworkMethod> afters = getTestClass().getAnnotatedMethods(After.class);
         return afters.isEmpty() ? statement : new RunAfters(statement, afters, instance);
     }

--- a/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
@@ -138,9 +138,9 @@ public abstract class RuleTst {
 
                 report = processUsingStringReader(test, rule);
                 res = report.size();
-            } catch (Throwable t) {
-                t.printStackTrace();
-                throw new RuntimeException('"' + test.getDescription() + "\" failed", t);
+            } catch (Exception e) {
+                e.printStackTrace();
+                throw new RuntimeException('"' + test.getDescription() + "\" failed", e);
             }
             if (test.getNumberOfProblemsExpected() != res) {
                 printReport(test, report);

--- a/pmd-test/src/main/java/net/sourceforge/pmd/testframework/TestDescriptor.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/testframework/TestDescriptor.java
@@ -32,9 +32,8 @@ public class TestDescriptor {
     private boolean useAuxClasspath = true;
     private int numberInDocument = -1;
 
-    // Empty descriptor added to please mvn surefire plugin
     public TestDescriptor() {
-
+        // Empty default descriptor added to please mvn surefire plugin
     }
 
     public TestDescriptor(String code, String description, int numberOfProblemsExpected, Rule rule) {

--- a/pmd-test/src/main/java/net/sourceforge/pmd/testframework/TestDescriptor.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/testframework/TestDescriptor.java
@@ -128,6 +128,7 @@ public class TestDescriptor {
                 inRegressionMode = Boolean.parseBoolean(property);
             }
         } catch (IllegalArgumentException e) {
+            throw new RuntimeException("Invalid system property 'pmd.regress'", e);
         }
 
         return inRegressionMode;

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/Designer.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/Designer.java
@@ -53,10 +53,10 @@ public class Designer extends Application {
         DesignerRoot owner = new DesignerRoot(stage);
         MainDesignerController mainController = new MainDesignerController(owner);
 
-        NodeInfoPanelController nodeInfoPanelController = new NodeInfoPanelController(owner, mainController);
+        NodeInfoPanelController nodeInfoPanelController = new NodeInfoPanelController(mainController);
         XPathPanelController xpathPanelController = new XPathPanelController(owner, mainController);
         SourceEditorController sourceEditorController = new SourceEditorController(owner, mainController);
-        EventLogController eventLogController = new EventLogController(owner, mainController);
+        EventLogController eventLogController = new EventLogController(owner);
 
         loader.setControllerFactory(type -> {
             if (type == MainDesignerController.class) {

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/EditPropertyDialogController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/EditPropertyDialogController.java
@@ -68,7 +68,7 @@ public class EditPropertyDialogController implements Initializable {
 
 
     public EditPropertyDialogController() {
-
+        // default constructor
     }
 
 

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/EventLogController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/EventLogController.java
@@ -31,7 +31,6 @@ import javafx.scene.control.cell.PropertyValueFactory;
 public class EventLogController implements Initializable {
 
     private final DesignerRoot designerRoot;
-    private final MainDesignerController parent;
 
     @FXML
     private TableView<LogEntry> eventLogTableView;
@@ -45,9 +44,8 @@ public class EventLogController implements Initializable {
     private TextArea logDetailsTextArea;
 
 
-    public EventLogController(DesignerRoot owner, MainDesignerController mainController) {
+    public EventLogController(DesignerRoot owner) {
         this.designerRoot = owner;
-        parent = mainController;
     }
 
 

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/MainDesignerController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/MainDesignerController.java
@@ -66,6 +66,7 @@ import javafx.util.Duration;
  * @see XPathPanelController
  * @since 6.0.0
  */
+@SuppressWarnings("PMD.UnusedPrivateField")
 public class MainDesignerController implements Initializable, SettingsOwner {
 
     /**

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/MainDesignerController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/MainDesignerController.java
@@ -217,6 +217,7 @@ public class MainDesignerController implements Initializable, SettingsOwner {
             SettingsPersistenceUtil.persistProperties(this, DesignerUtil.getSettingsFile());
         } catch (IOException ioe) {
             // nevermind
+            ioe.printStackTrace();
         }
 
         sourceEditorController.shutdown(); // shutdown syntax highlighting

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/NodeInfoPanelController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/NodeInfoPanelController.java
@@ -39,9 +39,9 @@ import javafx.scene.control.TreeView;
  * @author Clément Fournier
  * @since 6.0.0
  */
+@SuppressWarnings("PMD.UnusedPrivateField")
 public class NodeInfoPanelController implements Initializable {
 
-    private final DesignerRoot designerRoot;
     private final MainDesignerController parent;
 
     @FXML
@@ -61,8 +61,7 @@ public class NodeInfoPanelController implements Initializable {
     private MetricEvaluator metricEvaluator = new MetricEvaluator();
 
 
-    public NodeInfoPanelController(DesignerRoot root, MainDesignerController mainController) {
-        this.designerRoot = root;
+    public NodeInfoPanelController(MainDesignerController mainController) {
         parent = mainController;
     }
 

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/SourceEditorController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/SourceEditorController.java
@@ -45,8 +45,6 @@ import javafx.scene.control.TreeView;
  * @since 6.0.0
  */
 public class SourceEditorController implements Initializable, SettingsOwner {
-
-    private final DesignerRoot designerRoot;
     private final MainDesignerController parent;
 
     @FXML
@@ -60,9 +58,8 @@ public class SourceEditorController implements Initializable, SettingsOwner {
 
 
     public SourceEditorController(DesignerRoot owner, MainDesignerController mainController) {
-        this.designerRoot = owner;
         parent = mainController;
-        astManager = new ASTManager(designerRoot);
+        astManager = new ASTManager(owner);
     }
 
 
@@ -100,7 +97,7 @@ public class SourceEditorController implements Initializable, SettingsOwner {
             invalidateAST(true);
             return;
         }
-        if (previous != current) {
+        if (!Objects.equals(previous, current)) {
             parent.invalidateAst();
             setUpToDateCompilationUnit(current);
         }

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/XPathPanelController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/XPathPanelController.java
@@ -73,6 +73,7 @@ public class XPathPanelController implements Initializable, SettingsOwner {
     @FXML
     private ListView<Node> xpathResultListView;
     // Actually a child of the main view toolbar, but this controller is responsible for it
+    @SuppressWarnings("PMD.SingularField")
     private ChoiceBox<String> xpathVersionChoiceBox;
 
 

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/model/ObservableXPathRuleBuilder.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/model/ObservableXPathRuleBuilder.java
@@ -4,11 +4,8 @@
 
 package net.sourceforge.pmd.util.fxdesigner.model;
 
-import java.util.Optional;
-
 import org.reactfx.value.Var;
 
-import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.util.fxdesigner.util.DesignerUtil;
 
 
@@ -49,9 +46,9 @@ public class ObservableXPathRuleBuilder extends ObservableRuleBuilder {
         return xpathExpression;
     }
 
-
-    @Override
-    public Optional<Rule> build() throws IllegalArgumentException {
-        return super.build(); //TODO
-    }
+    // TODO: Once the xpath expression changes, we'll need to rebuild the rule
+    //    @Override
+    //    public Optional<Rule> build() throws IllegalArgumentException {
+    //        return super.build();
+    //    }
 }

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/DesignerUtil.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/DesignerUtil.java
@@ -11,6 +11,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -32,7 +33,7 @@ import javafx.util.StringConverter;
  * @author Clément Fournier
  * @since 6.0.0
  */
-public class DesignerUtil {
+public final class DesignerUtil {
 
 
     private static final Path PMD_SETTINGS_DIR = Paths.get(System.getProperty("user.home"), ".pmd");
@@ -98,7 +99,7 @@ public class DesignerUtil {
 
     public static StringConverter<LanguageVersion> languageVersionStringConverter() {
         return DesignerUtil.stringConverter(LanguageVersion::getShortName,
-            s -> LanguageRegistry.findLanguageVersionByTerseName(s.toLowerCase()));
+            s -> LanguageRegistry.findLanguageVersionByTerseName(s.toLowerCase(Locale.ROOT)));
     }
 
 
@@ -114,7 +115,7 @@ public class DesignerUtil {
     }
 
 
-    public static LanguageVersion getLanguageVersionFromExtension(String filename) {
+    public static synchronized LanguageVersion getLanguageVersionFromExtension(String filename) {
         if (extensionsToLanguage == null) {
             extensionsToLanguage = getExtensionsToLanguageMap();
         }
@@ -127,7 +128,7 @@ public class DesignerUtil {
     }
 
 
-    public static List<LanguageVersion> getSupportedLanguageVersions() {
+    public static synchronized List<LanguageVersion> getSupportedLanguageVersions() {
         if (supportedLanguageVersions == null) {
             List<LanguageVersion> languageVersions = new ArrayList<>();
             for (LanguageVersion languageVersion : LanguageRegistry.findAllVersions()) {

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/beans/SettingsPersistenceUtil.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/beans/SettingsPersistenceUtil.java
@@ -44,7 +44,7 @@ import net.sourceforge.pmd.util.fxdesigner.util.beans.converters.RulePriorityCon
  * @see SettingsOwner
  * @since 6.1.0
  */
-public class SettingsPersistenceUtil {
+public final class SettingsPersistenceUtil {
 
     static {
         // register converters for custom types

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/codearea/CustomCodeArea.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/codearea/CustomCodeArea.java
@@ -152,7 +152,7 @@ public class CustomCodeArea extends CodeArea {
                 layer.reset(t.getValue());
                 this.paintCss();
             });
-        } catch (Exception e) {
+        } catch (Exception ignored) {
             // nevermind
         }
     }

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/codearea/SimpleRegexSyntaxHighlighter.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/codearea/SimpleRegexSyntaxHighlighter.java
@@ -64,7 +64,7 @@ public abstract class SimpleRegexSyntaxHighlighter implements SyntaxHighlighter 
 
                 lastKwEnd = matcher.end();
             }
-        } catch (StackOverflowError so) {
+        } catch (StackOverflowError ignored) {
             // matcher.find overflowed, might happen when coloring ginormous files with incorrect language
         }
 

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/ASTTreeItem.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/ASTTreeItem.java
@@ -15,7 +15,7 @@ import javafx.scene.control.TreeItem;
  * @author Clément Fournier
  * @since 6.0.0
  */
-public class ASTTreeItem extends TreeItem<Node> {
+public final class ASTTreeItem extends TreeItem<Node> {
 
 
     private ASTTreeItem(Node n) {

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/ScopeHierarchyTreeItem.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/ScopeHierarchyTreeItem.java
@@ -20,7 +20,7 @@ import javafx.scene.control.TreeItem;
  * @author Clément Fournier
  * @since 6.0.0
  */
-public class ScopeHierarchyTreeItem extends TreeItem<Object> {
+public final class ScopeHierarchyTreeItem extends TreeItem<Object> {
 
     private ScopeHierarchyTreeItem(Object scopeOrDecl) {
         super(scopeOrDecl);

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/VfHandler.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/VfHandler.java
@@ -12,25 +12,17 @@ import net.sourceforge.pmd.lang.ParserOptions;
 import net.sourceforge.pmd.lang.VisitorStarter;
 import net.sourceforge.pmd.lang.XPathHandler;
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.ast.xpath.AbstractASTXPathHandler;
+import net.sourceforge.pmd.lang.ast.xpath.DefaultASTXPathHandler;
 import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
 import net.sourceforge.pmd.lang.vf.ast.DumpFacade;
 import net.sourceforge.pmd.lang.vf.ast.VfNode;
 import net.sourceforge.pmd.lang.vf.rule.VfRuleViolationFactory;
 
-import net.sf.saxon.sxpath.IndependentContext;
-
 public class VfHandler extends AbstractLanguageVersionHandler {
 
     @Override
     public XPathHandler getXPathHandler() {
-        return new AbstractASTXPathHandler() {
-            public void initialize() {
-            }
-
-            public void initialize(IndependentContext context) {
-            }
-        };
+        return new DefaultASTXPathHandler();
     }
 
     public RuleViolationFactory getRuleViolationFactory() {

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/rule/security/VfCsrfRule.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/rule/security/VfCsrfRule.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.vf.rule.security;
 
 import java.util.List;
+import java.util.Locale;
 
 import net.sourceforge.pmd.lang.vf.ast.ASTAttribute;
 import net.sourceforge.pmd.lang.vf.ast.ASTElExpression;
@@ -29,7 +30,7 @@ public class VfCsrfRule extends AbstractVfRule {
             ASTElExpression valToReport = null;
 
             for (ASTAttribute attr : attribs) {
-                switch (attr.getName().toLowerCase()) {
+                switch (attr.getName().toLowerCase(Locale.ROOT)) {
                 case "action":
                     ASTElExpression value = attr.getFirstDescendantOfType(ASTElExpression.class);
                     if (value != null) {

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/rule/security/VfUnescapeElRule.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/rule/security/VfUnescapeElRule.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.vf.rule.security;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -107,11 +108,7 @@ public class VfUnescapeElRule extends AbstractVfRule {
         final String text = prevText.getImage().endsWith("'")
                 ? prevText.getImage().substring(0, prevText.getImage().length() - 1) : prevText.getImage();
 
-        if (text.endsWith("JSON.parse(") || text.endsWith("jQuery.parseJSON(") || text.endsWith("$.parseJSON(")) {
-            return true;
-        }
-
-        return false;
+        return text.endsWith("JSON.parse(") || text.endsWith("jQuery.parseJSON(") || text.endsWith("$.parseJSON(");
     }
 
     private boolean isUnbalanced(String image, char pattern) {
@@ -125,11 +122,7 @@ public class VfUnescapeElRule extends AbstractVfRule {
             }
 
             if (array[i] == ';') {
-                if (foundPattern) {
-                    return true;
-                } else {
-                    return false;
-                }
+                return foundPattern;
             }
         }
 
@@ -149,7 +142,7 @@ public class VfUnescapeElRule extends AbstractVfRule {
     }
 
     private void checkLimitedFlags(ASTElement node, Object data) {
-        switch (node.getName().toLowerCase()) {
+        switch (node.getName().toLowerCase(Locale.ROOT)) {
         case IFRAME_CONST:
         case APEXIFRAME_CONST:
         case A_CONST:
@@ -163,7 +156,7 @@ public class VfUnescapeElRule extends AbstractVfRule {
         final Set<ASTElExpression> toReport = new HashSet<>();
 
         for (ASTAttribute attr : attributes) {
-            String name = attr.getName().toLowerCase();
+            String name = attr.getName().toLowerCase(Locale.ROOT);
             // look for onevents
 
             if (HREF.equalsIgnoreCase(name) || SRC.equalsIgnoreCase(name)) {
@@ -172,8 +165,9 @@ public class VfUnescapeElRule extends AbstractVfRule {
                 final ASTText attrText = attr.getFirstDescendantOfType(ASTText.class);
                 if (attrText != null) {
                     if (0 == attrText.jjtGetChildIndex()) {
-                        if (attrText.getImage().startsWith("/") || attrText.getImage().toLowerCase().startsWith("http")
-                                || attrText.getImage().toLowerCase().startsWith("mailto")) {
+                        String lowerCaseImage = attrText.getImage().toLowerCase(Locale.ROOT);
+                        if (lowerCaseImage.startsWith("/") || lowerCaseImage.startsWith("http")
+                                || lowerCaseImage.startsWith("mailto")) {
                             startingWithSlashText = true;
                         }
                     }
@@ -215,7 +209,7 @@ public class VfUnescapeElRule extends AbstractVfRule {
         final Set<ASTElExpression> toReport = new HashSet<>();
 
         for (ASTAttribute attr : attributes) {
-            String name = attr.getName().toLowerCase();
+            String name = attr.getName().toLowerCase(Locale.ROOT);
             // look for onevents
 
             if (ON_EVENT.matcher(name).matches()) {
@@ -253,14 +247,15 @@ public class VfUnescapeElRule extends AbstractVfRule {
             
             final ASTIdentifier id = expression.getFirstChildOfType(ASTIdentifier.class);
             if (id != null) {
+                String lowerCaseId = id.getImage().toLowerCase(Locale.ROOT);
                 List<ASTArguments> args = expression.findChildrenOfType(ASTArguments.class);
                 if (!args.isEmpty()) {
-                    switch (id.getImage().toLowerCase()) {
+                    switch (lowerCaseId) {
                     case "urlfor":
                     case "casesafeid":
                     case "begins":
                     case "contains":
-                    case "len":                    
+                    case "len":
                     case "getrecordids":
                     case "linkto":
                     case "sqrt":
@@ -292,7 +287,7 @@ public class VfUnescapeElRule extends AbstractVfRule {
                     }
                 } else {
                     // has no arguments
-                    switch (id.getImage().toLowerCase()) {
+                    switch (lowerCaseId) {
                     case "$action":
                     case "$page":
                     case "$site":
@@ -318,9 +313,10 @@ public class VfUnescapeElRule extends AbstractVfRule {
         if (expression != null) {
             final ASTLiteral literal = expression.getFirstChildOfType(ASTLiteral.class);
             if (literal != null && literal.jjtGetChildIndex() == 0) {
-                if (literal.getImage().startsWith("'/") || literal.getImage().startsWith("\"/")
-                        || literal.getImage().toLowerCase().startsWith("'http")
-                        || literal.getImage().toLowerCase().startsWith("\"http")) {
+                String lowerCaseLiteral = literal.getImage().toLowerCase(Locale.ROOT);
+                if (lowerCaseLiteral.startsWith("'/") || lowerCaseLiteral.startsWith("\"/")
+                        || lowerCaseLiteral.startsWith("'http")
+                        || lowerCaseLiteral.startsWith("\"http")) {
                     return true;
                 }
             }
@@ -338,7 +334,7 @@ public class VfUnescapeElRule extends AbstractVfRule {
         boolean hasPlaceholders = false;
 
         for (ASTAttribute attr : attributes) {
-            String name = attr.getName().toLowerCase();
+            String name = attr.getName().toLowerCase(Locale.ROOT);
             switch (name) {
             case ESCAPE:
             case ITEM_ESCAPED:
@@ -457,7 +453,7 @@ public class VfUnescapeElRule extends AbstractVfRule {
             Node child = expression.jjtGetChild(i);
 
             if (child instanceof ASTIdentifier) {
-                switch (child.getImage().toLowerCase()) {
+                switch (child.getImage().toLowerCase(Locale.ROOT)) {
                 case "id":
                 case "size":
                 case "caseNumber":
@@ -488,7 +484,7 @@ public class VfUnescapeElRule extends AbstractVfRule {
             return false;
         }
 
-        switch (node.getName().toLowerCase()) { // vf is case insensitive
+        switch (node.getName().toLowerCase(Locale.ROOT)) { // vf is case insensitive
         case APEX_OUTPUT_TEXT:
         case APEX_PAGE_MESSAGE:
         case APEX_PAGE_MESSAGES:

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/rule/security/VfUnescapeElRule.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/rule/security/VfUnescapeElRule.java
@@ -104,7 +104,7 @@ public class VfUnescapeElRule extends AbstractVfRule {
     }
 
     private boolean isJsonParse(ASTText prevText) {
-        final String text = (prevText.getImage().endsWith("'") || prevText.getImage().endsWith("'"))
+        final String text = prevText.getImage().endsWith("'")
                 ? prevText.getImage().substring(0, prevText.getImage().length() - 1) : prevText.getImage();
 
         if (text.endsWith("JSON.parse(") || text.endsWith("jQuery.parseJSON(") || text.endsWith("$.parseJSON(")) {

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/rule/security/VfUnescapeElRule.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/rule/security/VfUnescapeElRule.java
@@ -448,7 +448,7 @@ public class VfUnescapeElRule extends AbstractVfRule {
     private boolean containsSafeFields(final AbstractVFNode expression) {
         final ASTExpression ex = expression.getFirstChildOfType(ASTExpression.class);
 
-        return ex == null ? false : innerContainsSafeFields(ex);
+        return ex != null && innerContainsSafeFields(ex);
 
     }
 

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/VmHandler.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/VmHandler.java
@@ -12,12 +12,10 @@ import net.sourceforge.pmd.lang.ParserOptions;
 import net.sourceforge.pmd.lang.VisitorStarter;
 import net.sourceforge.pmd.lang.XPathHandler;
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.ast.xpath.AbstractASTXPathHandler;
+import net.sourceforge.pmd.lang.ast.xpath.DefaultASTXPathHandler;
 import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
 import net.sourceforge.pmd.lang.vm.ast.AbstractVmNode;
 import net.sourceforge.pmd.lang.vm.rule.VmRuleViolationFactory;
-
-import net.sf.saxon.sxpath.IndependentContext;
 
 /**
  * Implementation of LanguageVersionHandler for the VM parser.
@@ -27,13 +25,7 @@ public class VmHandler extends AbstractLanguageVersionHandler {
 
     @Override
     public XPathHandler getXPathHandler() {
-        return new AbstractASTXPathHandler() {
-            public void initialize() {
-            }
-
-            public void initialize(final IndependentContext context) {
-            }
-        };
+        return new DefaultASTXPathHandler();
     }
 
     public RuleViolationFactory getRuleViolationFactory() {

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/ast/NodeUtils.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/ast/NodeUtils.java
@@ -29,7 +29,7 @@ import org.apache.commons.lang3.text.StrBuilder;
  * @author <a href="mailto:geirm@optonline.net">Geir Magnusson Jr.</a>
  * @version $Id: NodeUtils.java 687386 2008-08-20 16:57:07Z nbubna $
  */
-public class NodeUtils {
+public final class NodeUtils {
     private NodeUtils() { }
 
     /**

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/ast/TokenMgrError.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/ast/TokenMgrError.java
@@ -45,6 +45,7 @@ public class TokenMgrError extends RuntimeException {
      */
 
     public TokenMgrError() {
+        // default constructor
     }
 
     public TokenMgrError(final String message, final int reason) {

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/ast/TokenMgrError.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/ast/TokenMgrError.java
@@ -117,10 +117,10 @@ public class TokenMgrError extends RuntimeException {
      */
     protected static String lexicalError(final boolean eofSeen, final int lexState, final int errorLine,
             final int errorColumn, final String errorAfter, final char curChar) {
-        return ("Lexical error at line " + errorLine + ", column " + errorColumn + ".  Encountered: "
+        return "Lexical error at line " + errorLine + ", column " + errorColumn + ".  Encountered: "
                 + (eofSeen ? "<EOF> "
                         : ("\"" + addEscapes(String.valueOf(curChar)) + "\"") + " (" + (int) curChar + "), ")
-                + "after : \"" + addEscapes(errorAfter) + "\"");
+                + "after : \"" + addEscapes(errorAfter) + "\"";
     }
 
 }

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/AbstractStatisticalVmRule.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/AbstractStatisticalVmRule.java
@@ -23,7 +23,7 @@ public abstract class AbstractStatisticalVmRule extends AbstractVmRule implement
 
     @Override
     public Object[] getViolationParameters(final DataPoint point) {
-        return null;
+        return new Object[0];
     }
 
     @Override

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/util/DirectiveMapper.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/util/DirectiveMapper.java
@@ -20,7 +20,7 @@ import net.sourceforge.pmd.lang.vm.directive.Macro;
 import net.sourceforge.pmd.lang.vm.directive.Parse;
 import net.sourceforge.pmd.lang.vm.directive.Stop;
 
-public class DirectiveMapper {
+public final class DirectiveMapper {
     private DirectiveMapper() { }
 
     private static final Map<String, Directive> DIRECTIVE_MAP = new HashMap<>();

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/util/LogUtil.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/util/LogUtil.java
@@ -32,7 +32,7 @@ import net.sourceforge.pmd.lang.vm.directive.Directive;
  * @version $Id: Log.java 724825 2008-12-09 18:56:06Z nbubna $
  * @since 1.5
  */
-public class LogUtil {
+public final class LogUtil {
     private LogUtil() { }
 
     /**
@@ -40,7 +40,7 @@ public class LogUtil {
      * column of the given Directive. We use this routine to provide a cosistent
      * format for displaying file errors.
      */
-    public static final String formatFileString(final Directive directive) {
+    public static String formatFileString(final Directive directive) {
         return formatFileString(directive.getTemplateName(), directive.getLine(), directive.getColumn());
     }
 
@@ -49,7 +49,7 @@ public class LogUtil {
      * column of the given Node. We use this routine to provide a cosistent
      * format for displaying file errors.
      */
-    public static final String formatFileString(final AbstractVmNode node) {
+    public static String formatFileString(final AbstractVmNode node) {
         return formatFileString(node.getTemplateName(), node.getLine(), node.getColumn());
     }
 
@@ -65,7 +65,7 @@ public class LogUtil {
      * @param colnum
      *            Column number withing the file at linenum
      */
-    public static final String formatFileString(String template, final int linenum, final int colnum) {
+    public static String formatFileString(String template, final int linenum, final int colnum) {
         if (template == null || "".equals(template)) {
             template = "<unknown template>";
         }

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/util/VelocityCharStream.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/util/VelocityCharStream.java
@@ -113,37 +113,33 @@ public final class VelocityCharStream implements CharStream {
         int[] newbufline = new int[bufsize + nextBufExpand];
         int[] newbufcolumn = new int[bufsize + nextBufExpand];
 
-        try {
-            if (wrapAround) {
-                System.arraycopy(buffer, tokenBegin, newbuffer, 0, bufsize - tokenBegin);
-                System.arraycopy(buffer, 0, newbuffer, bufsize - tokenBegin, bufpos);
-                buffer = newbuffer;
+        if (wrapAround) {
+            System.arraycopy(buffer, tokenBegin, newbuffer, 0, bufsize - tokenBegin);
+            System.arraycopy(buffer, 0, newbuffer, bufsize - tokenBegin, bufpos);
+            buffer = newbuffer;
 
-                System.arraycopy(bufline, tokenBegin, newbufline, 0, bufsize - tokenBegin);
-                System.arraycopy(bufline, 0, newbufline, bufsize - tokenBegin, bufpos);
-                bufline = newbufline;
+            System.arraycopy(bufline, tokenBegin, newbufline, 0, bufsize - tokenBegin);
+            System.arraycopy(bufline, 0, newbufline, bufsize - tokenBegin, bufpos);
+            bufline = newbufline;
 
-                System.arraycopy(bufcolumn, tokenBegin, newbufcolumn, 0, bufsize - tokenBegin);
-                System.arraycopy(bufcolumn, 0, newbufcolumn, bufsize - tokenBegin, bufpos);
-                bufcolumn = newbufcolumn;
+            System.arraycopy(bufcolumn, tokenBegin, newbufcolumn, 0, bufsize - tokenBegin);
+            System.arraycopy(bufcolumn, 0, newbufcolumn, bufsize - tokenBegin, bufpos);
+            bufcolumn = newbufcolumn;
 
-                bufpos += bufsize - tokenBegin;
-                maxNextCharInd = bufpos;
-            } else {
-                System.arraycopy(buffer, tokenBegin, newbuffer, 0, bufsize - tokenBegin);
-                buffer = newbuffer;
+            bufpos += bufsize - tokenBegin;
+            maxNextCharInd = bufpos;
+        } else {
+            System.arraycopy(buffer, tokenBegin, newbuffer, 0, bufsize - tokenBegin);
+            buffer = newbuffer;
 
-                System.arraycopy(bufline, tokenBegin, newbufline, 0, bufsize - tokenBegin);
-                bufline = newbufline;
+            System.arraycopy(bufline, tokenBegin, newbufline, 0, bufsize - tokenBegin);
+            bufline = newbufline;
 
-                System.arraycopy(bufcolumn, tokenBegin, newbufcolumn, 0, bufsize - tokenBegin);
-                bufcolumn = newbufcolumn;
+            System.arraycopy(bufcolumn, tokenBegin, newbufcolumn, 0, bufsize - tokenBegin);
+            bufcolumn = newbufcolumn;
 
-                bufpos -= tokenBegin;
-                maxNextCharInd = bufpos;
-            }
-        } catch (Throwable t) {
-            throw new Error(t.getMessage());
+            bufpos -= tokenBegin;
+            maxNextCharInd = bufpos;
         }
 
         bufsize += nextBufExpand;

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/XmlHandler.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/XmlHandler.java
@@ -6,21 +6,17 @@ package net.sourceforge.pmd.lang.xml;
 
 import java.io.Writer;
 
-import org.jaxen.Navigator;
-
 import net.sourceforge.pmd.lang.AbstractLanguageVersionHandler;
 import net.sourceforge.pmd.lang.Parser;
 import net.sourceforge.pmd.lang.ParserOptions;
 import net.sourceforge.pmd.lang.VisitorStarter;
 import net.sourceforge.pmd.lang.XPathHandler;
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.ast.xpath.DocumentNavigator;
+import net.sourceforge.pmd.lang.ast.xpath.DefaultASTXPathHandler;
 import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
 import net.sourceforge.pmd.lang.xml.ast.DumpFacade;
 import net.sourceforge.pmd.lang.xml.ast.XmlNode;
 import net.sourceforge.pmd.lang.xml.rule.XmlRuleViolationFactory;
-
-import net.sf.saxon.sxpath.IndependentContext;
 
 /**
  * Implementation of LanguageVersionHandler for the XML.
@@ -29,17 +25,7 @@ public class XmlHandler extends AbstractLanguageVersionHandler {
 
     @Override
     public XPathHandler getXPathHandler() {
-        return new XPathHandler() {
-            public void initialize() {
-            }
-
-            public void initialize(IndependentContext context) {
-            }
-
-            public Navigator getNavigator() {
-                return new DocumentNavigator();
-            }
-        };
+        return new DefaultASTXPathHandler();
     }
 
     public RuleViolationFactory getRuleViolationFactory() {

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/AbstractDomNodeProxy.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/AbstractDomNodeProxy.java
@@ -49,6 +49,7 @@ public abstract class AbstractDomNodeProxy extends AbstractNode implements org.w
     }
 
 
+    @SuppressWarnings("PMD.AvoidUsingShortType")
     @Override
     public short getNodeType() {
         return node.getNodeType();
@@ -187,6 +188,7 @@ public abstract class AbstractDomNodeProxy extends AbstractNode implements org.w
     }
 
 
+    @SuppressWarnings("PMD.AvoidUsingShortType")
     @Override
     public short compareDocumentPosition(org.w3c.dom.Node other) throws DOMException {
         return node.compareDocumentPosition(other);

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/XmlNodeWrapper.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/XmlNodeWrapper.java
@@ -41,12 +41,6 @@ public class XmlNodeWrapper extends AbstractDomNodeProxy implements XmlNode {
 
 
     @Override
-    public void jjtOpen() {
-
-    }
-
-
-    @Override
     public void jjtClose() {
         throw new UnsupportedOperationException();
     }

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/AbstractDomXmlRule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/AbstractDomXmlRule.java
@@ -86,6 +86,7 @@ public class AbstractDomXmlRule extends AbstractXmlRule {
     }
 
     protected void visit(XmlNode node, Attr attr, RuleContext ctx) {
+        // does nothing by default since attributes are leaf nodes
     }
 
     protected void visit(XmlNode node, CharacterData characterData, RuleContext ctx) {

--- a/pom.xml
+++ b/pom.xml
@@ -528,6 +528,7 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
                     </rulesets>
                     <excludeRoots>
                         <excludeRoot>target/generated-sources/javacc</excludeRoot>
+                        <excludeRoot>target/generated-sources/antlr4</excludeRoot>
                     </excludeRoots>
                     <skipPmdError>false</skipPmdError>
                     <failOnViolation>true</failOnViolation>

--- a/pom.xml
+++ b/pom.xml
@@ -538,12 +538,12 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>
                         <artifactId>pmd-core</artifactId>
-                        <version>6.0.1</version>
+                        <version>6.1.0</version>
                     </dependency>
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>
                         <artifactId>pmd-java</artifactId>
-                        <version>6.0.1</version>
+                        <version>6.1.0</version>
                     </dependency>
                     <!-- This contains the dogfood ruleset -->
                     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -515,7 +515,7 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
                     <execution>
                         <phase>verify</phase>
                         <goals>
-                            <goal>pmd</goal>
+                            <goal>check</goal>
                             <goal>cpd</goal>
                         </goals>
                     </execution>
@@ -524,12 +524,14 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
                     <minimumTokens>100</minimumTokens>
                     <targetJdk>1.${java.version}</targetJdk>
                     <rulesets>
-                        <ruleset>${pmd.dogfood.ruleset}</ruleset>
+                        <ruleset>/net/sourceforge/pmd/pmd-dogfood-config.xml</ruleset>
                     </rulesets>
                     <excludeRoots>
                         <excludeRoot>target/generated-sources/javacc</excludeRoot>
                     </excludeRoots>
                     <skipPmdError>false</skipPmdError>
+                    <failOnViolation>true</failOnViolation>
+                    <printFailingErrors>true</printFailingErrors>
                 </configuration>
                 <dependencies>
                     <!-- Note: we can't use a property for the version here due to https://issues.apache.org/jira/browse/MRELEASE-932 -->
@@ -542,6 +544,12 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
                         <groupId>net.sourceforge.pmd</groupId>
                         <artifactId>pmd-java</artifactId>
                         <version>6.0.1</version>
+                    </dependency>
+                    <!-- This contains the dogfood ruleset -->
+                    <dependency>
+                        <groupId>net.sourceforge.pmd</groupId>
+                        <artifactId>pmd-build-tools-config</artifactId>
+                        <version>1.1.0-SNAPSHOT</version>
                     </dependency>
                 </dependencies>
             </plugin>


### PR DESCRIPTION
This enables PMD on PMD with a first rule. It will break the build, if a violation is found.
As suggested in #361, we'll do an incremental approach and the [ruleset](https://github.com/pmd/build-tools/blob/master/config/src/main/resources/net/sourceforge/pmd/pmd-dogfood-config.xml) only contains a single rule for now.

Note: Since I added now a snapshot dependency to pmd-build-tools, we'll need to release [build-tools](https://github.com/pmd/build-tools) before we release PMD 6.1.0.

The only rule for now is UnusedPrivateField.
It seems, we need to improve this rule to consider cases like in JavaFX, see #907 

