### PR TITLE
[java] Recommend StringBuilder next to StringBuffer

### DIFF
--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -935,7 +935,7 @@ public String convert(int i) {
 
     <rule name="UseStringBufferForStringAppends"
           since="3.1"
-          message="Prefer StringBuffer over += for concatenating strings"
+          message="Prefer StringBuilder (non-synchronized) or StringBuffer (synchronized) over += for concatenating strings"
           class="net.sourceforge.pmd.lang.java.rule.performance.UseStringBufferForStringAppendsRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_performance.html#usestringbufferforstringappends">
         <description>


### PR DESCRIPTION
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [ ] `./mvnw test` passes.
 - [x] `./mvnw pmd:check` passes.
 - [x] `./mvnw checkstyle:check` passes. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

There seems to be some confusion about the use of `./mvnw test` which fails with OpenJDK 8 because 9 is enforced and causes test failures even on `master` with 9.

**PR Description:**
StringBuilder is a faster non-synchronized alternative to StringBuffer
which should be used where synchronization is not needed. Since "use
StringBuilder or StringBuffer" would immediately lead to the question
which one to use the hints "non-synchronized" and "synchronized" are
added.
