### PR TITLE
[ui] Hide context menu arrows on XPath autocomplete popup

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -28,6 +28,8 @@ This is a minor release.
     *   [#1216](https://github.com/pmd/pmd/issues/1216): \[java] UnnecessaryFullyQualifiedName false positive for the same name method
 *   java-design
     *   [#1217](https://github.com/pmd/pmd/issues/1217): \[java] CyclomaticComplexityRule counts ?-operator twice
+*   ui
+    *   [#1233](https://github.com/pmd/pmd/issues/1233): \[ui] XPath autocomplete arrows on first and last items 
 
 ### API Changes
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -29,7 +29,7 @@ This is a minor release.
 *   java-design
     *   [#1217](https://github.com/pmd/pmd/issues/1217): \[java] CyclomaticComplexityRule counts ?-operator twice
 *   ui
-    *   [#1233](https://github.com/pmd/pmd/issues/1233): \[ui] XPath autocomplete arrows on first and last items 
+    *   [#1233](https://github.com/pmd/pmd/issues/1233): \[ui] XPath autocomplete arrows on first and last items
 
 ### API Changes
 

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/XPathPanelController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/XPathPanelController.java
@@ -43,6 +43,7 @@ import net.sourceforge.pmd.util.fxdesigner.util.beans.SettingsOwner;
 import net.sourceforge.pmd.util.fxdesigner.util.beans.SettingsPersistenceUtil.PersistentProperty;
 import net.sourceforge.pmd.util.fxdesigner.util.codearea.SyntaxHighlightingCodeArea;
 import net.sourceforge.pmd.util.fxdesigner.util.codearea.syntaxhighlighting.XPathSyntaxHighlighter;
+import net.sourceforge.pmd.util.fxdesigner.util.controls.ContextMenuWithNoArrows;
 import net.sourceforge.pmd.util.fxdesigner.util.controls.PropertyTableView;
 import net.sourceforge.pmd.util.fxdesigner.util.controls.XpathViolationListCell;
 
@@ -153,7 +154,7 @@ public class XPathPanelController implements Initializable, SettingsOwner {
                                                     .map(searchPoint -> xpathExpressionArea.getCaretPosition());
 
         // captured in the closure
-        final ContextMenu autoCompletePopup = new ContextMenu();
+        final ContextMenu autoCompletePopup = new ContextMenuWithNoArrows();
         autoCompletePopup.setId("xpathAutocomplete");
         autoCompletePopup.setHideOnEscape(true);
 

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/ContextMenuWithNoArrows.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/ContextMenuWithNoArrows.java
@@ -1,0 +1,22 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.fxdesigner.util.controls;
+
+import javafx.scene.control.ContextMenu;
+
+
+/**
+ * Context menu which has no scroll arrows (which by default appear on the top and bottom element).
+ * Implemented with simple CSS.
+ *
+ * @author Clément Fournier
+ * @since 6.6.0
+ */
+public class ContextMenuWithNoArrows extends ContextMenu {
+
+    public ContextMenuWithNoArrows() {
+        getStyleClass().add("no-scroll-arrows"); // sync with designer.less
+    }
+}

--- a/pmd-ui/src/main/resources/net/sourceforge/pmd/util/fxdesigner/less/designer.less
+++ b/pmd-ui/src/main/resources/net/sourceforge/pmd/util/fxdesigner/less/designer.less
@@ -60,7 +60,7 @@
         -fx-border-color: transparent;
     }
 
-    .menu-up-arrow, .menu-down-arrow, .scroll-arrow {
+    .scroll-arrow {
         -fx-padding: 0 0 0 0;
     }
 

--- a/pmd-ui/src/main/resources/net/sourceforge/pmd/util/fxdesigner/less/designer.less
+++ b/pmd-ui/src/main/resources/net/sourceforge/pmd/util/fxdesigner/less/designer.less
@@ -51,6 +51,20 @@
     -fx-background-color: transparent, white, transparent, white;
 }
 
+.context-menu.no-scroll-arrows {
+
+    .menu-item {
+        // OK this is weird but it does solve a padding bug on the context menu.
+        // Without it, items are offset to the bottom, and the last one is partially hidden
+        -fx-border-style: solid;
+        -fx-border-color: transparent;
+    }
+
+    .menu-up-arrow, .menu-down-arrow, .scroll-arrow {
+        -fx-padding: 0 0 0 0;
+    }
+
+}
 /**************/
 /* Split pane */
 /**************/


### PR DESCRIPTION
In the end I found a way to do that with css. Fix #1233 
