### PR TITLE
[doc] Add Rouge XPath syntax highlighter 

### DIFF
--- a/docs/_plugins/xpath_lexer.rb
+++ b/docs/_plugins/xpath_lexer.rb
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*- #
+
+require 'rouge'
+
+module Rouge
+  module Lexers
+    class XPath < RegexLexer
+
+      title "XPath"
+      desc "The XPath query language (http://en.wikipedia.org/wiki/XPath)"
+      tag 'xpath'
+      aliases 'xpath'
+      filenames '*.xpath'
+      mimetypes 'text/x-xpath'
+
+      state :basic do
+        rule /\s+/, Text
+        rule /[(][:](?![)])/, Comment, :nested_comment
+
+        rule /[\[\](){}|.,;!]/, Punctuation
+
+        rule /"[^"]*+"/, Str::Double
+        rule /'[^']*+'/, Str::Single
+
+        rule /\.\d++\b/, Num
+        rule /\b\d++\./, Num
+        rule /\b\d++(\.\d*+)?([eE][+-]?\d+)?\b/, Num
+      end
+
+      state :operators do
+        rule /(<|>|=<|>=|==|\/\/|[\/*+-])(?=\s|[a-zA-Z0-9\[])/, Operator
+        # operators
+        rule /(or|and|not|mod|ne|eq|lt|le|gt|ge)/, Operator
+        # keywords
+        rule /some|in|satisfies|as|is|for|every|cast|castable|treat|instance|of|to|if|then|else|return|let|intersect|except|union|div|idiv/, Keyword::Reserved
+        # axes
+        rule /(self|child|attribute|descendant|descendant-or-self|ancestor|ancestor-or-self|following|following-sibling|namespace|parent|preceding-sibling)::/, Keyword::Namespace
+        # kind tests
+        rule /(node|document-node|text|comment|namespace-node|processing-instruction|attribute|schema-attribute|element|schema-element|function)\(\)/, Keyword::Reserved
+        # functions
+        rule /[a-zA-Z\-]+(?=\()/, Name::Function
+      end
+
+      state :names do
+        rule /[a-zA-Z\-]+:/, Name::Namespace
+        rule /@[a-zA-Z][_\-a-zA-Z0-9]*/, Name::Attribute
+        rule /\$[a-zA-Z][_\-a-zA-Z0-9]*/, Name::Variable
+        # Node names
+        rule /[a-zA-Z]+/, Name::Tag
+      end
+
+      state :root do
+        mixin :basic
+        mixin :names
+        mixin :operators
+      end
+
+      state :nested_comment do
+        rule /[^(:)]+/, Comment
+        rule /\(:/, Comment, :push
+        rule /:\)/, Comment, :pop!
+        rule /[(:)]/, Comment
+      end
+    end
+  end
+end

--- a/docs/_plugins/xpath_lexer.rb
+++ b/docs/_plugins/xpath_lexer.rb
@@ -14,13 +14,13 @@ module Rouge
       mimetypes 'text/x-xpath'
 
       state :basic do
-        rule /\s+/, Text
-        rule /[(][:](?![)])/, Comment, :nested_comment
+        rule /\s+/, Text::Whitespace
+        rule /[(]:(?![)])/, Comment, :nested_comment
 
         rule /[\[\](){}|.,;!]/, Punctuation
 
-        rule /"[^"]*+"/, Str::Double
-        rule /'[^']*+'/, Str::Single
+        rule /"([^"]|"")*+"/, Str::Double
+        rule /'([^']|'')*+'/, Str::Single
 
         rule /\.\d++\b/, Num
         rule /\b\d++\./, Num
@@ -28,31 +28,34 @@ module Rouge
       end
 
       state :operators do
-        rule /(<|>|=<|>=|==|\/\/|[\/*+-])(?=\s|[a-zA-Z0-9\[])/, Operator
+        rule /(<|>|=<|>=|==|\/\/|[|\/*+-])(?=\s|[a-zA-Z0-9\[])/, Operator
         # operators
-        rule /(or|and|not|mod|ne|eq|lt|le|gt|ge)/, Operator
+        rule /(or|and|not|mod|ne|eq|lt|le|gt|ge)/, Operator::Word
         # keywords
         rule /some|in|satisfies|as|is|for|every|cast|castable|treat|instance|of|to|if|then|else|return|let|intersect|except|union|div|idiv/, Keyword::Reserved
         # axes
         rule /(self|child|attribute|descendant|descendant-or-self|ancestor|ancestor-or-self|following|following-sibling|namespace|parent|preceding-sibling)::/, Keyword::Namespace
         # kind tests
         rule /(node|document-node|text|comment|namespace-node|processing-instruction|attribute|schema-attribute|element|schema-element|function)\(\)/, Keyword::Reserved
-        # functions
-        rule /[a-zA-Z\-]+(?=\()/, Name::Function
       end
 
       state :names do
+        # Function or node namespace
         rule /[a-zA-Z\-]+:/, Name::Namespace
+        # Attributes
         rule /@[a-zA-Z][_\-a-zA-Z0-9]*/, Name::Attribute
+        # XPath variables
         rule /\$[a-zA-Z][_\-a-zA-Z0-9]*/, Name::Variable
+        # Functions
+        rule /[a-zA-Z\-]+(?=\s*+\()/, Name::Function
         # Node names
-        rule /[a-zA-Z]+/, Name::Tag
+        rule /[a-zA-Z]+/, Name::Class
       end
 
       state :root do
         mixin :basic
-        mixin :names
         mixin :operators
+        mixin :names
       end
 
       state :nested_comment do

--- a/docs/_plugins/xpath_lexer.rb
+++ b/docs/_plugins/xpath_lexer.rb
@@ -13,6 +13,12 @@ module Rouge
       filenames '*.xpath'
       mimetypes 'text/x-xpath'
 
+      state :root do
+        mixin :basic
+        mixin :operators
+        mixin :names
+      end
+
       state :basic do
         rule /\s+/, Text::Whitespace
         rule /[(]:(?![)])/, Comment, :nested_comment
@@ -28,7 +34,7 @@ module Rouge
       end
 
       state :operators do
-        rule /(<|>|=<|>=|==|\/\/|[|\/*+-])(?=\s|[a-zA-Z0-9\[])/, Operator
+        rule /(<|>|=<|>=|==|:=|\/\/|[|\/*+-])(?=\s|[a-zA-Z0-9\[])/, Operator
         # operators
         rule /(or|and|not|mod|ne|eq|lt|le|gt|ge)/, Operator::Word
         # keywords
@@ -45,17 +51,11 @@ module Rouge
         # Attributes
         rule /@[a-zA-Z][_\-a-zA-Z0-9]*/, Name::Attribute
         # XPath variables
-        rule /\$[a-zA-Z][_\-a-zA-Z0-9]*/, Name::Variable
+        rule /\$\s*[a-zA-Z][_\-a-zA-Z0-9]*/, Name::Variable
         # Functions
         rule /[a-zA-Z\-]+(?=\s*+\()/, Name::Function
         # Node names
-        rule /[a-zA-Z]+/, Name::Class
-      end
-
-      state :root do
-        mixin :basic
-        mixin :operators
-        mixin :names
+        rule /[a-zA-Z]+/, Name::Tag
       end
 
       state :nested_comment do

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleDocGenerator.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleDocGenerator.java
@@ -391,7 +391,7 @@ public class RuleDocGenerator {
 
                     if (rule instanceof XPathRule || rule instanceof RuleReference && ((RuleReference) rule).getRule() instanceof XPathRule) {
                         lines.add("**This rule is defined by the following XPath expression:**");
-                        lines.add("```xpath");
+                        lines.add("``` xpath");
                         lines.addAll(toLines(StringUtils.stripToEmpty(rule.getProperty(XPathRule.XPATH_DESCRIPTOR))));
                         lines.add("```");
                     } else {

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleDocGenerator.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleDocGenerator.java
@@ -391,7 +391,7 @@ public class RuleDocGenerator {
 
                     if (rule instanceof XPathRule || rule instanceof RuleReference && ((RuleReference) rule).getRule() instanceof XPathRule) {
                         lines.add("**This rule is defined by the following XPath expression:**");
-                        lines.add("```");
+                        lines.add("```xpath");
                         lines.addAll(toLines(StringUtils.stripToEmpty(rule.getProperty(XPathRule.XPATH_DESCRIPTOR))));
                         lines.add("```");
                     } else {

--- a/pmd-doc/src/test/resources/expected/sample.md
+++ b/pmd-doc/src/test/resources/expected/sample.md
@@ -19,7 +19,7 @@ language: Java
 Just some description of a deprecated rule.
 
 **This rule is defined by the following XPath expression:**
-```
+``` xpath
 //ForStatement
 ```
 
@@ -37,7 +37,7 @@ Just some description of a deprecated rule.
 Avoid jumbled loop incrementers - its usually a mistake, and is confusing even if intentional.
 
 **This rule is defined by the following XPath expression:**
-```
+``` xpath
 //ForStatement
  [
   ForUpdate/StatementExpressionList/StatementExpression/PostfixExpression/PrimaryExpression/PrimaryPrefix/Name/@Image
@@ -86,7 +86,7 @@ The rule has been moved to another ruleset. Use instead: [JumbledIncrementer](pm
 Avoid jumbled loop incrementers - its usually a mistake, and is confusing even if intentional.
 
 **This rule is defined by the following XPath expression:**
-```
+``` xpath
 //ForStatement
   [
     ForUpdate/StatementExpressionList/StatementExpression/PostfixExpression/PrimaryExpression/PrimaryPrefix/Name/@Image
@@ -177,7 +177,7 @@ This rule has been renamed. Use instead: [JumbledIncrementer](#jumbledincremente
 Avoid jumbled loop incrementers - its usually a mistake, and is confusing even if intentional.
 
 **This rule is defined by the following XPath expression:**
-```
+``` xpath
 //ForStatement
  [
   ForUpdate/StatementExpressionList/StatementExpression/PostfixExpression/PrimaryExpression/PrimaryPrefix/Name/@Image


### PR DESCRIPTION
This is only used when building the site, like the Liquid extensions. The changeset doesn't strictly depend on #1138, unless there are some updates to do to the release / site building scripts

Preview:

![capture du 2018-05-31 10-24-12](https://user-images.githubusercontent.com/24524930/40771154-d572e724-64bc-11e8-824a-5c2a49af14d2.png)

Edit: I corrected a bug, the highlighting is now richer:

![capture du 2018-06-04 23-46-27](https://user-images.githubusercontent.com/24524930/40943514-ae6f179a-6851-11e8-967e-b04da7da7f92.png)




