### PR TITLE
Upgrade checkstyle, make build work under Windows

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -31,6 +31,9 @@ Both are bugfixing releases.
 
 ### Fixed Issues
 
+*   all
+    *   [#928](https://github.com/pmd/pmd/issues/928): \[core] PMD build failure on Windows
+
 ### API Changes
 
 ### External Contributions

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/AnalysisResult.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/AnalysisResult.java
@@ -38,7 +38,7 @@ public class AnalysisResult {
     private static long computeFileChecksum(final File sourceFile) {
         try (
             CheckedInputStream stream = new CheckedInputStream(
-               new BufferedInputStream(new FileInputStream(sourceFile)), new Adler32());
+                new BufferedInputStream(new FileInputStream(sourceFile)), new Adler32());
         ) {
             // Just read it, the CheckedInputStream will update the checksum on it's own
             IOUtils.skipFully(stream, sourceFile.length());

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/GUI.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/GUI.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-
 import javax.swing.AbstractButton;
 import javax.swing.BorderFactory;
 import javax.swing.JButton;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/GridBagHelper.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/GridBagHelper.java
@@ -10,7 +10,6 @@ import java.awt.Container;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
-
 import javax.swing.JLabel;
 import javax.swing.SwingConstants;
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLRenderer.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Iterator;
-
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XSLTRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XSLTRenderer.java
@@ -12,7 +12,6 @@ import java.io.InputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
-
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/designer/CreateXMLRulePanel.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/designer/CreateXMLRulePanel.java
@@ -8,7 +8,6 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-
 import javax.swing.JButton;
 import javax.swing.JLabel;
 import javax.swing.JPanel;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/designer/DFAPanel.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/designer/DFAPanel.java
@@ -10,7 +10,6 @@ import java.awt.Dimension;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.util.List;
-
 import javax.swing.BorderFactory;
 import javax.swing.DefaultListModel;
 import javax.swing.JComponent;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/designer/Designer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/designer/Designer.java
@@ -35,7 +35,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-
 import javax.swing.AbstractAction;
 import javax.swing.AbstractButton;
 import javax.swing.ActionMap;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/gui/ASTPanel.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/gui/ASTPanel.java
@@ -10,7 +10,6 @@ import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
 import javax.swing.BorderFactory;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/gui/EvaluationResultsPanel.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/gui/EvaluationResultsPanel.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.util.viewer.gui;
 
 import java.awt.BorderLayout;
 import java.util.Vector;
-
 import javax.swing.JList;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/gui/MainFrame.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/gui/MainFrame.java
@@ -8,7 +8,6 @@ import java.awt.BorderLayout;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-
 import javax.swing.ButtonGroup;
 import javax.swing.JButton;
 import javax.swing.JFrame;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/gui/ParseExceptionHandler.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/gui/ParseExceptionHandler.java
@@ -8,7 +8,6 @@ import java.awt.BorderLayout;
 import java.awt.FlowLayout;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
 import javax.swing.JDialog;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/gui/SourceCodePanel.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/gui/SourceCodePanel.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.util.viewer.gui;
 
 import java.awt.BorderLayout;
 import java.awt.Color;
-
 import javax.swing.BorderFactory;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/gui/XPathPanel.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/gui/XPathPanel.java
@@ -5,7 +5,6 @@
 package net.sourceforge.pmd.util.viewer.gui;
 
 import java.awt.Dimension;
-
 import javax.swing.BorderFactory;
 import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/gui/menu/AttributesSubMenu.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/gui/menu/AttributesSubMenu.java
@@ -5,7 +5,6 @@
 package net.sourceforge.pmd.util.viewer.gui.menu;
 
 import java.text.MessageFormat;
-
 import javax.swing.JMenu;
 
 import net.sourceforge.pmd.lang.ast.Node;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/gui/menu/SimpleNodeSubMenu.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/gui/menu/SimpleNodeSubMenu.java
@@ -5,7 +5,6 @@
 package net.sourceforge.pmd.util.viewer.gui.menu;
 
 import java.text.MessageFormat;
-
 import javax.swing.JMenu;
 
 import net.sourceforge.pmd.lang.ast.Node;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/gui/menu/XPathFragmentAddingItem.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/gui/menu/XPathFragmentAddingItem.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.util.viewer.gui.menu;
 
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-
 import javax.swing.JMenuItem;
 
 import net.sourceforge.pmd.util.viewer.model.ViewerModel;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/model/ASTModel.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/model/ASTModel.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.util.viewer.model;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.swing.event.TreeModelEvent;
 import javax.swing.event.TreeModelListener;
 import javax.swing.tree.TreeModel;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/model/SimpleNodeTreeNodeAdapter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/model/SimpleNodeTreeNodeAdapter.java
@@ -8,7 +8,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
-
 import javax.swing.tree.TreeNode;
 
 import net.sourceforge.pmd.lang.ast.Node;

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetSchemaTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetSchemaTest.java
@@ -15,7 +15,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-
 import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/XMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/XMLRendererTest.java
@@ -13,7 +13,6 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.junit.Test;

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
@@ -5,7 +5,6 @@
 package net.sourceforge.pmd.renderers;
 
 import java.io.StringReader;
-
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.junit.Assert;

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symboltable/SimpleTypedNameDeclarationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symboltable/SimpleTypedNameDeclarationTest.java
@@ -7,7 +7,6 @@ package net.sourceforge.pmd.lang.java.symboltable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
 import javax.swing.JComponent;
 import javax.swing.JTextField;
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/TypeInferenceTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/TypeInferenceTest.java
@@ -30,7 +30,6 @@ import net.sourceforge.pmd.lang.java.typeresolution.typeinference.Constraint;
 import net.sourceforge.pmd.lang.java.typeresolution.typeinference.InferenceRuleType;
 import net.sourceforge.pmd.lang.java.typeresolution.typeinference.TypeInferenceResolver;
 import net.sourceforge.pmd.lang.java.typeresolution.typeinference.Variable;
-
 import net.sourceforge.pmd.typeresolution.testdata.dummytypes.SuperClassA;
 import net.sourceforge.pmd.typeresolution.testdata.dummytypes.SuperClassA2;
 import net.sourceforge.pmd.typeresolution.testdata.dummytypes.SuperClassAOther;

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/NameFinder.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/NameFinder.java
@@ -14,7 +14,6 @@ import net.sourceforge.pmd.lang.plsql.ast.ASTName;
 import net.sourceforge.pmd.lang.plsql.ast.ASTPrimaryExpression;
 import net.sourceforge.pmd.lang.plsql.ast.ASTPrimaryPrefix;
 import net.sourceforge.pmd.lang.plsql.ast.ASTPrimarySuffix;
-//import net.sourceforge.pmd.lang.plsql.ast.ASTMemberSelector;
 import net.sourceforge.pmd.lang.plsql.ast.PLSQLNode;
 
 public class NameFinder {

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/AbstractPLSQLParserTst.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/AbstractPLSQLParserTst.java
@@ -19,9 +19,7 @@ import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.lang.LanguageVersionHandler;
 import net.sourceforge.pmd.lang.ast.Node;
-// Root Production comprising PLSQL definitions, and SQL*PLus, DDL, GRANTS etc.
 import net.sourceforge.pmd.lang.plsql.ast.ASTInput;
-//Covers all executbale code units, such as package and object type bodies, standalone procedures and functions, and triggers 
 import net.sourceforge.pmd.lang.plsql.ast.PLSQLParserVisitor;
 import net.sourceforge.pmd.lang.plsql.dfa.DataFlowFacade;
 import net.sourceforge.pmd.lang.plsql.symboltable.SymbolFacade;

--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,7 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
 
         <javacc.version>5.0</javacc.version>
         <surefire.version>2.20.1</surefire.version>
-        <checkstyle.version>2.17</checkstyle.version>
+        <checkstyle.version>3.0.0</checkstyle.version>
         <pmd.plugin.version>3.9.0</pmd.plugin.version>
         <ant.version>1.10.1</ant.version>
         <javadoc.plugin.version>3.0.0-M1</javadoc.plugin.version>
@@ -273,7 +273,7 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
 
         <config.basedir>${basedir}/pmd-core</config.basedir>
         <pmd.dogfood.ruleset>${config.basedir}/src/main/resources/rulesets/internal/dogfood.xml</pmd.dogfood.ruleset>
-        <pmd.build-tools.version>1.0.1</pmd.build-tools.version>
+        <pmd.build-tools.version>1.1.0-SNAPSHOT</pmd.build-tools.version>
     </properties>
 
     <build>
@@ -561,7 +561,7 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>7.2</version>
+                        <version>8.8</version>
                     </dependency>
                     <dependency>
                         <groupId>net.sourceforge.pmd</groupId>


### PR DESCRIPTION
This upgrades checkstyle, activates the fix from https://github.com/pmd/build-tools/pull/3
The new checkstyle version (and its configuration) should now also be compatible with the latest IDE plugins again.

Note: We use now the snapshot version of pmd's build-tools. It should just work (because the oss-snapshot repo is activated), but we'll need to release this dependency before we can release PMD.

This fixes also the last problem described in #928:
Now, PMD can be build under Windows, regardless of how the source code has been obtained (via git clone or via zip download).
