### PR TITLE
[java] Derive correct classname for non-public non-classes

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolation.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolation.java
@@ -9,13 +9,13 @@ import java.util.Set;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
+import net.sourceforge.pmd.lang.java.ast.AbstractAnyTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.AccessNode;
 import net.sourceforge.pmd.lang.java.ast.CanSuppressWarnings;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
@@ -97,7 +97,7 @@ public class JavaRuleViolation extends ParametricRuleViolation<JavaNode> {
 
     private void setClassNameFrom(JavaNode node) {
         String qualifiedName = null;
-        for (ASTClassOrInterfaceDeclaration parent : node.getParentsOfType(ASTClassOrInterfaceDeclaration.class)) {
+        for (AbstractAnyTypeDeclaration parent : node.getParentsOfType(AbstractAnyTypeDeclaration.class)) {
             String clsName = parent.getScope().getEnclosingScope(ClassScope.class).getClassName();
             if (qualifiedName == null) {
                 qualifiedName = clsName;

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolationTest.java
@@ -64,6 +64,20 @@ public class JavaRuleViolationTest {
     }
 
     /**
+     * Tests that the enum name is taken correctly from the given node.
+     *
+     * @see <a href="https://sourceforge.net/p/pmd/bugs/1250/">#1250</a>
+     */
+    @Test
+    public void testEnumName() {
+        ASTCompilationUnit ast = parse("enum Foo {FOO; void bar(int x) {} }");
+        ASTMethodDeclaration md = ast.getFirstDescendantOfType(ASTMethodDeclaration.class);
+        final RuleContext context = new RuleContext();
+        final JavaRuleViolation violation = new JavaRuleViolation(null, context, md, null);
+        assertEquals("Foo", violation.getClassName());
+    }
+
+    /**
      * Tests that the class name is taken correctly, even if the node is outside
      * of a class scope, e.g. a import declaration.
      * 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolationTest.java
@@ -65,8 +65,6 @@ public class JavaRuleViolationTest {
 
     /**
      * Tests that the enum name is taken correctly from the given node.
-     *
-     * @see <a href="https://sourceforge.net/p/pmd/bugs/1250/">#1250</a>
      */
     @Test
     public void testEnumName() {


### PR DESCRIPTION
To build the class name JavaRuleViolation#setClassNameFrom(JavaNode) either iterates all ClassOrInterfaceDeclaration's or finds the first public class/enum declaration.
This fails if the file only contains a non-public non-class, e.g. a package-private enum.

This PR makes it iterate all java types (class/interface, enum and annotations).
