### PR TITLE
[core] `run.sh` Designer: Give an error message when openjfx is missing

### DIFF
--- a/pmd-dist/src/main/scripts/run.sh
+++ b/pmd-dist/src/main/scripts/run.sh
@@ -148,7 +148,7 @@ exit_code=${PIPESTATUS[0]}
 
 # Did the java command fail because we're missing net.sourceforge.pmd.util.fxdesigner.Designer?
 if grep -q "net.sourceforge.pmd.util.fxdesigner.Designer" temp_file; then
-  echo "It looks like you're missing the class net.sourceforge.pmd.util.fxdesigner.Designer. A solution might be available here: https://github.com/pmd/pmd/issues/962"
+  echo "You seem to be missing the JavaFX runtime. Please install JavaFX on your system and try again."
 fi
 
 rm ${temp_file}

--- a/pmd-dist/src/main/scripts/run.sh
+++ b/pmd-dist/src/main/scripts/run.sh
@@ -141,5 +141,9 @@ cygwin_paths
 
 java_heapsize_settings
 
-java ${HEAPSIZE} $(jre_specific_vm_options) -cp "${classpath}" "${CLASSNAME}" "$@"
+# Construct a pipe to capture output from the java command. Ref https://unix.stackexchange.com/a/3521/128823
+mkfifo mypipe
+if java ${HEAPSIZE} $(jre_specific_vm_options) -cp "${classpath}" "${CLASSNAME}" "$@" 2> mypipe | grep "net.sourceforge.pmd.util.fxdesigner.Designer" mypipe; then
+  echo "It looks like you're missing the class net.sourceforge.pmd.util.fxdesigner.Designer. A solution might be available here: https://github.com/pmd/pmd/issues/962"
+fi
 


### PR DESCRIPTION
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw test` passes.
 - [x] `./mvnw pmd:check` passes.
 - [x] `./mvnw checkstyle:check` passes. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

I ran into this problem and [others have as well](https://github.com/pmd/pmd/issues/962), so I thought I'd add an error message hinting at a solution so that the next person who runs into this will be able to solve it without wasting time.

I'm sorry about not verifying that test/pmd:check/checkstyle:check still passes, but I'm about 93% sure none of those leads to any checks of the `run.sh` script.