### PR TITLE
[core] Distinguish MultiThread and SingleThread environment in RuleContext attributes map

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/MultiThreadedRuleContextMap.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/MultiThreadedRuleContextMap.java
@@ -1,0 +1,32 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Map used for multi threaded PMD execution
+ * @param <K> the type of keys
+ * @param <V> the type of values
+ */
+/* default */ class MultiThreadedRuleContextMap<K, V> implements RuleContextMap<K, V> {
+    private final ConcurrentMap<K, V> map = new ConcurrentHashMap<>();
+
+    @Override
+    public V putIfAbsent(K name, V value) {
+        return map.putIfAbsent(name, value);
+    }
+
+    @Override
+    public V get(K name) {
+        return map.get(name);
+    }
+
+    @Override
+    public V remove(K name) {
+        return map.remove(name);
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
@@ -216,7 +216,7 @@ public class PMD {
 
             Benchmarker.mark(Benchmark.Reporting, System.nanoTime() - reportStart, 0);
 
-            RuleContext ctx = new RuleContext();
+            RuleContext ctx = RuleContext.fromNumberOfThreads(configuration.getThreads());
             final AtomicInteger violations = new AtomicInteger(0);
             ctx.getReport().addListener(new ThreadSafeReportListener() {
                 @Override

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleContext.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleContext.java
@@ -5,8 +5,6 @@
 package net.sourceforge.pmd;
 
 import java.io.File;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 import net.sourceforge.pmd.lang.LanguageVersion;
 
@@ -33,14 +31,40 @@ public class RuleContext {
     private File sourceCodeFile;
     private String sourceCodeFilename;
     private LanguageVersion languageVersion;
-    private final ConcurrentMap<String, Object> attributes;
+    private final RuleContextMap<String, Object> attributes;
     private boolean ignoreExceptions = true;
 
     /**
-     * Default constructor.
+     * Instances an appropriate RuleContext according to the number of threads.
+     *
+     * @param threads the number of threads on which PMD will run
+     * @return a thread-safe rule context if the number of threads is greater than zero; else a non thread-safe rule
+     * context if the number of threads is equal to zero (i.e. PMD will run on a unique thread)
+     */
+    /* default */ static RuleContext fromNumberOfThreads(final int threads) {
+        if (threads > 0) {
+            return RuleContext.forMultiThread();
+        }
+        return RuleContext.forSingleThread();
+    }
+
+    private static RuleContext forSingleThread() {
+        return new RuleContext(new SingleThreadedRuleContextMap<String, Object>());
+    }
+
+    private static RuleContext forMultiThread() {
+        return new RuleContext(new MultiThreadedRuleContextMap<String, Object>());
+    }
+
+    private RuleContext(final RuleContextMap<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    /**
+     * Default constructor (MultiThread Rule Context).
      */
     public RuleContext() {
-        attributes = new ConcurrentHashMap<>();
+        this(new MultiThreadedRuleContextMap<String, Object>());
     }
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleContextMap.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleContextMap.java
@@ -1,0 +1,26 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd;
+
+/**
+ * Generic Map interface used by {@link RuleContext} to store the attributes, depending on whether it is used in a
+ * multi-threaded environment or single-threaded environment.
+ * <p>
+ * Note: When PMD starts using Java 8, {@link java.util.Map} interface will already include putIfAbsent method
+ * (in Java 7 it only exists in {@link java.util.concurrent.ConcurrentMap}). This means that this interface and its
+ * implementations will be removed and {@link RuleContext} will directly instance a new {@link java.util.HashMap} or
+ * {@link java.util.concurrent.ConcurrentHashMap}.
+ * </p>
+ *
+ * @param <K> the type of the keys
+ * @param <V> the type of the values
+ */
+/* default */ interface RuleContextMap<K, V> {
+    V putIfAbsent(K name, V value);
+
+    V get(K name);
+
+    V remove(K name);
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/SingleThreadedRuleContextMap.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/SingleThreadedRuleContextMap.java
@@ -1,0 +1,34 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd;
+
+import java.util.HashMap;
+
+/**
+ * Map used for single threaded PMD execution
+ * @param <K> the type of keys
+ * @param <V> the type of values
+ */
+/* default */ class SingleThreadedRuleContextMap<K, V> implements RuleContextMap<K, V> {
+    private final java.util.Map<K, V> map = new HashMap<>();
+
+    @Override
+    public V putIfAbsent(K key, V value) {
+        if (!map.containsKey(key)) {
+            return map.put(key, value);
+        }
+        return map.get(key);
+    }
+
+    @Override
+    public V get(K key) {
+        return map.get(key);
+    }
+
+    @Override
+    public V remove(K key) {
+        return map.remove(key);
+    }
+}


### PR DESCRIPTION
# Summary
`RuleContext` stores a `ConcurrentMap` regardless of the number of threads used in PMD. This means that synchronisation is unnecessarily done when using a single thread.

# Solution
Make transparent to the `RuleContext` which map implementation is using, which means having the same interface for all the operations made on the attributes. Due to the project language level being Java 7, `Map` interface does not have the method `putIfAbsent` as `ConcurrentMap` has. This means that a small interface needs to be added to support a `HashMap` as well as a `ConcurrentHashMap`, at least until PMD is built with Java 8.