### PR TITLE
[doc] Render release notes for sourceforge 

### DIFF
--- a/.travis/build-deploy.sh
+++ b/.travis/build-deploy.sh
@@ -90,13 +90,33 @@ elif travis_isPush; then
         else
             log_success "Successfully uploaded pmd-*-${VERSION}.zip to sourceforge"
         fi
-        rsync -avh docs/pages/release_notes.md ${PMD_SF_USER}@web.sourceforge.net:/home/frs/project/pmd/pmd/${VERSION}/ReadMe.md
-        if [ $? -ne 0 ]; then
+
+    )
+
+    (   # UPLOAD RELEASE NOTES TO SOURCEFORGE
+
+        # This handler is called if any command fails
+        function release_notes_fail() {
             log_error "Error while uploading release_notes.md as ReadMe.md to sourceforge!"
             log_error "Please upload manually: https://sourceforge.net/projects/pmd/files/pmd/"
-        else
-            log_success "Successfully uploaded release_notes.md as ReadMe.md to sourceforge"
-        fi
+        }
+
+        # exit subshell after trap
+        set -e
+        trap release_notes_fail ERR
+
+        RELEASE_NOTES_TMP=$(mktemp -t)
+
+        .travis/render_release_notes.rb docs/pages/release_notes.md | tail -n +6 > "$RELEASE_NOTES_TMP"
+
+        rsync -avh "$RELEASE_NOTES_TMP" ${PMD_SF_USER}@web.sourceforge.net:/home/frs/project/pmd/pmd/${VERSION}/ReadMe.md
+
+        log_success "Successfully uploaded release_notes.md as ReadMe.md to sourceforge"
+
+    )
+
+
+    (
 
         upload_baseline
 

--- a/do-release.sh
+++ b/do-release.sh
@@ -143,7 +143,7 @@ permalink: pmd_release_notes.html
 keywords: changelog, release notes
 ---
 
-## {{ site.pmd.date }} - {{ site.pmd.version | append_unless: is_release_version, "-SNAPSHOT" }}
+## {{ site.pmd.date }} - {{ site.pmd.version }}
 
 The PMD team is pleased to announce PMD {{ site.pmd.version }}.
 

--- a/docs/pages/pmd/projectdocs/committers/releasing.md
+++ b/docs/pages/pmd/projectdocs/committers/releasing.md
@@ -145,7 +145,7 @@ permalink: pmd_release_notes.html
 keywords: changelog, release notes
 ---
 
-## {{ site.pmd.date }} - {{ site.pmd.version | append_unless: is_release_version, "-SNAPSHOT" }}
+## {{ site.pmd.date }} - {{ site.pmd.version }}
 
 The PMD team is pleased to announce PMD {{ site.pmd.version }}.
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -4,7 +4,7 @@ permalink: pmd_release_notes.html
 keywords: changelog, release notes
 ---
 
-## {{ site.pmd.date }} - {{ site.pmd.version | append_unless: is_release_version, "-SNAPSHOT" }}
+## {{ site.pmd.date }} - {{ site.pmd.version }}
 
 The PMD team is pleased to announce PMD {{ site.pmd.version }}.
 


### PR DESCRIPTION

The release notes were not rendered before being pushed to sourceforge: https://sourceforge.net/projects/pmd/files/pmd/6.7.0-SNAPSHOT/

I'm not sure we can keep the `--without=release_notes_preprocessing` now, since this is in build-deploy. 