### PR TITLE
Add checkSingleIfStmt property to ControlStatementBraces

### DIFF
--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -489,6 +489,7 @@ boolean bar(int x, int y) {
         <priority>3</priority>
         <properties>
             <property name="checkIfElseStmt" type="Boolean" value="true" description="Require that 'if ... else' statements use braces" />
+            <property name="checkSingleIfStmt" type="Boolean" value="true" description="Require that 'if' statements with a single branch use braces" />
             <property name="checkWhileStmt" type="Boolean" value="true" description="Require that 'while' loops use braces" />
             <property name="checkForStmt" type="Boolean" value="true" description="Require that 'for' loops should use braces" />
             <property name="checkDoWhileStmt" type="Boolean" value="true" description="Require that 'do ... while' loops use braces" />
@@ -506,7 +507,13 @@ boolean bar(int x, int y) {
                 //DoStatement[$checkDoWhileStmt and not(Statement/Block) and not($allowEmptyLoop and Statement/EmptyStatement)]
                 |
                 (: The violation is reported on the sub statement -- not the if statement :)
-                //Statement[$checkIfElseStmt and parent::IfStatement and not(child::Block or child::IfStatement)]
+                //Statement[$checkIfElseStmt and parent::IfStatement and not(child::Block or child::IfStatement)
+                            (: Whitelists single if statements :)
+                            and ($checkSingleIfStmt
+                                 (: Inside this not(...) is the definition of a "single if statement" :)
+                                 or not(count(../Statement) = 1 (: No else stmt :)
+                                        (: Not the last branch of an 'if ... else if' chain :)
+                                        and not(parent::IfStatement[parent::Statement[parent::IfStatement]])))]
                 |
                 (: Reports case labels if one of their subordinate statements is not braced :)
                 //SwitchLabel[$checkCaseStmt]

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ControlStatementBraces.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ControlStatementBraces.xml
@@ -310,6 +310,98 @@
             ]]></code>
     </test-code>
 
+    <test-code>
+        <description>Single if, allowed</description>
+        <rule-property name="checkSingleIfStmt">false</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class Foo {
+                void foo() {
+                    int x = 0;
+                    if (true)
+                        x++; // this is allowed
+                }
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>If chain, checkSingleIfStmt doesn't apply</description>
+        <rule-property name="checkSingleIfStmt">false</rule-property>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>5,10</expected-linenumbers>
+        <code><![CDATA[
+            public class Foo {
+                void foo() {
+                    int x = 0;
+                    if (true)
+                        x++; // here
+                     else if (false) {
+                        x--;
+                    } else
+
+                        ; // and here
+                }
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>If chain, checkSingleIfStmt doesn't apply (even on last branch)</description>
+        <!-- This test is necessary because if chains are represented as nested if stmt nodes. The
+        last branch, if it has no catch-all 'else' branch, could be naively identified as a "single
+        if statement" -->
+        <rule-property name="checkSingleIfStmt">false</rule-property>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>5,7</expected-linenumbers>
+        <code><![CDATA[
+            public class Foo {
+                void foo() {
+                    int x = 0;
+                    if (true)
+                        x++; // here
+                    else if (false)
+                        x--; // and here
+
+                }
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>If else, braces on else, checkSingleIfStmt doesn't apply</description>
+        <rule-property name="checkSingleIfStmt">false</rule-property>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+            public class Foo {
+                void foo() {
+                    int x = 0;
+                    if (true)
+                        x++;
+                    else {
+                        x--;
+                    }
+                }
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Single if, checkIfElseStmt overrides checkSingleIfStmt</description>
+        <rule-property name="checkSingleIfStmt">true</rule-property>
+        <rule-property name="checkIfElseStmt">false</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class Foo {
+                void foo() {
+                    int x = 0;
+                    if (true)
+                        x++; // this is allowed
+                }
+            }
+            ]]></code>
+    </test-code>
+
 
     <test-code>
         <description>Case, no braces, allowed</description>


### PR DESCRIPTION
Setting this property to false whitelists if statements without braces,
provided they do not appear in an if statement chain.

The property checkIfElseStmt overrides the new property. Unsetting the
former causes the latter to be noop.

Fixes #1004 
