### PR TITLE
[core] Upgrading Apache Commons IO from 2.4 to 2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -815,7 +815,7 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.4</version>
+                <version>2.6</version>
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>


### PR DESCRIPTION
**PR Description:** This updates the version of Apache Commons IO from 2.4 (released June 2012) to 2.6 (released October 2017).

Ran `mvnw.cmd clean verify` on my local machine and got a successful build.