### PR TITLE
Use Files.move instead of File.renameTo

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/document/DocumentFile.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/document/DocumentFile.java
@@ -14,6 +14,7 @@ import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Scanner;
@@ -152,10 +153,7 @@ public class DocumentFile implements Document, Closeable {
         reader.close();
         writer.close();
 
-        if (!temporaryPath.toFile().renameTo(filePath.toFile())) {
-            throw new IOException("Fixed file could not be renamed. Original path = " + filePath.toAbsolutePath());
-        }
-        temporaryPath.toFile().delete();
+        Files.move(temporaryPath, filePath, StandardCopyOption.REPLACE_EXISTING);
     }
 
     private void writeUntilEOF() throws IOException {


### PR DESCRIPTION
This prevents problems when building PMD under Windows

Seems like the code works fine under Linux, but fails under Windows. The target file (filePath) exists and temporaryPath can't be renamed. Furthermore, temporaryPath - if renamed successfully - should not exist anymore and doesn't need to be deleted?

I've changed the code to use Files.move(...) with REPLACE_EXISTING option - at least it builds again under Windows.
