### PR TITLE
[java] NullAssignment false positive

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -114,6 +114,7 @@ Other languages are equivalent.
     *   [#1003](https://github.com/pmd/pmd/issues/1003): \[java] UnnecessaryConstructor triggered on required empty constructor (Dagger @Inject)
     *   [#1023](https://github.com/pmd/pmd/issues/1023): \[java] False positive for useless parenthesis
 *   java-errorprone
+    *   [#629](https://github.com/pmd/pmd/issues/629): \[java] NullAssignment false positive
     *   [#816](https://github.com/pmd/pmd/issues/816): \[java] SingleMethodSingleton false positives with inner classes
 *   java-performance
     *   [#586](https://github.com/pmd/pmd/issues/586): \[java] AvoidUsingShortType erroneously triggered on overrides of 3rd party methods

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/NullAssignmentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/NullAssignmentRule.java
@@ -9,6 +9,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTBlockStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTConditionalExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTEqualityExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTLambdaExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
 import net.sourceforge.pmd.lang.java.ast.ASTNullLiteral;
 import net.sourceforge.pmd.lang.java.ast.ASTReturnStatement;
@@ -59,18 +60,19 @@ public class NullAssignmentRule extends AbstractJavaRule {
                 && ((AccessNode) ((VariableNameDeclaration) name.getNameDeclaration()).getAccessNodeParent()).isFinal();
     }
 
-    private boolean isBadTernary(ASTConditionalExpression n) {
+    private boolean isBadTernary(ASTConditionalExpression ternary) {
         boolean isInitializer = false;
 
-        ASTVariableInitializer variableInitializer = n.getFirstParentOfType(ASTVariableInitializer.class);
+        ASTVariableInitializer variableInitializer = ternary.getFirstParentOfType(ASTVariableInitializer.class);
         if (variableInitializer != null) {
-            ASTBlockStatement statement = n.getFirstParentOfType(ASTBlockStatement.class);
+            ASTBlockStatement statement = ternary.getFirstParentOfType(ASTBlockStatement.class);
             isInitializer = statement == variableInitializer.getFirstParentOfType(ASTBlockStatement.class);
         }
 
-        return n.isTernary()
-                && !(n.jjtGetChild(0) instanceof ASTEqualityExpression)
+        return ternary.isTernary()
+                && !(ternary.jjtGetChild(0) instanceof ASTEqualityExpression)
                 && !isInitializer
-                && !(n.getNthParent(2) instanceof ASTReturnStatement);
+                && !(ternary.getNthParent(2) instanceof ASTReturnStatement)
+                && !(ternary.getNthParent(2) instanceof ASTLambdaExpression);
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/NullAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/NullAssignment.xml
@@ -163,8 +163,8 @@ public class NullAssignmentFP {
     </test-code>
 
     <test-code>
-        <description>[java] NullAssignment false positive - actual assignment #629</description>
-        <expected-problems>1</expected-problems>
+        <description>[java] NullAssignment false positive - no direct assignment, but lambda #629</description>
+        <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class NullAssignmentFP {
     public void foo() {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/NullAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/NullAssignment.xml
@@ -64,10 +64,8 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-null assignment in ternary
-     ]]></description>
-        <expected-problems>1</expected-problems>
+        <description>null assignment in ternary - initialization</description>
+        <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
  public void foo() {
@@ -77,14 +75,36 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-null assignment in ternary, part deux
-     ]]></description>
+        <description>null assignment in ternary</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Foo {
  public void foo() {
+  String x;
+  x = bar() ? "fiz" : null;
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description>null assignment in ternary, part deux - initialization</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ public void foo() {
   String x = bar() ? null : "fiz";
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description>null assignment in ternary, part deux</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ public void foo() {
+  String x;
+  x = bar() ? null : "fiz";
  }
 }
      ]]></code>
@@ -128,5 +148,42 @@ public class Foo {
  }
 }
      ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] NullAssignment false positive - initialization #629</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class NullAssignmentFP {
+    public void foo() {
+        Type result = someHash.computeIfAbsent(a, _unused -> test ? truthy : null);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] NullAssignment false positive - actual assignment #629</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class NullAssignmentFP {
+    public void foo() {
+        Type result;
+        result = someHash.computeIfAbsent(a, _unused -> test ? truthy : null);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] NullAssignment false positive - return with ternary #629</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class NullAssignmentFP {
+    public DateTime foo(DateTime dateTime) {
+        return dateTime.getYear() < 2100 ? dateTime : null;
+    }
+}
+        ]]></code>
     </test-code>
 </test-data>


### PR DESCRIPTION
Fixes #629

Note: This is a partial fix only.
This FP is not detected:

```java
String key;
if (a) {
	key = "a";
} else if (b) {
	key = "b";
} else {
	key = null;
}
```
