### PR TITLE
Java 11 and OpenJFX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-dist: trusty
-sudo: false
 addons:
   ssh_known_hosts:
     - web.sourceforge.net
@@ -16,14 +14,33 @@ env:
   - secure: "geOU/7VR83KYTOCR5XkgFqnHJEnXeB6hNDE7UFcN4ZsL9uVLhxlDVWV3ujJ87nyBzggG1KfSnUx11UwOQrbBl0K6sEXo/B2q5ytOsWoSLi7+0qm/uhhw/DTBOq57p8TIDKFM7rDhO7uajSn7Y86LeZkh9wIs5265Fh1yhCkiPbczDUMsX4P0GGg2qgkIKSBw4DZf6sPDc4xjJq/4/cLnjXo/K0ZYAIoSLqDfe1gmkzMtQlad+1t8Lwv/gOJ4BNRF4a5aEvGF6kbFovFoeFWCQTKlkn6VJtY+BETGKW2RH9efGeMs7JbBbNm+nnpoNsbJ0gdmGlhSbWT8enIm72/P0ThTBJWVcLJ30tUd0UeYD9C49wbJ3RHSxsoUKP9YhHJ+XKNx+8irkJ8LPCkNMQEFE153gEVvU7tCgah9Uq6laYZv9cQE0dWzNt3//Ymls8BzY38Ha4PbrIIJqEuWwnAX6ZgTgzVtXx1AJjkDFG9KFKPhN7NfNMbh7rn5C84a1h5zrIydm+6RcIBC+xTLDEiN7djiquf3PcNtyGLcO8dNN4Uv8iU0Jw8ch3+w0PJO53v5py+IS1V8pwwYaYF2iVPOoziS0tP8MsgYVGwpTZhvz3v8x0ge8r6KJE4zdvoPtCRNr2Oo3sJGYqkt86Hu6agKFiljP5AgJNx7iQD5GQn6J3w="
   - secure: "gqyPF3d75JuwZptnQQQKO6rGUILXGO09y9dZhShdX8qq5Mexa2ISk77Y/b0yyAdhJMgEglls5cWlbHkwCAB0i4yL25RE5CtQUe4er+CIKwBIs0M56ghbcOwWAFB/cXeyyWmXDHBVnVUeKm7IJ34txsEclnMzQSR/DInSzsCFMUQok8HEaWZNssMjyRgo6goKGdG5vNWGfLLY7mKGMe/6PpYJD0G8k+Na08aX06ZWph38He8O3imUAngoQrxiSp0UYmnHDkigbV7S2LdZOsj7kMxkiyigzK/P1eygHVbFAhohLroaqS9B4CBK7QeOyup2vxVKqJVzFwOCylD0786CImvaG2ZYMtvJkapvaEE0mdMlyYpHgdIkmHZu28aMW7hXEhxHyBAxKuPcj5eGCGziO+ztCvfYIA9CGs1uA4KLrED7SahvB0oXnt3KTFdRc857cWcpp2NmRKihLzVdgHlmT8zcYaec3zP1VdMoa2bmLHoaZtAwvMTcAG56FcET1p7f9v+uiU88ZeptEjTJfpAWlq34tpwZXNyIQi5IROocSHM+PKTgLAsAMP5klGascr8E0sEzREl7tg8hqEwXKym/sVKyT+HMptA3UZcrZZhm07/cmQ0pUVvbV9QDb0MzU3O2wF7vT3U7R7Fb1u0LxMjblPyEazTp8ldabVRJREwlsDc="
   - secure: "JIhuqaI0i+zvuqqXiQBHpuKr7AQ8jfk6Gbr8Qgiq4yJtdEWXZGxnAT9BmlbjkgT7ABXvLgxf2CIdUOMo1yYfBlxQL/y5+e89jaVpYF3tvNAzYQ1e12VzQRsd/jDb7qvm7tw3rDHEn3dSEot7Q6KbPcL6WzWJINVMCCmOgvq9gKHgE6Y5q5EgZ5rxiXyuO27ndzcbxaor4PIaiSzHO9+AJQ7p2zDLP+kG4nKVTBX0l9VoKiYFhIpIhpbigi3jyLDMDRiWpwTWZC6P8/RXfZg/lc5ADOuM2DM8oXPpZuqOa/g31LWQOSCuEnQ1G16vbLgipSPpgAc7jYWD5cywhG9dLkiKaZDh5x0meLM2RoAgz6eAnQfTTqJ68OM9o9yXjubEedsNpNRAr9/DXMd+fbh10W2vbvL5HCNB3lic3anehhR9le7PLuEKxg654wXt3KM2PZGVWbotIyBK0CvGzqGkppvwT23QdDDqSdkWuGQIhGQ0xBOdYkwebycxP5wwPUmObG+mymQ1Be2BXvmghttsiJdKlt4CVSYOJUMus6kU32G95hdTgKblsX4J1Of2i1nYsjyMKh3k945tqXwQrIsxOOQug0oIkz24zlLaOaQcorWtJ6Y1HPaZKpVIFUEF0y8Uq/O4oB2bOYC6WDUQfpj7nRG6xbi+BeBS84m1ttCEk4g="
-  matrix:
-  - BUILD=deploy
-  - BUILD=doc
-  - BUILD=sonar
-  - BUILD=coveralls
 
 matrix:
   fast_finish: true
+  include:
+    - name: "linux - mvn deploy"
+      os: linux
+      dist: trusty
+      sudo: false
+      env: BUILD=deploy
+    - name: "linux - build documentation"
+      os: linux
+      dist: trusty
+      sudo: false
+      env: BUILD=doc
+    - name: "linux - run sonar"
+      os: linux
+      dist: trusty
+      sudo: false
+      env: BUILD=sonar
+    - name: "linux - run coveralls"
+      os: linux
+      dist: trusty
+      sudo: false
+      env: BUILD=coveralls
+    - name: "macosx - mvn verify"
+      os: osx
+      env: BUILD=deploy
 
 before_install:
   - wget https://github.com/sormuras/bach/raw/master/install-jdk.sh
@@ -31,9 +48,10 @@ before_install:
   - bash .travis/configure-maven.sh
   - rvm install 2.4.1
   - rvm use 2.4.1
-# Install OracleJDK 10 - see https://sormuras.github.io/blog/2018-03-20-jdk-matrix.html
+# Install OpenJDK 11 - see https://sormuras.github.io/blog/2018-03-20-jdk-matrix.html
 install:
-  - . ./install-jdk.sh -F 10 -L BCL
+  - . ./install-jdk.sh -F 11 -L GPL -W $HOME/jdk
+  - gem install bundler
   - bundle install
 before_script: true
 script: source .travis/build-$BUILD.sh
@@ -71,7 +89,8 @@ notifications:
 cache:
   directories:
   - "$HOME/.m2"
-
+  - "$HOME/jdk"
+  - "$HOME/.rvm/"
 
 # Secure Keys, that need to be set for snapshot builds
 #

--- a/.travis/build-deploy.sh
+++ b/.travis/build-deploy.sh
@@ -48,7 +48,12 @@ log_info "Building PMD ${VERSION} on branch ${TRAVIS_BRANCH}"
 
 MVN_BUILD_FLAGS="-B -V"
 
-if travis_isPullRequest; then
+if travis_isOSX; then
+
+    log_info "The build is running on OSX"
+    ./mvnw verify $MVN_BUILD_FLAGS
+
+elif travis_isPullRequest; then
 
     log_info "This is a pull-request build"
     ./mvnw verify $MVN_BUILD_FLAGS

--- a/.travis/common-functions.sh
+++ b/.travis/common-functions.sh
@@ -10,6 +10,7 @@ echo "TRAVIS_SECURE_ENV_VARS: ${TRAVIS_SECURE_ENV_VARS}"
 echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
 echo "TRAVIS_TAG: ${TRAVIS_TAG}"
 echo "TRAVIS_ALLOW_FAILURE: ${TRAVIS_ALLOW_FAILURE}"
+echo "TRAVIS_OS_NAME: ${TRAVIS_OS_NAME}"
 
 function travis_isPullRequest() {
     if [ "${TRAVIS_REPO_SLUG}" != "pmd/pmd" ] || [ "${TRAVIS_PULL_REQUEST}" != "false" ]; then
@@ -21,6 +22,14 @@ function travis_isPullRequest() {
 
 function travis_isPush() {
     if [ "${TRAVIS_REPO_SLUG}" = "pmd/pmd" ] && [ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ "${TRAVIS_SECURE_ENV_VARS}" = "true" ]; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+function travis_isOSX() {
+    if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
         return 0
     else
         return 1

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,7 +1,8 @@
 # How to build PMD
 
-PMD uses [Maven](https://maven.apache.org/) and requires [Java 9](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
-for building.
+PMD uses [Maven](https://maven.apache.org/) and requires at least Java 10 for building.
+You can get Java 10 from [Oracle](http://www.oracle.com/technetwork/java/javase/downloads/index.html)
+or from the [OpenJDK Project](http://jdk.java.net).
 
 PMD uses the [maven wrapper](https://github.com/takari/maven-wrapper), so you can simply build PMD as following:
 

--- a/docs/pages/pmd/devdocs/building.md
+++ b/docs/pages/pmd/devdocs/building.md
@@ -10,10 +10,9 @@ author: Tom Copeland, Xavier Le Vourch <xlv@users.sourceforge.net>
 
 # Compiling PMD
 
-*   JDK 9 or higher
-*   [Apache Maven](http://maven.apache.org) 3 or later.
+*   JDK 10 or higher
 
-{% include note.html content="While Java 9 is required for building, running PMD only requires Java 7 (or Java 8 for Apex)." %}
+{% include note.html content="While Java 10 is required for building, running PMD only requires Java 7 (or Java 8 for Apex and the Designer)." %}
 
 You’ll need to either check out the source code or download the latest source release. Assuming you’ve got the latest source release, unzip it to a directory:
 

--- a/docs/pages/pmd/userdocs/installation.md
+++ b/docs/pages/pmd/userdocs/installation.md
@@ -17,6 +17,9 @@ sidebar: pmd_sidebar
     * For Windows: [Winzip](http://winzip.com) or the free [7-zip](http://www.7-zip.org/)
     * For Linux / Unix: [InfoZip](http://www.info-zip.org/pub/infozip/)
 
+{% include note.html content="For executing the Designer (./run.sh designer) using [OpenJDK](http://jdk.java.net) or Java 11, you need additionally [OpenJFX](http://jdk.java.net). Download it, extract it and set the environment variable JAVAFX_HOME." %}
+
+
 ### Installation
 
 PMD is distributed as a zip archive, which includes both [PMD](#running-pmd-via-command-line) and [CPD](/pmd_userdocs_cpd.html). 

--- a/pmd-dist/src/main/scripts/designer.bat
+++ b/pmd-dist/src/main/scripts/designer.bat
@@ -3,4 +3,49 @@ set TOPDIR=%~dp0..
 set OPTS=
 set MAIN_CLASS=net.sourceforge.pmd.util.fxdesigner.DesignerStarter
 
-java -classpath "%TOPDIR%\lib\*" %OPTS% %MAIN_CLASS% %*
+
+:: sets the jver variable to the java version, eg 901 for 9.0.1+x or 180 for 1.8.0_171-b11
+:: sets the jvendor variable to either java (oracle) or openjdk
+for /f tokens^=1^,3^,4^,5^ delims^=.-_+^"^  %%j in ('java -version 2^>^&1 ^| find "version"') do (
+  set jvendor=%%j
+  if %%l EQU ea (
+    set /A "jver=%%k00"
+  ) else (
+    set /A jver=%%k%%l%%m
+  )
+)
+
+Set "jreopts="
+:: oracle java 9 and 10 has javafx included as a module
+if /I "%jvendor%" EQU "java" (
+    if %jver% GEQ 900 (
+        if %jver% LSS 1100 (
+            :: enable reflection
+            Set jreopts=--add-opens javafx.controls/javafx.scene.control.skin=ALL-UNNAMED
+        )
+    )
+)
+
+set "_needjfxlib=0"
+if /I "%jvendor%" EQU "openjdk" set _needjfxlib=1
+if /I "%jvendor%" EQU "java" (
+    if %jver% GEQ 1100 set _needjfxlib=1
+)
+if %_needjfxlib% EQU 1 (
+    if %jver% LSS 1000 (
+        echo For openjfx at least java 10 is required.
+        pause
+        exit
+    )
+    if [%JAVAFX_HOME%] EQU [] (
+        echo The environment variable JAVAFX_HOME is missing.
+        pause
+        exit
+    )
+    set "classpath=%TOPDIR%\lib\*;%JAVAFX_HOME%\lib\*"
+) else (
+    set "classpath=%TOPDIR%\lib\*"
+)
+
+
+java %jreopts% -classpath "%classpath%" %OPTS% %MAIN_CLASS% %*

--- a/pmd-dist/src/main/scripts/designer.bat
+++ b/pmd-dist/src/main/scripts/designer.bat
@@ -3,16 +3,4 @@ set TOPDIR=%~dp0..
 set OPTS=
 set MAIN_CLASS=net.sourceforge.pmd.util.fxdesigner.DesignerStarter
 
-
-:: sets the jver variable to the java version, eg 901 for 9.0.1+x or 180 for 1.8.0_171-b11
-for /f tokens^=2-4^ delims^=.-_+^" %%j in ('java -fullversion 2^>^&1') do set /A jver="%%j%%k%%l"
-
-if "%jver%" GEQ "900" (
-    :: enable reflection    
-    Set jreopts=--add-opens javafx.controls/javafx.scene.control.skin=ALL-UNNAMED
-) else (
-    Set jreopts=
-)
-
-
-java %jreopts% -classpath "%TOPDIR%\lib\*" %OPTS% %MAIN_CLASS% %*
+java -classpath "%TOPDIR%\lib\*" %OPTS% %MAIN_CLASS% %*

--- a/pmd-dist/src/main/scripts/run.sh
+++ b/pmd-dist/src/main/scripts/run.sh
@@ -74,34 +74,6 @@ check_lib_dir() {
   fi
 }
 
-jre_specific_vm_options() {
-  full_ver=$(java -version 2>&1)
-  # java_ver is eg "18" for java 1.8, "90" for java 9.0, "100" for java 10.0.x
-  java_ver=$(echo $full_ver | sed -n '{
-      # replace early access versions, e.g. 11-ea with 11.0.0
-      s/-ea/.0.0/
-      # replace versions such as 10 with 10.0.0
-      s/version "\([0-9]\{1,\}\)"/version "\1.0.0"/
-      # extract the major and minor parts of the version
-      s/^.* version "\(.*\)\.\(.*\)\..*".*$/\1\2/p
-  }')
-  options=""
-
-  if [ "$java_ver" -ge 90 ] && [ "${APPNAME}" = "designer" ]
-  then # open internal module of javafx to reflection (for our TreeViewWrapper)
-    options="--add-opens javafx.controls/javafx.scene.control.skin=ALL-UNNAMED"
-    # The rest here is for RichtextFX
-    options+=" --add-opens javafx.graphics/javafx.scene.text=ALL-UNNAMED"
-    options+=" --add-opens javafx.graphics/com.sun.javafx.scene.text=ALL-UNNAMED"
-    options+=" --add-opens javafx.graphics/com.sun.javafx.text=ALL-UNNAMED"
-    options+=" --add-opens javafx.graphics/com.sun.javafx.geom=ALL-UNNAMED"
-    # Warn of remaining illegal accesses
-    options+=" --illegal-access=warn"
-  fi
-
-  echo $options
-}
-
 readonly APPNAME="${1}"
 if [ -z "${APPNAME}" ]; then
     usage
@@ -156,5 +128,5 @@ cygwin_paths
 
 java_heapsize_settings
 
-java ${HEAPSIZE} $(jre_specific_vm_options) -cp "${classpath}" "${CLASSNAME}" "$@"
+java ${HEAPSIZE} -cp "${classpath}" "${CLASSNAME}" "$@"
 

--- a/pmd-dist/src/main/scripts/run.sh
+++ b/pmd-dist/src/main/scripts/run.sh
@@ -29,6 +29,7 @@ cygwin_paths() {
     # For Cygwin, switch paths to Windows format before running java
     if ${cygwin} ; then
         [ -n "${JAVA_HOME}" ] && JAVA_HOME=$(cygpath --windows "${JAVA_HOME}")
+        [ -n "${JAVAFX_HOME}" ] && JAVAFX_HOME=$(cygpath --windows "${JAVAFX_HOME}")
         [ -n "${DIRECTORY}" ] && DIRECTORY=$(cygpath --windows "${DIRECTORY}")
         classpath=$(cygpath --path --windows "${classpath}")
     fi
@@ -38,6 +39,7 @@ convert_cygwin_vars() {
     # If cygwin, convert to Unix form before manipulating
     if ${cygwin} ; then
         [ -n "${JAVA_HOME}" ] && JAVA_HOME=$(cygpath --unix "${JAVA_HOME}")
+        [ -n "${JAVAFX_HOME}" ] && JAVAFX_HOME=$(cygpath --unix "${JAVAFX_HOME}")
         [ -n "${CLASSPATH}" ] && CLASSPATH=$(cygpath --path --unix "${CLASSPATH}")
     fi
 }
@@ -71,6 +73,91 @@ set_lib_dir() {
 check_lib_dir() {
   if [ ! -e "${LIB_DIR}" ]; then
     echo "The jar directory [${LIB_DIR}] does not exist"
+  fi
+}
+
+function script_exit() {
+    echo $1 >&2
+    exit 1
+}
+
+determine_java_version() {
+    local full_ver=$(java -version 2>&1)
+    # java_ver is eg "18" for java 1.8, "90" for java 9.0, "100" for java 10.0.x
+    readonly java_ver=$(echo $full_ver | sed -n '{
+        # replace early access versions, e.g. 11-ea with 11.0.0
+        s/-ea/.0.0/
+        # replace versions such as 10 with 10.0.0
+        s/version "\([0-9]\{1,\}\)"/version "\1.0.0"/
+        # extract the major and minor parts of the version
+        s/^.* version "\(.*\)\.\(.*\)\..*".*$/\1\2/p
+    }')
+    # java_vendor is either java (oracle) or openjdk
+    readonly java_vendor=$(echo $full_ver | sed -n -e 's/^\(.*\) version .*$/\1/p')
+}
+
+jre_specific_vm_options() {
+  if [ "${APPNAME}" = "designer" ]
+  then
+    options=""
+
+    if [ "$java_ver" -ge 80 ] && [ "$java_ver" -lt 90 ]
+    then
+      # no options needed for java8.
+      options=""
+    elif [ "$java_ver" -ge 90 ] && [ "$java_ver" -lt 110 ] && [ "$java_vendor" = "java" ]
+    then
+      # java9 and java10 from oracle contain javafx as a module
+      # open internal module of javafx to reflection (for our TreeViewWrapper)
+      options="--add-opens javafx.controls/javafx.scene.control.skin=ALL-UNNAMED"
+      # The rest here is for RichtextFX
+      options+=" --add-opens javafx.graphics/javafx.scene.text=ALL-UNNAMED"
+      options+=" --add-opens javafx.graphics/com.sun.javafx.scene.text=ALL-UNNAMED"
+      options+=" --add-opens javafx.graphics/com.sun.javafx.text=ALL-UNNAMED"
+      options+=" --add-opens javafx.graphics/com.sun.javafx.geom=ALL-UNNAMED"
+      # Warn of remaining illegal accesses
+      options+=" --illegal-access=warn"
+    elif [ "$java_vendor" = "openjdk" ] || ( [ "$java_vendor" = "java" ] && [ "$java_ver" -ge 110 ] )
+    then
+      # openjdk and java11 from oracle onwards do not contain javafx directly
+      # there are no extra options either - javafx will be added to the classpath without modules
+      options=""
+    fi
+
+    echo $options
+  else
+    echo ""
+  fi
+}
+
+function add_pmd_classpath() {
+    if [ -n "$classpath" ]; then
+        classpath="$classpath:${LIB_DIR}/*"
+    else
+        classpath="${LIB_DIR}/*"
+    fi
+}
+
+function add_openjfx_classpath() {
+  if [ "${APPNAME}" = "designer" ]
+  then
+    if [ "$java_vendor" = "openjdk" ] && [ "$java_ver" -lt 100 ]
+    then
+      script_exit "For openjfx at least java 10 is required"
+    elif [ "$java_vendor" = "openjdk" ] || ( [ "$java_vendor" = "java" ] && [ "$java_ver" -ge 110 ] )
+    then
+      # openjfx is required for openjdk builds and oracle java 11 or later
+      if [ -z "${JAVAFX_HOME}" ]
+      then
+        script_exit "The environment variable JAVAFX_HOME is missing."
+      else
+        if [ -n "$classpath" ]; then
+          classpath="$classpath:${JAVAFX_HOME}/lib/*"
+        else
+          classpath="${JAVAFX_HOME}/lib/*"
+        fi
+      fi
+    fi
   fi
 }
 
@@ -114,19 +201,12 @@ convert_cygwin_vars
 
 classpath=$CLASSPATH
 
-cd "${CWD}"
-
-for jarfile in "${LIB_DIR}"/*.jar; do
-    if [ -n "$classpath" ]; then
-        classpath=$classpath:$jarfile
-    else
-        classpath=$jarfile
-    fi
-done
+add_pmd_classpath
+determine_java_version
+add_openjfx_classpath
 
 cygwin_paths
 
 java_heapsize_settings
 
-java ${HEAPSIZE} -cp "${classpath}" "${CLASSNAME}" "$@"
-
+java ${HEAPSIZE} $(jre_specific_vm_options) -cp "${classpath}" "${CLASSNAME}" "$@"

--- a/pmd-ui/pom.xml
+++ b/pmd-ui/pom.xml
@@ -15,6 +15,8 @@
         <!-- Workaround for https://youtrack.jetbrains.com/issue/IDEA-188690 -->
         <maven.compiler.source>1.${java.version}</maven.compiler.source>
         <maven.compiler.target>1.${java.version}</maven.compiler.target>
+
+        <openjfx.version>11-ea+19</openjfx.version>
     </properties>
 
     <build>
@@ -29,15 +31,6 @@
         </resources>
 
         <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration combine.self="override">
-                    <source>${java.version}</source>
-                    <target>${java.version}</target>
-                </configuration>
-            </plugin>
-
             <!-- Compiles Less files into CSS files. Currently compatible with Less 1.7.0 -->
             <!-- If need be, we can probably update the Less version by using the lessJs
                  configuration property and having a custom less.js file around. -->
@@ -76,13 +69,51 @@
         <dependency>
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-core</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-java</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <!-- OpenJFX dependencies are provided. OpenJFX needs to be installed separately. -->
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-base</artifactId>
+            <version>${openjfx.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-controls</artifactId>
+            <version>${openjfx.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-fxml</artifactId>
+            <version>${openjfx.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-graphics</artifactId>
+            <version>${openjfx.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-media</artifactId>
+            <version>${openjfx.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjfx</groupId>
+            <artifactId>javafx-web</artifactId>
+            <version>${openjfx.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.fxmisc.richtext</groupId>
             <artifactId>richtextfx</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -519,7 +519,7 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[9,)</version>
+                                    <version>[10,)</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>


### PR DESCRIPTION
This uses the available openjfx dependencies instead of relying that jfx is available. With that change, PMD builds under Linux with plain OpenJDK 11.
Since the openjfx jars are included as dependencies, we don't use the module system of java9 anymore when running the Designer, so we don't need the extra vm flags. The openjfx jars are just available on the classpath.

The resulting pmd-bin-...zip is also bigger, since the openjfx jars are included now.

However, the resulting pmd-bin-....zip would only be runnable right now on Linux, since the dependencies automatically include the platform dependent part.
This happens in the parent pom of openjfx: https://search.maven.org/#artifactdetails%7Corg.openjfx%7Cjavafx%7C11-ea%2B19%7Cpom

```
        <profile>
            <id>linux</id>
            <activation>
                <os>
                    <name>linux</name>
                </os>
            </activation>
            <properties>
                <javafx.platform>linux</javafx.platform>
            </properties>
        </profile>
```

So, we probably need to add all dependencies in pmd-dist explicitly and select the correct platform in our run.sh script...

