### PR TITLE
[java] OneDeclarationPerLine should check fields too

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -14,6 +14,11 @@ This is a {{ site.pmd.release_type }} release.
 
 ### New and noteworthy
 
+#### Modified Rules
+
+*   The Java rule {% rule java/bestpractices/OneDeclarationPerLine %} (`java-bestpractices`) has been revamped to
+    consider not only local variable declarations, but field declarations too.
+
 #### New Rules
 
 *   The new Java rule {% rule java/codestyle/LinguisticNaming %} (`java-codestyle`)

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -817,6 +817,10 @@ can lead to quite messy code. This rule looks for several declarations on the sa
 //LocalVariableDeclaration
    [count(VariableDeclarator) > 1]
    [$strictMode or count(distinct-values(VariableDeclarator/@BeginLine)) != count(VariableDeclarator)]
+|
+//FieldDeclaration
+   [count(VariableDeclarator) > 1]
+   [$strictMode or count(distinct-values(VariableDeclarator/@BeginLine)) != count(VariableDeclarator)]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/OneDeclarationPerLine.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/OneDeclarationPerLine.xml
@@ -65,4 +65,28 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Check for field declarations without strictMode</description>
+        <rule-property name="strictMode">false</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    String name,
+           lastname;
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Check for field declarations with strictMode</description>
+        <rule-property name="strictMode">true</rule-property>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    String name,
+           lastname;
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
The `OneDeclarationPerLine` check was only checking local variables. In order to match it's behavior with the Apex equivalent (#1315), I added checks for fields too.

One interesting thing 'though. The Apex rule is under the `codestyle` category, but the Java one is under `bestpractices`... I'm not sure why we decided to place it here, and I'm tending to think this was a mistake... Having it as `codestyle`, as Apex do seems more accurate.