### PR TITLE
[core] Abstract away optional AST traversals (first step)

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ApexHandler.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ApexHandler.java
@@ -6,7 +6,7 @@ package net.sourceforge.pmd.lang.apex;
 
 import java.io.Writer;
 
-import net.sourceforge.pmd.lang.AbstractLanguageVersionHandler;
+import net.sourceforge.pmd.lang.AbstractPmdLanguageVersionHandler;
 import net.sourceforge.pmd.lang.Parser;
 import net.sourceforge.pmd.lang.ParserOptions;
 import net.sourceforge.pmd.lang.VisitorStarter;
@@ -18,7 +18,7 @@ import net.sourceforge.pmd.lang.apex.rule.ApexRuleViolationFactory;
 import net.sourceforge.pmd.lang.ast.xpath.DefaultASTXPathHandler;
 import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
 
-public class ApexHandler extends AbstractLanguageVersionHandler {
+public class ApexHandler extends AbstractPmdLanguageVersionHandler {
 
     @Override
     public VisitorStarter getMultifileFacade() {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/Rule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/Rule.java
@@ -6,9 +6,11 @@ package net.sourceforge.pmd;
 
 import java.util.List;
 
+import net.sourceforge.pmd.annotation.Experimental;
 import net.sourceforge.pmd.lang.Language;
 import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.lang.ParserOptions;
+import net.sourceforge.pmd.lang.ast.AstProcessingStage;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.properties.PropertySource;
 import net.sourceforge.pmd.properties.StringProperty;
@@ -256,6 +258,32 @@ public interface Rule extends PropertySource {
      */
     ParserOptions getParserOptions();
 
+
+    /**
+     * Returns true if this rule depends on the given processing stage
+     * to run. If so, any ruleset including this rule, in which the rule
+     * is not misconfigured, will execute the analysis reified in the
+     * given stage before applying rules on the AST.
+     *
+     * <p>The default returns false. Each language should implement this
+     * method in its abstract rule base class, and probably mark its
+     * implementation as final for consistency within the language
+     * implementation. AST processing stages are language-specific, and
+     * any non-trivial implementation should throw an {@link IllegalArgumentException}
+     * when given a stage that isn't defined on the language of the rule.
+     *
+     * @param stage Processing stage for which to check for a dependency.
+     *
+     * @return True if this rule depends on the given processing stage.
+     *
+     * @since 7.0.0
+     */
+    @Experimental
+    default boolean dependsOn(AstProcessingStage<?> stage) {
+        return false;
+    }
+
+
     /**
      * Sets whether this Rule uses Data Flow Analysis.
      * @deprecated Use {@link #setDfa(boolean)} instead.
@@ -415,7 +443,7 @@ public interface Rule extends PropertySource {
      *            the rule context
      */
     void end(RuleContext ctx);
-    
+
     /**
      * Creates a new copy of this rule.
      * @return A new exact copy of this rule

--- a/pmd-core/src/main/java/net/sourceforge/pmd/Rule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/Rule.java
@@ -266,6 +266,7 @@ public interface Rule extends PropertySource {
     /**
      * Sets whether this Rule uses Data Flow Analysis.
      */
+    @Deprecated
     void setDfa(boolean isDfa);
 
     /**
@@ -282,6 +283,7 @@ public interface Rule extends PropertySource {
      *
      * @return <code>true</code> if Data Flow Analysis is used.
      */
+    @Deprecated
     boolean isDfa();
 
     /**
@@ -294,6 +296,7 @@ public interface Rule extends PropertySource {
     /**
      * Sets whether this Rule uses Type Resolution.
      */
+    @Deprecated
     void setTypeResolution(boolean usingTypeResolution);
 
     /**
@@ -311,6 +314,7 @@ public interface Rule extends PropertySource {
      *
      * @return <code>true</code> if Type Resolution is used.
      */
+    @Deprecated
     boolean isTypeResolution();
 
     /**
@@ -323,6 +327,7 @@ public interface Rule extends PropertySource {
     /**
      * Sets whether this Rule uses multi-file analysis.
      */
+    @Deprecated
     void setMultifile(boolean multifile);
 
     /**
@@ -340,6 +345,7 @@ public interface Rule extends PropertySource {
      *
      * @return <code>true</code> if the multi file analysis is used.
      */
+    @Deprecated
     boolean isMultifile();
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
@@ -596,6 +596,8 @@ public class RuleSet implements ChecksumAware {
         return includePatterns;
     }
 
+
+
     /**
      * Does any Rule for the given Language use the DFA layer?
      *
@@ -604,6 +606,7 @@ public class RuleSet implements ChecksumAware {
      * @return <code>true</code> if a Rule for the Language uses the DFA layer,
      *         <code>false</code> otherwise.
      */
+    @Deprecated
     public boolean usesDFA(Language language) {
         for (Rule r : rules) {
             if (r.getLanguage().equals(language) && r.isDfa()) {
@@ -621,6 +624,7 @@ public class RuleSet implements ChecksumAware {
      * @return <code>true</code> if a Rule for the Language uses Type
      *         Resolution, <code>false</code> otherwise.
      */
+    @Deprecated
     public boolean usesTypeResolution(Language language) {
         for (Rule r : rules) {
             if (r.getLanguage().equals(language) && r.isTypeResolution()) {
@@ -640,6 +644,7 @@ public class RuleSet implements ChecksumAware {
      * @return {@code true} if a Rule for the Language uses multi file analysis,
      *         {@code false} otherwise.
      */
+    @Deprecated
     public boolean usesMultifile(Language language) {
         for (Rule r : rules) {
             if (r.getLanguage().equals(language) && r.isMultifile()) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSets.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSets.java
@@ -161,6 +161,7 @@ public class RuleSets {
      *            the language of a source
      * @return true if any rule in the RuleSet needs the DFA layer
      */
+    @Deprecated
     public boolean usesDFA(Language language) {
         for (RuleSet ruleSet : ruleSets) {
             if (ruleSet.usesDFA(language)) {
@@ -210,6 +211,7 @@ public class RuleSets {
      * @return <code>true</code> if a Rule for the Language uses Type
      *         Resolution, <code>false</code> otherwise.
      */
+    @Deprecated
     public boolean usesTypeResolution(Language language) {
         for (RuleSet ruleSet : ruleSets) {
             if (ruleSet.usesTypeResolution(language)) {
@@ -228,6 +230,7 @@ public class RuleSets {
      * @return {@code true} if a Rule for the Language uses multi file analysis,
      *         {@code false} otherwise.
      */
+    @Deprecated
     public boolean usesMultifile(Language language) {
         for (RuleSet ruleSet : ruleSets) {
             if (ruleSet.usesMultifile(language)) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/SourceCodeProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/SourceCodeProcessor.java
@@ -173,6 +173,34 @@ public class SourceCodeProcessor {
         Parser parser = PMD.parserFor(languageVersion, configuration);
 
         Node rootNode = parse(ctx, sourceCode, parser);
+        // basically:
+        // 1. make the union of all stage dependencies of each rule, by language, for the Rulesets
+        // 2. order them by dependency
+        // 3. run them and time them if needed
+
+        // The problem is the first two steps need only be done once.
+        // They're probably costly and if we do this here without changing anything,
+        // they'll be done on each file! Btw currently the "usesDfa" and such are nested loops testing
+        // all rules of all rulesets, but they're run on each file too!
+
+        // Also, the benchmarking framework needs a small refactor. TimedOperationCategory needs to be
+        // made extensible -> probably should be turned to a class with static constants + factory methods
+        // and not an enum.
+
+        // With mutable RuleSets, caching of the value can't be guaranteed to be accurate...
+        // The approach I'd like to take is either
+        // * to create a new RunnableRulesets class which is immutable, and performs all these preliminary
+        //   computations upon construction.
+        // * or to modify Ruleset and Rulesets to be immutable. This IMO is a better option because it makes
+        //   these objects easier to reason about and pass around from thread to thread. It also avoid creating
+        //   a new class, and breaking SourceCodeProcessor's API too much.
+        //
+        // The "preliminary computations" also include:
+        // * removing dysfunctional rules
+        // * separating rulechain rules from normal rules
+        // * grouping rules by language/ file extension
+        // * etc.
+
         resolveQualifiedNames(rootNode, languageVersionHandler);
         symbolFacade(rootNode, languageVersionHandler);
         Language language = languageVersion.getLanguage();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/AbstractCpdLanguageVersionHandler.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/AbstractCpdLanguageVersionHandler.java
@@ -1,0 +1,34 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang;
+
+import java.util.Collections;
+import java.util.List;
+
+import net.sourceforge.pmd.lang.ast.AstProcessingStage;
+import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
+
+
+/**
+ * Base language version handler for languages that only support CPD.
+ *
+ * @author Clément Fournier
+ * @since 6.10.0
+ */
+public abstract class AbstractCpdLanguageVersionHandler extends AbstractLanguageVersionHandler {
+    @Override
+    public List<? extends AstProcessingStage<?>> getProcessingStages() {
+        return Collections.emptyList();
+    }
+
+
+    protected abstract String getLanguageName();
+
+
+    @Override
+    public RuleViolationFactory getRuleViolationFactory() {
+        throw new UnsupportedOperationException("getRuleViolationFactory() is not supported for " + getLanguageName());
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/AbstractPmdLanguageVersionHandler.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/AbstractPmdLanguageVersionHandler.java
@@ -1,0 +1,56 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang;
+
+import java.util.Collections;
+import java.util.List;
+
+import org.apache.commons.lang3.EnumUtils;
+
+import net.sourceforge.pmd.lang.ast.AstProcessingStage;
+
+
+/**
+ * Base language version handler for languages that support PMD, i.e. can build an AST
+ * and support AST processing stages.
+ *
+ * @author Clément Fournier
+ * @since 6.10.0
+ */
+public abstract class AbstractPmdLanguageVersionHandler extends AbstractLanguageVersionHandler {
+
+
+    private final List<? extends AstProcessingStage<?>> processingStages;
+
+
+    /**
+     * Declare processing stages within an enum. An enum is the best way
+     * to declare them since the illegality of forward references naturally
+     * prevents circular dependencies to be declared. The natural ordering
+     * on enums is also a sound and stable ordering for processing stages.
+     *
+     * @param processingStagesEnum Enum class
+     * @param <T>                  Type of the enum class
+     */
+    protected <T extends Enum<T> & AstProcessingStage<T>> AbstractPmdLanguageVersionHandler(Class<T> processingStagesEnum) {
+        this.processingStages = EnumUtils.getEnumList(processingStagesEnum);
+    }
+
+
+    /**
+     * Declare no optional processing stages as of yet.
+     */
+    protected AbstractPmdLanguageVersionHandler() {
+        this.processingStages = Collections.emptyList();
+    }
+
+
+    @Override
+    public final List<? extends AstProcessingStage<?>> getProcessingStages() {
+        return processingStages;
+    }
+
+
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageVersionHandler.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageVersionHandler.java
@@ -5,9 +5,13 @@
 package net.sourceforge.pmd.lang;
 
 import java.io.Writer;
+import java.util.List;
 
+import net.sourceforge.pmd.annotation.Experimental;
 import net.sourceforge.pmd.lang.dfa.DFAGraphRule;
+import net.sourceforge.pmd.lang.ast.AstProcessingStage;
 import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
+
 
 /**
  * Interface for obtaining the classes necessary for checking source files of a
@@ -17,20 +21,21 @@ import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
  */
 public interface LanguageVersionHandler {
 
-    /**
-     * Get the DataFlowHandler.
-     */
-    DataFlowHandler getDataFlowHandler();
 
     /**
      * Get the XPathHandler.
      */
     XPathHandler getXPathHandler();
 
+
     /**
-     * Get the RuleViolationFactory.
+     * Returns the list of all supported optional processing stages.
+     *
+     * @return A list of all optional processing stages.
      */
-    RuleViolationFactory getRuleViolationFactory();
+    @Experimental
+    List<? extends AstProcessingStage<?>> getProcessingStages();
+
 
     /**
      * Get the default ParserOptions.
@@ -39,6 +44,7 @@ public interface LanguageVersionHandler {
      */
     ParserOptions getDefaultParserOptions();
 
+
     /**
      * Get the Parser.
      *
@@ -46,46 +52,70 @@ public interface LanguageVersionHandler {
      */
     Parser getParser(ParserOptions parserOptions);
 
+
+    /**
+     * Get the RuleViolationFactory.
+     */
+    RuleViolationFactory getRuleViolationFactory();
+
+
+    /**
+     * Get the DumpFacade.
+     *
+     * @param writer The writer to dump to.
+     *
+     * @return VisitorStarter
+     */
+    // TODO should we deprecate? Not much use to it.
+    // Plus if it's not implemented, then it does nothing to the writer which is unexpected.
+    VisitorStarter getDumpFacade(Writer writer, String prefix, boolean recurse);
+
+
+    /**
+     * Get the DataFlowHandler.
+     */
+    @Deprecated
+    DataFlowHandler getDataFlowHandler();
+
+
     /**
      * Get the DataFlowFacade.
      *
      * @return VisitorStarter
      */
+    @Deprecated
     VisitorStarter getDataFlowFacade();
 
-    /**
-     * Get the SymbolFacade.
-     *
-     * @return VisitorStarter
-     */
-    VisitorStarter getSymbolFacade();
 
     /**
      * Get the SymbolFacade.
      *
-     * @param classLoader
-     *            A ClassLoader to use for resolving Types.
      * @return VisitorStarter
      */
+    @Deprecated
+    VisitorStarter getSymbolFacade();
+
+
+    /**
+     * Get the SymbolFacade.
+     *
+     * @param classLoader A ClassLoader to use for resolving Types.
+     *
+     * @return VisitorStarter
+     */
+    @Deprecated
     VisitorStarter getSymbolFacade(ClassLoader classLoader);
+
 
     /**
      * Get the TypeResolutionFacade.
      *
-     * @param classLoader
-     *            A ClassLoader to use for resolving Types.
-     * @return VisitorStarter
-     */
-    VisitorStarter getTypeResolutionFacade(ClassLoader classLoader);
-
-    /**
-     * Get the DumpFacade.
+     * @param classLoader A ClassLoader to use for resolving Types.
      *
-     * @param writer
-     *            The writer to dump to.
      * @return VisitorStarter
      */
-    VisitorStarter getDumpFacade(Writer writer, String prefix, boolean recurse);
+    @Deprecated
+    VisitorStarter getTypeResolutionFacade(ClassLoader classLoader);
 
 
     /**
@@ -93,6 +123,7 @@ public interface LanguageVersionHandler {
      *
      * @return The visitor starter
      */
+    @Deprecated
     VisitorStarter getMultifileFacade();
 
 
@@ -104,8 +135,10 @@ public interface LanguageVersionHandler {
      *
      * @return The visitor starter
      */
+    @Deprecated
     VisitorStarter getQualifiedNameResolutionFacade(ClassLoader classLoader);
 
 
+    @Deprecated
     DFAGraphRule getDFAGraphRule();
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageVersionHandler.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageVersionHandler.java
@@ -8,8 +8,8 @@ import java.io.Writer;
 import java.util.List;
 
 import net.sourceforge.pmd.annotation.Experimental;
-import net.sourceforge.pmd.lang.dfa.DFAGraphRule;
 import net.sourceforge.pmd.lang.ast.AstProcessingStage;
+import net.sourceforge.pmd.lang.dfa.DFAGraphRule;
 import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
 
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/XPathHandler.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/XPathHandler.java
@@ -48,6 +48,9 @@ public interface XPathHandler {
     /**
      * Get a Jaxen Navigator for this Language. May return <code>null</code> if
      * there is no Jaxen Navigation for this language.
+     *
+     * @deprecated PMD 7.0.0 will remove support for Jaxen
      */
+    @Deprecated
     Navigator getNavigator();
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AstAnalysisConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AstAnalysisConfiguration.java
@@ -1,0 +1,34 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.ast;
+
+import net.sourceforge.pmd.annotation.Experimental;
+import net.sourceforge.pmd.lang.LanguageVersion;
+
+
+/**
+ * Configuration relevant to e.g. an {@link AstProcessingStage}.
+ *
+ * @author Clément Fournier
+ * @since 6.10.0
+ */
+@Experimental
+public interface AstAnalysisConfiguration {
+
+
+    /**
+     * Gets the classloader used for type resolution.
+     *
+     * @return The classloader.
+     */
+    ClassLoader getTypeResolutionClassLoader();
+
+
+    /**
+     * Returns the language version used for this analysis.
+     */
+    LanguageVersion getLanguageVersion();
+
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AstProcessingStage.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AstProcessingStage.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.lang.ast;
 
 import java.util.List;
 
-import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleSets;
 import net.sourceforge.pmd.annotation.Experimental;
 import net.sourceforge.pmd.lang.LanguageVersionHandler;
@@ -50,7 +49,7 @@ import net.sourceforge.pmd.lang.LanguageVersionHandler;
  *
  *
  * @author Clément Fournier
- * @since 6.10.0
+ * @since 7.0.0
  */
 // @formatter:on
 @Experimental
@@ -85,26 +84,5 @@ public interface AstProcessingStage<T extends AstProcessingStage<T>> extends Com
      */
     void processAST(RootNode rootNode, AstAnalysisConfiguration configuration);
 
-
-    /**
-     * Returns true if the given rule depends on this stage,
-     * in which case, any ruleset containing that rule depends
-     * on this stage too.
-     *
-     * @param rule Rule to test
-     *
-     * @return true if the given rule depends on this stage.
-     */
-    // This can be customized for each step.
-    // For now we use the Rule.isDfa() / Rule.isTypeRes()
-    // In the future we can check an annotation.
-    // If the rule is an XPath rule, then additional work
-    // performed by the XPath analyser will be taken into account.
-
-    // This separation based on the type of rule means that the
-    // method for dependency determination should probably be on the
-    // Rule interface, but I don't know for now.
-    @Experimental
-    boolean ruleDependsOnThisStage(Rule rule);
 
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AstProcessingStage.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AstProcessingStage.java
@@ -1,0 +1,110 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.ast;
+
+import java.util.List;
+
+import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.RuleSets;
+import net.sourceforge.pmd.annotation.Experimental;
+import net.sourceforge.pmd.lang.LanguageVersionHandler;
+
+// @formatter:off
+/**
+ * Represents one of the stages applying on the AST
+ * after parsing is done. Each of these stages implicitly
+ * depends on the parser stage.
+ *
+ * <p>An analysis on a file goes through the following stages:
+ * <ul>
+ *     <li> Parsing stage: taking the source and configuration, and returning an AST
+ *     <li> Language-specific AST visits: sequence of stages specific to each language.
+ *          Each stage performs side effects on the AST, e.g. to resolve such things as comments,
+ *          types, DFA graph, etc.
+ *     <li> Rulechain application: all rulechain rules are run on the final AST
+ *     <li> Rule application: other rules are run
+ * </ul>
+ *
+ * <p>These steps are run on each file during the analysis, unless the cache entry of the file is up-to-date.
+ * They're all run sequentially by the same thread. Rule application performs side-effects on the Report,
+ * which is rendered after all files have been processed.
+ *
+ * <p>Parsing and rule[chain] application stages are considered special and are handled differently for now.
+ * A {@link LanguageVersionHandler} is responsible for listing all available {@link AstProcessingStage}s
+ * (see {@link LanguageVersionHandler#getProcessingStages()}). The actual set of stages that will get executed
+ * for a run is the union of the dependencies of the rules in the run {@link RuleSets}.
+ *
+ * <p>Additional doc, to be moved elsewhere probably:
+ * <p>PMD's execution goes through other more global stages (not sure about the exact order):
+ * <ul>
+ *   <li> Rule loading: creates a {@link RuleSets} from the ruleset files
+ *   <li> Cache loading: loads the cache file for incremental analysis if any, creates the new cache
+ *   <li> Report creation: creates a report object for the rules to act on
+ *   <li> File collection: collects the files to analyse and dispatches them to worker threads.
+ *        Each file undergoes the steps described above.
+ *   <li> Report rendering
+ *   <li> Cache persisting
+ * </ul>
+ *
+ *
+ * @author Clément Fournier
+ * @since 6.10.0
+ */
+// @formatter:on
+@Experimental
+public interface AstProcessingStage<T extends AstProcessingStage<T>> extends Comparable<T> {
+
+
+    /**
+     * Gets the stages on which this stage depends.
+     * E.g. the type resolution stage may depend on the
+     * qualified name resolution stage.
+     *
+     * <p>Returns an empty list if this stage only depends
+     * on the parser stage.
+     */
+    List<T> getDependencies();
+
+
+    /**
+     * Returns the name of this stage, used e.g. to display in a
+     * benchmark report.
+     *
+     * @return The name of the stage.
+     */
+    String getDisplayName();
+
+
+    /**
+     * Performs some side effects on the AST, e.g. to resolve something.
+     *
+     * @param rootNode      Root of the tree
+     * @param configuration Configuration
+     */
+    void processAST(RootNode rootNode, AstAnalysisConfiguration configuration);
+
+
+    /**
+     * Returns true if the given rule depends on this stage,
+     * in which case, any ruleset containing that rule depends
+     * on this stage too.
+     *
+     * @param rule Rule to test
+     *
+     * @return true if the given rule depends on this stage.
+     */
+    // This can be customized for each step.
+    // For now we use the Rule.isDfa() / Rule.isTypeRes()
+    // In the future we can check an annotation.
+    // If the rule is an XPath rule, then additional work
+    // performed by the XPath analyser will be taken into account.
+
+    // This separation based on the type of rule means that the
+    // method for dependency determination should probably be on the
+    // Rule interface, but I don't know for now.
+    @Experimental
+    boolean ruleDependsOnThisStage(Rule rule);
+
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
@@ -318,6 +318,7 @@ public abstract class AbstractRule extends AbstractPropertySource implements Rul
     @Override
     public void addRuleChainVisit(Class<? extends Node> nodeClass) {
         if (!nodeClass.getSimpleName().startsWith("AST")) {
+            // Classes under the Comment hierarchy and stuff need to be refactored in the Java AST
             throw new IllegalArgumentException("Node class does not start with 'AST' prefix: " + nodeClass);
         }
         addRuleChainVisit(nodeClass.getSimpleName().substring("AST".length()));

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageModule.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageModule.java
@@ -61,7 +61,7 @@ public class DummyLanguageModule extends BaseLanguageModule {
         }
     }
 
-    public static class Handler extends AbstractLanguageVersionHandler {
+    public static class Handler extends AbstractPmdLanguageVersionHandler {
         @Override
         public RuleViolationFactory getRuleViolationFactory() {
             return new RuleViolationFactory();

--- a/pmd-cpp/src/main/java/net/sourceforge/pmd/lang/cpp/CppHandler.java
+++ b/pmd-cpp/src/main/java/net/sourceforge/pmd/lang/cpp/CppHandler.java
@@ -4,20 +4,20 @@
 
 package net.sourceforge.pmd.lang.cpp;
 
-import net.sourceforge.pmd.lang.AbstractLanguageVersionHandler;
+import net.sourceforge.pmd.lang.AbstractCpdLanguageVersionHandler;
 import net.sourceforge.pmd.lang.Parser;
 import net.sourceforge.pmd.lang.ParserOptions;
-import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
 
 /**
  * Implementation of LanguageVersionHandler for the C++ Language.
  */
-public class CppHandler extends AbstractLanguageVersionHandler {
+public class CppHandler extends AbstractCpdLanguageVersionHandler {
 
     @Override
-    public RuleViolationFactory getRuleViolationFactory() {
-        throw new UnsupportedOperationException("getRuleViolationFactory() is not supported for C++");
+    protected String getLanguageName() {
+        return "C++";
     }
+
 
     @Override
     public Parser getParser(ParserOptions parserOptions) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/AbstractJavaHandler.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/AbstractJavaHandler.java
@@ -42,7 +42,7 @@ import net.sf.saxon.sxpath.IndependentContext;
  */
 public abstract class AbstractJavaHandler extends AbstractPmdLanguageVersionHandler {
 
-    protected AbstractJavaHandler() {
+    AbstractJavaHandler() {
         super(JavaProcessingStage.class);
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/AbstractJavaHandler.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/AbstractJavaHandler.java
@@ -6,7 +6,7 @@ package net.sourceforge.pmd.lang.java;
 
 import java.io.Writer;
 
-import net.sourceforge.pmd.lang.AbstractLanguageVersionHandler;
+import net.sourceforge.pmd.lang.AbstractPmdLanguageVersionHandler;
 import net.sourceforge.pmd.lang.DataFlowHandler;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.VisitorStarter;
@@ -40,7 +40,12 @@ import net.sf.saxon.sxpath.IndependentContext;
  *
  * @author pieter_van_raemdonck - Application Engineers NV/SA - www.ae.be
  */
-public abstract class AbstractJavaHandler extends AbstractLanguageVersionHandler {
+public abstract class AbstractJavaHandler extends AbstractPmdLanguageVersionHandler {
+
+    protected AbstractJavaHandler() {
+        super(JavaProcessingStage.class);
+    }
+
 
     @Override
     public DataFlowHandler getDataFlowHandler() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/JavaProcessingStage.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/JavaProcessingStage.java
@@ -9,12 +9,15 @@ import java.util.Collections;
 import java.util.List;
 
 import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.annotation.Experimental;
+import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.ast.AstAnalysisConfiguration;
 import net.sourceforge.pmd.lang.ast.AstProcessingStage;
 import net.sourceforge.pmd.lang.ast.RootNode;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.dfa.DataFlowFacade;
 import net.sourceforge.pmd.lang.java.qname.QualifiedNameResolver;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.symboltable.SymbolFacade;
 import net.sourceforge.pmd.lang.java.typeresolution.TypeResolutionFacade;
 
@@ -23,8 +26,9 @@ import net.sourceforge.pmd.lang.java.typeresolution.TypeResolutionFacade;
  * Java processing stages.
  *
  * @author Clément Fournier
- * @since 6.10.0
+ * @since 7.0.0
  */
+@Experimental
 public enum JavaProcessingStage implements AstProcessingStage<JavaProcessingStage> {
 
     /**
@@ -68,7 +72,7 @@ public enum JavaProcessingStage implements AstProcessingStage<JavaProcessingStag
 
 
         @Override
-        public boolean ruleDependsOnThisStage(Rule rule) {
+        public boolean dependsOnImpl(Rule rule) {
             return rule.isDfa();
         }
     };
@@ -95,9 +99,36 @@ public enum JavaProcessingStage implements AstProcessingStage<JavaProcessingStag
         return displayName;
     }
 
-    @Override
-    public boolean ruleDependsOnThisStage(Rule rule) {
-        // most stages are enabled by default in java
+
+    /**
+     * Returns true if the given Java rule depends on this stage.
+     *
+     * <p>{@link AbstractJavaRule#dependsOn(AstProcessingStage)}
+     * delegates to this implementation after a validity check.
+     * Dispatching on the rule language & forwarding to the
+     * processing stage implementation allows specializing XPath
+     * rules differently from rules written in Java, while keeping
+     * dependency specification inside the processing stage declaration,
+     * for readability. By design, Java XPath rules ignore this
+     * method, it is only relevant to {@link AbstractJavaRule}.
+     *
+     * @param rule Rule to check
+     *
+     * @return True if the given rule depends on this stage
+     *
+     * @throws IllegalArgumentException if this rule is not a rule for Java.
+     */
+    @Experimental
+    public final boolean ruleDependsOnThisStage(Rule rule) {
+        if (!rule.getLanguage().equals(LanguageRegistry.findLanguageByTerseName("java"))) {
+            throw new IllegalArgumentException();
+        }
+        return dependsOnImpl(rule); // this is a template method
+    }
+
+
+    protected boolean dependsOnImpl(Rule rule) {
+        // most Java processing stages are run by default
         return true;
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/JavaProcessingStage.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/JavaProcessingStage.java
@@ -9,14 +9,14 @@ import java.util.Collections;
 import java.util.List;
 
 import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.lang.ast.AstAnalysisConfiguration;
+import net.sourceforge.pmd.lang.ast.AstProcessingStage;
 import net.sourceforge.pmd.lang.ast.RootNode;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.dfa.DataFlowFacade;
 import net.sourceforge.pmd.lang.java.qname.QualifiedNameResolver;
 import net.sourceforge.pmd.lang.java.symboltable.SymbolFacade;
 import net.sourceforge.pmd.lang.java.typeresolution.TypeResolutionFacade;
-import net.sourceforge.pmd.lang.ast.AstAnalysisConfiguration;
-import net.sourceforge.pmd.lang.ast.AstProcessingStage;
 
 
 /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/JavaProcessingStage.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/JavaProcessingStage.java
@@ -1,0 +1,103 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.lang.ast.RootNode;
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.lang.java.dfa.DataFlowFacade;
+import net.sourceforge.pmd.lang.java.qname.QualifiedNameResolver;
+import net.sourceforge.pmd.lang.java.symboltable.SymbolFacade;
+import net.sourceforge.pmd.lang.java.typeresolution.TypeResolutionFacade;
+import net.sourceforge.pmd.lang.ast.AstAnalysisConfiguration;
+import net.sourceforge.pmd.lang.ast.AstProcessingStage;
+
+
+/**
+ * Java processing stages.
+ *
+ * @author Clément Fournier
+ * @since 6.10.0
+ */
+public enum JavaProcessingStage implements AstProcessingStage<JavaProcessingStage> {
+
+    /**
+     * Qualified name resolution.
+     */
+    QNAME_RESOLUTION("Qualified name resolution") {
+        @Override
+        public void processAST(RootNode rootNode, AstAnalysisConfiguration configuration) {
+            new QualifiedNameResolver().initializeWith(configuration.getTypeResolutionClassLoader(), (ASTCompilationUnit) rootNode);
+        }
+    },
+
+    /**
+     * Symbol table analysis.
+     */
+    SYMBOL_RESOLUTION("Symbol table") {
+        @Override
+        public void processAST(RootNode rootNode, AstAnalysisConfiguration configuration) {
+            new SymbolFacade().initializeWith(configuration.getTypeResolutionClassLoader(), (ASTCompilationUnit) rootNode);
+        }
+    },
+
+    /**
+     * Type resolution, depends on QName resolution.
+     */
+    TYPE_RESOLUTION("Type resolution", QNAME_RESOLUTION) {
+        @Override
+        public void processAST(RootNode rootNode, AstAnalysisConfiguration configuration) {
+            new TypeResolutionFacade().initializeWith(configuration.getTypeResolutionClassLoader(), (ASTCompilationUnit) rootNode);
+        }
+    },
+
+    /**
+     * Data flow analysis.
+     */
+    DFA("Data flow analysis") {
+        @Override
+        public void processAST(RootNode rootNode, AstAnalysisConfiguration configuration) {
+            new DataFlowFacade().initializeWith(new JavaDataFlowHandler(), (ASTCompilationUnit) rootNode);
+        }
+
+
+        @Override
+        public boolean ruleDependsOnThisStage(Rule rule) {
+            return rule.isDfa();
+        }
+    };
+
+
+    private final String displayName;
+    private final List<JavaProcessingStage> dependencies;
+
+
+    JavaProcessingStage(String displayName, JavaProcessingStage... dependencies) {
+        this.displayName = displayName;
+        this.dependencies = Collections.unmodifiableList(Arrays.asList(dependencies));
+    }
+
+
+    @Override
+    public List<JavaProcessingStage> getDependencies() {
+        return dependencies;
+    }
+
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    @Override
+    public boolean ruleDependsOnThisStage(Rule rule) {
+        // most stages are enabled by default in java
+        return true;
+    }
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJavaRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJavaRule.java
@@ -8,8 +8,10 @@ import java.util.List;
 
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.LanguageRegistry;
+import net.sourceforge.pmd.lang.ast.AstProcessingStage;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.JavaLanguageModule;
+import net.sourceforge.pmd.lang.java.JavaProcessingStage;
 import net.sourceforge.pmd.lang.java.ast.*;
 import net.sourceforge.pmd.lang.rule.AbstractRule;
 import net.sourceforge.pmd.lang.rule.ImmutableLanguage;
@@ -73,6 +75,16 @@ public abstract class AbstractJavaRule extends AbstractRule implements JavaParse
     protected boolean isSuppressed(Node node) {
         return JavaRuleViolation.isSupressed(node, this);
     }
+
+
+    @Override
+    public final boolean dependsOn(AstProcessingStage<?> stage) {
+        if (!(stage instanceof JavaProcessingStage)) {
+            throw new IllegalArgumentException("Processing stage wasn't a Java one: " + stage);
+        }
+        return ((JavaProcessingStage) stage).ruleDependsOnThisStage(this);
+    }
+
 
     //
     // The following APIs are identical to those in JavaParserVisitorAdapter.

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/Ecmascript3Handler.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/Ecmascript3Handler.java
@@ -6,7 +6,7 @@ package net.sourceforge.pmd.lang.ecmascript;
 
 import java.io.Writer;
 
-import net.sourceforge.pmd.lang.AbstractLanguageVersionHandler;
+import net.sourceforge.pmd.lang.AbstractPmdLanguageVersionHandler;
 import net.sourceforge.pmd.lang.Parser;
 import net.sourceforge.pmd.lang.ParserOptions;
 import net.sourceforge.pmd.lang.VisitorStarter;
@@ -21,7 +21,7 @@ import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
 /**
  * Implementation of LanguageVersionHandler for the ECMAScript Version 3.
  */
-public class Ecmascript3Handler extends AbstractLanguageVersionHandler {
+public class Ecmascript3Handler extends AbstractPmdLanguageVersionHandler {
 
     @Override
     public XPathHandler getXPathHandler() {

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/JspHandler.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/JspHandler.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.jsp;
 import java.io.Writer;
 
 import net.sourceforge.pmd.lang.AbstractLanguageVersionHandler;
+import net.sourceforge.pmd.lang.AbstractPmdLanguageVersionHandler;
 import net.sourceforge.pmd.lang.Parser;
 import net.sourceforge.pmd.lang.ParserOptions;
 import net.sourceforge.pmd.lang.VisitorStarter;
@@ -23,7 +24,7 @@ import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
  *
  * @author pieter_van_raemdonck - Application Engineers NV/SA - www.ae.be
  */
-public class JspHandler extends AbstractLanguageVersionHandler {
+public class JspHandler extends AbstractPmdLanguageVersionHandler {
 
     @Override
     public XPathHandler getXPathHandler() {

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/JspHandler.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/JspHandler.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.lang.jsp;
 
 import java.io.Writer;
 
-import net.sourceforge.pmd.lang.AbstractLanguageVersionHandler;
 import net.sourceforge.pmd.lang.AbstractPmdLanguageVersionHandler;
 import net.sourceforge.pmd.lang.Parser;
 import net.sourceforge.pmd.lang.ParserOptions;

--- a/pmd-matlab/src/main/java/net/sourceforge/pmd/lang/matlab/MatlabHandler.java
+++ b/pmd-matlab/src/main/java/net/sourceforge/pmd/lang/matlab/MatlabHandler.java
@@ -4,20 +4,21 @@
 
 package net.sourceforge.pmd.lang.matlab;
 
-import net.sourceforge.pmd.lang.AbstractLanguageVersionHandler;
+import net.sourceforge.pmd.lang.AbstractCpdLanguageVersionHandler;
 import net.sourceforge.pmd.lang.Parser;
 import net.sourceforge.pmd.lang.ParserOptions;
-import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
+
 
 /**
  * Implementation of LanguageVersionHandler for the Matlab Language.
  */
-public class MatlabHandler extends AbstractLanguageVersionHandler {
+public class MatlabHandler extends AbstractCpdLanguageVersionHandler {
 
     @Override
-    public RuleViolationFactory getRuleViolationFactory() {
-        throw new UnsupportedOperationException("getRuleViolationFactory() is not supported for Matlab");
+    protected String getLanguageName() {
+        return "Matlab";
     }
+
 
     @Override
     public Parser getParser(ParserOptions parserOptions) {

--- a/pmd-objectivec/src/main/java/net/sourceforge/pmd/lang/objectivec/ObjectiveCHandler.java
+++ b/pmd-objectivec/src/main/java/net/sourceforge/pmd/lang/objectivec/ObjectiveCHandler.java
@@ -4,20 +4,21 @@
 
 package net.sourceforge.pmd.lang.objectivec;
 
-import net.sourceforge.pmd.lang.AbstractLanguageVersionHandler;
+import net.sourceforge.pmd.lang.AbstractCpdLanguageVersionHandler;
 import net.sourceforge.pmd.lang.Parser;
 import net.sourceforge.pmd.lang.ParserOptions;
-import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
+
 
 /**
  * Implementation of LanguageVersionHandler for the Objective-C Language.
  */
-public class ObjectiveCHandler extends AbstractLanguageVersionHandler {
+public class ObjectiveCHandler extends AbstractCpdLanguageVersionHandler {
 
     @Override
-    public RuleViolationFactory getRuleViolationFactory() {
-        throw new UnsupportedOperationException("getRuleViolationFactory() is not supported for Objective-C");
+    protected String getLanguageName() {
+        return "Objective-C";
     }
+
 
     @Override
     public Parser getParser(ParserOptions parserOptions) {

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/PLSQLHandler.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/PLSQLHandler.java
@@ -6,7 +6,7 @@ package net.sourceforge.pmd.lang.plsql;
 
 import java.io.Writer;
 
-import net.sourceforge.pmd.lang.AbstractLanguageVersionHandler;
+import net.sourceforge.pmd.lang.AbstractPmdLanguageVersionHandler;
 import net.sourceforge.pmd.lang.DataFlowHandler;
 import net.sourceforge.pmd.lang.Parser;
 import net.sourceforge.pmd.lang.ParserOptions;
@@ -30,7 +30,12 @@ import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
  *
  * @author sturton - PLDoc - pldoc.sourceforge.net
  */
-public class PLSQLHandler extends AbstractLanguageVersionHandler {
+public class PLSQLHandler extends AbstractPmdLanguageVersionHandler {
+
+
+    public PLSQLHandler() {
+        super(PlsqlProcessingStage.class);
+    }
 
     @Override
     public Parser getParser(ParserOptions parserOptions) {

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/PlsqlProcessingStage.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/PlsqlProcessingStage.java
@@ -1,0 +1,84 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.plsql;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.lang.ast.RootNode;
+import net.sourceforge.pmd.lang.plsql.ast.ASTInput;
+import net.sourceforge.pmd.lang.plsql.dfa.DataFlowFacade;
+import net.sourceforge.pmd.lang.plsql.symboltable.SymbolFacade;
+import net.sourceforge.pmd.lang.ast.AstAnalysisConfiguration;
+import net.sourceforge.pmd.lang.ast.AstProcessingStage;
+
+
+/**
+ * PL-SQL AST processing stages.
+ *
+ * @author Clément Fournier
+ * @since 6.10.0
+ */
+public enum PlsqlProcessingStage implements AstProcessingStage<PlsqlProcessingStage> {
+
+    /**
+     * Symbol table analysis.
+     */
+    SYMBOL_RESOLUTION("Symbol table") {
+        @Override
+        public void processAST(RootNode rootNode, AstAnalysisConfiguration configuration) {
+            new SymbolFacade().initializeWith((ASTInput) rootNode);
+        }
+
+
+        @Override
+        public boolean ruleDependsOnThisStage(Rule rule) {
+            return true;
+        }
+    },
+
+    /**
+     * Data flow analysis.
+     */
+    DFA("Data flow analysis") {
+        @Override
+        public void processAST(RootNode rootNode, AstAnalysisConfiguration configuration) {
+            new DataFlowFacade().initializeWith(new PLSQLDataFlowHandler(), (ASTInput) rootNode);
+        }
+
+
+        @Override
+        public boolean ruleDependsOnThisStage(Rule rule) {
+            return rule.isDfa();
+        }
+    };
+
+
+    private final String displayName;
+    private final List<PlsqlProcessingStage> dependencies;
+
+
+    PlsqlProcessingStage(String displayName, PlsqlProcessingStage... dependencies) {
+        this.displayName = displayName;
+        this.dependencies = Collections.unmodifiableList(Arrays.asList(dependencies));
+    }
+
+
+    @Override
+    public List<PlsqlProcessingStage> getDependencies() {
+        return dependencies;
+    }
+
+
+    @Override
+    public String getDisplayName() {
+        return displayName;
+    }
+
+
+}
+

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/PlsqlProcessingStage.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/PlsqlProcessingStage.java
@@ -9,11 +9,14 @@ import java.util.Collections;
 import java.util.List;
 
 import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.annotation.Experimental;
+import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.ast.AstAnalysisConfiguration;
 import net.sourceforge.pmd.lang.ast.AstProcessingStage;
 import net.sourceforge.pmd.lang.ast.RootNode;
 import net.sourceforge.pmd.lang.plsql.ast.ASTInput;
 import net.sourceforge.pmd.lang.plsql.dfa.DataFlowFacade;
+import net.sourceforge.pmd.lang.plsql.rule.AbstractPLSQLRule;
 import net.sourceforge.pmd.lang.plsql.symboltable.SymbolFacade;
 
 
@@ -21,8 +24,9 @@ import net.sourceforge.pmd.lang.plsql.symboltable.SymbolFacade;
  * PL-SQL AST processing stages.
  *
  * @author Clément Fournier
- * @since 6.10.0
+ * @since 7.0.0
  */
+@Experimental
 public enum PlsqlProcessingStage implements AstProcessingStage<PlsqlProcessingStage> {
 
     /**
@@ -36,7 +40,7 @@ public enum PlsqlProcessingStage implements AstProcessingStage<PlsqlProcessingSt
 
 
         @Override
-        public boolean ruleDependsOnThisStage(Rule rule) {
+        public boolean dependsOnImpl(Rule rule) {
             return true;
         }
     },
@@ -52,7 +56,7 @@ public enum PlsqlProcessingStage implements AstProcessingStage<PlsqlProcessingSt
 
 
         @Override
-        public boolean ruleDependsOnThisStage(Rule rule) {
+        public boolean dependsOnImpl(Rule rule) {
             return rule.isDfa();
         }
     };
@@ -80,5 +84,33 @@ public enum PlsqlProcessingStage implements AstProcessingStage<PlsqlProcessingSt
     }
 
 
+    /**
+     * Returns true if the given Java rule depends on this stage.
+     *
+     * <p>{@link AbstractPLSQLRule#dependsOn(AstProcessingStage)}
+     * delegates to this implementation after a validity check.
+     * Dispatching on the rule language & forwarding to the
+     * processing stage implementation allows specializing XPath
+     * rules differently from rules written in Java, while keeping
+     * dependency specification inside the processing stage declaration,
+     * for readability. By design, PLSQL XPath rules ignore this
+     * method, it is only relevant to {@link AbstractPLSQLRule}.
+     *
+     * @param rule Rule to check
+     *
+     * @return True if the given rule depends on this stage
+     *
+     * @throws IllegalArgumentException if this rule is not a PL-SQL rule.
+     */
+    @Experimental
+    public final boolean ruleDependsOnThisStage(Rule rule) {
+        if (!rule.getLanguage().equals(LanguageRegistry.findLanguageByTerseName("plsql"))) {
+            throw new IllegalArgumentException();
+        }
+        return dependsOnImpl(rule); // this is a template method
+    }
+
+
+    protected abstract boolean dependsOnImpl(Rule rule);
 }
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/PlsqlProcessingStage.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/PlsqlProcessingStage.java
@@ -9,12 +9,12 @@ import java.util.Collections;
 import java.util.List;
 
 import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.lang.ast.AstAnalysisConfiguration;
+import net.sourceforge.pmd.lang.ast.AstProcessingStage;
 import net.sourceforge.pmd.lang.ast.RootNode;
 import net.sourceforge.pmd.lang.plsql.ast.ASTInput;
 import net.sourceforge.pmd.lang.plsql.dfa.DataFlowFacade;
 import net.sourceforge.pmd.lang.plsql.symboltable.SymbolFacade;
-import net.sourceforge.pmd.lang.ast.AstAnalysisConfiguration;
-import net.sourceforge.pmd.lang.ast.AstProcessingStage;
 
 
 /**

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractPLSQLRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractPLSQLRule.java
@@ -95,7 +95,7 @@ public abstract class AbstractPLSQLRule extends AbstractRule implements PLSQLPar
     @Override
     public final boolean dependsOn(AstProcessingStage<?> stage) {
         if (!(stage instanceof PlsqlProcessingStage)) {
-            throw new IllegalArgumentException("Processing stage wasn't a Java one: " + stage);
+            throw new IllegalArgumentException("Processing stage wasn't a " + PLSQLLanguageModule.NAME + " one: " + stage);
         }
         return ((PlsqlProcessingStage) stage).ruleDependsOnThisStage(this);
     }

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractPLSQLRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractPLSQLRule.java
@@ -9,8 +9,10 @@ import java.util.logging.Logger;
 
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.LanguageRegistry;
+import net.sourceforge.pmd.lang.ast.AstProcessingStage;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.plsql.PLSQLLanguageModule;
+import net.sourceforge.pmd.lang.plsql.PlsqlProcessingStage;
 import net.sourceforge.pmd.lang.plsql.ast.*;
 import net.sourceforge.pmd.lang.rule.AbstractRule;
 import net.sourceforge.pmd.lang.rule.ImmutableLanguage;
@@ -88,6 +90,16 @@ public abstract class AbstractPLSQLRule extends AbstractRule implements PLSQLPar
     public static boolean importsPackage(ASTInput node, String packageName) {
         return false;
     }
+
+
+    @Override
+    public final boolean dependsOn(AstProcessingStage<?> stage) {
+        if (!(stage instanceof PlsqlProcessingStage)) {
+            throw new IllegalArgumentException("Processing stage wasn't a Java one: " + stage);
+        }
+        return ((PlsqlProcessingStage) stage).ruleDependsOnThisStage(this);
+    }
+
 
     /*
      * Duplicate PLSQLParserVisitor API

--- a/pmd-python/src/main/java/net/sourceforge/pmd/lang/python/PythonHandler.java
+++ b/pmd-python/src/main/java/net/sourceforge/pmd/lang/python/PythonHandler.java
@@ -4,20 +4,22 @@
 
 package net.sourceforge.pmd.lang.python;
 
-import net.sourceforge.pmd.lang.AbstractLanguageVersionHandler;
+import net.sourceforge.pmd.lang.AbstractCpdLanguageVersionHandler;
 import net.sourceforge.pmd.lang.Parser;
 import net.sourceforge.pmd.lang.ParserOptions;
-import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
+
 
 /**
  * Implementation of LanguageVersionHandler for the Python Language.
  */
-public class PythonHandler extends AbstractLanguageVersionHandler {
+public class PythonHandler extends AbstractCpdLanguageVersionHandler {
+
 
     @Override
-    public RuleViolationFactory getRuleViolationFactory() {
-        throw new UnsupportedOperationException("getRuleViolationFactory() is not supported for Python");
+    protected String getLanguageName() {
+        return "Python";
     }
+
 
     @Override
     public Parser getParser(ParserOptions parserOptions) {

--- a/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/DummyLanguageModule.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/DummyLanguageModule.java
@@ -14,8 +14,8 @@ import java.util.Map;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.RuleViolation;
-import net.sourceforge.pmd.lang.AbstractLanguageVersionHandler;
 import net.sourceforge.pmd.lang.AbstractParser;
+import net.sourceforge.pmd.lang.AbstractPmdLanguageVersionHandler;
 import net.sourceforge.pmd.lang.BaseLanguageModule;
 import net.sourceforge.pmd.lang.Parser;
 import net.sourceforge.pmd.lang.ParserOptions;
@@ -67,7 +67,7 @@ public class DummyLanguageModule extends BaseLanguageModule {
         }
     }
 
-    public static class Handler extends AbstractLanguageVersionHandler {
+    public static class Handler extends AbstractPmdLanguageVersionHandler {
         @Override
         public RuleViolationFactory getRuleViolationFactory() {
             return new RuleViolationFactory();

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/VfHandler.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/VfHandler.java
@@ -6,7 +6,7 @@ package net.sourceforge.pmd.lang.vf;
 
 import java.io.Writer;
 
-import net.sourceforge.pmd.lang.AbstractLanguageVersionHandler;
+import net.sourceforge.pmd.lang.AbstractPmdLanguageVersionHandler;
 import net.sourceforge.pmd.lang.Parser;
 import net.sourceforge.pmd.lang.ParserOptions;
 import net.sourceforge.pmd.lang.VisitorStarter;
@@ -18,7 +18,7 @@ import net.sourceforge.pmd.lang.vf.ast.DumpFacade;
 import net.sourceforge.pmd.lang.vf.ast.VfNode;
 import net.sourceforge.pmd.lang.vf.rule.VfRuleViolationFactory;
 
-public class VfHandler extends AbstractLanguageVersionHandler {
+public class VfHandler extends AbstractPmdLanguageVersionHandler {
 
     @Override
     public XPathHandler getXPathHandler() {

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/VmHandler.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/VmHandler.java
@@ -6,7 +6,7 @@ package net.sourceforge.pmd.lang.vm;
 
 import java.io.Writer;
 
-import net.sourceforge.pmd.lang.AbstractLanguageVersionHandler;
+import net.sourceforge.pmd.lang.AbstractPmdLanguageVersionHandler;
 import net.sourceforge.pmd.lang.Parser;
 import net.sourceforge.pmd.lang.ParserOptions;
 import net.sourceforge.pmd.lang.VisitorStarter;
@@ -21,7 +21,7 @@ import net.sourceforge.pmd.lang.vm.rule.VmRuleViolationFactory;
  * Implementation of LanguageVersionHandler for the VM parser.
  *
  */
-public class VmHandler extends AbstractLanguageVersionHandler {
+public class VmHandler extends AbstractPmdLanguageVersionHandler {
 
     @Override
     public XPathHandler getXPathHandler() {

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/XmlHandler.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/XmlHandler.java
@@ -6,7 +6,7 @@ package net.sourceforge.pmd.lang.xml;
 
 import java.io.Writer;
 
-import net.sourceforge.pmd.lang.AbstractLanguageVersionHandler;
+import net.sourceforge.pmd.lang.AbstractPmdLanguageVersionHandler;
 import net.sourceforge.pmd.lang.Parser;
 import net.sourceforge.pmd.lang.ParserOptions;
 import net.sourceforge.pmd.lang.VisitorStarter;
@@ -21,7 +21,7 @@ import net.sourceforge.pmd.lang.xml.rule.XmlRuleViolationFactory;
 /**
  * Implementation of LanguageVersionHandler for the XML.
  */
-public class XmlHandler extends AbstractLanguageVersionHandler {
+public class XmlHandler extends AbstractPmdLanguageVersionHandler {
 
     @Override
     public XPathHandler getXPathHandler() {


### PR DESCRIPTION
First PR for 7.0.0! :smile: :metal: 

Basically this is a first step to simplify the way we handle optional AST traversals like typeresolution or symbol table. It's necessary to detect XPath dependencies automatically, and globally will make our life easier.


### Why we need a change

Type resolution, DFA, etc. all use a visitor that runs on the AST, wrapped in not-so-useful "façades" and provided by a LanguageVersionHandler. At the moment:
* Every language must have all of them, even if it's just a dummy. This is bad because these stages are ultimately language-specific ---e.g. not all languages will implement their type res with a preliminary qname resolution like Java  
  * Each language should be able to define themselves the visits they want to schedule independently of how other languages do it
* They are all executed in the same order for all language (logic is in SourceCodeProcessor), even though the order is an implementation detail which should rest... with the language *implementation*.
* Adding a new processing stage which only some rules activate is useful, yet requires a change to the LanguageVersionHandler interface, to its abstract class, to the SourceCodeProcessor, to the Rule interface, etc. The change must cascade from Rule to RuleSet to RuleSets. It also requires a change to the ruleset schema. Hmm spaghetti :spaghetti: 
  * These optional AST visits should be handled uniformly by pmd-core, and adding or removing them only entail changes to the language implementation, not pmd-core
* Current timing logic and check for dependency is duplicated for dfa, typeres, multifile, etc.


AST processing stages all have in common that:
* They take an AST + other config (e.g. a classloader) and perform side effects on the AST (e.g. to populate qnames). 
* They all run after the parsing stage and before rule application

This forms a basis for abstracting them.

### What's in this PR

* Processing stages are reified under the interface AstProcessingStage.
* LanguageVersionHandlers know the full set of AstProcessingStage a language version supports.
* AstProcessingStages may declare dependencies on other stages. E.g. Java typeres depends on qname resolution.
* AstProcessingStages are implemented by an enum for each language that supports some. This is quite natural for ordering reasons. Adding or removing AST visits is easy, so is specifying dependencies. 
* The Rule interface has a new method `dependsOn(AstProcessingStage)`, that returns whether the rule depends on the stage or not. 
  * Having it there instead of on the AstProcessingStage allows us to implement it differently in XPath rules and Java rules. 
  * E.g. Java rules may use annotations and XPath rules may use some analysis of the XPath expression (#437)
### What's not in this PR

* ~The actual way a rule declares a dependency on an stage is still unclear. Probably there will be a method on the Rule interface that returns the AstProcessingStages the rule depends on. This can then be implemented by abstract rule classes.~
  * ~E.g. Java rules may use annotations and XPath rules may use some analysis of the XPath expression (#437)~ 
  * ~This is left for future work, so is kind of WIP in this PR.~
* The processing stages are not wired into SourceCodeProcessor for now.
  * TimedOperationCategory needs to be refactored to a class to be extensible. This is probably the next PR.
  * The fact that RuleSets is mutable poses a problem to avoiding unnecessary computation. Either we make it immutable, or we have a new immutable class that takes care of precomputing all that can be done in advance. I'd really like them to make them immutable, because it will be much simpler to build them and reason about them, but this will change the API significantly. Wdyt?
  * This is further explained in a comment in SourceCodeProcessor.
* Since it's not wired I haven't removed the former API, just deprecated it. Deprecations will need to be ported to the master branch.