### PR TITLE
[java] Add javadoc to some AST nodes

### DIFF
--- a/pmd-java/etc/grammar/Java.jjt
+++ b/pmd-java/etc/grammar/Java.jjt
@@ -1523,6 +1523,7 @@ TOKEN :
 | < XOR: "^" >
 | < REM: "%" >
 | < LSHIFT: "<<" >
+// Notice the absence of >> or >>>, to not conflict with generics
 | < PLUSASSIGN: "+=" >
 | < MINUSASSIGN: "-=" >
 | < STARASSIGN: "*=" >
@@ -1895,6 +1896,8 @@ void Type():
 void ReferenceType():
 {}
 {
+  // The grammar here is mildly wrong, the annotations can be before each []
+  // This will wait for #997
    PrimitiveType() (TypeAnnotation())* ( LOOKAHEAD(2) "[" "]" { jjtThis.bumpArrayDepth(); })+
   |
    ( ClassOrInterfaceType()) (TypeAnnotation())* ( LOOKAHEAD(2) "[" "]" { jjtThis.bumpArrayDepth(); })*
@@ -1996,6 +1999,11 @@ void Expression() :
  * a primary expression.  Consider adding a semantic predicate to work
  * around this.
  */
+ // It also allows lambda expressions in many more contexts as allowed by the JLS.
+ // Lambda expressions are not a PrimaryExpression in the JLS, instead they're
+ // separated from the AssignmentExpression production. Their use is restricted
+ // to method and constructor argument, cast operand, and the RHS of assignments.
+ // https://docs.oracle.com/javase/specs/jls/se9/html/jls-15.html#jls-15.27
 {}
 {
   ConditionalExpression()
@@ -2021,6 +2029,8 @@ void AssignmentOperator() :
     | "|="    {jjtThis.setImage("|="); jjtThis.setCompound();}
 }
 
+// TODO Setting isTernary is unnecessary, since the node is only pushed on the stack if there is at least one child,
+// ie if it's a ternary
 void ConditionalExpression() #ConditionalExpression(>1) :
 {}
 {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAdditiveExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAdditiveExpression.java
@@ -5,6 +5,20 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents an addition operation on two or more values, or string concatenation.
+ * This has a precedence greater than {@link ASTShiftExpression}, and lower
+ * than {@link ASTMultiplicativeExpression}.
+ *
+ * <p>Note that the children of this node are not necessarily {@link ASTMultiplicativeExpression},
+ * rather, they are expressions with an operator precedence greater or equal to MultiplicativeExpression.
+ *
+ * <pre>
+ *
+ * AdditiveExpression ::= {@linkplain ASTMultiplicativeExpression MultiplicativeExpression} ( ( "+" | "-" ) {@linkplain ASTMultiplicativeExpression MultiplicativeExpression} )+
+ *
+ * </pre>
+ */
 public class ASTAdditiveExpression extends AbstractJavaTypeNode {
     public ASTAdditiveExpression(int id) {
         super(id);
@@ -14,12 +28,16 @@ public class ASTAdditiveExpression extends AbstractJavaTypeNode {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
     }
 
+
+    /**
+     * Returns the image of the operator, i.e. "+" or "-".
+     */
+    public String getOperator() {
+        return getImage();
+    }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAndExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAndExpression.java
@@ -5,6 +5,21 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents a non-shortcut boolean AND-expression.
+ * This has a precedence greater than {@link ASTExclusiveOrExpression},
+ * and lower than {@link ASTEqualityExpression}.
+ *
+ * <p>Note that the children of this node are not necessarily {@link ASTEqualityExpression},
+ * rather, they are expressions with an operator precedence greater or equal to EqualityExpression.
+ *
+ *
+ * <pre>
+ *
+ * AndExpression ::=  {@linkplain ASTEqualityExpression EqualityExpression} ( "&" {@linkplain ASTEqualityExpression EqualityExpression} )+
+ *
+ * </pre>
+ */
 public class ASTAndExpression extends AbstractJavaTypeNode {
     public ASTAndExpression(int id) {
         super(id);
@@ -14,9 +29,6 @@ public class ASTAndExpression extends AbstractJavaTypeNode {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotation.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotation.java
@@ -11,6 +11,19 @@ import java.util.List;
 import net.sourceforge.pmd.Rule;
 
 
+/**
+ * Represents an annotation. This node has three possible children,
+ * that correspond to specific syntactic variants.
+ *
+ * <pre>
+ *
+ * Annotation ::= {@linkplain ASTNormalAnnotation NormalAnnotation}
+ *              | {@linkplain ASTSingleMemberAnnotation SingleMemberAnnotation}
+ *              | {@linkplain ASTMarkerAnnotation MarkerAnnotation}
+ *
+ * </pre>
+ *
+ */
 public class ASTAnnotation extends AbstractJavaTypeNode {
 
     private static final List<String> UNUSED_RULES
@@ -86,9 +99,6 @@ public class ASTAnnotation extends AbstractJavaTypeNode {
         return "SuppressWarnings".equals(getAnnotationName()) || "java.lang.SuppressWarnings".equals(getAnnotationName());
     }
 
-    /**
-     * Accept the visitor.
-     */
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAssignmentOperator.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAssignmentOperator.java
@@ -5,6 +5,15 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents an assignment operator in an {@linkplain ASTExpression assignment expression}.
+ *
+ * <pre>
+ *
+ *  AssignmentOperator ::= "=" | "*=" | "/=" | "%=" | "+=" | "-=" | "<<=" | ">>=" | ">>>=" | "&=" | "^=" | "|="
+ *
+ * </pre>
+ */
 public class ASTAssignmentOperator extends AbstractJavaNode {
     private boolean isCompound;
 
@@ -16,6 +25,7 @@ public class ASTAssignmentOperator extends AbstractJavaNode {
         super(p, id);
     }
 
+    // TODO this could be determined from the image of the operator, no need to set it in the parser...
     public void setCompound() {
         isCompound = true;
     }
@@ -24,9 +34,6 @@ public class ASTAssignmentOperator extends AbstractJavaNode {
         return this.isCompound;
     }
 
-    /**
-     * Accept the visitor. *
-     */
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassOrInterfaceType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassOrInterfaceType.java
@@ -7,6 +7,17 @@ package net.sourceforge.pmd.lang.java.ast;
 
 import net.sourceforge.pmd.lang.ast.Node;
 
+
+/**
+ * Represents a class or interface type, possibly parameterised with type arguments.
+ *
+ * <pre>
+ *
+ * ClassOrInterfaceType ::= &lt;IDENTIFIER&gt; {@linkplain ASTTypeArguments TypeArguments}? ( "." &lt;IDENTIFIER&gt;  {@linkplain ASTTypeArguments TypeArguments}? )*
+ *
+ * </pre>
+ *
+ */
 public class ASTClassOrInterfaceType extends AbstractJavaTypeNode {
     public ASTClassOrInterfaceType(int id) {
         super(id);
@@ -16,9 +27,6 @@ public class ASTClassOrInterfaceType extends AbstractJavaTypeNode {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTConditionalAndExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTConditionalAndExpression.java
@@ -5,18 +5,31 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents a boolean AND-expression. This has a precedence greater than {@link ASTConditionalOrExpression},
+ * and lower than {@link ASTInclusiveOrExpression}.
+ *
+ * <p>Note that the children of this node are not necessarily {@link ASTInclusiveOrExpression},
+ * rather, they are expressions with an operator precedence greater or equal to InclusiveOrExpression.
+ *
+ *
+ * <pre>
+ *
+ * ConditionalAndExpression ::=  {@linkplain ASTInclusiveOrExpression InclusiveOrExpression} ( "&&" {@linkplain ASTInclusiveOrExpression InclusiveOrExpression} )+
+ *
+ * </pre>
+ */
 public class ASTConditionalAndExpression extends AbstractJavaTypeNode {
     public ASTConditionalAndExpression(int id) {
         super(id);
     }
 
+
     public ASTConditionalAndExpression(JavaParser p, int id) {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
+
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTConditionalExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTConditionalExpression.java
@@ -5,6 +5,21 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents a conditional expression, aka ternary expression. This operation has
+ * a greater precedence as {@linkplain ASTExpression assignment expressions},
+ * and lower as {@link ASTConditionalOrExpression}.
+ *
+ * <p>Note that the children of this node are not necessarily {@link ASTConditionalOrExpression},
+ * rather, they are expressions with an operator precedence greater or equal to ConditionalOrExpression.
+ *
+ * <pre>
+ *
+ * ConditionalExpression ::= {@linkplain ASTConditionalOrExpression ConditionalOrExpression} "?"  {@linkplain ASTExpression Expression} ":" {@linkplain ASTConditionalExpression ConditionalExpression}
+ *
+ * </pre>
+ *
+ */
 public class ASTConditionalExpression extends AbstractJavaTypeNode {
 
     private boolean isTernary;
@@ -21,13 +36,11 @@ public class ASTConditionalExpression extends AbstractJavaTypeNode {
         isTernary = true;
     }
 
+    // TODO this could be deprecated, there's no way this node is *not* a ternary
     public boolean isTernary() {
         return this.isTernary;
     }
 
-    /**
-     * Accept the visitor. *
-     */
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTConditionalOrExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTConditionalOrExpression.java
@@ -5,6 +5,20 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents a boolean OR-expression. This has a precedence greater than {@link ASTConditionalExpression},
+ * and lower than {@link ASTConditionalAndExpression}.
+ *
+ * <p>Note that the children of this node are not necessarily {@link ASTConditionalAndExpression},
+ * rather, they are expressions with an operator precedence greater or equal to ConditionalAndExpression.
+ *
+ *
+ * <pre>
+ *
+ * ConditionalOrExpression ::=  {@linkplain ASTConditionalAndExpression ConditionalAndExpression} ( "||" {@linkplain ASTConditionalAndExpression ConditionalAndExpression} )+
+ *
+ * </pre>
+ */
 public class ASTConditionalOrExpression extends AbstractJavaTypeNode {
     public ASTConditionalOrExpression(int id) {
         super(id);
@@ -14,9 +28,6 @@ public class ASTConditionalOrExpression extends AbstractJavaTypeNode {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTEqualityExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTEqualityExpression.java
@@ -5,6 +5,21 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents an identity test between two values or more values.
+ * This has a precedence greater than {@link ASTAndExpression},
+ * and lower than {@link ASTInstanceOfExpression} and {@link ASTRelationalExpression}.
+ *
+ * <p>Note that the children of this node are not necessarily {@link ASTInstanceOfExpression},
+ * rather, they are expressions with an operator precedence greater or equal to InstanceOfExpression.
+ *
+ *
+ * <pre>
+ *
+ * EqualityExpression ::=  {@linkplain ASTInstanceOfExpression InstanceOfExpression}  ( ( "==" | "!=" ) {@linkplain ASTInstanceOfExpression InstanceOfExpression}  )+
+ *
+ * </pre>
+ */
 public class ASTEqualityExpression extends AbstractJavaTypeNode {
     public ASTEqualityExpression(int id) {
         super(id);
@@ -14,12 +29,17 @@ public class ASTEqualityExpression extends AbstractJavaTypeNode {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
+    }
+
+
+    /**
+     * Returns the image of the operator, i.e. "==" or "!=".
+     */
+    public String getOperator() {
+        return getImage();
     }
 
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExclusiveOrExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExclusiveOrExpression.java
@@ -5,6 +5,20 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents a boolean XOR-expression. This has a precedence greater than {@link ASTInclusiveOrExpression},
+ * and lower than {@link ASTAndExpression}.
+ *
+ * <p>Note that the children of this node are not necessarily {@link ASTAndExpression},
+ * rather, they are expressions with an operator precedence greater or equal to AndExpression.
+ *
+ *
+ * <pre>
+ *
+ * ExclusiveOrExpression ::=  {@linkplain ASTAndExpression AndExpression} ( "^" {@linkplain ASTAndExpression AndExpression} )+
+ *
+ * </pre>
+ */
 public class ASTExclusiveOrExpression extends AbstractJavaTypeNode {
     public ASTExclusiveOrExpression(int id) {
         super(id);
@@ -14,9 +28,6 @@ public class ASTExclusiveOrExpression extends AbstractJavaTypeNode {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExpression.java
@@ -5,6 +5,18 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents an expression, in the most general sense.
+ * This corresponds roughly to the <a href="https://docs.oracle.com/javase/specs/jls/se9/html/jls-15.html#jls-AssignmentExpression">AssignmentExpression</a>
+ * of the JLS. One difference though, is that this production
+ * also matches lambda expressions, contrary to the JLS.
+ *
+ * <pre>
+ *
+ * Expression ::= {@linkplain ASTConditionalExpression ConditionalExpression} ( {@linkplain ASTAssignmentOperator AssignmentOperator} Expression )?
+ *
+ * </pre>
+ */
 public class ASTExpression extends AbstractJavaTypeNode {
     public ASTExpression(int id) {
         super(id);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTInclusiveOrExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTInclusiveOrExpression.java
@@ -5,18 +5,32 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents a non-shortcut boolean OR-expression. This has a precedence
+ * greater than {@link ASTConditionalAndExpression}, and lower than
+ * {@link ASTExclusiveOrExpression}.
+ *
+ * <p>Note that the children of this node are not necessarily {@link ASTExclusiveOrExpression},
+ * rather, they are expressions with an operator precedence greater or equal to ExclusiveOrExpression.
+ *
+ *
+ * <pre>
+ *
+ * InclusiveOrExpression ::=  {@linkplain ASTExclusiveOrExpression ExclusiveOrExpression} ( "|" {@linkplain ASTExclusiveOrExpression ExclusiveOrExpression} )+
+ *
+ * </pre>
+ */
 public class ASTInclusiveOrExpression extends AbstractJavaTypeNode {
     public ASTInclusiveOrExpression(int id) {
         super(id);
     }
 
+
     public ASTInclusiveOrExpression(JavaParser p, int id) {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
+
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTInstanceOfExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTInstanceOfExpression.java
@@ -5,20 +5,42 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents a type test on an object. This has a precedence greater than {@link ASTEqualityExpression},
+ * and lower than {@link ASTShiftExpression}. This has the same precedence as a {@link ASTRelationalExpression}.
+ *
+ * <p>Note that the children of this node are not necessarily {@link ASTRelationalExpression},
+ * rather, they are expressions with an operator precedence greater or equal to RelationalExpression.
+ *
+ *
+ * <pre>
+ *
+ * InstanceOfExpression ::=  {@linkplain ASTShiftExpression ShiftExpression} "instanceof" {@linkplain ASTType Type}
+ *
+ * </pre>
+ */
 public class ASTInstanceOfExpression extends AbstractJavaTypeNode {
     public ASTInstanceOfExpression(int id) {
         super(id);
     }
 
+
     public ASTInstanceOfExpression(JavaParser p, int id) {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
+
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
     }
+
+
+    /**
+     * Gets the type against which the expression is tested.
+     */
+    public ASTType getTypeNode() {
+        return (ASTType) jjtGetChild(1);
+    }
+
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMarkerAnnotation.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMarkerAnnotation.java
@@ -5,20 +5,49 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents an annotation with no declared member, e.g. {@code @Override}.
+ *
+ * <pre>
+ *
+ * MarkerAnnotation ::= "@" {@linkplain ASTAnnotation Name}
+ *
+ * </pre>
+ *
+ * @see ASTSingleMemberAnnotation
+ * @see ASTNormalAnnotation
+ */
 public class ASTMarkerAnnotation extends AbstractJavaTypeNode {
+
     public ASTMarkerAnnotation(int id) {
         super(id);
     }
+
 
     public ASTMarkerAnnotation(JavaParser p, int id) {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
+
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
     }
+
+
+    /**
+     * Returns the name of the annotation as it is used,
+     * eg {@code java.lang.Override} or {@code Override}.
+     */
+    public String getAnnotationName() {
+        return jjtGetChild(0).getImage();
+    }
+
+
+    @Override
+    public ASTAnnotation jjtGetParent() {
+        return (ASTAnnotation) super.jjtGetParent();
+    }
+
+
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMemberValue.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMemberValue.java
@@ -5,18 +5,30 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents the value of a member of an annotation.
+ * This can appear in a {@linkplain ASTMemberValuePair member-value pair},
+ * or in a {@linkplain ASTSingleMemberAnnotation single-member annotation}.
+ *
+ * <pre>
+ *
+ * MemberValue ::= {@linkplain ASTAnnotation Annotation}
+ *               | {@linkplain ASTMemberValueArrayInitializer MemberValueArrayInitializer}
+ *               | &lt; any expression, excluding assignment expressions and lambda expressions &gt;
+ *
+ * </pre>
+ */
 public class ASTMemberValue extends AbstractJavaNode {
     public ASTMemberValue(int id) {
         super(id);
     }
 
+
     public ASTMemberValue(JavaParser p, int id) {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
+
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMemberValueArrayInitializer.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMemberValueArrayInitializer.java
@@ -5,7 +5,22 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
-public class ASTMemberValueArrayInitializer extends AbstractJavaNode {
+
+import java.util.Iterator;
+
+
+/**
+ * Represents an array of member values in an annotation {@linkplain ASTMemberValue member value}.
+ *
+ * <pre>
+ *
+ * MemberValueArrayInitializer ::= "{" ( {@linkplain ASTMemberValue MemberValue} ( "," {@linkplain ASTMemberValue MemberValue} )*  ","? )? "}"
+ *
+ * </pre>
+ *
+ *
+ */
+public class ASTMemberValueArrayInitializer extends AbstractJavaNode implements Iterable<ASTMemberValue> {
     public ASTMemberValueArrayInitializer(int id) {
         super(id);
     }
@@ -14,11 +29,14 @@ public class ASTMemberValueArrayInitializer extends AbstractJavaNode {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
+    }
+
+
+    @Override
+    public Iterator<ASTMemberValue> iterator() {
+        return new NodeChildrenIterator<>(this, ASTMemberValue.class);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMemberValuePair.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMemberValuePair.java
@@ -5,18 +5,48 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents a single member-value pair in an annotation.
+ *
+ * <pre>
+ *
+ * MemberValuePair ::=  &lt;IDENTIFIER&gt; "=" {@linkplain ASTMemberValue MemberValue}
+ *
+ * </pre>
+ */
 public class ASTMemberValuePair extends AbstractJavaNode {
     public ASTMemberValuePair(int id) {
         super(id);
     }
 
+
     public ASTMemberValuePair(JavaParser p, int id) {
         super(p, id);
     }
 
+
     /**
-     * Accept the visitor. *
+     * Returns the name of the member set by this pair.
      */
+    public String getMemberName() {
+        return getImage();
+    }
+
+
+    /**
+     * Returns the value of the member set by this pair.
+     */
+    public ASTMemberValue getMemberValue() {
+        return (ASTMemberValue) jjtGetChild(0);
+    }
+
+
+    @Override
+    public ASTMemberValuePairs jjtGetParent() {
+        return (ASTMemberValuePairs) super.jjtGetParent();
+    }
+
+
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMemberValuePairs.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMemberValuePairs.java
@@ -5,20 +5,49 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
-public class ASTMemberValuePairs extends AbstractJavaNode {
+import java.util.Iterator;
+
+
+/**
+ * Represents a list of member values in an {@linkplain ASTNormalAnnotation annotation}.
+ *
+ * <pre>
+ *
+ *  MemberValuePairs ::= {@linkplain ASTMemberValuePair MemberValuePair} ( "," {@linkplain ASTMemberValuePair MemberValuePair} )*
+ *
+ * </pre>
+ */
+public class ASTMemberValuePairs extends AbstractJavaNode implements Iterable<ASTMemberValuePair> {
     public ASTMemberValuePairs(int id) {
         super(id);
     }
+
 
     public ASTMemberValuePairs(JavaParser p, int id) {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
+
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
+    }
+
+
+    @Override
+    public ASTMemberValuePair jjtGetChild(int index) {
+        return (ASTMemberValuePair) super.jjtGetChild(index);
+    }
+
+
+    @Override
+    public ASTNormalAnnotation jjtGetParent() {
+        return (ASTNormalAnnotation) super.jjtGetParent();
+    }
+
+
+    @Override
+    public Iterator<ASTMemberValuePair> iterator() {
+        return new NodeChildrenIterator<>(this, ASTMemberValuePair.class);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMultiplicativeExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMultiplicativeExpression.java
@@ -5,6 +5,20 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents a multiplication, division, or modulo operation on
+ * two or more values. This has a precedence greater than {@link ASTAdditiveExpression},
+ * and lower than {@linkplain ASTUnaryExpression UnaryExpression}.
+ *
+ * <p>Note that the children of this node are not necessarily {@link ASTUnaryExpression}s,
+ * rather, they are expressions with an operator precedence greater or equal to UnaryExpression.
+ *
+ * <pre>
+ *
+ * MultiplicativeExpression ::= {@linkplain ASTUnaryExpression UnaryExpression} ( ( "*" | "/" | "%" ) {@linkplain ASTUnaryExpression UnaryExpression} )+
+ *
+ * </pre>
+ */
 public class ASTMultiplicativeExpression extends AbstractJavaTypeNode {
     public ASTMultiplicativeExpression(int id) {
         super(id);
@@ -14,11 +28,16 @@ public class ASTMultiplicativeExpression extends AbstractJavaTypeNode {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
+    }
+
+
+    /**
+     * Returns the image of the operator, i.e. "*", "/" or "%".
+     */
+    public String getOperator() {
+        return getImage();
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTNormalAnnotation.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTNormalAnnotation.java
@@ -5,20 +5,47 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents an annotation that with a parenthesized list
+ * of key-value pairs (possibly empty).
+ *
+ * <pre>
+ *
+ * NormalAnnotation ::=  "@" {@linkplain ASTName Name} "(" {@linkplain ASTMemberValuePairs MemberValuePairs}? ")"
+ *
+ * </pre>
+ *
+ * @see ASTSingleMemberAnnotation
+ * @see ASTMarkerAnnotation
+ */
 public class ASTNormalAnnotation extends AbstractJavaTypeNode {
     public ASTNormalAnnotation(int id) {
         super(id);
     }
 
+
     public ASTNormalAnnotation(JavaParser p, int id) {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
+
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
+    }
+
+
+    /**
+     * Returns the name of the annotation as it is used,
+     * eg {@code java.lang.Override} or {@code Override}.
+     */
+    public String getAnnotationName() {
+        return jjtGetChild(0).getImage();
+    }
+
+
+    @Override
+    public ASTAnnotation jjtGetParent() {
+        return (ASTAnnotation) super.jjtGetParent();
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPostfixExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPostfixExpression.java
@@ -5,6 +5,17 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents a unary postfix operation on a value.
+ * This is one of the {@linkplain ASTUnaryExpression PrefixExpression}
+ * and has the same precedence.
+ *
+ * <pre>
+ *
+ * PostfixExpression ::= {@linkplain ASTPrimaryExpression PrimaryExpression} ( "++" | "--" )
+ *
+ * </pre>
+ */
 public class ASTPostfixExpression extends AbstractJavaTypeNode {
 
     public ASTPostfixExpression(int id) {
@@ -15,12 +26,17 @@ public class ASTPostfixExpression extends AbstractJavaTypeNode {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
+    }
+
+
+    /**
+     * Returns the image of this unary operator, i.e. "++" or "--".
+     */
+    public String getOperator() {
+        return getImage();
     }
 
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPreDecrementExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPreDecrementExpression.java
@@ -5,6 +5,17 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents a pre-decrement expression on a variable.
+ * This has the same precedence as {@linkplain ASTUnaryExpression UnaryExpression}
+ * and the like.
+ *
+ * <pre>
+ *
+ * PreDecrementExpression ::= "--" {@linkplain ASTPrimaryExpression PrimaryExpression}
+ *
+ * </pre>
+ */
 public class ASTPreDecrementExpression extends AbstractJavaTypeNode {
     public ASTPreDecrementExpression(int id) {
         super(id);
@@ -14,9 +25,6 @@ public class ASTPreDecrementExpression extends AbstractJavaTypeNode {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPreIncrementExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPreIncrementExpression.java
@@ -5,6 +5,17 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents a pre-increment expression on a variable.
+ * This has the same precedence as {@linkplain ASTUnaryExpression UnaryExpression}
+ * and the like.
+ *
+ * <pre>
+ *
+ * PreIncrementExpression ::= "++" {@linkplain ASTPrimaryExpression PrimaryExpression}
+ *
+ * </pre>
+ */
 public class ASTPreIncrementExpression extends AbstractJavaTypeNode {
     public ASTPreIncrementExpression(int id) {
         super(id);
@@ -14,9 +25,6 @@ public class ASTPreIncrementExpression extends AbstractJavaTypeNode {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPrimitiveType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPrimitiveType.java
@@ -5,6 +5,15 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents a primitive type.
+ *
+ * <pre>
+ *
+ * PrimitiveType ::= "boolean" | "char" | "byte" | "short" | "int" | "long" | "float" | "double"
+ *
+ * </pre>
+ */
 public class ASTPrimitiveType extends AbstractJavaTypeNode implements Dimensionable {
 
     private int arrayDepth;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTReferenceType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTReferenceType.java
@@ -5,6 +5,18 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents a reference type, i.e. a {@linkplain ASTClassOrInterfaceType class or interface type},
+ * or an array type.
+ *
+ * <pre>
+ *
+ *  ReferenceType ::= {@linkplain ASTPrimitiveType PrimitiveType} {@linkplain ASTAnnotation Annotation}* ( "[" "]" )+
+ *                  | {@linkplain ASTClassOrInterfaceType ClassOrInterfaceType} {@linkplain ASTAnnotation Annotation}* ( "[" "]" )*
+ *
+ * </pre>
+ *
+ */
 public class ASTReferenceType extends AbstractJavaTypeNode implements Dimensionable {
 
     private int arrayDepth;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTRelationalExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTRelationalExpression.java
@@ -5,6 +5,20 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents a comparison on two numeric values. This has a precedence greater than {@link ASTEqualityExpression},
+ * and lower than {@link ASTShiftExpression}. This has the same precedence as a {@link ASTInstanceOfExpression}.
+ *
+ * <p>Note that the children of this node are not necessarily {@link ASTShiftExpression},
+ * rather, they are expressions with an operator precedence greater or equal to ShiftExpression.
+ *
+ *
+ * <pre>
+ *
+ * RelationalExpression ::=  {@linkplain ASTShiftExpression ShiftExpression} ( ( "<" | ">" | "<=" | ">=" ) {@linkplain ASTShiftExpression ShiftExpression} )+
+ *
+ * </pre>
+ */
 public class ASTRelationalExpression extends AbstractJavaTypeNode {
     public ASTRelationalExpression(int id) {
         super(id);
@@ -14,9 +28,6 @@ public class ASTRelationalExpression extends AbstractJavaTypeNode {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTShiftExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTShiftExpression.java
@@ -5,6 +5,21 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents a shift expression on a numeric value. This has a precedence greater than {@link ASTRelationalExpression},
+ * and lower than {@link ASTAdditiveExpression}.
+ *
+ * <p>Note that the children of this node are not necessarily {@link ASTAdditiveExpression},
+ * rather, they are expressions with an operator precedence greater or equal to AdditiveExpression.
+ *
+ *
+ * <pre>
+ *
+ * ShiftExpression ::=  {@linkplain ASTAdditiveExpression AdditiveExpression} ( ( "<<"  | {@linkplain ASTRSIGNEDSHIFT RSIGNEDSHIFT} | {@linkplain ASTRUNSIGNEDSHIFT RUNSIGNEDSHIFT} ) {@linkplain ASTAdditiveExpression AdditiveExpression} )+
+ *
+ * </pre>
+ */
+// TODO we could merge the productions for ASTRSIGNEDSHIFT and ASTRUNSIGNEDSHIFT into this node using a #void production that sets the image of the parent
 public class ASTShiftExpression extends AbstractJavaTypeNode {
     public ASTShiftExpression(int id) {
         super(id);
@@ -14,11 +29,22 @@ public class ASTShiftExpression extends AbstractJavaTypeNode {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
     }
+
+
+    /**
+     * Returns the image of the operator, i.e. "<<", ">>", or ">>>".
+     */
+    public String getOperator() {
+        if (getImage() != null) {
+            return getImage(); // <<
+        }
+
+        ASTRSIGNEDSHIFT rsshift = (ASTRSIGNEDSHIFT) jjtGetChild(1);
+        return rsshift != null ? ">>" : ">>>";
+    }
+
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSingleMemberAnnotation.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSingleMemberAnnotation.java
@@ -5,6 +5,18 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents an annotation using the shorthand syntax for the default member.
+ *
+ * <pre>
+ *
+ * SingleMemberAnnotation ::=  "@"  {@linkplain ASTName Name} "(" {@linkplain ASTMemberValue MemberValue} ")"
+ *
+ * </pre>
+ *
+ * @see ASTMarkerAnnotation
+ * @see ASTNormalAnnotation
+ */
 public class ASTSingleMemberAnnotation extends AbstractJavaTypeNode {
     public ASTSingleMemberAnnotation(int id) {
         super(id);
@@ -14,11 +26,32 @@ public class ASTSingleMemberAnnotation extends AbstractJavaTypeNode {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
+    }
+
+
+    /**
+     * Returns the value of the default member
+     * set by this annotation.
+     */
+    public ASTMemberValue getMemberValue() {
+        return (ASTMemberValue) jjtGetChild(1);
+    }
+
+
+    /**
+     * Returns the name of the annotation as it is used,
+     * eg {@code java.lang.Override} or {@code Override}.
+     */
+    public String getAnnotationName() {
+        return jjtGetChild(0).getImage();
+    }
+
+
+    @Override
+    public ASTAnnotation jjtGetParent() {
+        return (ASTAnnotation) super.jjtGetParent();
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTType.java
@@ -9,7 +9,9 @@ package net.sourceforge.pmd.lang.java.ast;
  * Represents a type reference.
  *
  * <pre>
- * Type ::= ReferenceType | PrimitiveType
+ *
+ * Type ::= {@linkplain ASTReferenceType ReferenceType} | {@linkplain ASTPrimitiveType PrimitiveType}
+ *
  * </pre>
  *
  * Note: it is not exactly the same the "UnnanType" defined in JLS.

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeArgument.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeArgument.java
@@ -5,6 +5,17 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+
+/**
+ * Represents a single type argument in a {@linkplain ASTTypeArguments type arguments list}.
+ *
+ * <pre>
+ *
+ * TypeArgument ::= ( {@linkplain ASTAnnotation Annotation} )* ( {@linkplain ASTReferenceType ReferenceType} | "?" {@linkplain ASTWildcardBounds WildcardBounds}? )
+ *
+ * </pre>
+ */
+// TODO should implement Annotatable when we use can use Java 8 mixins instead of an abstract class
 public class ASTTypeArgument extends AbstractJavaTypeNode {
     public ASTTypeArgument(int id) {
         super(id);
@@ -14,9 +25,24 @@ public class ASTTypeArgument extends AbstractJavaTypeNode {
         super(p, id);
     }
 
+
     /**
-     * Accept the visitor. *
+     * Returns true if this node is a wildcard argument (bounded or not).
      */
+    public boolean isWildcard() {
+        return getTypeNode() == null;
+    }
+
+
+    /**
+     * Returns the type node of this type argument.
+     * Returns {@code null} if this is a wildcard argument.
+     */
+    public ASTReferenceType getTypeNode() {
+        return getFirstChildOfType(ASTReferenceType.class);
+    }
+
+
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeArguments.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeArguments.java
@@ -5,7 +5,20 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
-public class ASTTypeArguments extends AbstractJavaNode {
+import java.util.Iterator;
+
+
+/**
+ * Represents a list of type arguments. This is different from {@linkplain ASTTypeParameters type parameters}!
+ *
+ * <pre>
+ *
+ *  TypeArguments ::= "<" {@linkplain ASTTypeArgument TypeArgument} ( "," {@linkplain ASTTypeArgument TypeArgument} )* ">"
+ *                  | "<" ">"
+ * </pre>
+ *
+ */
+public class ASTTypeArguments extends AbstractJavaNode implements Iterable<ASTTypeArgument> {
     public ASTTypeArguments(int id) {
         super(id);
     }
@@ -14,15 +27,23 @@ public class ASTTypeArguments extends AbstractJavaNode {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
     }
 
+
+    /**
+     * Returns true if this is a diamond, that is, the
+     * actual type arguments are inferred.
+     */
     public boolean isDiamond() {
         return jjtGetNumChildren() == 0;
+    }
+
+
+    @Override
+    public Iterator<ASTTypeArgument> iterator() {
+        return new NodeChildrenIterator<>(this, ASTTypeArgument.class);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeBound.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeBound.java
@@ -5,18 +5,42 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import java.util.List;
+
+
+/**
+ * Represents a type bound on a {@linkplain ASTTypeParameter type parameter}.
+ * Type bounds specify the type of the type variable to which they apply as
+ * an <a href="https://docs.oracle.com/javase/specs/jls/se9/html/jls-4.html#jls-4.9">intersection type</a>.
+ * The first bound type is a class or interface type, while the additional
+ * bounds are necessarily interface types.
+ *
+ * <pre>
+ *
+ * TypeBound ::= "extends" {@linkplain ASTAnnotation Annotation}* {@linkplain ASTClassOrInterfaceType ClassOrInterfaceType} ( "&" {@linkplain ASTAnnotation Annotation}* {@linkplain ASTClassOrInterfaceType ClassOrInterfaceType} )*
+ *
+ * </pre>
+ */
 public class ASTTypeBound extends AbstractJavaTypeNode {
     public ASTTypeBound(int id) {
         super(id);
     }
 
+
     public ASTTypeBound(JavaParser p, int id) {
         super(p, id);
     }
 
+
     /**
-     * Accept the visitor. *
+     * Returns a list with the type bounds of this node.
+     * The returned list has at least one element.
      */
+    public List<ASTClassOrInterfaceType> getBoundTypeNodes() {
+        return findChildrenOfType(ASTClassOrInterfaceType.class);
+    }
+
+
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeParameter.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeParameter.java
@@ -5,18 +5,57 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+
+/**
+ * Represents a type parameter declaration of a method, constructor, class or interface declaration.
+ *
+ * <pre>
+ *
+ * TypeParameter ::= {@linkplain ASTAnnotation Annotation}* &lt;IDENTIFIER&gt; {@linkplain ASTTypeBound TypeBound}?
+ *
+ * </pre>
+ *
+ *  @see <a href="https://docs.oracle.com/javase/specs/jls/se9/html/jls-4.html#jls-4.4">JLS</a>
+ */
+// TODO should implement Annotatable when we use can use Java 8 mixins instead of an abstract class
 public class ASTTypeParameter extends AbstractJavaTypeNode {
     public ASTTypeParameter(int id) {
         super(id);
     }
 
+
     public ASTTypeParameter(JavaParser p, int id) {
         super(p, id);
     }
 
+
     /**
-     * Accept the visitor. *
+     * Returns the name of the type variable introduced by this declaration.
      */
+    public String getParameterName() {
+        return getImage();
+    }
+
+
+    /**
+     * Returns true if this type parameter is bounded,
+     * in which case {@link #getTypeBoundNode()} doesn't
+     * return {@code null}.
+     */
+    public final boolean hasTypeBound() {
+        return getTypeBoundNode() != null;
+    }
+
+
+    /**
+     * Returns the type bound node of this parameter,
+     * or null if it is not bounded.
+     */
+    public final ASTTypeBound getTypeBoundNode() {
+        return getFirstChildOfType(ASTTypeBound.class);
+    }
+
+
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeParameters.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeParameters.java
@@ -5,7 +5,22 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
-public class ASTTypeParameters extends AbstractJavaNode {
+
+import java.util.Iterator;
+
+
+/**
+ * Represents a list of type parameters.
+ *
+ * <pre>
+ *
+ * TypeParameters ::= "<" {@linkplain ASTTypeParameter TypeParameter} ( "," {@linkplain ASTTypeParameter TypeParameter} )* ">"
+ *
+ * </pre>
+ *
+ *
+ */
+public class ASTTypeParameters extends AbstractJavaNode implements Iterable<ASTTypeParameter> {
     public ASTTypeParameters(int id) {
         super(id);
     }
@@ -14,11 +29,14 @@ public class ASTTypeParameters extends AbstractJavaNode {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
+    }
+
+
+    @Override
+    public Iterator<ASTTypeParameter> iterator() {
+        return new NodeChildrenIterator<>(this, ASTTypeParameter.class);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTUnaryExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTUnaryExpression.java
@@ -5,6 +5,26 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+
+/**
+ * Represents a unary prefix operation on a value.
+ * This has a precedence greater than {@link ASTMultiplicativeExpression}.
+ *
+ * <p>UnaryExpression has the same precedence as {@linkplain ASTPreIncrementExpression PreIncrementExpression},
+ * {@linkplain ASTPreDecrementExpression PreDecrementExpression} and
+ * {@linkplain ASTUnaryExpressionNotPlusMinus UnaryExpressionNotPlusMinus}.
+ *
+ * <p>Note that the child of this node is not necessarily a UnaryExpression,
+ * rather, it can be an expression with an operator precedence greater or equal
+ * to a UnaryExpression.
+ *
+ *
+ * <pre>
+ *
+ * UnaryExpression ::= ( "+" | "-" ) UnaryExpression
+ *
+ * </pre>
+ */
 public class ASTUnaryExpression extends AbstractJavaTypeNode {
     public ASTUnaryExpression(int id) {
         super(id);
@@ -14,12 +34,17 @@ public class ASTUnaryExpression extends AbstractJavaTypeNode {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
+    }
+
+
+    /**
+     * Returns the image of this unary operator, i.e. "+" or "-".
+     */
+    public String getOperator() {
+        return getImage();
     }
 
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTUnaryExpressionNotPlusMinus.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTUnaryExpressionNotPlusMinus.java
@@ -5,6 +5,20 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents a boolean negation or bitwise inverse operation.
+ * This has the same precedence as {@linkplain ASTUnaryExpression UnaryExpression}
+ * and the like.
+ *
+ * <p>Note that the child of this node is not necessarily an {@link ASTUnaryExpression},
+ * rather, it can be an expression with an operator precedence greater or equal to a UnaryExpression.
+ *
+ * <pre>
+ *
+ * UnaryExpressionNotPlusMinus ::=  ( "~" | "!" ) {@linkplain ASTUnaryExpression UnaryExpression}
+ *
+ * </pre>
+ */
 public class ASTUnaryExpressionNotPlusMinus extends AbstractJavaTypeNode {
     public ASTUnaryExpressionNotPlusMinus(int id) {
         super(id);
@@ -14,12 +28,18 @@ public class ASTUnaryExpressionNotPlusMinus extends AbstractJavaTypeNode {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
     }
+
+
+    /**
+     * Returns the image of this unary operator, i.e. "~" or "!".
+     */
+    public String getOperator() {
+        return getImage();
+    }
+
 
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTWildcardBounds.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTWildcardBounds.java
@@ -5,18 +5,53 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents a type bound on a wildcard {@linkplain ASTTypeArgument type argument}.
+ *
+ * <pre>
+ *
+ * WildcardBounds ::=  ( "extends" | "super" ) ( {@linkplain ASTAnnotation Annotation} )* {@linkplain ASTReferenceType ReferenceType}
+ *
+ * </pre>
+ */
 public class ASTWildcardBounds extends AbstractJavaTypeNode {
     public ASTWildcardBounds(int id) {
         super(id);
     }
 
+
     public ASTWildcardBounds(JavaParser p, int id) {
         super(p, id);
     }
 
+
     /**
-     * Accept the visitor. *
+     * Returns true if this is an upper type bound, e.g.
+     * in {@code <? extends Integer>}.
      */
+    public boolean isUpperBound() {
+        return jjtGetFirstToken().toString().equals("extends");
+    }
+
+
+    /**
+     * Returns true if this is a lower type bound, e.g.
+     * in {@code <? super Node>}.
+     */
+    public boolean isLowerBound() {
+        return !isUpperBound();
+    }
+
+
+    /**
+     * Returns the type node representing the bound, e.g.
+     * the {@code Node} in {@code <? super Node>}.
+     */
+    public ASTReferenceType getTypeBoundNode() {
+        return getFirstChildOfType(ASTReferenceType.class);
+    }
+
+
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/package-info.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+/**
+ * Contains the classes and interfaces modelling the Java AST.
+ */
+package net.sourceforge.pmd.lang.java.ast;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/package-info.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+/**
+ * Contains the built-in rules bundled with the Java distribution.
+ */
+package net.sourceforge.pmd.lang.java.rule;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -1054,11 +1054,11 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
     public Object visit(ASTWildcardBounds node, Object data) {
         super.visit(node, data);
 
-        JavaTypeDefinition childType = ((TypeNode) node.jjtGetChild(0)).getTypeDefinition();
+        JavaTypeDefinition childType = node.getTypeBoundNode().getTypeDefinition();
 
-        if (node.jjtGetFirstToken().toString().equals("super")) {
+        if (node.isLowerBound()) {
             node.setTypeDefinition(JavaTypeDefinition.forClass(LOWER_WILDCARD, childType));
-        } else { // equals "extends"
+        } else { // upper bound
             node.setTypeDefinition(JavaTypeDefinition.forClass(UPPER_WILDCARD, childType));
         }
 
@@ -1073,8 +1073,9 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
             TypeNode parent = (TypeNode) node.jjtGetParent();
 
             final JavaTypeDefinition[] boundGenerics = new JavaTypeDefinition[node.jjtGetNumChildren()];
-            for (int i = 0; i < node.jjtGetNumChildren(); ++i) {
-                boundGenerics[i] = ((TypeNode) node.jjtGetChild(i)).getTypeDefinition();
+            int i = 0;
+            for (ASTTypeParameter arg : node) {
+                boundGenerics[i++] = arg.getTypeDefinition();
             }
 
             parent.setTypeDefinition(JavaTypeDefinition.forClass(parent.getType(), boundGenerics));
@@ -1085,7 +1086,7 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
 
     @Override
     public Object visit(ASTTypeParameter node, Object data) {
-        if (node.jjtGetNumChildren() == 0) { // type parameter doesn't have declared upper bounds
+        if (node.hasTypeBound()) { // type parameter doesn't have declared upper bounds
             node.setTypeDefinition(JavaTypeDefinition.forClass(UPPER_BOUND, Object.class));
         } else {
             super.visit(node, data);
@@ -1099,13 +1100,13 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
     public Object visit(ASTTypeBound node, Object data) {
         super.visit(node, data);
 
-        // selecting only the type nodes, since the types can be preceded by annotations
-        List<TypeNode> typeNodes = node.findChildrenOfType(TypeNode.class);
+        List<ASTClassOrInterfaceType> typeNodes = node.getBoundTypeNodes();
 
         // TypeBound will have at least one child, but maybe more
         JavaTypeDefinition[] bounds = new JavaTypeDefinition[typeNodes.size()];
-        for (int index = 0; index < typeNodes.size(); index++) {
-            bounds[index] = typeNodes.get(index).getTypeDefinition();
+        int i = 0;
+        for (ASTClassOrInterfaceType bound : typeNodes) {
+            bounds[i++] = bound.getTypeDefinition();
         }
 
         node.setTypeDefinition(JavaTypeDefinition.forClass(UPPER_BOUND, bounds));

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -1086,7 +1086,7 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
 
     @Override
     public Object visit(ASTTypeParameter node, Object data) {
-        if (node.hasTypeBound()) { // type parameter doesn't have declared upper bounds
+        if (!node.hasTypeBound()) { // type parameter doesn't have declared upper bounds
             node.setTypeDefinition(JavaTypeDefinition.forClass(UPPER_BOUND, Object.class));
         } else {
             super.visit(node, data);


### PR DESCRIPTION
Some nodes also have new methods when they make sense, or implement `Iterable<SomeChildNode>`

The grammar excerpts don't necessarily correspond to the actual JJTree grammar. Instead, they match only the alternatives that the node can represent at runtime, after parsing. E.g. UnaryExpression has a complicated production:

https://github.com/pmd/pmd/blob/7a6bc498264ad87f3783e6dfde0b7e4bc9d4bcbf/pmd-java/etc/grammar/Java.jjt#L2107-L2114

But since the node is only pushed on the stack if its image is not null, ie only in the first alternative, the javadoc grammar hint is
```
UnaryExpression ::= ( "+" | "-" ) UnaryExpression
``` 

### TODO

I found some things that could get a cleanup in the grammar (API breaking):

* isTernary in ConditionalExpression is unnecessary, the grammar doesn't allow
  any case in which a ConditionalExpression is not a ternary when it's pushed on the stack, because it has a guard on the number of children:

https://github.com/pmd/pmd/blob/7a6bc498264ad87f3783e6dfde0b7e4bc9d4bcbf/pmd-java/etc/grammar/Java.jjt#L2024-L2028

* For ShiftExpression, it makes no sense to have these extra
  RUNSIGNEDSHIFT and RSIGNEDSHIFT, which only match the token anyway. They could
  set the image on their parent, but shouldn't be pushed on the stack... we can
  use a #void production for that, like in oowekyala/pmd@87f05fcb7ff94deae007463dd
* We could technically merge UnaryExpression and UnaryExpressionNotPlusMinus
  to reduce the complexity of the AST. The productions need to stay, but need 
  not necessarily push a new node on the stack. Same as for above, we could set
  the image of the parent. That's not necessary at all though


