### PR TITLE
[java] Fix tests of ClassTypeResolver

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
@@ -278,7 +278,7 @@ public abstract class AbstractNode implements Node {
 
         for (int i = 0; i < node.jjtGetNumChildren(); i++) {
             Node child = node.jjtGetChild(i);
-            if (child.getClass() == targetType) {
+            if (targetType.isAssignableFrom(child.getClass())) {
                 results.add(targetType.cast(child));
             }
 


### PR DESCRIPTION
Some tests previously didn't test anything since `node.findDescendantsOfType(TypeNode.class)` returned an empty list. The correct way to resolve is to allow findDescendantsOfType to match subtypes.

The tests were still broken though, since the nodes had some subexpressions that were also tested (by mistake). E.g.

```java
int[][] a = new int[1][];
```

tested both the expressions `new int[1][]` and `1` for the type `int[][]`, and also the PrimitiveType node `int`. I thus replaced the whole subtree comparison by a simple assertEquals.

