### PR TITLE
[java] Migrate internal rulesets used in unit tests

### DIFF
--- a/pmd-java/src/test/java/net/sourceforge/pmd/RuleSetFactoryTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/RuleSetFactoryTest.java
@@ -4,7 +4,6 @@
 
 package net.sourceforge.pmd;
 
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import org.junit.Test;
@@ -22,26 +21,11 @@ public class RuleSetFactoryTest extends AbstractRuleSetFactoryTest {
                         + "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n"
                         + "    xsi:schemaLocation=\"http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd\">\n"
                         + "  <description>Custom ruleset for tests</description>\n"
-                        + "  <rule ref=\"rulesets/java/unnecessary.xml\">\n"
+                        + "  <rule ref=\"category/java/codestyle.xml\">\n"
                         + "    <exclude name=\"UselessParentheses\"/>\n" + "  </rule>\n" + "</ruleset>\n");
         RuleSetFactory ruleSetFactory = new RuleSetFactory();
         RuleSet ruleset = ruleSetFactory.createRuleSet(ref);
         Rule rule = ruleset.getRuleByName("UselessParentheses");
         assertNull(rule);
-    }
-
-    /**
-     * Makes sure that the internal dogfood.xml ruleset is valid and doesn't
-     * reference any unknown rules.
-     * 
-     * @throws RuleSetNotFoundException
-     *             if dogfood couldn't be found at all
-     */
-    @Test
-    public void testDogfoodRuleset() throws RuleSetNotFoundException {
-        RuleSetReferenceId ref = RuleSetReferenceId.parse("rulesets/internal/dogfood.xml").get(0);
-        RuleSetFactory ruleSetFactory = new RuleSetFactory();
-        RuleSet ruleset = ruleSetFactory.createRuleSet(ref);
-        assertNotNull(ruleset);
     }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/cli/CLITest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/cli/CLITest.java
@@ -21,25 +21,25 @@ import net.sourceforge.pmd.util.FileUtil;
 public class CLITest extends BaseCLITest {
     @Test
     public void minimalArgs() {
-        String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "java-unnecessary,java-design", };
+        String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "category/java/bestpractices.xml,category/java/design.xml", };
         runTest(args, "minimalArgs");
     }
 
     @Test
     public void minimumPriority() {
-        String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "java-design", "-min", "1", };
+        String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "category/java/design.xml", "-min", "1", };
         runTest(args, "minimumPriority");
     }
 
     @Test
     public void usingDebug() {
-        String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "java-design", "-debug", };
+        String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "category/java/design.xml", "-debug", };
         runTest(args, "minimalArgsWithDebug");
     }
 
     @Test
     public void changeJavaVersion() {
-        String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "java-design", "-version", "1.5", "-language",
+        String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "category/java/design.xml", "-version", "1.5", "-language",
             "java", "-debug", };
         String resultFilename = runTest(args, "chgJavaVersion");
         assertTrue("Invalid Java version",
@@ -48,20 +48,20 @@ public class CLITest extends BaseCLITest {
 
     @Test
     public void exitStatusNoViolations() {
-        String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "java-design", };
+        String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "category/java/design.xml", };
         runTest(args, "exitStatusNoViolations");
     }
 
     @Test
     public void exitStatusWithViolations() {
-        String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "java-empty", };
+        String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "category/java/errorprone.xml", };
         String resultFilename = runTest(args, "exitStatusWithViolations", 4);
         assertTrue(FileUtil.findPatternInFile(new File(resultFilename), "Avoid empty if"));
     }
 
     @Test
     public void exitStatusWithViolationsAndWithoutFailOnViolations() {
-        String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "java-empty", "-failOnViolation", "false", };
+        String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "category/java/errorprone.xml", "-failOnViolation", "false", };
         String resultFilename = runTest(args, "exitStatusWithViolationsAndWithoutFailOnViolations", 0);
         assertTrue(FileUtil.findPatternInFile(new File(resultFilename), "Avoid empty if"));
     }
@@ -71,13 +71,13 @@ public class CLITest extends BaseCLITest {
      */
     @Test
     public void testWrongRuleset() throws Exception {
-        String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "java-designn", };
+        String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "category/java/designn.xml", };
         String filename = TEST_OUPUT_DIRECTORY + "testWrongRuleset.txt";
         createTestOutputFile(filename);
         runPMDWith(args);
         Assert.assertEquals(1, getStatusCode());
         assertTrue(FileUtil.findPatternInFile(new File(filename),
-                "Can't find resource 'null' for rule 'java-designn'." + "  Make sure the resource is a valid file"));
+                "Can't find resource 'category/java/designn.xml' for rule 'null'." + "  Make sure the resource is a valid file"));
     }
 
     /**
@@ -85,13 +85,13 @@ public class CLITest extends BaseCLITest {
      */
     @Test
     public void testWrongRulesetWithRulename() throws Exception {
-        String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "java-designn/UseCollectionIsEmpty", };
+        String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "category/java/designn.xml/UseCollectionIsEmpty", };
         String filename = TEST_OUPUT_DIRECTORY + "testWrongRuleset.txt";
         createTestOutputFile(filename);
         runPMDWith(args);
         Assert.assertEquals(1, getStatusCode());
         assertTrue(FileUtil.findPatternInFile(new File(filename),
-                "Can't find resource 'null' for rule " + "'java-designn/UseCollectionIsEmpty'."));
+                "Can't find resource 'category/java/designn.xml' for rule " + "'UseCollectionIsEmpty'."));
     }
 
     /**
@@ -99,12 +99,12 @@ public class CLITest extends BaseCLITest {
      */
     @Test
     public void testWrongRulename() throws Exception {
-        String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "java-design/ThisRuleDoesNotExist", };
+        String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "category/java/design.xml/ThisRuleDoesNotExist", };
         String filename = TEST_OUPUT_DIRECTORY + "testWrongRuleset.txt";
         createTestOutputFile(filename);
         runPMDWith(args);
         Assert.assertEquals(1, getStatusCode());
         assertTrue(FileUtil.findPatternInFile(new File(filename), Pattern
-                .quote("No rules found. Maybe you mispelled a rule name?" + " (java-design/ThisRuleDoesNotExist)")));
+                .quote("No rules found. Maybe you mispelled a rule name?" + " (category/java/design.xml/ThisRuleDoesNotExist)")));
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/ant/xml/pmdtasktest.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/ant/xml/pmdtasktest.xml
@@ -6,8 +6,8 @@
 
 	<target name="testNestedRuleset">
 		<pmd>
-			<ruleset>${pmd.home}/src/main/resources/rulesets/java/codesize.xml</ruleset>
-			<ruleset>${pmd.home}/src/main/resources/rulesets/java/design.xml</ruleset>
+			<ruleset>${pmd.home}/src/main/resources/category/java/codestyle.xml</ruleset>
+			<ruleset>${pmd.home}/src/main/resources/category/java/design.xml</ruleset>
 			<formatter type="text" toConsole="true"/>
 			<fileset dir="${pmd.home}/src/test/resources/ant/java">
 				<include name="*.java"/>
@@ -17,8 +17,8 @@
 
 	<target name="testFormatterWithProperties">
 		<pmd>
-			<ruleset>${pmd.home}/src/main/resources/rulesets/java/codesize.xml</ruleset>
-			<ruleset>${pmd.home}/src/main/resources/rulesets/java/design.xml</ruleset>
+			<ruleset>${pmd.home}/src/main/resources/category/java/codestyle.xml</ruleset>
+			<ruleset>${pmd.home}/src/main/resources/category/java/design.xml</ruleset>
 			<formatter type="summaryhtml" toConsole="true">
 				<param name="linkPrefix" value="link_prefix"/>
 				<param name="linePrefix" value="line_prefix"/>
@@ -30,7 +30,7 @@
 	</target>
 
 	<target name="testAbstractNames">
-		<pmd rulesetfiles="java-codesize,java-design">
+		<pmd rulesetfiles="category/java/codestyle.xml,category/java/design.xml">
 			<formatter type="text" toConsole="true"/>
 			<fileset dir="${pmd.home}/src/test/resources/ant/java">
 				<include name="*.java"/>
@@ -40,8 +40,8 @@
 
 	<target name="testAbstractNamesInNestedRuleset">
 		<pmd>
-			<ruleset>java-codesize</ruleset>
-			<ruleset>java-design</ruleset>
+			<ruleset>category/java/codestyle.xml</ruleset>
+			<ruleset>category/java/design.xml</ruleset>
 			<formatter type="text" toConsole="true"/>
 			<fileset dir="${pmd.home}/src/test/resources/ant/java">
 				<include name="*.java"/>
@@ -50,7 +50,7 @@
 	</target>
 
 	<target name="testCommaInRulesetfiles">
-		<pmd rulesetfiles="${pmd.home}/src/main/resources/rulesets/java/codesize.xml,${pmd.home}/src/main/resources/rulesets/java/design.xml">
+		<pmd rulesetfiles="${pmd.home}/src/main/resources/category/java/codestyle.xml,${pmd.home}/src/main/resources/category/java/design.xml">
 			<formatter type="text" toConsole="true"/>
 			<fileset dir="${pmd.home}/src/test/resources/ant/java">
 				<include name="*.java"/>
@@ -61,7 +61,7 @@
 	<target name="testRelativeRulesets">
 		<pmd>
 			<ruleset>custom_ruleset.xml</ruleset>
-			<ruleset>rulesets/java/design.xml</ruleset>
+			<ruleset>category/java/codestyle.xml</ruleset>
 			<formatter type="text" toConsole="true"/>
 			<fileset dir="${pmd.home}/src/test/resources/ant/java">
 				<include name="*.java"/>
@@ -70,7 +70,7 @@
 	</target>
 
 	<target name="testRelativeRulesetsInRulesetfiles">
-		<pmd rulesetfiles="custom_ruleset.xml,src/main/resources/rulesets/java/design.xml">
+		<pmd rulesetfiles="custom_ruleset.xml,src/main/resources/category/java/codestyle.xml">
 			<formatter type="text" toConsole="true"/>
 			<fileset dir="${pmd.home}/src/test/resources/ant/java">
 				<include name="*.java"/>
@@ -79,7 +79,7 @@
 	</target>
 
 	<target name="testNoFormattersValidation">
-		<pmd rulesetfiles="${pmd.home}/src/main/resources/rulesets/java/design.xml">
+		<pmd rulesetfiles="${pmd.home}/src/main/resources/category/java/codestyle.xml">
             <fileset dir="${pmd.home}/src/test/resources/ant/java">
                 <include name="*.java"/>
             </fileset>
@@ -87,7 +87,7 @@
 	</target>
 
 	<target name="testExplicitRuleInRuleSet">
-		<pmd rulesetfiles="src/main/resources/rulesets/java/codesize.xml/ExcessiveMethodLength">
+		<pmd rulesetfiles="src/main/resources/category/java/design.xml/ExcessiveMethodLength">
 			<formatter type="text" toConsole="true"/>
 			<fileset dir="${pmd.home}/src/test/resources/ant/java">
 				<include name="*.java"/>
@@ -111,8 +111,7 @@
     <target name="testFormatterEncodingWithXML">
         <!-- source encoding is cp1252 -->
         <pmd encoding="cp1252">
-            <ruleset>java-strings</ruleset>
-            <ruleset>java-unusedcode</ruleset>
+            <ruleset>category/java/bestpractices.xml</ruleset>
             <!--
             <formatter type="xml" toConsole="true"/>
             -->
@@ -129,7 +128,7 @@
     <target name="testFormatterEncodingWithXMLConsole">
         <!-- source encoding is cp1252 -->
         <pmd encoding="cp1252">
-            <ruleset>java-unusedcode</ruleset>
+            <ruleset>category/java/bestpractices.xml</ruleset>
             <formatter type="xml" toConsole="true">
                 <!-- specifying a encoding here will override the console encoding.
                      The output might have junk characters in it.


### PR DESCRIPTION
Avoiding deprecation warnings
References #946 

I've removed the dogfood ruleset check from RuleSetFactoryTest - we'll remove the (old) dogfood ruleset anyway.