### PR TITLE
[core] Deprecate ReportTree

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -35,6 +35,7 @@ This is a minor release.
 
 *   core
     *   [#1191](https://github.com/pmd/pmd/issues/1191): \[core] Test Framework: Sort violations by line/column
+    *   [#1283](https://github.com/pmd/pmd/issues/1283): \[core] Deprecate ReportTree
     *   [#1288](https://github.com/pmd/pmd/issues/1288): \[core] No supported build listeners found with Gradle
     *   [#1300](https://github.com/pmd/pmd/issues/1300): \[core] PMD stops processing file completely, if one rule in a rule chain fails
 *   java-bestpractices
@@ -53,6 +54,11 @@ This is a minor release.
     *   [#681](https://github.com/pmd/pmd/issues/681): \[plsql] Parse error with Cursor For Loop
 
 ### API Changes
+
+*   All classes in the package `net.sourceforge.pmd.lang.dfa.report` have been deprecated and will be removed
+    with PMD 7.0.0. This includes the class `net.sourceforge.pmd.lang.dfa.report.ReportTree`. The reason is,
+    that this class is very specific to Java and not suitable for other languages. It has only been used for
+    `YAHTMLRenderer`, which has been rewritten to work without these classes.
 
 ### External Contributions
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/dfa/report/AbstractReportNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/dfa/report/AbstractReportNode.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.dfa.report;
 import java.util.ArrayList;
 import java.util.List;
 
+@Deprecated // will be removed with PMD 7.0.0 without replacement. See net.sourceforge.pmd.lang.dfa.report.ReportTree for details.
 public abstract class AbstractReportNode {
     private List<AbstractReportNode> childNodes = new ArrayList<>();
     private AbstractReportNode parentNode = null;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/dfa/report/ClassNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/dfa/report/ClassNode.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.dfa.report;
 
+@Deprecated // will be removed with PMD 7.0.0 without replacement. See net.sourceforge.pmd.lang.dfa.report.ReportTree for details.
 public class ClassNode extends AbstractReportNode {
 
     private String className;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/dfa/report/PackageNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/dfa/report/PackageNode.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.dfa.report;
 
+@Deprecated // will be removed with PMD 7.0.0 without replacement. See net.sourceforge.pmd.lang.dfa.report.ReportTree for details.
 public class PackageNode extends AbstractReportNode {
 
     private String packageName;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/dfa/report/ReportHTMLPrintVisitor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/dfa/report/ReportHTMLPrintVisitor.java
@@ -25,6 +25,7 @@ import net.sourceforge.pmd.RuleViolation;
  *
  * @author raik
  */
+@Deprecated // will be removed with PMD 7.0.0 without replacement. See net.sourceforge.pmd.lang.dfa.report.ReportTree for details.
 public class ReportHTMLPrintVisitor extends ReportVisitor {
 
     @SuppressWarnings("PMD.AvoidStringBufferField")

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/dfa/report/ReportTree.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/dfa/report/ReportTree.java
@@ -8,6 +8,14 @@ import java.util.Iterator;
 
 import net.sourceforge.pmd.RuleViolation;
 
+/**
+ *
+ * @deprecated This class will be removed with PMD 7.0.0 without replacement.
+ * It is very specific for Java as it tries to recreate the package hierarchy
+ * of the analyzed classes and put the found violations in there.
+ * So it is of limited use for any other language.
+ */
+@Deprecated // will be removed with PMD 7.0.0 without replacement
 public class ReportTree implements Iterable<RuleViolation> {
 
     private PackageNode rootNode = new PackageNode("");

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/dfa/report/ReportVisitor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/dfa/report/ReportVisitor.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.dfa.report;
 
+@Deprecated // will be removed with PMD 7.0.0 without replacement. See net.sourceforge.pmd.lang.dfa.report.ReportTree for details.
 public abstract class ReportVisitor {
 
     public void visit(AbstractReportNode node) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/dfa/report/ViolationNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/dfa/report/ViolationNode.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.dfa.report;
 
 import net.sourceforge.pmd.RuleViolation;
 
+@Deprecated // will be removed with PMD 7.0.0 without replacement. See net.sourceforge.pmd.lang.dfa.report.ReportTree for details.
 public class ViolationNode extends AbstractReportNode {
 
     private RuleViolation ruleViolation;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/YAHTMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/YAHTMLRenderer.java
@@ -4,11 +4,20 @@
 
 package net.sourceforge.pmd.renderers;
 
+import java.io.File;
+import java.io.FileWriter;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+import org.apache.commons.lang3.StringUtils;
 
 import net.sourceforge.pmd.PMD;
-import net.sourceforge.pmd.lang.dfa.report.ReportHTMLPrintVisitor;
-import net.sourceforge.pmd.lang.dfa.report.ReportTree;
+import net.sourceforge.pmd.RuleViolation;
 import net.sourceforge.pmd.properties.StringProperty;
 
 /**
@@ -17,8 +26,9 @@ import net.sourceforge.pmd.properties.StringProperty;
 public class YAHTMLRenderer extends AbstractAccumulatingRenderer {
 
     public static final String NAME = "yahtml";
-
     public static final StringProperty OUTPUT_DIR = new StringProperty("outputDir", "Output directory.", null, 0);
+
+    private SortedMap<String, ReportNode> reportNodesByPackage = new TreeMap<>();
 
     public YAHTMLRenderer() {
         // YA = Yet Another?
@@ -31,12 +41,211 @@ public class YAHTMLRenderer extends AbstractAccumulatingRenderer {
         return "html";
     }
 
+    private void addViolation(RuleViolation violation) {
+        String packageName = violation.getPackageName();
+
+        // report each part of the package name: e.g. net.sf.pmd.test will create nodes for
+        // net, net.sf, net.sf.pmd, and net.sf.pmd.test
+        int index = packageName.indexOf('.', 0);
+        while (index > -1) {
+            String currentPackage = packageName.substring(0, index);
+            ReportNode reportNode = reportNodesByPackage.get(currentPackage);
+            if (reportNode == null) {
+                reportNode = new ReportNode(currentPackage);
+                reportNodesByPackage.put(currentPackage, reportNode);
+            }
+            reportNode.incrementViolations();
+
+            int oldIndex = index;
+            index = packageName.indexOf('.', index + 1);
+            if (index == -1 && oldIndex != packageName.length()) {
+                index = packageName.length();
+            }
+        }
+
+        // add one node per class collecting the actual violations
+        String fqClassName = packageName + "." + violation.getClassName();
+        ReportNode classNode = reportNodesByPackage.get(fqClassName);
+        if (classNode == null) {
+            classNode = new ReportNode(packageName, violation.getClassName());
+            reportNodesByPackage.put(fqClassName, classNode);
+        }
+        classNode.addRuleViolation(violation);
+
+        // count the overall violations in the root node
+        ReportNode rootNode = reportNodesByPackage.get(ReportNode.ROOT_NODE_NAME);
+        if (rootNode == null) {
+            rootNode = new ReportNode("Aggregate");
+            reportNodesByPackage.put(ReportNode.ROOT_NODE_NAME, rootNode);
+        }
+        rootNode.incrementViolations();
+    }
+
     @Override
     public void end() throws IOException {
         String outputDir = getProperty(OUTPUT_DIR);
-        ReportTree tree = report.getViolationTree();
-        tree.getRootNode().accept(new ReportHTMLPrintVisitor(outputDir == null ? ".." : outputDir));
+
+        Iterator<RuleViolation> violations = report.iterator();
+        while (violations.hasNext()) {
+            addViolation(violations.next());
+        }
+
+        renderIndex(outputDir);
+        renderClasses(outputDir);
+
         writer.write("<h3 align=\"center\">The HTML files are located "
                 + (outputDir == null ? "above the project directory" : "in '" + outputDir + '\'') + ".</h3>" + PMD.EOL);
+    }
+
+    private void renderIndex(String outputDir) throws IOException {
+        try (PrintWriter out = new PrintWriter(new FileWriter(new File(outputDir, "index.html")))) {
+            out.println("<html>");
+            out.println("    <head>");
+            out.println("        <title>PMD</title>");
+            out.println("    </head>");
+            out.println("    <body>");
+            out.println("    <h2>Package View</h2>");
+            out.println("    <table border=\"1\" align=\"center\" cellspacing=\"0\" cellpadding=\"3\">");
+            out.println("        <tr><th>Package</th><th>Class</th><th>#</th></tr>");
+
+            for (ReportNode node : reportNodesByPackage.values()) {
+                out.print("        <tr><td><b>");
+                out.print(node.getPackageName());
+                out.print("</b></td> <td>");
+                if (node.hasViolations()) {
+                    out.print("<a href=\"");
+                    out.print(node.getClassName());
+                    out.print(".html");
+                    out.print("\">");
+                    out.print(node.getClassName());
+                    out.print("</a>");
+                } else {
+                    out.print(node.getClassName());
+                }
+                out.print("</td> <td>");
+                out.print(node.getViolationCount());
+                out.print("</td></tr>");
+                out.println();
+            }
+
+            out.println("    </table>");
+            out.println("    </body>");
+            out.println("</html>");
+        }
+    }
+
+    private void renderClasses(String outputDir) throws IOException {
+        for (ReportNode node : reportNodesByPackage.values()) {
+            if (node.hasViolations()) {
+                try (PrintWriter out = new PrintWriter(new FileWriter(new File(outputDir, node.getClassName() + ".html")))) {
+                    out.println("<html>");
+                    out.println("    <head>");
+                    out.print("        <title>PMD - ");
+                    out.print(node.getClassName());
+                    out.println("</title>");
+                    out.println("    </head>");
+                    out.println("    <body>");
+                    out.println("        <h2>Class View</h2>");
+                    out.print("        <h3 align=\"center\">Class: ");
+                    out.print(node.getClassName());
+                    out.println("</h3>");
+                    out.println("        <table border=\"\" align=\"center\" cellspacing=\"0\" cellpadding=\"3\">");
+                    out.println("        <tr><th>Method</th><th>Violation</th></tr>");
+                    for (RuleViolation violation : node.getViolations()) {
+                        out.print("        <tr><td>");
+                        out.print(violation.getMethodName());
+                        out.print("</td><td>");
+                        out.print("<table border=\"0\">");
+
+                        out.print(renderViolationRow("Rule:", violation.getRule().getName()));
+                        out.print(renderViolationRow("Description:", violation.getDescription()));
+
+                        if (StringUtils.isNotBlank(violation.getVariableName())) {
+                            out.print(renderViolationRow("Variable:", violation.getVariableName()));
+                        }
+
+                        out.print(renderViolationRow("Line:", violation.getEndLine() > 0
+                                ? violation.getBeginLine() + " and " + violation.getEndLine()
+                                : String.valueOf(violation.getBeginLine())));
+
+                        out.print("</table>");
+
+                        out.print("</td></tr>");
+                        out.println();
+                    }
+                    out.println("        </table>");
+                    out.println("    </body>");
+                    out.println("</html>");
+                }
+            }
+        }
+    }
+
+    private String renderViolationRow(String name, String value) {
+        StringBuilder row = new StringBuilder(40 + name.length() + value.length());
+        row.append("<tr><td><b>")
+            .append(name)
+            .append("</b></td>")
+            .append("<td>")
+            .append(value)
+            .append("</td></tr>");
+        return row.toString();
+    }
+
+    private static class ReportNode {
+        // deliberately starts with a space, so that it is sorted before the packages
+        private static final String ROOT_NODE_NAME = " <root> ";
+
+        private final String packageName;
+        private final String className;
+        private int violationCount;
+        private final List<RuleViolation> violations = new LinkedList<>();
+
+        ReportNode(String packageName) {
+            this.packageName = packageName;
+            this.className = "-";
+        }
+
+        ReportNode(String packageName, String className) {
+            this.packageName = packageName;
+            this.className = className;
+        }
+
+        public void incrementViolations() {
+            violationCount++;
+        }
+
+        public void addRuleViolation(RuleViolation violation) {
+            violations.add(violation);
+        }
+
+        public String getPackageName() {
+            return packageName;
+        }
+
+        public String getClassName() {
+            return className;
+        }
+
+        public int getViolationCount() {
+            return violationCount + violations.size();
+        }
+
+        public List<RuleViolation> getViolations() {
+            return violations;
+        }
+
+        public boolean hasViolations() {
+            return !violations.isEmpty();
+        }
+
+        @Override
+        public String toString() {
+            return "ReportNode[packageName=" + packageName
+                + ",className=" + className
+                + ",violationCount=" + violationCount
+                + ",violations=" + violations.size()
+                + "]";
+        }
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/AbstractRendererTst.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/AbstractRendererTst.java
@@ -37,7 +37,7 @@ public abstract class AbstractRendererTst {
     public String getExpectedError(ProcessingError error) {
         return "";
     }
-    
+
     public String getExpectedError(ConfigurationError error) {
         return "";
     }
@@ -68,7 +68,7 @@ public abstract class AbstractRendererTst {
         return report;
     }
 
-    private RuleViolation newRuleViolation(int endColumn) {
+    protected RuleViolation newRuleViolation(int endColumn) {
         DummyNode node = createNode(endColumn);
         RuleContext ctx = new RuleContext();
         ctx.setSourceCodeFilename(getSourceCodeFilename());
@@ -127,7 +127,7 @@ public abstract class AbstractRendererTst {
         String actual = ReportTest.render(getRenderer(), rep);
         assertEquals(filter(getExpectedError(err)), filter(actual));
     }
-    
+
     @Test
     public void testConfigError() throws Exception {
         Report rep = new Report();

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/YAHTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/YAHTMLRendererTest.java
@@ -4,15 +4,31 @@
 
 package net.sourceforge.pmd.renderers;
 
-import java.io.File;
-import java.io.IOException;
+import static org.junit.Assert.assertEquals;
 
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+
+import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Test;
 
+import net.sourceforge.pmd.FooRule;
 import net.sourceforge.pmd.PMD;
+import net.sourceforge.pmd.Report;
 import net.sourceforge.pmd.Report.ConfigurationError;
 import net.sourceforge.pmd.Report.ProcessingError;
+import net.sourceforge.pmd.ReportTest;
+import net.sourceforge.pmd.RuleContext;
+import net.sourceforge.pmd.RuleViolation;
+import net.sourceforge.pmd.lang.ast.DummyNode;
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.rule.ParametricRuleViolation;
 
 public class YAHTMLRendererTest extends AbstractRendererTst {
 
@@ -49,6 +65,50 @@ public class YAHTMLRendererTest extends AbstractRendererTst {
             }
         }
         dir.delete();
+    }
+
+    private RuleViolation newRuleViolation(int endColumn, final String packageNameArg, final String classNameArg) {
+        DummyNode node = createNode(endColumn);
+        RuleContext ctx = new RuleContext();
+        ctx.setSourceCodeFilename(getSourceCodeFilename());
+        return new ParametricRuleViolation<Node>(new FooRule(), ctx, node, "blah") {
+            {
+                packageName = packageNameArg;
+                className = classNameArg;
+            }
+        };
+    }
+
+    @Override
+    protected RuleViolation newRuleViolation(int endColumn) {
+        return newRuleViolation(endColumn, "net.sf.pmd.test", "YAHTMLSampleClass");
+    }
+
+    @Test
+    public void testReportMultipleViolations() throws Exception {
+        Report report = new Report();
+        report.addRuleViolation(newRuleViolation(1, "net.sf.pmd.test", "YAHTMLSampleClass1"));
+        report.addRuleViolation(newRuleViolation(2, "net.sf.pmd.test", "YAHTMLSampleClass1"));
+        report.addRuleViolation(newRuleViolation(1, "net.sf.pmd.other", "YAHTMLSampleClass2"));
+        String actual = ReportTest.render(getRenderer(), report);
+        assertEquals(filter(getExpected()), filter(actual));
+
+        String[] htmlFiles = new File(outputDir).list();
+        assertEquals(3, htmlFiles.length);
+        Arrays.sort(htmlFiles);
+        assertEquals("YAHTMLSampleClass1.html", htmlFiles[0]);
+        assertEquals("YAHTMLSampleClass2.html", htmlFiles[1]);
+        assertEquals("index.html", htmlFiles[2]);
+
+        for (String file : htmlFiles) {
+            try (FileInputStream in = new FileInputStream(new File(outputDir, file));
+                    InputStream expectedIn = YAHTMLRendererTest.class.getResourceAsStream("yahtml/" + file)) {
+                String data = IOUtils.toString(in, StandardCharsets.UTF_8);
+                String expected = IOUtils.toString(expectedIn, StandardCharsets.UTF_8);
+
+                assertEquals("File " + file + " is different", expected, data);
+            }
+        }
     }
 
     @Override

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/yahtml/YAHTMLSampleClass1.html
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/yahtml/YAHTMLSampleClass1.html
@@ -1,0 +1,14 @@
+<html>
+    <head>
+        <title>PMD - YAHTMLSampleClass1</title>
+    </head>
+    <body>
+        <h2>Class View</h2>
+        <h3 align="center">Class: YAHTMLSampleClass1</h3>
+        <table border="" align="center" cellspacing="0" cellpadding="3">
+        <tr><th>Method</th><th>Violation</th></tr>
+        <tr><td></td><td><table border="0"><tr><td><b>Rule:</b></td><td>Foo</td></tr><tr><td><b>Description:</b></td><td>blah</td></tr><tr><td><b>Line:</b></td><td>1 and 1</td></tr></table></td></tr>
+        <tr><td></td><td><table border="0"><tr><td><b>Rule:</b></td><td>Foo</td></tr><tr><td><b>Description:</b></td><td>blah</td></tr><tr><td><b>Line:</b></td><td>1 and 1</td></tr></table></td></tr>
+        </table>
+    </body>
+</html>

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/yahtml/YAHTMLSampleClass2.html
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/yahtml/YAHTMLSampleClass2.html
@@ -1,0 +1,13 @@
+<html>
+    <head>
+        <title>PMD - YAHTMLSampleClass2</title>
+    </head>
+    <body>
+        <h2>Class View</h2>
+        <h3 align="center">Class: YAHTMLSampleClass2</h3>
+        <table border="" align="center" cellspacing="0" cellpadding="3">
+        <tr><th>Method</th><th>Violation</th></tr>
+        <tr><td></td><td><table border="0"><tr><td><b>Rule:</b></td><td>Foo</td></tr><tr><td><b>Description:</b></td><td>blah</td></tr><tr><td><b>Line:</b></td><td>1 and 1</td></tr></table></td></tr>
+        </table>
+    </body>
+</html>

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/yahtml/index.html
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/yahtml/index.html
@@ -1,0 +1,19 @@
+<html>
+    <head>
+        <title>PMD</title>
+    </head>
+    <body>
+    <h2>Package View</h2>
+    <table border="1" align="center" cellspacing="0" cellpadding="3">
+        <tr><th>Package</th><th>Class</th><th>#</th></tr>
+        <tr><td><b>Aggregate</b></td> <td>-</td> <td>3</td></tr>
+        <tr><td><b>net</b></td> <td>-</td> <td>3</td></tr>
+        <tr><td><b>net.sf</b></td> <td>-</td> <td>3</td></tr>
+        <tr><td><b>net.sf.pmd</b></td> <td>-</td> <td>3</td></tr>
+        <tr><td><b>net.sf.pmd.other</b></td> <td>-</td> <td>1</td></tr>
+        <tr><td><b>net.sf.pmd.other</b></td> <td><a href="YAHTMLSampleClass2.html">YAHTMLSampleClass2</a></td> <td>1</td></tr>
+        <tr><td><b>net.sf.pmd.test</b></td> <td>-</td> <td>2</td></tr>
+        <tr><td><b>net.sf.pmd.test</b></td> <td><a href="YAHTMLSampleClass1.html">YAHTMLSampleClass1</a></td> <td>2</td></tr>
+    </table>
+    </body>
+</html>


### PR DESCRIPTION
* This change deprecates ReportTree and all related classes
  in net.sourceforge.pmd.lang.dfa.report
* Reworked YAHTMLRender to work without ReportTree
* Adds a unit test for YAHTMLRenderer

Fixes #1283
