### PR TITLE
[java] Add exclude property to FieldNamingConventions

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclaratorId.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclaratorId.java
@@ -134,6 +134,14 @@ public class ASTVariableDeclaratorId extends AbstractJavaTypeNode implements Dim
 
 
     /**
+     * Returns the name of the variable.
+     */
+    public String getVariableName() {
+        return getImage();
+    }
+
+
+    /**
      * Returns true if the variable declared by this node is declared final.
      * Doesn't account for the "effectively-final" nuance. Resource
      * declarations are implicitly final.

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldNamingConventionsRule.java
@@ -11,6 +11,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.RegexProperty;
+import net.sourceforge.pmd.properties.StringMultiProperty;
 
 
 /**
@@ -20,6 +21,14 @@ import net.sourceforge.pmd.properties.RegexProperty;
  * @since 6.7.0
  */
 public class FieldNamingConventionsRule extends AbstractNamingConventionRule<ASTVariableDeclaratorId> {
+    // TODO we need a more powerful scheme to match some fields, e.g. include modifiers/type
+    // We could define a new property, but specifying property values as a single string doesn't scale
+    private static final StringMultiProperty EXCLUDED_NAMES = StringMultiProperty.named("exclusions")
+                                                                                 .desc("Names of fields to whitelist.")
+                                                                                 .defaultValues("serialVersionUID")
+                                                                                 .build();
+
+
     private final RegexProperty publicConstantFieldRegex = defaultProp("public constant").defaultValue("[A-Z][A-Z_0-9]*").build();
     private final RegexProperty constantFieldRegex = defaultProp("constant").desc("Regex which applies to non-public static final field names").defaultValue("[A-Z][A-Z_0-9]*").build();
     private final RegexProperty enumConstantRegex = defaultProp("enum constant").defaultValue("[A-Z][A-Z_0-9]*").build();
@@ -35,6 +44,7 @@ public class FieldNamingConventionsRule extends AbstractNamingConventionRule<AST
         definePropertyDescriptor(finalFieldRegex);
         definePropertyDescriptor(staticFieldRegex);
         definePropertyDescriptor(defaultFieldRegex);
+        definePropertyDescriptor(EXCLUDED_NAMES);
 
         addRuleChainVisit(ASTFieldDeclaration.class);
         addRuleChainVisit(ASTEnumConstant.class);
@@ -43,8 +53,11 @@ public class FieldNamingConventionsRule extends AbstractNamingConventionRule<AST
 
     @Override
     public Object visit(ASTFieldDeclaration node, Object data) {
-
         for (ASTVariableDeclaratorId id : node) {
+            if (getProperty(EXCLUDED_NAMES).contains(id.getVariableName())) {
+                continue;
+            }
+
             if (node.isFinal() && node.isStatic()) {
                 checkMatches(id, node.isPublic() ? publicConstantFieldRegex : constantFieldRegex, data);
             } else if (node.isFinal()) {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/CodeStyleRulesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/CodeStyleRulesTest.java
@@ -35,6 +35,7 @@ public class CodeStyleRulesTest extends SimpleAggregatorTst {
         addRule(RULESET, "EmptyMethodInAbstractClassShouldBeAbstract");
         addRule(RULESET, "ExtendsObject");
         addRule(RULESET, "FieldDeclarationsShouldBeAtStartOfClass");
+        addRule(RULESET, "FieldNamingConventions");
         addRule(RULESET, "ForLoopsMustUseBraces");
         addRule(RULESET, "ForLoopShouldBeWhileLoop");
         addRule(RULESET, "FormalParameterNamingConventions");

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/FieldNamingConventions.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/FieldNamingConventions.xml
@@ -166,4 +166,28 @@
             ]]></code>
     </test-code>
 
+
+
+    <test-code>
+        <description>Exclude serialVersionUID by default</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class MyException extends RuntimeException {
+
+                private static final long serialVersionUID = -8134636876462178354L;
+
+
+                public MyException(String message, Throwable cause) {
+                    super(message, cause);
+                }
+
+
+                public MyException(String message) {
+                    super(message);
+                }
+
+            }
+            ]]></code>
+    </test-code>
+
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/FieldNamingConventions.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/FieldNamingConventions.xml
@@ -128,10 +128,13 @@
     <test-code>
         <description>Test public constant property</description>
         <rule-property name="publicConstantPattern">cons_[A-Z][A-Z0-9]+</rule-property>
-        <expected-problems>2</expected-problems>
+        <expected-problems>5</expected-problems>
         <expected-messages>
+            <message>The field name 'Foo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The final field name 'Hoo' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The static field name 'Bar' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+            <message>The constant name 'cons_BOLG_FIELD' doesn't match '[A-Z][A-Z_0-9]*'</message>
             <message>The public constant name 'DDD' doesn't match 'cons_[A-Z][A-Z0-9]+'</message>
-            <message>The constant name 'cons_BOLG_FIELD' doesn't match '[A-Z][A-Z0-9]+'</message>
         </expected-messages>
         <code><![CDATA[
             public class Bar {
@@ -148,12 +151,12 @@
 
 
     <test-code>
-        <description>Interface fields should be treated like constants</description>
+        <description>Interface fields should be treated like public constants</description>
         <expected-problems>3</expected-problems>
         <expected-messages>
-            <message>The constant name 'Foo' doesn't match '[A-Z][A-Z_0-9]*'</message>
-            <message>The constant name 'Hoo' doesn't match '[A-Z][A-Z_0-9]*'</message>
-            <message>The constant name 'Bar' doesn't match '[A-Z][A-Z_0-9]*'</message>
+            <message>The public constant name 'Foo' doesn't match '[A-Z][A-Z_0-9]*'</message>
+            <message>The public constant name 'Hoo' doesn't match '[A-Z][A-Z_0-9]*'</message>
+            <message>The public constant name 'Bar' doesn't match '[A-Z][A-Z_0-9]*'</message>
         </expected-messages>
         <code><![CDATA[
             public interface Bar {
@@ -185,6 +188,19 @@
                 public MyException(String message) {
                     super(message);
                 }
+
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>More exclusions can be configured</description>
+        <rule-property name="exclusions">m$mangled</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class MyException {
+
+                private static final long m$mangled = -8134636876462178354L;
 
             }
             ]]></code>


### PR DESCRIPTION
Exclude serialVersionUID by default. Fix #1329 

I think it would be better to have a more powerful scheme to match excluded fields than just comparing the name. But property versatility is stuck for now, because values are expected to be a single string.

