### PR TITLE
[java] Don't report UseUtilityClass when extending

### DIFF
--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UseUtilityClass.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UseUtilityClass.xml
@@ -345,4 +345,19 @@ public class Foo {
      ]]></code>
     </test-code>
 
+	<test-code>
+        <description><![CDATA[
+#824 False Positive when extending another class
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.ArrayList;
+
+public class FooLocal extends ThreadLocal<Integer> {
+ public static FooLocal get() {
+  return new FooLocal();
+ }
+}
+     ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
 - Since the parent class is not a utility, we are neither (the parent
class may have non-static methods and fields).
 - Since this is more general than the original check for exception
types, we remove that
 - Fixes #824
 - Take the chance to have the rule use the rulechain
