### PR TITLE
[java] False negative in AvoidThrowingRawExceptionTypes

### DIFF
--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -266,13 +266,13 @@ Exception, or Error, use a subclassed exception or error instead.
 <![CDATA[
 //ThrowStatement//AllocationExpression
  /ClassOrInterfaceType[
- (@Image='Throwable' and count(//ImportDeclaration/Name[ends-with(@Image,'Throwable')]) = 0)
+ typeof(@Image, 'java.lang.Throwable', 'Throwable')
 or
- (@Image='Exception' and count(//ImportDeclaration/Name[ends-with(@Image,'Exception')]) = 0)
+ typeof(@Image, 'java.lang.Exception', 'Exception')
 or
- (@Image='Error'  and count(//ImportDeclaration/Name[ends-with(@Image,'Error')]) = 0)
+ typeof(@Image, 'java.lang.Error', 'Error')
 or
-( @Image='RuntimeException'  and count(//ImportDeclaration/Name[ends-with(@Image,'RuntimeException')]) = 0)
+ typeof(@Image, 'java.lang.RuntimeException', 'RuntimeException')
 ]
 ]]>
                 </value>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidThrowingRawExceptionTypes.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidThrowingRawExceptionTypes.xml
@@ -56,4 +56,18 @@ public class PmdTest {
 }
 ]]></code>
     </test-code>
+    <test-code>
+        <description>False negative when importing another exception</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import java.io.IOException;
+
+public class Foo {
+
+    public void bar() {
+        throw new Exception();
+    }
+}
+]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
 - Use type resolution to find raw exception type usage
 - Magically make it 100X faster as we avoid all those `//ImportDeclaration`. Analyzing the whole PMD source, there are 1,877 throw statements which on my machine took ~12 seconds to analyze, vs 120ms it takes now.