### PR TITLE
[ecmascript] Update rhino to 1.7.7.2

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -19,6 +19,10 @@ This is a minor release.
 
 ### New and noteworthy
 
+#### Ecmascript (JavaScript)
+
+The [Rhino Library](https://github.com/mozilla/rhino) has been upgraded to version 1.7.7.2.
+
 ### Fixed Issues
 
 *   all

--- a/pom.xml
+++ b/pom.xml
@@ -791,7 +791,7 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
             <dependency>
                 <groupId>org.mozilla</groupId>
                 <artifactId>rhino</artifactId>
-                <version>1.7.7</version>
+                <version>1.7.7.2</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>


### PR DESCRIPTION
Refs #699

Note: this only updates to 1.7.7.2.
Rhino 1.7.8 is also available, but requires Java8 as runtime (currently only java7 is required).
I'd keep #699 open and would schedule the update to rhino 1.7.8 (or later) for PMD 7.0.0.
