### PR TITLE
[java] [GSoC] Pmdtester test case - the PR may change the behavior of all java rules

### DIFF
--- a/.travis/build-deploy.sh
+++ b/.travis/build-deploy.sh
@@ -60,7 +60,7 @@ elif travis_isPullRequest; then
 	(
 	    set +e
 	    log_info "Running danger"
-	    bundle exec danger --verbose
+	    danger --verbose
 	)
 
 elif travis_isPush; then

--- a/.travis/build-deploy.sh
+++ b/.travis/build-deploy.sh
@@ -60,7 +60,7 @@ elif travis_isPullRequest; then
 	(
 	    set +e
 	    log_info "Running danger"
-	    danger --verbose
+	    bundle exec danger --verbose
 	)
 
 elif travis_isPush; then

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org/'
 
-gem 'pmdtester', '~> 1.0.0.pre.beta3'
+gem 'pmdtester', :git => 'git://github.com/pmd/pmd-regression-tester.git'
 gem 'danger', '~> 5.6', '>= 5.6'
 
 # This group is only needed for rendering release notes

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractAnyTypeDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractAnyTypeDeclaration.java
@@ -45,10 +45,11 @@ public abstract class AbstractAnyTypeDeclaration extends AbstractJavaAccessTypeN
     // TODO 7.0.0 move that up to ASTAnyTypeDeclaration
     public final boolean enclosingTypeIsA(TypeKind... kinds) {
 
-        ASTAnyTypeDeclaration parent = getEnclosingTypeDeclaration();
-        if (parent == null) {
+        if (!isNested()) {
             return false;
         }
+
+        ASTAnyTypeDeclaration parent = getEnclosingTypeDeclaration();
 
         for (TypeKind k : kinds) {
             if (parent.getTypeKind() == k) {
@@ -71,7 +72,7 @@ public abstract class AbstractAnyTypeDeclaration extends AbstractJavaAccessTypeN
         }
         Node parent = getNthParent(3);
 
-        return parent instanceof ASTAnyTypeDeclaration ? (ASTAnyTypeDeclaration) parent : null;
+        return parent instanceof ASTAnyTypeDeclaration ? (ASTAnyTypeDeclaration) getNthParent(3) : null;
     }
 
     @Override


### PR DESCRIPTION
The PR should not be merged and is a test case for [pmdtester](https://github.com/pmd/pmd-regression-tester). This test case is mainly used to test whether pmdtester works fine when PR may change all java rules and may introduce new PMD error.
*Expected base ruleset:* all java ruleset
*Expected patch ruleset:* all java ruleset
*Expected new PMD error:* `java.lang.NullPointerException at net.sourceforge.pmd.lang.java.ast.AbstractAnyTypeDeclaration.enclosingTypeIsA(AbstractAnyTypeDeclaration.java:55)`