### PR TITLE
[java] Deprecate old naming conventions rules

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -51,6 +51,17 @@ This is a minor release.
 
 ### API Changes
 
+#### Deprecated rules
+
+*   The Java rules [`VariableNamingConventions`](pmd_rules_java_codestyle.html#variablenamingconventions),
+    [`MIsLeadingVariableName`](pmd_rules_java_codestyle.html#misleadingvariablename),
+    [`SuspiciousConstantFieldName`](pmd_rules_java_codestyle.html#suspiciousconstantfieldname),
+    and [`AvoidPrefixingMethodParameters`](pmd_rules_java_codestyle.html#avoidprefixingmethodparameters) are now deprecated,
+    and will be removed with version 7.0.0. They are replaced by the more general
+    [`FieldNamingConventions`](pmd_rules_java_codestyle.html#fieldnamingconventions),
+    [`FormalParameterNamingConventions`](pmd_rules_java_codestyle.html#formalparameternamingconventions), and
+    [`LocalVariableNamingConventions`](pmd_rules_java_codestyle.html#localvariablenamingconventions).
+
 ### External Contributions
 
 *   [#109](https://github.com/pmd/pmd/pull/109): \[java] Add two linguistics rules under naming - [Arda Aslan](https://github.com/ardaasln)

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/VariableNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/VariableNamingConventionsRule.java
@@ -23,6 +23,7 @@ import net.sourceforge.pmd.properties.BooleanProperty;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.StringMultiProperty;
 
+@Deprecated
 public class VariableNamingConventionsRule extends AbstractJavaRule {
 
     private boolean checkMembers;

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -126,6 +126,7 @@ public class MyClass {
     <rule name="AvoidPrefixingMethodParameters"
           language="java"
           since="5.0"
+          deprecated="true"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           message="Avoid prefixing parameters by in, out or inOut. Uses Javadoc to document this behavior."
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#avoidprefixingmethodparameters">
@@ -1257,6 +1258,7 @@ public class Foo {
     <rule name="MIsLeadingVariableName"
           language="java"
           since="3.4"
+          deprecated="true"
           message="Avoid naming non-fields with the prefix 'm_'"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#misleadingvariablename">
@@ -1579,6 +1581,7 @@ public class Something {
     <rule name="SuspiciousConstantFieldName"
           language="java"
           since="2.0"
+          deprecated="true"
           message="The field name indicates a constant but its modifiers do not"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#suspiciousconstantfieldname">
@@ -1955,6 +1958,7 @@ public class Foo {
 
     <rule name="VariableNamingConventions"
           since="1.2"
+          deprecated="true"
           message="{0} variable {1} should begin with {2}"
           class="net.sourceforge.pmd.lang.java.rule.codestyle.VariableNamingConventionsRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#variablenamingconventions">


### PR DESCRIPTION
This is part of #972, and should be merged with #1296 

I think, it may be good to have an idiom to link to a rule in markdown, eg a Liquid tag `{% rule 'java/codestyle/VariableNamingConventions' %}`