### PR TITLE
[core] Report rule exceptions

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
@@ -504,6 +504,7 @@ public class RuleSet implements ChecksumAware {
                 }
             } catch (RuntimeException e) {
                 if (ctx.isIgnoreExceptions()) {
+                    ctx.getReport().addError(new Report.ProcessingError(e, ctx.getSourceCodeFilename()));
                     if (LOG.isLoggable(Level.WARNING)) {
                         LOG.log(Level.WARNING, "Exception applying rule " + rule.getName() + " on file "
                                 + ctx.getSourceCodeFilename() + ", continuing with next rule", e);

--- a/pmd-java/src/test/java/net/sourceforge/pmd/coverage/PMDCoverageTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/coverage/PMDCoverageTest.java
@@ -18,6 +18,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.StandardErrorStreamLog;
 import org.junit.contrib.java.lang.system.StandardOutputStreamLog;
 
 import net.sourceforge.pmd.PMD;
@@ -26,6 +27,9 @@ public class PMDCoverageTest {
 
     @Rule
     public StandardOutputStreamLog output = new StandardOutputStreamLog();
+
+    @Rule
+    public StandardErrorStreamLog errorStream = new StandardErrorStreamLog();
 
     /**
      * Test some of the PMD command line options
@@ -56,9 +60,12 @@ public class PMDCoverageTest {
 
             PMD.run(args);
 
-            assertFalse("There was at least one exception mentioned in the output", output.getLog().contains("Exception applying rule"));
-            assertFalse("Wrong configuration? Ruleset not found", output.getLog().contains("Ruleset not found"));
-            assertFalse("Some XPath rules use deprecated attributes", output.getLog().contains("Use of deprecated attribute"));
+            assertEquals("Nothing should be output to stdout", 0, output.getLog().length());
+
+
+            assertEquals("No exceptions expected", 0, StringUtils.countMatches(errorStream.getLog(), "Exception applying rule"));
+            assertFalse("Wrong configuration? Ruleset not found", errorStream.getLog().contains("Ruleset not found"));
+            assertEquals("No usage of deprected XPath attributes expected", 0, StringUtils.countMatches(errorStream.getLog(), "Use of deprecated attribute"));
 
             String report = FileUtils.readFileToString(f);
             assertEquals("No processing errors expected", 0, StringUtils.countMatches(report, "Error while processing"));

--- a/pmd-java/src/test/java/net/sourceforge/pmd/coverage/PMDCoverageTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/coverage/PMDCoverageTest.java
@@ -52,10 +52,12 @@ public class PMDCoverageTest {
         try {
             f = File.createTempFile("pmd", ".txt");
             int n = args.length;
-            String[] a = new String[n + 2];
+            String[] a = new String[n + 2 + 2];
             System.arraycopy(args, 0, a, 0, n);
             a[n] = "-reportfile";
             a[n + 1] = f.getAbsolutePath();
+            a[n + 2] = "-threads";
+            a[n + 3] = String.valueOf(Runtime.getRuntime().availableProcessors());
             args = a;
 
             PMD.run(args);


### PR DESCRIPTION
While working on java10 support, I stumbled across these problems:
* PMDCoverageTest didn't break when rules where failing
* There was no processing error reported in the report, even though, rules were failing
* PMDCoverageTest was running single threaded

