### PR TITLE
[core] Log only once all messages

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -56,6 +56,7 @@ we have measured up to 10% improvements during Type Resolution, Symbol Table ana
 
 *   all
     *   [#988](https://github.com/pmd/pmd/issues/988): \[core] FileNotFoundException for missing classes directory with analysis cache enabled
+    *   [#1036](https://github.com/pmd/pmd/issues/1036): \[core] Non-XML output breaks XML-based CLI integrations
 *   documentation
     *   [#994](https://github.com/pmd/pmd/issues/994): \[doc] Delete duplicate page contributing.md on the website
 *   java

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
@@ -15,7 +15,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Handler;
+import java.util.logging.ConsoleHandler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -45,7 +45,6 @@ import net.sourceforge.pmd.util.database.DBURI;
 import net.sourceforge.pmd.util.database.SourceObject;
 import net.sourceforge.pmd.util.datasource.DataSource;
 import net.sourceforge.pmd.util.datasource.ReaderDataSource;
-import net.sourceforge.pmd.util.log.ConsoleLogHandler;
 import net.sourceforge.pmd.util.log.ScopedLogHandlersManager;
 
 /**
@@ -450,8 +449,7 @@ public class PMD {
         final PMDConfiguration configuration = params.toConfiguration();
 
         final Level logLevel = params.isDebug() ? Level.FINER : Level.INFO;
-        final Handler logHandler = new ConsoleLogHandler();
-        final ScopedLogHandlersManager logHandlerManager = new ScopedLogHandlersManager(logLevel, logHandler);
+        final ScopedLogHandlersManager logHandlerManager = new ScopedLogHandlersManager(logLevel, new ConsoleHandler());
         final Level oldLogLevel = LOG.getLevel();
         // Need to do this, since the static logger has already been initialized
         // at this point

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/log/ConsoleLogHandler.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/log/ConsoleLogHandler.java
@@ -14,7 +14,9 @@ import java.util.logging.LogRecord;
  * Log to the console using a basic formatter.
  *
  * @author Wouter Zelle
+ * @deprecated This class will be complety removed in 7.0.0
  */
+@Deprecated
 public class ConsoleLogHandler extends Handler {
 
     private static final Formatter FORMATTER = new PmdLogFormatter();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/log/ScopedLogHandlersManager.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/log/ScopedLogHandlersManager.java
@@ -36,7 +36,9 @@ public class ScopedLogHandlersManager {
         }
         for (Handler handler : newHandlers) {
             logger.addHandler(handler);
+            handler.setLevel(level);
         }
+        logger.setUseParentHandlers(false);
     }
 
     public void close() {
@@ -47,5 +49,6 @@ public class ScopedLogHandlersManager {
             logger.addHandler(handler);
         }
         logger.setLevel(oldLogLevel);
+        logger.setUseParentHandlers(true);
     }
 }


### PR DESCRIPTION
 - CLI runs log only to stderr, never to stdout
 - Both Ant and CLI runs log only once, the root logger never gets a
hold of the logs, completely isolating PMD
 - Fixes #1036 
