### PR TITLE
[cpd] Render to Writers instead of Strings

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -23,6 +23,7 @@ This is a minor release.
 
 *   all
     *   [#569](https://github.com/pmd/pmd/issues/569): \[core] XPath support requires specific toString implementations
+    *   [#795](https://github.com/pmd/pmd/issues/795): \[cpd] java.lang.OutOfMemoryError
     *   [#848](https://github.com/pmd/pmd/issues/848): \[doc] Test failures when building pmd-doc under Windows
     *   [#872](https://github.com/pmd/pmd/issues/872): \[core] NullPointerException at FileDataSource.glomName()
 *   doc
@@ -55,6 +56,15 @@ with existing implementors.
 The `toString` method of a Node is not changed for the time being, and still produces
 the name of the XPath node. That behaviour may however change in future major releases,
 e.g. to produce a more useful message for debugging.
+
+#### Changes to CPD renderers
+
+The interface `net.sourceforge.pmd.cpd.Renderer` has been deprecated. A new interface `net.sourceforge.pmd.cpd.renderer.CPDRenderer`
+has been introduced  to replace it. The main difference is that the new interface is meant to render directly to a `java.io.Writer`
+rather than to a String. This allows to greatly reduce the memory footprint of CPD, as on large projects, with many duplications,
+it was causing `OutOfMemotyError`s (see [#795](https://github.com/pmd/pmd/issues/795)).
+
+`net.sourceforge.pmd.cpd.FileReporter` has also been deprecated as part of this change, as it's no longer needed.
 
 ### External Contributions
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDCommandLineInterface.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDCommandLineInterface.java
@@ -4,9 +4,11 @@
 
 package net.sourceforge.pmd.cpd;
 
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -84,7 +86,12 @@ public class CPDCommandLineInterface {
             addSourceFilesToCPD(cpd, arguments);
 
             cpd.go();
-            System.out.println(arguments.getRenderer().render(cpd.getMatches()));
+            if (arguments.getCPDRenderer() == null) {
+                // legacy writer
+                System.out.println(arguments.getRenderer().render(cpd.getMatches()));
+            } else {
+                arguments.getCPDRenderer().render(cpd.getMatches(), new BufferedWriter(new OutputStreamWriter(System.out)));
+            }
             if (cpd.getMatches().hasNext()) {
                 if (arguments.isFailOnViolation()) {
                     setStatusCodeOrExit(DUPLICATE_CODE_FOUND);
@@ -94,7 +101,7 @@ public class CPDCommandLineInterface {
             } else {
                 setStatusCodeOrExit(0);
             }
-        } catch (RuntimeException e) {
+        } catch (IOException | RuntimeException e) {
             e.printStackTrace();
             setStatusCodeOrExit(ERROR_STATUS);
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/FileReporter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/FileReporter.java
@@ -14,9 +14,13 @@ import java.io.Writer;
 
 import org.apache.commons.io.IOUtils;
 
+import net.sourceforge.pmd.cpd.renderer.CPDRenderer;
+
 /**
  * @author Philippe T'Seyen
+ * @deprecated {@link CPDRenderer} directly renders to a Writer
  */
+@Deprecated
 public class FileReporter {
     private File reportFile;
     private String encoding;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/Renderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/Renderer.java
@@ -6,9 +6,13 @@ package net.sourceforge.pmd.cpd;
 
 import java.util.Iterator;
 
+import net.sourceforge.pmd.cpd.renderer.CPDRenderer;
+
 /**
  * @author Philippe T'Seyen
+ * @deprecated Use {@link CPDRenderer} instead
  */
+@Deprecated
 public interface Renderer {
     String render(Iterator<Match> matches);
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/SimpleRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/SimpleRenderer.java
@@ -4,12 +4,16 @@
 
 package net.sourceforge.pmd.cpd;
 
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.util.Iterator;
 
 import net.sourceforge.pmd.PMD;
+import net.sourceforge.pmd.cpd.renderer.CPDRenderer;
 import net.sourceforge.pmd.util.StringUtil;
 
-public class SimpleRenderer implements Renderer {
+public class SimpleRenderer implements Renderer, CPDRenderer {
 
     private String separator;
     private boolean trimLeadingWhitespace;
@@ -29,19 +33,18 @@ public class SimpleRenderer implements Renderer {
         separator = theSeparator;
     }
 
-    private void renderOn(StringBuilder rpt, Match match) {
+    private void renderOn(Writer writer, Match match) throws IOException {
 
-        rpt.append("Found a ").append(match.getLineCount()).append(" line (").append(match.getTokenCount())
+        writer.append("Found a ").append(String.valueOf(match.getLineCount())).append(" line (").append(String.valueOf(match.getTokenCount()))
                 .append(" tokens) duplication in the following files: ").append(PMD.EOL);
 
         for (Iterator<Mark> occurrences = match.iterator(); occurrences.hasNext();) {
             Mark mark = occurrences.next();
-            rpt.append("Starting at line ").append(mark.getBeginLine()).append(" of ").append(mark.getFilename())
+            writer.append("Starting at line ").append(String.valueOf(mark.getBeginLine())).append(" of ").append(mark.getFilename())
                     .append(PMD.EOL);
         }
 
-        rpt.append(PMD.EOL); // add a line to separate the source from the desc
-        // above
+        writer.append(PMD.EOL); // add a line to separate the source from the desc above
 
         String source = match.getSourceCodeSlice();
 
@@ -52,30 +55,37 @@ public class SimpleRenderer implements Renderer {
                 lines = StringUtil.trimStartOn(lines, trimDepth);
             }
             for (int i = 0; i < lines.length; i++) {
-                rpt.append(lines[i]).append(PMD.EOL);
+                writer.append(lines[i]).append(PMD.EOL);
             }
             return;
         }
 
-        rpt.append(source).append(PMD.EOL);
+        writer.append(source).append(PMD.EOL);
     }
 
     @Override
     public String render(Iterator<Match> matches) {
+        StringWriter writer = new StringWriter(300);
+        try {
+            render(matches, writer);
+        } catch (IOException ignored) {
+            // Not really possible with a StringWriter
+        }
+        return writer.toString();
+    }
 
-        StringBuilder rpt = new StringBuilder(300);
-
+    @Override
+    public void render(Iterator<Match> matches, Writer writer) throws IOException {
         if (matches.hasNext()) {
-            renderOn(rpt, matches.next());
+            renderOn(writer, matches.next());
         }
 
         Match match;
         while (matches.hasNext()) {
             match = matches.next();
-            rpt.append(separator).append(PMD.EOL);
-            renderOn(rpt, match);
-
+            writer.append(separator).append(PMD.EOL);
+            renderOn(writer, match);
         }
-        return rpt.toString();
+        writer.flush();
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/VSRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/VSRenderer.java
@@ -4,28 +4,40 @@
 
 package net.sourceforge.pmd.cpd;
 
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
 import java.util.Iterator;
 
 import net.sourceforge.pmd.PMD;
+import net.sourceforge.pmd.cpd.renderer.CPDRenderer;
 
-public class VSRenderer implements Renderer {
+public class VSRenderer implements Renderer, CPDRenderer {
 
     @Override
     public String render(Iterator<Match> matches) {
+        StringWriter writer = new StringWriter(300);
+        try {
+            render(matches, writer);
+        } catch (IOException ignored) {
+            // Not really possible with a StringWriter
+        }
+        return writer.toString();
+    }
 
-        StringBuilder buffer = new StringBuilder(300);
-
+    @Override
+    public void render(Iterator<Match> matches, Writer writer) throws IOException {
         for (Match match; matches.hasNext();) {
             match = matches.next();
             Mark mark;
             for (Iterator<Mark> iterator = match.iterator(); iterator.hasNext();) {
                 mark = iterator.next();
-                buffer.append(mark.getFilename());
-                buffer.append('(').append(mark.getBeginLine()).append("):");
-                buffer.append(" Between lines " + mark.getBeginLine() + " and "
+                writer.append(mark.getFilename())
+                    .append('(').append(String.valueOf(mark.getBeginLine())).append("):")
+                    .append(" Between lines " + mark.getBeginLine() + " and "
                         + (mark.getBeginLine() + match.getLineCount()) + PMD.EOL);
             }
         }
-        return buffer.toString();
+        writer.flush();
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLRenderer.java
@@ -4,7 +4,9 @@
 
 package net.sourceforge.pmd.cpd;
 
+import java.io.IOException;
 import java.io.StringWriter;
+import java.io.Writer;
 import java.util.Iterator;
 
 import javax.xml.parsers.DocumentBuilder;
@@ -20,12 +22,14 @@ import javax.xml.transform.stream.StreamResult;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+import net.sourceforge.pmd.cpd.renderer.CPDRenderer;
+
 /**
  * @author Philippe T'Seyen - original implementation
  * @author Romain Pelisse - javax.xml implementation
  *
  */
-public final class XMLRenderer implements Renderer {
+public final class XMLRenderer implements Renderer, CPDRenderer {
 
     private String encoding;
 
@@ -69,7 +73,7 @@ public final class XMLRenderer implements Renderer {
         }
     }
 
-    private String xmlDocToString(Document doc) {
+    private void dumpDocToWriter(Document doc, Writer writer) {
         try {
             TransformerFactory tf = TransformerFactory.newInstance();
             Transformer transformer = tf.newTransformer();
@@ -77,9 +81,7 @@ public final class XMLRenderer implements Renderer {
             transformer.setOutputProperty(OutputKeys.ENCODING, encoding);
             transformer.setOutputProperty(OutputKeys.INDENT, "yes");
             transformer.setOutputProperty(OutputKeys.CDATA_SECTION_ELEMENTS, "codefragment");
-            StringWriter writer = new StringWriter();
             transformer.transform(new DOMSource(doc), new StreamResult(writer));
-            return writer.toString();
         } catch (TransformerException e) {
             throw new IllegalStateException(e);
         }
@@ -87,6 +89,17 @@ public final class XMLRenderer implements Renderer {
 
     @Override
     public String render(Iterator<Match> matches) {
+        StringWriter writer = new StringWriter();
+        try {
+            render(matches, writer);
+        } catch (IOException ignored) {
+            // Not really possible with a StringWriter
+        }
+        return writer.toString();
+    }
+    
+    @Override
+    public void render(Iterator<Match> matches, Writer writer) throws IOException {
         Document doc = createDocument();
         Element root = doc.createElement("pmd-cpd");
         doc.appendChild(root);
@@ -97,7 +110,8 @@ public final class XMLRenderer implements Renderer {
             root.appendChild(addCodeSnippet(doc,
                     addFilesToDuplicationElement(doc, createDuplicationElement(doc, match), match), match));
         }
-        return xmlDocToString(doc);
+        dumpDocToWriter(doc, writer);
+        writer.flush();
     }
 
     private Element addFilesToDuplicationElement(Document doc, Element duplication, Match match) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/renderer/CPDRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/renderer/CPDRenderer.java
@@ -1,0 +1,15 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.cpd.renderer;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Iterator;
+
+import net.sourceforge.pmd.cpd.Match;
+
+public interface CPDRenderer {
+    void render(Iterator<Match> matches, Writer writer) throws IOException;
+}

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CPDCommandLineInterfaceTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CPDCommandLineInterfaceTest.java
@@ -12,8 +12,6 @@ import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.contrib.java.lang.system.StandardOutputStreamLog;
 import org.junit.rules.TestRule;
 
-import net.sourceforge.pmd.PMD;
-
 public class CPDCommandLineInterfaceTest {
     @Rule
     public final TestRule restoreSystemProperties = new RestoreSystemProperties();

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CPDCommandLineInterfaceTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CPDCommandLineInterfaceTest.java
@@ -25,6 +25,6 @@ public class CPDCommandLineInterfaceTest {
         System.setProperty(CPDCommandLineInterface.NO_EXIT_AFTER_RUN, "true");
         CPDCommandLineInterface.main(new String[] { "--minimum-tokens", "340", "--language", "java", "--files",
             "src/test/resources/net/sourceforge/pmd/cpd/files/", "--format", "xml", });
-        Assert.assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "\n" + "<pmd-cpd/>" + PMD.EOL, log.getLog());
+        Assert.assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "\n" + "<pmd-cpd/>", log.getLog());
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CPDConfigurationTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CPDConfigurationTest.java
@@ -10,19 +10,37 @@ import java.util.Map;
 import org.junit.Assert;
 import org.junit.Test;
 
+import net.sourceforge.pmd.cpd.renderer.CPDRenderer;
+
 public class CPDConfigurationTest {
 
     @Test
     public void testRenderers() {
-        Map<String, Class<? extends Renderer>> renderersToTest = new HashMap<>();
+        Map<String, Class<? extends CPDRenderer>> renderersToTest = new HashMap<>();
         renderersToTest.put("csv", CSVRenderer.class);
         renderersToTest.put("xml", XMLRenderer.class);
         renderersToTest.put("csv_with_linecount_per_file", CSVWithLinecountPerFileRenderer.class);
         renderersToTest.put("vs", VSRenderer.class);
         renderersToTest.put("text", SimpleRenderer.class);
 
-        for (Map.Entry<String, Class<? extends Renderer>> entry : renderersToTest.entrySet()) {
+        for (Map.Entry<String, Class<? extends CPDRenderer>> entry : renderersToTest.entrySet()) {
             Renderer r = CPDConfiguration.getRendererFromString(entry.getKey(), "UTF-8");
+            Assert.assertNotNull(r);
+            Assert.assertSame(entry.getValue(), r.getClass());
+        }
+    }
+    
+    @Test
+    public void testCPDRenderers() {
+        Map<String, Class<? extends CPDRenderer>> renderersToTest = new HashMap<>();
+        renderersToTest.put("csv", CSVRenderer.class);
+        renderersToTest.put("xml", XMLRenderer.class);
+        renderersToTest.put("csv_with_linecount_per_file", CSVWithLinecountPerFileRenderer.class);
+        renderersToTest.put("vs", VSRenderer.class);
+        renderersToTest.put("text", SimpleRenderer.class);
+
+        for (Map.Entry<String, Class<? extends CPDRenderer>> entry : renderersToTest.entrySet()) {
+            CPDRenderer r = CPDConfiguration.getCPDRendererFromString(entry.getKey(), "UTF-8");
             Assert.assertNotNull(r);
             Assert.assertSame(entry.getValue(), r.getClass());
         }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CSVRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CSVRendererTest.java
@@ -6,17 +6,20 @@ package net.sourceforge.pmd.cpd;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.IOException;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
 
 import net.sourceforge.pmd.PMD;
+import net.sourceforge.pmd.cpd.renderer.CPDRenderer;
 
 public class CSVRendererTest {
     @Test
-    public void testLineCountPerFile() {
-        Renderer renderer = new CSVRenderer(true);
+    public void testLineCountPerFile() throws IOException {
+        CPDRenderer renderer = new CSVRenderer(true);
         List<Match> list = new ArrayList<>();
         String codeFragment = "code\nfragment";
         Mark mark1 = createMark("public", "/var/Foo.java", 48, 10, codeFragment);
@@ -24,7 +27,9 @@ public class CSVRendererTest {
         Match match = new Match(75, mark1, mark2);
 
         list.add(match);
-        String report = renderer.render(list.iterator());
+        StringWriter sw = new StringWriter();
+        renderer.render(list.iterator(), sw);
+        String report = sw.toString();
         String expectedReport = "tokens,occurrences" + PMD.EOL + "75,2,48,10,/var/Foo.java,73,20,/var/Bar.java"
                 + PMD.EOL;
 
@@ -32,8 +37,8 @@ public class CSVRendererTest {
     }
 
     @Test
-    public void testFilenameEscapes() {
-        Renderer renderer = new CSVRenderer();
+    public void testFilenameEscapes() throws IOException {
+        CPDRenderer renderer = new CSVRenderer();
         List<Match> list = new ArrayList<>();
         String codeFragment = "code\nfragment";
         Mark mark1 = createMark("public", "/var,with,commas/Foo.java", 48, 10, codeFragment);
@@ -41,7 +46,9 @@ public class CSVRendererTest {
         Match match = new Match(75, mark1, mark2);
         list.add(match);
 
-        String report = renderer.render(list.iterator());
+        StringWriter sw = new StringWriter();
+        renderer.render(list.iterator(), sw);
+        String report = sw.toString();
         String expectedReport = "lines,tokens,occurrences" + PMD.EOL
                 + "10,75,2,48,\"/var,with,commas/Foo.java\",73,\"/var,with,commas/Bar.java\"" + PMD.EOL;
         assertEquals(expectedReport, report);

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/XMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/XMLRendererTest.java
@@ -9,6 +9,8 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,6 +20,8 @@ import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
+
+import net.sourceforge.pmd.cpd.renderer.CPDRenderer;
 
 /**
  * @author Philippe T'Seyen
@@ -29,11 +33,13 @@ public class XMLRendererTest {
     private static final String ENCODING = (String) System.getProperties().get("file.encoding");
 
     @Test
-    public void testWithNoDuplication() {
+    public void testWithNoDuplication() throws IOException {
 
-        Renderer renderer = new XMLRenderer();
+        CPDRenderer renderer = new XMLRenderer();
         List<Match> list = new ArrayList<>();
-        String report = renderer.render(list.iterator());
+        StringWriter sw = new StringWriter();
+        renderer.render(list.iterator(), sw);
+        String report = sw.toString();
         try {
             Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder()
                     .parse(new ByteArrayInputStream(report.getBytes(ENCODING)));
@@ -48,8 +54,8 @@ public class XMLRendererTest {
     }
 
     @Test
-    public void testWithOneDuplication() {
-        Renderer renderer = new XMLRenderer();
+    public void testWithOneDuplication() throws IOException {
+        CPDRenderer renderer = new XMLRenderer();
         List<Match> list = new ArrayList<>();
         int lineCount = 6;
         String codeFragment = "code\nfragment";
@@ -58,7 +64,9 @@ public class XMLRendererTest {
         Match match = new Match(75, mark1, mark2);
 
         list.add(match);
-        String report = renderer.render(list.iterator());
+        StringWriter sw = new StringWriter();
+        renderer.render(list.iterator(), sw);
+        String report = sw.toString();
         try {
             Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder()
                     .parse(new ByteArrayInputStream(report.getBytes(ENCODING)));
@@ -88,8 +96,8 @@ public class XMLRendererTest {
     }
 
     @Test
-    public void testRenderWithMultipleMatch() {
-        Renderer renderer = new XMLRenderer();
+    public void testRenderWithMultipleMatch() throws IOException {
+        CPDRenderer renderer = new XMLRenderer();
         List<Match> list = new ArrayList<>();
         int lineCount1 = 6;
         String codeFragment1 = "code fragment";
@@ -105,7 +113,9 @@ public class XMLRendererTest {
 
         list.add(match1);
         list.add(match2);
-        String report = renderer.render(list.iterator());
+        StringWriter sw = new StringWriter();
+        renderer.render(list.iterator(), sw);
+        String report = sw.toString();
         try {
             Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder()
                     .parse(new ByteArrayInputStream(report.getBytes(ENCODING)));
@@ -118,15 +128,18 @@ public class XMLRendererTest {
     }
 
     @Test
-    public void testRendererEncodedPath() {
-        Renderer renderer = new XMLRenderer();
+    public void testRendererEncodedPath() throws IOException {
+        CPDRenderer renderer = new XMLRenderer();
         List<Match> list = new ArrayList<>();
         final String espaceChar = "&lt;";
         Mark mark1 = createMark("public", "/var/F" + '<' + "oo.java", 48, 6, "code fragment");
         Mark mark2 = createMark("void", "/var/F<oo.java", 73, 6, "code fragment");
         Match match1 = new Match(75, mark1, mark2);
         list.add(match1);
-        String report = renderer.render(list.iterator());
+        
+        StringWriter sw = new StringWriter();
+        renderer.render(list.iterator(), sw);
+        String report = sw.toString();
         assertTrue(report.contains(espaceChar));
     }
 


### PR DESCRIPTION
 - Refactor CPD renderers to write directly to `java.io.Writer` instead of building the whole report into a single `String`. This is done by introducing a new interface to avoid a breaking API change. The old interface and related objects / methods are deprecated, to be removed on 7.0.0
 - Fixes #795 
 - Supersedes #815 

This changeset allows to fully process large codebases with lots of duplicates such as Lucene using `--ignore-identifiers --ignore-literals --minimum-tokens 75` with the default heap / stack; which previously required ~7-8GB as per https://github.com/pmd/pmd/issues/185#issuecomment-273597773