### PR TITLE
[core] Fix logs when creating cache file

### DIFF
--- a/docs/pages/pmd/userdocs/cli_reference.md
+++ b/docs/pages/pmd/userdocs/cli_reference.md
@@ -51,7 +51,10 @@ The tool comes with a rather extensive help text, simply running with `-help`!
     %}
     {% include custom/cli_option_row.html options="-cache"
                option_arg="path"
-               description="Specifies a location for the analysis cache file to use.
+               description="Specify the location of the cache file for incremental analysis.
+                            This should be the full path to the file, including the desired file name (not just the parent directory).
+                            If the file doesn't exist, it will be created on the first run. The file will be overwritten on each run
+                            with the most up-to-date rule violations.
                             This can greatly improve analysis performance and is **highly recommended**."
     %}
     {% include custom/cli_option_row.html options="-debug,-verbose,-D,-V"

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/FileAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/FileAnalysisCache.java
@@ -26,7 +26,7 @@ import net.sourceforge.pmd.RuleViolation;
 public class FileAnalysisCache extends AbstractAnalysisCache {
 
     private final File cacheFile;
-    
+
     /**
      * Creates a new cache backed by the given file, and attempts to load pre-existing data from it.
      * @param cache The file on which to store analysis cache
@@ -43,26 +43,26 @@ public class FileAnalysisCache extends AbstractAnalysisCache {
      * @param cacheFile The file which backs the file analysis cache.
      */
     private void loadFromFile(final File cacheFile) {
-        if (cacheFile.exists()) {
+        if (cacheExists()) {
             try (
                 DataInputStream inputStream = new DataInputStream(
                     new BufferedInputStream(new FileInputStream(cacheFile)));
             ) {
                 final String cacheVersion = inputStream.readUTF();
-                
+
                 if (PMDVersion.VERSION.equals(cacheVersion)) {
                     // Cache seems valid, load the rest
-                    
+
                     // Get checksums
                     rulesetChecksum = inputStream.readLong();
                     auxClassPathChecksum = inputStream.readLong();
                     executionClassPathChecksum = inputStream.readLong();
-                    
+
                     // Cached results
                     while (inputStream.available() > 0) {
                         final String fileName = inputStream.readUTF();
                         final long checksum = inputStream.readLong();
-                        
+
                         final int countViolations = inputStream.readInt();
                         final List<RuleViolation> violations = new ArrayList<>(countViolations);
                         for (int i = 0; i < countViolations; i++) {
@@ -81,13 +81,23 @@ public class FileAnalysisCache extends AbstractAnalysisCache {
             } catch (final IOException e) {
                 LOG.severe("Could not load analysis cache from file. " + e.getMessage());
             }
+        } else if (cacheFile.isDirectory()) {
+            LOG.severe("The configured cache location must be the path to a file, but is a directory.");
         }
     }
 
     @Override
     public void persist() {
+
+        if (cacheFile.isDirectory()) {
+            LOG.severe("Cannot persist the cache, the given path points to a directory.");
+            return;
+        }
+
+        boolean cacheFileShouldBeCreated = !cacheFile.exists();
+
         // Create directories missing along the way
-        if (!cacheFile.exists()) {
+        if (cacheFileShouldBeCreated) {
             final File parentFile = cacheFile.getAbsoluteFile().getParentFile();
             if (parentFile != null && !parentFile.exists()) {
                 parentFile.mkdirs();
@@ -99,26 +109,35 @@ public class FileAnalysisCache extends AbstractAnalysisCache {
                 new BufferedOutputStream(new FileOutputStream(cacheFile)))
         ) {
             outputStream.writeUTF(pmdVersion);
-            
+
             outputStream.writeLong(rulesetChecksum);
             outputStream.writeLong(auxClassPathChecksum);
             outputStream.writeLong(executionClassPathChecksum);
-            
+
             for (final Map.Entry<String, AnalysisResult> resultEntry : updatedResultsCache.entrySet()) {
                 final List<RuleViolation> violations = resultEntry.getValue().getViolations();
 
                 outputStream.writeUTF(resultEntry.getKey());
                 outputStream.writeLong(resultEntry.getValue().getFileChecksum());
-                
+
                 outputStream.writeInt(violations.size());
                 for (final RuleViolation rv : violations) {
                     CachedRuleViolation.storeToStream(outputStream, rv);
                 }
             }
-            
-            LOG.info("Analysis cache updated");
+            if (cacheFileShouldBeCreated) {
+                LOG.info("Analysis cache created");
+            } else {
+                LOG.info("Analysis cache updated");
+            }
         } catch (final IOException e) {
             LOG.severe("Could not persist analysis cache to file. " + e.getMessage());
         }
+    }
+
+
+    @Override
+    protected boolean cacheExists() {
+        return cacheFile.exists() && cacheFile.isFile() && cacheFile.length() > 0;
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cli/PMDParameters.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cli/PMDParameters.java
@@ -66,7 +66,7 @@ public class PMDParameters {
     private boolean showsuppressed = false;
 
     @Parameter(names = "-suppressmarker",
-            description = "Specifies the string that marks the a line which PMD should ignore; default is NOPMD.")
+            description = "Specifies the string that marks a line which PMD should ignore; default is NOPMD.")
     private String suppressmarker = "NOPMD";
 
     @Parameter(names = { "-minimumpriority", "-min" },
@@ -99,8 +99,12 @@ public class PMDParameters {
     @Parameter(names = "-norulesetcompatibility",
             description = "Disable the ruleset compatibility filter. The filter is active by default and tries automatically 'fix' old ruleset files with old rule names")
     private boolean noRuleSetCompatibility = false;
-    
-    @Parameter(names = "-cache", description = "Specify the location of the cache file for incremental analysis.")
+
+    @Parameter(names = "-cache", arity = 1,
+            description = "Specify the location of the cache file for incremental analysis. "
+                    + "This should be the full path to the file, including the desired file name (not just the parent directory). "
+                    + "If the file doesn't exist, it will be created on the first run. The file will be overwritten on each run "
+                    + "with the most up-to-date rule violations.")
     private String cacheLocation = null;
 
     @Parameter(names = "-no-cache", description = "Explicitly disable incremental analysis. The '-cache' option is ignored if this switch is present in the command line.")


### PR DESCRIPTION
Fixes #1394 

When the cache file 
* Is a valid file name and doesn't exist, a single log "Analysis cache created" is output
* Is a valid file name and exists, previous checks and logs about the rulesets and classpath are run. If the rulesets have changed, the classpath isn't checked anymore
* Is a directory name, then two special logs are output when trying to load and persist the cache
* Everything else is the same

This adds an abstract method to AbstractFileAnalysisCache though I don't think it's API breaking since AbstractFileAnalysisCache should be internal, right?