### PR TITLE
Test Framework: Only show "Unit Tests" node, if there are unit tests

### DIFF
--- a/pmd-test/src/main/java/net/sourceforge/pmd/testframework/PMDTestRunner.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/testframework/PMDTestRunner.java
@@ -23,13 +23,13 @@ import org.junit.runners.model.InitializationError;
  * A JUnit Runner, that combines the default {@link JUnit4}
  * and our custom {@link RuleTestRunner}.
  * It allows to selectively execute single test cases (it is {@link Filterable}).
- * 
+ *
  * <p>Note: Since we actually run two runners one after another, the static {@code BeforeClass}
  * and {@Code AfterClass} methods will be executed twice and the test class will be instantiated twice, too.</p>
  *
  * <p>In order to use it, you'll need to subclass {@link SimpleAggregatorTst} and
  * annotate your test class with RunWith:</p>
- * 
+ *
  * <pre>
  * &#64;RunWith(PMDTestRunner.class)
  * public class MyRuleSetTest extends SimpleAggregatorTst {
@@ -78,7 +78,9 @@ public class PMDTestRunner extends Runner implements Filterable, Sortable {
     public Description getDescription() {
         Description description = Description.createSuiteDescription(klass);
         description.addChild(createChildrenDescriptions(ruleTests, "Rule Tests"));
-        description.addChild(createChildrenDescriptions(unitTests, "Unit Tests"));
+        if (ruleTests.hasUnitTests()) {
+            description.addChild(createChildrenDescriptions(unitTests, "Unit Tests"));
+        }
         return description;
     }
 


### PR DESCRIPTION
This is a small improvements on how the JUnit Tests are reported in Eclipse:

Before:
![pmd-test-runner-before](https://user-images.githubusercontent.com/1573684/43678702-d259b3ee-9818-11e8-9770-f9de816238e7.png)

After:
![pmd-test-runner-after](https://user-images.githubusercontent.com/1573684/43678704-d67141d6-9818-11e8-9765-8f4fd538281f.png)

So, if there are no unit tests on a test class (just rule tests), then there is no empty node "Unit Tests" anymore, and the class is completely green.