### PR TITLE
[doc] Add sitemap generation to release procedure

### DIFF
--- a/.travis/release.sh
+++ b/.travis/release.sh
@@ -64,10 +64,15 @@ mkdir pmd.github.io
     rsync -a ../docs/pmd-doc-${RELEASE_VERSION}/ pmd-${RELEASE_VERSION}/
     git add pmd-${RELEASE_VERSION}
     git commit -q -m "Added pmd-${RELEASE_VERSION}"
+
     git rm -qr latest
     cp -a pmd-${RELEASE_VERSION} latest
     git add latest
     git commit -q -m "Copying pmd-${RELEASE_VERSION} to latest"
+
+    ./sitemap_generator.sh
+    git add sitemap.xml
+    git commit -q -m "Generated sitemap.xml"
     git push origin master
 )
 

--- a/.travis/release.sh
+++ b/.travis/release.sh
@@ -70,7 +70,7 @@ mkdir pmd.github.io
     git add latest
     git commit -q -m "Copying pmd-${RELEASE_VERSION} to latest"
 
-    ./sitemap_generator.sh
+    ./sitemap_generator.sh > sitemap.xml
     git add sitemap.xml
     git commit -q -m "Generated sitemap.xml"
     git push origin master

--- a/.travis/sitemap_generator.sh
+++ b/.travis/sitemap_generator.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+# Sitemap generator
+# Assumes we have the latest version of the site under "latest" and "pmd-${RELEASE_VERSION}"
+
+
+WEBSITE_PREFIX="https://pmd.github.io/"
+DOC_PREFIX="pmd-${RELEASE_VERSION}/"
+LATEST_PRIORITY=0.8
+DATE=`date +%Y-%m-%d`
+
+writePage () {
+local pageLoc=$1
+
+
+cat << ENTRY_END >> sitemap.xml
+<url>
+    <loc>${WEBSITE_PREFIX}$pageLoc</loc> 
+    <priority>$LATEST_PRIORITY</priority>
+    <changefreq>monthly</changefreq>
+    <lastmod>$DATE</lastmod>
+</url>
+
+ENTRY_END
+}
+
+
+# Start of the output writing
+
+cat << HEADER_END > sitemap.xml
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+
+HEADER_END
+
+
+for page in pmd-${RELEASE_VERSION}/pmd_*.html
+do
+	writePage $page
+done
+
+
+for page in latest/pmd_*.html
+do
+	writePage $page
+done
+
+echo "</urlset>" >> sitemap.xml 
+

--- a/.travis/sitemap_generator.sh
+++ b/.travis/sitemap_generator.sh
@@ -6,8 +6,10 @@
 
 WEBSITE_PREFIX="https://pmd.github.io/"
 DOC_PREFIX="pmd-${RELEASE_VERSION}/"
-LATEST_PRIORITY=0.8
 DATE=`date +%Y-%m-%d`
+# Priority is relative to the website, can be chosen in {0.1, 0.2, ..., 1}
+# Default priority is 0.5
+LATEST_PRIORITY=0.8
 
 
 # Start of the output writing
@@ -50,5 +52,5 @@ ENTRY_END
 
 done
 
-echo "</urlset>" >> sitemap.xml 
+echo "</urlset>" >> sitemap.xml
 

--- a/.travis/sitemap_generator.sh
+++ b/.travis/sitemap_generator.sh
@@ -9,21 +9,6 @@ DOC_PREFIX="pmd-${RELEASE_VERSION}/"
 LATEST_PRIORITY=0.8
 DATE=`date +%Y-%m-%d`
 
-writePage () {
-local pageLoc=$1
-
-
-cat << ENTRY_END >> sitemap.xml
-<url>
-    <loc>${WEBSITE_PREFIX}$pageLoc</loc> 
-    <priority>$LATEST_PRIORITY</priority>
-    <changefreq>monthly</changefreq>
-    <lastmod>$DATE</lastmod>
-</url>
-
-ENTRY_END
-}
-
 
 # Start of the output writing
 
@@ -36,13 +21,17 @@ HEADER_END
 
 for page in pmd-${RELEASE_VERSION}/pmd_*.html
 do
-	writePage $page
-done
 
+cat << ENTRY_END >> sitemap.xml
+<url>
+    <loc>${WEBSITE_PREFIX}$page</loc> 
+    <priority>$LATEST_PRIORITY</priority>
+    <changefreq>monthly</changefreq>
+    <lastmod>$DATE</lastmod>
+</url>
 
-for page in latest/pmd_*.html
-do
-	writePage $page
+ENTRY_END
+
 done
 
 echo "</urlset>" >> sitemap.xml 

--- a/.travis/sitemap_generator.sh
+++ b/.travis/sitemap_generator.sh
@@ -2,7 +2,7 @@
 
 # Sitemap generator
 # Assumes we have the latest version of the site under "latest" and "pmd-${RELEASE_VERSION}"
-
+# https://www.sitemaps.org/protocol.html
 
 WEBSITE_PREFIX="https://pmd.github.io/"
 DOC_PREFIX="pmd-${RELEASE_VERSION}/"
@@ -16,19 +16,35 @@ cat << HEADER_END > sitemap.xml
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 
+    <url>
+        <loc>${WEBSITE_PREFIX}index.html</loc>
+        <priority>1</priority>
+        <changefreq>monthly</changefreq>
+        <lastmod>$DATE</lastmod>
+    </url>
+
+    <url>
+        <loc>${WEBSITE_PREFIX}${DOC_PREFIX}index.html</loc>
+        <priority>0.9</priority>
+        <changefreq>monthly</changefreq>
+        <lastmod>$DATE</lastmod>
+    </url>
+
+
+
 HEADER_END
 
 
-for page in pmd-${RELEASE_VERSION}/pmd_*.html
+for page in ${DOC_PREFIX}pmd_*.html
 do
 
-cat << ENTRY_END >> sitemap.xml
-<url>
-    <loc>${WEBSITE_PREFIX}$page</loc> 
-    <priority>$LATEST_PRIORITY</priority>
-    <changefreq>monthly</changefreq>
-    <lastmod>$DATE</lastmod>
-</url>
+    cat << ENTRY_END >> sitemap.xml
+    <url>
+        <loc>${WEBSITE_PREFIX}$page</loc>
+        <priority>$LATEST_PRIORITY</priority>
+        <changefreq>monthly</changefreq>
+        <lastmod>$DATE</lastmod>
+    </url>
 
 ENTRY_END
 

--- a/.travis/sitemap_generator.sh
+++ b/.travis/sitemap_generator.sh
@@ -12,9 +12,9 @@ DATE=`date +%Y-%m-%d`
 LATEST_PRIORITY=0.8
 
 
-# Start of the output writing
+# Writes to standard output
 
-cat << HEADER_END > sitemap.xml
+cat << HEADER_END
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 
@@ -40,7 +40,7 @@ HEADER_END
 for page in ${DOC_PREFIX}pmd_*.html
 do
 
-    cat << ENTRY_END >> sitemap.xml
+    cat << ENTRY_END
     <url>
         <loc>${WEBSITE_PREFIX}$page</loc>
         <priority>$LATEST_PRIORITY</priority>
@@ -52,5 +52,5 @@ ENTRY_END
 
 done
 
-echo "</urlset>" >> sitemap.xml
+echo "</urlset>"
 


### PR DESCRIPTION
This is an attempt to fix #802 by adding a sitemap generation step to the release procedure. The sitemap is normally placed at the root of the website, and assigns a higher relative priority to the newest version of the pages (under `/pmd-$version`), which web crawlers should normally acknowledge. Pages under `/latest` are not given special priority, because they're copies anyway. The index.html are given the highest priorities. 

Sample output:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">

    <url>
        <loc>https://pmd.github.io/index.html</loc>
        <priority>1</priority>
        <changefreq>monthly</changefreq>
        <lastmod>2018-05-18</lastmod>
    </url>

    <url>
        <loc>https://pmd.github.io/pmd-6.3.0/index.html</loc>
        <priority>0.9</priority>
        <changefreq>monthly</changefreq>
        <lastmod>2018-05-18</lastmod>
    </url>



    <url>
        <loc>https://pmd.github.io/pmd-6.3.0/pmd_about_help.html</loc>
        <priority>0.8</priority>
        <changefreq>monthly</changefreq>
        <lastmod>2018-05-18</lastmod>
    </url>

    <url>
        <loc>https://pmd.github.io/pmd-6.3.0/pmd_apex_metrics_index.html</loc>
        <priority>0.8</priority>
        <changefreq>monthly</changefreq>
        <lastmod>2018-05-18</lastmod>
    </url>

    <url>
        <loc>https://pmd.github.io/pmd-6.3.0/pmd_devdocs_building.html</loc>
        <priority>0.8</priority>
        <changefreq>monthly</changefreq>
        <lastmod>2018-05-18</lastmod>
    </url>

    <url>
        <loc>https://pmd.github.io/pmd-6.3.0/pmd_devdocs_development.html</loc>
        <priority>0.8</priority>
        <changefreq>monthly</changefreq>
        <lastmod>2018-05-18</lastmod>
    </url>

...

</urlset>
```