### PR TITLE
[java] Make ClassNamingConventions' utility class definition more precise

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ClassNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ClassNamingConventionsRule.java
@@ -66,10 +66,18 @@ public class ClassNamingConventionsRule extends AbstractJavaRule {
             return false;
         }
 
+        ASTClassOrInterfaceDeclaration classNode = (ASTClassOrInterfaceDeclaration) node;
+
+        // A class with a superclass or interfaces should not be considered
+        if (classNode.getSuperClassTypeNode() != null
+                || !classNode.getSuperInterfacesTypeNodes().isEmpty()) {
+            return false;
+        }
+
         // A class without declarations shouldn't be reported
         boolean hasAny = false;
 
-        for (ASTAnyTypeBodyDeclaration decl : node.getDeclarations()) {
+        for (ASTAnyTypeBodyDeclaration decl : classNode.getDeclarations()) {
             switch (decl.getKind()) {
             case FIELD:
             case METHOD:

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ClassNamingConventions.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ClassNamingConventions.xml
@@ -3,6 +3,7 @@
         xmlns="http://pmd.sourceforge.net/rule-tests"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
     <test-code>
         <description>Default config reports on every type decl</description>
         <expected-problems>5</expected-problems>
@@ -185,6 +186,31 @@
         <expected-problems>0</expected-problems>
         <code><![CDATA[
             public class Md5Checksum {
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Class extending another class should not be utility class</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class StringList extends ArrayList<String> {
+                static StringList emptyList() {
+                    return new StringList();
+                }
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Class extending another class should not be utility class 2</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            // I couldn't reproduce the original failure, but we can use another regression test.
+            public class MyException extends RuntimeException {
+                public MyException(Exception exception) {
+                    super(exception);
+                }
             }
             ]]></code>
     </test-code>


### PR DESCRIPTION
Fixes #1064

Classes with a superclass or which implement an interface are not flagged as utility classes anymore. 