### PR TITLE
[java] Avoid a NPE in Type Resolution

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -204,11 +204,7 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
             if (className != null) {
                 populateClassName(node, className);
             }
-        } catch (ClassNotFoundException e) {
-            if (LOG.isLoggable(Level.FINE)) {
-                LOG.log(Level.FINE, "Could not find class " + className + ", due to: " + e);
-            }
-        } catch (NoClassDefFoundError e) {
+        } catch (ClassNotFoundException | NoClassDefFoundError e) {
             if (LOG.isLoggable(Level.FINE)) {
                 LOG.log(Level.FINE, "Could not find class " + className + ", due to: " + e);
             }
@@ -1344,9 +1340,7 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
         try {
             pmdClassLoader.loadClass(fullyQualifiedClassName);
             return true; // Class found
-        } catch (ClassNotFoundException e) {
-            return false;
-        } catch (NoClassDefFoundError e) {
+        } catch (ClassNotFoundException | NoClassDefFoundError e) {
             return false;
         }
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typedefinition/JavaTypeDefinition.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typedefinition/JavaTypeDefinition.java
@@ -62,7 +62,12 @@ public abstract class JavaTypeDefinition implements TypeDefinition {
             return typeDef;
         }
 
-        final JavaTypeDefinition newDef = new JavaTypeDefinitionSimple(clazz);
+        final JavaTypeDefinition newDef;
+        try {
+            newDef = new JavaTypeDefinitionSimple(clazz);
+        } catch (final NoClassDefFoundError e) {
+            return null; // Can happen if a parent class references a class not in classpath
+        }
 
         CLASS_EXACT_TYPE_DEF_CACHE.put(clazz, newDef);
 


### PR DESCRIPTION
 - If a class extends a class that references / extends a missing class,
it's possible for the `NoClassDefFoundError` to only rise once we call
`isAnonymousClass()` on the `Class`.
 - For consistency with missing classes, we set the type to null.
 - Logging such missing classes is still pending #194