### PR TITLE
[core] Remove unnecessary ThreadLocal context from PmdRunnable

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/processor/MonoThreadProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/processor/MonoThreadProcessor.java
@@ -34,8 +34,5 @@ public final class MonoThreadProcessor extends AbstractPMDProcessor {
         for (Report r : reports) {
             super.renderReports(renderers, r);
         }
-
-        // Since this thread may run PMD again, clean up the runnable
-        PmdRunnable.reset();
     }
 }


### PR DESCRIPTION
# Summary
A `ThreadLocal` was stored inside `PmdRunnable` for each thread. Its only _outside_ use was when the `MonoThreadProcessor` was resetting the PmdRunnable to make it reusable by removing the value stored in the `ThreadLocal` instance. Also the `call()` method to the `PmdRunnable` for one file is not done more than one time before making a `reset()` call.

# Solution
Remove altogether the ThreadLocal instance variable and the class ThreadContext whose instance was stored in it.