### PR TITLE
[all] Replacing IOUtils.closeQuietly(foo) with try-with-resources statements

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
@@ -13,7 +13,6 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.tools.ant.AntClassLoader;
 import org.apache.tools.ant.BuildException;
@@ -240,12 +239,13 @@ public class PMDTaskImpl {
         Throwable cause = pmde.getCause();
 
         if (cause != null) {
-            StringWriter strWriter = new StringWriter();
-            PrintWriter printWriter = new PrintWriter(strWriter);
-            cause.printStackTrace(printWriter);
-            project.log(strWriter.toString(), Project.MSG_VERBOSE);
-            IOUtils.closeQuietly(printWriter);
-
+            try (StringWriter strWriter = new StringWriter();
+                 PrintWriter printWriter = new PrintWriter(strWriter)) {
+                cause.printStackTrace(printWriter);
+                project.log(strWriter.toString(), Project.MSG_VERBOSE);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
             if (StringUtils.isNotBlank(cause.getMessage())) {
                 project.log(cause.getMessage(), Project.MSG_VERBOSE);
             }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
@@ -244,7 +244,7 @@ public class PMDTaskImpl {
                 cause.printStackTrace(printWriter);
                 project.log(strWriter.toString(), Project.MSG_VERBOSE);
             } catch (IOException e) {
-                e.printStackTrace();
+                project.log("Error while closing stream", e, Project.MSG_ERR);
             }
             if (StringUtils.isNotBlank(cause.getMessage())) {
                 project.log(cause.getMessage(), Project.MSG_VERBOSE);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/Benchmarker.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/Benchmarker.java
@@ -15,7 +15,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import net.sourceforge.pmd.PMD;
@@ -145,11 +144,8 @@ public final class Benchmarker {
         long start = System.currentTimeMillis();
 
         for (DataSource dataSource : dataSources) {
-            InputStreamReader reader = new InputStreamReader(dataSource.getInputStream());
-            try {
+            try (InputStreamReader reader = new InputStreamReader(dataSource.getInputStream())) {
                 parser.parse(dataSource.getNiceFileName(false, null), reader);
-            } finally {
-                IOUtils.closeQuietly(reader);
             }
         }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/AnyTokenizer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/AnyTokenizer.java
@@ -9,8 +9,6 @@ import java.io.CharArrayReader;
 import java.io.IOException;
 import java.util.StringTokenizer;
 
-import org.apache.commons.io.IOUtils;
-
 /**
  * This class does a best-guess try-anything tokenization.
  *
@@ -22,8 +20,7 @@ public class AnyTokenizer implements Tokenizer {
     @Override
     public void tokenize(SourceCode sourceCode, Tokens tokenEntries) {
         StringBuilder sb = sourceCode.getCodeBuffer();
-        BufferedReader reader = new BufferedReader(new CharArrayReader(sb.toString().toCharArray()));
-        try {
+        try (BufferedReader reader = new BufferedReader(new CharArrayReader(sb.toString().toCharArray()))) {
             int lineNumber = 1;
             String line = reader.readLine();
             while (line != null) {
@@ -41,7 +38,6 @@ public class AnyTokenizer implements Tokenizer {
         } catch (IOException ignored) {
             ignored.printStackTrace();
         } finally {
-            IOUtils.closeQuietly(reader);
             tokenEntries.add(TokenEntry.getEOF());
         }
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/FileReporter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/FileReporter.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.cpd;
 
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -37,13 +38,14 @@ public class FileReporter {
     }
 
     public void report(String content) throws ReportException {
-        try {
-            try (OutputStream outputStream = reportFile == null ? System.out : new FileOutputStream(reportFile);
-                 Writer writer = new BufferedWriter(new OutputStreamWriter(outputStream, encoding))) {
-                writer.write(content);
-            }
+        try (Writer writer = new BufferedWriter(new OutputStreamWriter(getOutputStream(), encoding))) {
+            writer.write(content);
         } catch (IOException ioe) {
             throw new ReportException(ioe);
         }
+    }
+
+    private OutputStream getOutputStream() throws FileNotFoundException {
+        return reportFile == null ? System.out : new FileOutputStream(reportFile);
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/FileReporter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/FileReporter.java
@@ -12,8 +12,6 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 
-import org.apache.commons.io.IOUtils;
-
 import net.sourceforge.pmd.cpd.renderer.CPDRenderer;
 
 /**
@@ -40,18 +38,9 @@ public class FileReporter {
 
     public void report(String content) throws ReportException {
         try {
-            Writer writer = null;
-            try {
-                OutputStream outputStream;
-                if (reportFile == null) {
-                    outputStream = System.out;
-                } else {
-                    outputStream = new FileOutputStream(reportFile);
-                }
-                writer = new BufferedWriter(new OutputStreamWriter(outputStream, encoding));
+            try (OutputStream outputStream = reportFile == null ? System.out : new FileOutputStream(reportFile);
+                 Writer writer = new BufferedWriter(new OutputStreamWriter(outputStream, encoding))) {
                 writer.write(content);
-            } finally {
-                IOUtils.closeQuietly(writer);
             }
         } catch (IOException ioe) {
             throw new ReportException(ioe);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/dcd/graph/UsageGraphBuilder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/dcd/graph/UsageGraphBuilder.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.commons.io.IOUtils;
 import org.objectweb.asm.AnnotationVisitor;
 import org.objectweb.asm.Attribute;
 import org.objectweb.asm.ClassReader;
@@ -52,13 +51,10 @@ public class UsageGraphBuilder {
             if (classFilter.filter(className)) {
                 if (!usageGraph.isClass(className)) {
                     usageGraph.defineClass(className);
-                    InputStream inputStream = this.getClass().getClassLoader()
-                            .getResourceAsStream(classResourceName + ".class");
-                    ClassReader classReader = new ClassReader(inputStream);
-                    try {
+                    try (InputStream inputStream = this.getClass().getClassLoader()
+                            .getResourceAsStream(classResourceName + ".class")) {
+                        ClassReader classReader = new ClassReader(inputStream);
                         classReader.accept(getNewClassVisitor(), 0);
-                    } finally {
-                        IOUtils.closeQuietly(inputStream);
                     }
                 }
             }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/dfa/report/ReportHTMLPrintVisitor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/dfa/report/ReportHTMLPrintVisitor.java
@@ -9,7 +9,6 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import net.sourceforge.pmd.PMD;
@@ -45,9 +44,9 @@ public class ReportHTMLPrintVisitor extends ReportVisitor {
      * Writes the buffer to file.
      */
     private void write(String filename, StringBuilder buf) throws IOException {
-        BufferedWriter bw = new BufferedWriter(new FileWriter(new File(baseDir + FILE_SEPARATOR + filename)));
-        bw.write(buf.toString(), 0, buf.length());
-        IOUtils.closeQuietly(bw);
+        try (BufferedWriter bw = new BufferedWriter(new FileWriter(new File(baseDir + FILE_SEPARATOR + filename)))) {
+            bw.write(buf.toString(), 0, buf.length());
+        }
     }
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextColorRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextColorRenderer.java
@@ -13,8 +13,6 @@ import java.io.Reader;
 import java.util.Iterator;
 import java.util.Map;
 
-import org.apache.commons.io.IOUtils;
-
 import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.Report;
 import net.sourceforge.pmd.RuleViolation;
@@ -191,17 +189,13 @@ public class TextColorRenderer extends AbstractAccumulatingRenderer {
      */
     private String getLine(String sourceFile, int line) {
         String code = null;
-        BufferedReader br = null;
-        try {
-            br = new BufferedReader(getReader(sourceFile));
+        try (BufferedReader br = new BufferedReader(getReader(sourceFile))) {
             for (int i = 0; line > i; i++) {
                 String txt = br.readLine();
                 code = txt == null ? "" : txt.trim();
             }
         } catch (IOException ioErr) {
             ioErr.printStackTrace();
-        } finally {
-            IOUtils.closeQuietly(br);
         }
         return code;
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/database/DBType.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/database/DBType.java
@@ -15,8 +15,6 @@ import java.util.ResourceBundle;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.io.IOUtils;
-
 /**
  * Encapsulate the settings needed to access database source code.
  *
@@ -159,7 +157,6 @@ public class DBType {
         LOGGER.entering(DBType.class.getCanonicalName(), matchString);
         // Locale locale = Control.g;
         ResourceBundle resourceBundle = null;
-        InputStream stream = null;
 
         if (LOGGER.isLoggable(Level.FINEST)) {
             LOGGER.finest("class_path+" + System.getProperty("java.class.path"));
@@ -170,12 +167,11 @@ public class DBType {
          * properties suffix File path without properties suffix Resource
          * without class prefix Resource with class prefix
          */
-        try {
-            File propertiesFile = new File(matchString);
-            if (LOGGER.isLoggable(Level.FINEST)) {
-                LOGGER.finest("Attempting File no file suffix: " + matchString);
-            }
-            stream = new FileInputStream(propertiesFile);
+        File propertiesFile = new File(matchString);
+        if (LOGGER.isLoggable(Level.FINEST)) {
+            LOGGER.finest("Attempting File no file suffix: " + matchString);
+        }
+        try (InputStream stream = new FileInputStream(propertiesFile)) {
             resourceBundle = new PropertyResourceBundle(stream);
             propertiesSource = propertiesFile.getAbsolutePath();
             LOGGER.finest("FileSystemWithoutExtension");
@@ -184,9 +180,8 @@ public class DBType {
                 LOGGER.finest("notFoundOnFilesystemWithoutExtension");
                 LOGGER.finest("Attempting File with added file suffix: " + matchString + ".properties");
             }
-            try {
-                File propertiesFile = new File(matchString + ".properties");
-                stream = new FileInputStream(propertiesFile);
+            try (InputStream stream = new FileInputStream(propertiesFile)) {
+                propertiesFile = new File(matchString + ".properties");
                 resourceBundle = new PropertyResourceBundle(stream);
                 propertiesSource = propertiesFile.getAbsolutePath();
                 LOGGER.finest("FileSystemWithExtension");
@@ -214,8 +209,6 @@ public class DBType {
                     }
                 }
             }
-        } finally {
-            IOUtils.closeQuietly(stream);
         }
 
         // Properties in this matched resource

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/designer/Designer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/designer/Designer.java
@@ -92,7 +92,6 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -992,12 +991,10 @@ public class Designer implements ClipboardOwner {
     }
 
     private void loadSettings() {
-        InputStream stream = null;
-        try {
-            File file = new File(SETTINGS_FILE_NAME);
-            if (file.exists()) {
+        File file = new File(SETTINGS_FILE_NAME);
+        if (file.exists()) {
+            try (InputStream stream = new FileInputStream(file)) {
                 DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-                stream = new FileInputStream(file);
                 Document document = builder.parse(stream);
                 Element settingsElement = document.getDocumentElement();
                 Element codeElement = (Element) settingsElement.getElementsByTagName("code").item(0);
@@ -1018,15 +1015,13 @@ public class Designer implements ClipboardOwner {
                         break;
                     }
                 }
+            } catch (ParserConfigurationException e) {
+                e.printStackTrace();
+            } catch (IOException e) {
+                e.printStackTrace();
+            } catch (SAXException e) {
+                e.printStackTrace();
             }
-        } catch (ParserConfigurationException e) {
-            e.printStackTrace();
-        } catch (IOException e) {
-            e.printStackTrace();
-        } catch (SAXException e) {
-            e.printStackTrace();
-        } finally {
-            IOUtils.closeQuietly(stream);
         }
     }
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/database/DBTypeTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/database/DBTypeTest.java
@@ -11,7 +11,6 @@ import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.ResourceBundle;
 
-import org.apache.commons.io.IOUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
@@ -39,17 +38,12 @@ public class DBTypeTest {
         includeProperties.putAll(testProperties);
         includeProperties.put("prop3", "include3");
 
-        PrintStream printStream = null;
-        try {
-            absoluteFile = File.createTempFile("dbtypetest", ".properties");
-            FileOutputStream fileOutputStream = new FileOutputStream(absoluteFile);
-            printStream = new PrintStream(fileOutputStream);
-
+        absoluteFile = File.createTempFile("dbtypetest", ".properties");
+        try (FileOutputStream fileOutputStream = new FileOutputStream(absoluteFile);
+             PrintStream printStream = new PrintStream(fileOutputStream)) {
             for (Entry<?, ?> entry : testProperties.entrySet()) {
                 printStream.printf("%s=%s\n", entry.getKey(), entry.getValue());
             }
-        } finally {
-            IOUtils.closeQuietly(printStream);
         }
     }
 

--- a/pmd-cs/src/main/java/net/sourceforge/pmd/cpd/CsTokenizer.java
+++ b/pmd-cs/src/main/java/net/sourceforge/pmd/cpd/CsTokenizer.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.io.PushbackReader;
 import java.util.Properties;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 
 /**
@@ -31,41 +30,43 @@ public class CsTokenizer implements Tokenizer {
 
     @Override
     public void tokenize(SourceCode sourceCode, Tokens tokenEntries) {
-        Tokenizer tokenizer = new Tokenizer(sourceCode.getCodeBuffer().toString());
-        Token token = tokenizer.getNextToken();
+        try (Tokenizer tokenizer = new Tokenizer(sourceCode.getCodeBuffer().toString())) {
+            Token token = tokenizer.getNextToken();
 
-        while (!token.equals(Token.EOF)) {
-            Token lookAhead = tokenizer.getNextToken();
+            while (!token.equals(Token.EOF)) {
+                Token lookAhead = tokenizer.getNextToken();
 
-            // Ignore using directives
-            // Only using directives should be ignored, because these are used
-            // to import namespaces
-            //
-            // Using directive: 'using System.Math;'
-            // Using statement: 'using (Font font1 = new Font(..)) { .. }'
-            if (ignoreUsings && "using".equals(token.image) && !"(".equals(lookAhead.image)) {
-                // We replace the 'using' token by a random token, because it
-                // should not be part of
-                // any duplication block. When we omit it from the token stream,
-                // there is a change that
-                // we get a duplication block that starts before the 'using'
-                // directives and ends afterwards.
-                String randomTokenText = RandomStringUtils.randomAlphanumeric(20);
+                // Ignore using directives
+                // Only using directives should be ignored, because these are used
+                // to import namespaces
+                //
+                // Using directive: 'using System.Math;'
+                // Using statement: 'using (Font font1 = new Font(..)) { .. }'
+                if (ignoreUsings && "using".equals(token.image) && !"(".equals(lookAhead.image)) {
+                    // We replace the 'using' token by a random token, because it
+                    // should not be part of
+                    // any duplication block. When we omit it from the token stream,
+                    // there is a change that
+                    // we get a duplication block that starts before the 'using'
+                    // directives and ends afterwards.
+                    String randomTokenText = RandomStringUtils.randomAlphanumeric(20);
 
-                token = new Token(randomTokenText, token.lineNumber);
-                // Skip all other tokens of the using directive to prevent a
-                // partial matching
-                while (!";".equals(lookAhead.image) && !lookAhead.equals(Token.EOF)) {
-                    lookAhead = tokenizer.getNextToken();
+                    token = new Token(randomTokenText, token.lineNumber);
+                    // Skip all other tokens of the using directive to prevent a
+                    // partial matching
+                    while (!";".equals(lookAhead.image) && !lookAhead.equals(Token.EOF)) {
+                        lookAhead = tokenizer.getNextToken();
+                    }
                 }
+                if (!";".equals(token.image)) {
+                    tokenEntries.add(new TokenEntry(token.image, sourceCode.getFileName(), token.lineNumber));
+                }
+                token = lookAhead;
             }
-            if (!";".equals(token.image)) {
-                tokenEntries.add(new TokenEntry(token.image, sourceCode.getFileName(), token.lineNumber));
-            }
-            token = lookAhead;
+            tokenEntries.add(TokenEntry.getEOF());
+        } catch (IOException e) {
+            e.printStackTrace();
         }
-        tokenEntries.add(TokenEntry.getEOF());
-        IOUtils.closeQuietly(tokenizer);
     }
 
     public void setIgnoreUsings(boolean ignoreUsings) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDuplicateLiteralsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDuplicateLiteralsRule.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
@@ -116,17 +115,13 @@ public class AvoidDuplicateLiteralsRule extends AbstractJavaRule {
             exceptions = p.parse(getProperty(EXCEPTION_LIST_DESCRIPTOR));
         } else if (getProperty(EXCEPTION_FILE_DESCRIPTOR) != null) {
             exceptions = new HashSet<>();
-            LineNumberReader reader = null;
-            try {
-                reader = getLineReader();
+            try (LineNumberReader reader = getLineReader()) {
                 String line;
                 while ((line = reader.readLine()) != null) {
                     exceptions.add(line);
                 }
             } catch (IOException ioe) {
                 ioe.printStackTrace();
-            } finally {
-                IOUtils.closeQuietly(reader);
             }
         }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDuplicateLiteralsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDuplicateLiteralsRule.java
@@ -121,7 +121,7 @@ public class AvoidDuplicateLiteralsRule extends AbstractJavaRule {
                     exceptions.add(line);
                 }
             } catch (IOException ioe) {
-                ioe.printStackTrace();
+                throw new RuntimeException(ioe);
             }
         }
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
@@ -275,13 +275,10 @@ public class ParserCornersTest {
     }
 
     private String readAsString(String resource) {
-        InputStream in = ParserCornersTest.class.getResourceAsStream(resource);
-        try {
+        try (InputStream in = ParserCornersTest.class.getResourceAsStream(resource)) {
             return IOUtils.toString(in, StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new RuntimeException(e);
-        } finally {
-            IOUtils.closeQuietly(in);
         }
     }
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/cpd/EcmascriptTokenizer.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/cpd/EcmascriptTokenizer.java
@@ -4,10 +4,9 @@
 
 package net.sourceforge.pmd.cpd;
 
+import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
-
-import org.apache.commons.io.IOUtils;
 
 import net.sourceforge.pmd.cpd.token.JavaCCTokenFilter;
 import net.sourceforge.pmd.cpd.token.TokenFilter;
@@ -26,11 +25,9 @@ public class EcmascriptTokenizer implements Tokenizer {
     @Override
     public void tokenize(SourceCode sourceCode, Tokens tokenEntries) {
         StringBuilder buffer = sourceCode.getCodeBuffer();
-        Reader reader = null;
-        try {
+        try (Reader reader = new StringReader(buffer.toString())) {
             LanguageVersionHandler languageVersionHandler = LanguageRegistry.getLanguage(EcmascriptLanguageModule.NAME)
                     .getDefaultVersion().getLanguageVersionHandler();
-            reader = new StringReader(buffer.toString());
             TokenFilter tokenFilter = new JavaCCTokenFilter(languageVersionHandler
                     .getParser(languageVersionHandler.getDefaultParserOptions())
                     .getTokenManager(sourceCode.getFileName(), reader));
@@ -46,8 +43,8 @@ public class EcmascriptTokenizer implements Tokenizer {
             err.printStackTrace();
             System.err.println("Skipping " + sourceCode.getFileName() + " due to parse error");
             tokenEntries.add(TokenEntry.getEOF());
-        } finally {
-            IOUtils.closeQuietly(reader);
+        } catch (IOException e) {
+            e.printStackTrace();
         }
     }
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/cpd/JSPTokenizer.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/cpd/JSPTokenizer.java
@@ -4,10 +4,9 @@
 
 package net.sourceforge.pmd.cpd;
 
+import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
-
-import org.apache.commons.io.IOUtils;
 
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersionHandler;
@@ -23,11 +22,8 @@ public class JSPTokenizer implements Tokenizer {
         StringBuilder buffer = sourceCode.getCodeBuffer();
         LanguageVersionHandler languageVersionHandler = LanguageRegistry.getLanguage(JspLanguageModule.NAME)
                 .getDefaultVersion().getLanguageVersionHandler();
-        Reader reader = null;
 
-        try {
-            reader = new StringReader(buffer.toString());
-            reader = IOUtil.skipBOM(reader);
+        try (Reader reader = IOUtil.skipBOM(new StringReader(buffer.toString()))) {
             TokenManager tokenMgr = languageVersionHandler.getParser(languageVersionHandler.getDefaultParserOptions())
                     .getTokenManager(sourceCode.getFileName(), reader);
             Token currentToken = (Token) tokenMgr.getNextToken();
@@ -37,8 +33,8 @@ public class JSPTokenizer implements Tokenizer {
                         currentToken.beginLine));
                 currentToken = (Token) tokenMgr.getNextToken();
             }
-        } finally {
-            IOUtils.closeQuietly(reader);
+        } catch (IOException e) {
+            e.printStackTrace();
         }
         tokenEntries.add(TokenEntry.getEOF());
     }

--- a/pmd-matlab/src/main/java/net/sourceforge/pmd/cpd/MatlabTokenizer.java
+++ b/pmd-matlab/src/main/java/net/sourceforge/pmd/cpd/MatlabTokenizer.java
@@ -4,10 +4,9 @@
 
 package net.sourceforge.pmd.cpd;
 
+import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
-
-import org.apache.commons.io.IOUtils;
 
 import net.sourceforge.pmd.cpd.token.JavaCCTokenFilter;
 import net.sourceforge.pmd.cpd.token.TokenFilter;
@@ -26,12 +25,10 @@ public class MatlabTokenizer implements Tokenizer {
     @Override
     public void tokenize(SourceCode sourceCode, Tokens tokenEntries) {
         StringBuilder buffer = sourceCode.getCodeBuffer();
-        Reader reader = null;
-        try {
+        try (Reader reader = IOUtil.skipBOM(new StringReader(buffer.toString()))) {
             LanguageVersionHandler languageVersionHandler = LanguageRegistry.getLanguage(MatlabLanguageModule.NAME)
                     .getDefaultVersion().getLanguageVersionHandler();
-            reader = new StringReader(buffer.toString());
-            reader = IOUtil.skipBOM(reader);
+
             final TokenFilter tokenFilter = new JavaCCTokenFilter(languageVersionHandler
                     .getParser(languageVersionHandler.getDefaultParserOptions())
                     .getTokenManager(sourceCode.getFileName(), reader));
@@ -42,12 +39,10 @@ public class MatlabTokenizer implements Tokenizer {
             }
             tokenEntries.add(TokenEntry.getEOF());
             System.err.println("Added " + sourceCode.getFileName());
-        } catch (TokenMgrError err) {
+        } catch (TokenMgrError | IOException err) {
             err.printStackTrace();
             System.err.println("Skipping " + sourceCode.getFileName() + " due to parse error");
             tokenEntries.add(TokenEntry.getEOF());
-        } finally {
-            IOUtils.closeQuietly(reader);
         }
     }
 }

--- a/pmd-objectivec/src/main/java/net/sourceforge/pmd/cpd/ObjectiveCTokenizer.java
+++ b/pmd-objectivec/src/main/java/net/sourceforge/pmd/cpd/ObjectiveCTokenizer.java
@@ -4,10 +4,9 @@
 
 package net.sourceforge.pmd.cpd;
 
+import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
-
-import org.apache.commons.io.IOUtils;
 
 import net.sourceforge.pmd.cpd.token.JavaCCTokenFilter;
 import net.sourceforge.pmd.cpd.token.TokenFilter;
@@ -25,11 +24,9 @@ public class ObjectiveCTokenizer implements Tokenizer {
     @Override
     public void tokenize(SourceCode sourceCode, Tokens tokenEntries) {
         StringBuilder buffer = sourceCode.getCodeBuffer();
-        Reader reader = null;
-        try {
+        try (Reader reader = new StringReader(buffer.toString())) {
             LanguageVersionHandler languageVersionHandler = LanguageRegistry.getLanguage(ObjectiveCLanguageModule.NAME)
                     .getDefaultVersion().getLanguageVersionHandler();
-            reader = new StringReader(buffer.toString());
             final TokenFilter tokenFilter = new JavaCCTokenFilter(languageVersionHandler
                     .getParser(languageVersionHandler.getDefaultParserOptions())
                     .getTokenManager(sourceCode.getFileName(), reader));
@@ -44,8 +41,8 @@ public class ObjectiveCTokenizer implements Tokenizer {
             err.printStackTrace();
             System.err.println("Skipping " + sourceCode.getFileName() + " due to parse error");
             tokenEntries.add(TokenEntry.getEOF());
-        } finally {
-            IOUtils.closeQuietly(reader);
+        } catch (IOException e) {
+            e.printStackTrace();
         }
     }
 }

--- a/pmd-scala/src/main/java/org/sonar/plugins/scala/util/StringUtils.java
+++ b/pmd-scala/src/main/java/org/sonar/plugins/scala/util/StringUtils.java
@@ -26,8 +26,6 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.io.IOUtils;
-
 public final class StringUtils {
     private StringUtils() {
         // to prevent instantiation
@@ -35,15 +33,11 @@ public final class StringUtils {
 
     public static List<String> convertStringToListOfLines(String string) throws IOException {
         final List<String> lines = new ArrayList<>();
-        BufferedReader reader = null;
-        try {
-            reader = new BufferedReader(new StringReader(string));
+        try (BufferedReader reader = new BufferedReader(new StringReader(string))) {
             String line = null;
             while ((line = reader.readLine()) != null) {
                 lines.add(line);
             }
-        } finally {
-            IOUtils.closeQuietly(reader);
         }
         return lines;
     }

--- a/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
@@ -25,7 +25,6 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 
-import org.apache.commons.io.IOUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -328,13 +327,12 @@ public abstract class RuleTst {
      */
     public TestDescriptor[] extractTestsFromXml(Rule rule, String testsFileName, String baseDirectory) {
         String testXmlFileName = baseDirectory + testsFileName + ".xml";
-        InputStream inputStream = getClass().getResourceAsStream(testXmlFileName);
-        if (inputStream == null) {
-            throw new RuntimeException("Couldn't find " + testXmlFileName);
-        }
 
         Document doc;
-        try {
+        try (InputStream inputStream = getClass().getResourceAsStream(testXmlFileName)) {
+            if (inputStream == null) {
+                throw new RuntimeException("Couldn't find " + testXmlFileName);
+            }
             doc = documentBuilder.parse(inputStream);
         } catch (FactoryConfigurationError fce) {
             throw new RuntimeException("Couldn't parse " + testXmlFileName + ", due to: " + fce, fce);
@@ -342,8 +340,6 @@ public abstract class RuleTst {
             throw new RuntimeException("Couldn't parse " + testXmlFileName + ", due to: " + ioe, ioe);
         } catch (SAXException se) {
             throw new RuntimeException("Couldn't parse " + testXmlFileName + ", due to: " + se, se);
-        } finally {
-            IOUtils.closeQuietly(inputStream);
         }
 
         return parseTests(rule, doc);

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/beans/SettingsPersistenceUtil.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/beans/SettingsPersistenceUtil.java
@@ -24,7 +24,6 @@ import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.commons.beanutils.ConvertUtils;
 import org.apache.commons.beanutils.PropertyUtils;
-import org.apache.commons.io.IOUtils;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -92,17 +91,13 @@ public final class SettingsPersistenceUtil {
      * @param file File to parse
      */
     private static Optional<Document> getDocument(File file) {
-        InputStream stream = null;
         if (file.exists()) {
-            try {
+            try (InputStream stream = new FileInputStream(file)) {
                 DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
-                stream = new FileInputStream(file);
                 Document document = builder.parse(stream);
                 return Optional.of(document);
             } catch (SAXException | ParserConfigurationException | IOException e) {
                 e.printStackTrace();
-            } finally {
-                IOUtils.closeQuietly(stream);
             }
         }
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/cpd/VfTokenizer.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/cpd/VfTokenizer.java
@@ -4,10 +4,9 @@
 
 package net.sourceforge.pmd.cpd;
 
+import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
-
-import org.apache.commons.io.IOUtils;
 
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersionHandler;
@@ -27,11 +26,8 @@ public class VfTokenizer implements Tokenizer {
         StringBuilder buffer = sourceCode.getCodeBuffer();
         LanguageVersionHandler languageVersionHandler = LanguageRegistry.getLanguage(VfLanguageModule.NAME)
                 .getDefaultVersion().getLanguageVersionHandler();
-        Reader reader = null;
 
-        try {
-            reader = new StringReader(buffer.toString());
-            reader = IOUtil.skipBOM(reader);
+        try (Reader reader = IOUtil.skipBOM(new StringReader(buffer.toString()))) {
             TokenManager tokenMgr = languageVersionHandler.getParser(languageVersionHandler.getDefaultParserOptions())
                     .getTokenManager(sourceCode.getFileName(), reader);
             Token currentToken = (Token) tokenMgr.getNextToken();
@@ -41,8 +37,8 @@ public class VfTokenizer implements Tokenizer {
                         currentToken.beginLine));
                 currentToken = (Token) tokenMgr.getNextToken();
             }
-        } finally {
-            IOUtils.closeQuietly(reader);
+        } catch (IOException e) {
+            e.printStackTrace();
         }
         tokenEntries.add(TokenEntry.getEOF());
     }


### PR DESCRIPTION
Replaces most `IOUtils.closeQuietly(foo)` calls with try-with-resources statements for better memory handling. I have run `./mvnw clean verify` and it passes. 

There were two remaining issues that I was unsure of how to address:
 - In some cases, `IOUtils.closeQuietly(foo)` was suppressing an `IOException`, and since that's a checked exception, I had to catch it if it wasn't being closed already. The most common way of handling this I saw in existing code was to just print the stack trace, so that's what I did. If I should handle it differently, let me know.
 - There were several instances in PMD Core where I couldn't get rid of `IOUtils.closeQuietly()`, and I would appreciate suggestions on how to handle them:
    - [RuleSetWriter L65](https://github.com/pmd/pmd/blob/master/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetWriter.java#L65) has it as the only call in a public `close()` method.
    - [Formatter L192](https://github.com/pmd/pmd/blob/master/pmd-core/src/main/java/net/sourceforge/pmd/ant/Formatter.java#L192) calls `IOUtils.closeQuietly()` if we're in an error state, but the method returns the unclosed `Writer` if not, and that becomes an instance variable that is closed at a later time.
     - [AbstractRenderer L82](https://github.com/pmd/pmd/blob/master/pmd-core/src/main/java/net/sourceforge/pmd/renderers/AbstractRenderer.java#L82) has the call as part of a `flush()` method
     - [IOUtil L56](https://github.com/pmd/pmd/blob/master/pmd-core/src/main/java/net/sourceforge/pmd/util/IOUtil.java#L56) has it as the only operation of `tryCloseClassLoader(ClassLoader classLoader)`, which is a public method.

Please let me know if I should handle the remaining issues in any way, and if there are any other issues with the code I have changed.