### PR TITLE
[java] UselessParentheses: Fix false positive with assignments

### DIFF
--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1769,6 +1769,7 @@ public class Foo {
     [not(./CastExpression)]
     [not(./ConditionalExpression)]
     [not(./AdditiveExpression)]
+    [not(./AssignmentOperator)]
 |
 //Expression[not(parent::PrimaryPrefix)]/PrimaryExpression[count(*)=1]
   /PrimaryPrefix/Expression

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UselessParentheses.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UselessParentheses.xml
@@ -486,4 +486,20 @@ public class Test {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[java] False positive "UselessParentheses" for parentheses that contain assignment #1285</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Test {
+    public void test() {
+        Pattern p;
+        Matcher m;
+        if ((m = p.matcher("hello world")).matches()) {
+            System.out.println("Hello world");
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
…arentheses in condition statement.

This PR passes the checks mentioned.
NOTE: I have not performed a full build of root module, as this requires JavaFX. (I am currently running OpenJDK without having a full JavaFX distribution available.) I have built, tested, pmd-checked, checkstyle-checked the 'pmd-java' module.
The fix consists only of XPath rule changes and subsequent test passes all other testcases, so I assume this is okay.

This fixes issue #1285, which I have also reported previously. I have added an XPath condition and a test-case to prove it works for a short piece of code which triggers the issue.