### PR TITLE
[scala] Upgrade scala version to support Java 9

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -41,6 +41,8 @@ This is a minor release.
     *   [#877](https://github.com/pmd/pmd/issues/877): \[java] CommentRequired valid rule configuration causes PMD error
 *   java-errorprone
     *   [#885](https://github.com/pmd/pmd/issues/885): \[java] CompareObjectsWithEqualsRule trigger by enum1 != enum2
+*   scala
+    *   [#853](https://github.com/pmd/pmd/issues/853): \[scala] Upgrade scala version to support Java 9
 *   xml
     *   [#739](https://github.com/pmd/pmd/issues/739): \[xml] IllegalAccessException when accessing attribute using Saxon on JRE 9
 

--- a/pmd-dist/pom.xml
+++ b/pmd-dist/pom.xml
@@ -158,6 +158,11 @@
         </dependency>
         <dependency>
             <groupId>net.sourceforge.pmd</groupId>
+            <artifactId>pmd-scala</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-swift</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -171,6 +176,7 @@
             <artifactId>pmd-xml</artifactId>
             <version>${project.version}</version>
         </dependency>
+
 
         <dependency>
             <groupId>commons-io</groupId>
@@ -210,24 +216,6 @@
                 <dependency>
                     <groupId>net.sourceforge.pmd</groupId>
                     <artifactId>pmd-ui</artifactId>
-                    <version>${project.version}</version>
-                </dependency>
-            </dependencies>
-        </profile>
-        <profile>
-            <id>jdk9-disabled</id>
-            <activation>
-                <jdk>!9</jdk>
-            </activation>
-            <dependencies>
-                <!--
-                    https://github.com/scala/scala-dev/issues/139
-                    https://issues.scala-lang.org/browse/SI-9103
-                    https://sourceforge.net/p/pmd/bugs/1314/
-                 -->
-                <dependency>
-                    <groupId>net.sourceforge.pmd</groupId>
-                    <artifactId>pmd-scala</artifactId>
                     <version>${project.version}</version>
                 </dependency>
             </dependencies>

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistributionIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistributionIT.java
@@ -21,12 +21,12 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import net.sourceforge.pmd.PMD;
+import net.sourceforge.pmd.PMDVersion;
 
 public class BinaryDistributionIT {
 
     private static File getBinaryDistribution() {
-        return new File(".", "target/pmd-bin-" + PMD.VERSION + ".zip");
+        return new File(".", "target/pmd-bin-" + PMDVersion.VERSION + ".zip");
     }
 
     /**
@@ -57,13 +57,13 @@ public class BinaryDistributionIT {
 
     private Set<String> getExpectedFileNames() {
         Set<String> result = new HashSet<>();
-        String basedir = "pmd-bin-" + PMD.VERSION + "/";
+        String basedir = "pmd-bin-" + PMDVersion.VERSION + "/";
         result.add(basedir);
         result.add(basedir + "bin/run.sh");
         result.add(basedir + "bin/pmd.bat");
         result.add(basedir + "bin/cpd.bat");
-        result.add(basedir + "lib/pmd-core-" + PMD.VERSION + ".jar");
-        result.add(basedir + "lib/pmd-java-" + PMD.VERSION + ".jar");
+        result.add(basedir + "lib/pmd-core-" + PMDVersion.VERSION + ".jar");
+        result.add(basedir + "lib/pmd-java-" + PMDVersion.VERSION + ".jar");
         return result;
     }
 

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistributionIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistributionIT.java
@@ -17,8 +17,6 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.JavaVersion;
-import org.apache.commons.lang3.SystemUtils;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -110,12 +108,7 @@ public class BinaryDistributionIT {
 
         result = CpdExecutor.runCpd(tempDir, "-h");
 
-        if (SystemUtils.isJavaVersionAtLeast(JavaVersion.JAVA_9)) {
-            // with java9, scala is not supported
-            result.assertExecutionResult(1, "Supported languages: [apex, cpp, cs, ecmascript, fortran, go, groovy, java, jsp, matlab, objectivec, perl, php, plsql, python, ruby, swift, vf]");
-        } else {
-            result.assertExecutionResult(1, "Supported languages: [apex, cpp, cs, ecmascript, fortran, go, groovy, java, jsp, matlab, objectivec, perl, php, plsql, python, ruby, scala, swift, vf]");
-        }
+        result.assertExecutionResult(1, "Supported languages: [apex, cpp, cs, ecmascript, fortran, go, groovy, java, jsp, matlab, objectivec, perl, php, plsql, python, ruby, scala, swift, vf]");
 
         result = CpdExecutor.runCpd(tempDir, "--minimum-tokens", "10", "--format", "text", "--files", srcDir);
         result.assertExecutionResult(4, "Found a 10 line (55 tokens) duplication in the following files:");

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/CpdExecutor.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/CpdExecutor.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.SystemUtils;
 
-import net.sourceforge.pmd.PMD;
+import net.sourceforge.pmd.PMDVersion;
 
 /**
  * Executes CPD from command line. Deals with the differences, when CPD is run on Windows or on Linux.
@@ -25,7 +25,7 @@ public class CpdExecutor {
     }
 
     private static ExecutionResult runCpdUnix(Path tempDir, String ... arguments) throws Exception {
-        String cmd = tempDir.resolve(PMD_BIN_PREFIX + PMD.VERSION + "/bin/run.sh").toAbsolutePath().toString();
+        String cmd = tempDir.resolve(PMD_BIN_PREFIX + PMDVersion.VERSION + "/bin/run.sh").toAbsolutePath().toString();
         ProcessBuilder pb = new ProcessBuilder(cmd, "cpd");
         pb.command().addAll(Arrays.asList(arguments));
         pb.redirectErrorStream(true);
@@ -37,7 +37,7 @@ public class CpdExecutor {
     }
 
     private static ExecutionResult runCpdWindows(Path tempDir, String ... arguments) throws Exception {
-        String cmd = tempDir.resolve(PMD_BIN_PREFIX + PMD.VERSION + "/bin/cpd.bat").toAbsolutePath().toString();
+        String cmd = tempDir.resolve(PMD_BIN_PREFIX + PMDVersion.VERSION + "/bin/cpd.bat").toAbsolutePath().toString();
         ProcessBuilder pb = new ProcessBuilder(cmd);
         pb.command().addAll(Arrays.asList(arguments));
         pb.redirectErrorStream(true);

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/PMDExecutor.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/PMDExecutor.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.SystemUtils;
 
-import net.sourceforge.pmd.PMD;
+import net.sourceforge.pmd.PMDVersion;
 
 /**
  * Executes PMD from command line. Deals with the differences, when PMD is run on Windows or on Linux.
@@ -29,7 +29,7 @@ public class PMDExecutor {
     }
 
     private static ExecutionResult runPMDUnix(Path tempDir, String ... arguments) throws Exception {
-        String cmd = tempDir.resolve(PMD_BIN_PREFIX + PMD.VERSION + "/bin/run.sh").toAbsolutePath().toString();
+        String cmd = tempDir.resolve(PMD_BIN_PREFIX + PMDVersion.VERSION + "/bin/run.sh").toAbsolutePath().toString();
         ProcessBuilder pb = new ProcessBuilder(cmd, "pmd");
         pb.command().addAll(Arrays.asList(arguments));
         pb.redirectErrorStream(true);
@@ -41,7 +41,7 @@ public class PMDExecutor {
     }
 
     private static ExecutionResult runPMDWindows(Path tempDir, String ... arguments) throws Exception {
-        String cmd = tempDir.resolve(PMD_BIN_PREFIX + PMD.VERSION + "/bin/pmd.bat").toAbsolutePath().toString();
+        String cmd = tempDir.resolve(PMD_BIN_PREFIX + PMDVersion.VERSION + "/bin/pmd.bat").toAbsolutePath().toString();
         ProcessBuilder pb = new ProcessBuilder(cmd);
         pb.command().addAll(Arrays.asList(arguments));
         pb.redirectErrorStream(true);

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/SourceDistributionIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/SourceDistributionIT.java
@@ -10,11 +10,11 @@ import java.io.File;
 
 import org.junit.Test;
 
-import net.sourceforge.pmd.PMD;
+import net.sourceforge.pmd.PMDVersion;
 
 public class SourceDistributionIT {
     private File getSourceDistribution() {
-        return new File(".", "target/pmd-src-" + PMD.VERSION + ".zip");
+        return new File(".", "target/pmd-src-" + PMDVersion.VERSION + ".zip");
     }
 
     @Test

--- a/pmd-scala/pom.xml
+++ b/pmd-scala/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <config.basedir>${basedir}/../pmd-core</config.basedir>
-        <scala.version>2.10.4</scala.version>
+        <scala.version>2.12.4</scala.version>
     </properties>
 
     <build>
@@ -21,7 +21,7 @@
                 <plugin>
                     <groupId>net.alchim31.maven</groupId>
                     <artifactId>scala-maven-plugin</artifactId>
-                    <version>3.2.0</version>
+                    <version>3.3.1</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -44,6 +44,7 @@
                     <jvmArgs>
                         <jvmArg>-Dscalac.patmat.analysisBudget=off</jvmArg>
                     </jvmArgs>
+                    <scalaVersion>${scala.version}</scalaVersion>
                 </configuration>
                 <executions>
                     <execution>

--- a/pmd-scala/pom.xml
+++ b/pmd-scala/pom.xml
@@ -41,9 +41,7 @@
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
                 <configuration>
-                    <jvmArgs>
-                        <jvmArg>-Dscalac.patmat.analysisBudget=off</jvmArg>
-                    </jvmArgs>
+                    <addScalacArgs>-deprecation</addScalacArgs>
                     <scalaVersion>${scala.version}</scalaVersion>
                 </configuration>
                 <executions>
@@ -55,6 +53,12 @@
                             <goal>compile</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>doc-jar</goal>
+                        </goals>
+                    </execution>
                 </executions>
             </plugin>
 
@@ -64,6 +68,21 @@
                 <configuration>
                     <suppressionsLocation>pmd-scala-checkstyle-suppressions.xml</suppressionsLocation>
                 </configuration>
+            </plugin>
+
+            <!-- Disabling the default javadoc plugin - we use scala-maven-plugin instead -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <phase>none</phase>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -1056,5 +1056,6 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
         <module>pmd-visualforce</module>
         <module>pmd-vm</module>
         <module>pmd-xml</module>
+        <module>pmd-scala</module>
     </modules>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -976,21 +976,6 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
         </profile>
 
         <profile>
-            <id>jdk9-disabled</id>
-            <activation>
-                <jdk>!9</jdk>
-            </activation>
-            <modules>
-                <!--
-                    https://github.com/scala/scala-dev/issues/139
-                    https://issues.scala-lang.org/browse/SI-9103
-                    https://sourceforge.net/p/pmd/bugs/1314/
-                 -->
-                <module>pmd-scala</module>
-            </modules>
-        </profile>
-
-        <profile>
             <id>doclint</id>
             <build>
                 <pluginManagement>
@@ -1051,11 +1036,11 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
         <module>pmd-plsql</module>
         <module>pmd-python</module>
         <module>pmd-ruby</module>
+        <module>pmd-scala</module>
         <module>pmd-swift</module>
         <module>pmd-test</module>
         <module>pmd-visualforce</module>
         <module>pmd-vm</module>
         <module>pmd-xml</module>
-        <module>pmd-scala</module>
     </modules>
 </project>


### PR DESCRIPTION
This fixes #853 

I did a small integration test locally and CPD for Scala was still working when running on java9.
Building with java9 works as well.
