### PR TITLE
[java] Add FormalParameterNamingConventions and LocalVariableNamingConventions

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLocalVariableDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLocalVariableDeclaration.java
@@ -5,9 +5,26 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import java.util.Iterator;
+
 import net.sourceforge.pmd.Rule;
 
-public class ASTLocalVariableDeclaration extends AbstractJavaAccessNode implements Dimensionable, CanSuppressWarnings {
+
+/**
+ * Represents a local variable declaration. This is a {@linkplain ASTBlockStatement block statement},
+ * but the node is also used in {@linkplain ASTForInit for-loop initialisers} and
+ * {@linkplain ASTForStatement foreach statements}.
+ *
+ * <p>This statement may define several variables, possibly of different types (see {@link ASTVariableDeclaratorId#getType()}).
+ * The nodes corresponding to the declared variables are accessible through {@link #iterator()}.
+ *
+ * <p>
+ *
+ * LocalVariableDeclaration ::=  ( "final" | {@linkplain ASTAnnotation Annotation} )* {@linkplain ASTType Type} {@linkplain ASTVariableDeclarator VariableDeclarator} ( "," {@linkplain ASTVariableDeclarator VariableDeclarator} )*
+ *
+ * </p>
+ */
+public class ASTLocalVariableDeclaration extends AbstractJavaAccessNode implements Dimensionable, CanSuppressWarnings, Iterable<ASTVariableDeclaratorId> {
 
     public ASTLocalVariableDeclaration(int id) {
         super(id);
@@ -17,9 +34,6 @@ public class ASTLocalVariableDeclaration extends AbstractJavaAccessNode implemen
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
@@ -50,11 +64,13 @@ public class ASTLocalVariableDeclaration extends AbstractJavaAccessNode implemen
     }
 
     @Override
+    // TODO deprecate
     public boolean isArray() {
         return getArrayDepth() > 0;
     }
 
     @Override
+    // TODO deprecate
     public int getArrayDepth() {
         return getArrayDimensionOnType() + getArrayDimensionOnDeclaratorId();
     }
@@ -87,17 +103,30 @@ public class ASTLocalVariableDeclaration extends AbstractJavaAccessNode implemen
     }
 
     /**
-     * Gets the variable name of this field. This method searches the first
+     * Gets the variable name of this declaration. This method searches the first
      * VariableDeclartorId node and returns it's image or <code>null</code> if
      * the child node is not found.
      *
      * @return a String representing the name of the variable
      */
+    // TODO deprecate.
+    // It would be nice to have a way to inform XPath users of the intended replacement
+    // for a deprecated attribute. We may use another annotation for that.
     public String getVariableName() {
         ASTVariableDeclaratorId decl = getFirstDescendantOfType(ASTVariableDeclaratorId.class);
         if (decl != null) {
             return decl.getImage();
         }
         return null;
+    }
+
+
+    /**
+     * Returns an iterator over the ids of the variables
+     * declared in this statement.
+     */
+    @Override
+    public Iterator<ASTVariableDeclaratorId> iterator() {
+        return new NodeChildrenIterator<>(this, ASTVariableDeclaratorId.class);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclaratorId.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclaratorId.java
@@ -48,9 +48,6 @@ public class ASTVariableDeclaratorId extends AbstractJavaTypeNode implements Dim
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
@@ -101,9 +98,75 @@ public class ASTVariableDeclaratorId extends AbstractJavaTypeNode implements Dim
      */
     public boolean isFormalParameter() {
         return jjtGetParent() instanceof ASTFormalParameter && !isExceptionBlockParameter() && !isResourceDeclaration()
-                || jjtGetParent() instanceof ASTLambdaExpression;
+                || isLambdaParamWithNoType();
     }
 
+
+    /**
+     * Returns true if this node declares a local variable.
+     */
+    public boolean isLocalVariable() {
+        return getNthParent(2) instanceof ASTLocalVariableDeclaration;
+    }
+
+
+    /**
+     * Returns true if this node declares a formal parameter for
+     * a lambda expression. In that case, the type of this parameter
+     * is not necessarily inferred, see {@link #isTypeInferred()}.
+     */
+    public boolean isLambdaParameter() {
+        return isLambdaParamWithNoType() || jjtGetParent() instanceof ASTFormalParameter && getNthParent(3) instanceof ASTLambdaExpression;
+    }
+
+
+    private boolean isLambdaParamWithNoType() {
+        return jjtGetParent() instanceof ASTLambdaExpression;
+    }
+
+
+    /**
+     * Returns true if this node declares a field.
+     */
+    public boolean isField() {
+        return getNthParent(2) instanceof ASTFieldDeclaration;
+    }
+
+
+    /**
+     * Returns true if the variable declared by this node is declared final.
+     * Doesn't account for the "effectively-final" nuance. Resource
+     * declarations are implicitly final.
+     */
+    public boolean isFinal() {
+        if (isResourceDeclaration()) {
+            // this is implicit even if "final" is not explicitly declared.
+            return true;
+        } else if (isLambdaParamWithNoType()) {
+            return false;
+        }
+
+        if (jjtGetParent() instanceof ASTFormalParameter) {
+            // This accounts for exception parameters too for now
+            return ((ASTFormalParameter) jjtGetParent()).isFinal();
+        }
+
+        Node grandpa = getNthParent(2);
+
+        if (grandpa instanceof ASTLocalVariableDeclaration) {
+            return ((ASTLocalVariableDeclaration) grandpa).isFinal();
+        } else if (grandpa instanceof ASTFieldDeclaration) {
+            return ((ASTFieldDeclaration) grandpa).isFinal();
+        }
+
+        throw new IllegalStateException("All cases should be handled");
+    }
+
+
+    /**
+     * @deprecated Will be made private with 7.0.0
+     */
+    @Deprecated
     public void setExplicitReceiverParameter() {
         explicitReceiverParameter = true;
     }
@@ -142,15 +205,13 @@ public class ASTVariableDeclaratorId extends AbstractJavaTypeNode implements Dim
      * since the type node is absent.
      */
     public boolean isTypeInferred() {
-        return isLambdaExpression() || isLocalVariableTypeInferred();
+        // TODO think about supporting var for lambda parameters
+        return isLambdaParamWithNoType() || isLocalVariableTypeInferred();
     }
 
-    private boolean isLambdaExpression() {
-        return jjtGetParent() instanceof ASTLambdaExpression;
-    }
 
     private boolean isLocalVariableTypeInferred() {
-        if (jjtGetParent() instanceof ASTResource) {
+        if (isResourceDeclaration()) {
             // covers "var" in try-with-resources
             return jjtGetParent().getFirstChildOfType(ASTType.class) == null;
         } else if (getNthParent(2) instanceof ASTLocalVariableDeclaration) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/AbstractNamingConventionRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/AbstractNamingConventionRule.java
@@ -26,6 +26,8 @@ import net.sourceforge.pmd.util.StringUtil;
  */
 abstract class AbstractNamingConventionRule<T extends JavaNode> extends AbstractJavaRule {
 
+    static final String CAMEL_CASE = "[a-z][a-zA-Z0-9]+";
+    static final String PASCAL_CASE = "[A-Z][a-zA-Z0-9]+";
 
     /** The argument is interpreted as the display name, and is converted to camel case to get the property name. */
     RegexPBuilder defaultProp(String name) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ClassNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ClassNamingConventionsRule.java
@@ -142,7 +142,7 @@ public class ClassNamingConventionsRule extends AbstractNamingConventionRule<AST
 
     @Override
     String defaultConvention() {
-        return "[A-Z][a-zA-Z0-9]+";
+        return PASCAL_CASE;
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FormalParameterNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FormalParameterNamingConventionsRule.java
@@ -1,0 +1,72 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.codestyle;
+
+
+import java.util.regex.Pattern;
+
+import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.RegexProperty;
+
+
+/**
+ * Enforces a naming convention for lambda and method parameters.
+ *
+ * @author Clément Fournier
+ * @since 6.6.0
+ */
+public final class FormalParameterNamingConventionsRule extends AbstractNamingConventionRule<ASTVariableDeclaratorId> {
+
+    // These are not exhaustive, but are chosen to be the most useful, for a start
+
+
+    private final RegexProperty formalParamRegex = defaultProp("methodParameter", "formal parameter").build();
+    private final RegexProperty finalFormalParamRegex = defaultProp("finalMethodParameter", "final formal parameter").build();
+
+    private final RegexProperty lambdaParamRegex = defaultProp("lambdaParameter", "inferred-type lambda parameter").build();
+    private final RegexProperty explicitLambdaParamRegex = defaultProp("explicitLambdaParameter", "explicitly-typed lambda parameter").build();
+
+
+    public FormalParameterNamingConventionsRule() {
+        definePropertyDescriptor(formalParamRegex);
+        definePropertyDescriptor(finalFormalParamRegex);
+        definePropertyDescriptor(lambdaParamRegex);
+        definePropertyDescriptor(explicitLambdaParamRegex);
+
+        addRuleChainVisit(ASTVariableDeclaratorId.class);
+    }
+
+
+    @Override
+    public Object visit(ASTVariableDeclaratorId node, Object data) {
+
+        if (node.isLambdaParameter()) {
+            checkMatches(node, node.isTypeInferred() ? lambdaParamRegex : explicitLambdaParamRegex, data);
+        } else if (node.isFormalParameter()) {
+            checkMatches(node, node.isFinal() ? finalFormalParamRegex : formalParamRegex, data);
+        }
+
+        return data;
+    }
+
+
+    @Override
+    String defaultConvention() {
+        return CAMEL_CASE;
+    }
+
+
+    @Override
+    String kindDisplayName(ASTVariableDeclaratorId node, PropertyDescriptor<Pattern> descriptor) {
+        if (node.isLambdaParameter()) {
+            return node.isTypeInferred() ? "lambda parameter" : "explicitly-typed lambda parameter";
+        } else if (node.isFormalParameter()) { // necessarily a method parameter here
+            return node.isFinal() ? "final method parameter" : "method parameter";
+        }
+
+        throw new UnsupportedOperationException("This rule doesn't handle this case");
+    }
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableNamingConventionsRule.java
@@ -1,0 +1,69 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.codestyle;
+
+import java.util.regex.Pattern;
+
+import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.RegexProperty;
+
+
+/**
+ * Enforces a naming convention for local variables and other locally scoped variables.
+ *
+ * @author Clément Fournier
+ * @since 6.6.0
+ */
+public final class LocalVariableNamingConventionsRule extends AbstractNamingConventionRule<ASTVariableDeclaratorId> {
+
+    // These are not exhaustive, but are chosen to be the most useful, for a start
+
+    private final RegexProperty localVarRegex = defaultProp("localVar", "non-final local variable").build();
+    private final RegexProperty finalVarRegex = defaultProp("finalVar", "final local variable").build();
+
+    private final RegexProperty exceptionBlockParameterRegex = defaultProp("catchParameter", "exception block parameter").build();
+
+
+    public LocalVariableNamingConventionsRule() {
+        definePropertyDescriptor(localVarRegex);
+        definePropertyDescriptor(finalVarRegex);
+        definePropertyDescriptor(exceptionBlockParameterRegex);
+
+        addRuleChainVisit(ASTVariableDeclaratorId.class);
+    }
+
+
+
+    @Override
+    public Object visit(ASTVariableDeclaratorId node, Object data) {
+
+        if (node.isExceptionBlockParameter()) {
+            checkMatches(node, exceptionBlockParameterRegex, data);
+        } else if (node.isLocalVariable()) {
+            checkMatches(node, node.isFinal() ? finalVarRegex : localVarRegex, data);
+        }
+
+        return data;
+    }
+
+
+    @Override
+    String defaultConvention() {
+        return CAMEL_CASE;
+    }
+
+
+    @Override
+    String kindDisplayName(ASTVariableDeclaratorId node, PropertyDescriptor<Pattern> descriptor) {
+        if (node.isExceptionBlockParameter()) {
+            return "exception block parameter";
+        } else if (node.isLocalVariable()) {
+            return node.isFinal() ? "final local variable" : "local variable";
+        }
+
+        throw new UnsupportedOperationException("This rule doesn't handle this case");
+    }
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/MethodNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/MethodNamingConventionsRule.java
@@ -100,7 +100,7 @@ public class MethodNamingConventionsRule extends AbstractNamingConventionRule<AS
 
     @Override
     String defaultConvention() {
-        return "[a-z][a-zA-Z0-9]+";
+        return CAMEL_CASE;
     }
 
 

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -764,7 +764,25 @@ for (int i = 0; i < 42; i++)
         <priority>1</priority>
         <example>
             <![CDATA[
-            // TODO
+            class Foo {
+
+                abstract void bar(int myInt); // This is Camel case, so it's ok
+
+                void bar(int my_i) { // this will be reported
+
+                }
+
+                void lambdas() {
+
+                    // lambdas parameters can be configured separately
+                    Consumer<String> lambda1 = s_str -> { };
+
+                    // lambda parameters with an explicit type can be configured separately
+                    Consumer<String> lambda1 = (String str) -> { };
+
+                }
+
+            }
             ]]>
         </example>
     </rule>
@@ -1023,8 +1041,8 @@ public class Bar {
           class="net.sourceforge.pmd.lang.java.rule.codestyle.LocalVariableNamingConventionsRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#localvariablenamingconventions">
         <description>
-            Configurable naming conventions for local variable declarations. This rule reports
-            variable declarations which do not match the regex that applies to their
+            Configurable naming conventions for local variable declarations and other locally-scoped
+            variables. This rule reports variable declarations which do not match the regex that applies to their
             specific kind (e.g. final variable, or catch-clause parameter). Each regex can be configured through
             properties.
 
@@ -1033,7 +1051,21 @@ public class Bar {
         <priority>1</priority>
         <example>
             <![CDATA[
-            // TODO
+            class Foo {
+                void bar() {
+                    int localVariable = 1; // This is in camel case, so it's ok
+                    int local_variable = 1; // This will be reported unless you change the regex
+
+                    final int i_var = 1; // final local variables can be configured separately
+
+                    try {
+                        foo();
+                    } catch (IllegalArgumentException e_illegal) {
+                        // exception block parameters can be configured separately
+                    }
+
+                }
+            }
             ]]>
         </example>
     </rule>

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -747,6 +747,28 @@ for (int i = 0; i < 42; i++)
         </example>
     </rule>
 
+
+    <rule name="FormalParameterNamingConventions"
+          since="6.6.0"
+          message="The {0} name ''{1}'' doesn''t match ''{2}''"
+          class="net.sourceforge.pmd.lang.java.rule.codestyle.FormalParameterNamingConventionsRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#formalparameternamingconventions">
+        <description>
+            Configurable naming conventions for formal parameters of methods and lambdas.
+            This rule reports formal parameters which do not match the regex that applies to their
+            specific kind (e.g. lambda parameter, or final formal parameter). Each regex can be
+            configured through properties.
+
+            By default this rule uses the standard Java naming convention (Camel case).
+        </description>
+        <priority>1</priority>
+        <example>
+            <![CDATA[
+            // TODO
+            ]]>
+        </example>
+    </rule>
+
     <rule name="GenericsNaming"
           language="java"
           since="4.2.6"
@@ -992,6 +1014,27 @@ public class Bar {
     }
 }
 ]]>
+        </example>
+    </rule>
+
+    <rule name="LocalVariableNamingConventions"
+          since="6.6.0"
+          message="The {0} name ''{1}'' doesn''t match ''{2}''"
+          class="net.sourceforge.pmd.lang.java.rule.codestyle.LocalVariableNamingConventionsRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#localvariablenamingconventions">
+        <description>
+            Configurable naming conventions for local variable declarations. This rule reports
+            variable declarations which do not match the regex that applies to their
+            specific kind (e.g. final variable, or catch-clause parameter). Each regex can be configured through
+            properties.
+
+            By default this rule uses the standard Java naming convention (Camel case).
+        </description>
+        <priority>1</priority>
+        <example>
+            <![CDATA[
+            // TODO
+            ]]>
         </example>
     </rule>
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/CodeStyleRulesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/CodeStyleRulesTest.java
@@ -45,6 +45,7 @@ public class CodeStyleRulesTest extends SimpleAggregatorTst {
         addRule(RULESET, "LocalHomeNamingConvention");
         addRule(RULESET, "LocalInterfaceSessionNamingConvention");
         addRule(RULESET, "LocalVariableCouldBeFinal");
+        addRule(RULESET, "LongVariable");
         addRule(RULESET, "LocalVariableNamingConventions");
         addRule(RULESET, "MDBAndSessionBeanNamingConvention");
         addRule(RULESET, "MethodArgumentCouldBeFinal");

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/CodeStyleRulesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/CodeStyleRulesTest.java
@@ -37,6 +37,7 @@ public class CodeStyleRulesTest extends SimpleAggregatorTst {
         addRule(RULESET, "FieldDeclarationsShouldBeAtStartOfClass");
         addRule(RULESET, "ForLoopsMustUseBraces");
         addRule(RULESET, "ForLoopShouldBeWhileLoop");
+        addRule(RULESET, "FormalParameterNamingConventions");
         addRule(RULESET, "GenericsNaming");
         addRule(RULESET, "IdenticalCatchBranches");
         addRule(RULESET, "IfElseStmtsMustUseBraces");
@@ -44,7 +45,7 @@ public class CodeStyleRulesTest extends SimpleAggregatorTst {
         addRule(RULESET, "LocalHomeNamingConvention");
         addRule(RULESET, "LocalInterfaceSessionNamingConvention");
         addRule(RULESET, "LocalVariableCouldBeFinal");
-        addRule(RULESET, "LongVariable");
+        addRule(RULESET, "LocalVariableNamingConventions");
         addRule(RULESET, "MDBAndSessionBeanNamingConvention");
         addRule(RULESET, "MethodArgumentCouldBeFinal");
         addRule(RULESET, "MethodNamingConventions");

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/FormalParameterNamingConventions.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/FormalParameterNamingConventions.xml
@@ -1,0 +1,251 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+    <test-code>
+        <description>Default is camel case</description>
+        <expected-problems>5</expected-problems>
+        <expected-messages>
+            <message>The method parameter name 'Foo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The final method parameter name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The lambda parameter name 'Koo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The explicitly-typed lambda parameter name 'Voo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The explicitly-typed lambda parameter name 'Ooo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+        </expected-messages>
+        <code><![CDATA[
+            import java.util.function.Consumer;
+
+
+            public class Bar {
+
+                void foo(int Foo) {
+
+                }
+
+
+                void bar(final int Hoo) {
+
+                }
+
+
+                {
+                    Consumer<String> i = (Koo) -> {
+
+                    };
+
+                    Consumer<String> k = (String Voo) -> {
+
+                    };
+
+                    Consumer<String> l = (final String Ooo) -> {
+
+                    };
+                }
+
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Test method param pattern</description>
+        <rule-property name="methodParameterPattern">[A-Z]+</rule-property>
+        <expected-problems>5</expected-problems>
+        <expected-messages>
+            <message>The method parameter name 'Foo' doesn't match '[A-Z]+'</message>
+            <message>The final method parameter name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The lambda parameter name 'Koo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The explicitly-typed lambda parameter name 'Voo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The explicitly-typed lambda parameter name 'Ooo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+        </expected-messages>
+        <code><![CDATA[
+            import java.util.function.Consumer;
+
+
+            public class Bar {
+
+                void foo(int Foo) {
+
+                }
+
+                void fooBar(int FOO) { // that's ok
+
+                }
+
+
+                void bar(final int Hoo) {
+
+                }
+
+
+                {
+                    Consumer<String> i = (Koo) -> {
+
+                    };
+
+                    Consumer<String> k = (String Voo) -> {
+
+                    };
+
+                    Consumer<String> l = (final String Ooo) -> {
+
+                    };
+                }
+
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Test final method param pattern</description>
+        <rule-property name="finalMethodParameterPattern">[A-Z]+</rule-property>
+        <expected-problems>5</expected-problems>
+        <expected-messages>
+            <message>The method parameter name 'Foo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The final method parameter name 'Hoo' doesn't match '[A-Z]+'</message>
+            <message>The lambda parameter name 'Koo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The explicitly-typed lambda parameter name 'Voo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The explicitly-typed lambda parameter name 'Ooo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+        </expected-messages>
+        <code><![CDATA[
+            import java.util.function.Consumer;
+
+
+            public class Bar {
+
+                void foo(int Foo) {
+
+                }
+
+                void fooBar(final int FOO) { // that's ok
+
+                }
+
+
+                void bar(final int Hoo) {
+
+                }
+
+
+                {
+                    Consumer<String> i = (Koo) -> {
+
+                    };
+
+                    Consumer<String> k = (String Voo) -> {
+
+                    };
+
+                    Consumer<String> l = (final String Ooo) -> {
+
+                    };
+                }
+
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Test inferred lambda parameter pattern</description>
+        <rule-property name="lambdaParameterPattern">[A-Z]+</rule-property>
+        <expected-problems>5</expected-problems>
+        <expected-messages>
+            <message>The method parameter name 'Foo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The final method parameter name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The lambda parameter name 'Koo' doesn't match '[A-Z]+'</message>
+            <message>The explicitly-typed lambda parameter name 'Voo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The explicitly-typed lambda parameter name 'Ooo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+        </expected-messages>
+        <code><![CDATA[
+            import java.util.function.Consumer;
+
+
+            public class Bar {
+
+                void foo(int Foo) {
+
+                }
+
+
+                void bar(final int Hoo) {
+
+                }
+
+
+                {
+                    Consumer<String> i = (Koo) -> {
+
+                    };
+
+                    Consumer<String> q = (KOO) -> { // that's ok
+
+                    };
+
+                    Consumer<String> k = (String Voo) -> {
+
+                    };
+
+                    Consumer<String> l = (final String Ooo) -> {
+
+                    };
+                }
+
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Test explicitly-typed lambda parameter pattern</description>
+        <rule-property name="explicitLambdaParameterPattern">[A-Z]+</rule-property>
+        <expected-problems>5</expected-problems>
+        <expected-messages>
+            <message>The method parameter name 'Foo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The final method parameter name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The lambda parameter name 'Koo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The explicitly-typed lambda parameter name 'Voo' doesn't match '[A-Z]+'</message>
+            <message>The explicitly-typed lambda parameter name 'Ooo' doesn't match '[A-Z]+'</message>
+        </expected-messages>
+        <code><![CDATA[
+            import java.util.function.Consumer;
+
+
+            public class Bar {
+
+                void foo(int Foo) {
+
+                }
+
+
+                void bar(final int Hoo) {
+
+                }
+
+
+                {
+                    Consumer<String> i = (Koo) -> {
+
+                    };
+
+                    Consumer<String> q = (String KOO) -> { // that's ok
+
+                    };
+
+                    Consumer<String> qq = (final String MOO) -> { // that's ok
+
+                    };
+
+                    Consumer<String> k = (String Voo) -> {
+
+                    };
+
+                    Consumer<String> l = (final String Ooo) -> {
+
+                    };
+                }
+
+            }
+            ]]></code>
+    </test-code>
+
+
+</test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableNamingConventions.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableNamingConventions.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+    <test-code>
+        <description>Default is camel case</description>
+        <expected-problems>3</expected-problems>
+        <expected-messages>
+            <message>The local variable name 'Foo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The final local variable name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The exception block parameter name 'E' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+        </expected-messages>
+        <code><![CDATA[
+            public class Bar {
+
+                {
+                    int Foo;
+                    final int Hoo;
+
+                    try {
+
+                    } catch (Exception E) {
+
+                    }
+                }
+
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Test local variable property</description>
+        <rule-property name="localVarPattern">[A-Z][A-Z0-9]+</rule-property>
+        <expected-problems>3</expected-problems>
+        <expected-messages>
+            <message>The local variable name 'Foo' doesn't match '[A-Z][A-Z0-9]+'</message>
+            <message>The final local variable name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The exception block parameter name 'E' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+        </expected-messages>
+        <code><![CDATA[
+            public class Bar {
+
+                {
+                    int Foo;
+                    int FOO; // that's ok
+                    final int Hoo;
+
+                    try {
+
+                    } catch (Exception E) {
+
+                    }
+                }
+
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Test final local variable property</description>
+        <rule-property name="finalVarPattern">[A-Z][A-Z0-9]+</rule-property>
+        <expected-problems>3</expected-problems>
+        <expected-messages>
+            <message>The local variable name 'Foo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The final local variable name 'Hoo' doesn't match '[A-Z][A-Z0-9]+'</message>
+            <message>The exception block parameter name 'E' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+        </expected-messages>
+        <code><![CDATA[
+            public class Bar {
+
+                {
+                    int Foo;
+                    final int FOO; // that's ok
+                    final int Hoo;
+
+                    try {
+
+                    } catch (Exception E) {
+
+                    }
+                }
+
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Test exception parameter property</description>
+        <rule-property name="catchParameterPattern">[A-Z][A-Z0-9]+</rule-property>
+        <expected-problems>3</expected-problems>
+        <expected-messages>
+            <message>The local variable name 'Foo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The final local variable name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The exception block parameter name 'Eff' doesn't match '[A-Z][A-Z0-9]+'</message>
+        </expected-messages>
+        <code><![CDATA[
+            public class Bar {
+
+                {
+                    int Foo;
+                    final int Hoo;
+
+                    try {
+
+                    } catch (Exception Eff) {
+
+                    }
+
+                    try {
+
+                    } catch (Exception EFF) { // that's ok
+
+                    }
+                }
+
+            }
+            ]]></code>
+    </test-code>
+
+
+</test-data>


### PR DESCRIPTION
These replace VariableNamingConventions in part. Still FieldNamingConventions to go. I'll add the release note and deprecate old rules when that last rule is added.

Refs #972 