### PR TITLE
[java] Add rule for field naming conventions

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -31,6 +31,10 @@ This is a minor release.
     enforces a naming convention for "for loops". Both "cursor for loops" and "index for loops" are covered.
     The rule can be customized via patterns. By default, short variable names are reported.
 
+*   The new Java rule [`FieldNamingConventions`](pmd_rules_java_codestyle.html#fieldnamingconventions) (`java-codestyle`)
+    detects field names that don't comply to a given convention. It defaults to standard Java convention of using camelCase,
+    but can be configured with ease for e.g. constants or static fields.
+
 ### Fixed Issues
 
 *   core

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassOrInterfaceBody.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassOrInterfaceBody.java
@@ -5,6 +5,16 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Represents the body of a {@linkplain ASTClassOrInterfaceDeclaration class or interface declaration}.
+ * This includes anonymous classes, including those defined within an {@linkplain ASTEnumConstant enum constant}.
+ *
+ * <pre>
+ *
+ * ClassOrInterfaceBody ::=  "{"  {@linkplain ASTClassOrInterfaceBodyDeclaration ClassOrInterfaceBodyDeclaration}* "}"
+ *
+ * </pre>
+ */
 public class ASTClassOrInterfaceBody extends AbstractJavaNode {
     public ASTClassOrInterfaceBody(int id) {
         super(id);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassOrInterfaceDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassOrInterfaceDeclaration.java
@@ -13,17 +13,17 @@ import net.sourceforge.pmd.util.CollectionUtil;
 
 
 /**
- * Represents class and interface declarations.
+ * Represents class and interface declarations. This is a {@linkplain Node#isFindBoundary() find boundary}
+ * for tree traversal methods.
  *
  * <pre>
  *
- * ClassOrInterfaceDeclaration ::=
- *          ( "class" | "interface" )
- *          &lt;IDENTIFIER&gt;
- *          [ TypeParameters ]
- *          [ ExtendsList ]
- *          [ ImplementsList ]
- *          ClassOrInterfaceBody
+ * ClassOrInterfaceDeclaration ::= ( "class" | "interface" )
+ *                                 &lt;IDENTIFIER&gt;
+ *                                 {@linkplain ASTTypeParameters TypeParameters}?
+ *                                 {@linkplain ASTExtendsList ExtendsList}?
+ *                                 {@linkplain ASTImplementsList ImplementsList}?
+ *                                 {@linkplain ASTClassOrInterfaceBody ClassOrInterfaceBody}
  * </pre>
  *
  */

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTEnumConstant.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTEnumConstant.java
@@ -8,6 +8,17 @@ package net.sourceforge.pmd.lang.java.ast;
 import net.sourceforge.pmd.lang.java.qname.JavaTypeQualifiedName;
 
 
+/**
+ * Represents an enum constant declaration within an {@linkplain ASTEnumDeclaration enum declaration}.
+ *
+ * <p>TODO since there's no VariableDeclaratorId, this might not play well with the symbol table!
+ *
+ * <pre>
+ *
+ * EnumConstant ::= &lt;IDENTIFIER&gt; {@linkplain ASTArguments Arguments}? {@linkplain ASTClassOrInterfaceBody ClassOrInterfaceBody}?
+ *
+ * </pre>
+ */
 public class ASTEnumConstant extends AbstractJavaNode implements JavaQualifiableNode {
 
     private JavaTypeQualifiedName qualifiedName;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFieldDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFieldDeclaration.java
@@ -5,10 +5,37 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import java.util.Iterator;
+
+import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.ast.SignedNode;
 import net.sourceforge.pmd.lang.java.multifile.signature.JavaFieldSignature;
 
-public class ASTFieldDeclaration extends AbstractJavaAccessTypeNode implements Dimensionable, SignedNode<ASTFieldDeclaration> {
+
+/**
+ * Represents a field declaration in the body of a type declaration.
+ *
+ * <p>This statement may define several variables, possibly of different types (see {@link ASTVariableDeclaratorId#getType()}).
+ * The nodes corresponding to the declared variables are accessible through {@link #iterator()}.
+ *
+ * <p>{@link AccessNode} methods take into account the syntactic context of the
+ * declaration, e.g. {@link #isPublic()} will always return true if the field is
+ * declared inside an interface, regardless of whether the {@code public} modifier
+ * was specified or not. If you want to know whether the modifier was explicitly
+ * stated, use e.g {@link #isSyntacticallyPublic()}.
+ *
+ * <pre>
+ *
+ * FieldDeclaration ::= Modifiers {@linkplain ASTType Type} {@linkplain ASTVariableDeclarator VariableDeclarator} ( "," {@linkplain ASTVariableDeclarator VariableDeclarator} )*
+ *
+ * Modifiers        ::= "public" | "static" | "protected" | "private"
+ *                    | "final"  | "abstract" | "synchronized"
+ *                    | "native" | "transient" | "volatile" | "strictfp"
+ *                    | "default"  | {@linkplain ASTAnnotation Annotation}
+ *
+ * </pre>
+ */
+public class ASTFieldDeclaration extends AbstractJavaAccessTypeNode implements Dimensionable, SignedNode<ASTFieldDeclaration>, Iterable<ASTVariableDeclaratorId> {
 
     private JavaFieldSignature signature;
 
@@ -151,5 +178,40 @@ public class ASTFieldDeclaration extends AbstractJavaAccessTypeNode implements D
         }
 
         return signature;
+    }
+
+
+    /**
+     * Returns an iterator over the ids of the fields
+     * declared in this statement.
+     */
+    @Override
+    public Iterator<ASTVariableDeclaratorId> iterator() {
+        return iterateIds(this);
+    }
+
+
+    /* only for LocalVarDeclaration */ static Iterator<ASTVariableDeclaratorId> iterateIds(Node parent) {
+        // TODO this can be made clearer with iterator mapping (Java 8)
+        final Iterator<ASTVariableDeclarator> declarators = new NodeChildrenIterator<>(parent, ASTVariableDeclarator.class);
+
+        return new Iterator<ASTVariableDeclaratorId>() {
+            @Override
+            public boolean hasNext() {
+                return declarators.hasNext();
+            }
+
+
+            @Override
+            public ASTVariableDeclaratorId next() {
+                return declarators.next().getVariableId();
+            }
+
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        };
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLocalVariableDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLocalVariableDeclaration.java
@@ -18,11 +18,11 @@ import net.sourceforge.pmd.Rule;
  * <p>This statement may define several variables, possibly of different types (see {@link ASTVariableDeclaratorId#getType()}).
  * The nodes corresponding to the declared variables are accessible through {@link #iterator()}.
  *
- * <p>
+ * <pre>
  *
- * LocalVariableDeclaration ::=  ( "final" | {@linkplain ASTAnnotation Annotation} )* {@linkplain ASTType Type} {@linkplain ASTVariableDeclarator VariableDeclarator} ( "," {@linkplain ASTVariableDeclarator VariableDeclarator} )*
+ * LocalVariableDeclaration ::= ( "final" | {@linkplain ASTAnnotation Annotation} )* {@linkplain ASTType Type} {@linkplain ASTVariableDeclarator VariableDeclarator} ( "," {@linkplain ASTVariableDeclarator VariableDeclarator} )*
  *
- * </p>
+ * </pre>
  */
 public class ASTLocalVariableDeclaration extends AbstractJavaAccessNode implements Dimensionable, CanSuppressWarnings, Iterable<ASTVariableDeclaratorId> {
 
@@ -127,6 +127,6 @@ public class ASTLocalVariableDeclaration extends AbstractJavaAccessNode implemen
      */
     @Override
     public Iterator<ASTVariableDeclaratorId> iterator() {
-        return new NodeChildrenIterator<>(this, ASTVariableDeclaratorId.class);
+        return ASTFieldDeclaration.iterateIds(this);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclarator.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclarator.java
@@ -5,25 +5,66 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * Groups a variable ID and its initializer if it exists.
+ * May be found as a child of {@linkplain ASTFieldDeclaration field declarations} and
+ * {@linkplain ASTLocalVariableDeclaration local variable declarations}.
+ *
+ * <pre>
+ *
+ * VariableDeclarator ::= {@linkplain ASTVariableDeclaratorId VariableDeclaratorId} ( "=" {@linkplain ASTVariableInitializer VariableInitializer} )?
+ *
+ * </pre>
+ */
 public class ASTVariableDeclarator extends AbstractJavaTypeNode {
     public ASTVariableDeclarator(int id) {
         super(id);
     }
 
+
     public ASTVariableDeclarator(JavaParser p, int id) {
         super(p, id);
     }
 
-    /**
-     * Accept the visitor. *
-     */
+
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
     }
 
+
+    /**
+     * Returns the name of the declared variable.
+     */
     public String getName() {
         // first child will be VariableDeclaratorId
         return jjtGetChild(0).getImage();
     }
+
+
+    /**
+     * Returns the id of the declared variable.
+     */
+    public ASTVariableDeclaratorId getVariableId() {
+        return (ASTVariableDeclaratorId) jjtGetChild(0);
+    }
+
+
+    /**
+     * Returns true if the declared variable is initialized.
+     * Otherwise, {@link #getInitializer()} returns null.
+     */
+    public boolean hasInitializer() {
+        return jjtGetNumChildren() > 1;
+    }
+
+
+    /**
+     * Returns the initializer, of the variable, or null if it doesn't exist.
+     */
+    public ASTVariableInitializer getInitializer() {
+        return hasInitializer() ? (ASTVariableInitializer) jjtGetChild(1) : null;
+    }
+
+
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldNamingConventionsRule.java
@@ -1,0 +1,95 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.codestyle;
+
+import java.util.regex.Pattern;
+
+import net.sourceforge.pmd.lang.java.ast.ASTEnumConstant;
+import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.RegexProperty;
+
+
+/**
+ * Configurable naming conventions for field declarations.
+ *
+ * @author Clément Fournier
+ * @since 6.7.0
+ */
+public class FieldNamingConventionsRule extends AbstractNamingConventionRule<ASTVariableDeclaratorId> {
+    private final RegexProperty constantFieldRegex = defaultProp("constant").defaultValue("[A-Z][A-Z_0-9]*").build();
+    private final RegexProperty enumConstantRegex = defaultProp("enum constant").defaultValue("[A-Z][A-Z_0-9]*").build();
+    private final RegexProperty finalFieldRegex = defaultProp("final field").build();
+    private final RegexProperty staticFieldRegex = defaultProp("static field").build();
+    private final RegexProperty defaultFieldRegex = defaultProp("defaultField", "field").build();
+
+
+    public FieldNamingConventionsRule() {
+        definePropertyDescriptor(constantFieldRegex);
+        definePropertyDescriptor(enumConstantRegex);
+        definePropertyDescriptor(finalFieldRegex);
+        definePropertyDescriptor(staticFieldRegex);
+        definePropertyDescriptor(defaultFieldRegex);
+
+        addRuleChainVisit(ASTFieldDeclaration.class);
+        addRuleChainVisit(ASTEnumConstant.class);
+    }
+
+
+    @Override
+    public Object visit(ASTFieldDeclaration node, Object data) {
+
+        for (ASTVariableDeclaratorId id : node) {
+            if (node.isFinal() && node.isStatic()) {
+                checkMatches(id, constantFieldRegex, data);
+            } else if (node.isFinal()) {
+                checkMatches(id, finalFieldRegex, data);
+            } else if (node.isStatic()) {
+                checkMatches(id, staticFieldRegex, data);
+            } else {
+                checkMatches(id, defaultFieldRegex, data);
+            }
+        }
+        return data;
+    }
+
+
+    @Override
+    public Object visit(ASTEnumConstant node, Object data) {
+        // This inlines checkMatches because there's no variable declarator id
+
+        if (!getProperty(enumConstantRegex).matcher(node.getImage()).matches()) {
+            addViolation(data, node, new Object[]{
+                    "enum constant",
+                    node.getImage(),
+                    getProperty(enumConstantRegex).toString(),
+            });
+        }
+
+        return data;
+    }
+
+
+    @Override
+    String defaultConvention() {
+        return CAMEL_CASE;
+    }
+
+
+    @Override
+    String kindDisplayName(ASTVariableDeclaratorId node, PropertyDescriptor<Pattern> descriptor) {
+        ASTFieldDeclaration field = (ASTFieldDeclaration) node.getNthParent(2);
+
+        if (field.isFinal()) {
+            return field.isStatic() ? "constant" : "final field";
+        } else if (field.isStatic()) {
+            return "static field";
+        } else {
+            return "field";
+        }
+    }
+
+}

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -687,6 +687,43 @@ public class HelloWorldBean {
         </example>
     </rule>
 
+
+    <rule name="FieldNamingConventions"
+          since="6.7.0"
+          message="The {0} name ''{1}'' doesn''t match ''{2}''"
+          class="net.sourceforge.pmd.lang.java.rule.codestyle.FieldNamingConventionsRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#fieldnamingconventions">
+        <description>
+            Configurable naming conventions for field declarations. This rule reports variable declarations
+            which do not match the regex that applies to their specific kind ---e.g. constants (static final),
+            enum constant, final field. Each regex can be configured through properties.
+
+            By default this rule uses the standard Java naming convention (Camel case), and uses the ALL_UPPER
+            convention for constants and enum constants.
+        </description>
+        <priority>1</priority>
+        <example>
+            <![CDATA[
+            class Foo {
+                int myField = 1; // This is in camel case, so it's ok
+                int my_Field = 1; // This contains an underscore, it's not ok by default
+                                  // but you may allow it, or even require the "my_" prefix
+
+                final int FinalField = 1; // you may configure a different convention for final fields,
+                                          // e.g. here PascalCase: [A-Z][a-zA-Z0-9]*
+
+                interface Interface {
+                    double PI = 3.14; // interface "fields" use the constantPattern property
+                }
+
+                enum AnEnum {
+                    ORG, NET, COM; // These use a separate property but are set to ALL_UPPER by default
+                }
+            }
+            ]]>
+        </example>
+    </rule>
+
     <rule name="ForLoopShouldBeWhileLoop"
           language="java"
           since="1.02"

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/FieldNamingConventions.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/FieldNamingConventions.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+    <test-code>
+        <description>Test property defaults</description>
+        <expected-problems>4</expected-problems>
+        <expected-messages>
+            <message>The field name 'Foo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The final field name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The static field name 'Bar' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The constant name 'BOLGaaa_FIELD' doesn't match '[A-Z][A-Z_0-9]*'</message>
+        </expected-messages>
+        <code><![CDATA[
+            public class Bar {
+
+                int Foo;
+                final int Hoo;
+                static int Bar;
+                static final int BOLGaaa_FIELD;
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Test default field property</description>
+        <rule-property name="defaultFieldPattern">[A-Z][A-Z0-9]+</rule-property>
+        <expected-problems>3</expected-problems>
+        <expected-messages>
+            <message>The field name 'Foo' doesn't match '[A-Z][A-Z0-9]+'</message>
+            <message>The final field name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The static field name 'Bar' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+        </expected-messages>
+        <code><![CDATA[
+            public class Bar {
+
+                int Foo;
+                final int Hoo;
+                static int Bar;
+                static final int BOLG_FIELD;
+
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Test final field property</description>
+        <rule-property name="finalFieldPattern">[A-Z][A-Z0-9]+</rule-property>
+        <expected-problems>3</expected-problems>
+        <expected-messages>
+            <message>The field name 'Foo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The final field name 'Hoo' doesn't match '[A-Z][A-Z0-9]+'</message>
+            <message>The static field name 'Bar' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+        </expected-messages>
+        <code><![CDATA[
+            public class Bar {
+
+                int Foo;
+                final int Hoo;
+                static int Bar;
+                static final int BOLG_FIELD;
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Test static field property</description>
+        <rule-property name="staticFieldPattern">[A-Z][A-Z0-9]+</rule-property>
+        <expected-problems>3</expected-problems>
+        <expected-messages>
+            <message>The field name 'Foo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The final field name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The static field name 'Bar' doesn't match '[A-Z][A-Z0-9]+'</message>
+        </expected-messages>
+        <code><![CDATA[
+            public class Bar {
+
+                int Foo;
+                final int Hoo;
+                static int Bar;
+                static final int BOLG_FIELD;
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Test constant field property</description>
+        <rule-property name="constantPattern">cons_[A-Z][A-Z0-9]+</rule-property>
+        <expected-problems>4</expected-problems>
+        <expected-messages>
+            <message>The field name 'Foo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The final field name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The static field name 'Bar' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The constant name 'BOLG_FIELD' doesn't match 'cons_[A-Z][A-Z0-9]+'</message>
+        </expected-messages>
+        <code><![CDATA[
+            public class Bar {
+
+                int Foo;
+                final int Hoo;
+                static int Bar;
+                static final int BOLG_FIELD;
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Test enum constant property</description>
+        <rule-property name="enumConstantPattern">cons_[A-Z][A-Z0-9]+</rule-property>
+        <expected-problems>2</expected-problems>
+        <expected-messages>
+            <message>The enum constant name 'NET' doesn't match 'cons_[A-Z][A-Z0-9]+'</message>
+            <message>The enum constant name 'ORG' doesn't match 'cons_[A-Z][A-Z0-9]+'</message>
+        </expected-messages>
+        <code><![CDATA[
+            public class Bar {
+
+                enum AnEnum {
+                    ORG, NET, cons_COM;
+                }
+
+            }
+            ]]></code>
+    </test-code>
+
+
+
+    <test-code>
+        <description>Interface fields should be treated like constants</description>
+        <expected-problems>3</expected-problems>
+        <expected-messages>
+            <message>The constant name 'Foo' doesn't match '[A-Z][A-Z_0-9]*'</message>
+            <message>The constant name 'Hoo' doesn't match '[A-Z][A-Z_0-9]*'</message>
+            <message>The constant name 'Bar' doesn't match '[A-Z][A-Z_0-9]*'</message>
+        </expected-messages>
+        <code><![CDATA[
+            public interface Bar {
+
+                int Foo;
+                final int Hoo;
+                static int Bar;
+                static final int BOLG_FIELD;
+            }
+            ]]></code>
+    </test-code>
+
+</test-data>


### PR DESCRIPTION
This is the last major item on #972. With it, VariableNamingConventions can finally be deprecated 

I'm leaving deprecating the older rules and generalising GenericsNaming for other small PRs, which I'll try to put up shortly