### PR TITLE
[core] Use current classloader instead of context classloader for LanguageRegistry

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -23,6 +23,8 @@ as comments are recognized as such and ignored.
 
 ### Fixed Issues
 
+*   all
+    *   [#1377](https://github.com/pmd/pmd/issues/1377): \[core] LanguageRegistry uses default class loader when invoking ServiceLocator 
 *   java
     *   [#1330](https://github.com/pmd/pmd/issues/1330): \[java] PMD crashes with java.lang.ClassFormatError: Absent Code attribute in method that is not native or abstract in class file javax/xml/ws/Service
 *   java-bestpractices

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageRegistry.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageRegistry.java
@@ -27,7 +27,8 @@ public final class LanguageRegistry {
 
     private LanguageRegistry() {
         List<Language> languagesList = new ArrayList<>();
-        ServiceLoader<Language> languageLoader = ServiceLoader.load(Language.class);
+        // Use current class' classloader instead of the threads context classloader, see https://github.com/pmd/pmd/issues/1377
+        ServiceLoader<Language> languageLoader = ServiceLoader.load(Language.class, getClass().getClassLoader());
         Iterator<Language> iterator = languageLoader.iterator();
         while (iterator.hasNext()) {
             try {


### PR DESCRIPTION
Attempts to fix #1377 