### PR TITLE
[java] AtLeastOneConstructor supports Lombok

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
@@ -4,8 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -33,9 +33,7 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
 
     @Override
     protected Collection<String> defaultSuppressionAnnotations() {
-        Collection<String> defaultValues = new ArrayList<>();
-        defaultValues.add("java.lang.Deprecated");
-        return defaultValues;
+        return Collections.singletonList("java.lang.Deprecated");
     }
 
     /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/AtLeastOneConstructorRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/AtLeastOneConstructorRule.java
@@ -1,0 +1,74 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.codestyle;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
+import net.sourceforge.pmd.lang.java.rule.AbstractIgnoredAnnotationRule;
+import net.sourceforge.pmd.lang.java.rule.design.UseUtilityClassRule;
+
+/**
+ * This rule detects non-static classes with no constructors;
+ * requiring even the default constructor to be explicit.
+ * It ignores classes with solely static methods,
+ * use {@link UseUtilityClassRule} to flag those.
+ */
+public class AtLeastOneConstructorRule extends AbstractIgnoredAnnotationRule {
+
+    public AtLeastOneConstructorRule() {
+        addRuleChainVisit(ASTClassOrInterfaceDeclaration.class);
+    }
+
+    @Override
+    protected Collection<String> defaultSuppressionAnnotations() {
+        return Arrays.asList("lombok.Data",
+                "lombok.Value",
+                "lombok.Builder",
+                "lombok.NoArgsConstructor",
+                "lombok.RequiredArgsConstructor",
+                "lombok.AllArgsConstructorAtLeastOneConstructor");
+    }
+
+    @Override
+    public Object visit(final ASTClassOrInterfaceDeclaration node, final Object data) {
+        // Ignore interfaces / static classes / classes that have a constructor / classes ignored through annotations
+        if (node.isInterface() || node.isStatic() || node.hasDescendantOfType(ASTConstructorDeclaration.class)
+                || hasIgnoredAnnotation(node)) {
+            return data;
+        }
+
+        boolean atLeastOneMember = false;
+
+        // Do we have any non-static methods?
+        for (final ASTMethodDeclaration m : node.findDescendantsOfType(ASTMethodDeclaration.class)) {
+            if (!m.isStatic()) {
+                addViolation(data, node);
+                return data;
+            }
+            atLeastOneMember = true;
+        }
+
+        // .. or fields?
+        for (final ASTFieldDeclaration f : node.findDescendantsOfType(ASTFieldDeclaration.class)) {
+            if (!f.isStatic()) {
+                addViolation(data, node);
+                return data;
+            }
+            atLeastOneMember = true;
+        }
+
+        // Class has no declared members
+        if (!atLeastOneMember) {
+            addViolation(data, node);
+        }
+
+        return data;
+    }
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryConstructorRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryConstructorRule.java
@@ -4,8 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 
 import net.sourceforge.pmd.lang.ast.Node;
@@ -26,7 +26,7 @@ public class UnnecessaryConstructorRule extends AbstractIgnoredAnnotationRule {
 
     @Override
     protected Collection<String> defaultSuppressionAnnotations() {
-        return Arrays.asList("javax.inject.Inject");
+        return Collections.singletonList("javax.inject.Inject");
     }
 
     @Override

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -49,28 +49,15 @@ public abstract class Foo { // should be AbstractFoo
           language="java"
           since="1.04"
           message="Each class should declare at least one constructor"
-          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          class="net.sourceforge.pmd.lang.java.rule.codestyle.AtLeastOneConstructorRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#atleastoneconstructor">
         <description>
-Each class should declare at least one constructor.
+<![CDATA[
+Each non-static class should declare at least one constructor.
+Classes with solely static members are ignored, refer to [UseUtilityClassRule](pmd_rules_java_design.html#useutilityclass) to detect those.
+]]>
         </description>
         <priority>3</priority>
-        <properties>
-            <property name="xpath">
-                <value>
-<![CDATA[
-//ClassOrInterfaceDeclaration[
-  not(ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/ConstructorDeclaration)
-  and
-  (@Static = 'false')
-  and
-  (count(./descendant::MethodDeclaration[@Static = 'true']) < 1)
-]
-  [@Interface='false']
-]]>
-                </value>
-            </property>
-        </properties>
         <example>
 <![CDATA[
 public class Foo {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/AtLeastOneConstructor.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/AtLeastOneConstructor.xml
@@ -100,8 +100,8 @@ skip classes with only static methods
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public static class Foo {
-	public static void method() {}
-	public static void otherMethods() {}
+    public static void method() {}
+    public static void otherMethods() {}
 }
      ]]></code>
     </test-code>
@@ -113,6 +113,37 @@ public class TestAtLeastOneConstructor {
     public void NotStatic() {
         System.out.println("This class should have a constructor");
     }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Ignore classes with lombok-generated constructors</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import lombok.Value;
+
+@Value
+public class TestAtLeastOneConstructor {
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Report classes with at least one non-static method</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class TestAtLeastOneConstructor {
+    public static void foo() { }
+    public void bar () { }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Report classes with at least one non-static field</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class TestAtLeastOneConstructor {
+    public int bar;
+    public static void foo() { }
 }
         ]]></code>
     </test-code>


### PR DESCRIPTION
 - Lombok annotations that create a constructor whitelist the class
 - Take the chance to cover a bunch of other FNs
 - Improve documentation on the rule
 - Some other minor improvements
 - Fixes #667 
