### PR TITLE
[java] Allow length 1 identifiers in naming convention rules

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/AbstractNamingConventionRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/AbstractNamingConventionRule.java
@@ -26,8 +26,8 @@ import net.sourceforge.pmd.util.StringUtil;
  */
 abstract class AbstractNamingConventionRule<T extends JavaNode> extends AbstractJavaRule {
 
-    static final String CAMEL_CASE = "[a-z][a-zA-Z0-9]+";
-    static final String PASCAL_CASE = "[A-Z][a-zA-Z0-9]+";
+    static final String CAMEL_CASE = "[a-z][a-zA-Z0-9]*";
+    static final String PASCAL_CASE = "[A-Z][a-zA-Z0-9]*";
 
     /** The argument is interpreted as the display name, and is converted to camel case to get the property name. */
     RegexPBuilder defaultProp(String name) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ClassNamingConventions.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ClassNamingConventions.xml
@@ -36,7 +36,7 @@
         <rule-property name="annotationPattern">[a-z][A-Za-z]*</rule-property>
         <expected-problems>1</expected-problems>
         <expected-messages>
-            <message>The class name 'foo' doesn't match '[A-Z][a-zA-Z0-9]+'</message>
+            <message>The class name 'foo' doesn't match '[A-Z][a-zA-Z0-9]*'</message>
         </expected-messages>
         <code><![CDATA[
             @covfefe

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/FormalParameterNamingConventions.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/FormalParameterNamingConventions.xml
@@ -7,11 +7,11 @@
         <description>Default is camel case</description>
         <expected-problems>5</expected-problems>
         <expected-messages>
-            <message>The method parameter name 'Foo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
-            <message>The final method parameter name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
-            <message>The lambda parameter name 'Koo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
-            <message>The explicitly-typed lambda parameter name 'Voo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
-            <message>The explicitly-typed lambda parameter name 'Ooo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The method parameter name 'Foo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The final method parameter name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The lambda parameter name 'Koo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The explicitly-typed lambda parameter name 'Voo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The explicitly-typed lambda parameter name 'Ooo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
         </expected-messages>
         <code><![CDATA[
             import java.util.function.Consumer;
@@ -53,10 +53,10 @@
         <expected-problems>5</expected-problems>
         <expected-messages>
             <message>The method parameter name 'Foo' doesn't match '[A-Z]+'</message>
-            <message>The final method parameter name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
-            <message>The lambda parameter name 'Koo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
-            <message>The explicitly-typed lambda parameter name 'Voo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
-            <message>The explicitly-typed lambda parameter name 'Ooo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The final method parameter name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The lambda parameter name 'Koo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The explicitly-typed lambda parameter name 'Voo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The explicitly-typed lambda parameter name 'Ooo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
         </expected-messages>
         <code><![CDATA[
             import java.util.function.Consumer;
@@ -101,11 +101,11 @@
         <rule-property name="finalMethodParameterPattern">[A-Z]+</rule-property>
         <expected-problems>5</expected-problems>
         <expected-messages>
-            <message>The method parameter name 'Foo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The method parameter name 'Foo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
             <message>The final method parameter name 'Hoo' doesn't match '[A-Z]+'</message>
-            <message>The lambda parameter name 'Koo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
-            <message>The explicitly-typed lambda parameter name 'Voo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
-            <message>The explicitly-typed lambda parameter name 'Ooo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The lambda parameter name 'Koo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The explicitly-typed lambda parameter name 'Voo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The explicitly-typed lambda parameter name 'Ooo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
         </expected-messages>
         <code><![CDATA[
             import java.util.function.Consumer;
@@ -150,11 +150,11 @@
         <rule-property name="lambdaParameterPattern">[A-Z]+</rule-property>
         <expected-problems>5</expected-problems>
         <expected-messages>
-            <message>The method parameter name 'Foo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
-            <message>The final method parameter name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The method parameter name 'Foo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The final method parameter name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
             <message>The lambda parameter name 'Koo' doesn't match '[A-Z]+'</message>
-            <message>The explicitly-typed lambda parameter name 'Voo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
-            <message>The explicitly-typed lambda parameter name 'Ooo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The explicitly-typed lambda parameter name 'Voo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The explicitly-typed lambda parameter name 'Ooo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
         </expected-messages>
         <code><![CDATA[
             import java.util.function.Consumer;
@@ -199,9 +199,9 @@
         <rule-property name="explicitLambdaParameterPattern">[A-Z]+</rule-property>
         <expected-problems>5</expected-problems>
         <expected-messages>
-            <message>The method parameter name 'Foo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
-            <message>The final method parameter name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
-            <message>The lambda parameter name 'Koo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The method parameter name 'Foo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The final method parameter name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The lambda parameter name 'Koo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
             <message>The explicitly-typed lambda parameter name 'Voo' doesn't match '[A-Z]+'</message>
             <message>The explicitly-typed lambda parameter name 'Ooo' doesn't match '[A-Z]+'</message>
         </expected-messages>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableNamingConventions.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableNamingConventions.xml
@@ -7,9 +7,9 @@
         <description>Default is camel case</description>
         <expected-problems>3</expected-problems>
         <expected-messages>
-            <message>The local variable name 'Foo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
-            <message>The final local variable name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
-            <message>The exception block parameter name 'E' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The local variable name 'Foo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The final local variable name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The exception block parameter name 'E' doesn't match '[a-z][a-zA-Z0-9]*'</message>
         </expected-messages>
         <code><![CDATA[
             public class Bar {
@@ -35,8 +35,8 @@
         <expected-problems>3</expected-problems>
         <expected-messages>
             <message>The local variable name 'Foo' doesn't match '[A-Z][A-Z0-9]+'</message>
-            <message>The final local variable name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
-            <message>The exception block parameter name 'E' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The final local variable name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The exception block parameter name 'E' doesn't match '[a-z][a-zA-Z0-9]*'</message>
         </expected-messages>
         <code><![CDATA[
             public class Bar {
@@ -62,9 +62,9 @@
         <rule-property name="finalVarPattern">[A-Z][A-Z0-9]+</rule-property>
         <expected-problems>3</expected-problems>
         <expected-messages>
-            <message>The local variable name 'Foo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The local variable name 'Foo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
             <message>The final local variable name 'Hoo' doesn't match '[A-Z][A-Z0-9]+'</message>
-            <message>The exception block parameter name 'E' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The exception block parameter name 'E' doesn't match '[a-z][a-zA-Z0-9]*'</message>
         </expected-messages>
         <code><![CDATA[
             public class Bar {
@@ -90,8 +90,8 @@
         <rule-property name="catchParameterPattern">[A-Z][A-Z0-9]+</rule-property>
         <expected-problems>3</expected-problems>
         <expected-messages>
-            <message>The local variable name 'Foo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
-            <message>The final local variable name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The local variable name 'Foo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The final local variable name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
             <message>The exception block parameter name 'Eff' doesn't match '[A-Z][A-Z0-9]+'</message>
         </expected-messages>
         <code><![CDATA[

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/MethodNamingConventions.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/MethodNamingConventions.xml
@@ -16,7 +16,7 @@ public class Foo {
         <description>method names should not contain underscores</description>
         <expected-problems>1</expected-problems>
         <expected-messages>
-            <message>The instance method name 'bar_foo' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The instance method name 'bar_foo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
         </expected-messages>
         <code><![CDATA[
 public class Foo {
@@ -49,7 +49,7 @@ public class Foo {
         <expected-problems>1</expected-problems>
         <expected-linenumbers>2</expected-linenumbers>
         <expected-messages>
-            <message>The native method name '__surfunc__' doesn't match '[a-z][a-zA-Z0-9]+'</message>
+            <message>The native method name '__surfunc__' doesn't match '[a-z][a-zA-Z0-9]*'</message>
         </expected-messages>
         <code><![CDATA[
 public class Foo {


### PR DESCRIPTION
Without them, the rules flag loop index variables and other stuff, eg short method parameters. This is not completely wrong, but I think makes the adoption cost greater by adding some noise to the initial report. Besides, for now, we have other rules about name length.