### PR TITLE
[doc] Add qa-eclipse as new tool

### DIFF
--- a/docs/pages/pmd/userdocs/tools/tools.md
+++ b/docs/pages/pmd/userdocs/tools/tools.md
@@ -49,6 +49,13 @@ author: David Dixon-Peugh <dpeugh@users.sourceforge.net>
         <td><a href="https://github.com/pmd/pmd-eclipse-plugin">github: pmd/pmd-eclipse</a></td>
         <td>Philippe Herlin</td>
     </tr>
+    
+    <tr>
+    <td>qa-Eclipse</td>
+    <td></td>
+    <td><a href="https://github.com/ChristianWulf/qa-eclipse-plugin">qa-Eclipse</a></td>
+    <td>Christian Wulf</td>       
+    </tr>
 
     <tr>
         <td>eclipse-pmd</td>

--- a/docs/pages/pmd/userdocs/tools/tools.md
+++ b/docs/pages/pmd/userdocs/tools/tools.md
@@ -51,10 +51,10 @@ author: David Dixon-Peugh <dpeugh@users.sourceforge.net>
     </tr>
     
     <tr>
-    <td>qa-Eclipse</td>
-    <td></td>
-    <td><a href="https://github.com/ChristianWulf/qa-eclipse-plugin">qa-Eclipse</a></td>
-    <td>Christian Wulf</td>       
+        <td>qa-Eclipse</td>
+        <td></td>
+        <td><a href="https://github.com/ChristianWulf/qa-eclipse-plugin">qa-Eclipse</a></td>
+        <td>Christian Wulf</td>       
     </tr>
 
     <tr>


### PR DESCRIPTION
Added a qa-Eclipse plugin to the table.


**PR Description:**
In reference to the issues #909 added the plugin to the list of tools available.


