### PR TITLE
[all] Upgrading SLF4J from 1.7.12 to 1.7.25

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -830,7 +830,7 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
             <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
-                <version>1.7.12</version>
+                <version>1.7.25</version>
             </dependency>
             <dependency>
                 <groupId>com.github.tomakehurst</groupId>


### PR DESCRIPTION
Upgrading SLF4J from 1.7.12 (released March 2015) to 1.7.25 (released March 2017).

Ran `mvnw.cmd clean verify` and it built successfully.