### PR TITLE
[java] SignatureDeclareThrowsException's IgnoreJUnitCompletely property not honored for constructors

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SignatureDeclareThrowsExceptionRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SignatureDeclareThrowsExceptionRule.java
@@ -155,7 +155,9 @@ public class SignatureDeclareThrowsExceptionRule extends AbstractJavaRule {
 
     @Override
     public Object visit(ASTConstructorDeclaration constructorDeclaration, Object o) {
-        checkExceptions(constructorDeclaration, o);
+        if (!junitImported || !getProperty(IGNORE_JUNIT_COMPLETELY_DESCRIPTOR)) {
+            checkExceptions(constructorDeclaration, o);
+        }
 
         return super.visit(constructorDeclaration, o);
     }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/SignatureDeclareThrowsException.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/SignatureDeclareThrowsException.xml
@@ -216,4 +216,18 @@ public class BugSignature implements LousyInterface {
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>SignatureDeclareThrowsException's IgnoreJUnitCompletely property not honored for constructors</description>
+        <rule-property name="IgnoreJUnitCompletely">true</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import junit.framework.*;
+
+public class JUnitAnnotationTest extends TestCase {
+    public JUnitAnnotationTest() throws Exception {
+    }
+}
+]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
…roperty not honored for constructors

Fixed issue #839 

