### PR TITLE
[java] Better handle explicit receiver parameters

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -38,6 +38,7 @@ we have measured up to 10% improvements during Type Resolution, Symbol Table ana
     *   [#994](https://github.com/pmd/pmd/issues/994): \[doc] Delete duplicate page contributing.md on the website
 *   java-bestpracrtices
     *   [#370](https://github.com/pmd/pmd/issues/370): \[java] GuardLogStatementJavaUtil not considering lambdas
+    *   [#719](https://github.com/pmd/pmd/issues/719): \[java] Unused Code: Java 8 receiver parameter with an internal class
 
 ### API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFormalParameters.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFormalParameters.java
@@ -18,7 +18,8 @@ public class ASTFormalParameters extends AbstractJavaNode implements Iterable<AS
     }
 
     public int getParameterCount() {
-        return jjtGetNumChildren();
+        return jjtGetNumChildren() > 0 && getFirstChildOfType(ASTFormalParameter.class).isExplicitReceiverParameter()
+                ? jjtGetNumChildren() - 1 : jjtGetNumChildren();
     }
 
     /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFormalParameters.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFormalParameters.java
@@ -6,6 +6,7 @@
 package net.sourceforge.pmd.lang.java.ast;
 
 import java.util.Iterator;
+import java.util.List;
 
 
 public class ASTFormalParameters extends AbstractJavaNode implements Iterable<ASTFormalParameter> {
@@ -18,8 +19,9 @@ public class ASTFormalParameters extends AbstractJavaNode implements Iterable<AS
     }
 
     public int getParameterCount() {
-        return jjtGetNumChildren() > 0 && getFirstChildOfType(ASTFormalParameter.class).isExplicitReceiverParameter()
-                ? jjtGetNumChildren() - 1 : jjtGetNumChildren();
+        final List<ASTFormalParameter> parameters = findChildrenOfType(ASTFormalParameter.class);
+        return !parameters.isEmpty() && parameters.get(0).isExplicitReceiverParameter()
+                ? parameters.size() - 1 : parameters.size();
     }
 
     /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodDeclarator.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodDeclarator.java
@@ -15,7 +15,7 @@ public class ASTMethodDeclarator extends AbstractJavaNode {
     }
 
     public int getParameterCount() {
-        return this.jjtGetChild(0).jjtGetNumChildren();
+        return getFirstChildOfType(ASTFormalParameters.class).getParameterCount();
     }
 
     /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedFormalParameterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedFormalParameterRule.java
@@ -19,6 +19,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclarator;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
 import net.sourceforge.pmd.lang.java.ast.ASTNameList;
 import net.sourceforge.pmd.lang.java.ast.ASTType;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.symboltable.JavaNameOccurrence;
@@ -85,6 +86,12 @@ public class UnusedFormalParameterRule extends AbstractJavaRule {
                     .getDeclarations(VariableNameDeclaration.class);
             for (Map.Entry<VariableNameDeclaration, List<NameOccurrence>> entry : vars.entrySet()) {
                 VariableNameDeclaration nameDecl = entry.getKey();
+                
+                ASTVariableDeclaratorId declNode = (ASTVariableDeclaratorId) nameDecl.getNode();
+                if (declNode.isExplicitReceiverParameter()) {
+                    continue;
+                }
+                
                 if (actuallyUsed(nameDecl, entry.getValue())) {
                     continue;
                 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/ClassScope.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/ClassScope.java
@@ -369,6 +369,10 @@ public class ClassScope extends AbstractJavaScope {
         Map<String, Node> qualifiedTypeNames = fileScope.getQualifiedTypeNames();
 
         for (ASTFormalParameter p : parameters) {
+            if (p.isExplicitReceiverParameter()) {
+                continue;
+            }
+            
             String typeImage = p.getTypeNode().getTypeImage();
             // typeImage might be qualified/unqualified. If it refers to a type,
             // defined in the same toplevel class,

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedFormalParameter.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedFormalParameter.xml
@@ -16,6 +16,18 @@ class Foo {
     </test-code>
     <test-code>
         <description><![CDATA[
+Explicit receiver parameters are ignored
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Foo {
+  private void test(@AnnotatedUsage Foo this) {
+  }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
 method called on param
      ]]></description>
         <expected-problems>0</expected-problems>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
@@ -1563,5 +1563,20 @@ public class Something {
         }
         ]]></code>
     </test-code>
-
+    <test-code>
+        <description><![CDATA[
+Explicit receiver parameters are ignored when matching methods
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Foo {
+  public void bar() {
+    test();
+  }
+  
+  private void test(@AnnotatedUsage Foo this) {
+  }
+}
+     ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
 - UnusedFormalParameter ignores them explicitly
 - The symbol table is updated to ignore it when matching calls. The AST to ignore it from `getParameterCount()` calls
 - Resolves #719