### PR TITLE
[apex] Add OneDeclarationPerStatement rule

### DIFF
--- a/pmd-apex/src/main/resources/category/apex/codestyle.xml
+++ b/pmd-apex/src/main/resources/category/apex/codestyle.xml
@@ -149,6 +149,32 @@ public class Foo {
         </example>
     </rule>
 
+    <rule name="OneDeclarationPerStatement"
+          since="6.7.0"
+          message="Use one line for each declaration, it enhances code readability."
+          class="net.sourceforge.pmd.lang.apex.rule.ApexXPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_codestyle.html#onedeclarationperstatement">
+        <description>Foo</description>
+        <priority>1</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+<![CDATA[
+//VariableDeclarationStatements[VariableDeclaration[2]]|//FieldDeclarationStatements[FieldDeclaration[2]]
+]]>
+                </value>
+            </property>
+        </properties>
+        <example>
+<![CDATA[
+Integer a, b;   // not recommended
+
+Integer a;      // preferred approach
+Integer b;
+]]>
+        </example>
+    </rule>
+
     <rule name="VariableNamingConventions"
           since="5.5.0"
           message="{0} variable {1} should begin with {2}"

--- a/pmd-apex/src/main/resources/category/apex/codestyle.xml
+++ b/pmd-apex/src/main/resources/category/apex/codestyle.xml
@@ -154,7 +154,10 @@ public class Foo {
           message="Use one line for each declaration, it enhances code readability."
           class="net.sourceforge.pmd.lang.apex.rule.ApexXPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_codestyle.html#onedeclarationperstatement">
-        <description>Foo</description>
+        <description>
+Apex allows the use of several variables declaration of the same type on one line. However, it
+can lead to quite messy code. This rule looks for several declarations on the same line.
+        </description>
         <priority>1</priority>
         <properties>
             <property name="xpath">

--- a/pmd-apex/src/main/resources/category/apex/codestyle.xml
+++ b/pmd-apex/src/main/resources/category/apex/codestyle.xml
@@ -151,7 +151,7 @@ public class Foo {
 
     <rule name="OneDeclarationPerStatement"
           since="6.7.0"
-          message="Use one line for each declaration, it enhances code readability."
+          message="Use one statement for each declaration, it enhances code readability."
           class="net.sourceforge.pmd.lang.apex.rule.ApexXPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_codestyle.html#onedeclarationperstatement">
         <description>
@@ -163,7 +163,8 @@ can lead to quite messy code. This rule looks for several declarations on the sa
             <property name="xpath">
                 <value>
 <![CDATA[
-//VariableDeclarationStatements[VariableDeclaration[2]]|//FieldDeclarationStatements[FieldDeclaration[2]]
+//VariableDeclarationStatements[count(VariableDeclaration) > 1] |
+//FieldDeclarationStatements[count(FieldDeclaration) > 1]
 ]]>
                 </value>
             </property>

--- a/pmd-apex/src/main/resources/rulesets/apex/ruleset.xml
+++ b/pmd-apex/src/main/resources/rulesets/apex/ruleset.xml
@@ -419,4 +419,15 @@
          <property name="cc_block_highlighting" value="false" />
       </properties>
    </rule>
+
+   <!-- STYLE -->
+   <rule ref="category/apex/codestyle.xml/OneDeclarationPerStatement" message="Use one statement for each declaration">
+      <priority>3</priority>
+      <properties>
+         <!-- relevant for Code Climate output only -->
+         <property name="cc_categories" value="Style" />
+         <property name="cc_remediation_points_multiplier" value="5" />
+         <property name="cc_block_highlighting" value="false" />
+      </properties>
+   </rule>
 </ruleset>

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/CodeStyleRulesTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/CodeStyleRulesTest.java
@@ -17,6 +17,7 @@ public class CodeStyleRulesTest extends SimpleAggregatorTst {
         addRule(RULESET, "IfElseStmtsMustUseBraces");
         addRule(RULESET, "IfStmtsMustUseBraces");
         addRule(RULESET, "MethodNamingConventions");
+        addRule(RULESET, "OneDeclarationPerStatement");
         addRule(RULESET, "VariableNamingConventions");
         addRule(RULESET, "WhileLoopsMustUseBraces");
     }

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/OneDeclarationPerStatement.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/OneDeclarationPerStatement.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+    <test-code>
+        <description>one field declaration per statement</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    Integer a, b;
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>one variable declaration per statement</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        Integer a, b;
+    }
+}
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>all is well</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    Integer a;
+    Integer b;
+    void bar() {
+        Integer c;
+        Integer d;
+    }
+}
+        ]]></code>
+    </test-code>
+
+</test-data>


### PR DESCRIPTION
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw test` passes.
 - [x] `./mvnw pmd:check` passes.
 - [x] `./mvnw checkstyle:check` passes. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

This PR adds the OneDeclarationPerStatement rule to apex. It applies to field declarations (inside classes) and variable declarations (inside methods).

```
Integer a, b;   // not recommended

Integer a;      // preferred approach
Integer b;
```
