### PR TITLE
[java] NoClassDefFoundError when analyzing PMD with PMD

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -58,6 +58,8 @@ we have measured up to 10% improvements during Type Resolution, Symbol Table ana
     *   [#988](https://github.com/pmd/pmd/issues/988): \[core] FileNotFoundException for missing classes directory with analysis cache enabled
 *   documentation
     *   [#994](https://github.com/pmd/pmd/issues/994): \[doc] Delete duplicate page contributing.md on the website
+*   java
+    *   [#1030](https://github.com/pmd/pmd/pull/1030): \[java] NoClassDefFoundError when analyzing PMD with PMD
 *   java-bestpractices
     *   [#370](https://github.com/pmd/pmd/issues/370): \[java] GuardLogStatementJavaUtil not considering lambdas
     *   [#558](https://github.com/pmd/pmd/issues/558): \[java] ProperLogger Warnings for enums

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/qname/JavaTypeQualifiedName.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/qname/JavaTypeQualifiedName.java
@@ -68,7 +68,7 @@ public final class JavaTypeQualifiedName extends JavaQualifiedName {
      */
     static void setClassLoader(ClassLoader cl) {
         ClassLoader asmCL = PMDASMClassLoader.getInstance(cl);
-        if (asmCL != null && asmCL.equals(classLoader)) {
+        if (asmCL != null && !asmCL.equals(classLoader)) {
             classLoader = asmCL;
         }
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/qname/QualifiedNameFactory.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/qname/QualifiedNameFactory.java
@@ -108,7 +108,7 @@ public final class QualifiedNameFactory {
             name = '.' + name; // unnamed package, marked by a full stop. See ofString's format below
         }
 
-        return (JavaTypeQualifiedName) ofString(name);
+        return ((JavaTypeQualifiedName) ofString(name)).withClassLoader(clazz.getClassLoader());
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/qname/QualifiedNameFactory.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/qname/QualifiedNameFactory.java
@@ -108,7 +108,13 @@ public final class QualifiedNameFactory {
             name = '.' + name; // unnamed package, marked by a full stop. See ofString's format below
         }
 
-        return ((JavaTypeQualifiedName) ofString(name)).withClassLoader(clazz.getClassLoader());
+        JavaTypeQualifiedName qualifiedName = (JavaTypeQualifiedName) ofString(name);
+        if (qualifiedName != null) {
+            // Note: this assumes, that clazz has been loaded through the correct classloader,
+            // specifically through the auxclasspath classloader.
+            qualifiedName.withClassLoader(clazz.getClassLoader());
+        }
+        return qualifiedName;
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/qname/QualifiedNameResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/qname/QualifiedNameResolver.java
@@ -31,6 +31,7 @@ import net.sourceforge.pmd.lang.java.ast.JavaParserVisitorReducedAdapter;
 import net.sourceforge.pmd.lang.java.ast.JavaQualifiableNode;
 import net.sourceforge.pmd.lang.java.ast.MethodLikeNode;
 import net.sourceforge.pmd.lang.java.qname.ImmutableList.ListFactory;
+import net.sourceforge.pmd.lang.java.typeresolution.PMDASMClassLoader;
 
 
 /**
@@ -98,6 +99,12 @@ public class QualifiedNameResolver extends JavaParserVisitorReducedAdapter {
      */
     private ImmutableList<String> classNames;
 
+    /**
+     * The classloader that must be used to load classes for resolving types,
+     * e.g. for qualified names.
+     * This is the auxclasspath.
+     */
+    private ClassLoader classLoader;
 
     /**
      * Initialises the visitor and starts it.
@@ -106,7 +113,7 @@ public class QualifiedNameResolver extends JavaParserVisitorReducedAdapter {
      * @param rootNode The root hierarchy
      */
     public void initializeWith(ClassLoader classLoader, ASTCompilationUnit rootNode) {
-        JavaTypeQualifiedName.setClassLoader(classLoader);
+        this.classLoader = PMDASMClassLoader.getInstance(classLoader);
         rootNode.jjtAccept(this, null);
     }
 
@@ -348,7 +355,8 @@ public class QualifiedNameResolver extends JavaParserVisitorReducedAdapter {
 
     /** Creates a new class qname from the current context (fields). */
     private JavaTypeQualifiedName contextClassQName() {
-        return new JavaTypeQualifiedName(packages, classNames, localIndices);
+        return new JavaTypeQualifiedName(packages, classNames, localIndices)
+                    .withClassLoader(classLoader);
     }
 
 


### PR DESCRIPTION
I tried to update PMD dogfood, to enable the MissingOverride rule. But I ran into the following issue:
When resolving the QualifiedNames, we run into LinkageErrors, telling the "org.apache.tools.ant.BuildException" has not been found. This is in ant.jar and this dependency has scope provided (so it is on the compile classpath but not on the runtime classpath...).
It turned out, that we were using not our auxclasspath, but the runtime classpath (that one, that is used by the maven plugin).
This is fixed by the first commit.

Then I tried, to refactor, how make the auxclasspath available to the qualified names. I'm not sure, whether this is really an improvement or not. While I like the idea, that the visitor (QualifiedNameResolver) knows about the classloader, I don't see an easy solution for the factory in `QualifiedNameFactory.ofString(...)`. With this change, the qualified names created via this factory method cannot load their type, since the classloader is not known. Apparently we only use this factory right now only in unit tests, but it is a public API.
We could introduce a static variable in the factory, but that kind of reverts my refactoring (just moving the static variable for the classloader from JavaTypeQualifiedName to QualifiedNameFactory).


Original error messages:
`Failed to execute goal org.apache.maven.plugins:maven-pmd-plugin:3.9.0:pmd (pmd) on project pmd-core: Execution pmd of goal org.apache.maven.plugins:maven-pmd-plugin:3.9.0:pmd failed: A required class was missing while executing org.apache.maven.plugins:maven-pmd-plugin:3.9.0:pmd: org/apache/tools/ant/BuildException`

Apparently the maven classloader monitors failures and reports it - I didn't see, that we ever threw a ClassNotFoundException explicitely.

Our own log:
`[WARNING] Error during type resolution due to: java.lang.NoClassDefFoundError: org/apache/tools/ant/BuildException`
