### PR TITLE
[cpp] Fix NullPointerException in CPPTokenizer:99

### DIFF
--- a/pmd-cpp/src/main/java/net/sourceforge/pmd/cpd/CPPLanguage.java
+++ b/pmd-cpp/src/main/java/net/sourceforge/pmd/cpd/CPPLanguage.java
@@ -16,7 +16,12 @@ public class CPPLanguage extends AbstractLanguage {
      * for c/c++ files.
      */
     public CPPLanguage() {
+        this(System.getProperties());
+    }
+
+    public CPPLanguage(Properties properties) {
         super("C++", "cpp", new CPPTokenizer(), ".h", ".hpp", ".hxx", ".c", ".cpp", ".cxx", ".cc", ".C");
+        setProperties(properties);
     }
 
     /*


### PR DESCRIPTION
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw test` passes.
 - [x] `./mvnw pmd:check` passes.
 - [x] `./mvnw checkstyle:check` passes. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

Due to `skipBlocks = true` and `skipBlocksStart` being uninitialised in `CPPTokenizer`, `maybeSkipBlocks` would always throw a NullPointerException as it is assuming that `setProperties` is always called after the constructor.
Changed `CPPLanguage` to always invoke `setProperties`, similarly to `CsLanguage`.
This only happens in programmatic invocations.
