### PR TITLE
[core] Upgrading JCommander from 1.48 to 1.72

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -842,7 +842,7 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
             <dependency>
               <groupId>com.beust</groupId>
               <artifactId>jcommander</artifactId>
-              <version>1.48</version>
+              <version>1.72</version>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>


### PR DESCRIPTION
Upgrading JCommander 1.48 (released April 2015) to 1.72 (released June 2017).

`mvnw clean verify` passes.