### PR TITLE
[ci] Use Java9 for building PMD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ sudo: false
 addons:
   apt:
     packages:
-      - oracle-java8-installer
+      - oracle-java9-installer
   ssh_known_hosts:
     - web.sourceforge.net
 
 language: java
 
-jdk: oraclejdk8
+jdk: oraclejdk9
 
 env:
   global:

--- a/.travis/build-coveralls.sh
+++ b/.travis/build-coveralls.sh
@@ -14,7 +14,7 @@ fi
 #
 # for java9: enable all modules.
 # coveralls plugin seems to need java.xml.bind module
-# echo "MAVEN_OPTS='-Xms1g -Xmx1g --add-modules java.se.ee'" > ${HOME}/.mavenrc
+echo "MAVEN_OPTS='-Xms1g -Xmx1g --add-modules java.se.ee'" > ${HOME}/.mavenrc
 
 ./mvnw clean install -DskipTests=true -Dmaven.javadoc.skip=true -B -V
 ./mvnw test jacoco:report coveralls:report -Pcoveralls -B -V

--- a/.travis/build-deploy.sh
+++ b/.travis/build-deploy.sh
@@ -25,10 +25,7 @@ function push_docs() {
 VERSION=$(./mvnw -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.5.0:exec | tail -1)
 echo "Building PMD ${VERSION} on branch ${TRAVIS_BRANCH}"
 
-# determine java 7 path
-JAVA7_HOME=$(jdk_switcher home openjdk7)
-
-MVN_BUILD_FLAGS="-B -V -Djava7.home=${JAVA7_HOME}"
+MVN_BUILD_FLAGS="-B -V"
 
 if travis_isPullRequest; then
 

--- a/.travis/build-sonar.sh
+++ b/.travis/build-sonar.sh
@@ -14,7 +14,7 @@ fi
 #
 # for java9: enable all modules.
 # sonar plugin seems to need java.xml.bind module
-# echo "MAVEN_OPTS='-Xms1g -Xmx1g --add-modules java.se.ee'" > ${HOME}/.mavenrc
+echo "MAVEN_OPTS='-Xms1g -Xmx1g --add-modules java.se.ee'" > ${HOME}/.mavenrc
 
 # Run the build, truncate output due to Travis log limits
 ./mvnw clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=${SONAR_TOKEN} -B -V

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -26,6 +26,7 @@ This is a minor release.
     *   [#795](https://github.com/pmd/pmd/issues/795): \[cpd] java.lang.OutOfMemoryError
     *   [#848](https://github.com/pmd/pmd/issues/848): \[doc] Test failures when building pmd-doc under Windows
     *   [#872](https://github.com/pmd/pmd/issues/872): \[core] NullPointerException at FileDataSource.glomName()
+    *   [#854](https://github.com/pmd/pmd/issues/854): \[ci] Use Java9 for building PMD
 *   doc
     *   [#791](https://github.com/pmd/pmd/issues/791): \[doc] Documentation site reorganisation
     *   [#891](https://github.com/pmd/pmd/issues/891): \[doc] Apex @SuppressWarnings should use single quotes instead of double quotes

--- a/pmd-apex-jorje/pom.xml
+++ b/pmd-apex-jorje/pom.xml
@@ -14,7 +14,6 @@
   <properties>
     <config.basedir>${basedir}/../pmd-core</config.basedir>
     <java.version>8</java.version>
-    <java.home>${env.JAVA_HOME}</java.home>
     <apex.jorje.version>2017-11-17</apex.jorje.version>
   </properties>
 

--- a/pmd-apex/pom.xml
+++ b/pmd-apex/pom.xml
@@ -14,7 +14,6 @@
     <config.basedir>${basedir}/../pmd-core</config.basedir>
 
     <java.version>8</java.version>
-    <java.home>${env.JAVA_HOME}</java.home>
   </properties>
 
   <build>

--- a/pmd-doc/pom.xml
+++ b/pmd-doc/pom.xml
@@ -13,7 +13,6 @@
 
     <properties>
         <java.version>8</java.version>
-        <java.home>${env.JAVA_HOME}</java.home>
         <config.basedir>${basedir}/../pmd-core</config.basedir>
     </properties>
 

--- a/pmd-java8/pom.xml
+++ b/pmd-java8/pom.xml
@@ -13,7 +13,6 @@
     <properties>
         <config.basedir>${basedir}/../pmd-core</config.basedir>
         <java.version>8</java.version>
-        <java.home>${env.JAVA_HOME}</java.home>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -256,7 +256,6 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
 
     <properties>
         <java.version>7</java.version>
-        <java.home>${env.JAVA_HOME}</java.home>
 
         <javacc.version>5.0</javacc.version>
         <surefire.version>2.20.1</surefire.version>
@@ -341,11 +340,7 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.7.0</version>
                     <configuration>
-                        <source>${java.version}</source>
-                        <target>${java.version}</target>
-                        <compilerArguments>
-                            <bootclasspath>${java.home}/jre/lib/rt.jar</bootclasspath>
-                        </compilerArguments>
+                        <release>${java.version}</release>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -483,7 +478,7 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[1.8,)</version>
+                                    <version>[9,)</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>
@@ -930,18 +925,6 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
         </profile>
 
         <profile>
-            <id>jdk7-settings</id>
-            <activation>
-                <property>
-                    <name>java7.home</name>
-                </property>
-            </activation>
-            <properties>
-                <java.home>${java7.home}</java.home>
-            </properties>
-        </profile>
-
-        <profile>
             <id>jdk8-modules</id>
             <activation>
                 <jdk>[1.8,</jdk>
@@ -953,26 +936,6 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
                 <module>pmd-ui</module>
                 <module>pmd-doc</module>
             </modules>
-        </profile>
-
-        <profile>
-            <id>jdk9-config</id>
-            <activation>
-                <jdk>[9,</jdk>
-            </activation>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-compiler-plugin</artifactId>
-                            <configuration>
-                                <release>${java.version}</release>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
         </profile>
 
         <profile>


### PR DESCRIPTION
Fixes #854

**Note:** This will enforce to use java9 for building... We had this described already in the docs (BUILDING.md, and pmd_devdocs_building), but this might be suprising now...
