### PR TITLE
[java] Fix Issue 1343: Update CommentDefaultAccessModifierRule

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/CommentDefaultAccessModifierRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/CommentDefaultAccessModifierRule.java
@@ -22,16 +22,17 @@ import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 import net.sourceforge.pmd.lang.java.ast.AbstractAnyTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.AbstractJavaAccessNode;
 import net.sourceforge.pmd.lang.java.ast.Comment;
-import net.sourceforge.pmd.lang.java.rule.documentation.AbstractCommentRule;
+import net.sourceforge.pmd.lang.java.rule.AbstractIgnoredAnnotationRule;
 import net.sourceforge.pmd.properties.RegexProperty;
 
 /**
  * Check for Methods, Fields and Nested Classes that have a default access
  * modifier
+ * This class ignores all nodes annotated with @VisibleForTesting
  *
  * @author Damián Techeira
  */
-public class CommentDefaultAccessModifierRule extends AbstractCommentRule {
+public class CommentDefaultAccessModifierRule extends AbstractIgnoredAnnotationRule {
 
     private static final RegexProperty REGEX_DESCRIPTOR = RegexProperty.named("regex")
             .desc("Regular expression").defaultValue("\\/\\*\\s+(default|package)\\s+\\*\\/").uiOrder(1.0f).build();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/CommentDefaultAccessModifierRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/CommentDefaultAccessModifierRule.java
@@ -6,16 +6,13 @@ package net.sourceforge.pmd.lang.java.rule.codestyle;
 
 import java.util.*;
 
-import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBodyDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclarator;
-import net.sourceforge.pmd.lang.java.ast.ASTName;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 import net.sourceforge.pmd.lang.java.ast.AbstractAnyTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.AbstractJavaAccessNode;
@@ -41,13 +38,13 @@ public class CommentDefaultAccessModifierRule extends AbstractIgnoredAnnotationR
 
     public CommentDefaultAccessModifierRule() {
         definePropertyDescriptor(REGEX_DESCRIPTOR);
-        defaultSuppressionAnnotations();
     }
 
     @Override
     protected Collection<String> defaultSuppressionAnnotations() {
         Collection<String> ignoredStrings = new ArrayList<>();
-        ignoredStrings.add("VisibleForTesting");
+        ignoredStrings.add("com.google.common.annotations.VisibleForTesting");
+        ignoredStrings.add("android.support.annotation.VisibleForTesting");
         return ignoredStrings;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/CommentDefaultAccessModifierRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/CommentDefaultAccessModifierRule.java
@@ -4,9 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
@@ -28,7 +26,8 @@ import net.sourceforge.pmd.properties.RegexProperty;
 /**
  * Check for Methods, Fields and Nested Classes that have a default access
  * modifier
- * This class ignores all nodes annotated with @VisibleForTesting
+ * This rule ignores all nodes annotated with @VisibleForTesting by default.
+ * Use the ignoredAnnotationsDescriptor property to customize the ignored rules.
  *
  * @author Damián Techeira
  */
@@ -42,6 +41,14 @@ public class CommentDefaultAccessModifierRule extends AbstractIgnoredAnnotationR
 
     public CommentDefaultAccessModifierRule() {
         definePropertyDescriptor(REGEX_DESCRIPTOR);
+        defaultSuppressionAnnotations();
+    }
+
+    @Override
+    protected Collection<String> defaultSuppressionAnnotations() {
+        Collection<String> ignoredStrings = new ArrayList<>();
+        ignoredStrings.add("VisibleForTesting");
+        return ignoredStrings;
     }
 
     @Override
@@ -113,16 +120,8 @@ public class CommentDefaultAccessModifierRule extends AbstractIgnoredAnnotationR
 
     private boolean hasNoVisibleForTestingAnnotation(AbstractJavaAccessNode decl) {
         boolean result = true;
-        ASTClassOrInterfaceBodyDeclaration parent = decl.getFirstParentOfType(ASTClassOrInterfaceBodyDeclaration.class);
-        if (parent != null) {
-            List<ASTAnnotation> annotations = parent.findChildrenOfType(ASTAnnotation.class);
-            for (ASTAnnotation annotation : annotations) {
-                final ASTName name = annotation.getFirstDescendantOfType(ASTName.class);
-                if (name.hasImageEqualTo("VisibleForTesting")) {
-                    result = false;
-                    break;
-                }
-            }
+        if(hasIgnoredAnnotation(decl)){
+            result = false;
         }
         return result;
     }


### PR DESCRIPTION

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

Fixes #1343, the class CommentDefaultAccessModifierRule now extends AbstractIgnoredAnnotationRule. Also added a small comment about the ignored nodes in CommentDefaultAccessModifierRule.