### PR TITLE
[java] Use typeof in MissingSerialVersionUID

### DIFF
--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2277,6 +2277,7 @@ public void bar(int status) {
           since="3.0"
           message="Classes implementing Serializable should set a serialVersionUID"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
+          typeResolution="true"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#missingserialversionuid">
         <description>
 Serializable classes should provide a serialVersionUID field.
@@ -2287,14 +2288,10 @@ Serializable classes should provide a serialVersionUID field.
                 <value>
 <![CDATA[
 //ClassOrInterfaceDeclaration
- [
-  count(ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration
-   /FieldDeclaration/VariableDeclarator/VariableDeclaratorId[@Image='serialVersionUID']) = 0
-and
-  //ClassOrInterfaceType[typeof(@Image, 'java.io.Serializable','Serializable')]
-and
-   @Abstract = 'false'
-]
+    [@Abstract = 'false']
+    [count(ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration
+        /FieldDeclaration/VariableDeclarator/VariableDeclaratorId[@Image='serialVersionUID']) = 0]
+    [(ImplementsList | ExtendsList)/ClassOrInterfaceType[typeIs('java.io.Serializable')]]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2291,9 +2291,7 @@ Serializable classes should provide a serialVersionUID field.
   count(ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration
    /FieldDeclaration/VariableDeclarator/VariableDeclaratorId[@Image='serialVersionUID']) = 0
 and
-  count(ImplementsList
-   [ClassOrInterfaceType/@Image='Serializable'
-   or ClassOrInterfaceType/@Image='java.io.Serializable']) =1
+  //ClassOrInterfaceType[typeof(@Image, 'java.io.Serializable','Serializable')]
 and
    @Abstract = 'false'
 ]

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/MissingSerialVersionUIDBase.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/MissingSerialVersionUIDBase.java
@@ -1,0 +1,14 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone;
+
+import java.io.Serializable;
+
+/**
+ * This class is used for a test case for the rule MissingSerialVersionUID.
+ */
+public class MissingSerialVersionUIDBase implements Serializable {
+    private static final long serialVersionUID = 1234567L;
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/MissingSerialVersionUID.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/MissingSerialVersionUID.xml
@@ -88,4 +88,15 @@ public class Foo implements Serializable {
 }
      ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#1078 [java] MissingSerialVersionUID rule does not seem to catch inherited classes</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+package net.sourceforge.pmd.lang.java.rule.errorprone;
+public class MissingSerialVersionUIDTest extends MissingSerialVersionUIDBase {
+    // ... no serialVersionUID value defined ...
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw test` passes.
 - [x] `./mvnw pmd:check` passes.
 - [x] `./mvnw checkstyle:check` passes. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
I'm not 100% sure about the following, however #1078 is open since May and @jsotuyod suggested the solution which I hope I understood correctly.

The construct

```
count(ImplementsList
[ClassOrInterfaceType/@Image='Serializable'
or ClassOrInterfaceType/@Image='java.io.Serializable']) =1
```

doesn't cover subclasses of a class or interface implementing or
extending Serializable whereas the `typeof` operator does.

close #1078