### PR TITLE
[java] Allow numbers in class names by default

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -21,6 +21,11 @@ This is a bug fixing release.
 
 ### Fixed Issues
 
+*   all
+*   java
+*   java-codestyle
+    *   [#1065](https://github.com/pmd/pmd/issues/1065): \[java] ClassNamingConventions shouldn't prohibit numbers in class names
+
 ### API Changes
 
 ### External Contributions

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ClassNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ClassNamingConventionsRule.java
@@ -128,7 +128,7 @@ public class ClassNamingConventionsRule extends AbstractJavaRule {
     private static RegexPBuilder defaultProp(String name) {
         return RegexProperty.named(StringUtil.toCamelCase(name) + "Pattern")
                             .desc("Regex which applies to " + name.trim() + " names")
-                            .defaultValue("[A-Z][a-zA-Z]+");
+                            .defaultValue("[A-Z][a-zA-Z0-9]+");
 
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ClassNamingConventions.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ClassNamingConventions.xml
@@ -35,7 +35,7 @@
         <rule-property name="annotationPattern">[a-z][A-Za-z]*</rule-property>
         <expected-problems>1</expected-problems>
         <expected-messages>
-            <message>The class name 'foo' doesn't match '[A-Z][a-zA-Z]+'</message>
+            <message>The class name 'foo' doesn't match '[A-Z][a-zA-Z0-9]+'</message>
         </expected-messages>
         <code><![CDATA[
             @covfefe
@@ -176,6 +176,15 @@
                 private Foo() {
                 }
 
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Numbers should be allowed by default</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class Md5Checksum {
             }
             ]]></code>
     </test-code>


### PR DESCRIPTION
Fix #1065