### PR TITLE
[core] Improvements and planned updates around PropertySource

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/Rule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/Rule.java
@@ -112,6 +112,7 @@ public interface Rule extends PropertySource {
      *
      * @return the name
      */
+    @Override
     String getName();
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractDelegateRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractDelegateRule.java
@@ -21,7 +21,11 @@ import net.sourceforge.pmd.properties.PropertySource;
 
 /**
  * Base class for Rule implementations which delegate to another Rule instance.
+ *
+ * @deprecated This is only relevant to {@link RuleReference}, but prevents sharing the implementation
+ * of {@link net.sourceforge.pmd.properties.AbstractPropertySource}. Will be removed in 7.0.0
  */
+@Deprecated
 public abstract class AbstractDelegateRule implements Rule {
 
     private Rule rule;
@@ -30,6 +34,13 @@ public abstract class AbstractDelegateRule implements Rule {
         return rule;
     }
 
+
+    /**
+     * @deprecated This will be removed in 7.0.0
+     * I mark it specially deprecated because it's inherited by rule reference,
+     * even though a RuleReference has no business setting its rule after construction
+     */
+    @Deprecated
     public void setRule(Rule rule) {
         this.rule = rule;
     }
@@ -213,6 +224,10 @@ public abstract class AbstractDelegateRule implements Rule {
         rule.setProperty(propertyDescriptor, values);
     }
 
+    @Override
+    public boolean isPropertyOverridden(PropertyDescriptor<?> propertyDescriptor) {
+        return rule.isPropertyOverridden(propertyDescriptor);
+    }
 
     @Override
     public Map<PropertyDescriptor<?>, Object> getPropertiesByPropertyDescriptor() {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
@@ -66,7 +66,7 @@ public abstract class AbstractRule extends AbstractPropertySource implements Rul
         otherRule.examples = copyExamples();
         otherRule.externalInfoUrl = externalInfoUrl;
         otherRule.priority = priority;
-        otherRule.propertyDescriptors = copyPropertyDescriptors();
+        otherRule.propertyDescriptors = new ArrayList<>(getPropertyDescriptors());
         otherRule.propertyValuesByDescriptor = copyPropertyValues();
         otherRule.usesDFA = usesDFA;
         otherRule.usesTypeResolution = usesTypeResolution;
@@ -459,6 +459,7 @@ public abstract class AbstractRule extends AbstractPropertySource implements Rul
         }
         rule.setPriority(getPriority());
         for (final PropertyDescriptor<?> prop : getPropertyDescriptors()) {
+            // define the descriptor only if it doesn't yet exist
             if (rule.getPropertyDescriptor(prop.name()) == null) {
                 rule.definePropertyDescriptor(prop); // Property descriptors are immutable, and can be freely shared
             }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleReference.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleReference.java
@@ -5,12 +5,12 @@
 package net.sourceforge.pmd.lang.rule;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RulePriority;
@@ -43,17 +43,19 @@ public class RuleReference extends AbstractDelegateRule {
     private RulePriority priority;
     private RuleSetReference ruleSetReference;
 
-    private static final List<PropertyDescriptor<?>> EMPTY_DESCRIPTORS = Collections.emptyList();
 
-    @Deprecated // to be removed with PMD 7.0.0
-    // when creating a rule reference, always provide the rule and the ruleset, see
-    // the constructor RuleReference(Rule, RuleSetReference)
+    /**
+     * @deprecated to be removed with PMD 7.0.0. when creating a rule reference, always
+     * provide the rule and the ruleset, see the constructor RuleReference(Rule, RuleSetReference)
+     */
+    @Deprecated
     public RuleReference() {
         // default constructor
     }
 
     /**
-     * 
+     * Create a new reference to the given rule.
+     *
      * @param theRule the referenced rule
      * @param theRuleSetReference the rule set, where the rule is defined
      */
@@ -62,15 +64,38 @@ public class RuleReference extends AbstractDelegateRule {
         ruleSetReference = theRuleSetReference;
     }
 
+
+    /** copy constructor */
+    private RuleReference(RuleReference ref) {
+
+        this.language = ref.language;
+        this.minimumLanguageVersion = ref.minimumLanguageVersion;
+        this.maximumLanguageVersion = ref.maximumLanguageVersion;
+        this.deprecated = ref.deprecated;
+        this.name = ref.name;
+        this.propertyDescriptors = ref.propertyDescriptors;
+        this.propertyValues = ref.propertyValues == null ? null : new HashMap<>(ref.propertyValues);
+        this.message = ref.message;
+        this.description = ref.description;
+        this.examples = ref.examples == null ? null : new ArrayList<>(ref.examples);
+        this.externalInfoUrl = ref.externalInfoUrl;
+        this.priority = ref.priority;
+        this.ruleSetReference = ref.ruleSetReference;
+
+        this.setRule(ref.getRule().deepCopy());
+    }
+
     public Language getOverriddenLanguage() {
         return language;
     }
 
+    // FIXME should we really allow overriding the language of a rule?
+    // I don't see any case where this wouldn't just make the rule fail during execution
     @Override
     public void setLanguage(Language language) {
         // Only override if different than current value, or if already
         // overridden.
-        if (!isSame(language, super.getLanguage()) || this.language != null) {
+        if (!Objects.equals(language, super.getLanguage()) || this.language != null) {
             this.language = language;
             super.setLanguage(language);
         }
@@ -84,7 +109,7 @@ public class RuleReference extends AbstractDelegateRule {
     public void setMinimumLanguageVersion(LanguageVersion minimumLanguageVersion) {
         // Only override if different than current value, or if already
         // overridden.
-        if (!isSame(minimumLanguageVersion, super.getMinimumLanguageVersion()) || this.minimumLanguageVersion != null) {
+        if (!Objects.equals(minimumLanguageVersion, super.getMinimumLanguageVersion()) || this.minimumLanguageVersion != null) {
             this.minimumLanguageVersion = minimumLanguageVersion;
             super.setMinimumLanguageVersion(minimumLanguageVersion);
         }
@@ -98,7 +123,7 @@ public class RuleReference extends AbstractDelegateRule {
     public void setMaximumLanguageVersion(LanguageVersion maximumLanguageVersion) {
         // Only override if different than current value, or if already
         // overridden.
-        if (!isSame(maximumLanguageVersion, super.getMaximumLanguageVersion()) || this.maximumLanguageVersion != null) {
+        if (!Objects.equals(maximumLanguageVersion, super.getMaximumLanguageVersion()) || this.maximumLanguageVersion != null) {
             this.maximumLanguageVersion = maximumLanguageVersion;
             super.setMaximumLanguageVersion(maximumLanguageVersion);
         }
@@ -110,7 +135,7 @@ public class RuleReference extends AbstractDelegateRule {
 
     @Override
     public boolean isDeprecated() {
-        return deprecated != null && deprecated.booleanValue();
+        return deprecated != null && deprecated;
     }
 
     @Override
@@ -179,6 +204,10 @@ public class RuleReference extends AbstractDelegateRule {
 
     @Override
     public void addExample(String example) {
+        // TODO Intuitively, if some examples are overridden (even with empty value), then
+        // I think we should discard the previous ones. If the rule needs new examples,
+        // then the previous ones are not relevant.
+
         // TODO Meaningful override of examples is hard, because they are merely
         // a list of strings. How does one indicate override of a particular
         // value? Via index? Rule.setExample(int, String)? But the XML format
@@ -229,9 +258,11 @@ public class RuleReference extends AbstractDelegateRule {
         }
     }
 
-    public List<PropertyDescriptor<?>> getOverriddenPropertyDescriptors() {
 
-        return propertyDescriptors == null ? EMPTY_DESCRIPTORS : propertyDescriptors;
+    @Override
+    public List<PropertyDescriptor<?>> getOverriddenPropertyDescriptors() {
+        return propertyDescriptors == null ? Collections.<PropertyDescriptor<?>>emptyList()
+                                           : new ArrayList<>(propertyDescriptors);
     }
 
     @Override
@@ -246,14 +277,16 @@ public class RuleReference extends AbstractDelegateRule {
         propertyDescriptors.add(propertyDescriptor);
     }
 
+
+    @Override
     public Map<PropertyDescriptor<?>, Object> getOverriddenPropertiesByPropertyDescriptor() {
-        return propertyValues;
+        return propertyValues == null ? new HashMap<PropertyDescriptor<?>, Object>() : new HashMap<>(propertyValues);
     }
 
     @Override
     public <T> void setProperty(PropertyDescriptor<T> propertyDescriptor, T value) {
         // Only override if different than current value.
-        if (!isSame(super.getProperty(propertyDescriptor), value)) {
+        if (!Objects.equals(super.getProperty(propertyDescriptor), value)) {
             if (propertyValues == null) {
                 propertyValues = new HashMap<>();
             }
@@ -263,14 +296,15 @@ public class RuleReference extends AbstractDelegateRule {
     }
 
 
-
-
-
-
     public RuleSetReference getRuleSetReference() {
         return ruleSetReference;
     }
 
+
+    /**
+     * @deprecated There's no use in setting the ruleset reference after construction
+     */
+    @Deprecated
     public void setRuleSetReference(RuleSetReference ruleSetReference) {
         this.ruleSetReference = ruleSetReference;
     }
@@ -279,19 +313,6 @@ public class RuleReference extends AbstractDelegateRule {
         return StringUtil.isSame(s1, s2, true, false, true);
     }
 
-    @SuppressWarnings("PMD.CompareObjectsWithEquals")
-    private static boolean isSame(Object o1, Object o2) {
-        if (o1 instanceof Object[] && o2 instanceof Object[]) {
-            return isSame((Object[]) o1, (Object[]) o2);
-        }
-        return o1 == o2 || o1 != null && o2 != null && o1.equals(o2);
-    }
-
-    @SuppressWarnings("PMD.UnusedNullCheckInEquals")
-    // TODO: fix UnusedNullCheckInEquals rule for Arrays
-    private static boolean isSame(Object[] a1, Object[] a2) {
-        return a1 == a2 || a1 != null && a2 != null && Arrays.equals(a1, a2);
-    }
 
     private static boolean contains(Collection<String> collection, String s1) {
         for (String s2 : collection) {
@@ -308,11 +329,14 @@ public class RuleReference extends AbstractDelegateRule {
                 || super.hasDescriptor(descriptor);
     }
 
-    public boolean hasOverriddenProperty(PropertyDescriptor<?> descriptor) {
+
+    @Override
+    public boolean isPropertyOverridden(PropertyDescriptor<?> descriptor) {
         return propertyValues != null && propertyValues.containsKey(descriptor);
     }
 
     @Override
+    @Deprecated
     public boolean usesDefaultValues() {
 
         List<PropertyDescriptor<?>> descriptors = getOverriddenPropertyDescriptors();
@@ -321,7 +345,7 @@ public class RuleReference extends AbstractDelegateRule {
         }
 
         for (PropertyDescriptor<?> desc : descriptors) {
-            if (!isSame(desc.defaultValue(), getProperty(desc))) {
+            if (!Objects.equals(desc.defaultValue(), getProperty(desc))) {
                 return false;
             }
         }
@@ -330,6 +354,7 @@ public class RuleReference extends AbstractDelegateRule {
     }
 
     @Override
+    @Deprecated
     public void useDefaultValueFor(PropertyDescriptor<?> desc) {
 
         // not sure if we should go all the way through to the real thing?
@@ -348,29 +373,6 @@ public class RuleReference extends AbstractDelegateRule {
     
     @Override
     public Rule deepCopy() {
-        RuleReference rule = null;
-        try {
-            rule = getClass().newInstance();
-        } catch (InstantiationException | IllegalAccessException ignored) {
-            // Can't happen... we already have an instance
-            throw new RuntimeException(ignored); // in case it happens anyway, then something is really wrong...
-        }
-        rule.setRule(this.getRule().deepCopy());
-        
-        rule.language = language;
-        rule.minimumLanguageVersion = minimumLanguageVersion;
-        rule.maximumLanguageVersion = maximumLanguageVersion;
-        rule.deprecated = deprecated;
-        rule.name = name;
-        rule.propertyDescriptors = propertyDescriptors;
-        rule.propertyValues = propertyValues == null ? null : new HashMap<>(propertyValues);
-        rule.message = message;
-        rule.description = description;
-        rule.examples = examples == null ? null : new ArrayList<>(examples);
-        rule.externalInfoUrl = externalInfoUrl;
-        rule.priority = priority;
-        rule.ruleSetReference = ruleSetReference;
-        
-        return rule;
+        return new RuleReference(this);
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/AbstractPropertySource.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/AbstractPropertySource.java
@@ -13,19 +13,48 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.util.CollectionUtil;
 
 
 /**
- * Base class for objects which can be configured through properties. Rules and Reports are such objects.
+ * Base class for {@link PropertySource}.
  *
  * @author Brian Remedios
  */
 public abstract class AbstractPropertySource implements PropertySource {
 
-    /** The list of known properties that can be configured. */
+    // setProperty should probably be hidden from Rule implementations, they have no business using that
+    // The apex rules that do that could be refactored to do it in the XML
+
+    // TODO RuleReference should extend this class
+    // This would avoid duplicating the implementation between Rule and RuleReference,
+    // which should use exactly the same mechanism to override properties (XML).
+
+    // BUT to do that RuleReference should not extend AbstractDelegateRule
+    // Indeed, AbstractDelegateRule has no business having this overriding logic built-in,
+    // it would break its contract. For all deeds and purposes that class should be removed.
+
+    // TODO 7.0.0 these fields should be made private final
+
+    /**
+     * The list of known properties that can be configured.
+     *
+     * @deprecated Will be made private final
+     */
+    @Deprecated
     protected List<PropertyDescriptor<?>> propertyDescriptors = new ArrayList<>();
-    /** The values for each property. */
+
+    /**
+     * The values for each property that were overridden here.
+     * Default property values are not contained in this map.
+     * In other words, if this map doesn't contain a descriptor
+     * which is in {@link #propertyDescriptors}, then it's assumed
+     * to have a default value.
+     *
+     * @deprecated Will be made private final
+     */
+    @Deprecated
     protected Map<PropertyDescriptor<?>, Object> propertyValuesByDescriptor = new HashMap<>();
 
 
@@ -33,7 +62,9 @@ public abstract class AbstractPropertySource implements PropertySource {
      * Creates a copied list of the property descriptors and returns it.
      *
      * @return a copy of the property descriptors.
+     * @deprecated Just use {@link #getPropertyDescriptors()}
      */
+    @Deprecated
     protected List<PropertyDescriptor<?>> copyPropertyDescriptors() {
         return new ArrayList<>(propertyDescriptors);
     }
@@ -43,13 +74,16 @@ public abstract class AbstractPropertySource implements PropertySource {
      * Creates a copied map of the values of the properties and returns it.
      *
      * @return a copy of the values
+     *
+     * @deprecated Just use {@link #getPropertiesByPropertyDescriptor()} or {@link #getOverriddenPropertiesByPropertyDescriptor()}
      */
+    @Deprecated
     protected Map<PropertyDescriptor<?>, Object> copyPropertyValues() {
         return new HashMap<>(propertyValuesByDescriptor);
     }
 
-
     @Override
+    @Deprecated
     public Set<PropertyDescriptor<?>> ignoredProperties() {
         return Collections.emptySet();
     }
@@ -58,11 +92,10 @@ public abstract class AbstractPropertySource implements PropertySource {
     @Override
     public void definePropertyDescriptor(PropertyDescriptor<?> propertyDescriptor) {
         // Check to ensure the property does not already exist.
-        for (PropertyDescriptor<?> descriptor : propertyDescriptors) {
-            if (descriptor.name().equals(propertyDescriptor.name())) {
+        if (getPropertyDescriptor(propertyDescriptor.name()) != null) {
                 throw new IllegalArgumentException("There is already a PropertyDescriptor with name '"
-                                                   + propertyDescriptor.name() + "' defined on Rule " + getName() + ".");
-            }
+                                                           + propertyDescriptor.name() + "' defined on " + getPropertySourceType() + " " + getName() + ".");
+
         }
         propertyDescriptors.add(propertyDescriptor);
         // Sort in UI order
@@ -70,12 +103,9 @@ public abstract class AbstractPropertySource implements PropertySource {
     }
 
 
-    /**
-     * Gets the name of the property source. This is e.g. the rule name or the report name.
-     *
-     * @return the name
-     */
-    public abstract String getName();
+    private String getPropertySourceType() {
+        return this instanceof Rule ? "rule" : "renderer";
+    }
 
 
     @Override
@@ -91,18 +121,19 @@ public abstract class AbstractPropertySource implements PropertySource {
 
     @Override
     public boolean hasDescriptor(PropertyDescriptor<?> descriptor) {
+        return propertyDescriptors.contains(descriptor);
+    }
 
-        if (propertyValuesByDescriptor.isEmpty()) {
-            propertyValuesByDescriptor = getPropertiesByPropertyDescriptor();
-        }
 
-        return propertyValuesByDescriptor.containsKey(descriptor);
+    @Override
+    public final List<PropertyDescriptor<?>> getOverriddenPropertyDescriptors() {
+        return new ArrayList<>(propertyValuesByDescriptor.keySet());
     }
 
 
     @Override
     public List<PropertyDescriptor<?>> getPropertyDescriptors() {
-        return propertyDescriptors;
+        return Collections.unmodifiableList(propertyDescriptors);
     }
 
 
@@ -120,11 +151,16 @@ public abstract class AbstractPropertySource implements PropertySource {
 
 
     @Override
+    public boolean isPropertyOverridden(PropertyDescriptor<?> propertyDescriptor) {
+        return propertyValuesByDescriptor.containsKey(propertyDescriptor);
+    }
+
+
+    @Override
     public <T> void setProperty(PropertyDescriptor<T> propertyDescriptor, T value) {
         checkValidPropertyDescriptor(propertyDescriptor);
         if (value instanceof List) {
             propertyValuesByDescriptor.put(propertyDescriptor, Collections.unmodifiableList((List) value));
-
         } else {
             propertyValuesByDescriptor.put(propertyDescriptor, value);
         }
@@ -144,10 +180,15 @@ public abstract class AbstractPropertySource implements PropertySource {
      * @param propertyDescriptor The property descriptor to check
      */
     private void checkValidPropertyDescriptor(PropertyDescriptor<?> propertyDescriptor) {
-        if (!propertyDescriptors.contains(propertyDescriptor)) {
-            throw new IllegalArgumentException(
-                    "Property descriptor not defined for Rule " + getName() + ": " + propertyDescriptor);
+        if (!hasDescriptor(propertyDescriptor)) {
+            throw new IllegalArgumentException("Property descriptor not defined for " + getPropertySourceType() + " " + getName() + ": " + propertyDescriptor);
         }
+    }
+
+
+    @Override
+    public final Map<PropertyDescriptor<?>, Object> getOverriddenPropertiesByPropertyDescriptor() {
+        return new HashMap<>(propertyValuesByDescriptor);
     }
 
 
@@ -168,11 +209,12 @@ public abstract class AbstractPropertySource implements PropertySource {
             }
         }
 
-        return propertiesByPropertyDescriptor;
+        return Collections.unmodifiableMap(propertiesByPropertyDescriptor);
     }
 
 
     @Override
+    @Deprecated
     public boolean usesDefaultValues() {
 
         Map<PropertyDescriptor<?>, Object> valuesByProperty = getPropertiesByPropertyDescriptor();
@@ -191,11 +233,13 @@ public abstract class AbstractPropertySource implements PropertySource {
 
 
     @Override
+    @Deprecated
     public void useDefaultValueFor(PropertyDescriptor<?> desc) {
         propertyValuesByDescriptor.remove(desc);
     }
 
 
+    // todo Java 8 move up to interface
     @Override
     public String dysfunctionReason() {
         return null;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/AbstractPropertySource.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/AbstractPropertySource.java
@@ -93,8 +93,8 @@ public abstract class AbstractPropertySource implements PropertySource {
     public void definePropertyDescriptor(PropertyDescriptor<?> propertyDescriptor) {
         // Check to ensure the property does not already exist.
         if (getPropertyDescriptor(propertyDescriptor.name()) != null) {
-                throw new IllegalArgumentException("There is already a PropertyDescriptor with name '"
-                                                           + propertyDescriptor.name() + "' defined on " + getPropertySourceType() + " " + getName() + ".");
+            throw new IllegalArgumentException("There is already a PropertyDescriptor with name '"
+                                                       + propertyDescriptor.name() + "' defined on " + getPropertySourceType() + " " + getName() + ".");
 
         }
         propertyDescriptors.add(propertyDescriptor);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/RegexProperty.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/RegexProperty.java
@@ -12,7 +12,7 @@ import net.sourceforge.pmd.properties.builders.SingleValuePropertyBuilder;
 
 
 /**
- * Property which has a regex pattern as a value.This property has no multi-valued
+ * Property which has a regex pattern as a value. This property has no multi-valued
  * variant, since it would be ambiguous whether the delimiters are part of the regex
  * or not.
  *

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/Renderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/Renderer.java
@@ -40,6 +40,7 @@ public interface Renderer extends PropertySource {
      *
      * @return The name of the Renderer.
      */
+    @Override
     String getName();
 
     /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidUsingHardCodedIPRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidUsingHardCodedIPRule.java
@@ -15,7 +15,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTLiteral;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.properties.EnumeratedMultiProperty;
-import net.sourceforge.pmd.properties.PropertySource;
 
 public class AvoidUsingHardCodedIPRule extends AbstractJavaRule {
 
@@ -214,9 +213,7 @@ public class AvoidUsingHardCodedIPRule extends AbstractJavaRule {
         return getProperty(CHECK_ADDRESS_TYPES_DESCRIPTOR).size() > 0;
     }
 
-    /**
-     * @see PropertySource#dysfunctionReason()
-     */
+
     @Override
     public String dysfunctionReason() {
         return hasChosenAddressTypes() ? null : "No address types specified";

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/EcmascriptParserOptions.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/EcmascriptParserOptions.java
@@ -4,13 +4,14 @@
 
 package net.sourceforge.pmd.lang.ecmascript;
 
+import java.util.Objects;
+
 import org.mozilla.javascript.Context;
 
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.lang.ParserOptions;
 import net.sourceforge.pmd.properties.BooleanProperty;
 import net.sourceforge.pmd.properties.EnumeratedProperty;
-import net.sourceforge.pmd.util.StringUtil;
 
 public class EcmascriptParserOptions extends ParserOptions {
 
@@ -120,7 +121,7 @@ public class EcmascriptParserOptions extends ParserOptions {
             return false;
         }
         final EcmascriptParserOptions that = (EcmascriptParserOptions) obj;
-        return StringUtil.isSame(this.suppressMarker, that.suppressMarker, false, false, false)
+        return Objects.equals(this.suppressMarker, that.suppressMarker)
                 && this.recordingComments == that.recordingComments
                 && this.recordingLocalJsDocComments == that.recordingLocalJsDocComments
                 && this.rhinoLanguageVersion == that.rhinoLanguageVersion;

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/XmlParserOptions.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/XmlParserOptions.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.xml;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.Objects;
 
 import org.xml.sax.EntityResolver;
 import org.xml.sax.InputSource;
@@ -14,7 +15,6 @@ import org.xml.sax.SAXException;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.lang.ParserOptions;
 import net.sourceforge.pmd.properties.BooleanProperty;
-import net.sourceforge.pmd.util.StringUtil;
 
 public class XmlParserOptions extends ParserOptions {
 
@@ -182,7 +182,7 @@ public class XmlParserOptions extends ParserOptions {
             return false;
         }
         final XmlParserOptions that = (XmlParserOptions) obj;
-        return StringUtil.isSame(this.suppressMarker, that.suppressMarker, false, false, false)
+        return Objects.equals(this.suppressMarker, that.suppressMarker)
                 && this.coalescing == that.coalescing && this.expandEntityReferences == that.expandEntityReferences
                 && this.ignoringComments == that.ignoringComments
                 && this.ignoringElementContentWhitespace == that.ignoringElementContentWhitespace


### PR DESCRIPTION
I was working on making required properties a thing for #973 (the last comments), and it occurred to me that for that to work, PropertySources should provide kind of the same functionality as RuleReferences: track the overridden properties. This was already kind of the case, except it wasn't documented. 

This PR brushes up on PropertySource, fixing some inconsistencies, deprecating unneeded API, and making it consistent with RuleReference. The goal for 7.0.0 would be to have RuleReference extend AbstractPropertySource to share the implementation. This can't be done right now as making AbstractDelegateRule extend AbstractPropertySource would break the contract of AbstractDelegateRule by baking in some property overriding facilities. Since AbstractDelegateRule is only used by RuleReference anyway, I think we can remove it without regret come 7.0.0