### PR TITLE
[java] Fix false-positives on PrematureDeclaration

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -25,6 +25,7 @@ This is a bug fixing release.
     *   [#1063](https://github.com/pmd/pmd/issues/1063): \[java] MissingOverride is triggered in illegal places
 *   java-codestyle
     *   [#1065](https://github.com/pmd/pmd/issues/1065): \[java] ClassNamingConventions shouldn't prohibit numbers in class names
+    *   [#1067](https://github.com/pmd/pmd/issues/1067): \[java] [6.3.0] PrematureDeclaration false-positive
 
 ### API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/PrematureDeclarationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/PrematureDeclarationRule.java
@@ -143,8 +143,7 @@ public class PrematureDeclarationRule extends AbstractJavaRule {
      * @return boolean
      */
     private static boolean hasReferencesIn(ASTBlockStatement block, String varName) {
-
-        List<ASTName> names = block.findDescendantsOfType(ASTName.class);
+        List<ASTName> names = block.findDescendantsOfType(ASTName.class, true); // allow for closures on the var
 
         for (ASTName name : names) {
             if (isReference(varName, name.getImage())) {
@@ -220,7 +219,7 @@ public class PrematureDeclarationRule extends AbstractJavaRule {
         int count = block.jjtGetNumChildren();
         int start = indexOf(block, node.jjtGetParent()) + 1;
 
-        List<ASTBlockStatement> nextBlocks = new ArrayList<>(count);
+        List<ASTBlockStatement> nextBlocks = new ArrayList<>(count - start);
 
         for (int i = start; i < count; i++) {
             Node maybeBlock = block.jjtGetChild(i);

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/PrematureDeclaration.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/PrematureDeclaration.xml
@@ -105,4 +105,17 @@ public class PrematureDeclarationLambda {
 }
         ]]></code>
     </test-code>
+    
+    <test-code>
+        <description>#1067 PrematureDeclaration lambda closure false positive</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class PrematureDeclarationLambda {
+    public boolean lengthSumOf() {
+        String foo = "";
+        return new ArrayList<String>().stream().anyMatch(bar -> foo.equals(bar));
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
 - The code failed to detect closures once we enforced find boundaries,
so we now explicitly ask to cross them
 - Fixes #1067 
