### PR TITLE
[java] GuardLogStatement false positive on return statements and Math.log

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -21,6 +21,8 @@ This is a minor release.
 
 ### Fixed Issues
 
+*   java-bestpractices
+    *   [#869](https://github.com/pmd/pmd/issues/869): \[java] GuardLogStatement false positive on return statements and Math.log
 *   java-codestyle
     *   [#1158](https://github.com/pmd/pmd/issues/1158): \[java] Fix IdenticalCatchBranches false positive
 *   xml

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
@@ -66,6 +66,13 @@ public class GuardLogStatementRule extends AbstractJavaRule implements Rule {
 
     private Map<String, String> guardStmtByLogLevel = new HashMap<>(12);
 
+    /*
+     * java util methods, that need special handling, e.g. they require an argument, which
+     * determines the log level
+     */
+    private static final String JAVA_UTIL_LOG_METHOD = "log";
+    private static final String JAVA_UTIL_LOG_GUARD_METHOD = "isLoggable";
+
     public GuardLogStatementRule() {
         definePropertyDescriptor(LOG_LEVELS);
         definePropertyDescriptor(GUARD_METHODS);
@@ -92,7 +99,7 @@ public class GuardLogStatementRule extends AbstractJavaRule implements Rule {
             String methodCall = getMethodCallName(prefix);
             String logLevel = getLogLevelName(node, methodCall);
 
-            if (guardStmtByLogLevel.containsKey(methodCall)
+            if (guardStmtByLogLevel.containsKey(methodCall) && logLevel != null
                     && node.jjtGetChild(1) instanceof ASTPrimarySuffix
                     && node.jjtGetChild(1).hasDescendantOfType(ASTAdditiveExpression.class)) {
 
@@ -125,12 +132,12 @@ public class GuardLogStatementRule extends AbstractJavaRule implements Rule {
                 continue;
             }
 
-            String guardMethodCall = getLastPartOfName(guardCall.jjtGetChild(0).getImage());
+            String guardMethodCall = getLastPartOfName(guardCall.jjtGetChild(0));
             boolean guardMethodCallMatches = guardStmtByLogLevel.get(methodCall).contains(guardMethodCall);
             boolean hasArguments = guardCall.jjtGetParent().hasDescendantOfType(ASTArgumentList.class);
 
-            if (guardMethodCallMatches && !hasArguments) {
-                // simple case: guard method without arguments found
+            if (guardMethodCallMatches && !JAVA_UTIL_LOG_GUARD_METHOD.equals(guardMethodCall)) {
+                // simple case: guard method without the need to check arguments found
                 foundGuard = true;
             } else if (guardMethodCallMatches && hasArguments) {
                 // java.util.logging: guard method with argument. Verify the log level
@@ -154,15 +161,15 @@ public class GuardLogStatementRule extends AbstractJavaRule implements Rule {
     private String getMethodCallName(ASTPrimaryPrefix prefix) {
         String result = "";
         if (prefix.jjtGetNumChildren() == 1 && prefix.jjtGetChild(0) instanceof ASTName) {
-            result = getLastPartOfName(prefix.jjtGetChild(0).getImage());
+            result = getLastPartOfName(prefix.jjtGetChild(0));
         }
         return result;
     }
 
-    private String getLastPartOfName(String name) {
+    private String getLastPartOfName(Node name) {
         String result = "";
         if (name != null) {
-            result = name;
+            result = name.getImage();
         }
         int dotIndex = result.lastIndexOf('.');
         if (dotIndex > -1 && result.length() > dotIndex + 1) {
@@ -172,22 +179,53 @@ public class GuardLogStatementRule extends AbstractJavaRule implements Rule {
     }
 
     /**
+     * Gets the first child, first grand child, ... of the given types.
+     * The children must follow the given order of types
+     *
+     * @param root the node from where to start the search
+     * @param childrenTypes the list of types
+     * @param <N> should match the last type of childrenType, otherwise you'll get a ClassCastException
+     * @return the found child node or <code>null</code>
+     */
+    @SafeVarargs
+    private static <N> N getFirstChild(Node root, Class<? extends Node> ... childrenTypes) {
+        Node current = root;
+        for (Class<? extends Node> clazz : childrenTypes) {
+            Node child = current.getFirstChildOfType(clazz);
+            if (child != null) {
+                current = child;
+            } else {
+                return null;
+            }
+        }
+        @SuppressWarnings("unchecked")
+        N result = (N) current;
+        return result;
+    }
+
+    /**
      * Determines the log level, that is used. It is either the called method name
-     * itself or - if the method has a first argument a primary prefix - the first argument.
+     * itself or - in case java util logging is used, then it is the first argument of
+     * the method call (if it exists).
      *
      * @param node the method call
      * @param methodCallName the called method name previously determined
-     * @return the log level
+     * @return the log level or <code>null</code> if it could not be determined
      */
     private String getLogLevelName(Node node, String methodCallName) {
-        String logLevel = methodCallName;
+        if (!JAVA_UTIL_LOG_METHOD.equals(methodCallName) && !JAVA_UTIL_LOG_GUARD_METHOD.equals(methodCallName)) {
+            return methodCallName;
+        }
 
+        String logLevel = null;
         ASTPrimarySuffix suffix = node.getFirstDescendantOfType(ASTPrimarySuffix.class);
         if (suffix != null) {
             ASTArgumentList argumentList = suffix.getFirstDescendantOfType(ASTArgumentList.class);
-            if (argumentList != null && argumentList.hasDescendantOfType(ASTName.class)) {
-                ASTName name = argumentList.getFirstDescendantOfType(ASTName.class);
-                String lastPart = getLastPartOfName(name.getImage());
+            if (argumentList != null && argumentList.jjtGetNumChildren() > 0) {
+                // at least one argument - the log level. If the method call is "log", then a message might follow
+                ASTName name = GuardLogStatementRule.<ASTName>getFirstChild(argumentList.jjtGetChild(0),
+                        ASTPrimaryExpression.class, ASTPrimaryPrefix.class, ASTName.class);
+                String lastPart = getLastPartOfName(name);
                 lastPart = lastPart.toLowerCase(Locale.ROOT);
                 if (!lastPart.isEmpty()) {
                     logLevel = lastPart;

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
@@ -347,4 +347,16 @@ public class GuardLogStatement {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#869 [java] GuardLogStatement false positive with something.error on return</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class GuardLogStatement {
+    public String foo() {
+        return ThisIsNotALogger.error("message " + "");
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
@@ -334,4 +334,17 @@ public class Logger {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#869 [java] GuardLogStatement false positive with Math.log</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class GuardLogStatement {
+    public void foo() {
+        double confidence = 0.5;
+        int depth = (int) Math.ceil(-Math.log(1 - confidence) / Math.log(2));
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Fixes #869 

The rule is still very prone to false-positives, since we use string matching...