### PR TITLE
[java] Improve how we deal with broken classes

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -43,6 +43,7 @@ This is a bug fixing release.
     *   [#1018](https://github.com/pmd/pmd/issues/1018): \[java] Performance degradation of 250% between 6.1.0 and 6.2.0
 *   java
     *   [#1077](https://github.com/pmd/pmd/issues/1077): \[java] Analyzing enum with lambda passed in constructor fails with "The enclosing scope must exist."
+    *   [#1131](https://github.com/pmd/pmd/issues/1131): \[java] java.lang.ClassFormatError: Absent Code attribute in method that is not native or abstract in class file javax/faces/application/FacesMessage$Severity
 *   java-bestpractices
     *   [#527](https://github.com/pmd/pmd/issues/572): \[java] False Alarm of JUnit4TestShouldUseTestAnnotation on Predicates
     *   [#1063](https://github.com/pmd/pmd/issues/1063): \[java] MissingOverride is triggered in illegal places

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -1249,7 +1249,7 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
                     + qualifiedName.substring(qualifiedName.lastIndexOf('.') + 1);
             try {
                 myType = pmdClassLoader.loadClass(qualifiedNameInner);
-            } catch (Exception ignored) {
+            } catch (ClassNotFoundException ignored) {
                 // ignored, we'll try again with a different package name/fqcn
             } catch (LinkageError e) {
                 // we found the class, but there is a problem with it (see https://github.com/pmd/pmd/issues/1131)

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -1234,7 +1234,12 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
                 } catch (ClassNotFoundException e) {
                     myType = processOnDemand(qualifiedName);
                 } catch (LinkageError e) {
-                    myType = processOnDemand(qualifiedName);
+                    // we found the class, but there is a problem with it (see https://github.com/pmd/pmd/issues/1131)
+                    if (LOG.isLoggable(Level.FINE)) {
+                        LOG.log(Level.FINE, "Tried to load class " + qualifiedName + " from on demand import, "
+                                + "with an incomplete classpath.", e);
+                    }
+                    return;
                 }
             }
         }
@@ -1246,6 +1251,13 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
                 myType = pmdClassLoader.loadClass(qualifiedNameInner);
             } catch (Exception ignored) {
                 // ignored, we'll try again with a different package name/fqcn
+            } catch (LinkageError e) {
+                // we found the class, but there is a problem with it (see https://github.com/pmd/pmd/issues/1131)
+                if (LOG.isLoggable(Level.FINE)) {
+                    LOG.log(Level.FINE, "Tried to load class " + qualifiedNameInner + " from on demand import, "
+                            + "with an incomplete classpath.", e);
+                }
+                return;
             }
         }
         if (myType == null && qualifiedName != null && !qualifiedName.contains(".")) {
@@ -1302,8 +1314,11 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
         try {
             pmdClassLoader.loadClass(fullyQualifiedClassName);
             return true; // Class found
-        } catch (ClassNotFoundException | NoClassDefFoundError e) {
+        } catch (ClassNotFoundException e) {
             return false;
+        } catch (LinkageError e2) {
+            // Class exists, but may be invalid (see https://github.com/pmd/pmd/issues/1131)
+            return true;
         }
     }
 
@@ -1311,6 +1326,12 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
         try {
             return pmdClassLoader.loadClass(fullyQualifiedClassName);
         } catch (ClassNotFoundException e) {
+            return null;
+        } catch (LinkageError e2) {
+            if (LOG.isLoggable(Level.FINE)) {
+                LOG.log(Level.FINE, "Tried to load class " + fullyQualifiedClassName + " from on demand import, "
+                        + "with an incomplete classpath.", e2);
+            }
             return null;
         }
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelper.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelper.java
@@ -42,6 +42,9 @@ public final class TypeHelper {
                 // The requested type is not on the auxclasspath. This might happen, if the type node
                 // is probed for a specific type (e.g. is is a JUnit5 Test Annotation class).
                 // Failing to resolve clazzName does not necessarily indicate an incomplete auxclasspath.
+            } catch (final LinkageError expected) {
+                // We found the class but it's invalid / incomplete. This may be an incomplete auxclasspath
+                // if it was a NoClassDefFoundError. TODO : Report it?
             }
         }
 


### PR DESCRIPTION
 - Resolves #1131 
 - The codebase needs some rework. We have lots of code dealing with the classloader, so we may as well refactor it away (to the classloader itself?). The classloader however hides several `NoClassDefFoundError` as `ClassNotFoundException`, which is wrong and may lead us to believe a class doesn't exist when it's simply missing some pieces. I think this refactor is too large to make it into 6.4.0, but the quick fix here provided should be ok and get value to our users ASAP.