### PR TITLE
[core] Upgrading Apache Commons Lang 3 from 3.7 to 3.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -825,7 +825,7 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
-                <version>3.7</version>
+                <version>3.8.1</version>
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>


### PR DESCRIPTION
This updates the version of Apache Commons Lang 3 from 3.7 (released November 2017) to 3.8.1 (released September 2018).

Ran `mvnw.cmd clean verify` on my local machine and got a successful build.