### PR TITLE
[core] Rework benchmarking code

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
@@ -6,6 +6,8 @@ package net.sourceforge.pmd;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
 import java.net.URISyntaxException;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -19,9 +21,11 @@ import java.util.logging.ConsoleHandler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import net.sourceforge.pmd.benchmark.Benchmark;
-import net.sourceforge.pmd.benchmark.Benchmarker;
-import net.sourceforge.pmd.benchmark.TextReport;
+import net.sourceforge.pmd.benchmark.TextTimingReportRenderer;
+import net.sourceforge.pmd.benchmark.TimeTracker;
+import net.sourceforge.pmd.benchmark.TimedOperationCategory;
+import net.sourceforge.pmd.benchmark.TimingReport;
+import net.sourceforge.pmd.benchmark.TimingReportRenderer;
 import net.sourceforge.pmd.cache.NoopAnalysisCache;
 import net.sourceforge.pmd.cli.PMDCommandLineInterface;
 import net.sourceforge.pmd.cli.PMDParameters;
@@ -206,7 +210,7 @@ public class PMD {
         Set<Language> languages = getApplicableLanguages(configuration, ruleSets);
         List<DataSource> files = getApplicableFiles(configuration, languages);
 
-        long reportStart = System.nanoTime();
+        TimeTracker.startOperation(TimedOperationCategory.REPORTING);
         try {
             Renderer renderer = configuration.createRenderer();
             List<Renderer> renderers = Collections.singletonList(renderer);
@@ -214,14 +218,14 @@ public class PMD {
             renderer.setWriter(IOUtil.createWriter(configuration.getReportFile()));
             renderer.start();
 
-            Benchmarker.mark(Benchmark.Reporting, System.nanoTime() - reportStart, 0);
+            TimeTracker.finishOperation();
 
             RuleContext ctx = new RuleContext();
             final AtomicInteger violations = new AtomicInteger(0);
             ctx.getReport().addListener(new ThreadSafeReportListener() {
                 @Override
                 public void ruleViolationAdded(RuleViolation ruleViolation) {
-                    violations.incrementAndGet();
+                    violations.getAndIncrement();
                 }
 
                 @Override
@@ -230,9 +234,11 @@ public class PMD {
                 }
             });
 
+            TimeTracker.startOperation(TimedOperationCategory.FILE_PROCESSING);
             processFiles(configuration, ruleSetFactory, files, ctx, renderers);
+            TimeTracker.finishOperation();
 
-            reportStart = System.nanoTime();
+            TimeTracker.startOperation(TimedOperationCategory.REPORTING);
             renderer.end();
             renderer.flush();
             return violations.get();
@@ -247,8 +253,8 @@ public class PMD {
             LOG.info(PMDCommandLineInterface.buildUsageText());
             return 0;
         } finally {
-            Benchmarker.mark(Benchmark.Reporting, System.nanoTime() - reportStart, 0);
-
+            TimeTracker.finishOperation();
+            
             /*
              * Make sure it's our own classloader before attempting to close it....
              * Maven + Jacoco provide us with a cloaseable classloader that if closed
@@ -355,10 +361,9 @@ public class PMD {
      * @return List of {@link DataSource} of files
      */
     public static List<DataSource> getApplicableFiles(PMDConfiguration configuration, Set<Language> languages) {
-        long startFiles = System.nanoTime();
+        TimeTracker.startOperation(TimedOperationCategory.COLLECT_FILES);
         List<DataSource> files = internalGetApplicableFiles(configuration, languages);
-        long endFiles = System.nanoTime();
-        Benchmarker.mark(Benchmark.CollectFiles, endFiles - startFiles, 0);
+        TimeTracker.finishOperation();
         return files;
     }
 
@@ -443,9 +448,13 @@ public class PMD {
      *         violations found.
      */
     public static int run(String[] args) {
-        int status = 0;
-        long start = System.nanoTime();
         final PMDParameters params = PMDCommandLineInterface.extractParameters(new PMDParameters(), args, "pmd");
+        
+        if (params.isBenchmark()) {
+            TimeTracker.startGlobalTracking();
+        }
+        
+        int status = 0;
         final PMDConfiguration configuration = params.toConfiguration();
 
         final Level logLevel = params.isDebug() ? Level.FINER : Level.INFO;
@@ -470,14 +479,19 @@ public class PMD {
         } finally {
             logHandlerManager.close();
             LOG.setLevel(oldLogLevel);
+            
             if (params.isBenchmark()) {
-                long end = System.nanoTime();
-                Benchmarker.mark(Benchmark.TotalPMD, end - start, 0);
+                final TimingReport timingReport = TimeTracker.stopGlobalTracking();
 
                 // TODO get specified report format from config
-                TextReport report = new TextReport();
-
-                report.generate(Benchmarker.values(), System.err);
+                final TimingReportRenderer renderer = new TextTimingReportRenderer();
+                try {
+                    // Don't close this writer, we don't want to close stderr
+                    final Writer writer = new OutputStreamWriter(System.err);
+                    renderer.render(timingReport, writer);
+                } catch (final IOException e) {
+                    System.err.println(e.getMessage());
+                }
             }
         }
         return status;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
@@ -19,6 +19,7 @@ import java.util.logging.Logger;
 import org.apache.commons.lang3.StringUtils;
 
 import net.sourceforge.pmd.benchmark.TimeTracker;
+import net.sourceforge.pmd.benchmark.TimedOperation;
 import net.sourceforge.pmd.benchmark.TimedOperationCategory;
 import net.sourceforge.pmd.cache.ChecksumAware;
 import net.sourceforge.pmd.lang.Language;
@@ -493,29 +494,27 @@ public class RuleSet implements ChecksumAware {
      *            the current context
      */
     public void apply(List<? extends Node> acuList, RuleContext ctx) {
-        TimeTracker.startOperation(TimedOperationCategory.RULE);
-        for (Rule rule : rules) {
-            try {
+        try (TimedOperation to = TimeTracker.startOperation(TimedOperationCategory.RULE)) {
+            for (Rule rule : rules) {
                 if (!rule.isRuleChain() && applies(rule, ctx.getLanguageVersion())) {
-                    TimeTracker.startOperation(TimedOperationCategory.RULE, rule.getName());
-                    rule.apply(acuList, ctx);
-                    TimeTracker.finishOperation();
-                }
-            } catch (RuntimeException e) {
-                if (ctx.isIgnoreExceptions()) {
-                    TimeTracker.finishOperation();
-                    ctx.getReport().addError(new Report.ProcessingError(e, ctx.getSourceCodeFilename()));
-                    
-                    if (LOG.isLoggable(Level.WARNING)) {
-                        LOG.log(Level.WARNING, "Exception applying rule " + rule.getName() + " on file "
-                                + ctx.getSourceCodeFilename() + ", continuing with next rule", e);
+
+                    try (TimedOperation rto = TimeTracker.startOperation(TimedOperationCategory.RULE, rule.getName())) {
+                        rule.apply(acuList, ctx);
+                    } catch (RuntimeException e) {
+                        if (ctx.isIgnoreExceptions()) {
+                            ctx.getReport().addError(new Report.ProcessingError(e, ctx.getSourceCodeFilename()));
+
+                            if (LOG.isLoggable(Level.WARNING)) {
+                                LOG.log(Level.WARNING, "Exception applying rule " + rule.getName() + " on file "
+                                        + ctx.getSourceCodeFilename() + ", continuing with next rule", e);
+                            }
+                        } else {
+                            throw e;
+                        }
                     }
-                } else {
-                    throw e;
                 }
             }
         }
-        TimeTracker.finishOperation();
     }
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
@@ -18,8 +18,8 @@ import java.util.logging.Logger;
 
 import org.apache.commons.lang3.StringUtils;
 
-import net.sourceforge.pmd.benchmark.Benchmark;
-import net.sourceforge.pmd.benchmark.Benchmarker;
+import net.sourceforge.pmd.benchmark.TimeTracker;
+import net.sourceforge.pmd.benchmark.TimedOperationCategory;
 import net.sourceforge.pmd.cache.ChecksumAware;
 import net.sourceforge.pmd.lang.Language;
 import net.sourceforge.pmd.lang.LanguageVersion;
@@ -493,18 +493,19 @@ public class RuleSet implements ChecksumAware {
      *            the current context
      */
     public void apply(List<? extends Node> acuList, RuleContext ctx) {
-        long start = System.nanoTime();
+        TimeTracker.startOperation(TimedOperationCategory.RULE);
         for (Rule rule : rules) {
             try {
                 if (!rule.isRuleChain() && applies(rule, ctx.getLanguageVersion())) {
+                    TimeTracker.startOperation(TimedOperationCategory.RULE, rule.getName());
                     rule.apply(acuList, ctx);
-                    long end = System.nanoTime();
-                    Benchmarker.mark(Benchmark.Rule, rule.getName(), end - start, 1);
-                    start = end;
+                    TimeTracker.finishOperation();
                 }
             } catch (RuntimeException e) {
                 if (ctx.isIgnoreExceptions()) {
+                    TimeTracker.finishOperation();
                     ctx.getReport().addError(new Report.ProcessingError(e, ctx.getSourceCodeFilename()));
+                    
                     if (LOG.isLoggable(Level.WARNING)) {
                         LOG.log(Level.WARNING, "Exception applying rule " + rule.getName() + " on file "
                                 + ctx.getSourceCodeFilename() + ", continuing with next rule", e);
@@ -514,6 +515,7 @@ public class RuleSet implements ChecksumAware {
                 }
             }
         }
+        TimeTracker.finishOperation();
     }
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RulesetsFactoryUtils.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RulesetsFactoryUtils.java
@@ -7,8 +7,8 @@ package net.sourceforge.pmd;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import net.sourceforge.pmd.benchmark.Benchmark;
-import net.sourceforge.pmd.benchmark.Benchmarker;
+import net.sourceforge.pmd.benchmark.TimeTracker;
+import net.sourceforge.pmd.benchmark.TimedOperationCategory;
 import net.sourceforge.pmd.util.ResourceLoader;
 
 public final class RulesetsFactoryUtils {
@@ -62,13 +62,12 @@ public final class RulesetsFactoryUtils {
      *             a ruleset couldn't be found.
      */
     public static RuleSets getRuleSetsWithBenchmark(String rulesets, RuleSetFactory factory) {
-        long loadRuleStart = System.nanoTime();
+        TimeTracker.startOperation(TimedOperationCategory.LOAD_RULES);
         RuleSets ruleSets = null;
         try {
             ruleSets = getRuleSets(rulesets, factory);
         } finally {
-            long endLoadRules = System.nanoTime();
-            Benchmarker.mark(Benchmark.LoadRules, endLoadRules - loadRuleStart, 0);
+            TimeTracker.finishOperation();
         }
         return ruleSets;
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RulesetsFactoryUtils.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RulesetsFactoryUtils.java
@@ -8,6 +8,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import net.sourceforge.pmd.benchmark.TimeTracker;
+import net.sourceforge.pmd.benchmark.TimedOperation;
 import net.sourceforge.pmd.benchmark.TimedOperationCategory;
 import net.sourceforge.pmd.util.ResourceLoader;
 
@@ -62,14 +63,9 @@ public final class RulesetsFactoryUtils {
      *             a ruleset couldn't be found.
      */
     public static RuleSets getRuleSetsWithBenchmark(String rulesets, RuleSetFactory factory) {
-        TimeTracker.startOperation(TimedOperationCategory.LOAD_RULES);
-        RuleSets ruleSets = null;
-        try {
-            ruleSets = getRuleSets(rulesets, factory);
-        } finally {
-            TimeTracker.finishOperation();
+        try (TimedOperation to = TimeTracker.startOperation(TimedOperationCategory.LOAD_RULES)) {
+            return getRuleSets(rulesets, factory);
         }
-        return ruleSets;
     }
 
     public static RuleSetFactory getRulesetFactory(final PMDConfiguration configuration,

--- a/pmd-core/src/main/java/net/sourceforge/pmd/SourceCodeProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/SourceCodeProcessor.java
@@ -11,8 +11,8 @@ import java.io.Reader;
 import java.util.Collections;
 import java.util.List;
 
-import net.sourceforge.pmd.benchmark.Benchmark;
-import net.sourceforge.pmd.benchmark.Benchmarker;
+import net.sourceforge.pmd.benchmark.TimeTracker;
+import net.sourceforge.pmd.benchmark.TimedOperationCategory;
 import net.sourceforge.pmd.lang.Language;
 import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.lang.LanguageVersionHandler;
@@ -106,26 +106,23 @@ public class SourceCodeProcessor {
     }
 
     private Node parse(RuleContext ctx, Reader sourceCode, Parser parser) {
-        long start = System.nanoTime();
+        TimeTracker.startOperation(TimedOperationCategory.PARSER);
         Node rootNode = parser.parse(ctx.getSourceCodeFilename(), sourceCode);
         ctx.getReport().suppress(parser.getSuppressMap());
-        long end = System.nanoTime();
-        Benchmarker.mark(Benchmark.Parser, end - start, 0);
+        TimeTracker.finishOperation();
         return rootNode;
     }
 
     private void symbolFacade(Node rootNode, LanguageVersionHandler languageVersionHandler) {
-        long start = System.nanoTime();
+        TimeTracker.startOperation(TimedOperationCategory.SYMBOL_TABLE);
         languageVersionHandler.getSymbolFacade(configuration.getClassLoader()).start(rootNode);
-        long end = System.nanoTime();
-        Benchmarker.mark(Benchmark.SymbolTable, end - start, 0);
+        TimeTracker.finishOperation();
     }
 
     private void resolveQualifiedNames(Node rootNode, LanguageVersionHandler handler) {
-        long start = System.nanoTime();
+        TimeTracker.startOperation(TimedOperationCategory.QUALIFIED_NAME_RESOLUTION);
         handler.getQualifiedNameResolutionFacade(configuration.getClassLoader()).start(rootNode);
-        long end = System.nanoTime();
-        Benchmarker.mark(Benchmark.QualifiedNameResolution, end - start, 0);
+        TimeTracker.finishOperation();
     }
 
     // private ParserOptions getParserOptions(final LanguageVersionHandler
@@ -139,11 +136,10 @@ public class SourceCodeProcessor {
 
     private void usesDFA(LanguageVersion languageVersion, Node rootNode, RuleSets ruleSets, Language language) {
         if (ruleSets.usesDFA(language)) {
-            long start = System.nanoTime();
+            TimeTracker.startOperation(TimedOperationCategory.DFA);
             VisitorStarter dataFlowFacade = languageVersion.getLanguageVersionHandler().getDataFlowFacade();
             dataFlowFacade.start(rootNode);
-            long end = System.nanoTime();
-            Benchmarker.mark(Benchmark.DFA, end - start, 0);
+            TimeTracker.finishOperation();
         }
     }
 
@@ -151,11 +147,10 @@ public class SourceCodeProcessor {
             Language language) {
 
         if (ruleSets.usesTypeResolution(language)) {
-            long start = System.nanoTime();
+            TimeTracker.startOperation(TimedOperationCategory.TYPE_RESOLUTION);
             languageVersion.getLanguageVersionHandler().getTypeResolutionFacade(configuration.getClassLoader())
                     .start(rootNode);
-            long end = System.nanoTime();
-            Benchmarker.mark(Benchmark.TypeResolution, end - start, 0);
+            TimeTracker.finishOperation();
         }
     }
 
@@ -164,10 +159,9 @@ public class SourceCodeProcessor {
                                Language language) {
 
         if (ruleSets.usesMultifile(language)) {
-            long start = System.nanoTime();
+            TimeTracker.startOperation(TimedOperationCategory.MULTIFILE_ANALYSIS);
             languageVersionHandler.getMultifileFacade().start(rootNode);
-            long end = System.nanoTime();
-            Benchmarker.mark(Benchmark.Multifile, end - start, 0);
+            TimeTracker.finishOperation();
         }
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/SourceCodeProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/SourceCodeProcessor.java
@@ -12,6 +12,7 @@ import java.util.Collections;
 import java.util.List;
 
 import net.sourceforge.pmd.benchmark.TimeTracker;
+import net.sourceforge.pmd.benchmark.TimedOperation;
 import net.sourceforge.pmd.benchmark.TimedOperationCategory;
 import net.sourceforge.pmd.lang.Language;
 import net.sourceforge.pmd.lang.LanguageVersion;
@@ -106,23 +107,23 @@ public class SourceCodeProcessor {
     }
 
     private Node parse(RuleContext ctx, Reader sourceCode, Parser parser) {
-        TimeTracker.startOperation(TimedOperationCategory.PARSER);
-        Node rootNode = parser.parse(ctx.getSourceCodeFilename(), sourceCode);
-        ctx.getReport().suppress(parser.getSuppressMap());
-        TimeTracker.finishOperation();
-        return rootNode;
+        try (TimedOperation to = TimeTracker.startOperation(TimedOperationCategory.PARSER)) {
+            Node rootNode = parser.parse(ctx.getSourceCodeFilename(), sourceCode);
+            ctx.getReport().suppress(parser.getSuppressMap());
+            return rootNode;
+        }
     }
 
     private void symbolFacade(Node rootNode, LanguageVersionHandler languageVersionHandler) {
-        TimeTracker.startOperation(TimedOperationCategory.SYMBOL_TABLE);
-        languageVersionHandler.getSymbolFacade(configuration.getClassLoader()).start(rootNode);
-        TimeTracker.finishOperation();
+        try (TimedOperation to = TimeTracker.startOperation(TimedOperationCategory.SYMBOL_TABLE)) {
+            languageVersionHandler.getSymbolFacade(configuration.getClassLoader()).start(rootNode);
+        }
     }
 
     private void resolveQualifiedNames(Node rootNode, LanguageVersionHandler handler) {
-        TimeTracker.startOperation(TimedOperationCategory.QUALIFIED_NAME_RESOLUTION);
-        handler.getQualifiedNameResolutionFacade(configuration.getClassLoader()).start(rootNode);
-        TimeTracker.finishOperation();
+        try (TimedOperation to = TimeTracker.startOperation(TimedOperationCategory.QUALIFIED_NAME_RESOLUTION)) {
+            handler.getQualifiedNameResolutionFacade(configuration.getClassLoader()).start(rootNode);
+        }
     }
 
     // private ParserOptions getParserOptions(final LanguageVersionHandler
@@ -136,10 +137,10 @@ public class SourceCodeProcessor {
 
     private void usesDFA(LanguageVersion languageVersion, Node rootNode, RuleSets ruleSets, Language language) {
         if (ruleSets.usesDFA(language)) {
-            TimeTracker.startOperation(TimedOperationCategory.DFA);
-            VisitorStarter dataFlowFacade = languageVersion.getLanguageVersionHandler().getDataFlowFacade();
-            dataFlowFacade.start(rootNode);
-            TimeTracker.finishOperation();
+            try (TimedOperation to = TimeTracker.startOperation(TimedOperationCategory.DFA)) {
+                VisitorStarter dataFlowFacade = languageVersion.getLanguageVersionHandler().getDataFlowFacade();
+                dataFlowFacade.start(rootNode);
+            }
         }
     }
 
@@ -147,10 +148,10 @@ public class SourceCodeProcessor {
             Language language) {
 
         if (ruleSets.usesTypeResolution(language)) {
-            TimeTracker.startOperation(TimedOperationCategory.TYPE_RESOLUTION);
-            languageVersion.getLanguageVersionHandler().getTypeResolutionFacade(configuration.getClassLoader())
-                    .start(rootNode);
-            TimeTracker.finishOperation();
+            try (TimedOperation to = TimeTracker.startOperation(TimedOperationCategory.TYPE_RESOLUTION)) {
+                languageVersion.getLanguageVersionHandler().getTypeResolutionFacade(configuration.getClassLoader())
+                        .start(rootNode);
+            }
         }
     }
 
@@ -159,9 +160,9 @@ public class SourceCodeProcessor {
                                Language language) {
 
         if (ruleSets.usesMultifile(language)) {
-            TimeTracker.startOperation(TimedOperationCategory.MULTIFILE_ANALYSIS);
-            languageVersionHandler.getMultifileFacade().start(rootNode);
-            TimeTracker.finishOperation();
+            try (TimedOperation to = TimeTracker.startOperation(TimedOperationCategory.MULTIFILE_ANALYSIS)) {
+                languageVersionHandler.getMultifileFacade().start(rootNode);
+            }
         }
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/Benchmark.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/Benchmark.java
@@ -9,6 +9,7 @@ package net.sourceforge.pmd.benchmark;
  *
  * @author Brian Remedios
  */
+@Deprecated
 public enum Benchmark {
     // The constants must be sorted in execution order,
     // the index is derived from the ordinal of the constant

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/BenchmarkReport.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/BenchmarkReport.java
@@ -12,6 +12,7 @@ import java.util.Set;
  *
  * @author Brian Remedios
  */
+@Deprecated
 public interface BenchmarkReport {
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/BenchmarkResult.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/BenchmarkResult.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.benchmark;
 
+@Deprecated
 class BenchmarkResult implements Comparable<BenchmarkResult> {
 
     public final Benchmark type;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/Benchmarker.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/Benchmarker.java
@@ -37,9 +37,9 @@ import net.sourceforge.pmd.util.FileUtil;
 import net.sourceforge.pmd.util.datasource.DataSource;
 
 /**
- *
- *
+ * @deprecated use {@link TimeTracker} instead
  */
+@Deprecated
 public final class Benchmarker {
 
     private static final Map<String, BenchmarkResult> BENCHMARKS_BY_NAME = new HashMap<>();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/RuleDuration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/RuleDuration.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.benchmark;
 
 import net.sourceforge.pmd.Rule;
 
+@Deprecated
 public class RuleDuration implements Comparable<RuleDuration> {
 
     public Rule rule;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/StringBuilderCR.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/StringBuilderCR.java
@@ -10,6 +10,7 @@ package net.sourceforge.pmd.benchmark;
  *
  * @author Brian Remedios
  */
+@Deprecated
 public class StringBuilderCR {
 
     private final String cr;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TextReport.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TextReport.java
@@ -20,6 +20,7 @@ import net.sourceforge.pmd.PMD;
  *
  *
  */
+@Deprecated
 public class TextReport implements BenchmarkReport {
 
     private static final int TIME_COLUMN = 48;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TextTimingReportRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TextTimingReportRenderer.java
@@ -1,0 +1,150 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.benchmark;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.text.MessageFormat;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.TreeSet;
+
+import org.apache.commons.lang3.StringUtils;
+
+import net.sourceforge.pmd.PMD;
+import net.sourceforge.pmd.benchmark.TimeTracker.TimedResult;
+
+/**
+ * A text based renderer for {@link TimingReport}
+ * @author Juan Martín Sotuyo Dodero
+ */
+public class TextTimingReportRenderer implements TimingReportRenderer {
+    
+    private static final String TIME_FORMAT = "{0,number,0.0000}";
+    private static final String CUSTOM_COUNTER_FORMAT = "{0,number,###,###,###}";
+    
+    private static final int LABEL_COLUMN_WIDTH = 50;
+    private static final int TIME_COLUMN_WIDTH = 12;
+    private static final int SELF_TIME_COLUMN_WIDTH = 17;
+    private static final int CALL_COLUMN_WIDTH = 9;
+    private static final int COUNTER_COLUMN_WIDTH = 12;
+    
+    private static final int COLUMNS = LABEL_COLUMN_WIDTH + TIME_COLUMN_WIDTH
+            + SELF_TIME_COLUMN_WIDTH + CALL_COLUMN_WIDTH + COUNTER_COLUMN_WIDTH;
+
+    @Override
+    public void render(final TimingReport report, final Writer writer) throws IOException {
+        for (final TimedOperationCategory category : TimedOperationCategory.values()) {
+            final Map<String, TimedResult> labeledMeassurements = report.getLabeledMeassurements(category);
+            if (!labeledMeassurements.isEmpty()) {
+                renderCategoryMeassurements(category, labeledMeassurements, writer);
+            }
+        }
+        
+        renderHeader("Summary", writer);
+        
+        for (final TimedOperationCategory category : TimedOperationCategory.values()) {
+            final TimedResult timedResult = report.getUnlabeledMeassurements(category);
+            if (timedResult != null) {
+                renderMeassurement(category.displayName(), timedResult, writer);
+            }
+        }
+        
+        writer.write(PMD.EOL);
+        renderHeader("Total", writer);
+        
+        writer.write(StringUtils.rightPad("Wall Clock Time", LABEL_COLUMN_WIDTH));
+        final String wallClockTime = MessageFormat.format(TIME_FORMAT, report.getWallClockTimeMs() / 1000.0);
+        writer.write(StringUtils.leftPad(wallClockTime, TIME_COLUMN_WIDTH));
+        writer.write(PMD.EOL);
+        
+        writer.flush();
+    }
+
+    private void renderMeassurement(final String label, final TimedResult timedResult,
+            final Writer writer) throws IOException {
+        writer.write(StringUtils.rightPad(label, LABEL_COLUMN_WIDTH));
+        
+        final String time = MessageFormat.format(TIME_FORMAT, timedResult.totalTime.get() / 1000000000.0);
+        writer.write(StringUtils.leftPad(time, TIME_COLUMN_WIDTH));
+        
+        final String selfTime = MessageFormat.format(TIME_FORMAT, timedResult.selfTime.get() / 1000000000.0);
+        writer.write(StringUtils.leftPad(selfTime, SELF_TIME_COLUMN_WIDTH));
+        
+        if (timedResult.callCount.get() > 0) {
+            final String callCount = MessageFormat.format(CUSTOM_COUNTER_FORMAT, timedResult.callCount.get());
+            writer.write(StringUtils.leftPad(callCount, CALL_COLUMN_WIDTH));
+            
+            if (timedResult.extraDataCounter.get() > 0) {
+                final String counter = MessageFormat.format(CUSTOM_COUNTER_FORMAT, timedResult.extraDataCounter.get());
+                writer.write(StringUtils.leftPad(counter, COUNTER_COLUMN_WIDTH));
+            }
+        }
+        
+        writer.write(PMD.EOL);
+    }
+
+    private void renderCategoryMeassurements(final TimedOperationCategory category,
+            final Map<String, TimedResult> labeledMeassurements, final Writer writer) throws IOException {
+        renderHeader(category.displayName(), writer);
+        
+        final TimedResult grandTotal = new TimedResult();
+        final TreeSet<Map.Entry<String, TimedResult>> sortedKeySet = new TreeSet<>(
+            new Comparator<Map.Entry<String, TimedResult>>() {
+                @Override
+                public int compare(final Entry<String, TimedResult> o1, final Entry<String, TimedResult> o2) {
+                    final long diff = o1.getValue().selfTime.get() - o2.getValue().selfTime.get();
+                    if (diff > 0) {
+                        return 1;
+                    } else if (diff < 0) {
+                        return -1;
+                    }
+                    return 0;
+                }
+            });
+        sortedKeySet.addAll(labeledMeassurements.entrySet());
+        
+        for (final Map.Entry<String, TimedResult> entry : sortedKeySet) {
+            renderMeassurement(entry.getKey(), entry.getValue(), writer);
+            grandTotal.mergeTimes(entry.getValue());
+        }
+        
+        writer.write(PMD.EOL);
+        renderMeassurement("Total " + category.displayName(), grandTotal, writer);
+        writer.write(PMD.EOL);
+    }
+
+    private void renderHeader(final String displayName, final Writer writer) throws IOException {
+        final StringBuilder sb = new StringBuilder(COLUMNS)
+                .append(displayName);
+        
+        // Make sure we have an even-length string
+        if (displayName.length() % 2 == 1) {
+            sb.append(' ');
+        }
+        
+        // Surround with <<< and >>>
+        sb.insert(0, "<<< ").append(" >>>");
+        
+        // Create the ruler
+        while (sb.length() < COLUMNS) {
+            sb.insert(0, '-').append('-');
+        }
+        
+        writer.write(sb.toString());
+        writer.write(PMD.EOL);
+        
+        // Write table titles
+        writer.write(StringUtils.rightPad("Label", LABEL_COLUMN_WIDTH));
+        writer.write(StringUtils.leftPad("Time (secs)", TIME_COLUMN_WIDTH));
+        writer.write(StringUtils.leftPad("Self Time (secs)", SELF_TIME_COLUMN_WIDTH));
+        writer.write(StringUtils.leftPad("# Calls", CALL_COLUMN_WIDTH));
+        writer.write(StringUtils.leftPad("Counter", COUNTER_COLUMN_WIDTH));
+        writer.write(PMD.EOL);
+        writer.write(PMD.EOL);
+    }
+
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TextTimingReportRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TextTimingReportRenderer.java
@@ -57,7 +57,7 @@ public class TextTimingReportRenderer implements TimingReportRenderer {
         renderHeader("Total", writer);
         
         writer.write(StringUtils.rightPad("Wall Clock Time", LABEL_COLUMN_WIDTH));
-        final String wallClockTime = MessageFormat.format(TIME_FORMAT, report.getWallClockTimeMs() / 1000.0);
+        final String wallClockTime = MessageFormat.format(TIME_FORMAT, report.getWallClockMillis() / 1000.0);
         writer.write(StringUtils.leftPad(wallClockTime, TIME_COLUMN_WIDTH));
         writer.write(PMD.EOL);
         

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TextTimingReportRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TextTimingReportRenderer.java
@@ -68,10 +68,10 @@ public class TextTimingReportRenderer implements TimingReportRenderer {
             final Writer writer) throws IOException {
         writer.write(StringUtils.rightPad(label, LABEL_COLUMN_WIDTH));
         
-        final String time = MessageFormat.format(TIME_FORMAT, timedResult.totalTime.get() / 1000000000.0);
+        final String time = MessageFormat.format(TIME_FORMAT, timedResult.totalTimeNanos.get() / 1000000000.0);
         writer.write(StringUtils.leftPad(time, TIME_COLUMN_WIDTH));
         
-        final String selfTime = MessageFormat.format(TIME_FORMAT, timedResult.selfTime.get() / 1000000000.0);
+        final String selfTime = MessageFormat.format(TIME_FORMAT, timedResult.selfTimeNanos.get() / 1000000000.0);
         writer.write(StringUtils.leftPad(selfTime, SELF_TIME_COLUMN_WIDTH));
         
         if (timedResult.callCount.get() > 0) {
@@ -96,7 +96,7 @@ public class TextTimingReportRenderer implements TimingReportRenderer {
             new Comparator<Map.Entry<String, TimedResult>>() {
                 @Override
                 public int compare(final Entry<String, TimedResult> o1, final Entry<String, TimedResult> o2) {
-                    return Long.compare(o1.getValue().selfTime.get(), o2.getValue().selfTime.get());
+                    return Long.compare(o1.getValue().selfTimeNanos.get(), o2.getValue().selfTimeNanos.get());
                 }
             });
         sortedKeySet.addAll(labeledMeasurements.entrySet());

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TextTimingReportRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TextTimingReportRenderer.java
@@ -18,7 +18,7 @@ import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.benchmark.TimeTracker.TimedResult;
 
 /**
- * A text based renderer for {@link TimingReport}
+ * A text based renderer for {@link TimingReport}.
  * @author Juan Martín Sotuyo Dodero
  */
 public class TextTimingReportRenderer implements TimingReportRenderer {
@@ -38,18 +38,18 @@ public class TextTimingReportRenderer implements TimingReportRenderer {
     @Override
     public void render(final TimingReport report, final Writer writer) throws IOException {
         for (final TimedOperationCategory category : TimedOperationCategory.values()) {
-            final Map<String, TimedResult> labeledMeassurements = report.getLabeledMeassurements(category);
-            if (!labeledMeassurements.isEmpty()) {
-                renderCategoryMeassurements(category, labeledMeassurements, writer);
+            final Map<String, TimedResult> labeledMeasurements = report.getLabeledMeasurements(category);
+            if (!labeledMeasurements.isEmpty()) {
+                renderCategoryMeasurements(category, labeledMeasurements, writer);
             }
         }
         
         renderHeader("Summary", writer);
         
         for (final TimedOperationCategory category : TimedOperationCategory.values()) {
-            final TimedResult timedResult = report.getUnlabeledMeassurements(category);
+            final TimedResult timedResult = report.getUnlabeledMeasurements(category);
             if (timedResult != null) {
-                renderMeassurement(category.displayName(), timedResult, writer);
+                renderMeasurement(category.displayName(), timedResult, writer);
             }
         }
         
@@ -64,7 +64,7 @@ public class TextTimingReportRenderer implements TimingReportRenderer {
         writer.flush();
     }
 
-    private void renderMeassurement(final String label, final TimedResult timedResult,
+    private void renderMeasurement(final String label, final TimedResult timedResult,
             final Writer writer) throws IOException {
         writer.write(StringUtils.rightPad(label, LABEL_COLUMN_WIDTH));
         
@@ -87,8 +87,8 @@ public class TextTimingReportRenderer implements TimingReportRenderer {
         writer.write(PMD.EOL);
     }
 
-    private void renderCategoryMeassurements(final TimedOperationCategory category,
-            final Map<String, TimedResult> labeledMeassurements, final Writer writer) throws IOException {
+    private void renderCategoryMeasurements(final TimedOperationCategory category,
+            final Map<String, TimedResult> labeledMeasurements, final Writer writer) throws IOException {
         renderHeader(category.displayName(), writer);
         
         final TimedResult grandTotal = new TimedResult();
@@ -96,24 +96,18 @@ public class TextTimingReportRenderer implements TimingReportRenderer {
             new Comparator<Map.Entry<String, TimedResult>>() {
                 @Override
                 public int compare(final Entry<String, TimedResult> o1, final Entry<String, TimedResult> o2) {
-                    final long diff = o1.getValue().selfTime.get() - o2.getValue().selfTime.get();
-                    if (diff > 0) {
-                        return 1;
-                    } else if (diff < 0) {
-                        return -1;
-                    }
-                    return 0;
+                    return Long.compare(o1.getValue().selfTime.get(), o2.getValue().selfTime.get());
                 }
             });
-        sortedKeySet.addAll(labeledMeassurements.entrySet());
+        sortedKeySet.addAll(labeledMeasurements.entrySet());
         
         for (final Map.Entry<String, TimedResult> entry : sortedKeySet) {
-            renderMeassurement(entry.getKey(), entry.getValue(), writer);
+            renderMeasurement(entry.getKey(), entry.getValue(), writer);
             grandTotal.mergeTimes(entry.getValue());
         }
         
         writer.write(PMD.EOL);
-        renderMeassurement("Total " + category.displayName(), grandTotal, writer);
+        renderMeasurement("Total " + category.displayName(), grandTotal, writer);
         writer.write(PMD.EOL);
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimeTracker.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimeTracker.java
@@ -22,7 +22,7 @@ import java.util.concurrent.atomic.AtomicLong;
 public final class TimeTracker {
 
     private static boolean trackTime = false;
-    private static long wallClockStart = -1;
+    private static long wallClockStartMillis = -1;
     private static final ThreadLocal<Queue<TimerEntry>> TIMER_ENTRIES;
     private static final ConcurrentMap<TimedOperation, TimedResult> ACCUMULATED_RESULTS = new ConcurrentHashMap<>();
     
@@ -46,8 +46,9 @@ public final class TimeTracker {
      * Must be called once PMD starts if tracking is desired, no tracking will be performed otherwise.
      */
     public static void startGlobalTracking() {
-        wallClockStart = System.currentTimeMillis();
+        wallClockStartMillis = System.currentTimeMillis();
         trackTime = true;
+        ACCUMULATED_RESULTS.clear(); // just in case
         initThread(); // init main thread
     }
     
@@ -68,7 +69,7 @@ public final class TimeTracker {
                 new TimedOperation(TimedOperationCategory.UNACCOUNTED, null));
         unaccountedResult.totalTime.set(unaccountedResult.selfTime.get());
         
-        return new TimingReport(System.currentTimeMillis() - wallClockStart, ACCUMULATED_RESULTS);
+        return new TimingReport(System.currentTimeMillis() - wallClockStartMillis, ACCUMULATED_RESULTS);
     }
     
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimeTracker.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimeTracker.java
@@ -1,0 +1,240 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.benchmark;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * A time tracker class to measure time spent on different sections of PMD analysis.
+ * The class is thread-aware, allowing to differentiate CPU and wall clock time.
+ * 
+ * @author Juan Martín Sotuyo Dodero
+ */
+public final class TimeTracker {
+
+    private static boolean trackTime = false;
+    private static long wallClockStart = -1;
+    private static final ThreadLocal<Queue<TimerEntry>> TIMER_ENTRIES;
+    private static final ConcurrentMap<TimedOperation, TimedResult> ACCUMULATED_RESULTS = new ConcurrentHashMap<>();
+    
+    static {
+        TIMER_ENTRIES = new ThreadLocal<Queue<TimerEntry>>() {
+            @Override
+            protected Queue<TimerEntry> initialValue() {
+                final Queue<TimerEntry> queue = Collections.asLifoQueue(new LinkedList<TimerEntry>());
+                queue.add(new TimerEntry(TimedOperationCategory.UNACCOUNTED, null));
+                return queue;
+            }
+        };
+    }
+    
+    private TimeTracker() {
+        throw new AssertionError("Can't instantiate utility class");
+    }
+    
+    /**
+     * Starts global tracking. Allows tracking operations to take place and starts the wall clock.
+     * Must be called once PMD starts if tracking is desired, no tracking will be performed otherwise.
+     */
+    public static void startGlobalTracking() {
+        wallClockStart = System.currentTimeMillis();
+        trackTime = true;
+        initThread(); // init main thread
+    }
+    
+    /**
+     * Stops global tracking. Stops the wall clock. All further operations will be treated as NOOP.
+     * @return The timed data obtained through the run.
+     */
+    public static TimingReport stopGlobalTracking() {
+        if (!trackTime) {
+            return null;
+        }
+        
+        finishThread(); // finish the main thread
+        trackTime = false;
+        
+        // Fix UNACCOUNTED metric (total time is meaningless)
+        final TimedResult unaccountedResult = ACCUMULATED_RESULTS.get(
+                new TimedOperation(TimedOperationCategory.UNACCOUNTED, null));
+        unaccountedResult.totalTime.set(unaccountedResult.selfTime.get());
+        
+        return new TimingReport(System.currentTimeMillis() - wallClockStart, ACCUMULATED_RESULTS);
+    }
+    
+    /**
+     * Initialize a thread, starting to track it's own time.
+     */
+    public static void initThread() {
+        if (!trackTime) {
+            return;
+        }
+        
+        TIMER_ENTRIES.get(); // Just make sure it's initialized
+    }
+    
+    /**
+     * Finishes tracking a thread.
+     */
+    public static void finishThread() {
+        if (!trackTime) {
+            return;
+        }
+        
+        // if using a mono-thread, we may not be empty...
+        if (TIMER_ENTRIES.get().size() == 1) {
+            finishOperation();
+            TIMER_ENTRIES.remove();
+        }
+    }
+    
+    /**
+     * Starts tracking an operation
+     * @param category The category under which to track the operation.
+     */
+    public static void startOperation(final TimedOperationCategory category) {
+        startOperation(category, null);
+    }
+    
+    /**
+     * Starts tracking an operation
+     * @param category The category under which to track the operation.
+     * @param label A label to be added to the category. Allows to differentiate measures within a single category.
+     */
+    public static void startOperation(final TimedOperationCategory category, final String label) {
+        if (!trackTime) {
+            return;
+        }
+        
+        TIMER_ENTRIES.get().add(new TimerEntry(category, label));
+    }
+    
+    /**
+     * Finishes tracking an operation
+     */
+    public static void finishOperation() {
+        finishOperation(0);
+    }
+    
+    /**
+     * Finishes tracking an operation
+     * @param extraDataCounter An optional additional data counter to track along the measurements
+     */
+    public static void finishOperation(final long extraDataCounter) {
+        if (!trackTime) {
+            return;
+        }
+
+        final Queue<TimerEntry> queue = TIMER_ENTRIES.get();
+        final TimerEntry timerEntry = queue.remove();
+
+        // Compute if absent
+        TimedResult result = ACCUMULATED_RESULTS.get(timerEntry.operation);
+        if (result == null) {
+            ACCUMULATED_RESULTS.putIfAbsent(timerEntry.operation, new TimedResult());
+            result = ACCUMULATED_RESULTS.get(timerEntry.operation);
+        }
+
+        // Update counters and let next element on the stack ignore the time we spent
+        final long delta = result.accumulate(timerEntry, extraDataCounter);
+        if (!queue.isEmpty()) { 
+            queue.peek().inNestedOperations += delta;
+        }
+    }
+    
+    private static class TimerEntry {
+        /* package */ final TimedOperation operation;
+        /* package */ final long start;
+        /* package */ long inNestedOperations = 0;
+        
+        /* package */ TimerEntry(final TimedOperationCategory category, final String label) {
+            this.operation = new TimedOperation(category, label);
+            this.start = System.nanoTime();
+        }
+
+        @Override
+        public String toString() {
+            return "TimerEntry for " + operation;
+        }
+    }
+    
+    /* package */ static class TimedResult {
+        /* package */ AtomicLong totalTime = new AtomicLong();
+        /* package */ AtomicLong selfTime = new AtomicLong();
+        /* package */ AtomicInteger callCount = new AtomicInteger();
+        /* package */ AtomicLong extraDataCounter = new AtomicLong();
+        
+        /* package */ long accumulate(final TimerEntry timerEntry, final long extraData) {
+            final long delta = System.nanoTime() - timerEntry.start;
+            
+            totalTime.getAndAdd(delta);
+            selfTime.getAndAdd(delta - timerEntry.inNestedOperations);
+            callCount.getAndIncrement();
+            extraDataCounter.getAndAdd(extraData);
+            
+            return delta;
+        }
+        
+        /* package */ void mergeTimes(final TimedResult timedResult) {
+            totalTime.getAndAdd(timedResult.totalTime.get());
+            selfTime.getAndAdd(timedResult.selfTime.get());
+        }
+    }
+    
+    /* package */ static class TimedOperation {
+        /* package */ final TimedOperationCategory category;
+        /* package */ final String label;
+        
+        /* package */ TimedOperation(final TimedOperationCategory category, final String label) {
+            this.category = category;
+            this.label = label;
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((category == null) ? 0 : category.hashCode());
+            result = prime * result + ((label == null) ? 0 : label.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(final Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            TimedOperation other = (TimedOperation) obj;
+            if (category != other.category) {
+                return false;
+            }
+            if (label == null) {
+                if (other.label != null) {
+                    return false;
+                }
+            } else if (!label.equals(other.label)) {
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        public String toString() {
+            return "TimedOperation [category=" + category + ", label=" + label + "]";
+        }
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimeTracker.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimeTracker.java
@@ -6,13 +6,12 @@ package net.sourceforge.pmd.benchmark;
 
 import java.util.Collections;
 import java.util.LinkedList;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-
-import com.google.common.base.Objects;
 
 /**
  * A time tracker class to measure time spent on different sections of PMD analysis.
@@ -245,7 +244,7 @@ public final class TimeTracker {
             if (category != other.category) {
                 return false;
             }
-            return Objects.equal(label, other.label);
+            return Objects.equals(label, other.label);
         }
 
         @Override

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimedOperation.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimedOperation.java
@@ -16,15 +16,10 @@ public interface TimedOperation extends AutoCloseable {
     void close();
     
     /**
-     * Stops tracking with the given extra counter.
+     * Stops tracking if not already stopped.
      * @param extraDataCounter An optional additional data counter to track along the measurements.
      *                         Users are free to track any extra value they want (ie: number of analyzed nodes,
      *                         iterations in a loop, etc.)
      */
-    void stop(int extraDataCounter);
-    
-    /**
-     * Stops tracking if not already stopped.
-     */
-    void stop();
+    void close(int extraDataCounter);
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimedOperation.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimedOperation.java
@@ -1,0 +1,30 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.benchmark;
+
+/**
+ * Describes a timed operation. It's {@link AutoCloseable}, for ease of use.
+ */
+public interface TimedOperation extends AutoCloseable {
+
+    /**
+     * Stops tracking if not already stopped.
+     */
+    @Override
+    void close();
+    
+    /**
+     * Stops tracking with the given extra counter.
+     * @param extraDataCounter An optional additional data counter to track along the measurements.
+     *                         Users are free to track any extra value they want (ie: number of analyzed nodes,
+     *                         iterations in a loop, etc.)
+     */
+    void stop(int extraDataCounter);
+    
+    /**
+     * Stops tracking if not already stopped.
+     */
+    void stop();
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimedOperationCategory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimedOperationCategory.java
@@ -1,0 +1,39 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.benchmark;
+
+import java.util.Locale;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * @author Juan Martín Sotuyo Dodero
+ */
+public enum TimedOperationCategory {
+    RULE,
+    RULECHAIN_RULE,
+    COLLECT_FILES,
+    LOAD_RULES,
+    PARSER,
+    QUALIFIED_NAME_RESOLUTION,
+    SYMBOL_TABLE,
+    DFA,
+    TYPE_RESOLUTION,
+    RULECHAIN_VISIT,
+    MULTIFILE_ANALYSIS,
+    REPORTING,
+    FILE_PROCESSING,
+    UNACCOUNTED;
+    
+    public String displayName() {
+        final String[] parts = name().toLowerCase(Locale.getDefault()).split("_");
+        final StringBuilder sb = new StringBuilder();
+        for (final String part : parts) {
+            sb.append(StringUtils.capitalize(part)).append(' ');
+        }
+        sb.setLength(sb.length() - 1); // remove the final space
+        return sb.toString();
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimingReport.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimingReport.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.benchmark;
 import java.util.HashMap;
 import java.util.Map;
 
-import net.sourceforge.pmd.benchmark.TimeTracker.TimedOperation;
+import net.sourceforge.pmd.benchmark.TimeTracker.TimedOperationKey;
 import net.sourceforge.pmd.benchmark.TimeTracker.TimedResult;
 
 /**
@@ -17,9 +17,9 @@ import net.sourceforge.pmd.benchmark.TimeTracker.TimedResult;
 public class TimingReport {
 
     private final long wallClockMillis;
-    private final Map<TimedOperation, TimedResult> results;
+    private final Map<TimedOperationKey, TimedResult> results;
     
-    /* package */ TimingReport(final long wallClockMillis, final Map<TimedOperation, TimedResult> accumulatedResults) {
+    /* package */ TimingReport(final long wallClockMillis, final Map<TimedOperationKey, TimedResult> accumulatedResults) {
         this.wallClockMillis = wallClockMillis;
         results = accumulatedResults;
     }
@@ -27,8 +27,8 @@ public class TimingReport {
     public Map<String, TimedResult> getLabeledMeasurements(final TimedOperationCategory category) {
         final Map<String, TimedResult> ret = new HashMap<>();
         
-        for (final Map.Entry<TimedOperation, TimedResult> entry : results.entrySet()) {
-            final TimedOperation timedOperation = entry.getKey();
+        for (final Map.Entry<TimedOperationKey, TimedResult> entry : results.entrySet()) {
+            final TimedOperationKey timedOperation = entry.getKey();
             if (timedOperation.category == category && timedOperation.label != null) {
                 ret.put(timedOperation.label, entry.getValue());
             }
@@ -38,8 +38,8 @@ public class TimingReport {
     }
     
     public TimedResult getUnlabeledMeasurements(final TimedOperationCategory category) {
-        for (final Map.Entry<TimedOperation, TimedResult> entry : results.entrySet()) {
-            final TimedOperation timedOperation = entry.getKey();
+        for (final Map.Entry<TimedOperationKey, TimedResult> entry : results.entrySet()) {
+            final TimedOperationKey timedOperation = entry.getKey();
             if (timedOperation.category == category && timedOperation.label == null) {
                 return entry.getValue();
             }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimingReport.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimingReport.java
@@ -25,7 +25,7 @@ public class TimingReport {
         results = accumulatedResults;
     }
     
-    public Map<String, TimedResult> getLabeledMeassurements(final TimedOperationCategory category) {
+    public Map<String, TimedResult> getLabeledMeasurements(final TimedOperationCategory category) {
         final Map<String, TimedResult> ret = new HashMap<>();
         
         for (final Map.Entry<TimedOperation, TimedResult> entry : results.entrySet()) {
@@ -38,7 +38,7 @@ public class TimingReport {
         return ret;
     }
     
-    public TimedResult getUnlabeledMeassurements(final TimedOperationCategory category) {
+    public TimedResult getUnlabeledMeasurements(final TimedOperationCategory category) {
         for (final Map.Entry<TimedOperation, TimedResult> entry : results.entrySet()) {
             final TimedOperation timedOperation = entry.getKey();
             if (timedOperation.category == category && timedOperation.label == null) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimingReport.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimingReport.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.benchmark;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentMap;
 
 import net.sourceforge.pmd.benchmark.TimeTracker.TimedOperation;
 import net.sourceforge.pmd.benchmark.TimeTracker.TimedResult;
@@ -17,11 +16,11 @@ import net.sourceforge.pmd.benchmark.TimeTracker.TimedResult;
  */
 public class TimingReport {
 
-    private final long wallClockMs;
-    private final ConcurrentMap<TimedOperation, TimedResult> results;
+    private final long wallClockMillis;
+    private final Map<TimedOperation, TimedResult> results;
     
-    /* package */ TimingReport(final long wallClock, final ConcurrentMap<TimedOperation, TimedResult> accumulatedResults) {
-        wallClockMs = wallClock;
+    /* package */ TimingReport(final long wallClockMillis, final Map<TimedOperation, TimedResult> accumulatedResults) {
+        this.wallClockMillis = wallClockMillis;
         results = accumulatedResults;
     }
     
@@ -49,7 +48,7 @@ public class TimingReport {
         return null;
     }
     
-    public long getWallClockTimeMs() {
-        return wallClockMs;
+    public long getWallClockMillis() {
+        return wallClockMillis;
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimingReport.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimingReport.java
@@ -1,0 +1,55 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.benchmark;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+
+import net.sourceforge.pmd.benchmark.TimeTracker.TimedOperation;
+import net.sourceforge.pmd.benchmark.TimeTracker.TimedResult;
+
+/**
+ * A report on timing data obtained through the execution of PMD
+ * @author Juan Martín Sotuyo Dodero
+ */
+public class TimingReport {
+
+    private final long wallClockMs;
+    private final ConcurrentMap<TimedOperation, TimedResult> results;
+    
+    /* package */ TimingReport(final long wallClock, final ConcurrentMap<TimedOperation, TimedResult> accumulatedResults) {
+        wallClockMs = wallClock;
+        results = accumulatedResults;
+    }
+    
+    public Map<String, TimedResult> getLabeledMeassurements(final TimedOperationCategory category) {
+        final Map<String, TimedResult> ret = new HashMap<>();
+        
+        for (final Map.Entry<TimedOperation, TimedResult> entry : results.entrySet()) {
+            final TimedOperation timedOperation = entry.getKey();
+            if (timedOperation.category == category && timedOperation.label != null) {
+                ret.put(timedOperation.label, entry.getValue());
+            }
+        }
+        
+        return ret;
+    }
+    
+    public TimedResult getUnlabeledMeassurements(final TimedOperationCategory category) {
+        for (final Map.Entry<TimedOperation, TimedResult> entry : results.entrySet()) {
+            final TimedOperation timedOperation = entry.getKey();
+            if (timedOperation.category == category && timedOperation.label == null) {
+                return entry.getValue();
+            }
+        }
+        
+        return null;
+    }
+    
+    public long getWallClockTimeMs() {
+        return wallClockMs;
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimingReportRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimingReportRenderer.java
@@ -1,0 +1,23 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.benchmark;
+
+import java.io.IOException;
+import java.io.Writer;
+
+/**
+ * Defines a renderer for {@link TimingReport}
+ * @author Juan Martín Sotuyo Dodero
+ */
+public interface TimingReportRenderer {
+
+    /**
+     * Renders the given report into the given writer
+     * @param report The report data to render
+     * @param writer The writer on which to render
+     * @throws IOException if the write operation fails
+     */
+    void render(TimingReport report, Writer writer) throws IOException;
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimingReportRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimingReportRenderer.java
@@ -8,13 +8,13 @@ import java.io.IOException;
 import java.io.Writer;
 
 /**
- * Defines a renderer for {@link TimingReport}
+ * Defines a renderer for {@link TimingReport}.
  * @author Juan Martín Sotuyo Dodero
  */
 public interface TimingReportRenderer {
 
     /**
-     * Renders the given report into the given writer
+     * Renders the given report into the given writer.
      * @param report The report data to render
      * @param writer The writer on which to render
      * @throws IOException if the write operation fails

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRuleChainVisitor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRuleChainVisitor.java
@@ -92,7 +92,7 @@ public abstract class AbstractRuleChainVisitor implements RuleChainVisitor {
                             }
                             visits += ns.size();
                         }
-                        rcto.stop(visits);
+                        rcto.close(visits);
                     }
                 }
             }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRuleChainVisitor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRuleChainVisitor.java
@@ -17,6 +17,7 @@ import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.RuleSet;
 import net.sourceforge.pmd.benchmark.TimeTracker;
+import net.sourceforge.pmd.benchmark.TimedOperation;
 import net.sourceforge.pmd.benchmark.TimedOperationCategory;
 import net.sourceforge.pmd.lang.ast.Node;
 
@@ -59,42 +60,43 @@ public abstract class AbstractRuleChainVisitor implements RuleChainVisitor {
 
         // Perform a visitation of the AST to index nodes which need visiting by
         // type
-        TimeTracker.startOperation(TimedOperationCategory.RULECHAIN_VISIT);
-        indexNodes(nodes, ctx);
-        TimeTracker.finishOperation();
+        try (TimedOperation to = TimeTracker.startOperation(TimedOperationCategory.RULECHAIN_VISIT)) {
+            indexNodes(nodes, ctx);
+        }
 
         // For each RuleSet, only if this source file applies
-        TimeTracker.startOperation(TimedOperationCategory.RULECHAIN_RULE);
-        for (Map.Entry<RuleSet, List<Rule>> entry : ruleSetRules.entrySet()) {
-            RuleSet ruleSet = entry.getKey();
-            if (!ruleSet.applies(ctx.getSourceCodeFile())) {
-                continue;
-            }
-
-            // For each rule, allow it to visit the nodes it desires
-            for (Rule rule : entry.getValue()) {
-                int visits = 0;
-                if (!RuleSet.applies(rule, ctx.getLanguageVersion())) {
+        try (TimedOperation to = TimeTracker.startOperation(TimedOperationCategory.RULECHAIN_RULE)) {
+            for (Map.Entry<RuleSet, List<Rule>> entry : ruleSetRules.entrySet()) {
+                RuleSet ruleSet = entry.getKey();
+                if (!ruleSet.applies(ctx.getSourceCodeFile())) {
                     continue;
                 }
-                TimeTracker.startOperation(TimedOperationCategory.RULECHAIN_RULE, rule.getName());
-                final List<String> nodeNames = rule.getRuleChainVisits();
-                for (int j = 0; j < nodeNames.size(); j++) {
-                    List<Node> ns = nodeNameToNodes.get(nodeNames.get(j));
-                    for (Node node : ns) {
-                        // Visit with underlying Rule, not the RuleReference
-                        Rule actualRule = rule;
-                        while (actualRule instanceof RuleReference) {
-                            actualRule = ((RuleReference) actualRule).getRule();
-                        }
-                        visit(actualRule, node, ctx);
+
+                // For each rule, allow it to visit the nodes it desires
+                for (Rule rule : entry.getValue()) {
+                    int visits = 0;
+                    if (!RuleSet.applies(rule, ctx.getLanguageVersion())) {
+                        continue;
                     }
-                    visits += ns.size();
+                    try (TimedOperation rcto = TimeTracker.startOperation(TimedOperationCategory.RULECHAIN_RULE, rule.getName())) {
+                        final List<String> nodeNames = rule.getRuleChainVisits();
+                        for (int j = 0; j < nodeNames.size(); j++) {
+                            List<Node> ns = nodeNameToNodes.get(nodeNames.get(j));
+                            for (Node node : ns) {
+                                // Visit with underlying Rule, not the RuleReference
+                                Rule actualRule = rule;
+                                while (actualRule instanceof RuleReference) {
+                                    actualRule = ((RuleReference) actualRule).getRule();
+                                }
+                                visit(actualRule, node, ctx);
+                            }
+                            visits += ns.size();
+                        }
+                        rcto.stop(visits);
+                    }
                 }
-                TimeTracker.finishOperation(visits);
             }
         }
-        TimeTracker.finishOperation();
     }
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/processor/AbstractPMDProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/processor/AbstractPMDProcessor.java
@@ -20,6 +20,7 @@ import net.sourceforge.pmd.RuleSets;
 import net.sourceforge.pmd.RulesetsFactoryUtils;
 import net.sourceforge.pmd.SourceCodeProcessor;
 import net.sourceforge.pmd.benchmark.TimeTracker;
+import net.sourceforge.pmd.benchmark.TimedOperation;
 import net.sourceforge.pmd.benchmark.TimedOperationCategory;
 import net.sourceforge.pmd.renderers.Renderer;
 import net.sourceforge.pmd.util.datasource.DataSource;
@@ -40,15 +41,12 @@ public abstract class AbstractPMDProcessor {
 
     public void renderReports(final List<Renderer> renderers, final Report report) {
 
-        TimeTracker.startOperation(TimedOperationCategory.REPORTING);
-        try {
+        try (TimedOperation to = TimeTracker.startOperation(TimedOperationCategory.REPORTING)) {
             for (Renderer r : renderers) {
                 r.renderFileReport(report);
             }
         } catch (IOException ioe) {
             throw new RuntimeException(ioe);
-        } finally {
-            TimeTracker.finishOperation();
         }
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/processor/AbstractPMDProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/processor/AbstractPMDProcessor.java
@@ -19,8 +19,8 @@ import net.sourceforge.pmd.RuleSetFactory;
 import net.sourceforge.pmd.RuleSets;
 import net.sourceforge.pmd.RulesetsFactoryUtils;
 import net.sourceforge.pmd.SourceCodeProcessor;
-import net.sourceforge.pmd.benchmark.Benchmark;
-import net.sourceforge.pmd.benchmark.Benchmarker;
+import net.sourceforge.pmd.benchmark.TimeTracker;
+import net.sourceforge.pmd.benchmark.TimedOperationCategory;
 import net.sourceforge.pmd.renderers.Renderer;
 import net.sourceforge.pmd.util.datasource.DataSource;
 
@@ -40,16 +40,15 @@ public abstract class AbstractPMDProcessor {
 
     public void renderReports(final List<Renderer> renderers, final Report report) {
 
-        long start = System.nanoTime();
-
+        TimeTracker.startOperation(TimedOperationCategory.REPORTING);
         try {
             for (Renderer r : renderers) {
                 r.renderFileReport(report);
             }
-            long end = System.nanoTime();
-            Benchmarker.mark(Benchmark.Reporting, end - start, 1);
         } catch (IOException ioe) {
             throw new RuntimeException(ioe);
+        } finally {
+            TimeTracker.finishOperation();
         }
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/processor/PmdRunnable.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/processor/PmdRunnable.java
@@ -17,6 +17,7 @@ import net.sourceforge.pmd.Report;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.RuleSets;
 import net.sourceforge.pmd.SourceCodeProcessor;
+import net.sourceforge.pmd.benchmark.TimeTracker;
 import net.sourceforge.pmd.renderers.Renderer;
 import net.sourceforge.pmd.util.datasource.DataSource;
 
@@ -55,6 +56,8 @@ public class PmdRunnable implements Callable<Report> {
 
     @Override
     public Report call() {
+        TimeTracker.initThread();
+        
         ThreadContext tc = LOCAL_THREAD_CONTEXT.get();
         if (tc == null) {
             tc = new ThreadContext(new RuleSets(ruleSets), new RuleContext(ruleContext));
@@ -81,6 +84,8 @@ public class PmdRunnable implements Callable<Report> {
             addError(report, re, "RuntimeException during processing of " + fileName);
         }
 
+        TimeTracker.finishThread();
+        
         return report;
     }
 


### PR DESCRIPTION
The old implementation had many limitations:
 - Relayed ALL measuring logic to the client
 - Used `synchronized` methods
 - Was unable to measure nested operations without mixing values
 - Mixed wall-clock and CPU time, which caused trouble when running
multithreaded analysis (negative values for non-meassured time)
 - A separate `main` existed which was undocumented and unsupported.

So I reworked it and added some goodies along the way:
 - When not running in benchmark mode, all operations are NOOPs
 - Nested operations are the default. Total and self time are
differentiated. This allows and encourages to better track overhead (ie:
time spent in a loop over another timed operation)
 - We can meassure call count along with custom counters, which add
meaning to metrics
 - Wall clock time for total execution is separated from all other CPU
times
 - All meassurements are done by the `TimeTracker` itself
 - No `synchronized` use, all structs are thread-safe and lock as little
and sporadically as possible
 - Categories can be split up by labels
 - The tracker is generic, has little knowledge of what is being
tracked. Same applies to report rendering. This is extremely flexible to
add more and custom tracks in the future