### PR TITLE
[java] Make SwitchStmtsShouldHaveDefault aware of enum switches

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchLabel.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchLabel.java
@@ -5,6 +5,15 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents either a {@code case} or {@code default} label inside
+ * a {@linkplain ASTSwitchStatement switch statement}.
+ *
+ * <pre>
+ * SwitchLabel ::=  "case" {@linkplain ASTExpression Expression} ":"
+ *                | "default" ":"
+ * </pre>
+ */
 public class ASTSwitchLabel extends AbstractJavaNode {
 
     private boolean isDefault;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchStatement.java
@@ -5,7 +5,22 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
-public class ASTSwitchStatement extends AbstractJavaNode {
+import java.util.Iterator;
+import java.util.Set;
+
+import org.apache.commons.lang3.EnumUtils;
+
+
+/**
+ * Represents a {@code switch} statement.
+ *
+ * <pre>
+ *    SwitchStatement ::= "switch" "(" {@linkplain ASTExpression Expression} ")" "{"
+ *                        ( {@linkplain ASTSwitchLabel SwitchLabel} {@linkplain ASTBlockStatement BlockStatement}* )*
+ *                        "}"
+ * </pre>
+ */
+public class ASTSwitchStatement extends AbstractJavaNode implements Iterable<ASTSwitchLabel> {
     public ASTSwitchStatement(int id) {
         super(id);
     }
@@ -14,10 +29,69 @@ public class ASTSwitchStatement extends AbstractJavaNode {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
+
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
+    }
+
+
+    /**
+     * Returns true if this switch has a {@code default} case.
+     */
+    public boolean hasDefaultCase() {
+        for (ASTSwitchLabel label : this) {
+            if (label.isDefault()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    /**
+     * Gets the expression tested by this switch.
+     * This is the expression between the parentheses.
+     */
+    public ASTExpression getTestedExpression() {
+        return (ASTExpression) jjtGetChild(0);
+    }
+
+
+    /**
+     * Returns true if this switch statement tests an expression
+     * having an enum type and all the constants of this type
+     * are covered by a switch case. Returns false if the type of
+     * the tested expression could not be resolved.
+     */
+    public boolean isExhaustiveEnumSwitch() {
+        ASTExpression expression = getTestedExpression();
+
+        if (expression.getType() == null) {
+            return false;
+        }
+
+        if (Enum.class.isAssignableFrom(expression.getType())) {
+
+            @SuppressWarnings("unchecked")
+            Set<String> constantNames = EnumUtils.getEnumMap((Class<? extends Enum>) expression.getType()).keySet();
+
+            for (ASTSwitchLabel label : this) {
+                // since this is an enum switch, the labels are necessarily
+                // the simple name of some enum constant.
+
+                constantNames.remove(label.getFirstDescendantOfType(ASTName.class).getImage());
+
+            }
+
+            return constantNames.isEmpty();
+        }
+
+        return false;
+    }
+
+
+    @Override
+    public Iterator<ASTSwitchLabel> iterator() {
+        return new NodeChildrenIterator<>(this, ASTSwitchLabel.class);
     }
 }

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -1017,6 +1017,7 @@ public class Foo {
           language="java"
           since="1.0"
           message="Switch statements should have a default label"
+          typeResolution="true"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_bestpractices.html#switchstmtsshouldhavedefault">
         <description>
@@ -1024,8 +1025,12 @@ All switch statements should include a default option to catch any unspecified v
         </description>
         <priority>3</priority>
         <properties>
+            <property name="version" value="2.0"/>
             <property name="xpath">
-                <value>//SwitchStatement[not(SwitchLabel[@Default='true'])]</value>
+                <value><![CDATA[
+                //SwitchStatement[not(SwitchLabel[@Default = true()]
+                                  or Expression[pmd-java:typeIs('java.lang.Enum')])]
+            ]]></value>
             </property>
         </properties>
         <example>

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -1028,8 +1028,7 @@ All switch statements should include a default option to catch any unspecified v
             <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
-                //SwitchStatement[not(SwitchLabel[@Default = true()]
-                                  or Expression[pmd-java:typeIs('java.lang.Enum')])]
+                //SwitchStatement[@DefaultCase = false() and @ExhaustiveEnumSwitch = false()]
             ]]></value>
             </property>
         </properties>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/switchstmtsshouldhavedefault/SimpleEnum.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/switchstmtsshouldhavedefault/SimpleEnum.java
@@ -1,0 +1,15 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices.switchstmtsshouldhavedefault;
+
+/**
+ * @author Clément Fournier
+ * @since 6.5.0
+ */
+public enum  SimpleEnum {
+    FOO,
+    BAR,
+    BZAZ
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/switchstmtsshouldhavedefault/SimpleEnum.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/switchstmtsshouldhavedefault/SimpleEnum.java
@@ -8,7 +8,7 @@ package net.sourceforge.pmd.lang.java.rule.bestpractices.switchstmtsshouldhavede
  * @author Clément Fournier
  * @since 6.5.0
  */
-public enum  SimpleEnum {
+public enum SimpleEnum {
     FOO,
     BAR,
     BZAZ

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/SwitchStmtsShouldHaveDefault.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/SwitchStmtsShouldHaveDefault.xml
@@ -3,10 +3,8 @@
     xmlns="http://pmd.sourceforge.net/rule-tests"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
-    <test-code>
-        <description><![CDATA[
-simple failure case
-     ]]></description>
+ <test-code>
+        <description>simple failure case</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -19,10 +17,9 @@ public class Foo {
 }
      ]]></code>
     </test-code>
+
     <test-code>
-        <description><![CDATA[
-simple ok case
-     ]]></description>
+        <description>simple ok case</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -35,5 +32,52 @@ public class Foo {
  }
 }
      ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#651 Enum type, not ok</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+            import net.sourceforge.pmd.lang.java.rule.bestpractices.switchstmtsshouldhavedefault.SimpleEnum;
+
+            public class Foo {
+                void bar() {
+                    SimpleEnum a;
+
+                    // This switch is NOT exhaustive
+                    switch (a) {
+                    case SimpleEnum.BZAZ:
+                        int y = 8;
+                        break;
+                    }
+                }
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#651 Enum type, ok</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            import net.sourceforge.pmd.lang.java.rule.bestpractices.switchstmtsshouldhavedefault.SimpleEnum;
+
+            public class Foo {
+                void bar() {
+                    SimpleEnum x;
+
+                    // This switch is exhaustive
+                    switch (x) {
+                    case SimpleEnum.BZAZ:
+                        int y = 8;
+                        break;
+                    case SimpleEnum.FOO:
+                        break;
+                    case SimpleEnum.BAR:
+                        int w = 8;
+                        break;
+                    }
+                }
+            }
+            ]]></code>
     </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/SwitchStmtsShouldHaveDefault.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/SwitchStmtsShouldHaveDefault.xml
@@ -46,7 +46,7 @@ public class Foo {
 
                     // This switch is NOT exhaustive
                     switch (a) {
-                    case SimpleEnum.BZAZ:
+                    case BZAZ:
                         int y = 8;
                         break;
                     }
@@ -67,12 +67,12 @@ public class Foo {
 
                     // This switch is exhaustive
                     switch (x) {
-                    case SimpleEnum.BZAZ:
+                    case BZAZ:
                         int y = 8;
                         break;
-                    case SimpleEnum.FOO:
+                    case FOO:
                         break;
-                    case SimpleEnum.BAR:
+                    case BAR:
                         int w = 8;
                         break;
                     }


### PR DESCRIPTION
The rule now whitelists enum switches that test for all enum constants

Fix #651