### PR TITLE
[java] Simplify XPath access to type resolution

### DIFF
--- a/docs/pages/pmd/rules/java/bestpractices.md
+++ b/docs/pages/pmd/rules/java/bestpractices.md
@@ -566,10 +566,10 @@ In JUnit 4, only methods annotated with the @Test annotation are executed.
 ```
 //ClassOrInterfaceDeclaration[
        matches(@Image, $testClassPattern)
-        or ExtendsList/ClassOrInterfaceType[pmd-java:typeof(@Image, 'junit.framework.TestCase', 'TestCase')]]
+        or ExtendsList/ClassOrInterfaceType[pmd-java:typeIs('junit.framework.TestCase')]]
 
     /ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration[MethodDeclaration[@Public=true()]/MethodDeclarator[starts-with(@Image, 'test')]]
-    [not(Annotation//Name[pmd-java:typeof(@Image, 'org.junit.Test', 'Test')])]
+    [not(Annotation//Name[pmd-java:typeIs('org.junit.Test')])]
 ```
 
 **Example(s):**
@@ -1312,7 +1312,7 @@ This rule detects JUnit assertions in object equality. These assertions should b
     PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Name
     [ends-with(@Image, '.equals')]
 ]
-[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeof(@Image, 'junit.framework.TestCase','TestCase')] or //MarkerAnnotation/Name[pmd-java:typeof(@Image, 'org.junit.Test', 'Test')]]]
+[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeIs('junit.framework.TestCase')] or //MarkerAnnotation/Name[pmd-java:typeIs('org.junit.Test')]]]
 ```
 
 **Example(s):**
@@ -1350,7 +1350,7 @@ more specific methods, like assertNull, assertNotNull.
   Expression/EqualityExpression/PrimaryExpression/PrimaryPrefix/Literal/NullLiteral
  ]
 ]
-[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeof(@Image, 'junit.framework.TestCase','TestCase')] or //MarkerAnnotation/Name[pmd-java:typeof(@Image, 'org.junit.Test', 'Test')]]]
+[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeIs('junit.framework.TestCase')] or //MarkerAnnotation/Name[pmd-java:typeIs('org.junit.Test')]]]
 ```
 
 **Example(s):**
@@ -1390,7 +1390,7 @@ by more specific methods, like assertSame, assertNotSame.
 [PrimarySuffix/Arguments
  /ArgumentList/Expression
  /EqualityExpression[count(.//NullLiteral) = 0]]
-[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeof(@Image, 'junit.framework.TestCase','TestCase')] or //MarkerAnnotation/Name[pmd-java:typeof(@Image, 'org.junit.Test', 'Test')]]]
+[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeIs('junit.framework.TestCase')] or //MarkerAnnotation/Name[pmd-java:typeIs('org.junit.Test')]]]
 ```
 
 **Example(s):**

--- a/docs/pages/pmd/rules/java/design.md
+++ b/docs/pages/pmd/rules/java/design.md
@@ -23,7 +23,7 @@ protected constructor in order to prevent instantiation than make the class misl
 //ClassOrInterfaceDeclaration
     [@Abstract = 'true']
     [count(//MethodDeclaration) + count(//ConstructorDeclaration) = 0]
-    [not(../Annotation/MarkerAnnotation/Name[typeof(@Image, 'com.google.auto.value.AutoValue', 'AutoValue')])]
+    [not(../Annotation/MarkerAnnotation/Name[typeIs('com.google.auto.value.AutoValue')])]
 ```
 
 **Example(s):**
@@ -259,13 +259,13 @@ Exception, or Error, use a subclassed exception or error instead.
 ```
 //ThrowStatement//AllocationExpression
  /ClassOrInterfaceType[
- typeof(@Image, 'java.lang.Throwable', 'Throwable')
+ typeIsExactly('java.lang.Throwable')
 or
- typeof(@Image, 'java.lang.Exception', 'Exception')
+ typeIsExactly('java.lang.Exception')
 or
- typeof(@Image, 'java.lang.Error', 'Error')
+ typeIsExactly('java.lang.Error')
 or
- typeof(@Image, 'java.lang.RuntimeException', 'RuntimeException')
+ typeIsExactly('java.lang.RuntimeException')
 ]
 ```
 
@@ -518,7 +518,7 @@ Errors are system exceptions. Do not extend them.
 **This rule is defined by the following XPath expression:**
 ```
 //ClassOrInterfaceDeclaration/ExtendsList/ClassOrInterfaceType
-  [typeof(@Image,'java.lang.Error','Error')]
+  [typeIs('java.lang.Error')]
 ```
 
 **Example(s):**
@@ -1406,7 +1406,7 @@ PrimaryExpression/PrimarySuffix/Arguments/ArgumentList
  /Expression/UnaryExpressionNotPlusMinus[@Image='!']
 /PrimaryExpression/PrimaryPrefix
 ]
-[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeof(@Image, 'junit.framework.TestCase','TestCase')] or //MarkerAnnotation/Name[pmd-java:typeof(@Image, 'org.junit.Test', 'Test')]]]
+[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeIs('junit.framework.TestCase')] or //MarkerAnnotation/Name[pmd-java:typeIs('org.junit.Test')]]]
 ```
 
 **Example(s):**

--- a/docs/pages/pmd/rules/java/documentation.md
+++ b/docs/pages/pmd/rules/java/documentation.md
@@ -132,7 +132,7 @@ and unintentional empty constructors.
 ```
 //ConstructorDeclaration[@Private='false']
                         [count(BlockStatement) = 0 and ($ignoreExplicitConstructorInvocation = 'true' or not(ExplicitConstructorInvocation)) and @containsComment = 'false']
-                        [not(../Annotation/MarkerAnnotation/Name[typeof(@Image, 'javax.inject.Inject', 'Inject')])]
+                        [not(../Annotation/MarkerAnnotation/Name[typeIs('javax.inject.Inject')])]
 ```
 
 **Example(s):**

--- a/docs/pages/pmd/rules/java/errorprone.md
+++ b/docs/pages/pmd/rules/java/errorprone.md
@@ -796,9 +796,9 @@ Super should be called at the start of the method
     /Block[not(
       (BlockStatement[1]/Statement/StatementExpression/PrimaryExpression[./PrimaryPrefix[@SuperModifier='true']]/PrimarySuffix[@Image= ancestor::MethodDeclaration/MethodDeclarator/@Image]))]
 [ancestor::ClassOrInterfaceDeclaration[ExtendsList/ClassOrInterfaceType[
-  typeof(@Image, 'android.app.Activity', 'Activity') or
-  typeof(@Image, 'android.app.Application', 'Application') or
-  typeof(@Image, 'android.app.Service', 'Service')
+  typeIs('android.app.Activity') or
+  typeIs('android.app.Application') or
+  typeIs('android.app.Service')
 ]]]
 ```
 
@@ -839,9 +839,9 @@ Super should be called at the end of the method
    /Block/BlockStatement[last()]
     [not(Statement/StatementExpression/PrimaryExpression[./PrimaryPrefix[@SuperModifier='true']]/PrimarySuffix[@Image= ancestor::MethodDeclaration/MethodDeclarator/@Image])]
 [ancestor::ClassOrInterfaceDeclaration[ExtendsList/ClassOrInterfaceType[
-  typeof(@Image, 'android.app.Activity', 'Activity') or
-  typeof(@Image, 'android.app.Application', 'Application') or
-  typeof(@Image, 'android.app.Service', 'Service')
+  typeIs('android.app.Activity') or
+  typeIs('android.app.Application') or
+  typeIs('android.app.Service')
 ]]]
 ```
 
@@ -2176,7 +2176,7 @@ Some JUnit framework methods are easy to misspell.
  or (not(@Image = 'tearDown')
  and translate(@Image, 'TEARdOWN', 'tearDown') = 'tearDown')]
  [FormalParameters[count(*) = 0]]
-[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeof(@Image, 'junit.framework.TestCase','TestCase')] or //MarkerAnnotation/Name[pmd-java:typeof(@Image, 'org.junit.Test', 'Test')]]]
+[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeIs('junit.framework.TestCase')] or //MarkerAnnotation/Name[pmd-java:typeIs('org.junit.Test')]]]
 ```
 
 **Example(s):**
@@ -2208,7 +2208,7 @@ The suite() method in a JUnit test needs to be both public and static.
 //MethodDeclaration[not(@Static='true') or not(@Public='true')]
 [MethodDeclarator/@Image='suite']
 [MethodDeclarator/FormalParameters/@ParameterCount=0]
-[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeof(@Image, 'junit.framework.TestCase','TestCase')] or //MarkerAnnotation/Name[pmd-java:typeof(@Image, 'org.junit.Test', 'Test')]]]
+[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeIs('junit.framework.TestCase')] or //MarkerAnnotation/Name[pmd-java:typeIs('org.junit.Test')]]]
 ```
 
 **Example(s):**
@@ -3196,7 +3196,7 @@ or
 UnaryExpressionNotPlusMinus[@Image='!']
 /PrimaryExpression/PrimaryPrefix[Literal/BooleanLiteral or Name[count(../../*)=1]]]
 ]
-[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeof(@Image, 'junit.framework.TestCase','TestCase')] or //MarkerAnnotation/Name[pmd-java:typeof(@Image, 'org.junit.Test', 'Test')]]]
+[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeIs('junit.framework.TestCase')] or //MarkerAnnotation/Name[pmd-java:typeIs('org.junit.Test')]]]
 ```
 
 **Example(s):**

--- a/docs/pages/pmd/rules/java/multithreading.md
+++ b/docs/pages/pmd/rules/java/multithreading.md
@@ -64,7 +64,7 @@ it contains methods that are not thread-safe.
 
 **This rule is defined by the following XPath expression:**
 ```
-//AllocationExpression/ClassOrInterfaceType[pmd-java:typeof(@Image, 'java.lang.ThreadGroup')]|
+//AllocationExpression/ClassOrInterfaceType[pmd-java:typeIs('java.lang.ThreadGroup')]|
 //PrimarySuffix[contains(@Image, 'getThreadGroup')]
 ```
 
@@ -166,8 +166,8 @@ Explicitly calling Thread.run() method will execute in the caller's thread of co
     [
         ./Name[ends-with(@Image, '.run') or @Image = 'run']
         and substring-before(Name/@Image, '.') =//VariableDeclarator/VariableDeclaratorId/@Image
-            [../../../Type/ReferenceType/ClassOrInterfaceType[typeof(@Image, 'java.lang.Thread', 'Thread')]]
-        or (./AllocationExpression/ClassOrInterfaceType[typeof(@Image, 'java.lang.Thread', 'Thread')]
+            [../../../Type/ReferenceType/ClassOrInterfaceType[typeIs('java.lang.Thread')]]
+        or (./AllocationExpression/ClassOrInterfaceType[typeIs('java.lang.Thread')]
         and ../PrimarySuffix[@Image = 'run'])
     ]
 ]

--- a/docs/pages/pmd/rules/java/performance.md
+++ b/docs/pages/pmd/rules/java/performance.md
@@ -132,10 +132,10 @@ The FileReader and FileWriter constructors instantiate FileInputStream and FileO
 **This rule is defined by the following XPath expression:**
 ```
 //PrimaryPrefix/AllocationExpression/ClassOrInterfaceType[
-       typeof(@Image, 'java.io.FileInputStream', 'FileInputStream')
-    or typeof(@Image, 'java.io.FileOutputStream', 'FileOutputStream')
-    or typeof(@Image, 'java.io.FileReader', 'FileReader')
-    or typeof(@Image, 'java.io.FileWriter', 'FileWriter')
+       typeIs('java.io.FileInputStream')
+    or typeIs('java.io.FileOutputStream')
+    or typeIs('java.io.FileReader')
+    or typeIs('java.io.FileWriter')
   ]
 ```
 
@@ -208,10 +208,10 @@ adverse impacts on performance.
 ```
 //FieldDeclaration/Type/PrimitiveType[@Image = 'short']
 |
-//ClassOrInterfaceBodyDeclaration[not(Annotation/MarkerAnnotation/Name[typeof(@Image, 'java.lang.Override', 'Override')])]
+//ClassOrInterfaceBodyDeclaration[not(Annotation/MarkerAnnotation/Name[typeIs('java.lang.Override')])]
     /MethodDeclaration/ResultType/Type/PrimitiveType[@Image = 'short']
 |
-//ClassOrInterfaceBodyDeclaration[not(Annotation/MarkerAnnotation/Name[typeof(@Image, 'java.lang.Override', 'Override')])]
+//ClassOrInterfaceBodyDeclaration[not(Annotation/MarkerAnnotation/Name[typeIs('java.lang.Override')])]
     /MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/Type/PrimitiveType[@Image = 'short']
 |
 //LocalVariableDeclaration/Type/PrimitiveType[@Image = 'short']
@@ -300,7 +300,7 @@ Note that new Byte() is deprecated since JDK 9 for that reason.
 ```
 //AllocationExpression
 [not (ArrayDimsAndInits)
-and ClassOrInterfaceType[typeof(@Image, 'java.lang.Byte', 'Byte')]]
+and ClassOrInterfaceType[typeIs('java.lang.Byte')]]
 ```
 
 **Example(s):**
@@ -498,7 +498,7 @@ Note that new Integer() is deprecated since JDK 9 for that reason.
 ```
 //AllocationExpression
   [not (ArrayDimsAndInits)
-   and ClassOrInterfaceType[typeof(@Image, 'java.lang.Integer', 'Integer')]]
+   and ClassOrInterfaceType[typeIs('java.lang.Integer')]]
 ```
 
 **Example(s):**
@@ -528,7 +528,7 @@ Note that new Long() is deprecated since JDK 9 for that reason.
 ```
 //AllocationExpression
 [not (ArrayDimsAndInits)
-and ClassOrInterfaceType[typeof(@Image, 'java.lang.Long', 'Long')]]
+and ClassOrInterfaceType[typeIs('java.lang.Long')]]
 ```
 
 **Example(s):**
@@ -647,7 +647,7 @@ Note that new Short() is deprecated since JDK 9 for that reason.
 ```
 //AllocationExpression
 [not (ArrayDimsAndInits)
-and ClassOrInterfaceType[typeof(@Image, 'java.lang.Short', 'Short')]]
+and ClassOrInterfaceType[typeIs('java.lang.Short')]]
 ```
 
 **Example(s):**

--- a/docs/pages/pmd/userdocs/extending/writing_pmd_rules.md
+++ b/docs/pages/pmd/userdocs/extending/writing_pmd_rules.md
@@ -256,13 +256,13 @@ More information about writing XPath rules is [available here](pmd_userdocs_exte
 
 ### Inside an XPath query
 
-PMD XPath syntax includes now a new function called `typeof` which determines if a node (ClassOrInterfaceType only right now) is of the provided type. It also scans the type’s hierarchy, so if you extend a class it will also find this out.
+PMD XPath syntax includes two functions called `typeIs` and `typeIsExactly` which determines if a node is of the provided type (either exactly or any subtype).
 
 Here a an example of use, inside an XPath Query:
 
 ```xpath
 //ClassOrInterfaceDeclaration[
-    //ClassOrInterfaceType[typeof(@Image, 'junit.framework.TestCase','TestCase')]
+    //ClassOrInterfaceType[typeIs('junit.framework.TestCase')]
 ]
 ```
 

--- a/docs/pages/pmd/userdocs/suppressing_warnings.md
+++ b/docs/pages/pmd/userdocs/suppressing_warnings.md
@@ -174,7 +174,7 @@ suppress reporting specifically typed parameters which are unused:
 
     <rule ref="rulesets/java/unusedcode.xml/UnusedFormalParameter">
       <properties>
-        <property name="violationSuppressXPath" value=".[typeof('java.lang.String')]"/>
+        <property name="violationSuppressXPath" value=".[typeIs('java.lang.String')]"/>
       </properties>
     </rule>
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -24,8 +24,8 @@ This is a bug fixing release.
 
 #### XPath Type Resolution Methods
 
-For some time now PMD has supported Type Resolution, and exposed this functionality to XPath rules for Java language
-with the `typeof` method. This method however had a number of shortcomings:
+For some time now PMD has supported Type Resolution, and exposed this functionality to XPath rules for the Java language
+with the `typeof` function. This function however had a number of shortcomings:
 
 *   It would take a first arg with the name to match if types couldn't be resolved. In all cases this was `@Image`
     but was still required.
@@ -34,7 +34,7 @@ with the `typeof` method. This method however had a number of shortcomings:
 *   If only the Fully Qualified Class Name was provided, no short name check was performed (not documented,
     but abused on some rules to "fix" some false positives).
 
-In this release we are deprecating `typeof` in favor of a simpler `typeIs` method, which behaves exactly as the
+In this release we are deprecating `typeof` in favor of a simpler `typeIs` function, which behaves exactly as the
 old `typeof` when given all 3 arguments.
 
 `typeIs` receives a single parameter, containing the fully qualified name of the class to test against.
@@ -51,8 +51,8 @@ can now we expressed much more concisely as:
 //ClassOrInterfaceType[typeIs('junit.framework.TestCase')]
 ```
 
-Additionally, we have introduced a companion `typeIsExactly` method, that receives the same parameters, but
-will check for exact type matches without transversing the type hierarchy. That is, when using
+Additionally, we have introduced a companion `typeIsExactly` function, that receives the same parameters, but
+will check for exact type matches without traversing the type hierarchy. That is, when using
 `typeIsExactly('junit.framework.TestCase')` will match only if the class is an instance of `TestCase`, but
 not if it's a subclass of `TestCase`.
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -51,6 +51,9 @@ can now we expressed much more concisely as:
 //ClassOrInterfaceType[typeIs('junit.framework.TestCase')]
 ```
 
+With this change, we also allow to check against array types by just append `[]` to the fully quallified class name.
+These can be repeated for arrays of arrays (ie: `byte[][]` or `java.lang.String[]`)
+
 Additionally, we have introduced a companion `typeIsExactly` function, that receives the same parameters, but
 will check for exact type matches without traversing the type hierarchy. That is, when using
 `typeIsExactly('junit.framework.TestCase')` will match only if the class is an instance of `TestCase`, but

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -13,6 +13,7 @@ This is a bug fixing release.
 ### Table Of Contents
 
 * [New and noteworthy](#new-and-noteworthy)
+    *   [XPath Type Resolution Methods](#xpath-type-resolution-methods)
     *   [New Rules](#new-rules)
     *   [Modified Rules](#modified-rules)
 * [Fixed Issues](#fixed-issues)
@@ -20,6 +21,40 @@ This is a bug fixing release.
 * [External Contributions](#external-contributions)
 
 ### New and noteworthy
+
+#### XPath Type Resolution Methods
+
+For some time now PMD has supported Type Resolution, and exposed this functionality to XPath rules for Java language
+with the `typeof` method. This method however had a number of shortcomings:
+
+*   It would take a first arg with the name to match if types couldn't be resolved. In all cases this was `@Image`
+    but was still required.
+*   It required 2 separate arguments for the Fully Qualified Class Name and the short name of the class against
+    which to test.
+*   If only the Fully Qualified Class Name was provided, no short name check was performed (not documented,
+    but abused on some rules to "fix" some false positives).
+
+In this release we are deprecating `typeof` in favor of a simpler `typeIs` method, which behaves exactly as the
+old `typeof` when given all 3 arguments.
+
+`typeIs` receives a single parameter, containing the fully qualified name of the class to test against.
+
+So, calls such as:
+
+```xml`
+//ClassOrInterfaceType[typeof(@Image, 'junit.framework.TestCase', 'TestCase')]
+```
+
+can now we expressed much more concisely as:
+
+```xml`
+//ClassOrInterfaceType[typeIs('junit.framework.TestCase')]
+```
+
+Additionally, we have introduced a companion `typeIsExactly` method, that receives the same parameters, but
+will check for exact type matches without transversing the type hierarchy. That is, when using
+`typeIsExactly('junit.framework.TestCase')` will match only if the class is an instance of `TestCase`, but
+not if it's a subclass of `TestCase`.
 
 #### New Rules
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/AbstractJavaHandler.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/AbstractJavaHandler.java
@@ -27,6 +27,8 @@ import net.sourceforge.pmd.lang.java.typeresolution.TypeResolutionFacade;
 import net.sourceforge.pmd.lang.java.xpath.GetCommentOnFunction;
 import net.sourceforge.pmd.lang.java.xpath.JavaFunctions;
 import net.sourceforge.pmd.lang.java.xpath.MetricFunction;
+import net.sourceforge.pmd.lang.java.xpath.TypeIsExactlyFunction;
+import net.sourceforge.pmd.lang.java.xpath.TypeIsFunction;
 import net.sourceforge.pmd.lang.java.xpath.TypeOfFunction;
 import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
 
@@ -53,6 +55,8 @@ public abstract class AbstractJavaHandler extends AbstractLanguageVersionHandler
                 TypeOfFunction.registerSelfInSimpleContext();
                 GetCommentOnFunction.registerSelfInSimpleContext();
                 MetricFunction.registerSelfInSimpleContext();
+                TypeIsFunction.registerSelfInSimpleContext();
+                TypeIsExactlyFunction.registerSelfInSimpleContext();
             }
 
             @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ForLoopCanBeForeachRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ForLoopCanBeForeachRule.java
@@ -63,7 +63,7 @@ public class ForLoopCanBeForeachRule extends AbstractJavaRule {
         List<NameOccurrence> occurrences = indexDecl.getValue();
         VariableNameDeclaration index = indexDecl.getKey();
 
-        if (TypeHelper.isA(index, Iterator.class)) {
+        if (TypeHelper.isExactlyAny(index, Iterator.class)) {
             Entry<VariableNameDeclaration, List<NameOccurrence>> iterableInfo = getIterableDeclOfIteratorLoop(index, node.getScope());
 
             if (iterableInfo != null && isReplaceableIteratorLoop(indexDecl, guardCondition, iterableInfo, node)) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveAppendsShouldReuseRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveAppendsShouldReuseRule.java
@@ -129,7 +129,7 @@ public class ConsecutiveAppendsShouldReuseRule extends AbstractJavaRule {
         Map<VariableNameDeclaration, List<NameOccurrence>> declarations = node.getScope()
                 .getDeclarations(VariableNameDeclaration.class);
         for (VariableNameDeclaration decl : declarations.keySet()) {
-            if (decl.getName().equals(name) && TypeHelper.isEither(decl, StringBuilder.class, StringBuffer.class)) {
+            if (decl.getName().equals(name) && TypeHelper.isExactlyAny(decl, StringBuilder.class, StringBuffer.class)) {
                 return true;
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientStringBufferingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientStringBufferingRule.java
@@ -160,7 +160,7 @@ public class InefficientStringBufferingRule extends AbstractJavaRule {
         if (argList == null || argList.jjtGetNumChildren() > 1) {
             return false;
         }
-        return TypeHelper.isEither((TypedNameDeclaration) n.getNameDeclaration(), StringBuffer.class,
+        return TypeHelper.isExactlyAny((TypedNameDeclaration) n.getNameDeclaration(), StringBuffer.class,
                 StringBuilder.class);
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
@@ -55,7 +55,7 @@ public class InsufficientStringBufferDeclarationRule extends AbstractJavaRule {
 
     @Override
     public Object visit(ASTVariableDeclaratorId node, Object data) {
-        if (!TypeHelper.isEither(node.getNameDeclaration(), StringBuffer.class, StringBuilder.class)) {
+        if (!TypeHelper.isExactlyAny(node.getNameDeclaration(), StringBuffer.class, StringBuilder.class)) {
             return data;
         }
         Node rootNode = node;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/StringInstantiationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/StringInstantiationRule.java
@@ -50,7 +50,7 @@ public class StringInstantiationRule extends AbstractJavaRule {
             return data;
         }
 
-        if (nd instanceof TypedNameDeclaration && TypeHelper.isA((TypedNameDeclaration) nd, String.class)) {
+        if (nd instanceof TypedNameDeclaration && TypeHelper.isExactlyAny((TypedNameDeclaration) nd, String.class)) {
             addViolation(data, node);
         }
         return data;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/StringToStringRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/StringToStringRule.java
@@ -17,8 +17,8 @@ import net.sourceforge.pmd.lang.symboltable.ScopedNode;
 public class StringToStringRule extends AbstractJavaRule {
 
     public Object visit(ASTVariableDeclaratorId node, Object data) {
-        if (!TypeHelper.isA(node.getNameDeclaration(), String.class)
-                && !TypeHelper.isA(node.getNameDeclaration(), String[].class)) {
+        if (!TypeHelper.isExactlyAny(node.getNameDeclaration(), String.class)
+                && !TypeHelper.isExactlyAny(node.getNameDeclaration(), String[].class)) {
             return data;
         }
         boolean isArray = node.isArray();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/UseStringBufferLengthRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/UseStringBufferLengthRule.java
@@ -64,7 +64,7 @@ public class UseStringBufferLengthRule extends AbstractJavaRule {
             return data;
         }
         if (alreadySeen.contains(nd) || !(nd instanceof TypedNameDeclaration) || nd instanceof TypedNameDeclaration
-                && TypeHelper.isNeither((TypedNameDeclaration) nd, StringBuffer.class, StringBuilder.class)) {
+                && TypeHelper.isExactlyNone((TypedNameDeclaration) nd, StringBuffer.class, StringBuilder.class)) {
             return data;
         }
         alreadySeen.add(nd);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelper.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelper.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.typeresolution;
 
+import org.apache.commons.lang3.ClassUtils;
+
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.symboltable.TypedNameDeclaration;
@@ -61,7 +63,7 @@ public final class TypeHelper {
                 }
     
                 // If the requested type is in the classpath, using the same classloader should work
-                return classLoader.loadClass(clazzName);
+                return ClassUtils.getClass(classLoader, clazzName);
             } catch (final ClassNotFoundException ignored) {
                 // The requested type is not on the auxclasspath. This might happen, if the type node
                 // is probed for a specific type (e.g. is is a JUnit5 Test Annotation class).

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelper.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelper.java
@@ -24,6 +24,34 @@ public final class TypeHelper {
      * @return <code>true</code> if type node n is of type clazzName or a subtype of clazzName
      */
     public static boolean isA(final TypeNode n, final String clazzName) {
+        final Class<?> clazz = loadClassWithNodeClassloader(n, clazzName);
+
+        if (clazz != null) {
+            return isA(n, clazz);
+        }
+
+        return clazzName.equals(n.getImage()) || clazzName.endsWith("." + n.getImage());
+    }
+    
+    /**
+     * Checks whether the resolved type of the given {@link TypeNode} n is exactly of the type
+     * given by the clazzName.
+     *
+     * @param n the type node to check
+     * @param clazzName the class name to compare to
+     * @return <code>true</code> if type node n is exactly of type clazzName.
+     */
+    public static boolean isExactlyA(final TypeNode n, final String clazzName) {
+        final Class<?> clazz = loadClassWithNodeClassloader(n, clazzName);
+
+        if (clazz != null) {
+            return n.getType() == clazz;
+        }
+
+        return clazzName.equals(n.getImage()) || clazzName.endsWith("." + n.getImage());
+    }
+    
+    private static Class<?> loadClassWithNodeClassloader(final TypeNode n, final String clazzName) {
         if (n.getType() != null) {
             try {
                 ClassLoader classLoader = n.getType().getClassLoader();
@@ -31,21 +59,20 @@ public final class TypeHelper {
                     // Using the system classloader then
                     classLoader = ClassLoader.getSystemClassLoader();
                 }
-
+    
                 // If the requested type is in the classpath, using the same classloader should work
-                final Class<?> clazz = classLoader.loadClass(clazzName);
-
-                if (clazz != null) {
-                    return isA(n, clazz);
-                }
+                return classLoader.loadClass(clazzName);
             } catch (final ClassNotFoundException ignored) {
                 // The requested type is not on the auxclasspath. This might happen, if the type node
                 // is probed for a specific type (e.g. is is a JUnit5 Test Annotation class).
                 // Failing to resolve clazzName does not necessarily indicate an incomplete auxclasspath.
+            } catch (final LinkageError expected) {
+                // We found the class but it's invalid / incomplete. This may be an incomplete auxclasspath
+                // if it was a NoClassDefFoundError. TODO : Report it?
             }
         }
-
-        return clazzName.equals(n.getImage()) || clazzName.endsWith("." + n.getImage());
+        
+        return null;
     }
     
     public static boolean isA(TypeNode n, Class<?> clazz) {
@@ -56,16 +83,42 @@ public final class TypeHelper {
         return subclasses(n, class1) || subclasses(n, class2);
     }
 
-    public static boolean isA(TypedNameDeclaration vnd, Class<?> clazz) {
+    public static boolean isExactlyAny(TypedNameDeclaration vnd, Class<?>... clazzes) {
         Class<?> type = vnd.getType();
-        return type != null && type.equals(clazz) || type == null
-                && (clazz.getSimpleName().equals(vnd.getTypeImage()) || clazz.getName().equals(vnd.getTypeImage()));
+        for (final Class<?> clazz : clazzes) {
+            if (type != null && type.equals(clazz) || type == null
+                    && (clazz.getSimpleName().equals(vnd.getTypeImage()) || clazz.getName().equals(vnd.getTypeImage()))) {
+                return true;
+            }
+        }
+        
+        return false;
+    }
+    
+    public static boolean isExactlyNone(TypedNameDeclaration vnd, Class<?>... clazzes) {
+        return !isExactlyAny(vnd, clazzes);
+    }
+    
+    /**
+     * @deprecated use {@link #isExactlyAny(TypedNameDeclaration, Class...)}
+     */
+    @Deprecated
+    public static boolean isA(TypedNameDeclaration vnd, Class<?> clazz) {
+        return isExactlyAny(vnd, clazz);
     }
 
+    /**
+     * @deprecated use {@link #isExactlyAny(TypedNameDeclaration, Class...)}
+     */
+    @Deprecated
     public static boolean isEither(TypedNameDeclaration vnd, Class<?> class1, Class<?> class2) {
-        return isA(vnd, class1) || isA(vnd, class2);
+        return isExactlyAny(vnd, class1, class2);
     }
 
+    /**
+     * @deprecated use {@link #isExactlyNone(TypedNameDeclaration, Class...)}
+     */
+    @Deprecated
     public static boolean isNeither(TypedNameDeclaration vnd, Class<?> class1, Class<?> class2) {
         return !isA(vnd, class1) && !isA(vnd, class2);
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/xpath/JavaFunctions.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/xpath/JavaFunctions.java
@@ -18,16 +18,27 @@ public final class JavaFunctions {
         // utility class
     }
 
-    public static boolean typeof(XPathContext context, String nodeTypeName, String fullTypeName) {
+    @Deprecated
+    public static boolean typeof(final XPathContext context, final String nodeTypeName, final String fullTypeName) {
         return typeof(context, nodeTypeName, fullTypeName, null);
     }
 
-    public static boolean typeof(XPathContext context, String nodeTypeName, String fullTypeName, String shortTypeName) {
+    @Deprecated
+    public static boolean typeof(final XPathContext context, final String nodeTypeName,
+            final String fullTypeName, final String shortTypeName) {
         return TypeOfFunction.typeof((Node) ((ElementNode) context.getContextItem()).getUnderlyingNode(), nodeTypeName,
                 fullTypeName, shortTypeName);
     }
 
-    public static double metric(XPathContext context, String metricKeyName) {
+    public static double metric(final XPathContext context, final String metricKeyName) {
         return MetricFunction.getMetric((Node) ((ElementNode) context.getContextItem()).getUnderlyingNode(), metricKeyName);
+    }
+
+    public static boolean typeIs(final XPathContext context, final String fullTypeName) {
+        return TypeIsFunction.typeIs((Node) ((ElementNode) context.getContextItem()).getUnderlyingNode(), fullTypeName);
+    }
+
+    public static boolean typeIsExactly(final XPathContext context, final String fullTypeName) {
+        return TypeIsExactlyFunction.typeIsExactly((Node) ((ElementNode) context.getContextItem()).getUnderlyingNode(), fullTypeName);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/xpath/TypeIsExactlyFunction.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/xpath/TypeIsExactlyFunction.java
@@ -1,0 +1,54 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.xpath;
+
+import java.util.List;
+
+import org.jaxen.Context;
+import org.jaxen.Function;
+import org.jaxen.FunctionCallException;
+import org.jaxen.SimpleFunctionContext;
+import org.jaxen.XPathFunctionContext;
+
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.java.ast.TypeNode;
+import net.sourceforge.pmd.lang.java.typeresolution.TypeHelper;
+
+public class TypeIsExactlyFunction implements Function {
+
+    public static void registerSelfInSimpleContext() {
+        ((SimpleFunctionContext) XPathFunctionContext.getInstance()).registerFunction(null, "typeIsExactly",
+                new TypeIsExactlyFunction());
+    }
+
+    @Override
+    public Object call(final Context context, final List args) throws FunctionCallException {
+        if (args.size() != 1) {
+            throw new IllegalArgumentException(
+                    "typeIsExactly function takes a single String argument with the fully qualified type name to check against.");
+        }
+        final String fullTypeName = (String) args.get(0);
+        final Node n = (Node) context.getNodeSet().get(0);
+        
+        return typeIsExactly(n, fullTypeName);
+    }
+
+    /**
+     * Example XPath 1.0: {@code //ClassOrInterfaceType[typeIsExactly('java.lang.String')]}
+     * <p>
+     * Example XPath 2.0: {@code //ClassOrInterfaceType[pmd-java:typeIsExactly('java.lang.String')]}
+     *
+     * @param n The node on which to check for types
+     * @param fullTypeName The fully qualified name of the class or any supertype
+     * @return True if the type of the node matches, false otherwise.
+     */
+    public static boolean typeIsExactly(final Node n, final String fullTypeName) {
+        if (n instanceof TypeNode) {
+            return TypeHelper.isExactlyA((TypeNode) n, fullTypeName);
+        } else {
+            throw new IllegalArgumentException("typeIsExactly function may only be called on a TypeNode.");
+        }
+    }
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/xpath/TypeIsFunction.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/xpath/TypeIsFunction.java
@@ -1,0 +1,54 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.xpath;
+
+import java.util.List;
+
+import org.jaxen.Context;
+import org.jaxen.Function;
+import org.jaxen.FunctionCallException;
+import org.jaxen.SimpleFunctionContext;
+import org.jaxen.XPathFunctionContext;
+
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.java.ast.TypeNode;
+import net.sourceforge.pmd.lang.java.typeresolution.TypeHelper;
+
+public class TypeIsFunction implements Function {
+
+    public static void registerSelfInSimpleContext() {
+        ((SimpleFunctionContext) XPathFunctionContext.getInstance()).registerFunction(null, "typeIs",
+                new TypeIsFunction());
+    }
+
+    @Override
+    public Object call(final Context context, final List args) throws FunctionCallException {
+        if (args.size() != 1) {
+            throw new IllegalArgumentException(
+                    "typeIs function takes a single String argument with the fully qualified type name to check against.");
+        }
+        final String fullTypeName = (String) args.get(0);
+        final Node n = (Node) context.getNodeSet().get(0);
+        
+        return typeIs(n, fullTypeName);
+    }
+
+    /**
+     * Example XPath 1.0: {@code //ClassOrInterfaceType[typeIs('java.lang.String')]}
+     * <p>
+     * Example XPath 2.0: {@code //ClassOrInterfaceType[pmd-java:typeIs('java.lang.String')]}
+     *
+     * @param n The node on which to check for types
+     * @param fullTypeName The fully qualified name of the class or any supertype
+     * @return True if the type of the node matches, false otherwise.
+     */
+    public static boolean typeIs(final Node n, final String fullTypeName) {
+        if (n instanceof TypeNode) {
+            return TypeHelper.isA((TypeNode) n, fullTypeName);
+        } else {
+            throw new IllegalArgumentException("typeIs function may only be called on a TypeNode.");
+        }
+    }
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/xpath/TypeOfFunction.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/xpath/TypeOfFunction.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.java.xpath;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.logging.Logger;
 
 import org.jaxen.Context;
 import org.jaxen.Function;
@@ -13,11 +14,16 @@ import org.jaxen.FunctionCallException;
 import org.jaxen.SimpleFunctionContext;
 import org.jaxen.XPathFunctionContext;
 
+import net.sourceforge.pmd.PMDVersion;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.ast.xpath.Attribute;
 import net.sourceforge.pmd.lang.java.ast.TypeNode;
 
+@Deprecated
 public class TypeOfFunction implements Function {
+
+    private static final Logger LOG = Logger.getLogger(TypeOfFunction.class.getName());
+    private static boolean deprecationWarned = false;
 
     public static void registerSelfInSimpleContext() {
         ((SimpleFunctionContext) XPathFunctionContext.getInstance()).registerFunction(null, "typeof",
@@ -25,7 +31,8 @@ public class TypeOfFunction implements Function {
     }
 
     public Object call(Context context, List args) throws FunctionCallException {
-
+        nagDeprecatedFunction();
+        
         String nodeTypeName = null;
         String fullTypeName = null;
         String shortTypeName = null;
@@ -57,6 +64,14 @@ public class TypeOfFunction implements Function {
         return typeof(n, nodeTypeName, fullTypeName, shortTypeName);
     }
 
+    private static void nagDeprecatedFunction() {
+        if (!deprecationWarned) {
+            deprecationWarned = true;
+            LOG.warning("The XPath function typeof() is deprecated and will be removed in "
+                    + PMDVersion.getNextMajorRelease() + ". Use typeIs() instead.");
+        }
+    }
+
     /**
      * Example XPath 1.0: {@code //ClassOrInterfaceType[typeof(@Image, 'java.lang.String', 'String')]}
      * <p>
@@ -69,6 +84,8 @@ public class TypeOfFunction implements Function {
      * @return
      */
     public static boolean typeof(Node n, String nodeTypeName, String fullTypeName, String shortTypeName) {
+        nagDeprecatedFunction();
+        
         if (n instanceof TypeNode) {
             Class<?> type = ((TypeNode) n).getType();
             if (type == null) {

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -536,10 +536,10 @@ In JUnit 4, only methods annotated with the @Test annotation are executed.
 <![CDATA[
 //ClassOrInterfaceDeclaration[
        matches(@Image, $testClassPattern)
-        or ExtendsList/ClassOrInterfaceType[pmd-java:typeof(@Image, 'junit.framework.TestCase', 'TestCase')]]
+        or ExtendsList/ClassOrInterfaceType[pmd-java:typeIs('junit.framework.TestCase')]]
 
     /ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration[MethodDeclaration[@Public=true()]/MethodDeclarator[starts-with(@Image, 'test')]]
-    [not(Annotation//Name[pmd-java:typeof(@Image, 'org.junit.Test', 'Test')])]
+    [not(Annotation//Name[pmd-java:typeIs('org.junit.Test')])]
 ]]>
                 </value>
             </property>
@@ -1207,7 +1207,7 @@ This rule detects JUnit assertions in object equality. These assertions should b
     PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Name
     [ends-with(@Image, '.equals')]
 ]
-[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeof(@Image, 'junit.framework.TestCase','TestCase')] or //MarkerAnnotation/Name[pmd-java:typeof(@Image, 'org.junit.Test', 'Test')]]]
+[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeIs('junit.framework.TestCase')] or //MarkerAnnotation/Name[pmd-java:typeIs('org.junit.Test')]]]
 ]]>
                 </value>
             </property>
@@ -1247,7 +1247,7 @@ more specific methods, like assertNull, assertNotNull.
   Expression/EqualityExpression/PrimaryExpression/PrimaryPrefix/Literal/NullLiteral
  ]
 ]
-[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeof(@Image, 'junit.framework.TestCase','TestCase')] or //MarkerAnnotation/Name[pmd-java:typeof(@Image, 'org.junit.Test', 'Test')]]]
+[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeIs('junit.framework.TestCase')] or //MarkerAnnotation/Name[pmd-java:typeIs('org.junit.Test')]]]
 ]]>
                 </value>
             </property>
@@ -1289,7 +1289,7 @@ by more specific methods, like assertSame, assertNotSame.
 [PrimarySuffix/Arguments
  /ArgumentList/Expression
  /EqualityExpression[count(.//NullLiteral) = 0]]
-[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeof(@Image, 'junit.framework.TestCase','TestCase')] or //MarkerAnnotation/Name[pmd-java:typeof(@Image, 'org.junit.Test', 'Test')]]]
+[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeIs('junit.framework.TestCase')] or //MarkerAnnotation/Name[pmd-java:typeIs('org.junit.Test')]]]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -267,13 +267,13 @@ Exception, or Error, use a subclassed exception or error instead.
 <![CDATA[
 //ThrowStatement//AllocationExpression
  /ClassOrInterfaceType[
- typeIs('java.lang.Throwable')
+ typeIsExactly('java.lang.Throwable')
 or
- typeIs('java.lang.Exception')
+ typeIsExactly('java.lang.Exception')
 or
- typeIs('java.lang.Error')
+ typeIsExactly('java.lang.Error')
 or
- typeIs('java.lang.RuntimeException')
+ typeIsExactly('java.lang.RuntimeException')
 ]
 ]]>
                 </value>

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -29,7 +29,7 @@ protected constructor in order to prevent instantiation than make the class misl
 //ClassOrInterfaceDeclaration
     [@Abstract = 'true']
     [count(//MethodDeclaration) + count(//ConstructorDeclaration) = 0]
-    [not(../Annotation/MarkerAnnotation/Name[typeof(@Image, 'com.google.auto.value.AutoValue', 'AutoValue')])]
+    [not(../Annotation/MarkerAnnotation/Name[typeIs('com.google.auto.value.AutoValue')])]
 ]]>
                 </value>
             </property>
@@ -267,13 +267,13 @@ Exception, or Error, use a subclassed exception or error instead.
 <![CDATA[
 //ThrowStatement//AllocationExpression
  /ClassOrInterfaceType[
- typeof(@Image, 'java.lang.Throwable', 'Throwable')
+ typeIs('java.lang.Throwable')
 or
- typeof(@Image, 'java.lang.Exception', 'Exception')
+ typeIs('java.lang.Exception')
 or
- typeof(@Image, 'java.lang.Error', 'Error')
+ typeIs('java.lang.Error')
 or
- typeof(@Image, 'java.lang.RuntimeException', 'RuntimeException')
+ typeIs('java.lang.RuntimeException')
 ]
 ]]>
                 </value>
@@ -503,7 +503,7 @@ Errors are system exceptions. Do not extend them.
                 <value>
 <![CDATA[
 //ClassOrInterfaceDeclaration/ExtendsList/ClassOrInterfaceType
-  [typeof(@Image,'java.lang.Error','Error')]
+  [typeIs('java.lang.Error')]
 
 
 ]]>
@@ -1213,7 +1213,7 @@ PrimaryExpression/PrimarySuffix/Arguments/ArgumentList
  /Expression/UnaryExpressionNotPlusMinus[@Image='!']
 /PrimaryExpression/PrimaryPrefix
 ]
-[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeof(@Image, 'junit.framework.TestCase','TestCase')] or //MarkerAnnotation/Name[pmd-java:typeof(@Image, 'org.junit.Test', 'Test')]]]
+[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeIs('junit.framework.TestCase')] or //MarkerAnnotation/Name[pmd-java:typeIs('org.junit.Test')]]]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/main/resources/category/java/documentation.xml
+++ b/pmd-java/src/main/resources/category/java/documentation.xml
@@ -96,7 +96,7 @@ and unintentional empty constructors.
 <![CDATA[
 //ConstructorDeclaration[@Private='false']
                         [count(BlockStatement) = 0 and ($ignoreExplicitConstructorInvocation = 'true' or not(ExplicitConstructorInvocation)) and @containsComment = 'false']
-                        [not(../Annotation/MarkerAnnotation/Name[typeof(@Image, 'javax.inject.Inject', 'Inject')])]
+                        [not(../Annotation/MarkerAnnotation/Name[typeIs('javax.inject.Inject')])]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -707,9 +707,9 @@ public String bar(String string) {
     /Block[not(
       (BlockStatement[1]/Statement/StatementExpression/PrimaryExpression[./PrimaryPrefix[@SuperModifier='true']]/PrimarySuffix[@Image= ancestor::MethodDeclaration/MethodDeclarator/@Image]))]
 [ancestor::ClassOrInterfaceDeclaration[ExtendsList/ClassOrInterfaceType[
-  typeof(@Image, 'android.app.Activity', 'Activity') or
-  typeof(@Image, 'android.app.Application', 'Application') or
-  typeof(@Image, 'android.app.Service', 'Service')
+  typeIs('android.app.Activity') or
+  typeIs('android.app.Application') or
+  typeIs('android.app.Service')
 ]]]
 ]]>
                 </value>
@@ -752,9 +752,9 @@ Super should be called at the end of the method
    /Block/BlockStatement[last()]
     [not(Statement/StatementExpression/PrimaryExpression[./PrimaryPrefix[@SuperModifier='true']]/PrimarySuffix[@Image= ancestor::MethodDeclaration/MethodDeclarator/@Image])]
 [ancestor::ClassOrInterfaceDeclaration[ExtendsList/ClassOrInterfaceType[
-  typeof(@Image, 'android.app.Activity', 'Activity') or
-  typeof(@Image, 'android.app.Application', 'Application') or
-  typeof(@Image, 'android.app.Service', 'Service')
+  typeIs('android.app.Activity') or
+  typeIs('android.app.Application') or
+  typeIs('android.app.Service')
 ]]]
 ]]>
                 </value>
@@ -2058,7 +2058,7 @@ Some JUnit framework methods are easy to misspell.
  or (not(@Image = 'tearDown')
  and translate(@Image, 'TEARdOWN', 'tearDown') = 'tearDown')]
  [FormalParameters[count(*) = 0]]
-[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeof(@Image, 'junit.framework.TestCase','TestCase')] or //MarkerAnnotation/Name[pmd-java:typeof(@Image, 'org.junit.Test', 'Test')]]]
+[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeIs('junit.framework.TestCase')] or //MarkerAnnotation/Name[pmd-java:typeIs('org.junit.Test')]]]
 ]]>
                 </value>
             </property>
@@ -2092,7 +2092,7 @@ The suite() method in a JUnit test needs to be both public and static.
 //MethodDeclaration[not(@Static='true') or not(@Public='true')]
 [MethodDeclarator/@Image='suite']
 [MethodDeclarator/FormalParameters/@ParameterCount=0]
-[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeof(@Image, 'junit.framework.TestCase','TestCase')] or //MarkerAnnotation/Name[pmd-java:typeof(@Image, 'org.junit.Test', 'Test')]]]
+[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeIs('junit.framework.TestCase')] or //MarkerAnnotation/Name[pmd-java:typeIs('org.junit.Test')]]]
 ]]>
                 </value>
             </property>
@@ -3059,7 +3059,7 @@ or
 UnaryExpressionNotPlusMinus[@Image='!']
 /PrimaryExpression/PrimaryPrefix[Literal/BooleanLiteral or Name[count(../../*)=1]]]
 ]
-[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeof(@Image, 'junit.framework.TestCase','TestCase')] or //MarkerAnnotation/Name[pmd-java:typeof(@Image, 'org.junit.Test', 'Test')]]]
+[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeIs('junit.framework.TestCase')] or //MarkerAnnotation/Name[pmd-java:typeIs('org.junit.Test')]]]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/main/resources/category/java/multithreading.xml
+++ b/pmd-java/src/main/resources/category/java/multithreading.xml
@@ -68,7 +68,7 @@ it contains methods that are not thread-safe.
             <property name="xpath">
                 <value>
 <![CDATA[
-//AllocationExpression/ClassOrInterfaceType[pmd-java:typeof(@Image, 'java.lang.ThreadGroup')]|
+//AllocationExpression/ClassOrInterfaceType[pmd-java:typeIs('java.lang.ThreadGroup')]|
 //PrimarySuffix[contains(@Image, 'getThreadGroup')]
 ]]>
                 </value>
@@ -169,8 +169,8 @@ Explicitly calling Thread.run() method will execute in the caller's thread of co
     [
         ./Name[ends-with(@Image, '.run') or @Image = 'run']
         and substring-before(Name/@Image, '.') =//VariableDeclarator/VariableDeclaratorId/@Image
-            [../../../Type/ReferenceType/ClassOrInterfaceType[typeof(@Image, 'java.lang.Thread', 'Thread')]]
-        or (./AllocationExpression/ClassOrInterfaceType[typeof(@Image, 'java.lang.Thread', 'Thread')]
+            [../../../Type/ReferenceType/ClassOrInterfaceType[typeIs('java.lang.Thread')]]
+        or (./AllocationExpression/ClassOrInterfaceType[typeIs('java.lang.Thread')]
         and ../PrimarySuffix[@Image = 'run'])
     ]
 ]

--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -135,10 +135,10 @@ The FileReader and FileWriter constructors instantiate FileInputStream and FileO
                 <value>
 <![CDATA[
 //PrimaryPrefix/AllocationExpression/ClassOrInterfaceType[
-       typeof(@Image, 'java.io.FileInputStream', 'FileInputStream')
-    or typeof(@Image, 'java.io.FileOutputStream', 'FileOutputStream')
-    or typeof(@Image, 'java.io.FileReader', 'FileReader')
-    or typeof(@Image, 'java.io.FileWriter', 'FileWriter')
+       typeIs('java.io.FileInputStream')
+    or typeIs('java.io.FileOutputStream')
+    or typeIs('java.io.FileReader')
+    or typeIs('java.io.FileWriter')
   ]
 ]]>
                 </value>
@@ -209,10 +209,10 @@ adverse impacts on performance.
 <![CDATA[
 //FieldDeclaration/Type/PrimitiveType[@Image = 'short']
 |
-//ClassOrInterfaceBodyDeclaration[not(Annotation/MarkerAnnotation/Name[typeof(@Image, 'java.lang.Override', 'Override')])]
+//ClassOrInterfaceBodyDeclaration[not(Annotation/MarkerAnnotation/Name[typeIs('java.lang.Override')])]
     /MethodDeclaration/ResultType/Type/PrimitiveType[@Image = 'short']
 |
-//ClassOrInterfaceBodyDeclaration[not(Annotation/MarkerAnnotation/Name[typeof(@Image, 'java.lang.Override', 'Override')])]
+//ClassOrInterfaceBodyDeclaration[not(Annotation/MarkerAnnotation/Name[typeIs('java.lang.Override')])]
     /MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/Type/PrimitiveType[@Image = 'short']
 |
 //LocalVariableDeclaration/Type/PrimitiveType[@Image = 'short']
@@ -294,7 +294,7 @@ Note that new Byte() is deprecated since JDK 9 for that reason.
 <![CDATA[
 //AllocationExpression
 [not (ArrayDimsAndInits)
-and ClassOrInterfaceType[typeof(@Image, 'java.lang.Byte', 'Byte')]]
+and ClassOrInterfaceType[typeIs('java.lang.Byte')]]
 ]]>
                 </value>
             </property>
@@ -467,7 +467,7 @@ Note that new Integer() is deprecated since JDK 9 for that reason.
 <![CDATA[
 //AllocationExpression
   [not (ArrayDimsAndInits)
-   and ClassOrInterfaceType[typeof(@Image, 'java.lang.Integer', 'Integer')]]
+   and ClassOrInterfaceType[typeIs('java.lang.Integer')]]
 ]]>
                 </value>
             </property>
@@ -500,7 +500,7 @@ Note that new Long() is deprecated since JDK 9 for that reason.
 <![CDATA[
 //AllocationExpression
 [not (ArrayDimsAndInits)
-and ClassOrInterfaceType[typeof(@Image, 'java.lang.Long', 'Long')]]
+and ClassOrInterfaceType[typeIs('java.lang.Long')]]
 ]]>
                 </value>
             </property>
@@ -664,7 +664,7 @@ Note that new Short() is deprecated since JDK 9 for that reason.
 <![CDATA[
 //AllocationExpression
 [not (ArrayDimsAndInits)
-and ClassOrInterfaceType[typeof(@Image, 'java.lang.Short', 'Short')]]
+and ClassOrInterfaceType[typeIs('java.lang.Short')]]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/DesignRulesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/DesignRulesTest.java
@@ -73,4 +73,20 @@ public class DesignRulesTest extends SimpleAggregatorTst {
         // exist
         // addRule(RULESET, "TooManyHttpFilter"); This rule does not yet exist
     }
+    
+    public static class Throwable extends java.lang.Throwable {
+        private static final long serialVersionUID = 1798165250043760600L;
+    }
+
+    public static class Exception extends java.lang.Throwable {
+        private static final long serialVersionUID = -2518308549741147689L;
+    }
+
+    public static class RuntimeException extends java.lang.Throwable {
+        private static final long serialVersionUID = 6341520923058239682L;
+    }
+
+    public static class Error extends java.lang.Throwable {
+        private static final long serialVersionUID = -6965602141393320558L;
+    }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/MultithreadingRulesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/MultithreadingRulesTest.java
@@ -34,4 +34,9 @@ public class MultithreadingRulesTest extends SimpleAggregatorTst {
             System.out.println("test");
         }
     }
+    
+    // Used by AvoidThreadGroup test cases
+    public static class ThreadGroup {
+        
+    }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/ArrayVariableDeclaration.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/ArrayVariableDeclaration.java
@@ -24,10 +24,10 @@ public class ArrayVariableDeclaration {
      |   + PrimitiveType
      |
      |+ VariableDeclarator
-     | + VariableDeclaratorId[@Image="a" and @Array=false() and ArrayDims=0 and typeof(.)='int[].class']
+     | + VariableDeclaratorId[@Image="a" and @Array=false() and ArrayDims=0 and typeIs(.)='int[].class']
      |
      |+ VariableDeclarator
-     | + VariableDeclaratorId[@Image="b" and @Array=true() and ArrayDims=1 and typeof(.)='int[][].class']
+     | + VariableDeclaratorId[@Image="b" and @Array=true() and ArrayDims=1 and typeIs(.)='int[][].class']
     */
     public int[] a, b[];    // SUPPRESS CHECKSTYLE now
     public String[] c, d[]; // SUPPRESS CHECKSTYLE now

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedFormalParameter.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedFormalParameter.xml
@@ -236,7 +236,7 @@ class Foo {
 			violation suppression xpath works, by type
 		]]>
 	</description>
-	<rule-property name="violationSuppressXPath">.[typeof('java.lang.String')]</rule-property>
+	<rule-property name="violationSuppressXPath">.[typeIs('java.lang.String')]</rule-property>
 	<expected-problems>0</expected-problems>
 	<code>
 	<![CDATA[

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidThrowingRawExceptionTypes.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidThrowingRawExceptionTypes.xml
@@ -21,23 +21,23 @@ public class Foo {
     </test-code>
     <test-code>
         <description><![CDATA[
-Bug 1796928 : The code uses a classe that use the same names that the one this rule is
+Bug 1796928 : The code uses a class that uses the same names that the one this rule is
 				looking for...
      ]]></description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-import org.toto.Throwable;
-import org.toto.Exception;
-import org.toto.Error;
-import org.toto.RuntimeException;
+import net.sourceforge.pmd.lang.java.rule.design.DesignRulesTest.Throwable;
+import net.sourceforge.pmd.lang.java.rule.design.DesignRulesTest.Exception;
+import net.sourceforge.pmd.lang.java.rule.design.DesignRulesTest.Error;
+import net.sourceforge.pmd.lang.java.rule.design.DesignRulesTest.RuntimeException;
 
 public class PmdTest {
 
 	public void m() {
-		Throwable throwable = new Throwable();
-		Error e = new Error();
-		RuntimeException excep = new RuntimeException();
-		Exception ex = new Exception();
+		throw new Throwable();
+		throw new Error();
+		throw new RuntimeException();
+		throw new Exception();
 	}
 
 }
@@ -66,6 +66,20 @@ public class Foo {
 
     public void bar() {
         throw new Exception();
+    }
+}
+]]></code>
+    </test-code>
+    <test-code>
+        <description>Ok when throwing another exception</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.IOException;
+
+public class Foo {
+
+    public void bar() {
+        throw new IOException();
     }
 }
 ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/AvoidThreadGroup.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/AvoidThreadGroup.xml
@@ -61,7 +61,8 @@ ThreadGroup() but not java.lang.ThreadGroup
      ]]></description>
 		<expected-problems>0</expected-problems>
 		<code><![CDATA[
-import some.pkg.ThreadGroup;
+import net.sourceforge.pmd.lang.java.rule.multithreading.MultithreadingRulesTest.ThreadGroup;
+
 public class Foo {
  void bar() {
   ThreadGroup t = new ThreadGroup();

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/NodeInfoPanelController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/NodeInfoPanelController.java
@@ -146,7 +146,7 @@ public class NodeInfoPanelController implements Initializable {
         }
 
         if (node instanceof TypeNode) {
-            result.add("typeof() = " + ((TypeNode) node).getType());
+            result.add("typeIs() = " + ((TypeNode) node).getType());
         }
         Collections.sort(result);
         return result;


### PR DESCRIPTION
- Deprecate the old `typeof` function
- Have new functions `typeIs()` and `typeIsExactly()` with simpler syntaxes
- Nag about the deprecated usage of the old method
- Replace all internal usages with the new one
- Have the functions use the TypeHelper to avoid multiple separate implementations of the same behavior
- Tidy up a little the TypeHelper
- Update documentation
- Fixes #672 
- Fixes #1115 