### PR TITLE
[core] Detect deprecated XPath attribute usage

### DIFF
--- a/pmd-core/pom.xml
+++ b/pmd-core/pom.xml
@@ -122,6 +122,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>pl.pragmatists</groupId>
             <artifactId>JUnitParams</artifactId>
             <scope>test</scope>

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/Attribute.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/Attribute.java
@@ -6,8 +6,8 @@ package net.sourceforge.pmd.lang.ast.xpath;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -20,7 +20,7 @@ public class Attribute {
 
 
     private static final Logger LOG = Logger.getLogger(Attribute.class.getName());
-    private static final Set<String> DETECTED_DEPRECATED_ATTRIBUTES = new HashSet<>();
+    private static final Map<String, Boolean> DETECTED_DEPRECATED_ATTRIBUTES = new ConcurrentHashMap<>();
 
 
     private static final Object[] EMPTY_OBJ_ARRAY = new Object[0];
@@ -48,8 +48,8 @@ public class Attribute {
             return value;
         }
 
-        if (method.isAnnotationPresent(Deprecated.class) && LOG.isLoggable(Level.WARNING) && !DETECTED_DEPRECATED_ATTRIBUTES.contains(getLoggableAttributeName())) {
-            DETECTED_DEPRECATED_ATTRIBUTES.add(getLoggableAttributeName());
+        if (method.isAnnotationPresent(Deprecated.class) && LOG.isLoggable(Level.WARNING) && !DETECTED_DEPRECATED_ATTRIBUTES.containsKey(getLoggableAttributeName())) {
+            DETECTED_DEPRECATED_ATTRIBUTES.put(getLoggableAttributeName(), Boolean.TRUE);
             LOG.warning("Use of deprecated attribute '" + getLoggableAttributeName() + "' in xpath query");
         }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/Attribute.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/Attribute.java
@@ -6,6 +6,10 @@ package net.sourceforge.pmd.lang.ast.xpath;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import net.sourceforge.pmd.lang.ast.Node;
 
@@ -13,6 +17,11 @@ import net.sourceforge.pmd.lang.ast.Node;
  * @author daniels
  */
 public class Attribute {
+
+
+    private static final Logger LOG = Logger.getLogger(Attribute.class.getName());
+    private static final Set<String> DETECTED_DEPRECATED_ATTRIBUTES = new HashSet<>();
+
 
     private static final Object[] EMPTY_OBJ_ARRAY = new Object[0];
     private Node parent;
@@ -38,13 +47,17 @@ public class Attribute {
         if (value != null) {
             return value;
         }
+
+        if (method.isAnnotationPresent(Deprecated.class) && LOG.isLoggable(Level.WARNING) && !DETECTED_DEPRECATED_ATTRIBUTES.contains(getLoggableAttributeName())) {
+            DETECTED_DEPRECATED_ATTRIBUTES.add(getLoggableAttributeName());
+            LOG.warning("Use of deprecated attribute '" + getLoggableAttributeName() + "' in xpath query");
+        }
+
         // this lazy loading reduces calls to Method.invoke() by about 90%
         try {
             return method.invoke(parent, EMPTY_OBJ_ARRAY);
-        } catch (IllegalAccessException iae) {
+        } catch (IllegalAccessException | InvocationTargetException iae) {
             iae.printStackTrace();
-        } catch (InvocationTargetException ite) {
-            ite.printStackTrace();
         }
         return null;
     }
@@ -63,6 +76,10 @@ public class Attribute {
             stringValue = String.valueOf(v);
         }
         return stringValue;
+    }
+
+    private String getLoggableAttributeName() {
+        return parent.getXPathNodeName() + "/@" + name;
     }
 
     public String getName() {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/AttributeAxisIterator.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/AttributeAxisIterator.java
@@ -101,6 +101,9 @@ public class AttributeAxisIterator implements Iterator<Attribute> {
         return new Attribute(node, m.name, m.method);
     }
 
+
+
+
     private static final Set<Class<?>> CONSIDERED_RETURN_TYPES 
         = new HashSet<>(Arrays.<Class<?>>asList(Integer.TYPE, Boolean.TYPE, Double.TYPE, String.class, Long.TYPE, Character.TYPE, Float.TYPE));
     
@@ -109,10 +112,8 @@ public class AttributeAxisIterator implements Iterator<Attribute> {
     
     protected boolean isAttributeAccessor(Method method) {
         String methodName = method.getName();
-        boolean deprecated = method.getAnnotation(Deprecated.class) != null;
 
-        return !deprecated
-               && CONSIDERED_RETURN_TYPES.contains(method.getReturnType())
+        return CONSIDERED_RETURN_TYPES.contains(method.getReturnType())
                && method.getParameterTypes().length == 0
                && !methodName.startsWith("jjt")
                && !FILTERED_OUT_NAMES.contains(methodName);

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/AbstractNodeTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/AbstractNodeTest.java
@@ -236,7 +236,7 @@ public class AbstractNodeTest {
 
         class MyRootNode extends DummyNode implements RootNode {
 
-             private MyRootNode(int id) {
+            private MyRootNode(int id) {
                 super(id);
             }
         }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNodeWithDeprecatedAttribute.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNodeWithDeprecatedAttribute.java
@@ -6,7 +6,7 @@ package net.sourceforge.pmd.lang.ast;
 
 /**
  * @author Clément Fournier
- * @since 6.2.0
+ * @since 6.3.0
  */
 public class DummyNodeWithDeprecatedAttribute extends DummyNode {
 
@@ -15,7 +15,7 @@ public class DummyNodeWithDeprecatedAttribute extends DummyNode {
         super(id);
     }
 
-
+    // this is the deprecated attribute
     @Deprecated
     public int getSize() {
         return 2;

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNodeWithDeprecatedAttribute.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNodeWithDeprecatedAttribute.java
@@ -1,0 +1,23 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.ast;
+
+/**
+ * @author Clément Fournier
+ * @since 6.2.0
+ */
+public class DummyNodeWithDeprecatedAttribute extends DummyNode {
+
+
+    public DummyNodeWithDeprecatedAttribute(int id) {
+        super(id);
+    }
+
+
+    @Deprecated
+    public int getSize() {
+        return 2;
+    }
+}

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/xpath/AttributeAxisIteratorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/xpath/AttributeAxisIteratorTest.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.ast.xpath;
 
+import static junit.framework.TestCase.assertTrue;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -11,11 +13,20 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import net.sourceforge.pmd.lang.ast.DummyNode;
+import net.sourceforge.pmd.lang.ast.DummyNodeWithDeprecatedAttribute;
+import net.sourceforge.pmd.lang.ast.Node;
+
 
 /**
  * Unit test for {@link AttributeAxisIterator}
  */
 public class AttributeAxisIteratorTest {
+
+    @Test
+    public void testAttributeDeprecation() {
+        Node dummy = new DummyNodeWithDeprecatedAttribute(2);
+        assertTrue(toMap(new AttributeAxisIterator(dummy)).containsKey("Size"));
+    }
 
     /**
      * Test hasNext and next.
@@ -27,11 +38,7 @@ public class AttributeAxisIteratorTest {
         dummyNode.testingOnlySetBeginColumn(1);
 
         AttributeAxisIterator it = new AttributeAxisIterator(dummyNode);
-        Map<String, Attribute> atts = new HashMap<>();
-        while (it.hasNext()) {
-            Attribute attribute = it.next();
-            atts.put(attribute.getName(), attribute);
-        }
+        Map<String, Attribute> atts = toMap(it);
         Assert.assertEquals(7, atts.size());
         Assert.assertTrue(atts.containsKey("BeginColumn"));
         Assert.assertTrue(atts.containsKey("BeginLine"));
@@ -40,5 +47,15 @@ public class AttributeAxisIteratorTest {
         Assert.assertTrue(atts.containsKey("SingleLine"));
         Assert.assertTrue(atts.containsKey("EndColumn"));
         Assert.assertTrue(atts.containsKey("EndLine"));
+    }
+
+
+    private Map<String, Attribute> toMap(AttributeAxisIterator it) {
+        Map<String, Attribute> atts = new HashMap<>();
+        while (it.hasNext()) {
+            Attribute attribute = it.next();
+            atts.put(attribute.getName(), attribute);
+        }
+        return atts;
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/xpath/AttributeAxisIteratorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/xpath/AttributeAxisIteratorTest.java
@@ -4,11 +4,14 @@
 
 package net.sourceforge.pmd.lang.ast.xpath;
 
-import static junit.framework.TestCase.assertTrue;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import org.hamcrest.collection.IsMapContaining;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -25,7 +28,7 @@ public class AttributeAxisIteratorTest {
     @Test
     public void testAttributeDeprecation() {
         Node dummy = new DummyNodeWithDeprecatedAttribute(2);
-        assertTrue(toMap(new AttributeAxisIterator(dummy)).containsKey("Size"));
+        assertThat(toMap(new AttributeAxisIterator(dummy)), IsMapContaining.hasKey("Size"));
     }
 
     /**
@@ -40,13 +43,13 @@ public class AttributeAxisIteratorTest {
         AttributeAxisIterator it = new AttributeAxisIterator(dummyNode);
         Map<String, Attribute> atts = toMap(it);
         Assert.assertEquals(7, atts.size());
-        Assert.assertTrue(atts.containsKey("BeginColumn"));
-        Assert.assertTrue(atts.containsKey("BeginLine"));
-        Assert.assertTrue(atts.containsKey("FindBoundary"));
-        Assert.assertTrue(atts.containsKey("Image"));
-        Assert.assertTrue(atts.containsKey("SingleLine"));
-        Assert.assertTrue(atts.containsKey("EndColumn"));
-        Assert.assertTrue(atts.containsKey("EndLine"));
+        assertTrue(atts.containsKey("BeginColumn"));
+        assertTrue(atts.containsKey("BeginLine"));
+        assertTrue(atts.containsKey("FindBoundary"));
+        assertTrue(atts.containsKey("Image"));
+        assertTrue(atts.containsKey("SingleLine"));
+        assertTrue(atts.containsKey("EndColumn"));
+        assertTrue(atts.containsKey("EndLine"));
     }
 
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/coverage/PMDCoverageTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/coverage/PMDCoverageTest.java
@@ -58,6 +58,7 @@ public class PMDCoverageTest {
 
             assertFalse("There was at least one exception mentioned in the output", output.getLog().contains("Exception applying rule"));
             assertFalse("Wrong configuration? Ruleset not found", output.getLog().contains("Ruleset not found"));
+            assertFalse("Some XPath rules use deprecated attributes", output.getLog().contains("Use of deprecated attribute"));
 
             String report = FileUtils.readFileToString(f);
             assertEquals("No processing errors expected", 0, StringUtils.countMatches(report, "Error while processing"));

--- a/pom.xml
+++ b/pom.xml
@@ -801,6 +801,12 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
                 <version>4.12</version>
             </dependency>
             <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest-library</artifactId>
+                <version>1.3</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>pl.pragmatists</groupId>
                 <artifactId>JUnitParams</artifactId>
                 <version>1.1.0</version>


### PR DESCRIPTION
Deprecated attributes were previously removed from the attribute iterator entirely, thus producing breaking API changes. This changeset keeps them, but logs their usage as a warning. 

Closes #917 
