### PR TITLE
[doc] Improve documentation of multi valued properties

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -124,6 +124,7 @@ from the comunity during the processm but if you have a legitimate use case for 
     *   [#776](https://github.com/pmd/pmd/issues/776): \[apex] AvoidHardcodingId false positives
 *   documentation
     *   [#994](https://github.com/pmd/pmd/issues/994): \[doc] Delete duplicate page contributing.md on the website
+    *   [#1057](https://github.com/pmd/pmd/issues/1057): \[doc] Documentation of ignoredAnnotations property is misleading
 *   java
     *   [#894](https://github.com/pmd/pmd/issues/894): \[java] Maven PMD plugin fails to process some files without any explanation
     *   [#899](https://github.com/pmd/pmd/issues/899): \[java] JavaTypeDefinitionSimple.toString can cause NPEs

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleDocGenerator.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleDocGenerator.java
@@ -39,6 +39,7 @@ import net.sourceforge.pmd.RuleSetNotFoundException;
 import net.sourceforge.pmd.lang.Language;
 import net.sourceforge.pmd.lang.rule.RuleReference;
 import net.sourceforge.pmd.lang.rule.XPathRule;
+import net.sourceforge.pmd.properties.MultiValuePropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 
 public class RuleDocGenerator {
@@ -421,8 +422,8 @@ public class RuleDocGenerator {
                     if (!properties.isEmpty()) {
                         lines.add("**This rule has the following properties:**");
                         lines.add("");
-                        lines.add("|Name|Default Value|Description|");
-                        lines.add("|----|-------------|-----------|");
+                        lines.add("|Name|Default Value|Description|Multivalued|");
+                        lines.add("|----|-------------|-----------|-----------|");
                         for (PropertyDescriptor<?> propertyDescriptor : properties) {
                             String description = propertyDescriptor.description();
                             if (description != null && description.toLowerCase(Locale.ROOT).startsWith(DEPRECATED_RULE_PROPERTY_MARKER)) {
@@ -441,9 +442,18 @@ public class RuleDocGenerator {
                                 }
                             }
 
+                            String multiValued = "no";
+                            if (propertyDescriptor.isMultiValue()) {
+                                MultiValuePropertyDescriptor<?> multiValuePropertyDescriptor =
+                                        (MultiValuePropertyDescriptor<?>) propertyDescriptor;
+                                multiValued = "yes. Delimiter is '"
+                                        + multiValuePropertyDescriptor.multiValueDelimiter() + "'";
+                            }
+
                             lines.add("|" + propertyDescriptor.name()
                                 + "|" + defaultValue.replace("|", "\\|")
                                 + "|" + description
+                                + "|" + multiValued.replace("|", "\\|")
                                 + "|");
                         }
                         lines.add("");

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleDocGenerator.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleDocGenerator.java
@@ -429,8 +429,20 @@ public class RuleDocGenerator {
                                 description = DEPRECATION_LABEL_SMALL
                                         + description.substring(DEPRECATED_RULE_PROPERTY_MARKER.length());
                             }
+
+                            String defaultValue = "";
+                            if (propertyDescriptor.defaultValue() != null) {
+                                if (propertyDescriptor.isMultiValue()) {
+                                    @SuppressWarnings("unchecked") // multi valued properties are using a List
+                                    PropertyDescriptor<List<?>> multiPropertyDescriptor = (PropertyDescriptor<List<?>>) propertyDescriptor;
+                                    defaultValue = multiPropertyDescriptor.asDelimitedString(multiPropertyDescriptor.defaultValue());
+                                } else {
+                                    defaultValue = String.valueOf(propertyDescriptor.defaultValue());
+                                }
+                            }
+
                             lines.add("|" + propertyDescriptor.name()
-                                + "|" + (propertyDescriptor.defaultValue() != null ? String.valueOf(propertyDescriptor.defaultValue()) : "").replace("|", "\\|")
+                                + "|" + defaultValue.replace("|", "\\|")
                                 + "|" + description
                                 + "|");
                         }

--- a/pmd-doc/src/test/resources/expected/sample.md
+++ b/pmd-doc/src/test/resources/expected/sample.md
@@ -63,6 +63,7 @@ public class JumbledIncrementerRule1 {
 |Name|Default Value|Description|
 |----|-------------|-----------|
 |sampleAdditionalProperty|the value|This is a additional property for tests|
+|sampleMultiStringProperty|Value1\|Value2|Test property with multiple strings|
 |sampleDeprecatedProperty|test|<span style="border-radius: 0.25em; color: #fff; padding: 0.2em 0.6em 0.3em; display: inline; background-color: #d9534f; font-size: 75%;">Deprecated</span>  This is a sample deprecated property for tests|
 
 **Use this rule by referencing it:**
@@ -200,6 +201,7 @@ public class JumbledIncrementerRule1 {
 |Name|Default Value|Description|
 |----|-------------|-----------|
 |sampleAdditionalProperty|the value|This is a additional property for tests|
+|sampleMultiStringProperty|Value1\|Value2|Test property with multiple strings|
 |sampleDeprecatedProperty|test|<span style="border-radius: 0.25em; color: #fff; padding: 0.2em 0.6em 0.3em; display: inline; background-color: #d9534f; font-size: 75%;">Deprecated</span>  This is a sample deprecated property for tests|
 
 **Use this rule by referencing it:**

--- a/pmd-doc/src/test/resources/expected/sample.md
+++ b/pmd-doc/src/test/resources/expected/sample.md
@@ -60,11 +60,11 @@ public class JumbledIncrementerRule1 {
 
 **This rule has the following properties:**
 
-|Name|Default Value|Description|
-|----|-------------|-----------|
-|sampleAdditionalProperty|the value|This is a additional property for tests|
-|sampleMultiStringProperty|Value1\|Value2|Test property with multiple strings|
-|sampleDeprecatedProperty|test|<span style="border-radius: 0.25em; color: #fff; padding: 0.2em 0.6em 0.3em; display: inline; background-color: #d9534f; font-size: 75%;">Deprecated</span>  This is a sample deprecated property for tests|
+|Name|Default Value|Description|Multivalued|
+|----|-------------|-----------|-----------|
+|sampleAdditionalProperty|the value|This is a additional property for tests|no|
+|sampleMultiStringProperty|Value1\|Value2|Test property with multiple strings|yes. Delimiter is '\|'|
+|sampleDeprecatedProperty|test|<span style="border-radius: 0.25em; color: #fff; padding: 0.2em 0.6em 0.3em; display: inline; background-color: #d9534f; font-size: 75%;">Deprecated</span>  This is a sample deprecated property for tests|no|
 
 **Use this rule by referencing it:**
 ``` xml
@@ -198,11 +198,11 @@ public class JumbledIncrementerRule1 {
 
 **This rule has the following properties:**
 
-|Name|Default Value|Description|
-|----|-------------|-----------|
-|sampleAdditionalProperty|the value|This is a additional property for tests|
-|sampleMultiStringProperty|Value1\|Value2|Test property with multiple strings|
-|sampleDeprecatedProperty|test|<span style="border-radius: 0.25em; color: #fff; padding: 0.2em 0.6em 0.3em; display: inline; background-color: #d9534f; font-size: 75%;">Deprecated</span>  This is a sample deprecated property for tests|
+|Name|Default Value|Description|Multivalued|
+|----|-------------|-----------|-----------|
+|sampleAdditionalProperty|the value|This is a additional property for tests|no|
+|sampleMultiStringProperty|Value1\|Value2|Test property with multiple strings|yes. Delimiter is '\|'|
+|sampleDeprecatedProperty|test|<span style="border-radius: 0.25em; color: #fff; padding: 0.2em 0.6em 0.3em; display: inline; background-color: #d9534f; font-size: 75%;">Deprecated</span>  This is a sample deprecated property for tests|no|
 
 **Use this rule by referencing it:**
 ``` xml

--- a/pmd-doc/src/test/resources/rulesets/ruledoctest/sample.xml
+++ b/pmd-doc/src/test/resources/rulesets/ruledoctest/sample.xml
@@ -77,6 +77,7 @@ Avoid jumbled loop incrementers - its usually a mistake, and is confusing even i
              </value>
          </property>
          <property name="sampleAdditionalProperty" type="String" description="This is a additional property for tests" value="the value" />
+         <property name="sampleMultiStringProperty" type="List[String]" description="Test property with multiple strings" value="Value1|Value2" />
          <property name="sampleDeprecatedProperty" type="String" description="Deprecated! This is a sample deprecated property for tests" value="test" />
      </properties>
      <example>


### PR DESCRIPTION
Changed two things:

* the default values use now the correct delimiter
* added a additional column "Multivalued" with the delimiter

Fixes #1057 