### PR TITLE
[doc] Use https://pmd.sourceforge.io/ruleset_2_0_0.xsd as schema location

### DIFF
--- a/docs/pages/pmd/userdocs/extending/writing_pmd_rules.md
+++ b/docs/pages/pmd/userdocs/extending/writing_pmd_rules.md
@@ -169,7 +169,7 @@ The whole ruleset file should look something like this:
 <ruleset name="My custom rules"
 		xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+		xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
 	<rule name="WhileLoopsMustUseBracesRule"
 			message="Avoid using 'while' statements without curly braces"
 			class="WhileLoopsMustUseBracesRule">

--- a/docs/pages/pmd/userdocs/extending/writing_xpath_rules.md
+++ b/docs/pages/pmd/userdocs/extending/writing_xpath_rules.md
@@ -162,7 +162,7 @@ the example code and give your rule a useful name and message.
 <ruleset name="Custom Rules"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
     <description>
 Custom rules
     </description>

--- a/docs/pages/pmd/userdocs/making_rulesets.md
+++ b/docs/pages/pmd/userdocs/making_rulesets.md
@@ -24,7 +24,7 @@ The first step is to create a new empty ruleset. You can use the following templ
 <ruleset name="Custom Rules"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
 
     <description>
         My custom rules
@@ -97,7 +97,7 @@ You can exclude some files from being processed by a ruleset using **exclude pat
 <ruleset name="myruleset"
 		xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+		xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
 	<description>My ruleset</description>
 
 	<exclude-pattern>.*/some/package/.*</exclude-pattern>


### PR DESCRIPTION
Refs #1249

Fixes the wrong URL in the documentation and uses the https variant (note: hostname is now pmd.sourceforge.**io**) on the other places as well.

