### PR TITLE
[ui] Fix designer treeview scroll

### DIFF
--- a/pmd-dist/src/main/scripts/designer.bat
+++ b/pmd-dist/src/main/scripts/designer.bat
@@ -3,4 +3,16 @@ set TOPDIR=%~dp0..
 set OPTS=
 set MAIN_CLASS=net.sourceforge.pmd.util.fxdesigner.Designer
 
-java -classpath "%TOPDIR%\lib\*" %OPTS% %MAIN_CLASS% %*
+
+:: sets the jver variable to the java version, eg 901 for 9.0.1+x or 180 for 1.8.0_171-b11
+for /f tokens^=2-4^ delims^=.-_+^" %%j in ('java -fullversion 2^>^&1') do set /A jver="%%j%%k%%l"
+
+if "%jver%" GEQ "900" (
+    :: enable reflection    
+    Set jreopts=--add-opens javafx.controls/javafx.scene.control.skin=ALL-UNNAMED
+) else (
+    Set jreopts=
+)
+
+
+java %jreopts% -classpath "%TOPDIR%\lib\*" %OPTS% %MAIN_CLASS% %*

--- a/pmd-dist/src/main/scripts/run.sh
+++ b/pmd-dist/src/main/scripts/run.sh
@@ -74,6 +74,19 @@ check_lib_dir() {
   fi
 }
 
+jre_specific_vm_options() {
+  # java_ver is eg "18" for java 1.8, "90" for java 9.0
+  java_ver=$(java -version 2>&1 | sed -n ';s/.* version "\(.*\)\.\(.*\)\..*"/\1\2/p;')
+
+  if [ $java_ver -ge 90 ]
+  then
+    # Opens internal module of javafx to reflection
+    options="--add-opens javafx.controls/javafx.scene.control.skin=ALL-UNNAMED"
+
+    echo $options
+  fi
+}
+
 readonly APPNAME="${1}"
 if [ -z "${APPNAME}" ]; then
     usage
@@ -128,4 +141,5 @@ cygwin_paths
 
 java_heapsize_settings
 
-java ${HEAPSIZE} -cp "${classpath}" "${CLASSNAME}" "$@"
+java ${HEAPSIZE} $(jre_specific_vm_options) -cp "${classpath}" "${CLASSNAME}" "$@"
+

--- a/pmd-dist/src/main/scripts/run.sh
+++ b/pmd-dist/src/main/scripts/run.sh
@@ -78,7 +78,7 @@ jre_specific_vm_options() {
   # java_ver is eg "18" for java 1.8, "90" for java 9.0
   java_ver=$(java -version 2>&1 | sed -n ';s/.* version "\(.*\)\.\(.*\)\..*"/\1\2/p;')
   options=""
-  
+
   if [ $java_ver -ge 90 ] && [ "${APPNAME}" = "designer" ]
   then # open internal module of javafx to reflection
     options="--add-opens javafx.controls/javafx.scene.control.skin=ALL-UNNAMED"

--- a/pmd-dist/src/main/scripts/run.sh
+++ b/pmd-dist/src/main/scripts/run.sh
@@ -77,14 +77,14 @@ check_lib_dir() {
 jre_specific_vm_options() {
   # java_ver is eg "18" for java 1.8, "90" for java 9.0
   java_ver=$(java -version 2>&1 | sed -n ';s/.* version "\(.*\)\.\(.*\)\..*"/\1\2/p;')
-
-  if [ $java_ver -ge 90 ]
-  then
-    # Opens internal module of javafx to reflection
+  options=""
+  
+  if [ $java_ver -ge 90 ] && [ "${APPNAME}" = "designer" ]
+  then # open internal module of javafx to reflection
     options="--add-opens javafx.controls/javafx.scene.control.skin=ALL-UNNAMED"
-
-    echo $options
   fi
+
+  echo $options
 }
 
 readonly APPNAME="${1}"

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/MainDesignerController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/MainDesignerController.java
@@ -244,7 +244,7 @@ public class MainDesignerController implements Initializable, SettingsOwner {
 
 
     public void onNameDeclarationSelected(NameDeclaration declaration) {
-        sourceEditorController.clearNodeHighlight();
+        Platform.runLater(() -> onNodeItemSelected(declaration.getNode()));
 
         List<NameOccurrence> occ = declaration.getNode().getScope().getDeclarations().get(declaration);
         if (occ != null) {
@@ -253,7 +253,6 @@ public class MainDesignerController implements Initializable, SettingsOwner {
                                                               .collect(Collectors.toList()));
         }
 
-        sourceEditorController.highlightNodePrimary(declaration.getNode());
     }
 
 

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/MainDesignerController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/MainDesignerController.java
@@ -237,6 +237,8 @@ public class MainDesignerController implements Initializable, SettingsOwner {
      */
     public void onNodeItemSelected(Node selectedValue) {
         nodeInfoPanelController.displayInfo(selectedValue);
+        // The following line causes problems, since it wipes out the name occurrence highlighting,
+        // but it's already fixed in a PR to come soon
         sourceEditorController.clearNodeHighlight();
         sourceEditorController.highlightNodePrimary(selectedValue);
         sourceEditorController.focusNodeInTreeView(selectedValue);

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/NodeInfoPanelController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/NodeInfoPanelController.java
@@ -74,7 +74,7 @@ public class NodeInfoPanelController implements Initializable {
                     .filterMap(o -> o instanceof NameDeclaration, o -> (NameDeclaration) o)
                     .subscribe(parent::onNameDeclarationSelected);
 
-        scopeHierarchyTreeView.setCellFactory(view -> new ScopeHierarchyTreeCell(parent));
+        scopeHierarchyTreeView.setCellFactory(view -> new ScopeHierarchyTreeCell());
     }
 
 

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/NodeInfoPanelController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/NodeInfoPanelController.java
@@ -59,7 +59,7 @@ public class NodeInfoPanelController implements Initializable {
     @FXML
     private TreeView<Object> scopeHierarchyTreeView;
     private MetricEvaluator metricEvaluator = new MetricEvaluator();
-
+    private Node selectedNode;
 
     public NodeInfoPanelController(MainDesignerController mainController) {
         parent = mainController;
@@ -84,8 +84,11 @@ public class NodeInfoPanelController implements Initializable {
      * @param node Node to inspect
      */
     public void displayInfo(Node node) {
-
         Objects.requireNonNull(node, "Node cannot be null");
+
+        if (node.equals(selectedNode)) {
+            return;
+        }
 
         ObservableList<String> atts = getAttributes(node);
         xpathAttributesListView.setItems(atts);

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/SourceEditorController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/SourceEditorController.java
@@ -28,6 +28,7 @@ import net.sourceforge.pmd.util.fxdesigner.util.beans.SettingsPersistenceUtil.Pe
 import net.sourceforge.pmd.util.fxdesigner.util.codearea.AvailableSyntaxHighlighters;
 import net.sourceforge.pmd.util.fxdesigner.util.codearea.CustomCodeArea;
 import net.sourceforge.pmd.util.fxdesigner.util.codearea.SyntaxHighlighter;
+import net.sourceforge.pmd.util.fxdesigner.util.controls.ASTTreeCell;
 import net.sourceforge.pmd.util.fxdesigner.util.controls.ASTTreeItem;
 import net.sourceforge.pmd.util.fxdesigner.util.controls.TreeViewWrapper;
 
@@ -71,6 +72,8 @@ public class SourceEditorController implements Initializable, SettingsOwner {
     public void initialize(URL location, ResourceBundle resources) {
 
         treeViewWrapper = new TreeViewWrapper<>(astTreeView);
+
+        astTreeView.setCellFactory(treeView -> new ASTTreeCell(parent));
 
         languageVersionProperty().values()
                                  .filterMap(Objects::nonNull, LanguageVersion::getLanguage)

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/SourceEditorController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/SourceEditorController.java
@@ -29,6 +29,7 @@ import net.sourceforge.pmd.util.fxdesigner.util.codearea.AvailableSyntaxHighligh
 import net.sourceforge.pmd.util.fxdesigner.util.codearea.CustomCodeArea;
 import net.sourceforge.pmd.util.fxdesigner.util.codearea.SyntaxHighlighter;
 import net.sourceforge.pmd.util.fxdesigner.util.controls.ASTTreeItem;
+import net.sourceforge.pmd.util.fxdesigner.util.controls.TreeViewWrapper;
 
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
@@ -55,16 +56,22 @@ public class SourceEditorController implements Initializable, SettingsOwner {
     private CustomCodeArea codeEditorArea;
 
     private ASTManager astManager;
+    private TreeViewWrapper<Node> treeViewWrapper;
 
 
     public SourceEditorController(DesignerRoot owner, MainDesignerController mainController) {
         parent = mainController;
         astManager = new ASTManager(owner);
+
     }
+
 
 
     @Override
     public void initialize(URL location, ResourceBundle resources) {
+
+        treeViewWrapper = new TreeViewWrapper<>(astTreeView);
+
         languageVersionProperty().values()
                                  .filterMap(Objects::nonNull, LanguageVersion::getLanguage)
                                  .distinct()
@@ -162,7 +169,9 @@ public class SourceEditorController implements Initializable, SettingsOwner {
             SelectionModel<TreeItem<Node>> selectionModel = astTreeView.getSelectionModel();
             selectionModel.select(found);
             astTreeView.getFocusModel().focus(selectionModel.getSelectedIndex());
-            // astTreeView.scrollTo(selectionModel.getSelectedIndex());
+            if (!treeViewWrapper.isIndexVisible(selectionModel.getSelectedIndex())) {
+                astTreeView.scrollTo(selectionModel.getSelectedIndex());
+            }
         }
     }
 

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/SourceEditorController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/SourceEditorController.java
@@ -58,7 +58,7 @@ public class SourceEditorController implements Initializable, SettingsOwner {
 
     private ASTManager astManager;
     private TreeViewWrapper<Node> treeViewWrapper;
-
+    private ASTTreeItem selectedTreeItem;
 
     public SourceEditorController(DesignerRoot owner, MainDesignerController mainController) {
         parent = mainController;
@@ -165,19 +165,23 @@ public class SourceEditorController implements Initializable, SettingsOwner {
         highlightNodes(nodes, Collections.singleton("secondary-highlight"));
     }
 
-
     public void focusNodeInTreeView(Node node) {
-        ASTTreeItem found = ((ASTTreeItem) astTreeView.getRoot()).findItem(node);
-        if (found != null) {
-            SelectionModel<TreeItem<Node>> selectionModel = astTreeView.getSelectionModel();
-            selectionModel.select(found);
+        SelectionModel<TreeItem<Node>> selectionModel = astTreeView.getSelectionModel();
+
+        // node is different from the old one
+        if (selectedTreeItem == null && node != null
+                || selectedTreeItem != null && !Objects.equals(node, selectedTreeItem.getValue())) {
+            ASTTreeItem found = ((ASTTreeItem) astTreeView.getRoot()).findItem(node);
+            if (found != null) {
+                selectionModel.select(found);
+            }
+
             astTreeView.getFocusModel().focus(selectionModel.getSelectedIndex());
             if (!treeViewWrapper.isIndexVisible(selectionModel.getSelectedIndex())) {
                 astTreeView.scrollTo(selectionModel.getSelectedIndex());
             }
         }
     }
-
 
     private void invalidateAST(boolean error) {
         astTitleLabel.setText("Abstract syntax tree (" + (error ? "error" : "outdated") + ")");

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/ASTTreeCell.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/ASTTreeCell.java
@@ -5,10 +5,11 @@
 package net.sourceforge.pmd.util.fxdesigner.util.controls;
 
 import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.util.fxdesigner.MainDesignerController;
 
 import javafx.scene.control.TreeCell;
-import javafx.scene.control.TreeView;
-import javafx.util.Callback;
+import javafx.scene.input.MouseButton;
+import javafx.scene.input.MouseEvent;
 
 
 /**
@@ -19,6 +20,14 @@ import javafx.util.Callback;
  */
 public class ASTTreeCell extends TreeCell<Node> {
 
+    private final MainDesignerController controller;
+
+
+    public ASTTreeCell(MainDesignerController controller) {
+
+        this.controller = controller;
+    }
+
     @Override
     protected void updateItem(Node item, boolean empty) {
         super.updateItem(item, empty);
@@ -26,13 +35,19 @@ public class ASTTreeCell extends TreeCell<Node> {
         if (empty || item == null) {
             setText(null);
             setGraphic(null);
+            return;
         } else {
             setText(item.toString() + (item.getImage() == null ? "" : " \"" + item.getImage() + "\""));
         }
-    }
 
+        // Reclicking the selected node in the ast will scroll back to the node in the editor
+        this.addEventHandler(MouseEvent.MOUSE_CLICKED, t -> {
+            if (t.getButton() == MouseButton.PRIMARY
+                    && getTreeView().getSelectionModel().getSelectedItem().getValue() == item) {
+                controller.onNodeItemSelected(item);
+                t.consume();
+            }
+        });
 
-    public static Callback<TreeView<Node>, ASTTreeCell> callback() {
-        return p -> new ASTTreeCell();
     }
 }

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/ScopeHierarchyTreeCell.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/ScopeHierarchyTreeCell.java
@@ -13,8 +13,6 @@ import net.sourceforge.pmd.lang.symboltable.Scope;
 import net.sourceforge.pmd.util.fxdesigner.MainDesignerController;
 
 import javafx.scene.control.TreeCell;
-import javafx.scene.input.MouseButton;
-import javafx.scene.input.MouseEvent;
 
 
 /**
@@ -43,15 +41,6 @@ public class ScopeHierarchyTreeCell extends TreeCell<Object> {
             setText(item instanceof Scope ? getTextForScope((Scope) item)
                                           : getTextForDeclaration((NameDeclaration) item));
         }
-
-        this.addEventHandler(MouseEvent.MOUSE_CLICKED, t -> {
-            if (t.getButton() == MouseButton.PRIMARY 
-                && getTreeView().getSelectionModel().getSelectedItem() == item) {
-                if (item instanceof NameDeclaration) {
-                    controller.onNodeItemSelected(((NameDeclaration) item).getNode());
-                }
-            }
-        });
     }
 
 

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/ScopeHierarchyTreeCell.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/ScopeHierarchyTreeCell.java
@@ -10,7 +10,6 @@ import net.sourceforge.pmd.lang.java.symboltable.MethodNameDeclaration;
 import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
 import net.sourceforge.pmd.lang.symboltable.NameDeclaration;
 import net.sourceforge.pmd.lang.symboltable.Scope;
-import net.sourceforge.pmd.util.fxdesigner.MainDesignerController;
 
 import javafx.scene.control.TreeCell;
 
@@ -23,13 +22,6 @@ import javafx.scene.control.TreeCell;
  */
 public class ScopeHierarchyTreeCell extends TreeCell<Object> {
 
-    private final MainDesignerController controller;
-
-
-    public ScopeHierarchyTreeCell(MainDesignerController controller) {
-        this.controller = controller;
-    }
-    
     @Override
     protected void updateItem(Object item, boolean empty) {
         super.updateItem(item, empty);

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/ScopeHierarchyTreeItem.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/ScopeHierarchyTreeItem.java
@@ -65,14 +65,10 @@ public final class ScopeHierarchyTreeItem extends TreeItem<Object> {
 
         ScopeHierarchyTreeItem parent = buildAscendantHierarchyHelper(scope.getParent());
 
-        if (parent == null) {
-            return scopeTreeNode;
-        } else {
-            if (scopeTreeNode.getChildren().size() > 0) { // hides empty scopes
-                parent.getChildren().add(scopeTreeNode);
-            }
-            return scopeTreeNode;
+        if (parent != null) {
+            parent.getChildren().add(scopeTreeNode);
         }
+        return scopeTreeNode;
     }
 
 

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/TreeViewWrapper.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/TreeViewWrapper.java
@@ -50,6 +50,7 @@ public class TreeViewWrapper<T> {
 
         // we can't use wrapped.getSkin() because it may be null.
         // we don't care about the specific instance, we just want the class
+        @SuppressWarnings("PMD.UselessOverridingMethod")
         Skin<?> dftSkin = new TreeView<Object>() {
             @Override
             protected Skin<?> createDefaultSkin() {

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/TreeViewWrapper.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/TreeViewWrapper.java
@@ -1,0 +1,135 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.fxdesigner.util.controls;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.commons.lang3.reflect.MethodUtils;
+
+import javafx.scene.control.Skin;
+import javafx.scene.control.TreeCell;
+import javafx.scene.control.TreeView;
+
+
+/**
+ * Reflective solution to know if a cell in a TreeView is
+ * visible or not, to prevent confusing scrolling. Works
+ * under Java 8, 9, 10. Under Java 9+, requires the
+ * "--add-opens javafx.controls/javafx.scene.control.skin=ALL-UNNAMED"
+ * VM option.
+ *
+ * @param <T> Element type of the treeview
+ * @author Clément Fournier
+ * @since 6.4.0
+ */
+public class TreeViewWrapper<T> {
+    
+
+    private final TreeView<T> wrapped;
+    private Method treeViewFirstVisibleMethod;
+    private Method treeViewLastVisibleMethod;
+    // We can't use strong typing
+    // because the class has moved packages over different java versions
+    private Object virtualFlow = null;
+
+
+    public TreeViewWrapper(TreeView<T> wrapped) {
+        Objects.requireNonNull(wrapped);
+        this.wrapped = wrapped;
+        initialiseTreeViewReflection();
+    }
+
+
+    private void initialiseTreeViewReflection() {
+
+        // we can't use wrapped.getSkin() because it may be null.
+        // we don't care about the specific instance, we just want the class
+        Skin<?> dftSkin = new TreeView<Object>() {
+            @Override
+            protected Skin<?> createDefaultSkin() {
+                return super.createDefaultSkin();
+            }
+        }.createDefaultSkin();
+
+        Object flow = getVirtualFlow(dftSkin);
+
+        if (flow == null) {
+            return;
+        }
+
+        treeViewFirstVisibleMethod = MethodUtils.getMatchingMethod(flow.getClass(), "getFirstVisibleCell");
+        treeViewLastVisibleMethod = MethodUtils.getMatchingMethod(flow.getClass(), "getLastVisibleCell");
+    }
+
+
+    /**
+     * Returns true if the item at the given index
+     * is visible in the TreeView.
+     */
+    public boolean isIndexVisible(int index) {
+        if (virtualFlow == null && wrapped.getSkin() == null) {
+            return false;
+        } else if (virtualFlow == null && wrapped.getSkin() != null) {
+            // the flow is cached, so the skin must not be changed
+            virtualFlow = getVirtualFlow(wrapped.getSkin());
+        }
+
+        if (virtualFlow == null) {
+            return false;
+        }
+
+        Optional<TreeCell<T>> first = getFirstVisibleCell();
+        Optional<TreeCell<T>> last = getLastVisibleCell();
+
+        return first.isPresent()
+                && last.isPresent()
+                && first.get().getIndex() <= index
+                && last.get().getIndex() >= index;
+    }
+
+
+    private Optional<TreeCell<T>> getCellFromAccessor(Method accessor) {
+        return Optional.ofNullable(accessor).map(m -> {
+            try {
+                @SuppressWarnings("unchecked")
+                TreeCell<T> cell = (TreeCell<T>) m.invoke(virtualFlow);
+                return cell;
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                e.printStackTrace();
+            }
+            return null;
+        });
+    }
+
+
+    private Optional<TreeCell<T>> getFirstVisibleCell() {
+        return getCellFromAccessor(treeViewFirstVisibleMethod);
+    }
+
+
+    private Optional<TreeCell<T>> getLastVisibleCell() {
+        return getCellFromAccessor(treeViewLastVisibleMethod);
+    }
+
+
+    private static Object getVirtualFlow(Skin<?> skin) {
+        try {
+            // On JRE 9 and 10, the field is declared in TreeViewSkin
+            // http://hg.openjdk.java.net/openjfx/9/rt/file/c734b008e3e8/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeViewSkin.java#l85
+            // http://hg.openjdk.java.net/openjfx/10/rt/file/d14b61c6be12/modules/javafx.controls/src/main/java/javafx/scene/control/skin/TreeViewSkin.java#l85
+            // On JRE 8, the field is declared in the VirtualContainerBase superclass
+            // http://hg.openjdk.java.net/openjfx/8/master/rt/file/f89b7dc932af/modules/controls/src/main/java/com/sun/javafx/scene/control/skin/VirtualContainerBase.java#l68
+
+            return FieldUtils.readField(skin, "flow", true);
+        } catch (IllegalAccessException ignored) {
+
+        }
+        return null;
+    }
+}

--- a/pmd-ui/src/main/resources/net/sourceforge/pmd/util/fxdesigner/fxml/editor.fxml
+++ b/pmd-ui/src/main/resources/net/sourceforge/pmd/util/fxdesigner/fxml/editor.fxml
@@ -38,11 +38,7 @@
             <children>
                 <BorderPane prefHeight="200.0" prefWidth="200.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                     <center>
-                        <TreeView fx:id="astTreeView" prefHeight="200.0" prefWidth="200.0" styleClass="secondary-panel" BorderPane.alignment="CENTER">
-                            <cellFactory>
-                                <ASTTreeCell fx:factory="callback" />
-                            </cellFactory>
-                        </TreeView>
+                        <TreeView fx:id="astTreeView" prefHeight="200.0" prefWidth="200.0" styleClass="secondary-panel" BorderPane.alignment="CENTER"/>
                     </center>
                     <top>
                         <ToolBar prefHeight="40.0" prefWidth="200.0" styleClass="accent-header" BorderPane.alignment="CENTER">


### PR DESCRIPTION
This syncs the primary selected node between the AST treeview and the scopes tab. Selecting a node in the scopes tab now selects the correct node in the AST and scrolls to it if necessary. Clicking again on an already selected node makes the editor scroll to the node correctly. (These were listed in #714)

Selecting a node in the scopes tab or in the XPath result view now makes the Treeview scroll *only if the node is not already visible*, in which case it doesn't scroll and it's just highlighted. This makes the treeview much less confusing when selecting XPath results which are very close (in terms of AST), avoiding jumping every time. That was the reason why scrolling to the selected node was disabled in the treeview until now:

https://github.com/pmd/pmd/blob/master/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/SourceEditorController.java#L165

The only solution I could find to enable that behaviour is to reflectively hack into the TreeView Skin's VirtualFlow. I found evidence that there used to be a feature request at JavaFX to expose the relevant API directly on the controls, but nothing was done and I can't find the ticket anymore so I'm assuming it got lost 

I checked that it works on JRE 8, 9 and 10. On Java 9+, it requires opening the javafx private module to the unnamed module (in which PMD's code lives) via a CLI parameter, which is why the starter scripts have been modified.

This also fixes a bug with scopes containing no declaration cutting off the rest of the scopes. All scopes are now displayed, even if empty

**Known issue:** The name occurence highlighting is wiped out. I just noticed, but the logic around that was heavily modified in a PR soon to come, and it's probably already fixed there. So I won't attempt a fix in this PR
