### PR TITLE
[jsp] #1276 add support for jspf and tag extensions

### DIFF
--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/cpd/JSPLanguage.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/cpd/JSPLanguage.java
@@ -6,6 +6,6 @@ package net.sourceforge.pmd.cpd;
 
 public class JSPLanguage extends AbstractLanguage {
     public JSPLanguage() {
-        super("JSP", "jsp", new JSPTokenizer(), ".jsp", ".jspx");
+        super("JSP", "jsp", new JSPTokenizer(), ".jsp", ".jspx", ".jspf", ".tag");
     }
 }

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/JspLanguageModule.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/JspLanguageModule.java
@@ -16,7 +16,7 @@ public class JspLanguageModule extends BaseLanguageModule {
     public static final String TERSE_NAME = "jsp";
 
     public JspLanguageModule() {
-        super(NAME, "JSP", TERSE_NAME, JspRuleChainVisitor.class, "jsp");
+        super(NAME, "JSP", TERSE_NAME, JspRuleChainVisitor.class, "jsp", "jspx", "jspf", "tag");
         addVersion("", new JspHandler(), true);
     }
 }

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/JspParserTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/JspParserTest.java
@@ -4,12 +4,16 @@
 
 package net.sourceforge.pmd.lang.jsp;
 
+import java.io.File;
 import java.io.StringReader;
+import java.nio.file.Paths;
 
 import org.junit.Assert;
 import org.junit.Test;
 
 import net.sourceforge.pmd.lang.LanguageRegistry;
+import net.sourceforge.pmd.lang.LanguageVersion;
+import net.sourceforge.pmd.lang.LanguageVersionDiscoverer;
 import net.sourceforge.pmd.lang.LanguageVersionHandler;
 import net.sourceforge.pmd.lang.Parser;
 import net.sourceforge.pmd.lang.ast.Node;
@@ -38,6 +42,28 @@ public class JspParserTest {
         Node node = parse(
                 "<label><input type='checkbox' checked name=cheese disabled=''> Cheese</label>");
         Assert.assertNotNull(node);
+    }
+
+    @Test
+    public void testParseJsp() {
+        testInternalJspFile(Paths.get("sample.jsp").toFile());
+    }
+
+    @Test
+    public void testParseTag() {
+        testInternalJspFile(Paths.get("sample.tag").toFile());
+    }
+
+    @Test(expected = AssertionError.class)
+    public void testParseWrong() {
+        testInternalJspFile(Paths.get("sample.xxx").toFile());
+    }
+
+    private void testInternalJspFile(File jspFile) {
+        LanguageVersionDiscoverer discoverer = new LanguageVersionDiscoverer();
+        LanguageVersion languageVersion = discoverer.getDefaultLanguageVersionForFile(jspFile);
+        Assert.assertEquals("LanguageVersion must be JSP!",
+                LanguageRegistry.getLanguage(JspLanguageModule.NAME).getDefaultVersion(), languageVersion);
     }
 
     private Node parse(String code) {


### PR DESCRIPTION
**PR Description:**
Pmd-Jsp only support .jsp files but .jspf (jsp fragment) and also .tag extensions are valid
Both extensions are mentioned in sections E.16.48 and JSP.1.1.8 of the JSP spec http://download.oracle.com/otn-pub/jcp/jsp-2_3-mrel2-eval-spec/JSP2.3MR.pdf

Resolves #1276 