### PR TITLE
[ci] [GSoC] Integrating the danger and pmdtester to travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
 # Install OracleJDK 10 - see https://sormuras.github.io/blog/2018-03-20-jdk-matrix.html
 install:
   - . ./install-jdk.sh -F 10 -L BCL
-  - gem install pmdtester --pre
+  - bundle install
 before_script: true
 script: source .travis/build-$BUILD.sh
 after_success: true
@@ -82,7 +82,6 @@ cache:
 #
 # PMD_SF_USER - the sourceforge user, which is used to upload created binaries to sf files section. Note: an ssh key is
 #               required. See "before_install".
-#
 #
 # Secure Keys, that need to be set for releases:
 #

--- a/.travis/build-deploy.sh
+++ b/.travis/build-deploy.sh
@@ -50,6 +50,11 @@ if travis_isPullRequest; then
 
     log_info "This is a pull-request build"
     ./mvnw verify $MVN_BUILD_FLAGS
+	(
+	    set +e
+	    log_info "Running danger"
+	    bundle exec danger --verbose
+	)
 
 elif travis_isPush; then
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,57 @@
+require 'pmdtester/runner'
+require 'time'
+require 'logger'
+
+@logger = Logger.new(STDOUT)
+
+def run_pmdtester
+  Dir.chdir('..') do
+    argv = ['-r', './pmd', '-b', "#{ENV['TRAVIS_BRANCH']}", '-p', 'FETCH_HEAD', '-m', 'online']
+    Process.fork do
+	  begin
+        runner = PmdTester::Runner.new(argv)
+        runner.run # Optimize: get more information from runner, e.g. introduce new pmd errors?
+	  rescue StandardError => e
+	    @logger.error "Running pmdtester failed: #{e.msg}"
+	    warn("Running pmdtester failed, this message is mainly used to remind the maintainers of PMD.")
+	    exit 1
+	  end
+	end
+	Process.wait
+
+    upload_report if $?.success?
+  end
+end
+
+def upload_report
+  Dir.chdir('target/reports') do
+    tar_filename = "pr-#{ENV['TRAVIS_PULL_REQUEST']}-diff-report-#{Time.now.strftime("%Y-%m-%dT%H-%M-%SZ")}.tar"
+    unless Dir.exist?('diff/')
+      message("No java rules are changed!", sticky: true)
+      return
+    end
+
+    `tar -cf #{tar_filename} diff/`
+	report_url = `curl -u #{ENV['CHUNK_TOKEN']} -T #{tar_filename} chunk.io`
+	if $?.success?
+	  @logger.info "Successfully uploaded #{tar_filename} to chunk.io"
+
+      # set value of sticky to true and the message is kept after new commits are submited to the PR
+
+	  message("Please check the [regression diff report](#{report_url.chomp}/diff/index.html) to make sure that everything is expected", sticky: true)
+	else
+      @logger.error "Error while uploading #{tar_filename} to chunk.io: #{report_url}"
+      warn("Uploading the diff report failed, this message is mainly used to remind the maintainers of PMD.")
+    end
+  end
+end
+
+# Perform regression testing
+can_merge = github.pr_json['mergeable']
+if can_merge
+  run_pmdtester
+else
+  warn("This PR cannot be merged yet.", sticky: false)
+end
+
+# vim: syntax=ruby

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org/'
+
+gem 'pmdtester', '~> 1.0.0.pre.beta2'
+gem 'danger', '~> 5.6', '>= 5.6'
+
+# vim: syntax=ruby


### PR DESCRIPTION
* We only perform the regression testing when `mvn verify` runs successfully and the PR is mergeable.
* When contributor have submitted the new commits, old and new regression diff reports are both available.