### PR TITLE
[RFC] [POC] - report missing classes

### DIFF
--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/SuppressWarningsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/SuppressWarningsTest.java
@@ -17,7 +17,7 @@ import net.sourceforge.pmd.testframework.RuleTst;
 
 public class SuppressWarningsTest extends RuleTst {
 
-    private static class BarRule extends AbstractApexRule {
+    public static class BarRule extends AbstractApexRule {
         @Override
         public Object visit(ASTUserClass clazz, Object ctx) {
             if (clazz.getImage().equalsIgnoreCase("bar")) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/processor/PmdThreadContextHolder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/processor/PmdThreadContextHolder.java
@@ -1,0 +1,57 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.processor;
+
+import net.sourceforge.pmd.RuleContext;
+import net.sourceforge.pmd.RuleSets;
+
+public final class PmdThreadContextHolder {
+    private static final ThreadLocal<ThreadContext> HOLDER = new ThreadLocal<>();
+
+    private PmdThreadContextHolder() {
+        // utility class
+    }
+
+    public static void reset() {
+        HOLDER.remove();
+    }
+
+    public static void init(RuleSets ruleSets, RuleContext ruleContext) {
+        if (HOLDER.get() == null) {
+            HOLDER.set(new ThreadContext(new RuleSets(ruleSets), new RuleContext(ruleContext)));
+        }
+    }
+
+    public static RuleContext getRuleContext() {
+        ThreadContext tc = HOLDER.get();
+        if (tc == null) {
+            //throw new IllegalStateException("PmdThreadContext has not been initialized");
+            // just to make the tests running for now...
+            return new RuleContext();
+        }
+        return tc.ruleContext;
+    }
+
+    public static RuleSets getRuleSets() {
+        ThreadContext tc = HOLDER.get();
+        if (tc == null) {
+            //throw new IllegalStateException("PmdThreadContext has not been initialized");
+            // just to make the tests running for now...
+            return new RuleSets();
+        }
+        return tc.ruleSets;
+    }
+
+    private static class ThreadContext {
+        /* default */ final RuleSets ruleSets;
+        /* default */ final RuleContext ruleContext;
+
+        ThreadContext(RuleSets ruleSets, RuleContext ruleContext) {
+            this.ruleSets = ruleSets;
+            this.ruleContext = ruleContext;
+        }
+    }
+
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/qname/JavaTypeQualifiedName.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/qname/JavaTypeQualifiedName.java
@@ -10,7 +10,9 @@ import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
 
+import net.sourceforge.pmd.Report.ProcessingError;
 import net.sourceforge.pmd.lang.java.ast.JavaQualifiedName;
+import net.sourceforge.pmd.processor.PmdThreadContextHolder;
 
 
 /**
@@ -173,8 +175,10 @@ public final class JavaTypeQualifiedName extends JavaQualifiedName {
                 typeLoaded = true;
                 try {
                     representedType = loadType();
-                } catch (ClassNotFoundException e) {
+                } catch (ClassNotFoundException | LinkageError e) {
                     representedType = null;
+                    PmdThreadContextHolder.getRuleContext().getReport()
+                        .addError(new ProcessingError(e, PmdThreadContextHolder.getRuleContext().getSourceCodeFilename()));
                 }
             }
             return representedType;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/TypeSet.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/TypeSet.java
@@ -13,7 +13,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import net.sourceforge.pmd.Report.ProcessingError;
 import net.sourceforge.pmd.lang.java.typeresolution.PMDASMClassLoader;
+import net.sourceforge.pmd.processor.PmdThreadContextHolder;
 import net.sourceforge.pmd.util.ClasspathClassLoader;
 
 /**
@@ -472,7 +474,10 @@ public class TypeSet {
             final Class<?> c = resolveMaybeInner(name, name);
 
             if (c == null) {
-                throw new ClassNotFoundException("Type " + name + " not found");
+                ClassNotFoundException e = new ClassNotFoundException("Type " + name + " not found");
+                PmdThreadContextHolder.getRuleContext().getReport()
+                    .addError(new ProcessingError(e, PmdThreadContextHolder.getRuleContext().getSourceCodeFilename()));
+                throw e;
             }
 
             return c;
@@ -540,6 +545,8 @@ public class TypeSet {
                     // ignored, maybe another resolver will find the class
                 } catch (LinkageError le) {
                     // we found the class, but there is a problem with it (see https://github.com/pmd/pmd/issues/328)
+                    PmdThreadContextHolder.getRuleContext().getReport()
+                        .addError(new ProcessingError(le, PmdThreadContextHolder.getRuleContext().getSourceCodeFilename()));
                     return null;
                 }
             }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import net.sourceforge.pmd.Report.ProcessingError;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.ast.QualifiableNode;
 import net.sourceforge.pmd.lang.java.ast.ASTAdditiveExpression;
@@ -94,6 +95,7 @@ import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
 import net.sourceforge.pmd.lang.java.typeresolution.typedefinition.JavaTypeDefinition;
 import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
 import net.sourceforge.pmd.lang.symboltable.Scope;
+import net.sourceforge.pmd.processor.PmdThreadContextHolder;
 
 
 //
@@ -203,10 +205,14 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
             if (LOG.isLoggable(Level.FINE)) {
                 LOG.log(Level.FINE, "Could not find class " + className + ", due to: " + e);
             }
+            PmdThreadContextHolder.getRuleContext().getReport()
+                .addError(new ProcessingError(e, PmdThreadContextHolder.getRuleContext().getSourceCodeFilename()));
         } catch (LinkageError e) {
             if (LOG.isLoggable(Level.WARNING)) {
                 LOG.log(Level.WARNING, "Could not find class " + className + ", due to: " + e);
             }
+            PmdThreadContextHolder.getRuleContext().getReport()
+                .addError(new ProcessingError(e, PmdThreadContextHolder.getRuleContext().getSourceCodeFilename()));
         } finally {
             populateImports(node);
         }
@@ -1312,6 +1318,9 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
                      */
                     myType = pmdClassLoader.loadClass(qualifiedName);
                 } catch (ClassNotFoundException e) {
+                    PmdThreadContextHolder.getRuleContext().getReport()
+                        .addError(new ProcessingError(e, PmdThreadContextHolder.getRuleContext().getSourceCodeFilename()));
+
                     myType = processOnDemand(qualifiedName);
                 } catch (LinkageError e) {
                     // we found the class, but there is a problem with it (see https://github.com/pmd/pmd/issues/1131)
@@ -1319,6 +1328,8 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
                         LOG.log(Level.FINE, "Tried to load class " + qualifiedName + " from on demand import, "
                                 + "with an incomplete classpath.", e);
                     }
+                    PmdThreadContextHolder.getRuleContext().getReport()
+                        .addError(new ProcessingError(e, PmdThreadContextHolder.getRuleContext().getSourceCodeFilename()));
                     return;
                 }
             }
@@ -1337,6 +1348,8 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
                     LOG.log(Level.FINE, "Tried to load class " + qualifiedNameInner + " from on demand import, "
                             + "with an incomplete classpath.", e);
                 }
+                PmdThreadContextHolder.getRuleContext().getReport()
+                    .addError(new ProcessingError(e, PmdThreadContextHolder.getRuleContext().getSourceCodeFilename()));
                 return;
             }
         }
@@ -1398,6 +1411,8 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
             return false;
         } catch (LinkageError e2) {
             // Class exists, but may be invalid (see https://github.com/pmd/pmd/issues/1131)
+            PmdThreadContextHolder.getRuleContext().getReport()
+                .addError(new ProcessingError(e2, PmdThreadContextHolder.getRuleContext().getSourceCodeFilename()));
             return true;
         }
     }
@@ -1412,6 +1427,8 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
                 LOG.log(Level.FINE, "Tried to load class " + fullyQualifiedClassName + " from on demand import, "
                         + "with an incomplete classpath.", e2);
             }
+            PmdThreadContextHolder.getRuleContext().getReport()
+                .addError(new ProcessingError(e2, PmdThreadContextHolder.getRuleContext().getSourceCodeFilename()));
             return null;
         }
     }
@@ -1428,6 +1445,8 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
                     LOG.log(Level.FINE, "Tried to load class " + fullClassName + " from on demand import, "
                             + "with an incomplete classpath.", e);
                 }
+                PmdThreadContextHolder.getRuleContext().getReport()
+                    .addError(new ProcessingError(e, PmdThreadContextHolder.getRuleContext().getSourceCodeFilename()));
             }
         }
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelper.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelper.java
@@ -6,8 +6,10 @@ package net.sourceforge.pmd.lang.java.typeresolution;
 
 import org.apache.commons.lang3.ClassUtils;
 
+import net.sourceforge.pmd.Report.ProcessingError;
 import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.symboltable.TypedNameDeclaration;
+import net.sourceforge.pmd.processor.PmdThreadContextHolder;
 
 public final class TypeHelper {
 
@@ -33,7 +35,7 @@ public final class TypeHelper {
 
         return clazzName.equals(n.getImage()) || clazzName.endsWith("." + n.getImage());
     }
-    
+
     /**
      * Checks whether the resolved type of the given {@link TypeNode} n is exactly of the type
      * given by the clazzName.
@@ -51,7 +53,7 @@ public final class TypeHelper {
 
         return clazzName.equals(n.getImage()) || clazzName.endsWith("." + n.getImage());
     }
-    
+
     private static Class<?> loadClassWithNodeClassloader(final TypeNode n, final String clazzName) {
         if (n.getType() != null) {
             try {
@@ -60,7 +62,7 @@ public final class TypeHelper {
                     // Using the system classloader then
                     classLoader = ClassLoader.getSystemClassLoader();
                 }
-    
+
                 // If the requested type is in the classpath, using the same classloader should work
                 return ClassUtils.getClass(classLoader, clazzName);
             } catch (final ClassNotFoundException ignored) {
@@ -70,9 +72,12 @@ public final class TypeHelper {
             } catch (final LinkageError expected) {
                 // We found the class but it's invalid / incomplete. This may be an incomplete auxclasspath
                 // if it was a NoClassDefFoundError. TODO : Report it?
+                PmdThreadContextHolder.getRuleContext().getReport()
+                    .addError(new ProcessingError(expected, PmdThreadContextHolder.getRuleContext().getSourceCodeFilename()));
+
             }
         }
-        
+
         return null;
     }
 
@@ -93,14 +98,14 @@ public final class TypeHelper {
                 return true;
             }
         }
-        
+
         return false;
     }
-    
+
     public static boolean isExactlyNone(TypedNameDeclaration vnd, Class<?>... clazzes) {
         return !isExactlyAny(vnd, clazzes);
     }
-    
+
     /**
      * @deprecated use {@link #isExactlyAny(TypedNameDeclaration, Class...)}
      */

--- a/pmd-java/src/test/java/net/sourceforge/pmd/jaxen/DocumentNavigatorTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/jaxen/DocumentNavigatorTest.java
@@ -36,8 +36,7 @@ public class DocumentNavigatorTest extends RuleTst {
 
     private TestRule rule;
 
-    private class TestRule extends AbstractJavaRule {
-
+    public static class TestRule extends AbstractJavaRule {
         private Node compilationUnit;
         private Node importDeclaration;
         private Node statement;
@@ -48,26 +47,31 @@ public class DocumentNavigatorTest extends RuleTst {
          * @see net.sourceforge.pmd.lang.java.ast.JavaParserVisitor#visit(ASTCompilationUnit,
          *      Object)
          */
+        @Override
         public Object visit(ASTCompilationUnit node, Object data) {
             this.compilationUnit = node;
             return super.visit(node, data);
         }
 
+        @Override
         public Object visit(ASTImportDeclaration node, Object data) {
             this.importDeclaration = node;
             return super.visit(node, data);
         }
 
+        @Override
         public Object visit(ASTStatement node, Object data) {
             this.statement = node;
             return super.visit(node, data);
         }
 
+        @Override
         public Object visit(ASTPrimaryPrefix node, Object data) {
             this.primaryPrefix = node;
             return super.visit(node, data);
         }
 
+        @Override
         public Object visit(ASTPrimaryExpression node, Object data) {
             this.primaryExpression = node;
             return super.visit(node, data);

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/SuppressWarningsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/SuppressWarningsTest.java
@@ -19,7 +19,7 @@ import net.sourceforge.pmd.testframework.RuleTst;
 
 public class SuppressWarningsTest extends RuleTst {
 
-    private static class BarRule extends AbstractJavaRule {
+    public static class BarRule extends AbstractJavaRule {
         @Override
         public Object visit(ASTCompilationUnit cu, Object ctx) {
             // Convoluted rule to make sure the violation is reported for the

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/ReportTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/ReportTest.java
@@ -18,16 +18,18 @@ import net.sourceforge.pmd.testframework.RuleTst;
 
 public class ReportTest extends RuleTst {
 
+    public static class TestRule extends AbstractEcmascriptRule {
+        @Override
+        public Object visit(ASTFunctionNode node, Object data) {
+            EcmascriptRuleViolationFactory.INSTANCE.addViolation((RuleContext) data, this, node, "Test", null);
+            return super.visit(node, data);
+        }
+    }
+
     @Test
     public void testExclusionsInReportWithNOPMDEcmascript() throws Exception {
         Report rpt = new Report();
-        Rule rule = new AbstractEcmascriptRule() {
-            @Override
-            public Object visit(ASTFunctionNode node, Object data) {
-                EcmascriptRuleViolationFactory.INSTANCE.addViolation((RuleContext) data, this, node, "Test", null);
-                return super.visit(node, data);
-            }
-        };
+        Rule rule = new TestRule();
         String code = "function(x) // NOPMD test suppress\n" + "{ x = 1; }";
         runTestFromString(code, rule, rpt,
                 LanguageRegistry.getLanguage(EcmascriptLanguageModule.NAME).getDefaultVersion());

--- a/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
@@ -45,6 +45,7 @@ import net.sourceforge.pmd.RuleSets;
 import net.sourceforge.pmd.RuleViolation;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersion;
+import net.sourceforge.pmd.processor.PmdThreadContextHolder;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.renderers.TextRenderer;
 
@@ -271,7 +272,9 @@ public abstract class RuleTst {
             ctx.setLanguageVersion(languageVersion);
             ctx.setIgnoreExceptions(false);
             RuleSet rules = new RuleSetFactory().createSingleRuleRuleSet(rule);
+            PmdThreadContextHolder.init(new RuleSets(rules), ctx);
             p.getSourceCodeProcessor().processSourceCode(new StringReader(code), new RuleSets(rules), ctx);
+            PmdThreadContextHolder.reset();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/pmd-test/src/test/java/net/sourceforge/pmd/testframework/RuleTstTest.java
+++ b/pmd-test/src/test/java/net/sourceforge/pmd/testframework/RuleTstTest.java
@@ -43,12 +43,13 @@ public class RuleTstTest {
         Report report = new Report();
         when(rule.getLanguage()).thenReturn(dummyLanguage.getLanguage());
         when(rule.getName()).thenReturn("test rule");
+        when(rule.deepCopy()).thenReturn(rule);
 
         ruleTester.runTestFromString("the code", rule, report, dummyLanguage, false);
 
         verify(rule).start(any(RuleContext.class));
         verify(rule).end(any(RuleContext.class));
-        verify(rule, times(5)).getLanguage();
+        verify(rule, times(7)).getLanguage();
         verify(rule).isDfa();
         verify(rule).isTypeResolution();
         verify(rule).isMultifile();
@@ -58,6 +59,7 @@ public class RuleTstTest {
         verify(rule).apply(anyList(), any(RuleContext.class));
         verify(rule, times(4)).getName();
         verify(rule).getPropertiesByPropertyDescriptor();
+        verify(rule).deepCopy();
         verifyNoMoreInteractions(rule);
     }
 
@@ -65,6 +67,7 @@ public class RuleTstTest {
     public void shouldAssertLinenumbersSorted() {
         when(rule.getLanguage()).thenReturn(dummyLanguage.getLanguage());
         when(rule.getName()).thenReturn("test rule");
+        when(rule.deepCopy()).thenReturn(rule);
         Mockito.doAnswer(new Answer<Void>() {
             private RuleViolation createViolation(RuleContext context, int beginLine, String message) {
                 DummyNode node = new DummyNode(1);


### PR DESCRIPTION
This adds a PmdThreadContextHolder to have access to the report anywhere.

API is ugly and needs to be defined yet. The problem should be reported
as a configuration error rather than a processing error. But a
configuration error needs a rule and is unfortunately currently
ignored by the maven-pmd-plugin... (it doesn't end up in the report).

But in general, it works - the missing classes end up as processing
errors in the final report.

I probably missed some cases where we should report missing classes
or reporting the cases multiple times...
In the end, we should probably deduplicate and report each missing
class only once.

This would be part of #194 