### PR TITLE
[java] MissingOverrideRule exception when analyzing PMD under Java 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ bin/
 .idea
 *.patch
 */src/site/site.xml
+pmd-core/dependency-reduced-pom.xml

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -43,6 +43,7 @@ This is a minor release.
 *   ecmascript
     *   [#861](https://github.com/pmd/pmd/issues/861): \[ecmascript] InnaccurateNumericLiteral false positive with hex literals
 *   java
+    *   [#1074](https://github.com/pmd/pmd/issues/1074): \[java] MissingOverrideRule exception when analyzing PMD under Java 9
     *   [#1174](https://github.com/pmd/pmd/issues/1174): \[java] CommentUtil.multiLinesIn() could lead to StringIndexOutOfBoundsException
 *   java-bestpractices
     *   [#651](https://github.com/pmd/pmd/issues/651): \[java] SwitchStmtsShouldHaveDefault should be aware of enum types

--- a/pmd-core/pom.xml
+++ b/pmd-core/pom.xml
@@ -108,6 +108,15 @@
         <dependency>
             <groupId>jaxen</groupId>
             <artifactId>jaxen</artifactId>
+            <!--
+                Jaxen is optionally, so that it doesn't get inherited by default.
+                Jaxen is shaded into pmd-core (without org.w3c.dom.UserDataHandler).
+                Adding Jaxen again as a dependency would reintroduce the duplicated
+                org.w3c.dom.UserDataHandler interface.
+                See https://github.com/pmd/pmd/issues/1074
+                and https://github.com/pmd/pmd/pull/1201
+            -->
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>net.java.dev.javacc</groupId>

--- a/pmd-core/pom.xml
+++ b/pmd-core/pom.xml
@@ -60,6 +60,34 @@
                     <suppressionsLocation>pmd-core-checkstyle-suppressions.xml</suppressionsLocation>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <artifactSet>
+                        <includes>jaxen:jaxen</includes>
+                    </artifactSet>
+                    <filters>
+                        <filter>
+                            <artifact>jaxen:jaxen</artifact>
+                            <includes>
+                                <include>org/jaxen/**</include>
+                            </includes>
+                            <excludes>
+                                <exclude>org/w3c/dom/**</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/pmd-java/pom.xml
+++ b/pmd-java/pom.xml
@@ -108,10 +108,6 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>jaxen</groupId>
-            <artifactId>jaxen</artifactId>
-        </dependency>
-        <dependency>
             <groupId>net.java.dev.javacc</groupId>
             <artifactId>javacc</artifactId>
         </dependency>

--- a/pmd-java8/pom.xml
+++ b/pmd-java8/pom.xml
@@ -55,10 +55,6 @@
         </dependency>
 
         <dependency>
-            <groupId>jaxen</groupId>
-            <artifactId>jaxen</artifactId>
-        </dependency>
-        <dependency>
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-core</artifactId>
         </dependency>

--- a/pmd-plsql/pom.xml
+++ b/pmd-plsql/pom.xml
@@ -112,10 +112,6 @@
             <groupId>net.sourceforge.saxon</groupId>
             <artifactId>saxon</artifactId>
         </dependency>
-        <dependency>
-            <groupId>jaxen</groupId>
-            <artifactId>jaxen</artifactId>
-        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/pmd-xml/pom.xml
+++ b/pmd-xml/pom.xml
@@ -66,10 +66,6 @@
     </build>
     <dependencies>
         <dependency>
-            <groupId>jaxen</groupId>
-            <artifactId>jaxen</artifactId>
-        </dependency>
-        <dependency>
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-core</artifactId>
         </dependency>


### PR DESCRIPTION
Fixes #1074

Jaxen is now shaded into pmd-core, without org.w3c.dom.**

I gave it a try, but it doesn't seem to be working: If I remove the m-pmd-p configuration in pmd-xml and use the fixed snapshot version of PMD (with the shaded jaxen dep), m-pmd-p execution still fails when analyzing pmd-xml.

In the binary distribution, I don't see org.w3c.dom.UserDataHandler anymore in the libraries... so this is gone...