### PR TITLE
[java] Fix FN in UnnecessaryModifierRule

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotationMethodDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotationMethodDeclaration.java
@@ -6,7 +6,7 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
-public class ASTAnnotationMethodDeclaration extends AbstractJavaAccessNode {
+public class ASTAnnotationMethodDeclaration extends AbstractMethodLikeNode {
     public ASTAnnotationMethodDeclaration(int id) {
         super(id);
     }
@@ -18,6 +18,12 @@ public class ASTAnnotationMethodDeclaration extends AbstractJavaAccessNode {
     /** Accept the visitor. **/
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
+    }
+
+
+    @Override
+    public MethodLikeKind getKind() {
+        return MethodLikeKind.METHOD;
     }
 }
 /*

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractAnyTypeDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractAnyTypeDeclaration.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.qname.JavaTypeQualifiedName;
 import net.sourceforge.pmd.lang.java.typeresolution.typedefinition.JavaTypeDefinition;
 
@@ -26,15 +27,51 @@ public abstract class AbstractAnyTypeDeclaration extends AbstractJavaAccessTypeN
     }
 
 
-    /**
-     * Returns true if this type declaration is nested inside an interface, class or annotation.
-     */
     @Override
     public final boolean isNested() {
         return jjtGetParent() instanceof ASTClassOrInterfaceBodyDeclaration
                 || jjtGetParent() instanceof ASTAnnotationTypeMemberDeclaration;
     }
 
+
+    /**
+     * Returns true if the enclosing type of this type declaration
+     * is any of the given kinds. If this declaration is a top-level
+     * declaration, returns false. This won't consider anonymous classes
+     * until #905 is tackled. TODO 7.0.0
+     *
+     * @param kinds Kinds to test
+     */
+    // TODO 7.0.0 move that up to ASTAnyTypeDeclaration
+    public final boolean enclosingTypeIsA(TypeKind... kinds) {
+
+        if (!isNested()) {
+            return false;
+        }
+
+        Node parent = getNthParent(3);
+
+        for (TypeKind k : kinds) {
+            if (((ASTAnyTypeDeclaration) parent).getTypeKind() == k) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+
+    /**
+     * Returns the enclosing type of this type, if it is nested.
+     * Otherwise returns null. This won't consider anonymous classes
+     * until #905 is tackled. TODO 7.0.0
+     */
+    public final ASTAnyTypeDeclaration getEnclosingTypeDeclaration() {
+        if (!isNested()) {
+            return null;
+        }
+        return (ASTAnyTypeDeclaration) getNthParent(3);
+    }
 
     @Override
     public final JavaTypeQualifiedName getQualifiedName() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractAnyTypeDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractAnyTypeDeclaration.java
@@ -45,11 +45,10 @@ public abstract class AbstractAnyTypeDeclaration extends AbstractJavaAccessTypeN
     // TODO 7.0.0 move that up to ASTAnyTypeDeclaration
     public final boolean enclosingTypeIsA(TypeKind... kinds) {
 
-        if (!isNested()) {
+        ASTAnyTypeDeclaration parent = getEnclosingTypeDeclaration();
+        if (parent == null) {
             return false;
         }
-
-        ASTAnyTypeDeclaration parent = getEnclosingTypeDeclaration();
 
         for (TypeKind k : kinds) {
             if (parent.getTypeKind() == k) {
@@ -72,7 +71,7 @@ public abstract class AbstractAnyTypeDeclaration extends AbstractJavaAccessTypeN
         }
         Node parent = getNthParent(3);
 
-        return parent instanceof ASTAnyTypeDeclaration ? (ASTAnyTypeDeclaration) getNthParent(3) : null;
+        return parent instanceof ASTAnyTypeDeclaration ? (ASTAnyTypeDeclaration) parent : null;
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractAnyTypeDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractAnyTypeDeclaration.java
@@ -49,10 +49,10 @@ public abstract class AbstractAnyTypeDeclaration extends AbstractJavaAccessTypeN
             return false;
         }
 
-        Node parent = getNthParent(3);
+        ASTAnyTypeDeclaration parent = getEnclosingTypeDeclaration();
 
         for (TypeKind k : kinds) {
-            if (((ASTAnyTypeDeclaration) parent).getTypeKind() == k) {
+            if (parent.getTypeKind() == k) {
                 return true;
             }
         }
@@ -70,7 +70,9 @@ public abstract class AbstractAnyTypeDeclaration extends AbstractJavaAccessTypeN
         if (!isNested()) {
             return null;
         }
-        return (ASTAnyTypeDeclaration) getNthParent(3);
+        Node parent = getNthParent(3);
+
+        return parent instanceof ASTAnyTypeDeclaration ? (ASTAnyTypeDeclaration) getNthParent(3) : null;
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryModifierRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryModifierRule.java
@@ -4,23 +4,36 @@
 
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Locale;
+
+import org.apache.commons.lang3.StringUtils;
+
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTAllocationExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotationMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotationTypeDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration.TypeKind;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTEnumBody;
 import net.sourceforge.pmd.lang.java.ast.ASTEnumConstant;
 import net.sourceforge.pmd.lang.java.ast.ASTEnumDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTMarkerAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodOrConstructorDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTResource;
+import net.sourceforge.pmd.lang.java.ast.AccessNode;
+import net.sourceforge.pmd.lang.java.ast.MethodLikeNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
+
 public class UnnecessaryModifierRule extends AbstractJavaRule {
+
 
     public UnnecessaryModifierRule() {
         addRuleChainVisit(ASTEnumDeclaration.class);
@@ -32,94 +45,162 @@ public class UnnecessaryModifierRule extends AbstractJavaRule {
         addRuleChainVisit(ASTAnnotationMethodDeclaration.class);
         addRuleChainVisit(ASTConstructorDeclaration.class);
     }
-    
+
+
+    private void reportUnnecessaryModifiers(Object data, Node node,
+                                            Modifier unnecessaryModifier, String explanation) {
+        reportUnnecessaryModifiers(data, node, Collections.singletonList(unnecessaryModifier), explanation);
+    }
+
+
+    private void reportUnnecessaryModifiers(Object data, Node node,
+                                            List<Modifier> unnecessaryModifiers, String explanation) {
+        if (unnecessaryModifiers.isEmpty()) {
+            return;
+        }
+        super.addViolation(data, node, new String[]{
+                formatUnnecessaryModifiers(unnecessaryModifiers),
+                getPrintableNodeKind(node),
+                getNodeName(node),
+                explanation.isEmpty() ? "" : ": " + explanation,
+        });
+    }
+
+
+    // TODO this should probably make it into a PrettyPrintingUtil or something.
+    private String getNodeName(Node node) {
+        return node instanceof ASTMethodDeclaration
+               ? ((ASTMethodDeclaration) node).getMethodName()
+               : node instanceof ASTMethodOrConstructorDeclaration
+                 // constructors are differentiated by their parameters, while we only use method name for methods
+                 ? ((ASTConstructorDeclaration) node).getQualifiedName().getOperation()
+                 : node instanceof ASTFieldDeclaration
+                   ? ((ASTFieldDeclaration) node).getVariableName()
+                   : node instanceof ASTResource
+                     ? ((ASTResource) node).getVariableDeclaratorId().getImage()
+                     : node.getImage();
+    }
+
+
+    // TODO same here
+    private String getPrintableNodeKind(Node node) {
+        if (node instanceof ASTAnyTypeDeclaration) {
+            return ((ASTAnyTypeDeclaration) node).getTypeKind().getPrintableName();
+        } else if (node instanceof MethodLikeNode) {
+            return ((MethodLikeNode) node).getKind().getPrintableName();
+        } else if (node instanceof ASTFieldDeclaration) {
+            return "field";
+        } else if (node instanceof ASTResource) {
+            return "resource specification";
+        }
+        throw new UnsupportedOperationException("Node " + node + " is unaccounted for");
+    }
+
+
+    private String formatUnnecessaryModifiers(List<Modifier> lst) {
+        // prints in the standard modifier order, regardless of the actual order in which we checked
+        Collections.sort(lst, new Comparator<Modifier>() {
+            @Override
+            public int compare(Modifier o1, Modifier o2) {
+                return Integer.compare(o1.ordinal(), o2.ordinal());
+            }
+        });
+        return (lst.size() > 1 ? "s" : "") + " '" + StringUtils.join(lst, " ") + "'";
+    }
+
+
     @Override
     public Object visit(ASTEnumDeclaration node, Object data) {
+
+        if (node.isPublic()) {
+            checkDeclarationInInterfaceType(data, node, Collections.singletonList(Modifier.PUBLIC));
+        }
+
         if (node.isStatic()) {
             // a static enum
-            addViolation(data, node, getMessage());
+            reportUnnecessaryModifiers(data, node, Modifier.STATIC, "nested enums are implicitly static");
         }
 
         return data;
     }
 
+
     public Object visit(ASTAnnotationTypeDeclaration node, Object data) {
         if (node.isAbstract()) {
-            // an abstract annotation
-            addViolation(data, node, getMessage());
+            // may have several violations, with different explanations
+            reportUnnecessaryModifiers(data, node, Modifier.ABSTRACT, "annotations types are implicitly abstract");
+
         }
+
 
         if (!node.isNested()) {
             return data;
         }
 
-        Node parent = node.jjtGetParent().jjtGetParent().jjtGetParent();
-        boolean isParentInterfaceOrAnnotation = parent instanceof ASTAnnotationTypeDeclaration
-                || parent instanceof ASTClassOrInterfaceDeclaration && ((ASTClassOrInterfaceDeclaration) parent).isInterface();
-
         // a public annotation within an interface or annotation
-        if (node.isPublic() && isParentInterfaceOrAnnotation) {
-            addViolation(data, node, getMessage());
+        if (node.isPublic() && node.enclosingTypeIsA(TypeKind.INTERFACE, TypeKind.ANNOTATION)) {
+            reportUnnecessaryModifiers(data, node, Modifier.PUBLIC, "members of " + getPrintableNodeKind(node.getEnclosingTypeDeclaration()) + " types are implicitly public");
         }
 
         if (node.isStatic()) {
             // a static annotation
-            addViolation(data, node, getMessage());
+            reportUnnecessaryModifiers(data, node, Modifier.STATIC, "nested annotation types are implicitly static");
         }
 
         return data;
     }
 
+
     public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
+
         if (node.isInterface() && node.isAbstract()) {
             // an abstract interface
-            addViolation(data, node, getMessage());
+            reportUnnecessaryModifiers(data, node, Modifier.ABSTRACT, "interface types are implicitly abstract");
         }
 
         if (!node.isNested()) {
             return data;
         }
 
-        Node parent = node.jjtGetParent().jjtGetParent().jjtGetParent();
-        boolean isParentInterfaceOrAnnotation = parent instanceof ASTAnnotationTypeDeclaration
-                || parent instanceof ASTClassOrInterfaceDeclaration && ((ASTClassOrInterfaceDeclaration) parent).isInterface();
+        boolean isParentInterfaceOrAnnotation = node.enclosingTypeIsA(TypeKind.INTERFACE, TypeKind.ANNOTATION);
 
-        // a public interface within an interface or annotation
-        if (node.isInterface() && node.isPublic() && isParentInterfaceOrAnnotation) {
-            addViolation(data, node, getMessage());
+        // a public class or interface within an interface or annotation
+        if (node.isPublic() && isParentInterfaceOrAnnotation) {
+            reportUnnecessaryModifiers(data, node, Modifier.PUBLIC, "members of " + getPrintableNodeKind(node.getEnclosingTypeDeclaration()) + " types are implicitly public");
         }
 
-        if (node.isInterface() && node.isStatic()) {
-            // a static interface
-            addViolation(data, node, getMessage());
-        }
-
-        // a public and/or static class within an interface or annotation
-        if (!node.isInterface() && (node.isPublic() || node.isStatic()) && isParentInterfaceOrAnnotation) {
-            addViolation(data, node, getMessage());
+        if ((node.isInterface() || isParentInterfaceOrAnnotation) && node.isStatic()) {
+            // a static interface or class nested within an interface
+            reportUnnecessaryModifiers(data, node, Modifier.PUBLIC, "types nested within an interface type are implicitly static");
         }
 
         return data;
     }
     
     public Object visit(final ASTMethodDeclaration node, Object data) {
-        if (node.isSyntacticallyPublic() || node.isSyntacticallyAbstract()) {
-            check(node, data);
+        List<Modifier> unnecessary = new ArrayList<>();
+
+        if (node.isSyntacticallyPublic()) {
+            unnecessary.add(Modifier.PUBLIC);
         }
-        
+        if (node.isSyntacticallyAbstract()) {
+            unnecessary.add(Modifier.ABSTRACT);
+        }
+
+        checkDeclarationInInterfaceType(data, node, unnecessary);
+
         if (node.isFinal()) {
             // If the method is annotated by @SafeVarargs then it's ok
             if (!isSafeVarargs(node)) {
                 if (node.isPrivate()) {
-                    addViolation(data, node);
+                    reportUnnecessaryModifiers(data, node, Modifier.FINAL, "private methods cannot be overridden");
                 } else {
                     final Node n = node.getNthParent(3);
                     // A final method of an anonymous class / enum constant. Neither can be extended / overridden
                     if (n instanceof ASTAllocationExpression || n instanceof ASTEnumConstant) {
-                        addViolation(data, node);
-                    } else if (n instanceof ASTClassOrInterfaceDeclaration
-                            && ((ASTClassOrInterfaceDeclaration) n).isFinal()) {
-                        addViolation(data, node);
+                        reportUnnecessaryModifiers(data, node, Modifier.FINAL, "an anonymous class cannot be extended");
+                    } else if (n instanceof ASTClassOrInterfaceDeclaration && ((AccessNode) n).isFinal()) {
+                        reportUnnecessaryModifiers(data, node, Modifier.FINAL, "the method is already in a final class");
                     }
                 }
             }
@@ -130,57 +211,75 @@ public class UnnecessaryModifierRule extends AbstractJavaRule {
     
     public Object visit(final ASTResource node, final Object data) {
         if (node.isFinal()) {
-            addViolation(data, node);
+            reportUnnecessaryModifiers(data, node, Modifier.FINAL, "resources specifications are implicitly final");
         }
         
         return data;
     }
 
     public Object visit(ASTFieldDeclaration node, Object data) {
-        if (node.isSyntacticallyPublic() || node.isSyntacticallyStatic() || node.isSyntacticallyFinal()) {
-            check(node, data);
+        List<Modifier> unnecessary = new ArrayList<>();
+        if (node.isSyntacticallyPublic()) {
+            unnecessary.add(Modifier.PUBLIC);
         }
+        if (node.isSyntacticallyStatic()) {
+            unnecessary.add(Modifier.STATIC);
+        }
+        if (node.isSyntacticallyFinal()) {
+            unnecessary.add(Modifier.FINAL);
+        }
+
+        checkDeclarationInInterfaceType(data, node, unnecessary);
         return data;
     }
 
     public Object visit(ASTAnnotationMethodDeclaration node, Object data) {
-        if (node.isPublic() || node.isAbstract()) {
-            check(node, data);
+        List<Modifier> unnecessary = new ArrayList<>();
+        if (node.isPublic()) {
+            unnecessary.add(Modifier.PUBLIC);
         }
+        if (node.isAbstract()) {
+            unnecessary.add(Modifier.ABSTRACT);
+        }
+        checkDeclarationInInterfaceType(data, node, unnecessary);
         return data;
     }
     
     public Object visit(ASTConstructorDeclaration node, Object data) {
         if (node.getNthParent(2) instanceof ASTEnumBody) {
             if (node.isPrivate()) {
-                addViolation(data, node);
+                reportUnnecessaryModifiers(data, node, Modifier.PRIVATE, "enum constructors are implicitly private");
             }
         }
         return data;
     }
-    
+
+
     private boolean isSafeVarargs(final ASTMethodDeclaration node) {
-        for (final ASTAnnotation annotation : node.jjtGetParent().findChildrenOfType(ASTAnnotation.class)) {
-            final Node childAnnotation = annotation.jjtGetChild(0);
-            if (childAnnotation instanceof ASTMarkerAnnotation) {
-                final ASTMarkerAnnotation marker = (ASTMarkerAnnotation) childAnnotation;
-                if (marker.getType() != null && SafeVarargs.class.isAssignableFrom(marker.getType())) {
-                    return true;
-                }
-            }
-        }
-        
-        return false;
+        return node.isAnnotationPresent(SafeVarargs.class.getName());
     }
 
-    private void check(Node fieldOrMethod, Object data) {
+
+    private void checkDeclarationInInterfaceType(Object data, Node fieldOrMethod, List<Modifier> unnecessary) {
         // third ancestor could be an AllocationExpression
         // if this is a method in an anonymous inner class
         Node parent = fieldOrMethod.jjtGetParent().jjtGetParent().jjtGetParent();
         if (parent instanceof ASTAnnotationTypeDeclaration
                 || parent instanceof ASTClassOrInterfaceDeclaration
                 && ((ASTClassOrInterfaceDeclaration) parent).isInterface()) {
-            addViolation(data, fieldOrMethod);
+            reportUnnecessaryModifiers(data, fieldOrMethod, unnecessary, "the " + getPrintableNodeKind(fieldOrMethod) + " is declared in an " + getPrintableNodeKind(parent) + " type");
         }
     }
+
+
+    private enum Modifier {
+        PUBLIC, PRIVATE, PROTECTED, STATIC, FINAL, ABSTRACT;
+
+
+        @Override
+        public String toString() {
+            return name().toLowerCase(Locale.ROOT);
+        }
+    }
+
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryModifierRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryModifierRule.java
@@ -10,6 +10,8 @@ import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotationMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotationTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTEnumBody;
 import net.sourceforge.pmd.lang.java.ast.ASTEnumConstant;
 import net.sourceforge.pmd.lang.java.ast.ASTEnumDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
@@ -28,6 +30,7 @@ public class UnnecessaryModifierRule extends AbstractJavaRule {
         addRuleChainVisit(ASTResource.class);
         addRuleChainVisit(ASTFieldDeclaration.class);
         addRuleChainVisit(ASTAnnotationMethodDeclaration.class);
+        addRuleChainVisit(ASTConstructorDeclaration.class);
     }
     
     @Override
@@ -143,6 +146,15 @@ public class UnnecessaryModifierRule extends AbstractJavaRule {
     public Object visit(ASTAnnotationMethodDeclaration node, Object data) {
         if (node.isPublic() || node.isAbstract()) {
             check(node, data);
+        }
+        return data;
+    }
+    
+    public Object visit(ASTConstructorDeclaration node, Object data) {
+        if (node.getNthParent(2) instanceof ASTEnumBody) {
+            if (node.isPrivate()) {
+                addViolation(data, node);
+            }
         }
         return data;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryModifierRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryModifierRule.java
@@ -207,7 +207,7 @@ public class UnnecessaryModifierRule extends AbstractJavaRule {
     
     public Object visit(final ASTResource node, final Object data) {
         if (node.isFinal()) {
-            reportUnnecessaryModifiers(data, node, Modifier.FINAL, "resources specifications are implicitly final");
+            reportUnnecessaryModifiers(data, node, Modifier.FINAL, "resource specifications are implicitly final");
         }
         
         return data;

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1634,7 +1634,7 @@ public class Foo {
     <rule name="UnnecessaryModifier"
           language="java"
           since="1.02"
-          message="Avoid modifiers which are implied by the context"
+          message="Unnecessary modifier{0} on {1} ''{2}''{3}"
           class="net.sourceforge.pmd.lang.java.rule.codestyle.UnnecessaryModifierRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#unnecessarymodifier">
         <description>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryModifier.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryModifier.xml
@@ -598,4 +598,19 @@ class Foo {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>Private constructor of enum</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+enum Foo {
+    BAR("bar");
+    
+    private String name;
+    
+    private Foo(String s) {
+        name = s;
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryModifier.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryModifier.xml
@@ -636,7 +636,7 @@ public class Foo {
     <description>Unnecessary final of try-with-resources resource</description>
         <expected-problems>1</expected-problems>
         <expected-messages>
-            <message>Unnecessary modifier 'final' on resource specification 'fw': resources specifications are implicitly final</message>
+            <message>Unnecessary modifier 'final' on resource specification 'fw': resource specifications are implicitly final</message>
         </expected-messages>
         <code><![CDATA[
 public class Foo {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryModifier.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryModifier.xml
@@ -195,9 +195,30 @@ public class Foo {
 Unneeded 'public static final' in interface field inside another interface
      ]]></description>
         <expected-problems>2</expected-problems>
+        <expected-messages>
+            <message>Unnecessary modifier 'public' on interface 'Bar': members of interface types are implicitly public</message>
+            <message>Unnecessary modifiers 'public static final' on field 'X': the field is declared in an interface type</message>
+        </expected-messages>
         <code><![CDATA[
 public interface Foo {
  public interface Bar {
+  public static final int X = 0;
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+Unneeded 'public static final' in annotation field inside another interface
+     ]]></description>
+        <expected-problems>2</expected-problems>
+        <expected-messages>
+            <message>Unnecessary modifier 'public' on annotation 'Bar': members of interface types are implicitly public</message>
+            <message>Unnecessary modifiers 'public static final' on field 'X': the field is declared in an annotation type</message>
+        </expected-messages>
+        <code><![CDATA[
+public interface Foo {
+ public @interface Bar {
   public static final int X = 0;
  }
 }
@@ -303,6 +324,9 @@ public enum TestEnum {
     <test-code>
         <description>Unnecessary public on annotation element</description>
         <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>Unnecessary modifier 'public' on method 'message': the method is declared in an annotation type</message>
+        </expected-messages>
         <code><![CDATA[
 public @interface TestAnnotation {
     public String message();
@@ -312,6 +336,9 @@ public @interface TestAnnotation {
     <test-code>
         <description>Unnecessary abstract on annotation element</description>
         <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>Unnecessary modifier 'abstract' on method 'message': the method is declared in an annotation type</message>
+        </expected-messages>
         <code><![CDATA[
 public @interface TestAnnotation {
     abstract String message();
@@ -387,7 +414,11 @@ public @interface TestAnnotation {
     </test-code>
     <test-code>
         <description>Unnecessary static on annotation nested enum</description>
-        <expected-problems>1</expected-problems>
+        <expected-problems>2</expected-problems>
+        <expected-messages>
+            <message>Unnecessary modifier 'public' on enum 'Inner': the enum is declared in an annotation type</message>
+            <message>Unnecessary modifier 'static' on enum 'Inner': nested enums are implicitly static</message>
+        </expected-messages>
         <code><![CDATA[
 public @interface TestAnnotation {
     public static enum Inner {
@@ -397,7 +428,11 @@ public @interface TestAnnotation {
     </test-code>
     <test-code>
         <description>Unnecessary static on interface nested enum</description>
-        <expected-problems>1</expected-problems>
+        <expected-problems>2</expected-problems>
+        <expected-messages>
+            <message>Unnecessary modifier 'public' on enum 'Inner': the enum is declared in an interface type</message>
+            <message>Unnecessary modifier 'static' on enum 'Inner': nested enums are implicitly static</message>
+        </expected-messages>
         <code><![CDATA[
 public interface TestInterface {
     public static enum Inner {
@@ -408,6 +443,9 @@ public interface TestInterface {
     <test-code>
         <description>Unnecessary static on class nested enum</description>
         <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>Unnecessary modifier 'static' on enum 'Inner': nested enums are implicitly static</message>
+        </expected-messages>
         <code><![CDATA[
 public class TestClass {
     public static enum Inner {
@@ -418,6 +456,9 @@ public class TestClass {
     <test-code>
         <description>Unnecessary abstract on interface</description>
         <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>Unnecessary modifier 'abstract' on interface 'TestInterface': interface types are implicitly abstract</message>
+        </expected-messages>
         <code><![CDATA[
 public abstract interface TestInterface {
 }
@@ -426,6 +467,9 @@ public abstract interface TestInterface {
     <test-code>
         <description>Unnecessary abstract on annotation</description>
         <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>Unnecessary modifier 'abstract' on annotation 'TestAnnotation': annotations types are implicitly abstract</message>
+        </expected-messages>
         <code><![CDATA[
 public abstract @interface TestAnnotation {
 }
@@ -443,9 +487,7 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-final and non-final methods mixed
-     ]]></description>
+        <description>final and non-final methods mixed</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -459,6 +501,9 @@ public class Foo {
 final method on a final class
      ]]></description>
         <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>Unnecessary modifier 'final' on method 'foo': the method is already in a final class</message>
+        </expected-messages>
         <code><![CDATA[
 public final class Foo {
  public final void foo() { }
@@ -470,6 +515,9 @@ public final class Foo {
 mixed final and non-final methods on final class
      ]]></description>
         <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>Unnecessary modifier 'final' on method 'foo': the method is already in a final class</message>
+        </expected-messages>
         <code><![CDATA[
 public final class Foo {
  public final void foo() { }
@@ -509,6 +557,9 @@ public final class Foo {
 final method in inner final class 
      ]]></description>
         <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>Unnecessary modifier 'final' on method 'buz': the method is already in a final class</message>
+        </expected-messages>
         <code><![CDATA[
 public final class Foo {
  public final class Bar {
@@ -539,6 +590,9 @@ public final class InboxContents2 {
     <test-code>
     <description>Unnecessary final of private method</description>
         <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>Unnecessary modifier 'final' on method 'getValue': private methods cannot be overridden</message>
+        </expected-messages>
         <code><![CDATA[
 public class TestClass {
 	private final int getValue() {
@@ -550,6 +604,9 @@ public class TestClass {
     <test-code>
     <description>Unnecessary final of enum method</description>
         <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>Unnecessary modifier 'final' on method 'magic': an anonymous class cannot be extended</message>
+        </expected-messages>
         <code><![CDATA[
 public enum Foo {
     BAR {
@@ -578,6 +635,9 @@ public class Foo {
     <test-code>
     <description>Unnecessary final of try-with-resources resource</description>
         <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>Unnecessary modifier 'final' on resource specification 'fw': resources specifications are implicitly final</message>
+        </expected-messages>
         <code><![CDATA[
 public class Foo {
     public void stuff() {
@@ -601,6 +661,9 @@ class Foo {
     <test-code>
         <description>Private constructor of enum</description>
         <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>Unnecessary modifier 'private' on constructor 'Foo(String)': enum constructors are implicitly private</message>
+        </expected-messages>
         <code><![CDATA[
 enum Foo {
     BAR("bar");


### PR DESCRIPTION
 - Enum constructors are inherently private, no need to add that
modifier
