### PR TITLE
[java] Add Java default ruleset

### DIFF
--- a/pmd-java/src/main/resources/rulesets/java/default.xml
+++ b/pmd-java/src/main/resources/rulesets/java/default.xml
@@ -1,0 +1,330 @@
+<?xml version="1.0"?>
+<ruleset name="default"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+    <description>Default configuration of PMD. Includes the rules that are most likely to apply everywhere.</description>
+
+    <!-- <rule ref="category/java/bestpractices.xml/AbstractClassWithoutAbstractMethod" /> -->
+    <!-- <rule ref="category/java/bestpractices.xml/AccessorClassGeneration" /> -->
+    <!-- <rule ref="category/java/bestpractices.xml/AccessorMethodGeneration" /> -->
+    <!-- <rule ref="category/java/bestpractices.xml/ArrayIsStoredDirectly" /> -->
+    <!-- <rule ref="category/java/bestpractices.xml/AvoidPrintStackTrace" /> -->
+    <!-- <rule ref="category/java/bestpractices.xml/AvoidReassigningParameters" /> -->
+    <rule ref="category/java/bestpractices.xml/AvoidStringBufferField"/>
+    <rule ref="category/java/bestpractices.xml/AvoidUsingHardCodedIP"/>
+    <rule ref="category/java/bestpractices.xml/CheckResultSet"/>
+    <rule ref="category/java/bestpractices.xml/ConstantsInInterface"/>
+    <rule ref="category/java/bestpractices.xml/DefaultLabelNotLastInSwitchStmt"/>
+    <rule ref="category/java/bestpractices.xml/ForLoopCanBeForeach"/>
+    <rule ref="category/java/bestpractices.xml/GuardLogStatement"/>
+    <!-- <rule ref="category/java/bestpractices.xml/JUnit4SuitesShouldUseSuiteAnnotation" /> -->
+    <!-- <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseAfterAnnotation" /> -->
+    <!-- <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseBeforeAnnotation" /> -->
+    <!-- <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseTestAnnotation" /> -->
+    <!-- <rule ref="category/java/bestpractices.xml/JUnitAssertionsShouldIncludeMessage" /> -->
+    <!-- <rule ref="category/java/bestpractices.xml/JUnitTestContainsTooManyAsserts" /> -->
+    <!-- <rule ref="category/java/bestpractices.xml/JUnitTestsShouldIncludeAssert" /> -->
+    <!-- <rule ref="category/java/bestpractices.xml/JUnitUseExpected" /> -->
+    <rule ref="category/java/bestpractices.xml/LooseCoupling"/>
+    <!-- <rule ref="category/java/bestpractices.xml/MethodReturnsInternalArray" /> -->
+    <rule ref="category/java/bestpractices.xml/MissingOverride"/>
+
+    <rule ref="category/java/bestpractices.xml/OneDeclarationPerLine"/>
+    <rule ref="category/java/bestpractices.xml/PositionLiteralsFirstInCaseInsensitiveComparisons"/>
+    <rule ref="category/java/bestpractices.xml/PositionLiteralsFirstInComparisons"/>
+    <rule ref="category/java/bestpractices.xml/PreserveStackTrace"/>
+
+    <!-- <rule ref="category/java/bestpractices.xml/ReplaceEnumerationWithIterator" /> -->
+    <!-- <rule ref="category/java/bestpractices.xml/ReplaceHashtableWithMap" /> -->
+    <!-- <rule ref="category/java/bestpractices.xml/ReplaceVectorWithList" /> -->
+
+    <rule ref="category/java/bestpractices.xml/SwitchStmtsShouldHaveDefault"/>
+
+    <!-- <rule ref="category/java/bestpractices.xml/SystemPrintln" /> -->
+
+    <rule ref="category/java/bestpractices.xml/UnusedFormalParameter"/>
+
+    <rule ref="category/java/bestpractices.xml/UnusedImports"/>
+    <!-- <rule ref="category/java/errorprone.xml/ImportFromSamePackage" />-->
+
+    <rule ref="category/java/bestpractices.xml/UnusedLocalVariable"/>
+    <rule ref="category/java/bestpractices.xml/UnusedPrivateField"/>
+    <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod"/>
+
+    <rule ref="category/java/bestpractices.xml/UseAssertEqualsInsteadOfAssertTrue"/>
+    <rule ref="category/java/bestpractices.xml/UseAssertNullInsteadOfAssertTrue"/>
+    <rule ref="category/java/bestpractices.xml/UseAssertSameInsteadOfAssertTrue"/>
+    <rule ref="category/java/bestpractices.xml/UseAssertTrueInsteadOfAssertEquals"/>
+
+    <rule ref="category/java/bestpractices.xml/UseCollectionIsEmpty"/>
+    <!-- <rule ref="category/java/bestpractices.xml/UseVarargs" /> -->
+
+    <!-- <rule ref="category/java/codestyle.xml/AtLeastOneConstructor" /> -->
+    <!-- <rule ref="category/java/codestyle.xml/AvoidDollarSigns" /> -->
+    <!-- <rule ref="category/java/codestyle.xml/AvoidFinalLocalVariable" /> -->
+
+    <rule ref="category/java/codestyle.xml/AvoidProtectedFieldInFinalClass"/>
+
+    <rule ref="category/java/codestyle.xml/AvoidProtectedMethodInFinalClassNotExtending"/>
+
+    <!-- NAMING CONVENTIONS -->
+
+    <rule ref="category/java/codestyle.xml/FormalParameterNamingConventions"/>
+    <rule ref="category/java/codestyle.xml/ClassNamingConventions"/>
+    <rule ref="category/java/codestyle.xml/LocalVariableNamingConventions"/>
+    <rule ref="category/java/codestyle.xml/MethodNamingConventions"/>
+    <rule ref="category/java/codestyle.xml/PackageCase"/>
+
+    <!-- Unimplemented !-->
+    <!--<rule ref="category/java/codestyle.xml/FieldNamingConventions" />-->
+    <rule ref="category/java/codestyle.xml/GenericsNaming"/>
+
+    <!-- <rule ref="category/java/codestyle.xml/LongVariable" /> -->
+    <!-- <rule ref="category/java/codestyle.xml/ShortClassName" /> -->
+    <!-- <rule ref="category/java/codestyle.xml/ShortMethodName" /> -->
+    <!-- <rule ref="category/java/codestyle.xml/ShortVariable" /> -->
+
+    <!-- OTHER -->
+
+    <!-- <rule ref="category/java/codestyle.xml/AvoidUsingNativeCode"/>-->
+    <!-- <rule ref="category/java/codestyle.xml/BooleanGetMethodName" /> -->
+    <!-- <rule ref="category/java/codestyle.xml/CallSuperInConstructor" /> -->
+    <!-- <rule ref="category/java/codestyle.xml/CommentDefaultAccessModifier" /> -->
+    <!-- <rule ref="category/java/codestyle.xml/ConfusingTernary" /> -->
+    <rule ref="category/java/codestyle.xml/ControlStatementBraces"/>
+    <!--<rule ref="category/java/codestyle.xml/DefaultPackage"/>-->
+
+    <rule ref="category/java/codestyle.xml/DontImportJavaLang"/>
+    <rule ref="category/java/codestyle.xml/DuplicateImports"/>
+
+    <!-- <rule ref="category/java/codestyle.xml/EmptyMethodInAbstractClassShouldBeAbstract" /> -->
+
+    <rule ref="category/java/codestyle.xml/ExtendsObject"/>
+
+    <!-- <rule ref="category/java/codestyle.xml/FieldDeclarationsShouldBeAtStartOfClass" /> -->
+    <rule ref="category/java/codestyle.xml/ForLoopShouldBeWhileLoop"/>
+
+    <rule ref="category/java/codestyle.xml/IdenticalCatchBranches"/>
+
+    <!-- <rule ref="category/java/codestyle.xml/LocalVariableCouldBeFinal" /> -->
+    <!-- <rule ref="category/java/codestyle.xml/MethodArgumentCouldBeFinal" /> -->
+
+    <!-- <rule ref="category/java/codestyle.xml/MIsLeadingVariableName" /> -->
+    <rule ref="category/java/codestyle.xml/NoPackage"/>
+    <!-- <rule ref="category/java/codestyle.xml/OnlyOneReturn" /> -->
+    <!-- <rule ref="category/java/codestyle.xml/PrematureDeclaration" /> -->
+
+    <!-- <rule ref="category/java/codestyle.xml/SuspiciousConstantFieldName" /> -->
+    <!-- <rule ref="category/java/codestyle.xml/TooManyStaticImports" /> -->
+    <rule ref="category/java/codestyle.xml/UnnecessaryAnnotationValueElement"/>
+    <rule ref="category/java/codestyle.xml/UnnecessaryConstructor"/>
+    <rule ref="category/java/codestyle.xml/UnnecessaryFullyQualifiedName"/>
+    <rule ref="category/java/codestyle.xml/UnnecessaryLocalBeforeReturn"/>
+    <rule ref="category/java/codestyle.xml/UnnecessaryModifier"/>
+    <rule ref="category/java/codestyle.xml/UnnecessaryReturn"/>
+    <rule ref="category/java/codestyle.xml/UselessParentheses"/>
+    <rule ref="category/java/codestyle.xml/UselessQualifiedThis"/>
+
+    <rule ref="category/java/design.xml/AbstractClassWithoutAnyMethod"/>
+    <!-- <rule ref="category/java/design.xml/AvoidCatchingGenericException" /> -->
+    <!-- <rule ref="category/java/design.xml/AvoidDeeplyNestedIfStmts" /> -->
+    <!-- <rule ref="category/java/design.xml/AvoidRethrowingException" /> -->
+    <!-- <rule ref="category/java/design.xml/AvoidThrowingNewInstanceOfSameException" /> -->
+    <!-- <rule ref="category/java/design.xml/AvoidThrowingNullPointerException" /> -->
+    <!-- <rule ref="category/java/design.xml/AvoidThrowingRawExceptionTypes" /> -->
+    <rule ref="category/java/design.xml/ClassWithOnlyPrivateConstructorsShouldBeFinal"/>
+    <!--<rule ref="category/java/design.xml/CollapsibleIfStatements"/>-->
+    <!-- <rule ref="category/java/design.xml/CouplingBetweenObjects" /> -->
+    <!-- <rule ref="category/java/design.xml/DataClass" /> -->
+    <!-- <rule ref="category/java/design.xml/DoNotExtendJavaLangError" /> -->
+    <!-- <rule ref="category/java/design.xml/ExceptionAsFlowControl" /> -->
+    <!-- <rule ref="category/java/design.xml/ExcessiveClassLength" /> -->
+    <!-- <rule ref="category/java/design.xml/ExcessiveImports" /> -->
+    <!-- <rule ref="category/java/design.xml/ExcessiveMethodLength" /> -->
+    <!-- <rule ref="category/java/design.xml/ExcessiveParameterList" /> -->
+    <!-- <rule ref="category/java/design.xml/ExcessivePublicCount" /> -->
+    <rule ref="category/java/design.xml/FinalFieldCouldBeStatic"/>
+    <!-- <rule ref="category/java/design.xml/GodClass" /> -->
+    <!-- <rule ref="category/java/design.xml/ImmutableField" /> -->
+    <!-- <rule ref="category/java/design.xml/LawOfDemeter" /> -->
+    <rule ref="category/java/design.xml/LogicInversion"/>
+
+    <!-- <rule ref="category/java/design.xml/CyclomaticComplexity" /> -->
+    <!-- <rule ref="category/java/design.xml/NcssCount" /> -->
+    <!-- <rule ref="category/java/design.xml/NPathComplexity" /> -->
+
+    <!-- <rule ref="category/java/design.xml/SignatureDeclareThrowsException" /> -->
+
+    <rule ref="category/java/design.xml/SimplifiedTernary"/>
+
+    <!-- <rule ref="category/java/design.xml/SimplifyBooleanAssertion" /> -->
+    <!-- <rule ref="category/java/design.xml/SimplifyBooleanExpressions" /> -->
+
+    <rule ref="category/java/design.xml/SimplifyBooleanReturns"/>
+    <rule ref="category/java/design.xml/SimplifyConditional"/>
+    <rule ref="category/java/design.xml/SingularField"/>
+    <!-- <rule ref="category/java/design.xml/SwitchDensity" /> -->
+    <!-- <rule ref="category/java/design.xml/TooManyFields" /> -->
+    <!-- <rule ref="category/java/design.xml/TooManyMethods" /> -->
+    <rule ref="category/java/design.xml/UselessOverridingMethod"/>
+    <!-- <rule ref="category/java/design.xml/UseObjectForClearerAPI" /> -->
+    <rule ref="category/java/design.xml/UseUtilityClass"/>
+
+    <!-- <rule ref="category/java/documentation.xml/CommentContent" /> -->
+    <!-- <rule ref="category/java/documentation.xml/CommentRequired" /> -->
+    <!-- <rule ref="category/java/documentation.xml/CommentSize" /> -->
+    <rule ref="category/java/documentation.xml/UncommentedEmptyConstructor"/>
+    <rule ref="category/java/documentation.xml/UncommentedEmptyMethodBody"/>
+
+    <rule ref="category/java/errorprone.xml/AssignmentInOperand">
+        <properties>
+            <property name="allowWhile" value="true"/>
+        </properties>
+    </rule>
+    <rule ref="category/java/errorprone.xml/AssignmentToNonFinalStatic"/>
+    <rule ref="category/java/errorprone.xml/AvoidAccessibilityAlteration"/>
+    <!-- <rule ref="category/java/errorprone.xml/AvoidAssertAsIdentifier" /> -->
+    <rule ref="category/java/errorprone.xml/AvoidBranchingStatementAsLastInLoop"/>
+    <!-- <rule ref="category/java/errorprone.xml/AvoidCallingFinalize" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/AvoidCatchingNPE" /> -->
+    <rule ref="category/java/errorprone.xml/AvoidCatchingThrowable"/>
+    <rule ref="category/java/errorprone.xml/AvoidDecimalLiteralsInBigDecimalConstructor"/>
+    <!-- <rule ref="category/java/errorprone.xml/AvoidDuplicateLiterals" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/AvoidEnumAsIdentifier" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/AvoidFieldNameMatchingMethodName" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/AvoidFieldNameMatchingTypeName" /> -->
+    <rule ref="category/java/errorprone.xml/AvoidInstanceofChecksInCatchClause"/>
+    <!-- <rule ref="category/java/errorprone.xml/AvoidLiteralsInIfCondition" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/AvoidLosingExceptionInformation" /> -->
+    <rule ref="category/java/errorprone.xml/AvoidMultipleUnaryOperators"/>
+    <rule ref="category/java/errorprone.xml/AvoidUsingOctalValues"/>
+    <rule ref="category/java/errorprone.xml/BadComparison"/>
+    <!-- <rule ref="category/java/errorprone.xml/BeanMembersShouldSerialize" /> -->
+    <rule ref="category/java/errorprone.xml/BrokenNullCheck"/>
+    <!-- <rule ref="category/java/errorprone.xml/CallSuperFirst" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/CallSuperLast" /> -->
+    <rule ref="category/java/errorprone.xml/CheckSkipResult"/>
+    <rule ref="category/java/errorprone.xml/ClassCastExceptionWithToArray"/>
+    <rule ref="category/java/errorprone.xml/CloneMethodMustBePublic"/>
+    <rule ref="category/java/errorprone.xml/CloneMethodMustImplementCloneable"/>
+    <rule ref="category/java/errorprone.xml/CloneMethodReturnTypeMustMatchClassName"/>
+    <rule ref="category/java/errorprone.xml/CloneThrowsCloneNotSupportedException"/>
+    <rule ref="category/java/errorprone.xml/CloseResource"/>
+    <rule ref="category/java/errorprone.xml/CompareObjectsWithEquals"/>
+    <!-- <rule ref="category/java/errorprone.xml/ConstructorCallsOverridableMethod" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/DataflowAnomalyAnalysis" /> -->
+    <rule ref="category/java/errorprone.xml/DoNotCallGarbageCollectionExplicitly"/>
+    <!-- <rule ref="category/java/errorprone.xml/DoNotCallSystemExit" /> -->
+
+    <rule ref="category/java/errorprone.xml/DoNotExtendJavaLangThrowable"/>
+
+    <!-- <rule ref="category/java/errorprone.xml/DoNotHardCodeSDCard" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/DoNotThrowExceptionInFinally" /> -->
+
+    <!--<rule ref="category/java/errorprone.xml/DontImportSun" />-->
+
+    <rule ref="category/java/errorprone.xml/DontUseFloatTypeForLoopIndices"/>
+    <rule ref="category/java/errorprone.xml/EmptyCatchBlock"/>
+
+    <!-- <rule ref="category/java/errorprone.xml/EmptyFinalizer" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/EmptyFinallyBlock" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/EmptyIfStmt" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/EmptyInitializer" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/EmptyStatementBlock" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/EmptyStatementNotInLoop" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/EmptySwitchStatements" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/EmptySynchronizedBlock" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/EmptyTryBlock" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/EmptyWhileStmt" /> -->
+
+    <rule ref="category/java/errorprone.xml/EqualsNull"/>
+
+    <!-- <rule ref="category/java/errorprone.xml/FinalizeDoesNotCallSuperFinalize" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/FinalizeOnlyCallsSuperFinalize" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/FinalizeOverloaded" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/FinalizeShouldBeProtected" /> -->
+    <rule ref="category/java/errorprone.xml/IdempotentOperations"/>
+    <rule ref="category/java/errorprone.xml/InstantiationToGetClass"/>
+    <!-- <rule ref="category/java/errorprone.xml/InvalidSlf4jMessageFormat" /> -->
+    <rule ref="category/java/errorprone.xml/JumbledIncrementer"/>
+    <!-- <rule ref="category/java/errorprone.xml/JUnitSpelling" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/JUnitStaticSuite" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/LoggerIsNotStaticFinal" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/MethodWithSameNameAsEnclosingClass" /> -->
+    <rule ref="category/java/errorprone.xml/MisplacedNullCheck"/>
+    <rule ref="category/java/errorprone.xml/MissingBreakInSwitch"/>
+    <!-- <rule ref="category/java/errorprone.xml/MissingSerialVersionUID" /> -->
+    <rule ref="category/java/errorprone.xml/MissingStaticMethodInNonInstantiatableClass"/>
+    <!-- <rule ref="category/java/errorprone.xml/MoreThanOneLogger" /> -->
+    <rule ref="category/java/errorprone.xml/NonCaseLabelInSwitchStatement"/>
+    <rule ref="category/java/errorprone.xml/NonStaticInitializer"/>
+    <!-- <rule ref="category/java/errorprone.xml/NullAssignment" /> -->
+    <rule ref="category/java/errorprone.xml/OverrideBothEqualsAndHashcode"/>
+    <rule ref="category/java/errorprone.xml/ProperCloneImplementation"/>
+    <rule ref="category/java/errorprone.xml/ProperLogger"/>
+    <rule ref="category/java/errorprone.xml/ReturnEmptyArrayRatherThanNull"/>
+    <rule ref="category/java/errorprone.xml/ReturnFromFinallyBlock"/>
+    <!-- <rule ref="category/java/errorprone.xml/SimpleDateFormatNeedsLocale" /> -->
+    <rule ref="category/java/errorprone.xml/SingleMethodSingleton"/>
+    <rule ref="category/java/errorprone.xml/SingletonClassReturningNewInstance"/>
+    <!-- <rule ref="category/java/errorprone.xml/StaticEJBFieldShouldBeFinal" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/StringBufferInstantiationWithChar" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/SuspiciousEqualsMethodName" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/SuspiciousHashcodeMethodName" /> -->
+    <rule ref="category/java/errorprone.xml/SuspiciousOctalEscape"/>
+    <!-- <rule ref="category/java/errorprone.xml/TestClassWithoutTestCases" /> -->
+    <rule ref="category/java/errorprone.xml/UnconditionalIfStatement"/>
+    <!-- <rule ref="category/java/errorprone.xml/UnnecessaryBooleanAssertion" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/UnnecessaryCaseChange" /> -->
+    <rule ref="category/java/errorprone.xml/UnnecessaryConversionTemporary"/>
+    <rule ref="category/java/errorprone.xml/UnusedNullCheckInEquals"/>
+    <!-- <rule ref="category/java/errorprone.xml/UseCorrectExceptionLogging" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/UseEqualsToCompareStrings" /> -->
+    <rule ref="category/java/errorprone.xml/UselessOperationOnImmutable"/>
+    <rule ref="category/java/errorprone.xml/UseLocaleWithCaseConversions"/>
+    <!-- <rule ref="category/java/errorprone.xml/UseProperClassLoader" /> -->
+
+    <!-- <rule ref="category/java/multithreading.xml/AvoidSynchronizedAtMethodLevel" /> -->
+    <rule ref="category/java/multithreading.xml/AvoidThreadGroup"/>
+    <rule ref="category/java/multithreading.xml/AvoidUsingVolatile"/>
+    <!-- <rule ref="category/java/multithreading.xml/DoNotUseThreads" /> -->
+    <rule ref="category/java/multithreading.xml/DontCallThreadRun"/>
+    <rule ref="category/java/multithreading.xml/DoubleCheckedLocking"/>
+    <rule ref="category/java/multithreading.xml/NonThreadSafeSingleton"/>
+    <rule ref="category/java/multithreading.xml/UnsynchronizedStaticDateFormatter"/>
+    <!-- <rule ref="category/java/multithreading.xml/UseConcurrentHashMap" /> -->
+    <rule ref="category/java/multithreading.xml/UseNotifyAllInsteadOfNotify"/>
+
+    <!-- <rule ref="category/java/performance.xml/AddEmptyString" /> -->
+    <!-- <rule ref="category/java/performance.xml/AppendCharacterWithChar" /> -->
+    <!-- <rule ref="category/java/performance.xml/AvoidArrayLoops" /> -->
+    <!-- <rule ref="category/java/performance.xml/AvoidFileStream" /> -->
+    <!-- <rule ref="category/java/performance.xml/AvoidInstantiatingObjectsInLoops" /> -->
+    <rule ref="category/java/performance.xml/AvoidUsingShortType"/>
+    <rule ref="category/java/performance.xml/BigIntegerInstantiation"/>
+    <rule ref="category/java/performance.xml/BooleanInstantiation"/>
+    <!-- <rule ref="category/java/performance.xml/ByteInstantiation" /> -->
+    <!-- <rule ref="category/java/performance.xml/ConsecutiveAppendsShouldReuse" /> -->
+    <!-- <rule ref="category/java/performance.xml/ConsecutiveLiteralAppends" /> -->
+    <!-- <rule ref="category/java/performance.xml/InefficientEmptyStringCheck" /> -->
+    <!-- <rule ref="category/java/performance.xml/InefficientStringBuffering" /> -->
+    <!-- <rule ref="category/java/performance.xml/InsufficientStringBufferDeclaration" /> -->
+    <!-- <rule ref="category/java/performance.xml/IntegerInstantiation" /> -->
+    <!-- <rule ref="category/java/performance.xml/LongInstantiation" /> -->
+    <rule ref="category/java/performance.xml/OptimizableToArrayCall"/>
+    <!--<rule ref="category/java/performance.xml/RedundantFieldInitializer"/>-->
+    <!-- <rule ref="category/java/performance.xml/SimplifyStartsWith" /> -->
+    <!-- <rule ref="category/java/performance.xml/ShortInstantiation" /> -->
+    <!-- <rule ref="category/java/performance.xml/StringInstantiation" /> -->
+    <!-- <rule ref="category/java/performance.xml/StringToString" /> -->
+    <!--<rule ref="category/java/performance.xml/TooFewBranchesForASwitchStatement"/>-->
+    <!-- <rule ref="category/java/performance.xml/UnnecessaryWrapperObjectCreation" /> -->
+    <!-- <rule ref="category/java/performance.xml/UseArrayListInsteadOfVector" /> -->
+    <!-- <rule ref="category/java/performance.xml/UseArraysAsList" /> -->
+    <!-- <rule ref="category/java/performance.xml/UseIndexOfChar" /> -->
+    <!-- <rule ref="category/java/performance.xml/UselessStringValueOf" /> -->
+    <!-- <rule ref="category/java/performance.xml/UseStringBufferForStringAppends" /> -->
+    <!-- <rule ref="category/java/performance.xml/UseStringBufferLength" /> -->
+
+</ruleset>


### PR DESCRIPTION
This is a WIP to create a default "intro" ruleset for Java. Design goals of the ruleset would be to 
* not be too invasive, ie not report too many "unsignificant" violations, e.g. 1 letter variable names
* be as generic as possible, ie report things that apply to all code bases, and not enforce conventions that could be seen as arbitrary in some code bases (eg I excluded the rule SystemPrintln)

TODO:
* Update documentation

In the end we should have a "default.xml" ruleset for all languages (the name is up to discussion as well, until it's released). Maybe @rsoesemann could help with the Apex one?

Scheduling this for 6.6.0 for now, although it's up to discussion