### PR TITLE
[core] Allow to explicitly disable incremental analysis

### DIFF
--- a/docs/pages/pmd/userdocs/getting_started.md
+++ b/docs/pages/pmd/userdocs/getting_started.md
@@ -244,6 +244,13 @@ The tool comes with a rather extensive help text, simply running with `-help`!
         <td>no</td>
         <td></td>
     </tr>
+    <tr>
+        <td>-no-cache</td>
+        <td>Explicitly disable incremental analysis. This switch turns off suggestions to use Incremental Analysis,
+            and causes the <i>-cache</i> option to be discarded if it is provided.
+        </td>
+        <td></td>
+    </tr>
 </table>
 
 
@@ -255,7 +262,7 @@ This behavior has been introduced to ease PMD integration into scripts or hooks,
 <table>
 <tr><td>0</td><td>Everything is fine, no violations found</td></tr>
 <tr><td>1</td><td>Couldn't understand command line parameters or PMD exited with an exception</td></tr>
-<tr><td>4</td><td>At least one violation has been detected unless '-failOnViolation false' is set.</td></tr>
+<tr><td>4</td><td>At least one violation has been detected, unless '-failOnViolation false' is set.</td></tr>
 </table>
 
 

--- a/docs/pages/pmd/userdocs/tools/ant.md
+++ b/docs/pages/pmd/userdocs/tools/ant.md
@@ -77,7 +77,15 @@ Runs a set of static code analysis rules on some source code files and generates
       <td>
         The location of the analysis cache file to be used.
         Setting this property enables Incremental Analysis, which can greatly improve analysis time without loosing analysis quality.
-        <b>It's use is strongly recommended.</b>
+        <b>Its use is strongly recommended.</b>
+      </td>
+      <td>No</td>
+    </tr>
+    <tr>
+      <td>noCache</td>
+      <td>
+        Setting this property to true disables Incremental Analysis, even if <i>cacheLocation</i> is provided.
+        You can use this to explicitly turn off suggestions to use incremental analysis, or for testing purposes.
       </td>
       <td>No</td>
     </tr>

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -39,6 +39,9 @@ Both are bugfixing releases.
 
 ### API Changes
 
+* The static method `PMDParameters.transformParametersIntoConfiguration(PMDParameters)` is now deprecated,
+  for removal in 7.0.0. The new instance method `PMDParameters.toConfiguration()` replaces it.
+
 ### External Contributions
 
 * [#941](https://github.com/pmd/pmd/pull/941): \[java] Use char notation to represent a character to improve performance - [reudismam](https://github.com/reudismam)

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -39,6 +39,9 @@ Both are bugfixing releases.
 
 ### API Changes
 
+* A new CLI switch, `-no-cache`, disables incremental analysis and the related suggestion. This overrides the
+`-cache` option. The corresponding Ant task parameter is `noCache`.
+
 * The static method `PMDParameters.transformParametersIntoConfiguration(PMDParameters)` is now deprecated,
   for removal in 7.0.0. The new instance method `PMDParameters.toConfiguration()` replaces it.
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
@@ -437,7 +437,7 @@ public class PMD {
         int status = 0;
         long start = System.nanoTime();
         final PMDParameters params = PMDCommandLineInterface.extractParameters(new PMDParameters(), args, "pmd");
-        final PMDConfiguration configuration = PMDParameters.transformParametersIntoConfiguration(params);
+        final PMDConfiguration configuration = params.toConfiguration();
 
         final Level logLevel = params.isDebug() ? Level.FINER : Level.INFO;
         final Handler logHandler = new ConsoleLogHandler();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
@@ -204,14 +204,6 @@ public class PMD {
             return 0;
         }
 
-        if (!configuration.isIgnoreIncrementalAnalysis()
-                && configuration.getAnalysisCache() instanceof NoopAnalysisCache
-                && LOG.isLoggable(Level.WARNING)) {
-            final String version = PMDVersion.isUnknown() || PMDVersion.isSnapshot() ? "latest" : "pmd-" + PMDVersion.VERSION;
-            LOG.warning("This analysis could be faster, please consider using Incremental Analysis: "
-                                + "https://pmd.github.io/" + version + "/pmd_userdocs_getting_started.html#incremental-analysis");
-        }
-
         Set<Language> languages = getApplicableLanguages(configuration, ruleSets);
         List<DataSource> files = getApplicableFiles(configuration, languages);
 
@@ -303,6 +295,14 @@ public class PMD {
      */
     public static void processFiles(final PMDConfiguration configuration, final RuleSetFactory ruleSetFactory,
             final List<DataSource> files, final RuleContext ctx, final List<Renderer> renderers) {
+
+        if (!configuration.isIgnoreIncrementalAnalysis()
+                && configuration.getAnalysisCache() instanceof NoopAnalysisCache
+                && LOG.isLoggable(Level.WARNING)) {
+            final String version = PMDVersion.isUnknown() || PMDVersion.isSnapshot() ? "latest" : "pmd-" + PMDVersion.VERSION;
+            LOG.warning("This analysis could be faster, please consider using Incremental Analysis: "
+                                + "https://pmd.github.io/" + version + "/pmd_userdocs_getting_started.html#incremental-analysis");
+        }
 
         sortFiles(configuration, files);
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
@@ -203,6 +203,13 @@ public class PMD {
             return 0;
         }
 
+        // Log warning only once, if not explicitly disabled
+        if (!configuration.isIgnoreIncrementalAnalysis() && LOG.isLoggable(Level.WARNING)) {
+            final String version = PMDVersion.isUnknown() || PMDVersion.isSnapshot() ? "latest" : "pmd-" + PMDVersion.VERSION;
+            LOG.warning("This analysis could be faster, please consider using Incremental Analysis: "
+                                + "https://pmd.github.io/" + version + "/pmd_userdocs_getting_started.html#incremental-analysis");
+        }
+
         Set<Language> languages = getApplicableLanguages(configuration, ruleSets);
         List<DataSource> files = getApplicableFiles(configuration, languages);
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
@@ -22,6 +22,7 @@ import java.util.logging.Logger;
 import net.sourceforge.pmd.benchmark.Benchmark;
 import net.sourceforge.pmd.benchmark.Benchmarker;
 import net.sourceforge.pmd.benchmark.TextReport;
+import net.sourceforge.pmd.cache.NoopAnalysisCache;
 import net.sourceforge.pmd.cli.PMDCommandLineInterface;
 import net.sourceforge.pmd.cli.PMDParameters;
 import net.sourceforge.pmd.lang.Language;
@@ -203,8 +204,9 @@ public class PMD {
             return 0;
         }
 
-        // Log warning only once, if not explicitly disabled
-        if (!configuration.isIgnoreIncrementalAnalysis() && LOG.isLoggable(Level.WARNING)) {
+        if (!configuration.isIgnoreIncrementalAnalysis()
+                && configuration.getAnalysisCache() instanceof NoopAnalysisCache
+                && LOG.isLoggable(Level.WARNING)) {
             final String version = PMDVersion.isUnknown() || PMDVersion.isSnapshot() ? "latest" : "pmd-" + PMDVersion.VERSION;
             LOG.warning("This analysis could be faster, please consider using Incremental Analysis: "
                                 + "https://pmd.github.io/" + version + "/pmd_userdocs_getting_started.html#incremental-analysis");

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
@@ -572,7 +572,7 @@ public class PMDConfiguration extends AbstractConfiguration {
      */
     public AnalysisCache getAnalysisCache() {
         // Make sure we are not null
-        if (analysisCache == null || isIgnoreIncrementalAnalysis() && isAnalysisCacheFunctional()) {
+        if (analysisCache == null || isIgnoreIncrementalAnalysis() && !(analysisCache instanceof NoopAnalysisCache)) {
             // sets a noop cache
             setAnalysisCache(new NoopAnalysisCache());
         }
@@ -589,13 +589,9 @@ public class PMDConfiguration extends AbstractConfiguration {
      * @param cache The analysis cache to be used.
      */
     public void setAnalysisCache(final AnalysisCache cache) {
-        if (cache == null && isAnalysisCacheFunctional()) {
-            analysisCache = new NoopAnalysisCache();
-        } else {
-            analysisCache = cache;
-        }
         // the doc says it's a noop if incremental analysis was disabled,
         // but it's actually the getter that enforces that
+        this.analysisCache = cache == null ? new NoopAnalysisCache() : cache;
     }
 
     /**
@@ -610,10 +606,6 @@ public class PMDConfiguration extends AbstractConfiguration {
                                  : new FileAnalysisCache(new File(cacheLocation)));
     }
 
-    /** Returns true if the current analysis cache isn't noop. */
-    private boolean isAnalysisCacheFunctional() {
-        return !(analysisCache instanceof NoopAnalysisCache);
-    }
 
     /**
      * Sets whether the user has explicitly disabled incremental analysis or not.

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/PMDTask.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/PMDTask.java
@@ -256,6 +256,7 @@ public class PMDTask extends Task {
         this.cacheLocation = cacheLocation;
     }
 
+
     public boolean isNoCache() {
         return noCache;
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/PMDTask.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/PMDTask.java
@@ -36,6 +36,7 @@ public class PMDTask extends Task {
     private String failuresPropertyName;
     private SourceLanguage sourceLanguage;
     private String cacheLocation;
+    private boolean noCache;
     private final Collection<RuleSetWrapper> nestedRules = new ArrayList<>();
 
     @Override
@@ -253,5 +254,13 @@ public class PMDTask extends Task {
 
     public void setCacheLocation(String cacheLocation) {
         this.cacheLocation = cacheLocation;
+    }
+
+    public boolean isNoCache() {
+        return noCache;
+    }
+
+    public void setNoCache(boolean noCache) {
+        this.noCache = noCache;
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
@@ -81,6 +81,7 @@ public class PMDTaskImpl {
         this.failuresPropertyName = task.getFailuresPropertyName();
         configuration.setMinimumPriority(RulePriority.valueOf(task.getMinimumPriority()));
         configuration.setAnalysisCacheLocation(task.getCacheLocation());
+        configuration.setIgnoreIncrementalAnalysis(task.isNoCache());
 
         SourceLanguage version = task.getSourceLanguage();
         if (version != null) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/NoopAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/NoopAnalysisCache.java
@@ -7,10 +7,7 @@ package net.sourceforge.pmd.cache;
 import java.io.File;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
-import net.sourceforge.pmd.PMDVersion;
 import net.sourceforge.pmd.RuleSets;
 import net.sourceforge.pmd.RuleViolation;
 import net.sourceforge.pmd.stat.Metric;
@@ -19,16 +16,6 @@ import net.sourceforge.pmd.stat.Metric;
  * A NOOP analysis cache. Easier / safer than null-checking. 
  */
 public class NoopAnalysisCache implements AnalysisCache {
-
-    private static final Logger LOG = Logger.getLogger(NoopAnalysisCache.class.getName());
-    
-    public NoopAnalysisCache() {
-        if (LOG.isLoggable(Level.WARNING)) {
-            final String version = PMDVersion.isUnknown() || PMDVersion.isSnapshot() ? "latest" : "pmd-" + PMDVersion.VERSION;
-            LOG.warning("This analysis could be faster, please consider using Incremental Analysis: "
-                + "https://pmd.github.io/" + version + "/pmd_userdocs_getting_started.html#incremental-analysis");
-        }
-    }
     
     @Override
     public void ruleViolationAdded(final RuleViolation ruleViolation) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cli/PMDParameters.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cli/PMDParameters.java
@@ -152,8 +152,43 @@ public class PMDParameters {
      * @throws IllegalArgumentException if the parameters are inconsistent or incomplete
      */
     public PMDConfiguration toConfiguration() {
-        // the static method could probably be deprecated in favour of this one
-        return transformParametersIntoConfiguration(this);
+        if (null == this.getSourceDir() && null == this.getUri() && null == this.getFileListPath()) {
+            throw new IllegalArgumentException(
+                    "Please provide a parameter for source root directory (-dir or -d), database URI (-uri or -u), or file list path (-filelist).");
+        }
+        PMDConfiguration configuration = new PMDConfiguration();
+        configuration.setInputPaths(this.getSourceDir());
+        configuration.setInputFilePath(this.getFileListPath());
+        configuration.setInputUri(this.getUri());
+        configuration.setReportFormat(this.getFormat());
+        configuration.setBenchmark(this.isBenchmark());
+        configuration.setDebug(this.isDebug());
+        configuration.setMinimumPriority(this.getMinimumPriority());
+        configuration.setReportFile(this.getReportfile());
+        configuration.setReportProperties(this.getProperties());
+        configuration.setReportShortNames(this.isShortnames());
+        configuration.setRuleSets(this.getRulesets());
+        configuration.setRuleSetFactoryCompatibilityEnabled(!this.noRuleSetCompatibility);
+        configuration.setShowSuppressedViolations(this.isShowsuppressed());
+        configuration.setSourceEncoding(this.getEncoding());
+        configuration.setStressTest(this.isStress());
+        configuration.setSuppressMarker(this.getSuppressmarker());
+        configuration.setThreads(this.getThreads());
+        configuration.setFailOnViolation(this.isFailOnViolation());
+        configuration.setAnalysisCacheLocation(this.cacheLocation);
+        configuration.setIgnoreIncrementalAnalysis(this.isIgnoreIncrementalAnalysis());
+
+        LanguageVersion languageVersion = LanguageRegistry
+                .findLanguageVersionByTerseName(this.getLanguage() + ' ' + this.getVersion());
+        if (languageVersion != null) {
+            configuration.getLanguageVersionDiscoverer().setDefaultLanguageVersion(languageVersion);
+        }
+        try {
+            configuration.prependClasspath(this.getAuxclasspath());
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Invalid auxiliary classpath: " + e.getMessage(), e);
+        }
+        return configuration;
     }
 
 
@@ -162,44 +197,13 @@ public class PMDParameters {
     }
 
 
+    /**
+     * {@link #toConfiguration()}.
+     * @deprecated To be removed in 7.0.0. Use the instance method {@link #toConfiguration()}.
+     */
+    @Deprecated
     public static PMDConfiguration transformParametersIntoConfiguration(PMDParameters params) {
-        if (null == params.getSourceDir() && null == params.getUri() && null == params.getFileListPath()) {
-            throw new IllegalArgumentException(
-                    "Please provide a parameter for source root directory (-dir or -d), database URI (-uri or -u), or file list path (-filelist).");
-        }
-        PMDConfiguration configuration = new PMDConfiguration();
-        configuration.setInputPaths(params.getSourceDir());
-        configuration.setInputFilePath(params.getFileListPath());
-        configuration.setInputUri(params.getUri());
-        configuration.setReportFormat(params.getFormat());
-        configuration.setBenchmark(params.isBenchmark());
-        configuration.setDebug(params.isDebug());
-        configuration.setMinimumPriority(params.getMinimumPriority());
-        configuration.setReportFile(params.getReportfile());
-        configuration.setReportProperties(params.getProperties());
-        configuration.setReportShortNames(params.isShortnames());
-        configuration.setRuleSets(params.getRulesets());
-        configuration.setRuleSetFactoryCompatibilityEnabled(!params.noRuleSetCompatibility);
-        configuration.setShowSuppressedViolations(params.isShowsuppressed());
-        configuration.setSourceEncoding(params.getEncoding());
-        configuration.setStressTest(params.isStress());
-        configuration.setSuppressMarker(params.getSuppressmarker());
-        configuration.setThreads(params.getThreads());
-        configuration.setFailOnViolation(params.isFailOnViolation());
-        configuration.setAnalysisCacheLocation(params.cacheLocation);
-        configuration.setIgnoreIncrementalAnalysis(params.isIgnoreIncrementalAnalysis());
-
-        LanguageVersion languageVersion = LanguageRegistry
-                .findLanguageVersionByTerseName(params.getLanguage() + ' ' + params.getVersion());
-        if (languageVersion != null) {
-            configuration.getLanguageVersionDiscoverer().setDefaultLanguageVersion(languageVersion);
-        }
-        try {
-            configuration.prependClasspath(params.getAuxclasspath());
-        } catch (IOException e) {
-            throw new IllegalArgumentException("Invalid auxiliary classpath: " + e.getMessage(), e);
-        }
-        return configuration;
+        return params.toConfiguration();
     }
 
     public boolean isDebug() {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cli/PMDParameters.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cli/PMDParameters.java
@@ -102,6 +102,9 @@ public class PMDParameters {
     @Parameter(names = "-cache", description = "Specify the location of the cache file for incremental analysis.")
     private String cacheLocation = null;
 
+    @Parameter(names = "-no-cache", description = "Explicitly disable incremental analysis. The '-cache' option is ignored if this switch is present in the command line.")
+    private boolean noCache = false;
+
     // this has to be a public static class, so that JCommander can use it!
     public static class PropertyConverter implements IStringConverter<Properties> {
 
@@ -140,6 +143,25 @@ public class PMDParameters {
         }
     }
 
+
+    /**
+     * Converts these parameters into a configuration.
+     *
+     * @return A new PMDConfiguration corresponding to these parameters
+     *
+     * @throws IllegalArgumentException if the parameters are inconsistent or incomplete
+     */
+    public PMDConfiguration toConfiguration() {
+        // the static method could probably be deprecated in favour of this one
+        return transformParametersIntoConfiguration(this);
+    }
+
+
+    public boolean isIgnoreIncrementalAnalysis() {
+        return noCache;
+    }
+
+
     public static PMDConfiguration transformParametersIntoConfiguration(PMDParameters params) {
         if (null == params.getSourceDir() && null == params.getUri() && null == params.getFileListPath()) {
             throw new IllegalArgumentException(
@@ -165,6 +187,7 @@ public class PMDParameters {
         configuration.setThreads(params.getThreads());
         configuration.setFailOnViolation(params.isFailOnViolation());
         configuration.setAnalysisCacheLocation(params.cacheLocation);
+        configuration.setIgnoreIncrementalAnalysis(params.isIgnoreIncrementalAnalysis());
 
         LanguageVersion languageVersion = LanguageRegistry
                 .findLanguageVersionByTerseName(params.getLanguage() + ' ' + params.getVersion());

--- a/pmd-core/src/test/java/net/sourceforge/pmd/ConfigurationTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/ConfigurationTest.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -198,5 +199,22 @@ public class ConfigurationTest {
         assertNotNull("Not null cache location produces null cache", configuration.getAnalysisCache());
         assertTrue("File cache location doesn't produce a file cache",
                 configuration.getAnalysisCache() instanceof FileAnalysisCache);
+    }
+
+
+    @Test
+    public void testIgnoreIncrementalAnalysis() throws IOException {
+        final PMDConfiguration configuration = new PMDConfiguration();
+
+        // set dummy cache location
+        final File cacheFile = File.createTempFile("pmd-", ".cache");
+        cacheFile.deleteOnExit();
+        final FileAnalysisCache analysisCache = new FileAnalysisCache(cacheFile);
+        configuration.setAnalysisCache(analysisCache);
+        assertNotNull("Null cache location accepted", configuration.getAnalysisCache());
+        assertFalse("Non null cache location, cache should not be noop", configuration.getAnalysisCache() instanceof NoopAnalysisCache);
+
+        configuration.setIgnoreIncrementalAnalysis(true);
+        assertTrue("Ignoring incremental analysis should turn the cache into a noop", configuration.getAnalysisCache() instanceof NoopAnalysisCache);
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cli/PMDCommandLineInterfaceTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cli/PMDCommandLineInterfaceTest.java
@@ -4,12 +4,18 @@
 
 package net.sourceforge.pmd.cli;
 
+import static org.junit.Assert.assertTrue;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.ExpectedSystemExit;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+
+import net.sourceforge.pmd.PMDConfiguration;
+import net.sourceforge.pmd.cache.NoopAnalysisCache;
+
 
 /**
  * Unit test for {@link PMDCommandLineInterface}
@@ -46,6 +52,19 @@ public class PMDCommandLineInterfaceTest {
         Assert.assertEquals("/home/user/source/", params.getProperties().getProperty("sourcePath"));
         Assert.assertEquals("Foo.java", params.getProperties().getProperty("fileName"));
         Assert.assertEquals("Foo.method", params.getProperties().getProperty("classAndMethodName"));
+    }
+
+
+    @Test
+    public void testNoCacheSwitch() {
+        PMDParameters params = new PMDParameters();
+        String[] args = {"-d", "source_folder", "-f", "ideaj", "-R", "java-empty", "-cache", "/home/user/.pmd/cache", "-no-cache", };
+        PMDCommandLineInterface.extractParameters(params, args, "PMD");
+
+        assertTrue(params.isIgnoreIncrementalAnalysis());
+        PMDConfiguration config = params.toConfiguration();
+        assertTrue(config.isIgnoreIncrementalAnalysis());
+        assertTrue(config.getAnalysisCache() instanceof NoopAnalysisCache);
     }
 
     @Test

--- a/pmd-java/src/test/java/net/sourceforge/pmd/ant/PMDTaskTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/ant/PMDTaskTest.java
@@ -7,7 +7,6 @@ package net.sourceforge.pmd.ant;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.io.File;
 import java.lang.reflect.Field;
 import java.nio.charset.Charset;
 import java.util.Locale;
@@ -146,7 +145,7 @@ public class PMDTaskTest extends AbstractAntTestHelper {
         setDefaultCharset("cp1252");
 
         executeTarget("testFormatterEncodingWithXML");
-        String report = FileUtils.readFileToString(new File("target/testFormatterEncodingWithXML-pmd.xml"), "UTF-8");
+        String report = FileUtils.readFileToString(currentTempFile(), "UTF-8");
         assertTrue(report.contains("unusedVariableWithÜmlaut"));
     }
 
@@ -173,7 +172,7 @@ public class PMDTaskTest extends AbstractAntTestHelper {
         assertOutputContaining("Avoid really long methods");
         assertDoesntContain(buildRule.getLog(), "This analysis could be faster");
 
-        assertTrue(new File(buildRule.getProject().getProperty("tmpfile")).exists());
+        assertTrue(currentTempFile().exists());
     }
 
 
@@ -183,6 +182,6 @@ public class PMDTaskTest extends AbstractAntTestHelper {
         assertOutputContaining("Avoid really long methods");
         assertDoesntContain(buildRule.getLog(), "This analysis could be faster");
 
-        assertFalse(new File(buildRule.getProject().getProperty("tmpfile")).exists());
+        assertFalse(currentTempFile().exists());
     }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/ant/PMDTaskTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/ant/PMDTaskTest.java
@@ -4,6 +4,9 @@
 
 package net.sourceforge.pmd.ant;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.io.File;
 import java.lang.reflect.Field;
 import java.nio.charset.Charset;
@@ -11,7 +14,6 @@ import java.util.Locale;
 import java.util.Objects;
 
 import org.apache.commons.io.FileUtils;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
@@ -145,7 +147,7 @@ public class PMDTaskTest extends AbstractAntTestHelper {
 
         executeTarget("testFormatterEncodingWithXML");
         String report = FileUtils.readFileToString(new File("target/testFormatterEncodingWithXML-pmd.xml"), "UTF-8");
-        Assert.assertTrue(report.contains("unusedVariableWithÜmlaut"));
+        assertTrue(report.contains("unusedVariableWithÜmlaut"));
     }
 
     @Test
@@ -154,21 +156,33 @@ public class PMDTaskTest extends AbstractAntTestHelper {
 
         executeTarget("testFormatterEncodingWithXMLConsole");
         String report = buildRule.getOutput();
-        Assert.assertTrue(report.startsWith("<?xml version=\"1.0\" encoding=\"windows-1252\"?>"));
-        Assert.assertTrue(report.contains("unusedVariableWith&#xdc;mlaut"));
+        assertTrue(report.startsWith("<?xml version=\"1.0\" encoding=\"windows-1252\"?>"));
+        assertTrue(report.contains("unusedVariableWith&#xdc;mlaut"));
     }
 
-    // The following two tests just test that the switches are recognised. How to test analysis cache?
+    @Test
+    public void testMissingCacheLocation() {
+        executeTarget("testMissingCacheLocation");
+        assertOutputContaining("Avoid really long methods");
+        assertContains(buildRule.getLog(), "This analysis could be faster");
+    }
 
     @Test
     public void testAnalysisCache() {
         executeTarget("testAnalysisCache");
         assertOutputContaining("Avoid really long methods");
+        assertDoesntContain(buildRule.getLog(), "This analysis could be faster");
+
+        assertTrue(new File(buildRule.getProject().getProperty("tmpfile")).exists());
     }
+
 
     @Test
     public void testDisableIncrementalAnalysis() {
         executeTarget("testDisableIncrementalAnalysis");
         assertOutputContaining("Avoid really long methods");
+        assertDoesntContain(buildRule.getLog(), "This analysis could be faster");
+
+        assertFalse(new File(buildRule.getProject().getProperty("tmpfile")).exists());
     }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/ant/PMDTaskTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/ant/PMDTaskTest.java
@@ -149,12 +149,26 @@ public class PMDTaskTest extends AbstractAntTestHelper {
     }
 
     @Test
-    public void testFormatterEncodingWithXMLConsole() throws Exception {
+    public void testFormatterEncodingWithXMLConsole() {
         setDefaultCharset("cp1252");
 
         executeTarget("testFormatterEncodingWithXMLConsole");
         String report = buildRule.getOutput();
         Assert.assertTrue(report.startsWith("<?xml version=\"1.0\" encoding=\"windows-1252\"?>"));
         Assert.assertTrue(report.contains("unusedVariableWith&#xdc;mlaut"));
+    }
+
+    // The following two tests just test that the switches are recognised. How to test analysis cache?
+
+    @Test
+    public void testAnalysisCache() {
+        executeTarget("testAnalysisCache");
+        assertOutputContaining("Avoid really long methods");
+    }
+
+    @Test
+    public void testDisableIncrementalAnalysis() {
+        executeTarget("testDisableIncrementalAnalysis");
+        assertOutputContaining("Avoid really long methods");
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/ant/xml/pmdtasktest.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/ant/xml/pmdtasktest.xml
@@ -145,8 +145,17 @@
     </target>
 
 	<target name="testAnalysisCache">
-		<pmd rulesetfiles="src/main/resources/category/java/design.xml/ExcessiveMethodLength" cacheLocation="/home/user/.pmd/cache">
-			<formatter type="text" toConsole="true"/>
+		<pmd rulesetfiles="src/main/resources/category/java/design.xml/ExcessiveMethodLength" cacheLocation="${tmpfile}">
+			<formatter type="xml" toConsole="true"/>
+			<fileset dir="${pmd.home}/src/test/resources/ant/java">
+				<include name="*.java"/>
+			</fileset>
+		</pmd>
+	</target>
+
+	<target name="testMissingCacheLocation">
+		<pmd rulesetfiles="src/main/resources/category/java/design.xml/ExcessiveMethodLength">
+			<formatter type="xml" toConsole="true"/>
 			<fileset dir="${pmd.home}/src/test/resources/ant/java">
 				<include name="*.java"/>
 			</fileset>
@@ -154,8 +163,8 @@
 	</target>
 
 	<target name="testDisableIncrementalAnalysis">
-		<pmd rulesetfiles="src/main/resources/category/java/design.xml/ExcessiveMethodLength" noCache="true" cacheLocation="/home/user/.pmd/cache">
-			<formatter type="text" toConsole="true"/>
+		<pmd rulesetfiles="src/main/resources/category/java/design.xml/ExcessiveMethodLength" noCache="true" cacheLocation="${tmpfile}">
+			<formatter type="xml" toConsole="true"/>
 			<fileset dir="${pmd.home}/src/test/resources/ant/java">
 				<include name="*.java"/>
 			</fileset>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/ant/xml/pmdtasktest.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/ant/xml/pmdtasktest.xml
@@ -115,7 +115,7 @@
             <!--
             <formatter type="xml" toConsole="true"/>
             -->
-            <formatter type="xml" toFile="${pmd.home}/target/testFormatterEncodingWithXML-pmd.xml">
+            <formatter type="xml" toFile="${tmpfile}">
                 <param name="encoding" value="UTF-8" /> <!-- report encoding -->
             </formatter>
             <fileset dir="${pmd.home}/src/test/resources/ant/java">

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/ant/xml/pmdtasktest.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/ant/xml/pmdtasktest.xml
@@ -143,4 +143,22 @@
             </fileset>
         </pmd>
     </target>
+
+	<target name="testAnalysisCache">
+		<pmd rulesetfiles="src/main/resources/category/java/design.xml/ExcessiveMethodLength" cacheLocation="/home/user/.pmd/cache">
+			<formatter type="text" toConsole="true"/>
+			<fileset dir="${pmd.home}/src/test/resources/ant/java">
+				<include name="*.java"/>
+			</fileset>
+		</pmd>
+	</target>
+
+	<target name="testDisableIncrementalAnalysis">
+		<pmd rulesetfiles="src/main/resources/category/java/design.xml/ExcessiveMethodLength" noCache="true" cacheLocation="/home/user/.pmd/cache">
+			<formatter type="text" toConsole="true"/>
+			<fileset dir="${pmd.home}/src/test/resources/ant/java">
+				<include name="*.java"/>
+			</fileset>
+		</pmd>
+	</target>
 </project>

--- a/pmd-test/src/main/java/net/sourceforge/pmd/ant/AbstractAntTestHelper.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/ant/AbstractAntTestHelper.java
@@ -7,12 +7,16 @@ package net.sourceforge.pmd.ant;
 import static java.io.File.separator;
 
 import java.io.File;
+import java.nio.file.Path;
 
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.tools.ant.BuildFileRule;
 import org.apache.tools.ant.Project;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
+
 
 /**
  * Quite an ugly classe, arguably useful for just 2 units test - nevertheless as
@@ -46,6 +50,11 @@ public abstract class AbstractAntTestHelper {
         // initialize Ant
         buildRule.configureProject(pathToTestScript + separator + antTestScriptFilename);
 
+        // Each test case gets one temp file name, accessible with ${tmpfile}
+        // The file doesn't exist before the test is executed
+        Path tmpFilePath = FileUtils.getTempDirectory().toPath().resolve(RandomStringUtils.randomAlphabetic(30)).toAbsolutePath();
+        buildRule.getProject().setProperty("tmpfile", tmpFilePath.toString());
+
         Project project = buildRule.getProject();
         if (!project.getBaseDir().toString().endsWith(mvnWorkaround)) {
             // when running from maven, the path needs to be adapted...
@@ -66,7 +75,18 @@ public abstract class AbstractAntTestHelper {
     }
 
     public void assertOutputContaining(String text) {
-        Assert.assertTrue("Expected to find \"" + text + "\" in the output, but it's missing",
-                buildRule.getOutput().contains(text));
+        assertContains(buildRule.getOutput(), text);
+    }
+
+
+    public void assertContains(String text, String toFind) {
+        Assert.assertTrue("Expected to find \"" + toFind + "\", but it's missing",
+                          text.contains(toFind));
+    }
+
+
+    public void assertDoesntContain(String text, String toFind) {
+        Assert.assertTrue("Expected no occurrence of \"" + toFind + "\", but found at least one",
+                          !text.contains(toFind));
     }
 }

--- a/pmd-test/src/main/java/net/sourceforge/pmd/ant/AbstractAntTestHelper.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/ant/AbstractAntTestHelper.java
@@ -63,6 +63,17 @@ public abstract class AbstractAntTestHelper {
         }
     }
 
+
+    /**
+     * Returns the current temporary file. Replaced by a fresh (inexistent)
+     * file before each test.
+     */
+    public File currentTempFile() {
+        String tmpname = buildRule.getProject().getProperty("tmpfile");
+        return tmpname == null ? null : new File(tmpname);
+    }
+
+
     private void validatePostConstruct() {
         if (pathToTestScript == null || "".equals(pathToTestScript) || antTestScriptFilename == null
                 || "".equals(antTestScriptFilename) || mvnWorkaround == null || "".equals(mvnWorkaround)) {

--- a/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
@@ -260,6 +260,7 @@ public abstract class RuleTst {
         try {
             PMD p = new PMD();
             p.getConfiguration().setDefaultLanguageVersion(languageVersion);
+            p.getConfiguration().setIgnoreIncrementalAnalysis(true);
             if (isUseAuxClasspath) {
                 // configure the "auxclasspath" option for unit testing
                 p.getConfiguration().prependClasspath(".");


### PR DESCRIPTION
- The switch discards the argument provided to '-cache' if any
- Using the switch disables the suggestion to use incremental analysis
- Rule tests use that option to avoid the warning, which cluttered build logs. I measured the log to be about 4 times smaller (in bytes) than before.
- Refs #946

I couldn't find how to add the switch to maven or ant, only CLI