### PR TITLE
[core] Test Framework: Sort violations by line/column

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -28,6 +28,8 @@ This is a minor release.
 
 ### Fixed Issues
 
+*   core
+    *   [#1191](https://github.com/pmd/pmd/issues/1191): \[core] Test Framework: Sort violations by line/column
 *   java-errorprone
     *   [#1078](https://github.com/pmd/pmd/issues/1078): \[java] MissingSerialVersionUID rule does not seem to catch inherited classes
 *   plsql

--- a/pmd-core/src/test/java/net/sourceforge/pmd/ReportTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/ReportTest.java
@@ -88,14 +88,15 @@ public class ReportTest implements ThreadSafeReportListener {
     public void testSortedReportLine() throws IOException {
         Report r = new Report();
         RuleContext ctx = new RuleContext();
-        ctx.setSourceCodeFilename("foo1");
-        Node s = getNode(10, 5);
-        Rule rule1 = new MockRule("rule2", "rule2", "msg", "rulesetname");
-        r.addRuleViolation(new ParametricRuleViolation<>(rule1, ctx, s, rule1.getMessage()));
-        ctx.setSourceCodeFilename("foo2");
-        Node s1 = getNode(20, 5);
-        Rule rule2 = new MockRule("rule1", "rule1", "msg", "rulesetname");
-        r.addRuleViolation(new ParametricRuleViolation<>(rule2, ctx, s1, rule2.getMessage()));
+        ctx.setSourceCodeFilename("foo1"); // same file!!
+        Node node1 = getNode(20, 5); // line 20: after rule2 violation
+        Rule rule1 = new MockRule("rule1", "rule1", "msg", "rulesetname");
+        r.addRuleViolation(new ParametricRuleViolation<>(rule1, ctx, node1, rule1.getMessage()));
+
+        ctx.setSourceCodeFilename("foo1"); // same file!!
+        Node node2 = getNode(10, 5); // line 10: before rule1 violation
+        Rule rule2 = new MockRule("rule2", "rule2", "msg", "rulesetname");
+        r.addRuleViolation(new ParametricRuleViolation<>(rule2, ctx, node2, rule2.getMessage()));
         Renderer rend = new XMLRenderer();
         String result = render(rend, r);
         assertTrue("sort order wrong", result.indexOf("rule2") < result.indexOf("rule1"));
@@ -172,8 +173,8 @@ public class ReportTest implements ThreadSafeReportListener {
         parent.testingOnlySetBeginLine(line);
         parent.testingOnlySetBeginColumn(column);
         s.jjtSetParent(parent);
-        s.testingOnlySetBeginLine(10);
-        s.testingOnlySetBeginColumn(5);
+        s.testingOnlySetBeginLine(line);
+        s.testingOnlySetBeginColumn(column);
         return s;
     }
 

--- a/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
@@ -202,12 +202,12 @@ public abstract class RuleTst {
         }
 
         List<Integer> expected = test.getExpectedLineNumbers();
-        if (report.getViolationTree().size() != expected.size()) {
+        if (report.size() != expected.size()) {
             throw new RuntimeException("Test setup error: number of execpted line numbers doesn't match "
                     + "number of violations for test case '" + test.getDescription() + "'");
         }
 
-        Iterator<RuleViolation> it = report.getViolationTree().iterator();
+        Iterator<RuleViolation> it = report.iterator();
         int index = 0;
         while (it.hasNext()) {
             RuleViolation violation = it.next();

--- a/pmd-test/src/test/java/net/sourceforge/pmd/testframework/RuleTstTest.java
+++ b/pmd-test/src/test/java/net/sourceforge/pmd/testframework/RuleTstTest.java
@@ -12,27 +12,39 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
+
+import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import net.sourceforge.pmd.Report;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleContext;
+import net.sourceforge.pmd.RuleViolation;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersion;
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.rule.ParametricRuleViolation;
+import net.sourceforge.pmd.test.lang.ast.DummyNode;
 
 public class RuleTstTest {
+    private LanguageVersion dummyLanguage = LanguageRegistry.findLanguageByTerseName("dummy").getDefaultVersion();
+
+    private Rule rule = mock(Rule.class);
+
+    private RuleTst ruleTester = new RuleTst() {
+    };
 
     @Test
     public void shouldCallStartAndEnd() {
-        RuleTst ruleTester = new RuleTst() {
-        };
-        LanguageVersion languageVersion = LanguageRegistry.findLanguageByTerseName("dummy").getDefaultVersion();
         Report report = new Report();
-        Rule rule = mock(Rule.class);
-        when(rule.getLanguage()).thenReturn(languageVersion.getLanguage());
+        when(rule.getLanguage()).thenReturn(dummyLanguage.getLanguage());
         when(rule.getName()).thenReturn("test rule");
 
-        ruleTester.runTestFromString("the code", rule, report, languageVersion, false);
+        ruleTester.runTestFromString("the code", rule, report, dummyLanguage, false);
 
         verify(rule).start(any(RuleContext.class));
         verify(rule).end(any(RuleContext.class));
@@ -47,5 +59,41 @@ public class RuleTstTest {
         verify(rule, times(4)).getName();
         verify(rule).getPropertiesByPropertyDescriptor();
         verifyNoMoreInteractions(rule);
+    }
+
+    @Test
+    public void shouldAssertLinenumbersSorted() {
+        when(rule.getLanguage()).thenReturn(dummyLanguage.getLanguage());
+        when(rule.getName()).thenReturn("test rule");
+        Mockito.doAnswer(new Answer<Void>() {
+            private RuleViolation createViolation(RuleContext context, int beginLine, String message) {
+                DummyNode node = new DummyNode(1);
+                node.testingOnlySetBeginLine(beginLine);
+                node.testingOnlySetBeginColumn(1);
+                ParametricRuleViolation<Node> violation = new ParametricRuleViolation<Node>(rule, context, node, message);
+                return violation;
+            }
+
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                RuleContext context = invocation.getArgumentAt(1, RuleContext.class);
+                // the violations are reported out of order
+                context.getReport().addRuleViolation(createViolation(context, 15, "first reported violation"));
+                context.getReport().addRuleViolation(createViolation(context, 5, "second reported violation"));
+                return null;
+            }
+        }).when(rule).apply(Mockito.anyList(), Mockito.any(RuleContext.class));
+
+        TestDescriptor testDescriptor = new TestDescriptor("the code", "sample test", 2, rule, dummyLanguage);
+        testDescriptor.setReinitializeRule(false);
+        testDescriptor.setExpectedLineNumbers(Arrays.asList(5, 15));
+
+        try {
+            ruleTester.runTest(testDescriptor);
+            // there should be no assertion failures
+            // expected line numbers and actual line numbers match
+        } catch (AssertionError assertionError) {
+            Assert.fail(assertionError.toString());
+        }
     }
 }


### PR DESCRIPTION
Fixes #1191

It turned out, we were already sorting (Report.violations is a sorted list), but not using it for assertLinenumbers...

I've seen, that ReportTree is not used anymore by us... Should we mark this as deprecated and remove it with PMD 7?