### PR TITLE
[java] Simplify LongInstantiation and IntegerInstantiation

### DIFF
--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -447,11 +447,9 @@ Note that new Integer() is deprecated since JDK 9 for that reason.
             <property name="xpath">
                 <value>
 <![CDATA[
-//PrimaryPrefix
- /AllocationExpression
+//AllocationExpression
   [not (ArrayDimsAndInits)
-   and (ClassOrInterfaceType/@Image='Integer'
-    or ClassOrInterfaceType/@Image='java.lang.Integer')]
+   and ClassOrInterfaceType[typeof(@Image, 'java.lang.Integer', 'Integer')]]
 ]]>
                 </value>
             </property>
@@ -481,11 +479,9 @@ Note that new Long() is deprecated since JDK 9 for that reason.
             <property name="xpath">
                 <value>
 <![CDATA[
-//PrimaryPrefix
-/AllocationExpression
+//AllocationExpression
 [not (ArrayDimsAndInits)
-and (ClassOrInterfaceType/@Image='Long'
-or ClassOrInterfaceType/@Image='java.lang.Long')]
+and ClassOrInterfaceType[typeof(@Image, 'java.lang.Long', 'Long')]]
 ]]>
                 </value>
             </property>


### PR DESCRIPTION
 - Narrow down both rule's search space (therefore making better usage
of the rulechain and reducing number of checks performed)
 - Use type resolution to simplify the rules and avoid FPs when
declaring classes with the same names
