### PR TITLE
[all] Replacing deprecated IO methods with ones that specify a charset

### DIFF
--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexParserTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexParserTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.commons.io.FileUtils;
@@ -113,7 +114,7 @@ public class ApexParserTest {
 
         for (File file : fList) {
             if (file.isFile() && file.getName().endsWith(".cls")) {
-                String sourceCode = FileUtils.readFileToString(file);
+                String sourceCode = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
                 ApexNode<Compilation> rootNode = parse(sourceCode);
                 Assert.assertNotNull(rootNode);
             }
@@ -127,7 +128,8 @@ public class ApexParserTest {
      */
     @Test
     public void stackOverflowDuringClassParsing() throws Exception {
-        String source = IOUtils.toString(ApexParserTest.class.getResourceAsStream("StackOverflowClass.cls"));
+        String source = IOUtils.toString(ApexParserTest.class.getResourceAsStream("StackOverflowClass.cls"),
+                StandardCharsets.UTF_8);
         ApexNode<Compilation> rootNode = parse(source);
         Assert.assertNotNull(rootNode);
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/metrics/ApexProjectMirrorTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/metrics/ApexProjectMirrorTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -47,7 +48,8 @@ public class ApexProjectMirrorTest {
     static {
         try {
             acu = parseAndVisitForString(
-                IOUtils.toString(ApexMultifileVisitorTest.class.getResourceAsStream("MetadataDeployController.cls")));
+                IOUtils.toString(ApexMultifileVisitorTest.class.getResourceAsStream("MetadataDeployController.cls"),
+                        StandardCharsets.UTF_8));
         } catch (IOException ioe) {
             // Should definitely not happen
         }

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/multifile/ApexMultifileVisitorTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/multifile/ApexMultifileVisitorTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
@@ -39,7 +40,8 @@ public class ApexMultifileVisitorTest extends ApexParserTest {
     @Test
     public void testOperationsAreThere() throws IOException {
         ApexNode<Compilation> acu = parseAndVisitForString(
-            IOUtils.toString(ApexMultifileVisitorTest.class.getResourceAsStream("MetadataDeployController.cls")));
+            IOUtils.toString(ApexMultifileVisitorTest.class.getResourceAsStream("MetadataDeployController.cls"),
+                    StandardCharsets.UTF_8));
 
         final ApexSignatureMatcher toplevel = ApexProjectMirror.INSTANCE;
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetReferenceIdTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetReferenceIdTest.java
@@ -19,6 +19,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
@@ -122,7 +123,7 @@ public class RuleSetReferenceIdTest {
         assertRuleSetReferenceId(true, rulesetUrl, true, null, rulesetUrl, ruleSetReferenceId);
 
         try (InputStream inputStream = ruleSetReferenceId.getInputStream(new ResourceLoader())) {
-            String loaded = IOUtils.toString(inputStream, "UTF-8");
+            String loaded = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
             assertEquals("xyz", loaded);
         }
 
@@ -139,7 +140,7 @@ public class RuleSetReferenceIdTest {
         String completePath = path + "/DummyBasicMockRule";
         String hostpart = "http://localhost:" + wireMockRule.port();
         String basicRuleSet = IOUtils
-                .toString(RuleSetReferenceId.class.getResourceAsStream("/rulesets/dummy/basic.xml"));
+                .toString(RuleSetReferenceId.class.getResourceAsStream("/rulesets/dummy/basic.xml"), StandardCharsets.UTF_8);
 
         stubFor(head(urlEqualTo(completePath)).willReturn(aResponse().withStatus(404)));
         stubFor(head(urlEqualTo(path)).willReturn(aResponse().withStatus(200).withHeader("Content-type", "text/xml")));
@@ -151,7 +152,7 @@ public class RuleSetReferenceIdTest {
                 ruleSetReferenceId);
 
         try (InputStream inputStream = ruleSetReferenceId.getInputStream(new ResourceLoader())) {
-            String loaded = IOUtils.toString(inputStream, "UTF-8");
+            String loaded = IOUtils.toString(inputStream, StandardCharsets.UTF_8);
             assertEquals(basicRuleSet, loaded);
         }
 

--- a/pmd-cpp/src/test/java/net/sourceforge/pmd/cpd/CPPTokenizerTest.java
+++ b/pmd-cpp/src/test/java/net/sourceforge/pmd/cpd/CPPTokenizerTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertTrue;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
 import org.apache.commons.io.IOUtils;
@@ -67,21 +68,21 @@ public class CPPTokenizerTest {
 
     @Test
     public void testTokenizerWithSkipBlocks() throws Exception {
-        String test = IOUtils.toString(CPPTokenizerTest.class.getResourceAsStream("cpp/cpp_with_asm.cpp"));
+        String test = IOUtils.toString(CPPTokenizerTest.class.getResourceAsStream("cpp/cpp_with_asm.cpp"), StandardCharsets.UTF_8);
         Tokens tokens = parse(test, true);
         assertEquals(19, tokens.size());
     }
 
     @Test
     public void testTokenizerWithSkipBlocksPattern() throws Exception {
-        String test = IOUtils.toString(CPPTokenizerTest.class.getResourceAsStream("cpp/cpp_with_asm.cpp"));
+        String test = IOUtils.toString(CPPTokenizerTest.class.getResourceAsStream("cpp/cpp_with_asm.cpp"), StandardCharsets.UTF_8);
         Tokens tokens = parse(test, true, "#if debug|#endif");
         assertEquals(31, tokens.size());
     }
 
     @Test
     public void testTokenizerWithoutSkipBlocks() throws Exception {
-        String test = IOUtils.toString(CPPTokenizerTest.class.getResourceAsStream("cpp/cpp_with_asm.cpp"));
+        String test = IOUtils.toString(CPPTokenizerTest.class.getResourceAsStream("cpp/cpp_with_asm.cpp"), StandardCharsets.UTF_8);
         Tokens tokens = parse(test, false);
         assertEquals(37, tokens.size());
     }

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/CpdExecutor.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/CpdExecutor.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.it;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Arrays;
 
@@ -30,7 +31,7 @@ public class CpdExecutor {
         pb.command().addAll(Arrays.asList(arguments));
         pb.redirectErrorStream(true);
         Process process = pb.start();
-        String output = IOUtils.toString(process.getInputStream());
+        String output = IOUtils.toString(process.getInputStream(), StandardCharsets.UTF_8);
 
         int result = process.waitFor();
         return new ExecutionResult(result, output);
@@ -42,7 +43,7 @@ public class CpdExecutor {
         pb.command().addAll(Arrays.asList(arguments));
         pb.redirectErrorStream(true);
         Process process = pb.start();
-        String output = IOUtils.toString(process.getInputStream());
+        String output = IOUtils.toString(process.getInputStream(), StandardCharsets.UTF_8);
 
         int result = process.waitFor();
         return new ExecutionResult(result, output);

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/PMDExecutor.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/PMDExecutor.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.it;
 
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.Arrays;
 
@@ -34,7 +35,7 @@ public class PMDExecutor {
         pb.command().addAll(Arrays.asList(arguments));
         pb.redirectErrorStream(true);
         Process process = pb.start();
-        String output = IOUtils.toString(process.getInputStream());
+        String output = IOUtils.toString(process.getInputStream(), StandardCharsets.UTF_8);
 
         int result = process.waitFor();
         return new ExecutionResult(result, output);
@@ -46,7 +47,7 @@ public class PMDExecutor {
         pb.command().addAll(Arrays.asList(arguments));
         pb.redirectErrorStream(true);
         Process process = pb.start();
-        String output = IOUtils.toString(process.getInputStream());
+        String output = IOUtils.toString(process.getInputStream(), StandardCharsets.UTF_8);
 
         int result = process.waitFor();
         return new ExecutionResult(result, output);

--- a/pmd-doc/src/test/java/net/sourceforge/pmd/docs/RuleDocGeneratorTest.java
+++ b/pmd-doc/src/test/java/net/sourceforge/pmd/docs/RuleDocGeneratorTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -81,17 +82,17 @@ public class RuleDocGeneratorTest {
         assertEquals(3, writer.getData().size());
         FileEntry languageIndex = writer.getData().get(0);
         assertTrue(FilenameUtils.normalize(languageIndex.getFilename(), true).endsWith("docs/pages/pmd/rules/java.md"));
-        assertEquals(IOUtils.toString(RuleDocGeneratorTest.class.getResourceAsStream("/expected/java.md")),
+        assertEquals(IOUtils.toString(RuleDocGeneratorTest.class.getResourceAsStream("/expected/java.md"), StandardCharsets.UTF_8),
                 languageIndex.getContent());
 
         FileEntry ruleSetIndex = writer.getData().get(1);
         assertTrue(FilenameUtils.normalize(ruleSetIndex.getFilename(), true).endsWith("docs/pages/pmd/rules/java/sample.md"));
-        assertEquals(IOUtils.toString(RuleDocGeneratorTest.class.getResourceAsStream("/expected/sample.md")),
+        assertEquals(IOUtils.toString(RuleDocGeneratorTest.class.getResourceAsStream("/expected/sample.md"), StandardCharsets.UTF_8),
                 ruleSetIndex.getContent());
 
         FileEntry sidebar = writer.getData().get(2);
         assertTrue(FilenameUtils.normalize(sidebar.getFilename(), true).endsWith("docs/_data/sidebars/pmd_sidebar.yml"));
-        assertEquals(IOUtils.toString(RuleDocGeneratorTest.class.getResourceAsStream("/expected/pmd_sidebar.yml")),
+        assertEquals(IOUtils.toString(RuleDocGeneratorTest.class.getResourceAsStream("/expected/pmd_sidebar.yml"), StandardCharsets.UTF_8),
                 sidebar.getContent());
     }
 }

--- a/pmd-doc/src/test/java/net/sourceforge/pmd/docs/SidebarGeneratorTest.java
+++ b/pmd-doc/src/test/java/net/sourceforge/pmd/docs/SidebarGeneratorTest.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.docs;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.util.Arrays;
 import java.util.Collections;
@@ -54,6 +55,6 @@ public class SidebarGeneratorTest {
         }
         String yaml = new Yaml(options).dump(result);
 
-        assertEquals(IOUtils.toString(SidebarGeneratorTest.class.getResourceAsStream("sidebar.yml")), yaml);
+        assertEquals(IOUtils.toString(SidebarGeneratorTest.class.getResourceAsStream("sidebar.yml"), StandardCharsets.UTF_8), yaml);
     }
 }

--- a/pmd-groovy/src/main/java/net/sourceforge/pmd/cpd/GroovyTokenizer.java
+++ b/pmd-groovy/src/main/java/net/sourceforge/pmd/cpd/GroovyTokenizer.java
@@ -4,9 +4,8 @@
 
 package net.sourceforge.pmd.cpd;
 
-import java.nio.charset.StandardCharsets;
+import java.io.StringReader;
 
-import org.apache.commons.io.IOUtils;
 import org.codehaus.groovy.antlr.parser.GroovyLexer;
 
 import net.sourceforge.pmd.lang.ast.TokenMgrError;
@@ -24,7 +23,7 @@ public class GroovyTokenizer implements Tokenizer {
     public void tokenize(SourceCode sourceCode, Tokens tokenEntries) {
         StringBuilder buffer = sourceCode.getCodeBuffer();
 
-        GroovyLexer lexer = new GroovyLexer(IOUtils.toInputStream(buffer.toString(), StandardCharsets.UTF_8));
+        GroovyLexer lexer = new GroovyLexer(new StringReader(buffer.toString()));
         TokenStream tokenStream = lexer.plumb();
 
         try {

--- a/pmd-groovy/src/main/java/net/sourceforge/pmd/cpd/GroovyTokenizer.java
+++ b/pmd-groovy/src/main/java/net/sourceforge/pmd/cpd/GroovyTokenizer.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.cpd;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.commons.io.IOUtils;
 import org.codehaus.groovy.antlr.parser.GroovyLexer;
 
@@ -22,7 +24,7 @@ public class GroovyTokenizer implements Tokenizer {
     public void tokenize(SourceCode sourceCode, Tokens tokenEntries) {
         StringBuilder buffer = sourceCode.getCodeBuffer();
 
-        GroovyLexer lexer = new GroovyLexer(IOUtils.toInputStream(buffer.toString()));
+        GroovyLexer lexer = new GroovyLexer(IOUtils.toInputStream(buffer.toString(), StandardCharsets.UTF_8));
         TokenStream tokenStream = lexer.plumb();
 
         try {

--- a/pmd-groovy/src/test/java/net/sourceforge/pmd/cpd/GroovyTokenizerTest.java
+++ b/pmd-groovy/src/test/java/net/sourceforge/pmd/cpd/GroovyTokenizerTest.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.cpd;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
@@ -25,7 +26,7 @@ public class GroovyTokenizerTest extends AbstractTokenizerTest {
 
     @Override
     public String getSampleCode() throws IOException {
-        return IOUtils.toString(GroovyTokenizer.class.getResourceAsStream(FILENAME));
+        return IOUtils.toString(GroovyTokenizer.class.getResourceAsStream(FILENAME), StandardCharsets.UTF_8);
     }
 
     @Test

--- a/pmd-java/src/test/java/net/sourceforge/pmd/coverage/PMDCoverageTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/coverage/PMDCoverageTest.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -69,7 +70,7 @@ public class PMDCoverageTest {
             assertFalse("Wrong configuration? Ruleset not found", errorStream.getLog().contains("Ruleset not found"));
             assertEquals("No usage of deprecated XPath attributes expected", 0, StringUtils.countMatches(errorStream.getLog(), "Use of deprecated attribute"));
 
-            String report = FileUtils.readFileToString(f);
+            String report = FileUtils.readFileToString(f, StandardCharsets.UTF_8);
             assertEquals("No processing errors expected", 0, StringUtils.countMatches(report, "Error while processing"));
 
             // we might have explicit examples of parsing errors, so these are maybe false positives

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ParserTstUtil.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ParserTstUtil.java
@@ -11,6 +11,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -238,7 +239,7 @@ public class ParserTstUtil {
         }
         String source;
         try {
-            source = IOUtils.toString(is);
+            source = IOUtils.toString(is, StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
@@ -128,9 +128,8 @@ public class ParserCornersTest {
     }
 
     @Test
-    public void testLambdaBug1470() throws Exception {
-        String code = IOUtils.toString(ParserCornersTest.class.getResourceAsStream("LambdaBug1470.java"),
-                StandardCharsets.UTF_8);
+    public void testLambdaBug1470() {
+        String code = readAsString("LambdaBug1470.java");
         parseJava18(code);
     }
 
@@ -164,21 +163,20 @@ public class ParserCornersTest {
     }
 
     @Test
-    public void testBug1429ParseError() throws Exception {
-        String c = IOUtils.toString(this.getClass().getResourceAsStream("Bug1429.java"), StandardCharsets.UTF_8);
+    public void testBug1429ParseError() {
+        String c = readAsString("Bug1429.java");
         parseJava18(c);
     }
 
     @Test
-    public void testBug1530ParseError() throws Exception {
-        String c = IOUtils.toString(this.getClass().getResourceAsStream("Bug1530.java"), StandardCharsets.UTF_8);
+    public void testBug1530ParseError() {
+        String c = readAsString("Bug1530.java");
         parseJava18(c);
     }
     
     @Test
-    public void testGitHubBug207() throws Exception {
-        String c = IOUtils.toString(this.getClass().getResourceAsStream("GitHubBug207.java"),
-                StandardCharsets.UTF_8);
+    public void testGitHubBug207() {
+        String c = readAsString("GitHubBug207.java");
         parseJava18(c);
     }
 
@@ -192,9 +190,8 @@ public class ParserCornersTest {
     }
 
     @Test
-    public void testGitHubBug208ParseError() throws Exception {
-        String c = IOUtils.toString(this.getClass().getResourceAsStream("GitHubBug208.java"),
-                StandardCharsets.UTF_8);
+    public void testGitHubBug208ParseError() {
+        String c = readAsString("GitHubBug208.java");
         parseJava15(c);
     }
     

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
@@ -14,6 +14,7 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 
@@ -128,7 +129,8 @@ public class ParserCornersTest {
 
     @Test
     public void testLambdaBug1470() throws Exception {
-        String code = IOUtils.toString(ParserCornersTest.class.getResourceAsStream("LambdaBug1470.java"), "UTF-8");
+        String code = IOUtils.toString(ParserCornersTest.class.getResourceAsStream("LambdaBug1470.java"),
+                StandardCharsets.UTF_8);
         parseJava18(code);
     }
 
@@ -163,19 +165,20 @@ public class ParserCornersTest {
 
     @Test
     public void testBug1429ParseError() throws Exception {
-        String c = IOUtils.toString(this.getClass().getResourceAsStream("Bug1429.java"));
+        String c = IOUtils.toString(this.getClass().getResourceAsStream("Bug1429.java"), StandardCharsets.UTF_8);
         parseJava18(c);
     }
 
     @Test
     public void testBug1530ParseError() throws Exception {
-        String c = IOUtils.toString(this.getClass().getResourceAsStream("Bug1530.java"));
+        String c = IOUtils.toString(this.getClass().getResourceAsStream("Bug1530.java"), StandardCharsets.UTF_8);
         parseJava18(c);
     }
     
     @Test
     public void testGitHubBug207() throws Exception {
-        String c = IOUtils.toString(this.getClass().getResourceAsStream("GitHubBug207.java"));
+        String c = IOUtils.toString(this.getClass().getResourceAsStream("GitHubBug207.java"),
+                StandardCharsets.UTF_8);
         parseJava18(c);
     }
 
@@ -190,7 +193,8 @@ public class ParserCornersTest {
 
     @Test
     public void testGitHubBug208ParseError() throws Exception {
-        String c = IOUtils.toString(this.getClass().getResourceAsStream("GitHubBug208.java"));
+        String c = IOUtils.toString(this.getClass().getResourceAsStream("GitHubBug208.java"),
+                StandardCharsets.UTF_8);
         parseJava15(c);
     }
     
@@ -276,7 +280,7 @@ public class ParserCornersTest {
     private String readAsString(String resource) {
         InputStream in = ParserCornersTest.class.getResourceAsStream(resource);
         try {
-            return IOUtils.toString(in);
+            return IOUtils.toString(in, StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new RuntimeException(e);
         } finally {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symboltable/STBBaseTst.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symboltable/STBBaseTst.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.java.symboltable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 
@@ -49,7 +50,7 @@ public abstract class STBBaseTst {
         }
         final String source;
         try {
-            source = IOUtils.toString(is);
+            source = IOUtils.toString(is, StandardCharsets.UTF_8);
         } catch (final IOException e) {
             throw new RuntimeException(e);
         }

--- a/pmd-matlab/src/test/java/net/sourceforge/pmd/cpd/MatlabTokenizerTest.java
+++ b/pmd-matlab/src/test/java/net/sourceforge/pmd/cpd/MatlabTokenizerTest.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.cpd;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
@@ -28,7 +29,7 @@ public class MatlabTokenizerTest extends AbstractTokenizerTest {
 
     @Override
     public String getSampleCode() throws IOException {
-        return IOUtils.toString(MatlabTokenizer.class.getResourceAsStream(FILENAME));
+        return IOUtils.toString(MatlabTokenizer.class.getResourceAsStream(FILENAME), StandardCharsets.UTF_8);
     }
 
     @Test

--- a/pmd-objectivec/src/test/java/net/sourceforge/pmd/cpd/ObjectiveCTokenizerTest.java
+++ b/pmd-objectivec/src/test/java/net/sourceforge/pmd/cpd/ObjectiveCTokenizerTest.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.cpd;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
@@ -25,7 +26,7 @@ public class ObjectiveCTokenizerTest extends AbstractTokenizerTest {
 
     @Override
     public String getSampleCode() throws IOException {
-        return IOUtils.toString(ObjectiveCTokenizer.class.getResourceAsStream(FILENAME));
+        return IOUtils.toString(ObjectiveCTokenizer.class.getResourceAsStream(FILENAME), StandardCharsets.UTF_8);
     }
 
     @Test

--- a/pmd-objectivec/src/test/java/net/sourceforge/pmd/cpd/UTF8EscapesInStringLiteralObjCTokenizerTest.java
+++ b/pmd-objectivec/src/test/java/net/sourceforge/pmd/cpd/UTF8EscapesInStringLiteralObjCTokenizerTest.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.cpd;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
@@ -26,7 +27,7 @@ public class UTF8EscapesInStringLiteralObjCTokenizerTest extends AbstractTokeniz
 
     @Override
     public String getSampleCode() throws IOException {
-        return IOUtils.toString(ObjectiveCTokenizer.class.getResourceAsStream(FILENAME), "UTF-8");
+        return IOUtils.toString(ObjectiveCTokenizer.class.getResourceAsStream(FILENAME), StandardCharsets.UTF_8);
     }
 
     @Test

--- a/pmd-objectivec/src/test/java/net/sourceforge/pmd/cpd/UnicodeObjectiveCTokenizerTest.java
+++ b/pmd-objectivec/src/test/java/net/sourceforge/pmd/cpd/UnicodeObjectiveCTokenizerTest.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.cpd;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
@@ -29,7 +30,7 @@ public class UnicodeObjectiveCTokenizerTest extends AbstractTokenizerTest {
 
     @Override
     public String getSampleCode() throws IOException {
-        return IOUtils.toString(ObjectiveCTokenizer.class.getResourceAsStream(FILENAME), "UTF-8");
+        return IOUtils.toString(ObjectiveCTokenizer.class.getResourceAsStream(FILENAME), StandardCharsets.UTF_8);
     }
 
     @Test

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/cpd/PLSQLTokenizerTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/cpd/PLSQLTokenizerTest.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.cpd;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
@@ -28,7 +29,7 @@ public class PLSQLTokenizerTest extends AbstractTokenizerTest {
 
     @Override
     public String getSampleCode() throws IOException {
-        return IOUtils.toString(PLSQLTokenizer.class.getResourceAsStream(FILENAME));
+        return IOUtils.toString(PLSQLTokenizer.class.getResourceAsStream(FILENAME), StandardCharsets.UTF_8);
     }
 
     @Test

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/AbstractPLSQLParserTst.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/AbstractPLSQLParserTst.java
@@ -10,6 +10,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -133,7 +134,7 @@ public abstract class AbstractPLSQLParserTst {
 
     public String loadTestResource(String name) {
         try {
-            return IOUtils.toString(this.getClass().getResourceAsStream(name));
+            return IOUtils.toString(this.getClass().getResourceAsStream(name), StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/PLSQLParserTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/PLSQLParserTest.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.plsql;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
@@ -35,36 +37,36 @@ public class PLSQLParserTest extends AbstractPLSQLParserTst {
 
     @Test
     public void testBug1527() throws Exception {
-        parsePLSQL(IOUtils.toString(PLSQLParserTest.class.getResourceAsStream("ast/InlinePragmaProcError.pls")));
+        parsePLSQL(IOUtils.toString(PLSQLParserTest.class.getResourceAsStream("ast/InlinePragmaProcError.pls"), StandardCharsets.UTF_8));
     }
 
     @Test
     public void testBug1520IsOfType() throws Exception {
-        parsePLSQL(IOUtils.toString(PLSQLParserTest.class.getResourceAsStream("ast/IsOfType.pls")));
+        parsePLSQL(IOUtils.toString(PLSQLParserTest.class.getResourceAsStream("ast/IsOfType.pls"), StandardCharsets.UTF_8));
     }
 
     @Test
     public void testBug1520Using() throws Exception {
-        parsePLSQL(IOUtils.toString(PLSQLParserTest.class.getResourceAsStream("ast/Using.pls")));
+        parsePLSQL(IOUtils.toString(PLSQLParserTest.class.getResourceAsStream("ast/Using.pls"), StandardCharsets.UTF_8));
     }
 
     @Test
     public void testSingleLineSelect() throws Exception {
-        parsePLSQL(IOUtils.toString(PLSQLParserTest.class.getResourceAsStream("ast/SingleLineSelect.pls")));
+        parsePLSQL(IOUtils.toString(PLSQLParserTest.class.getResourceAsStream("ast/SingleLineSelect.pls"), StandardCharsets.UTF_8));
     }
 
     @Test
     public void testMultiLineSelect() throws Exception {
-        parsePLSQL(IOUtils.toString(PLSQLParserTest.class.getResourceAsStream("ast/MultiLineSelect.pls")));
+        parsePLSQL(IOUtils.toString(PLSQLParserTest.class.getResourceAsStream("ast/MultiLineSelect.pls"), StandardCharsets.UTF_8));
     }
 
     @Test
     public void testIsNull() throws Exception {
-        parsePLSQL(IOUtils.toString(PLSQLParserTest.class.getResourceAsStream("ast/IsNull.pls")));
+        parsePLSQL(IOUtils.toString(PLSQLParserTest.class.getResourceAsStream("ast/IsNull.pls"), StandardCharsets.UTF_8));
     }
 
     @Test
     public void testCodingStyleExample() throws Exception {
-        parsePLSQL(IOUtils.toString(PLSQLParserTest.class.getResourceAsStream("ast/CodingStyleExample.pls")));
+        parsePLSQL(IOUtils.toString(PLSQLParserTest.class.getResourceAsStream("ast/CodingStyleExample.pls"), StandardCharsets.UTF_8));
     }
 }

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/CreateTableTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/CreateTableTest.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.plsql.ast;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -14,7 +16,8 @@ public class CreateTableTest extends AbstractPLSQLParserTst {
 
     @Test
     public void parseCreateTable() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("CreateTable.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("CreateTable.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
         Assert.assertNotNull(input);
     }

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/DeleteStatementTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/DeleteStatementTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.plsql.ast;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
@@ -16,7 +17,8 @@ public class DeleteStatementTest extends AbstractPLSQLParserTst {
 
     @Test
     public void parseDeleteStatementExample() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("DeleteStatementExample.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("DeleteStatementExample.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
         List<ASTDeleteStatement> deleteStatements = input.findDescendantsOfType(ASTDeleteStatement.class);
         Assert.assertEquals(3, deleteStatements.size());

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ExecuteImmediateTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ExecuteImmediateTest.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.plsql.ast;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -14,14 +16,16 @@ public class ExecuteImmediateTest extends AbstractPLSQLParserTst {
 
     @Test
     public void parseExecuteImmediate1047a() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("ExecuteImmediate1047a.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("ExecuteImmediate1047a.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
         Assert.assertNotNull(input);
     }
 
     @Test
     public void parseExecuteImmediate1047b() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("ExecuteImmediate1047b.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("ExecuteImmediate1047b.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
         Assert.assertNotNull(input);
     }

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/JoinClauseTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/JoinClauseTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.plsql.ast;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
@@ -16,7 +17,8 @@ public class JoinClauseTest extends AbstractPLSQLParserTst {
 
     @Test
     public void testInnerCrossJoin() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("InnerCrossJoin.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("InnerCrossJoin.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
         List<ASTInnerCrossJoinClause> joins = input.findDescendantsOfType(ASTInnerCrossJoinClause.class);
         Assert.assertEquals(1, joins.size());
@@ -26,7 +28,8 @@ public class JoinClauseTest extends AbstractPLSQLParserTst {
 
     @Test
     public void testInnerNaturalJoin() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("InnerNaturalJoin.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("InnerNaturalJoin.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
         List<ASTInnerCrossJoinClause> joins = input.findDescendantsOfType(ASTInnerCrossJoinClause.class);
         Assert.assertEquals(1, joins.size());
@@ -36,7 +39,8 @@ public class JoinClauseTest extends AbstractPLSQLParserTst {
 
     @Test
     public void testInnerJoinUsing() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("InnerJoinUsing.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("InnerJoinUsing.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
         List<ASTInnerCrossJoinClause> joins = input.findDescendantsOfType(ASTInnerCrossJoinClause.class);
         Assert.assertEquals(1, joins.size());
@@ -49,7 +53,8 @@ public class JoinClauseTest extends AbstractPLSQLParserTst {
 
     @Test
     public void testOuterJoinUsing() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("OuterJoinUsing.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("OuterJoinUsing.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
         List<ASTOuterJoinClause> joins = input.findDescendantsOfType(ASTOuterJoinClause.class);
         Assert.assertEquals(1, joins.size());
@@ -62,7 +67,8 @@ public class JoinClauseTest extends AbstractPLSQLParserTst {
 
     @Test
     public void testRightOuterJoin() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("RightOuterJoin.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("RightOuterJoin.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
         List<ASTOuterJoinClause> joins = input.findDescendantsOfType(ASTOuterJoinClause.class);
         Assert.assertEquals(1, joins.size());
@@ -72,7 +78,8 @@ public class JoinClauseTest extends AbstractPLSQLParserTst {
 
     @Test
     public void testNaturalRightOuterJoin() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("NaturalRightOuterJoin.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("NaturalRightOuterJoin.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
         List<ASTOuterJoinClause> joins = input.findDescendantsOfType(ASTOuterJoinClause.class);
         Assert.assertEquals(1, joins.size());
@@ -83,7 +90,8 @@ public class JoinClauseTest extends AbstractPLSQLParserTst {
 
     @Test
     public void testOuterJoinPartitioned() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("OuterJoinPartitioned.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("OuterJoinPartitioned.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
         List<ASTOuterJoinClause> joins = input.findDescendantsOfType(ASTOuterJoinClause.class);
         Assert.assertEquals(1, joins.size());

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectExpressionsTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectExpressionsTest.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.plsql.ast;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Ignore;
@@ -16,7 +18,8 @@ public class SelectExpressionsTest extends AbstractPLSQLParserTst {
     @Test
     @Ignore
     public void parseSelectCount() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectExpressions.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectExpressions.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
         Assert.assertNotNull(input);
     }

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectIntoStatementTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectIntoStatementTest.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.plsql.ast;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
@@ -13,43 +15,50 @@ public class SelectIntoStatementTest extends AbstractPLSQLParserTst {
 
     @Test
     public void testParsingComplex() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectIntoStatement.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectIntoStatement.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
     }
 
     @Test
     public void testParsingExample1() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectIntoStatementExample1.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectIntoStatementExample1.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
     }
 
     @Test
     public void testParsingExample2() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectIntoStatementExample2.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectIntoStatementExample2.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
     }
 
     @Test
     public void testParsingExample3() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectIntoStatementExample3.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectIntoStatementExample3.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
     }
 
     @Test
     public void testParsingExample4() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectIntoStatementExample4.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectIntoStatementExample4.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
     }
 
     @Test
     public void testParsingExample5() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectIntoStatementExample5.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectIntoStatementExample5.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
     }
 
     @Test
     public void testParsingWithFunctionCall() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectIntoStatementFunctionCall.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectIntoStatementFunctionCall.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
     }
 }

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectIntoWithGroupByTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectIntoWithGroupByTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.plsql.ast;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
@@ -16,7 +17,8 @@ public class SelectIntoWithGroupByTest extends AbstractPLSQLParserTst {
 
     @Test
     public void testExample1() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectIntoWithGroupBy1.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectIntoWithGroupBy1.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
         ASTGroupByClause groupByClause = input.getFirstDescendantOfType(ASTGroupByClause.class);
         Assert.assertNotNull(groupByClause);
@@ -24,7 +26,8 @@ public class SelectIntoWithGroupByTest extends AbstractPLSQLParserTst {
 
     @Test
     public void testExample2() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectIntoWithGroupBy2.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectIntoWithGroupBy2.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
         ASTGroupByClause groupByClause = input.getFirstDescendantOfType(ASTGroupByClause.class);
         Assert.assertNotNull(groupByClause);
@@ -32,7 +35,8 @@ public class SelectIntoWithGroupByTest extends AbstractPLSQLParserTst {
 
     @Test
     public void testExample3WithCube() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectIntoWithGroupBy3.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectIntoWithGroupBy3.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
         ASTRollupCubeClause cubeClause = input.getFirstDescendantOfType(ASTRollupCubeClause.class);
         Assert.assertNotNull(cubeClause);
@@ -41,7 +45,8 @@ public class SelectIntoWithGroupByTest extends AbstractPLSQLParserTst {
 
     @Test
     public void testExample4WithGroupingSets() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectIntoWithGroupBy4.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectIntoWithGroupBy4.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
         ASTGroupingSetsClause groupingSetsClause = input.getFirstDescendantOfType(ASTGroupingSetsClause.class);
         Assert.assertNotNull(groupingSetsClause);

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ViewTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ViewTest.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.plsql.ast;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -14,7 +16,8 @@ public class ViewTest extends AbstractPLSQLParserTst {
 
     @Test
     public void parseCreateViewIssue981() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("ViewIssue981.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("ViewIssue981.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
         Assert.assertNotNull(input);
     }

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/WhereClauseTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/WhereClauseTest.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.plsql.ast;
 
+import java.nio.charset.StandardCharsets;
+
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
@@ -13,37 +15,43 @@ public class WhereClauseTest extends AbstractPLSQLParserTst {
 
     @Test
     public void testFunctionCall() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("WhereClauseFunctionCall.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("WhereClauseFunctionCall.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
     }
 
     @Test
     public void testLikeCondition() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("WhereClauseLike.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("WhereClauseLike.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
     }
 
     @Test
     public void testNullCondition() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("WhereClauseIsNull.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("WhereClauseIsNull.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
     }
 
     @Test
     public void testBetweenCondition() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("WhereClauseBetween.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("WhereClauseBetween.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
     }
 
     @Test
     public void testInCondition() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("WhereClauseIn.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("WhereClauseIn.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
     }
 
     @Test
     public void testIsOfTypeCondition() throws Exception {
-        String code = IOUtils.toString(this.getClass().getResourceAsStream("WhereClauseIsOfType.pls"));
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("WhereClauseIsOfType.pls"),
+                StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
     }
 }

--- a/pmd-python/src/test/java/net/sourceforge/pmd/cpd/PythonTokenizerTest.java
+++ b/pmd-python/src/test/java/net/sourceforge/pmd/cpd/PythonTokenizerTest.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.cpd;
 import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
@@ -28,7 +29,7 @@ public class PythonTokenizerTest extends AbstractTokenizerTest {
 
     @Override
     public String getSampleCode() throws IOException {
-        return IOUtils.toString(PythonTokenizer.class.getResourceAsStream(FILENAME));
+        return IOUtils.toString(PythonTokenizer.class.getResourceAsStream(FILENAME), StandardCharsets.UTF_8);
     }
 
     @Test

--- a/pmd-scala/src/test/java/net/sourceforge/pmd/cpd/ScalaTokenizerTest.java
+++ b/pmd-scala/src/test/java/net/sourceforge/pmd/cpd/ScalaTokenizerTest.java
@@ -6,6 +6,8 @@ package net.sourceforge.pmd.cpd;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -18,7 +20,7 @@ import net.sourceforge.pmd.testframework.AbstractTokenizerTest;
 
 public class ScalaTokenizerTest extends AbstractTokenizerTest {
 
-    private static final String ENCODING = "UTF-8";
+    private static final Charset ENCODING = StandardCharsets.UTF_8;
 
     private static final String FILENAME = "sample-LiftActor.scala";
 

--- a/pmd-swift/src/test/java/net/sourceforge/pmd/cpd/SwiftTokenizerTest.java
+++ b/pmd-swift/src/test/java/net/sourceforge/pmd/cpd/SwiftTokenizerTest.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.cpd;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Before;
@@ -25,7 +26,7 @@ public class SwiftTokenizerTest extends AbstractTokenizerTest {
 
     @Override
     public String getSampleCode() throws IOException {
-        return IOUtils.toString(SwiftTokenizer.class.getResourceAsStream(FILENAME));
+        return IOUtils.toString(SwiftTokenizer.class.getResourceAsStream(FILENAME), StandardCharsets.UTF_8);
     }
 
     @Test

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/MainDesignerController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/MainDesignerController.java
@@ -8,6 +8,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -329,7 +330,8 @@ public class MainDesignerController implements Initializable, SettingsOwner {
 
         ScrollPane scroll = new ScrollPane();
         try {
-            scroll.setContent(new TextArea(IOUtils.toString(getClass().getResourceAsStream("LICENSE"))));
+            scroll.setContent(new TextArea(IOUtils.toString(getClass().getResourceAsStream("LICENSE"),
+                    StandardCharsets.UTF_8)));
         } catch (IOException e) {
             e.printStackTrace();
         }
@@ -354,7 +356,7 @@ public class MainDesignerController implements Initializable, SettingsOwner {
     private void loadSourceFromFile(File file) {
         if (file != null) {
             try {
-                String source = IOUtils.toString(new FileInputStream(file));
+                String source = IOUtils.toString(new FileInputStream(file), StandardCharsets.UTF_8);
                 sourceEditorController.setText(source);
                 LanguageVersion guess = DesignerUtil.getLanguageVersionFromExtension(file.getName());
                 if (guess != null) { // guess the language from the extension

--- a/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/XmlParserTest.java
+++ b/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/XmlParserTest.java
@@ -10,6 +10,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.io.StringReader;
 import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.Locale;
 
@@ -371,7 +372,8 @@ public class XmlParserTest {
 
     @Test
     public void testBug1518() throws Exception {
-        String xml = IOUtils.toString(XmlParserTest.class.getResourceAsStream("parsertests/bug1518.xml"));
+        String xml = IOUtils.toString(XmlParserTest.class.getResourceAsStream("parsertests/bug1518.xml"),
+                StandardCharsets.UTF_8);
         Node document = parseXml(xml);
         assertNotNull(document);
     }


### PR DESCRIPTION
Standardizing with StandardCharsets.UTF_8, given that it was used in several places of code already, and it provides compile-time checking (as opposed to "UTF-8")

Ran `./mvnw clean verify` and everything passes.

