### PR TITLE
[java] Add rule to detect missing @Override annotations

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
@@ -344,7 +344,7 @@ public abstract class AbstractNode implements Node {
         int n = node.jjtGetNumChildren();
         for (int i = 0; i < n; i++) {
             Node n1 = node.jjtGetChild(i);
-            if (n1.getClass() == descendantType) {
+            if (descendantType.isAssignableFrom(n1.getClass())) {
                 return descendantType.cast(n1);
             }
             T n2 = getFirstDescendantOfType(descendantType, n1);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotation.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotation.java
@@ -66,7 +66,7 @@ public class ASTAnnotation extends AbstractJavaTypeNode {
         }
 
         // if (SuppressWarnings.class.equals(getType())) { // typeres is not always on
-        if ("SuppressWarnings".equals(getAnnotationName()) || "java.lang.SuppressWarnings".equals(getAnnotationName())) {
+        if (isSuppressWarnings()) {
             for (ASTLiteral element : findDescendantsOfType(ASTLiteral.class)) {
                 if (element.hasImageEqualTo("\"PMD\"") || element.hasImageEqualTo("\"PMD." + rule.getName() + "\"")
                         // Check for standard annotations values
@@ -79,6 +79,11 @@ public class ASTAnnotation extends AbstractJavaTypeNode {
         }
 
         return false;
+    }
+
+
+    private boolean isSuppressWarnings() {
+        return "SuppressWarnings".equals(getAnnotationName()) || "java.lang.SuppressWarnings".equals(getAnnotationName());
     }
 
     /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotation.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotation.java
@@ -27,6 +27,12 @@ public class ASTAnnotation extends AbstractJavaNode {
         super(p, id);
     }
 
+
+    public String getAnnotationName() {
+        return jjtGetChild(0).jjtGetChild(0).getImage();
+    }
+
+
     public boolean suppresses(Rule rule) {
         final String ruleAnno = "\"PMD." + rule.getName() + "\"";
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotation.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotation.java
@@ -9,15 +9,14 @@ import java.util.Arrays;
 import java.util.List;
 
 import net.sourceforge.pmd.Rule;
-import net.sourceforge.pmd.lang.ast.Node;
 
-public class ASTAnnotation extends AbstractJavaNode {
 
-    private static List<String> unusedRules = Arrays.asList(new String[] { "UnusedPrivateField", "UnusedLocalVariable",
-        "UnusedPrivateMethod", "UnusedFormalParameter", });
+public class ASTAnnotation extends AbstractJavaTypeNode {
 
-    private static List<String> serialRules = Arrays
-            .asList(new String[] { "BeanMembersShouldSerialize", "MissingSerialVersionUID" });
+    private static final List<String> UNUSED_RULES
+            = Arrays.asList("UnusedPrivateField", "UnusedLocalVariable", "UnusedPrivateMethod", "UnusedFormalParameter");
+
+    private static final List<String> SERIAL_RULES = Arrays.asList("BeanMembersShouldSerialize", "MissingSerialVersionUID");
 
     public ASTAnnotation(int id) {
         super(id);
@@ -28,42 +27,57 @@ public class ASTAnnotation extends AbstractJavaNode {
     }
 
 
+    /**
+     * Returns the name of the annotation as it is used,
+     * eg {@code java.lang.Override} or {@code Override}.
+     */
     public String getAnnotationName() {
         return jjtGetChild(0).jjtGetChild(0).getImage();
     }
 
-
+    // @formatter:off
+    /**
+     * Returns true if this annotation suppresses the given rule.
+     * The suppression annotation is {@link SuppressWarnings}.
+     * This method returns true if this annotation is a SuppressWarnings,
+     * and if the set of suppressed warnings ({@link SuppressWarnings#value()})
+     * contains at least one of those:
+     * <ul>
+     *     <li>"PMD" (suppresses all rules);
+     *     <li>"PMD.rulename", where rulename is the name of the given rule;
+     *     <li>"all" (conventional value to suppress all warnings).
+     * </ul>
+     *
+     * <p>Additionnally, the following values suppress a specific set of rules:
+     * <ul>
+     *     <li>{@code "unused"}: suppresses rules like UnusedLocalVariable or UnusedPrivateField;
+     *     <li>{@code "serial"}: suppresses BeanMembersShouldSerialize and MissingSerialVersionUID;
+     * </ul>
+     *
+     * @param rule The rule for which to check for suppression
+     *
+     * @return True if this annotation suppresses the given rule
+     */
+    // @formatter:on
     public boolean suppresses(Rule rule) {
-        final String ruleAnno = "\"PMD." + rule.getName() + "\"";
 
-        if (jjtGetChild(0) instanceof ASTSingleMemberAnnotation) {
-            ASTSingleMemberAnnotation n = (ASTSingleMemberAnnotation) jjtGetChild(0);
-            return checkAnnototation(n, ruleAnno, rule);
-        } else if (jjtGetChild(0) instanceof ASTNormalAnnotation) {
-            ASTNormalAnnotation n = (ASTNormalAnnotation) jjtGetChild(0);
-            return checkAnnototation(n, ruleAnno, rule);
+        if (jjtGetChild(0) instanceof ASTMarkerAnnotation) {
+            return false;
         }
-        return false;
-    }
 
-    private boolean checkAnnototation(Node n, String ruleAnno, Rule rule) {
-        if (n.jjtGetChild(0) instanceof ASTName) {
-            ASTName annName = (ASTName) n.jjtGetChild(0);
-
-            if ("SuppressWarnings".equals(annName.getImage())
-                    || "java.lang.SuppressWarnings".equals(annName.getImage())) {
-                List<ASTLiteral> nodes = n.findDescendantsOfType(ASTLiteral.class);
-                for (ASTLiteral element : nodes) {
-                    if (element.hasImageEqualTo("\"PMD\"") || element.hasImageEqualTo(ruleAnno)
-                            // Check for standard annotations values
-                            || element.hasImageEqualTo("\"all\"")
-                            || element.hasImageEqualTo("\"serial\"") && serialRules.contains(rule.getName())
-                            || element.hasImageEqualTo("\"unused\"") && unusedRules.contains(rule.getName())) {
-                        return true;
-                    }
+        // if (SuppressWarnings.class.equals(getType())) { // typeres is not always on
+        if ("SuppressWarnings".equals(getAnnotationName()) || "java.lang.SuppressWarnings".equals(getAnnotationName())) {
+            for (ASTLiteral element : findDescendantsOfType(ASTLiteral.class)) {
+                if (element.hasImageEqualTo("\"PMD\"") || element.hasImageEqualTo("\"PMD." + rule.getName() + "\"")
+                        // Check for standard annotations values
+                        || element.hasImageEqualTo("\"all\"")
+                        || element.hasImageEqualTo("\"serial\"") && SERIAL_RULES.contains(rule.getName())
+                        || element.hasImageEqualTo("\"unused\"") && UNUSED_RULES.contains(rule.getName())) {
+                    return true;
                 }
             }
         }
+
         return false;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassOrInterfaceType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassOrInterfaceType.java
@@ -51,7 +51,7 @@ public class ASTClassOrInterfaceType extends AbstractJavaTypeNode {
     }
 
     public boolean isAnonymousClass() {
-        return jjtGetParent().hasDescendantOfType(ASTClassOrInterfaceBody.class);
+        return jjtGetParent().getFirstChildOfType(ASTClassOrInterfaceBody.class) != null;
     }
 
     public boolean isArray() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTConstructorDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTConstructorDeclaration.java
@@ -61,4 +61,9 @@ public class ASTConstructorDeclaration extends AbstractJavaAccessNode implements
 
         return signature;
     }
+
+    @Override
+    public ASTFormalParameters getFormalParameters() {
+        return getFirstChildOfType(ASTFormalParameters.class);
+    }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFormalParameter.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFormalParameter.java
@@ -7,7 +7,8 @@ package net.sourceforge.pmd.lang.java.ast;
 
 import net.sourceforge.pmd.Rule;
 
-public class ASTFormalParameter extends AbstractJavaAccessNode implements Dimensionable, CanSuppressWarnings {
+
+public class ASTFormalParameter extends AbstractJavaAccessTypeNode implements Dimensionable, CanSuppressWarnings {
 
     private boolean isVarargs;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFormalParameters.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFormalParameters.java
@@ -5,7 +5,10 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
-public class ASTFormalParameters extends AbstractJavaNode {
+import java.util.Iterator;
+
+
+public class ASTFormalParameters extends AbstractJavaNode implements Iterable<ASTFormalParameter> {
     public ASTFormalParameters(int id) {
         super(id);
     }
@@ -23,5 +26,32 @@ public class ASTFormalParameters extends AbstractJavaNode {
      */
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
+    }
+
+
+    @Override
+    public Iterator<ASTFormalParameter> iterator() {
+        return new Iterator<ASTFormalParameter>() {
+
+            private int i = 0;
+
+
+            @Override
+            public boolean hasNext() {
+                return i < jjtGetNumChildren();
+            }
+
+
+            @Override
+            public ASTFormalParameter next() {
+                return ((ASTFormalParameter) jjtGetChild(i++));
+            }
+
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        };
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodDeclaration.java
@@ -5,13 +5,21 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.dfa.DFAGraphMethod;
 import net.sourceforge.pmd.lang.java.multifile.signature.JavaOperationSignature;
 
+
+/**
+ * Method declaration node.
+ *
+ * <pre>
+ * MethodDeclaration := [ TypeParameters() ] (TypeAnnotation())* ResultType() MethodDeclarator() [ "throws" NameList() ] ( Block() | ";" )
+ * </pre>
+ *
+ */
 public class ASTMethodDeclaration extends AbstractJavaAccessNode implements DFAGraphMethod, ASTMethodOrConstructorDeclaration {
 
     private JavaQualifiedName qualifiedName;
@@ -26,119 +34,120 @@ public class ASTMethodDeclaration extends AbstractJavaAccessNode implements DFAG
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
     }
 
     /**
-     * Gets the name of the method.
-     *
-     * @return a String representing the name of the method
+     * Returns the simple name of the method.
      */
     public String getMethodName() {
-        ASTMethodDeclarator md = getFirstChildOfType(ASTMethodDeclarator.class);
-        if (md != null) {
-            return md.getImage();
-        }
-        return null;
+        return getFirstChildOfType(ASTMethodDeclarator.class).getImage();
     }
 
+
+    @Override
     public String getName() {
         return getMethodName();
     }
 
+
+    /**
+     * Returns true if this method is explicitly modified by
+     * the {@code public} modifier.
+     */
     public boolean isSyntacticallyPublic() {
         return super.isPublic();
     }
 
+
+    /**
+     * Returns true if this method is explicitly modified by
+     * the {@code abstract} modifier.
+     */
     public boolean isSyntacticallyAbstract() {
         return super.isAbstract();
     }
 
+
+    /**
+     * Returns true if this method has public visibility.
+     * Non-private interface members are implicitly public,
+     * whether they declare the {@code public} modifier or
+     * not.
+     */
     @Override
     public boolean isPublic() {
         // interface methods are public by default, but could be private since java9
-        if (isInterfaceMember() && !isPrivate()) {
-            return true;
-        }
-        return super.isPublic();
+        return isInterfaceMember() && !isPrivate() || super.isPublic();
     }
 
+
+    /**
+     * Returns true if this method is abstract, so doesn't
+     * declare a body. Interface members are
+     * implicitly abstract, whether they declare the
+     * {@code abstract} modifier or not.
+     */
     @Override
     public boolean isAbstract() {
-        if (isInterfaceMember()) {
-            return true;
-        }
-        return super.isAbstract();
+        return isInterfaceMember() || super.isAbstract();
     }
 
 
+    /**
+     * Returns true if this method declaration is a member of an interface type.
+     */
     public boolean isInterfaceMember() {
         // for a real class/interface the 3rd parent is a ClassOrInterfaceDeclaration,
         // for anonymous classes, the parent is e.g. a AllocationExpression
         Node potentialTypeDeclaration = getNthParent(3);
 
-        if (potentialTypeDeclaration instanceof ASTClassOrInterfaceDeclaration) {
-            return ((ASTClassOrInterfaceDeclaration) potentialTypeDeclaration).isInterface();
-        }
-        return false;
+        return potentialTypeDeclaration instanceof ASTClassOrInterfaceDeclaration
+                && ((ASTClassOrInterfaceDeclaration) potentialTypeDeclaration).isInterface();
     }
 
+
+    /**
+     * Returns true if the result type of this method is {@code void}.
+     */
     public boolean isVoid() {
         return getResultType().isVoid();
     }
 
+
+    /**
+     * Returns the result type node of the method.
+     */
     public ASTResultType getResultType() {
         return getFirstChildOfType(ASTResultType.class);
     }
 
+
+    /**
+     * Returns the block defined by this method, or
+     * null if the method is abstract.
+     */
     public ASTBlock getBlock() {
-        for (int i = 0; i < jjtGetNumChildren(); i++) {
-            Node n = jjtGetChild(i);
-            if (n instanceof ASTBlock) {
-                return (ASTBlock) n;
-            }
-        }
-        return null;
+        return getFirstChildOfType(ASTBlock.class);
     }
 
+
+    /**
+     * Returns the exception names listed in the {@code throws} clause
+     * of this method declaration, or null if there are none.
+     */
     public ASTNameList getThrows() {
-        int declaratorIndex = -1;
-        for (int i = 0; i < jjtGetNumChildren(); i++) {
-            Node child = jjtGetChild(i);
-            if (child instanceof ASTMethodDeclarator) {
-                declaratorIndex = i;
-                break;
-            }
-        }
-        // the throws declaration is immediately followed by the
-        // MethodDeclarator
-        if (jjtGetNumChildren() > declaratorIndex + 1) {
-            Node n = jjtGetChild(declaratorIndex + 1);
-            if (n instanceof ASTNameList) {
-                return (ASTNameList) n;
-            }
-        }
-        return null;
+        return getFirstChildOfType(ASTNameList.class);
     }
 
 
+    /**
+     * Returns the annotations declared on this method declaration.
+     */
     public List<ASTAnnotation> getDeclaredAnnotations() {
-
-        List<ASTAnnotation> result = new ArrayList<>();
-        ASTClassOrInterfaceBodyDeclaration decl = ((ASTClassOrInterfaceBodyDeclaration) jjtGetParent());
-        for (int i = 0; i < decl.jjtGetNumChildren() - 1; i++) {
-            if (!(decl.jjtGetChild(i) instanceof ASTAnnotation)) {
-                break;
-            }
-            result.add((ASTAnnotation) decl.jjtGetChild(i));
-        }
-
-        return result;
+        return this.jjtGetParent().findChildrenOfType(ASTAnnotation.class);
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodDeclaration.java
@@ -5,6 +5,9 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.dfa.DFAGraphMethod;
 import net.sourceforge.pmd.lang.java.multifile.signature.JavaOperationSignature;
@@ -124,6 +127,21 @@ public class ASTMethodDeclaration extends AbstractJavaAccessNode implements DFAG
     }
 
 
+    public List<ASTAnnotation> getDeclaredAnnotations() {
+
+        List<ASTAnnotation> result = new ArrayList<>();
+        ASTClassOrInterfaceBodyDeclaration decl = ((ASTClassOrInterfaceBodyDeclaration) jjtGetParent());
+        for (int i = 0; i < decl.jjtGetNumChildren() - 1; i++) {
+            if (!(decl.jjtGetChild(i) instanceof ASTAnnotation)) {
+                break;
+            }
+            result.add((ASTAnnotation) decl.jjtGetChild(i));
+        }
+
+        return result;
+    }
+
+
     @Override
     public JavaQualifiedName getQualifiedName() {
         if (qualifiedName == null) {
@@ -140,5 +158,11 @@ public class ASTMethodDeclaration extends AbstractJavaAccessNode implements DFAG
         }
 
         return signature;
+    }
+
+
+    @Override
+    public ASTFormalParameters getFormalParameters() {
+        return getFirstChildOfType(ASTMethodDeclarator.class).getFirstChildOfType(ASTFormalParameters.class);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodOrConstructorDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodOrConstructorDeclaration.java
@@ -19,4 +19,10 @@ public interface ASTMethodOrConstructorDeclaration extends
     @Override
     JavaOperationSignature getSignature();
 
+
+    /**
+     * Returns the formal parameters node of this method or constructor.
+     */
+    ASTFormalParameters getFormalParameters();
+
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaQualifiedName.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaQualifiedName.java
@@ -315,15 +315,17 @@ public final class JavaQualifiedName implements QualifiedName {
         sb.append(methodName);
         sb.append('(');
 
-        int last = params.getParameterCount() - 1;
-        for (int i = 0; i < last; i++) {
-            // append type image of param
-            sb.append(params.jjtGetChild(i).getFirstDescendantOfType(ASTType.class).getTypeImage());
-            sb.append(", ");
-        }
+        boolean first = true;
+        for (ASTFormalParameter param : params) {
+            if (!first) {
+                sb.append(", ");
+            }
+            first = false;
 
-        if (last > -1) {
-            sb.append(params.jjtGetChild(last).getFirstDescendantOfType(ASTType.class).getTypeImage());
+            sb.append(param.getTypeNode().getTypeImage());
+            if (param.isVarargs()) {
+                sb.append("...");
+            }
         }
 
         sb.append(')');

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
@@ -4,7 +4,6 @@
 
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
-import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -347,10 +346,6 @@ public class MissingOverrideRule extends AbstractJavaRule {
                 if (pType == null) {
                     // fail, couldn't resolve one parameter
                     return null;
-                }
-
-                if (p.isVarargs()) {
-                    pType = Array.newInstance(pType, 1).getClass();
                 }
 
                 paramTypes[i++] = pType;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
@@ -5,7 +5,13 @@
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
 import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.Stack;
 
 import net.sourceforge.pmd.lang.java.ast.ASTAllocationExpression;
@@ -28,30 +34,30 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
  */
 public class MissingOverrideRule extends AbstractJavaRule {
 
-    private final Stack<Class<?>> currentExploredClass = new Stack<>();
+    private final Stack<MethodLookup> currentLookup = new Stack<>();
 
 
     @Override
     public Object visit(ASTCompilationUnit node, Object data) {
-        currentExploredClass.clear();
+        currentLookup.clear();
         return super.visit(node, data);
     }
 
 
     @Override
     public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
-        currentExploredClass.push(node.getType());
+        currentLookup.push(getMethodLookup(node.getType()));
         super.visit(node, data);
-        currentExploredClass.pop();
+        currentLookup.pop();
 
         return data;
     }
 
     @Override
     public Object visit(ASTEnumDeclaration node, Object data) {
-        currentExploredClass.push(node.getType());
+        currentLookup.push(getMethodLookup(node.getType()));
         super.visit(node, data);
-        currentExploredClass.pop();
+        currentLookup.pop();
 
         return data;
     }
@@ -61,12 +67,12 @@ public class MissingOverrideRule extends AbstractJavaRule {
     @Override
     public Object visit(ASTAllocationExpression node, Object data) {
         if (node.isAnonymousClass()) {
-            currentExploredClass.push(node.getType());
+            currentLookup.push(getMethodLookup(node.getType()));
         }
         super.visit(node, data);
 
         if (node.isAnonymousClass()) {
-            currentExploredClass.pop();
+            currentLookup.pop();
         }
 
         return data;
@@ -89,9 +95,90 @@ public class MissingOverrideRule extends AbstractJavaRule {
     }
 
 
+    /**
+     * Returns a map of method name to methods with the same name (overloads).
+     * The map contains a MethodWrapper for all methods declared in this class.
+     *
+     * @param exploredType Type to explore
+     */
+    private MethodLookup getMethodLookup(Class<?> exploredType) {
+        if (exploredType == null) {
+            return null;
+        }
+
+        Set<Method> overridden = overriddenMethods(exploredType);
+        Map<String, Map<Integer, List<Method>>> result = new HashMap<>();
+
+        for (Method m : exploredType.getDeclaredMethods()) {
+            if (!result.containsKey(m.getName())) {
+                result.put(m.getName(), new HashMap<Integer, List<Method>>());
+            }
+
+            Map<Integer, List<Method>> pCountToOverloads = result.get(m.getName());
+
+            int paramCount = m.getParameterTypes().length;
+            if (!pCountToOverloads.containsKey(paramCount)) {
+                pCountToOverloads.put(paramCount, new ArrayList<Method>());
+            }
+
+            pCountToOverloads.get(paramCount).add(m);
+        }
+
+        return new MethodLookup(result, overridden);
+    }
+
+
+    /**
+     * Returns the set of methods declared in this type that are overridden.
+     *
+     * @param exploredType The type to explore
+     */
+    private Set<Method> overriddenMethods(Class<?> exploredType) {
+        return overriddenMethodsRec(exploredType, true, new HashSet<Method>(Arrays.asList(exploredType.getDeclaredMethods())), new HashSet<Method>(), new HashSet<Class<?>>());
+    }
+
+
+    private Set<Method> overriddenMethodsRec(Class<?> exploredType, boolean skip, Set<Method> candidates, Set<Method> result, Set<Class<?>> alreadyExplored) {
+
+        if (candidates.isEmpty() || alreadyExplored.contains(exploredType)) {
+            return result;
+        }
+
+        alreadyExplored.add(exploredType);
+
+        if (!skip) {
+            Method toRemove = null;
+            for (Method dm : exploredType.getDeclaredMethods()) {
+                for (Method cand : candidates) {
+                    if (cand.getName().equals(dm.getName()) && Arrays.equals(cand.getParameterTypes(), dm.getParameterTypes())) {
+                        // cand is overriden
+                        result.add(cand);
+                        toRemove = cand;
+                        break;
+                    }
+                }
+                if (toRemove != null) {
+                    candidates.remove(toRemove); // no need to look for it elsewhere
+                }
+            }
+        }
+
+        Class<?> superClass = exploredType.getSuperclass();
+        if (superClass != null) {
+            overriddenMethodsRec(superClass, false, candidates, result, alreadyExplored);
+        }
+
+        for (Class<?> iface : exploredType.getInterfaces()) {
+            overriddenMethodsRec(iface, false, candidates, result, alreadyExplored);
+        }
+
+        return result;
+    }
+
+
     @Override
     public Object visit(ASTMethodDeclaration node, Object data) {
-        if (currentExploredClass.peek() == null) {
+        if (currentLookup.peek() == null) {
             return super.visit(node, data);
         }
 
@@ -102,20 +189,22 @@ public class MissingOverrideRule extends AbstractJavaRule {
             }
         }
 
-        ASTFormalParameters params = node.getFormalParameters();
-        Class<?>[] paramTypes = new Class[params.getParameterCount()];
-        int i = 0;
-        for (ASTFormalParameter p : params) {
-            Class<?> pType = p.getType();
-            if (pType == null) {
-                // fail, couldn't resolve one parameter
-                return super.visit(node, data);
-            }
+        boolean overridden = false;
+        try {
+            Boolean b = currentLookup.peek().isOverridden(node.getName(), node.getFormalParameters().getParameterCount());
 
-            paramTypes[i++] = pType;
+            if (b == null) { // try harder
+                Class<?>[] paramTypes = getParameterTypes(node);
+                overridden = currentLookup.peek().isOverridden(node.getName(), paramTypes);
+            } else {
+                overridden = b;
+            }
+        } catch (NoSuchMethodException e) {
+            e.printStackTrace();
+            super.visit(node, data);
         }
 
-        if (isMethodOverridden(node.getMethodName(), paramTypes, currentExploredClass.peek())) {
+        if (overridden) {
             // this method lacks an @Override annotation
             addViolation(data, node, new Object[]{node.getQualifiedName().getOperation()});
         }
@@ -124,36 +213,94 @@ public class MissingOverrideRule extends AbstractJavaRule {
     }
 
 
-    private boolean isMethodOverridden(String name, Class<?>[] paramTypes, final Class<?> exploredType) {
-        return isMethodDeclaredInType(name, paramTypes, exploredType, true);
+    private Class<?>[] getParameterTypes(ASTMethodDeclaration node) {
+        ASTFormalParameters params = node.getFormalParameters();
+        Class<?>[] paramTypes = new Class[params.getParameterCount()];
+        int i = 0;
+        for (ASTFormalParameter p : params) {
+            Class<?> pType = p.getType();
+            if (pType == null) {
+                // fail, couldn't resolve one parameter
+                return null;
+            }
+
+            paramTypes[i++] = pType;
+        }
+        return paramTypes;
     }
 
 
-    private boolean isMethodDeclaredInType(String name, final Class<?>[] paramTypes, final Class<?> exploredType, boolean skip) {
+    private static class MethodLookup {
 
-        if (!skip) {
-            for (Method dm : exploredType.getDeclaredMethods()) {
+        // method name, parameter count, methods
+        private final Map<String, Map<Integer, List<Method>>> map;
+        private final Set<Method> overridden;
 
-                if (name.equals(dm.getName()) && Arrays.equals(paramTypes, dm.getParameterTypes())) {
-                    return true;
+
+        private MethodLookup(Map<String, Map<Integer, List<Method>>> map, Set<Method> overridden) {
+            this.map = map;
+            this.overridden = overridden;
+        }
+
+
+        /**
+         * Tries to determine if the method with the given name and parameter count is overridden
+         *
+         * @return True or false if the method succeeds, null if there was an ambiguity.
+         * In that case, try harder using {@link #isOverridden(String, Class[])}.
+         *
+         * @throws NoSuchMethodException if no method is registered with this name and paramcount, which is a bug
+         */
+        public Boolean isOverridden(String name, int paramCount) throws NoSuchMethodException {
+            List<Method> methods = getMethods(name, paramCount);
+
+            if (methods.size() == 1) { // only one method with this name and parameter count, we can conclude
+                return overridden.contains(methods.get(0));
+            } else if (methods.size() == 2) { // maybe one of them is a bridge method
+                // TODO scale that up
+                int bridgeIndex = methods.get(0).isBridge() ? 0 : methods.get(1).isBridge() ? 1 : -1;
+                if (bridgeIndex >= 0) {
+                    return overridden.contains(methods.get(bridgeIndex));
+                } else {
+                    return null;
+                }
+            } else { // several overloads with same name and count, cannot be determined without comparing parameters
+                return null;
+            }
+        }
+
+
+        private List<Method> getMethods(String name, int paramCount) throws NoSuchMethodException {
+            Map<Integer, List<Method>> overloads = map.get(name);
+            if (overloads == null) {
+                throw new NoSuchMethodException(name);
+            }
+
+            List<Method> methods = overloads.get(paramCount);
+            if (methods == null || methods.isEmpty()) {
+                throw new NoSuchMethodException(name);
+            }
+            return methods;
+        }
+
+
+        /**
+         * Tries to determine if the method with the given name and parameter types is overridden
+         *
+         * @return True or false. Returns false if there was an ambiguity.
+         *
+         * @throws NoSuchMethodException if no method is registered with this name and paramcount, which is a bug
+         */
+        public boolean isOverridden(String name, Class<?>[] paramTypes) throws NoSuchMethodException {
+            for (Method m : getMethods(name, paramTypes.length)) {
+                if (Arrays.equals(m.getParameterTypes(), paramTypes)) {
+                    // we found our overload
+                    return overridden.contains(m);
                 }
             }
+            return false;
         }
 
-        Class<?> superClass = exploredType.getSuperclass();
-        if (superClass != null) {
-            if (isMethodDeclaredInType(name, paramTypes, superClass, false)) {
-                return true;
-            }
-        }
-
-        for (Class<?> iface : exploredType.getInterfaces()) {
-            if (isMethodDeclaredInType(name, paramTypes, iface, false)) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.Stack;
+import java.util.logging.Logger;
 
 import net.sourceforge.pmd.lang.java.ast.ASTAllocationExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
@@ -35,6 +36,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
  */
 public class MissingOverrideRule extends AbstractJavaRule {
 
+    private static final Logger LOG = Logger.getLogger(MissingOverrideRule.class.getName());
     private final Stack<MethodLookup> currentLookup = new Stack<>();
 
 
@@ -212,6 +214,8 @@ public class MissingOverrideRule extends AbstractJavaRule {
             // may happen in the body of an enum constant,
             // because the method lookup used is the one of
             // the parent class.
+            LOG.warning("MissingOverride encountered unexpected method " + node.getMethodName());
+            // throw new RuntimeException(e); // uncomment when enum constants are handled by typeres
         }
         return super.visit(node, data);
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
+import java.lang.reflect.Array;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -196,6 +197,9 @@ public class MissingOverrideRule extends AbstractJavaRule {
 
             if (b == null) { // try harder
                 Class<?>[] paramTypes = getParameterTypes(node);
+                if (paramTypes == null) {
+                    return super.visit(node, data);
+                }
                 overridden = currentLookup.peek().isOverridden(node.getName(), paramTypes);
             } else {
                 overridden = b;
@@ -225,6 +229,10 @@ public class MissingOverrideRule extends AbstractJavaRule {
             if (pType == null) {
                 // fail, couldn't resolve one parameter
                 return null;
+            }
+
+            if (p.isVarargs()) {
+                pType = Array.newInstance(pType, 1).getClass();
             }
 
             paramTypes[i++] = pType;
@@ -303,14 +311,6 @@ public class MissingOverrideRule extends AbstractJavaRule {
 
             if (methods.size() == 1) { // only one method with this name and parameter count, we can conclude
                 return overridden.contains(methods.get(0));
-            } else if (methods.size() == 2) { // maybe one of them is a bridge method
-                // TODO scale that up
-                int bridgeIndex = methods.get(0).isBridge() ? 0 : methods.get(1).isBridge() ? 1 : -1;
-                if (bridgeIndex >= 0) {
-                    return overridden.contains(methods.get(bridgeIndex));
-                } else {
-                    return null;
-                }
             } else { // several overloads with same name and count, cannot be determined without comparing parameters
                 return null;
             }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
@@ -96,7 +96,7 @@ public class MissingOverrideRule extends AbstractJavaRule {
         }
 
         for (ASTAnnotation annot : node.getDeclaredAnnotations()) {
-            if ("Override".equals(annot.getAnnotationName()) || "java.lang.Override".equals(annot.getAnnotationName())) {
+            if (Override.class.equals(annot.getType())) {
                 // we assume the compiler has already checked it, so it's correct
                 return super.visit(node, data);
             }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
@@ -1,0 +1,163 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Stack;
+
+import net.sourceforge.pmd.lang.java.ast.ASTAllocationExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
+import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.lang.java.ast.ASTEnumConstant;
+import net.sourceforge.pmd.lang.java.ast.ASTEnumDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
+import net.sourceforge.pmd.lang.java.ast.ASTFormalParameters;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
+
+
+/**
+ * Flags missing @Override annotations.
+ *
+ * @author Clément Fournier
+ * @since 6.1.0
+ */
+public class MissingOverrideRule extends AbstractJavaRule {
+
+    private final Stack<Class<?>> currentExploredClass = new Stack<>();
+
+
+    @Override
+    public Object visit(ASTCompilationUnit node, Object data) {
+        currentExploredClass.clear();
+        return super.visit(node, data);
+    }
+
+
+    @Override
+    public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
+        currentExploredClass.push(node.getType());
+        super.visit(node, data);
+        currentExploredClass.pop();
+
+        return data;
+    }
+
+    @Override
+    public Object visit(ASTEnumDeclaration node, Object data) {
+        currentExploredClass.push(node.getType());
+        super.visit(node, data);
+        currentExploredClass.pop();
+
+        return data;
+    }
+
+
+
+    @Override
+    public Object visit(ASTAllocationExpression node, Object data) {
+        if (node.isAnonymousClass()) {
+            currentExploredClass.push(node.getType());
+        }
+        super.visit(node, data);
+
+        if (node.isAnonymousClass()) {
+            currentExploredClass.pop();
+        }
+
+        return data;
+    }
+
+
+    @Override
+    public Object visit(ASTEnumConstant node, Object data) {
+        // FIXME, ASTEnumConstant needs typeres support!
+        //        if (node.isAnonymousClass()) {
+        //            currentExploredClass.push(node.getType());
+        //        }
+        super.visit(node, data);
+
+        //        if (node.isAnonymousClass()) {
+        //            currentExploredClass.pop();
+        //        }
+
+        return data;
+    }
+
+
+    @Override
+    public Object visit(ASTMethodDeclaration node, Object data) {
+        if (currentExploredClass.peek() == null) {
+            return super.visit(node, data);
+        }
+
+        for (ASTAnnotation annot : node.getDeclaredAnnotations()) {
+            if ("Override".equals(annot.getAnnotationName()) || "java.lang.Override".equals(annot.getAnnotationName())) {
+                // we assume the compiler has already checked it, so it's correct
+                return super.visit(node, data);
+            }
+        }
+
+        ASTFormalParameters params = node.getFormalParameters();
+        Class<?>[] paramTypes = new Class[params.getParameterCount()];
+        int i = 0;
+        for (ASTFormalParameter p : params) {
+            Class<?> pType = p.getTypeNode().getType();
+            if (pType == null) {
+                // fail, couldn't resolve one parameter
+                return super.visit(node, data);
+            }
+
+            paramTypes[i++] = pType;
+        }
+
+        if (isMethodOverridden(node.getMethodName(), paramTypes, currentExploredClass.peek())) {
+            // this method lacks an @Override annotation
+            addViolation(data, node, new Object[]{node.getQualifiedName().getOperation()});
+        }
+
+        return super.visit(node, data);
+    }
+
+
+    private boolean isMethodOverridden(String name, Class<?>[] paramTypes, final Class<?> exploredType) {
+        return isMethodDeclaredInType(name, paramTypes, exploredType, true);
+    }
+
+
+    private boolean isMethodDeclaredInType(String name, final Class<?>[] paramTypes, final Class<?> exploredType, boolean skip) {
+
+        if (!skip) {
+            for (Method dm : exploredType.getDeclaredMethods()) {
+
+                if (name.equals(dm.getName()) && Arrays.equals(paramTypes, dm.getParameterTypes())) {
+                    return true;
+                }
+            }
+        }
+
+        Class<?> superClass = exploredType.getSuperclass();
+        if (superClass != null) {
+            if (isMethodDeclaredInType(name, paramTypes, superClass, false)) {
+                return true;
+            }
+        }
+
+        for (Class<?> iface : exploredType.getInterfaces()) {
+            if (isMethodDeclaredInType(name, paramTypes, iface, false)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+
+}
+
+
+

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
@@ -106,7 +106,7 @@ public class MissingOverrideRule extends AbstractJavaRule {
         Class<?>[] paramTypes = new Class[params.getParameterCount()];
         int i = 0;
         for (ASTFormalParameter p : params) {
-            Class<?> pType = p.getTypeNode().getType();
+            Class<?> pType = p.getType();
             if (pType == null) {
                 // fail, couldn't resolve one parameter
                 return super.visit(node, data);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
@@ -174,6 +174,13 @@ public class MissingOverrideRule extends AbstractJavaRule {
             overriddenMethodsRec(iface, false, candidates, result, alreadyExplored);
         }
 
+        if (exploredType.isInterface() && exploredType.getInterfaces().length == 0) {
+            // implicit object member declarations
+            if (!alreadyExplored.contains(Object.class)) {
+                overriddenMethodsRec(Object.class, false, candidates, result, alreadyExplored);
+            }
+        }
+
         return result;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -27,6 +27,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTAdditiveExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTAllocationExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTAndExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotationTypeDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTArguments;
 import net.sourceforge.pmd.lang.java.ast.ASTArrayDimsAndInits;
@@ -1370,11 +1371,13 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
     }
 
     private String getClassName(ASTCompilationUnit node) {
-        ASTClassOrInterfaceDeclaration classDecl = node.getFirstDescendantOfType(ASTClassOrInterfaceDeclaration.class);
+        ASTAnyTypeDeclaration classDecl = node.getFirstDescendantOfType(ASTAnyTypeDeclaration.class);
         if (classDecl == null) {
-            // Happens if this compilation unit only contains an enum
+            // package-info.java?
             return null;
         }
+
+
         if (node.declarationsAreInDefaultPackage()) {
             return classDecl.getImage();
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -1165,6 +1165,10 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
     public Object visit(ASTFormalParameter node, Object data) {
         super.visit(node, data);
         node.setTypeDefinition(node.getTypeNode().getTypeDefinition());
+        if (node.isVarargs() && node.getType() != null) {
+            node.setType(Array.newInstance(node.getType(), 0).getClass());
+        }
+
         return data;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -49,6 +49,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTExclusiveOrExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTExtendsList;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTInclusiveOrExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTInstanceOfExpression;
@@ -1156,6 +1157,14 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
     public Object visit(ASTStatementExpression node, Object data) {
         super.visit(node, data);
         rollupTypeUnary(node);
+        return data;
+    }
+
+
+    @Override
+    public Object visit(ASTFormalParameter node, Object data) {
+        super.visit(node, data);
+        node.setTypeDefinition(node.getTypeNode().getTypeDefinition());
         return data;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -26,6 +26,7 @@ import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTAdditiveExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTAllocationExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTAndExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotationTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
@@ -1153,6 +1154,14 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
 
     @Override
     public Object visit(ASTStatementExpression node, Object data) {
+        super.visit(node, data);
+        rollupTypeUnary(node);
+        return data;
+    }
+
+
+    @Override
+    public Object visit(ASTAnnotation node, Object data) {
         super.visit(node, data);
         rollupTypeUnary(node);
         return data;

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -734,6 +734,34 @@ public class SecureSystem {
         </example>
     </rule>
 
+
+    <rule name="MissingOverride"
+          since="6.1.0"
+          minimumLanguageVersion="1.5"
+          message="The method ''{0}'' is missing an @Override annotation."
+          typeResolution="true"
+          class="net.sourceforge.pmd.lang.java.rule.bestpractices.MissingOverrideRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_bestpractices.html#missingoverride">
+        <description>
+            Annotating overridden methods with @Override ensures at compile time that
+            the method really overrides one, which helps refactoring and clarifies intent.
+
+            This rule is limited to resolving methods inherited from non-parameterized
+            or raw supertypes.
+        </description>
+        <priority>3</priority>
+        <example>
+            <![CDATA[
+            public class Foo implements Runnable {
+                // This method is overridden, and should have an @Override annotation
+                public void run() {
+
+                }
+            }
+            ]]>
+        </example>
+    </rule>
+
     <rule name="OneDeclarationPerLine"
           language="java"
           since="5.0"

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/BestPracticesRulesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/BestPracticesRulesTest.java
@@ -39,6 +39,7 @@ public class BestPracticesRulesTest extends SimpleAggregatorTst {
         addRule(RULESET, "JUnitUseExpected");
         addRule(RULESET, "LooseCoupling");
         addRule(RULESET, "MethodReturnsInternalArray");
+        addRule(RULESET, "MissingOverride");
         addRule(RULESET, "OneDeclarationPerLine");
         addRule(RULESET, "PositionLiteralsFirstInComparisons");
         addRule(RULESET, "PositionLiteralsFirstInCaseInsensitiveComparisons");

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AbsClassWithInterface.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AbsClassWithInterface.java
@@ -1,0 +1,12 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+/**
+ * @author Clément Fournier
+ * @since 6.1.0
+ */
+public abstract class AbsClassWithInterface implements Runnable {
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AbstractClass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AbstractClass.java
@@ -10,10 +10,17 @@ package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
  */
 public abstract class AbstractClass {
 
-    abstract Object fun(String s);
+    Object fun(String s) {
+        return new Object();
+    }
 
 
     public void arrayParams(String dflt, int[] keys, StringBuilder[] labels) {
+    }
+
+
+    public <T, R> R generic(T t, R r) {
+        return r;
     }
 
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AbstractClass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AbstractClass.java
@@ -1,0 +1,19 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+/**
+ * @author Clément Fournier
+ * @since 6.1.0
+ */
+public abstract class AbstractClass {
+
+    abstract Object fun(String s);
+
+
+    public void arrayParams(String dflt, int[] keys, StringBuilder[] labels) {
+    }
+
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AmbiguousOverload.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AmbiguousOverload.java
@@ -1,0 +1,28 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+import java.util.Comparator;
+
+
+public class AmbiguousOverload implements Comparator<StringBuilder> {
+
+
+    // only one of those overloads is an override, and so there's only one bridge,
+    // so we can't choose the inherited overload
+
+
+    @Override
+    public int compare(StringBuilder o1, StringBuilder o2) {
+        return 0;
+    }
+
+
+    public int compare(String s, String s2) {
+        return 0;
+    }
+
+
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AnonClassExample.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AnonClassExample.java
@@ -1,0 +1,16 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+public class AnonClassExample {
+    static {
+        new Thread(new Runnable() {
+            // missing
+            public void run() {
+
+            }
+        }).start();
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AnonClassExample.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AnonClassExample.java
@@ -14,3 +14,4 @@ public class AnonClassExample {
         }).start();
     }
 }
+

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/ConcreteClass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/ConcreteClass.java
@@ -1,0 +1,16 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+/**
+ * @author Clément Fournier
+ * @since 6.1.0
+ */
+public class ConcreteClass extends AbstractClass {
+    @Override
+    Object fun(String s) {
+        return null;
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/ConcreteClassArrayParams.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/ConcreteClassArrayParams.java
@@ -1,0 +1,18 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+public class ConcreteClassArrayParams extends AbstractClass {
+    @Override
+    Object fun(String s) {
+        return null;
+    }
+
+
+    @Override
+    public void arrayParams(String dflt, int[] keys, StringBuilder[] labels) {
+        super.arrayParams(dflt, keys, labels);
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/ConcreteClassTransitive.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/ConcreteClassTransitive.java
@@ -1,0 +1,16 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+/**
+ * @author Clément Fournier
+ * @since 6.1.0
+ */
+public class ConcreteClassTransitive extends AbsClassWithInterface {
+    @Override
+    public void run() {
+
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/CovariantReturnType.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/CovariantReturnType.java
@@ -1,0 +1,13 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+public class CovariantReturnType extends AbstractClass {
+
+    @Override
+    String fun(String s) {
+        return "";
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/EnumWithAnonClass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/EnumWithAnonClass.java
@@ -1,0 +1,24 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+/**
+ * @author Clément Fournier
+ * @since 6.1.0
+ */
+public enum EnumWithAnonClass {
+    Foo {
+        @Override
+        public String getSomething() {
+            return null;
+        }
+    };
+
+
+    public Object getSomething() {
+        return null;
+    }
+
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/EnumWithInterfaces.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/EnumWithInterfaces.java
@@ -1,0 +1,34 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
+import net.sourceforge.pmd.lang.metrics.Metric;
+import net.sourceforge.pmd.lang.metrics.MetricKey;
+
+
+/**
+ * @author Clément Fournier
+ * @since 6.1.0
+ */
+public enum EnumWithInterfaces implements MetricKey<ASTAnyTypeDeclaration> {
+    Foo {
+        @Override
+        public Metric<ASTAnyTypeDeclaration> getCalculator() {
+            return null;
+        }
+    };
+
+    @Override
+    public Metric<ASTAnyTypeDeclaration> getCalculator() {
+        return null;
+    }
+
+
+    @Override
+    public boolean supports(ASTAnyTypeDeclaration node) {
+        return false;
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/GenericInterfaceWithOverloads.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/GenericInterfaceWithOverloads.java
@@ -1,0 +1,25 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTPackageDeclaration;
+
+
+public interface GenericInterfaceWithOverloads<T, R extends Number> {
+
+    T visit(ASTCompilationUnit node, T data);
+
+
+    T visit(ASTPackageDeclaration node, T data);
+
+
+    T multi(ASTImportDeclaration node, T data, R r);
+
+
+    T multi(ASTPackageDeclaration node, T data, R r);
+
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/GenericWithOverloadsImpl.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/GenericWithOverloadsImpl.java
@@ -1,0 +1,47 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTPackageDeclaration;
+
+
+public class GenericWithOverloadsImpl implements GenericInterfaceWithOverloads<String, Integer> {
+
+    // a bridge method is generated for each of these that implement an interface method
+
+
+    @Override
+    public String visit(ASTCompilationUnit node, String data) {
+        return null;
+    }
+
+
+    @Override
+    public String visit(ASTPackageDeclaration node, String data) {
+        return null;
+    }
+
+
+    @Override
+    public String multi(ASTImportDeclaration node, String data, Integer integer) {
+        return null;
+    }
+
+
+    // this one is not overriden, no bridge
+    public String multi(ASTMethodDeclaration node, String data, Integer integer) {
+        return null;
+    }
+
+
+    @Override
+    public String multi(ASTPackageDeclaration node, String data, Integer integer) {
+        return null;
+    }
+
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/HierarchyWithSeveralBridges.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/HierarchyWithSeveralBridges.java
@@ -1,0 +1,39 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.java.ast.ASTType;
+import net.sourceforge.pmd.lang.java.ast.AbstractJavaTypeNode;
+import net.sourceforge.pmd.lang.java.ast.JavaNode;
+
+public abstract class HierarchyWithSeveralBridges<T extends Node> {
+
+    abstract void foo(T node);
+
+    public abstract static class SubclassOne<T extends JavaNode> extends HierarchyWithSeveralBridges<T> {
+
+        @Override
+        abstract void foo(T node);
+    }
+
+    public abstract static class SubclassTwo<T extends AbstractJavaTypeNode> extends SubclassOne<T> {
+        @Override
+        void foo(T node) {
+
+        }
+    }
+
+
+    public static class Concrete extends SubclassTwo<ASTType> {
+
+        // bridges: foo(AbstractJavaTypeNode), foo(JavaNode), foo(Node)
+
+        @Override
+        void foo(ASTType node) {
+
+        }
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/InterfaceWithNoSuperClass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/InterfaceWithNoSuperClass.java
@@ -1,0 +1,11 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+public interface InterfaceWithNoSuperClass {
+
+    @Override
+    String toString();
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/Option.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/Option.java
@@ -1,0 +1,12 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+/**
+ * @author Clément Fournier
+ * @since 6.1.0
+ */
+public class Option {
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/OptionTestCaseOneParam.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/OptionTestCaseOneParam.java
@@ -1,0 +1,12 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+/**
+ * @author Clément Fournier
+ * @since 6.1.0
+ */
+public class OptionTestCaseOneParam {
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/RunnableImpl.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/RunnableImpl.java
@@ -1,0 +1,12 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+public class RunnableImpl implements Runnable {
+    @Override
+    public void run() {
+
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/SubclassWithGenericMethod.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/SubclassWithGenericMethod.java
@@ -1,0 +1,13 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+public class SubclassWithGenericMethod extends AbstractClass {
+
+    @Override
+    public <T, R> R generic(T t, R r) {
+        return super.generic(t, r);
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
@@ -609,14 +609,6 @@ public class ClassTypeResolverTest {
         assertEquals("All expressions not tested", index, expressions.size());
     }
 
-    private static <T> List<T> convertList(List<Node> nodes, Class<T> target) {
-        List<T> converted = new ArrayList<>();
-        for (Node n : nodes) {
-            converted.add(target.cast(n));
-        }
-        return converted;
-    }
-
     @Test
     public void testBinaryNumericOperators() throws JaxenException {
         ASTCompilationUnit acu = parseAndTypeResolveForClass15(Operators.class);
@@ -1863,5 +1855,14 @@ public class ClassTypeResolverTest {
         languageVersionHandler.getSymbolFacade().start(acu);
         languageVersionHandler.getTypeResolutionFacade(ClassTypeResolverTest.class.getClassLoader()).start(acu);
         return acu;
+    }
+
+
+    private static <T> List<T> convertList(List<Node> nodes, Class<T> target) {
+        List<T> converted = new ArrayList<>();
+        for (Node n : nodes) {
+            converted.add(target.cast(n));
+        }
+        return converted;
     }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
@@ -11,6 +11,7 @@ import static net.sourceforge.pmd.lang.java.typeresolution.typedefinition.TypeDe
 import static net.sourceforge.pmd.lang.java.typeresolution.typeinference.InferenceRuleType.LOOSE_INVOCATION;
 import static net.sourceforge.pmd.lang.java.typeresolution.typeinference.InferenceRuleType.SUBTYPE;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
@@ -99,6 +100,7 @@ import net.sourceforge.pmd.typeresolution.testdata.MethodPotentialApplicability;
 import net.sourceforge.pmd.typeresolution.testdata.MethodSecondPhase;
 import net.sourceforge.pmd.typeresolution.testdata.MethodStaticAccess;
 import net.sourceforge.pmd.typeresolution.testdata.MethodThirdPhase;
+import net.sourceforge.pmd.typeresolution.testdata.NestedAllocationExpressions;
 import net.sourceforge.pmd.typeresolution.testdata.NestedAnonymousClass;
 import net.sourceforge.pmd.typeresolution.testdata.Operators;
 import net.sourceforge.pmd.typeresolution.testdata.OverloadedMethodsUsage;
@@ -1778,6 +1780,20 @@ public class ClassTypeResolverTest {
                      forClass(Integer.class));
         assertEquals(inferedMethod.getParameterTypes().get(3),
                      forClass(SuperClassAOther2.class));
+    }
+
+
+    @Test
+    public void testNestedAllocationExpressions() {
+        ASTCompilationUnit acu = parseAndTypeResolveForClass15(NestedAllocationExpressions.class);
+        List<ASTAllocationExpression> allocs = acu.findDescendantsOfType(ASTAllocationExpression.class);
+
+        assertFalse(allocs.get(0).isAnonymousClass());
+        assertEquals(Thread.class, allocs.get(0).getType());
+
+        assertTrue(allocs.get(1).isAnonymousClass());
+        // FUTURE 1.8 use Class.getTypeName() instead of toString
+        assertTrue(allocs.get(1).getType().toString().endsWith("NestedAllocationExpressions$1"));
     }
 
     @Test

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
@@ -204,7 +204,7 @@ public class ClassTypeResolverTest {
                      outerClassDeclaration.getFirstDescendantOfType(ASTClassOrInterfaceDeclaration.class).getType());
         // Method parameter as inner class
         ASTFormalParameter formalParameter = typeDeclaration.getFirstDescendantOfType(ASTFormalParameter.class);
-        assertEquals(theInnerClass, formalParameter.getTypeNode().getType());
+        assertEquals(theInnerClass, formalParameter.getType());
     }
 
     /**

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/NestedAllocationExpressions.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/NestedAllocationExpressions.java
@@ -1,0 +1,20 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.typeresolution.testdata;
+
+/**
+ * @author Clément Fournier
+ * @since 6.1.0
+ */
+public class NestedAllocationExpressions {
+    static {
+        new Thread(new Runnable() {
+            // missing
+            public void run() {
+
+            }
+        }).start();
+    }
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
@@ -185,9 +185,9 @@
     <test-code>
         <description>Consider methods with array parameters</description>
         <expected-problems>0</expected-problems> <!-- FIXME should be 1 - caused by #910 -->
-        <expected-messages>
-            <message>The method 'arrayParams(String, int[], StringBuilder[])' is missing an @Override annotation.</message>
-        </expected-messages>
+        <!--<expected-messages>-->
+            <!--<message>The method 'arrayParams(String, int[], StringBuilder[])' is missing an @Override annotation.</message>-->
+        <!--</expected-messages>-->
         <code><![CDATA[
             package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
@@ -1,0 +1,255 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+    <test-code>
+        <description>Missing override on method from interface</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+            package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+            public class RunnableImpl implements Runnable {
+                public void run() { }
+            }
+
+            ]]></code>
+    </test-code>
+    <test-code>
+        <description>Override present on method from interface</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+            public class RunnableImpl implements Runnable{
+                @Override
+                public void run() { }
+            }
+
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Override absent in method from superclass</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+            package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+            public class ConcreteClass extends AbstractClass {
+                Object fun(String s) {
+                    return null;
+                }
+            }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Override present in method from superclass</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+            public class ConcreteClass extends AbstractClass {
+                @Override
+                Object fun(String s) {
+                    return null;
+                }
+            }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Override present in method from interface transitively</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+            public class ConcreteClassTransitive extends AbsClassWithInterface {
+                @Override
+                public void run() {
+                }
+            }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Override absent in method from interface transitively</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+            package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+            public class ConcreteClassTransitive extends AbsClassWithInterface {
+                public void run() {
+                }
+            }
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Consider anonymous classes</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>The method 'run()' is missing an @Override annotation.</message>
+        </expected-messages>
+        <code><![CDATA[
+            package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+            public class AnonClassExample {
+                static {
+                    new Thread(new Runnable() {
+                        // missing
+                        public void run() {
+
+                        }
+                    }).start();
+                }
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Consider anonymous classes</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+            public class AnonClassExample {
+                static {
+                    new Thread(new Runnable() {
+                        @Override
+                        public void run() {
+                            bar();
+                        }
+
+                        public void bar() {
+
+                        }
+                    }).start();
+                }
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Consider enum methods</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+            import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
+            import net.sourceforge.pmd.lang.metrics.Metric;
+            import net.sourceforge.pmd.lang.metrics.MetricKey;
+
+            public enum EnumWithInterfaces implements MetricKey<ASTAnyTypeDeclaration> {
+                Foo {
+                    @Override
+                    public Metric<ASTAnyTypeDeclaration> getCalculator() {
+                        return null;
+                    }
+                };
+
+                @Override
+                public Metric<ASTAnyTypeDeclaration> getCalculator() {
+                    return null;
+                }
+
+
+                @Override
+                public boolean supports(ASTAnyTypeDeclaration node) {
+                    return false;
+                }
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Consider enum methods</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>9,15</expected-linenumbers>
+        <code><![CDATA[
+            package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+            import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
+            import net.sourceforge.pmd.lang.metrics.Metric;
+            import net.sourceforge.pmd.lang.metrics.MetricKey;
+
+            public enum EnumWithInterfaces implements MetricKey<ASTAnyTypeDeclaration> {
+                Foo {
+                    public Metric<ASTAnyTypeDeclaration> getCalculator() {
+                        return null;
+                    }
+                };
+
+
+                public Metric<ASTAnyTypeDeclaration> getCalculator() {
+                    return null;
+                }
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Consider methods with array parameters</description>
+        <expected-problems>0</expected-problems> <!-- FIXME should be 1 - caused by #910 -->
+        <expected-messages>
+            <message>The method 'arrayParams(String, int[], StringBuilder[])' is missing an @Override annotation.</message>
+        </expected-messages>
+        <code><![CDATA[
+            package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+            import org.objectweb.asm.Label;
+
+            public class ConcreteClassArrayParams extends AbstractClass {
+
+                // missing
+                public void arrayParams(String dflt, int[] keys, StringBuilder[] labels) {
+                    super.arrayParams(dflt, keys, labels);
+                }
+            }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Consider enum anon class</description>
+        <expected-problems>0</expected-problems> <!-- FIXME should be 1 - bug in typeres, anon constants are not resolved -->
+        <!--<expected-linenumbers>10</expected-linenumbers>-->
+        <code><![CDATA[
+            package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+            import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
+            import net.sourceforge.pmd.lang.metrics.Metric;
+            import net.sourceforge.pmd.lang.metrics.MetricKey;
+
+            public enum EnumWithAnonClass {
+                Foo {
+                    // missing
+                    public String getSomething() {
+                        return null;
+                    }
+                };
+
+
+                public Object getSomething() {
+                    return null;
+                }
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Consider generic methods</description>
+        <expected-problems>0</expected-problems> <!-- FIXME should be 1 - very hard-->
+        <!--<expected-linenumbers>11</expected-linenumbers>-->
+        <code><![CDATA[
+            package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+            import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
+            import net.sourceforge.pmd.lang.metrics.Metric;
+            import net.sourceforge.pmd.lang.metrics.MetricKey;
+
+            public enum EnumWithInterfaces implements MetricKey<ASTAnyTypeDeclaration> {
+                Foo;
+
+                // missing
+                public boolean supports(ASTAnyTypeDeclaration node) {
+                    return false;
+                }
+            }
+            ]]></code>
+    </test-code>
+
+</test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
@@ -184,7 +184,7 @@
     <test-code>
         <description>Consider methods with array parameters</description>
         <expected-problems>1</expected-problems>
-        <expected-messages>&lt;!&ndash;FIXME should be arrayParams(String, int[], StringBuilder[]) - caused by #910&ndash;&gt;
+        <expected-messages><!--FIXME should be arrayParams(String, int[], StringBuilder[]) - caused by #910 -->
             <message>The method 'arrayParams(String, int, StringBuilder)' is missing an @Override annotation.</message>
         </expected-messages>
         <code><![CDATA[
@@ -260,6 +260,39 @@
             ]]></code>
     </test-code>
 
+
+    <test-code>
+        <description>Consider method inherited from generic supertype with overloads</description>
+        <expected-problems>2</expected-problems>
+        <expected-messages>
+            <message>The method 'visit(ASTCompilationUnit, String)' is missing an @Override annotation.</message>
+            <message>The method 'visit(ASTPackageDeclaration, String)' is missing an @Override annotation.</message>
+        </expected-messages>
+        <code><![CDATA[
+            package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+            import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+            import net.sourceforge.pmd.lang.java.ast.ASTPackageDeclaration;
+
+
+            public class GenericWithOverloadsImpl implements GenericInterfaceWithOverloads<String, Integer> {
+
+                // a bridge method is generated for each of these
+
+
+                // missing
+                public String visit(ASTCompilationUnit node, String data) {
+                    return null;
+                }
+
+
+                // missing
+                public String visit(ASTPackageDeclaration node, String data) {
+                    return null;
+                }
+            }
+        ]]></code>
+    </test-code>
 
     <test-code>
         <description>Consider generic method</description>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
@@ -357,9 +357,32 @@
             public interface InterfaceWithNoSuperClass {
 
                 // missing
-                public String toString();
+                String toString();
             }
 
+            ]]>
+        </code>
+    </test-code>
+
+
+
+    <test-code>
+        <description>Consider covariant return types</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>The method 'fun(String)' is missing an @Override annotation.</message>
+        </expected-messages>
+        <code>
+            <![CDATA[
+            package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+            public class CovariantReturnType extends AbstractClass {
+
+                // missing
+                String fun(String s) {
+                    return "";
+                }
+            }
             ]]>
         </code>
     </test-code>
@@ -369,23 +392,23 @@
         <expected-problems>0</expected-problems>
         <code>
             <![CDATA[
-            package net.sourceforge.pmd;
+            package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
 
             import java.util.Comparator;
 
-            // this test case uses the production class file
-            public final class RuleViolationComparator implements Comparator<RuleViolation> {
 
-                // there's one bridge: compare(Object, Object)
+            public class AmbiguousOverload implements Comparator<StringBuilder> {
+
+                // only one of those overloads is an override, and so there's only one bridge,
+                // so we can't choose the inherited overload
 
                 // missing
-                public int compare(final RuleViolation r1, final RuleViolation r2) {
-                    return 1;
+                public int compare(StringBuilder o1, StringBuilder o2) {
+                    return 0;
                 }
 
-                // not overridden
-                private static int compare(final String s1, final String s2) {
-                    return 1;
+                public int compare(String s, String s2) {
+                    return 0;
                 }
             }
             ]]>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
@@ -315,4 +315,33 @@
         </code>
     </test-code>
 
+
+    <test-code>
+        <description>Consider varargs parameter</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>The method 'setProperty(MultiValuePropertyDescriptor, V...)' is missing an @Override annotation.</message>
+        </expected-messages>
+        <code>
+            <![CDATA[
+            package net.sourceforge.pmd.lang.rule;
+
+            import net.sourceforge.pmd.Rule;
+            import net.sourceforge.pmd.properties.MultiValuePropertyDescriptor;
+
+            /**
+             * Base class for Rule implementations which delegate to another Rule instance.
+             */
+            public abstract class AbstractDelegateRule implements Rule {
+
+                // missing
+                public <V> void setProperty(MultiValuePropertyDescriptor<V> propertyDescriptor, V... values) {
+                    rule.setProperty(propertyDescriptor, values);
+                }
+
+            }
+            ]]>
+        </code>
+    </test-code>
+
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
@@ -231,7 +231,7 @@
     </test-code>
 
     <test-code>
-        <description>Consider generic methods</description>
+        <description>Consider method inherited from generic supertype</description>
         <expected-problems>0</expected-problems> <!-- FIXME should be 1 - very hard-->
         <!--<expected-linenumbers>11</expected-linenumbers>-->
         <code><![CDATA[
@@ -250,6 +250,26 @@
                 }
             }
             ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Consider generic method</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code>
+            <![CDATA[
+            package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+            public class SubclassWithGenericMethod extends AbstractClass {
+
+                // missing
+                public <P, Q> Q generic(P t, Q r) { // generic param names are different from superclass
+                    return super.generic(t, r);
+                }
+            }
+            ]]>
+        </code>
     </test-code>
 
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
@@ -184,7 +184,7 @@
     <test-code>
         <description>Consider methods with array parameters</description>
         <expected-problems>1</expected-problems>
-        <expected-messages><!--FIXME should be arrayParams(String, int[], StringBuilder[]) - caused by #910 -->
+        <expected-messages> <!--FIXME should be arrayParams(String, int[], StringBuilder[]) - caused by #910 -->
             <message>The method 'arrayParams(String, int, StringBuilder)' is missing an @Override annotation.</message>
         </expected-messages>
         <code><![CDATA[
@@ -202,10 +202,10 @@
         ]]></code>
     </test-code>
 
-    <test-code>
+    <test-code regressionTest="false">  <!-- FIXME bug in typeres, anon constants are not resolved -->
         <description>Consider enum anon class</description>
-        <expected-problems>0</expected-problems> <!-- FIXME should be 1 - bug in typeres, anon constants are not resolved -->
-        <!--<expected-linenumbers>10</expected-linenumbers>-->
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>10</expected-linenumbers>
         <code><![CDATA[
             package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
@@ -344,4 +344,24 @@
         </code>
     </test-code>
 
+    <test-code>
+        <description>Consider Object methods inherited into interfaces</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>The method 'toString()' is missing an @Override annotation.</message>
+        </expected-messages>
+        <code>
+            <![CDATA[
+            package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+            public interface InterfaceWithNoSuperClass {
+
+                // missing
+                public String toString();
+            }
+
+            ]]>
+        </code>
+    </test-code>
+
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
@@ -364,4 +364,75 @@
         </code>
     </test-code>
 
+    <test-code>
+        <description>Avoid false positives when in ambiguous situation</description>
+        <expected-problems>0</expected-problems>
+        <code>
+            <![CDATA[
+            package net.sourceforge.pmd;
+
+            import java.util.Comparator;
+
+            // this test case uses the production class file
+            public final class RuleViolationComparator implements Comparator<RuleViolation> {
+
+                // there's one bridge: compare(Object, Object)
+
+                // missing
+                public int compare(final RuleViolation r1, final RuleViolation r2) {
+                    return 1;
+                }
+
+                // not overridden
+                private static int compare(final String s1, final String s2) {
+                    return 1;
+                }
+            }
+            ]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>Avoid false positives when in ambiguous situation</description>
+        <expected-problems>0</expected-problems>
+        <code>
+            <![CDATA[
+            package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+            import net.sourceforge.pmd.lang.ast.Node;
+            import net.sourceforge.pmd.lang.java.ast.ASTType;
+            import net.sourceforge.pmd.lang.java.ast.AbstractJavaTypeNode;
+            import net.sourceforge.pmd.lang.java.ast.JavaNode;
+
+            public abstract class HierarchyWithSeveralBridges<T extends Node> {
+
+                abstract void foo(T node);
+
+                public static abstract class SubclassOne<T extends JavaNode> extends HierarchyWithSeveralBridges<T> {
+
+                    // this one could be resolved
+                    // @Override
+                    // abstract void foo(T node);
+
+                }
+
+                public static abstract class SubclassTwo<T extends AbstractJavaTypeNode> extends SubclassOne<T> {
+
+                }
+
+
+                public static class Concrete extends SubclassTwo<ASTType> {
+
+                    // bridges: foo(AbstractJavaTypeNode), foo(JavaNode), foo(Node)
+
+                    // missing
+                    void foo(ASTType node) {
+
+                    }
+                }
+            }
+            ]]>
+        </code>
+    </test-code>
+
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
@@ -80,7 +80,6 @@
         ]]></code>
     </test-code>
 
-
     <test-code>
         <description>Consider anonymous classes</description>
         <expected-problems>1</expected-problems>
@@ -184,10 +183,10 @@
 
     <test-code>
         <description>Consider methods with array parameters</description>
-        <expected-problems>0</expected-problems> <!-- FIXME should be 1 - caused by #910 -->
-        <!--<expected-messages>-->
-            <!--<message>The method 'arrayParams(String, int[], StringBuilder[])' is missing an @Override annotation.</message>-->
-        <!--</expected-messages>-->
+        <expected-problems>1</expected-problems>
+        <expected-messages>&lt;!&ndash;FIXME should be arrayParams(String, int[], StringBuilder[]) - caused by #910&ndash;&gt;
+            <message>The method 'arrayParams(String, int, StringBuilder)' is missing an @Override annotation.</message>
+        </expected-messages>
         <code><![CDATA[
             package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
 
@@ -217,6 +216,12 @@
             public enum EnumWithAnonClass {
                 Foo {
                     // missing
+                    public String toString() {
+                        return super.toString();
+                    }
+
+
+                    // missing
                     public String getSomething() {
                         return null;
                     }
@@ -232,8 +237,10 @@
 
     <test-code>
         <description>Consider method inherited from generic supertype</description>
-        <expected-problems>0</expected-problems> <!-- FIXME should be 1 - very hard-->
-        <!--<expected-linenumbers>11</expected-linenumbers>-->
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>The method 'supports(ASTAnyTypeDeclaration)' is missing an @Override annotation.</message>
+        </expected-messages>
         <code><![CDATA[
             package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
 
@@ -245,6 +252,7 @@
                 Foo;
 
                 // missing
+                // this is determined from the bridge method, but only works if there are no overloads
                 public boolean supports(ASTAnyTypeDeclaration node) {
                     return false;
                 }
@@ -256,7 +264,9 @@
     <test-code>
         <description>Consider generic method</description>
         <expected-problems>1</expected-problems>
-        <expected-linenumbers>6</expected-linenumbers>
+        <expected-messages>
+            <message>The method 'generic(P, Q)' is missing an @Override annotation.</message>
+        </expected-messages>
         <code>
             <![CDATA[
             package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;


### PR DESCRIPTION
It uses reflection to look into the supertypes of the declared class, so it depends on type resolution. This closes https://sourceforge.net/p/pmd/bugs/1463/

Some known limitations of the rule are:
* #910 causes some false negatives. Although we could work around it in the rule, I'd rather fix the root cause
* Methods overridden in the body of an enum constant are not all flagged, because typeresolution doesn't resolve the type of those anonymous classes correctly yet. The fix is in oowekyala/pmd@9dff3bbd, in a branch implementing #864, but which depends on PR #895 
* Methods inherited from generic supertypes cannot be resolved via reflection (at least in jdk 7 and 8), and I think it would be very hard to implement the feature ourselves. (edit: we may be able to use the bridge method to infer which method is overridden)

All-in-all, a comparison with intellij's inspection as a reference yielded about 8% false negatives, 0% false positives on pmd-java. Good enough, I say!

The PR adds some small improvements to the API of some nodes, most importantly, Annotation and FormalParameter are now TypeNodes

