### PR TITLE
[java] False Alarm of JUnit4TestShouldUseTestAnnotation on Predicates

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -13,17 +13,25 @@ This is a bug fixing release.
 ### Table Of Contents
 
 * [New and noteworthy](#new-and-noteworthy)
+    *   [Modified Rules](#modified-rules)
 * [Fixed Issues](#fixed-issues)
 * [API Changes](#api-changes)
 * [External Contributions](#external-contributions)
 
 ### New and noteworthy
 
+#### Modified Rules
+
+*   The Java rule [JUnit4TestShouldUseTestAnnotation](pmd_rules_java_bestpractices.html#junit4testshouldusetestannotation) (`java-bestpractices`)
+    has a new parameter "testClassPattern". It is used to distinguish test classes from other classes and
+    avoid false positives. By default, any class, that has "Test" in its name, is considered a test class.
+
 ### Fixed Issues
 
 *   java
     *   [#1077](https://github.com/pmd/pmd/issues/1077): \[java] Analyzing enum with lambda passed in constructor fails with "The enclosing scope must exist."
 *   java-bestpractices
+    *   [#527](https://github.com/pmd/pmd/issues/572): \[java] False Alarm of JUnit4TestShouldUseTestAnnotation on Predicates
     *   [#1063](https://github.com/pmd/pmd/issues/1063): \[java] MissingOverride is triggered in illegal places
 *   java-codestyle
     *   [#1064](https://github.com/pmd/pmd/issues/1064): \[java] ClassNamingConventions suggests to add Util suffix for simple exception wrappers

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQuery.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQuery.java
@@ -8,6 +8,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.ast.Node;
@@ -250,6 +251,8 @@ public class SaxonXPathRuleQuery extends AbstractXPathRuleQuery {
             return new StringValue(value.toString());
         } else if (value instanceof Float) {
             return new FloatValue((Float) value);
+        } else if (value instanceof Pattern) {
+            return new StringValue(String.valueOf(value));
         } else {
             // We could maybe use UntypedAtomicValue
             throw new RuntimeException("Unable to create ValueRepresentation for value of type: " + value.getClass());

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/xpath/TypeOfFunction.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/xpath/TypeOfFunction.java
@@ -57,7 +57,17 @@ public class TypeOfFunction implements Function {
         return typeof(n, nodeTypeName, fullTypeName, shortTypeName);
     }
 
-    // TEST //ClassOrInterfaceType[typeof(@Image, 'java.lang.String')]
+    /**
+     * Example XPath 1.0: {@code //ClassOrInterfaceType[typeof(@Image, 'java.lang.String', 'String')]}
+     * <p>
+     * Example XPath 2.0: {@code //ClassOrInterfaceType[pmd-java:typeof(@Image, 'java.lang.String', 'String')]}
+     *
+     * @param n
+     * @param nodeTypeName Usually the {@code @Image} attribute of the node
+     * @param fullTypeName The fully qualified name of the class or any supertype
+     * @param shortTypeName The simple class name, might be <code>null</code>
+     * @return
+     */
     public static boolean typeof(Node n, String nodeTypeName, String fullTypeName, String shortTypeName) {
         if (n instanceof TypeNode) {
             Class<?> type = ((TypeNode) n).getType();

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -523,6 +523,7 @@ public class MyTest2 {
           since="4.0"
           message="JUnit 4 tests that execute tests should use the @Test annotation"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
+          typeResolution="true"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_bestpractices.html#junit4testshouldusetestannotation">
         <description>
 In JUnit 3, the framework executed all methods which started with the word test as a unit test. 
@@ -533,7 +534,8 @@ In JUnit 4, only methods annotated with the @Test annotation are executed.
             <property name="xpath">
                 <value>
 <![CDATA[
-//ClassOrInterfaceBodyDeclaration[MethodDeclaration[@Public='true']/MethodDeclarator[starts-with(@Image,'test')]]
+//ClassOrInterfaceDeclaration[ends-with(@Image, 'Test') or ExtendsList/ClassOrInterfaceType[typeof(@Image, 'junit.framework.TestCase', 'TestCase')]]
+    /ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration[MethodDeclaration[@Public='true']/MethodDeclarator[starts-with(@Image,'test')]]
 [count(Annotation//Name[@Image='Test'])=0]
 ]]>
                 </value>

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -534,12 +534,17 @@ In JUnit 4, only methods annotated with the @Test annotation are executed.
             <property name="xpath">
                 <value>
 <![CDATA[
-//ClassOrInterfaceDeclaration[ends-with(@Image, 'Test') or ExtendsList/ClassOrInterfaceType[typeof(@Image, 'junit.framework.TestCase', 'TestCase')]]
-    /ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration[MethodDeclaration[@Public='true']/MethodDeclarator[starts-with(@Image,'test')]]
-[count(Annotation//Name[@Image='Test'])=0]
+//ClassOrInterfaceDeclaration[
+       matches(@Image, $testClassPattern)
+        or ExtendsList/ClassOrInterfaceType[pmd-java:typeof(@Image, 'junit.framework.TestCase', 'TestCase')]]
+
+    /ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration[MethodDeclaration[@Public=true()]/MethodDeclarator[starts-with(@Image, 'test')]]
+    [not(Annotation//Name[pmd-java:typeof(@Image, 'org.junit.Test', 'Test')])]
 ]]>
                 </value>
             </property>
+            <property name="testClassPattern" type="Regex" description="The regex pattern used to identify test classes" value="Test" />
+            <property name="version" value="2.0"/>
         </properties>
         <example>
 <![CDATA[

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit4TestShouldUseTestAnnotation.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit4TestShouldUseTestAnnotation.xml
@@ -79,7 +79,10 @@ public class Foo extends TestCase{
         <description>#1197 JUnit4TestShouldUseTestAnnotation for private method</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-public class FaaTest
+import org.junit.Test;
+import static org.junit.Assert.fail;
+
+public class Faa
 {
     @Test
     public void test()
@@ -99,11 +102,55 @@ public class FaaTest
         <description>#572 [java] False Alarm of JUnit4TestShouldUseTestAnnotation on Predicates</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+import java.util.function.Predicate;
+
 public final class Whatever<T> implements Predicate<T> {
     @Override
     public boolean test(T t) {
         return false;
     }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Test class with test method not annotated</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import org.junit.Test;
+
+public class MyTest {
+    // should be annotated
+    public void testBad() { }
+
+    @Test
+    public void testGood() { }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Test class named TestCase with test method not annotated</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class MyTestCase {
+    public void testBad() { }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Test class prefix with Test with test method not annotated</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class TestForX {
+    public void testBad() { }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Test class named MyTests with test method not annotated</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class MyTests {
+    public void testBad() { }
 }
         ]]></code>
     </test-code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit4TestShouldUseTestAnnotation.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit4TestShouldUseTestAnnotation.xml
@@ -9,6 +9,7 @@ Contains test, no @Test
      ]]></description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
+import junit.framework.TestCase;
 public class Foo extends TestCase{
     public void testFoo() {
     }
@@ -21,6 +22,7 @@ OK
      ]]></description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+import junit.framework.TestCase;
 public class Foo extends TestCase{
     @Test
     public void testFoo() {
@@ -34,6 +36,7 @@ OK, renamed test
      ]]></description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+import junit.framework.TestCase;
 public class Foo extends TestCase{
     @Test
     public void foo() {
@@ -47,6 +50,7 @@ One test proper, the other incorrect
      ]]></description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
+import junit.framework.TestCase;
 public class Foo extends TestCase{
     public void testFoo() {
     }
@@ -62,6 +66,7 @@ Two tests
      ]]></description>
         <expected-problems>2</expected-problems>
         <code><![CDATA[
+import junit.framework.TestCase;
 public class Foo extends TestCase{
     public void testOne() {
     }
@@ -74,7 +79,7 @@ public class Foo extends TestCase{
         <description>#1197 JUnit4TestShouldUseTestAnnotation for private method</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-public class Faa
+public class FaaTest
 {
     @Test
     public void test()
@@ -85,6 +90,18 @@ public class Faa
 
     private boolean testHelper()  // <- JUnit4TestShouldUseTestAnnotation
     {
+        return false;
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>#572 [java] False Alarm of JUnit4TestShouldUseTestAnnotation on Predicates</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public final class Whatever<T> implements Predicate<T> {
+    @Override
+    public boolean test(T t) {
         return false;
     }
 }

--- a/pmd-test/src/main/java/net/sourceforge/pmd/AbstractRuleSetFactoryTest.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/AbstractRuleSetFactoryTest.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.StringTokenizer;
+import java.util.regex.Pattern;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
@@ -452,8 +453,14 @@ public abstract class AbstractRuleSetFactoryTest {
             List<PropertyDescriptor<?>> propertyDescriptors2 = rule2.getPropertyDescriptors();
             assertEquals(message + ", Rule property descriptor ", propertyDescriptors1, propertyDescriptors2);
             for (int j = 0; j < propertyDescriptors1.size(); j++) {
-                assertEquals(message + ", Rule property value " + j, rule1.getProperty(propertyDescriptors1.get(j)),
-                        rule2.getProperty(propertyDescriptors2.get(j)));
+                Object value1 = rule1.getProperty(propertyDescriptors1.get(j));
+                Object value2 = rule2.getProperty(propertyDescriptors2.get(j));
+                // special case for Pattern, there is no equals method
+                if (propertyDescriptors1.get(j).type() == Pattern.class) {
+                    value1 = ((Pattern) value1).pattern();
+                    value2 = ((Pattern) value2).pattern();
+                }
+                assertEquals(message + ", Rule property value " + j, value1, value2);
             }
             assertEquals(message + ", Rule property descriptor count", propertyDescriptors1.size(),
                     propertyDescriptors2.size());


### PR DESCRIPTION
Fixes #572

I gave it a try:
* The rule now assumes, that classes, that are supposed to be JUnit4 Tests, end with "Test". Otherwise it is difficult to know, whether the class should be a test or not - Junit4 tests classes are not special in any way.
* Typeresolution is used to determine TestCase (Junit3)

It will flag the class again, if you name your predicate "FooTest"... We could alternatively check, whether the method has an `@Override` annotation or whether the class specifically implements `java.util.function.Predicate`.
