### PR TITLE
[java] Deprecate Dimensionable

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -22,6 +22,22 @@ This is a {{ site.pmd.release_type }} release.
 
 ### API Changes
 
+#### Deprecated APIs
+
+* The interface `net.sourceforge.pmd.lang.java.ast.Dimensionable` has been deprecated.
+  It gets in the way of a grammar change for 7.0.0 and won't be needed anymore (see [#997](https://github.com/pmd/pmd/issues/997)).
+
+* Several methods from LocalVariableDeclaration and FieldDeclaration have also been
+  deprecated:
+  * FieldDeclaration won't be a TypeNode come 7.0.0, so `getType` and `getTypeDefinition` are deprecated
+  * The method `getVariableName` on those two nodes will be removed too
+
+  All these are deprecated because those nodes may declare several variables at once, possibly
+  with different types (and obviously with different names). They both implement `Iterator<ASTVariableDeclaratorId>`
+  though, so you should iterate on each declared variable. See [#910](https://github.com/pmd/pmd/issues/910)
+
+
+
 ### External Contributions
 
 *   [#1424](https://github.com/pmd/pmd/pull/1424): \[doc] #1341 Updating Regex Values in default Value Property - [avishvat](https://github.com/vishva007)

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTArrayDimsAndInits.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTArrayDimsAndInits.java
@@ -24,16 +24,19 @@ public class ASTArrayDimsAndInits extends AbstractJavaNode implements Dimensiona
         return visitor.visit(this, data);
     }
 
+    @Deprecated
     public void bumpArrayDepth() {
         arrayDepth++;
     }
 
     @Override
+    @Deprecated
     public int getArrayDepth() {
         return arrayDepth;
     }
 
     @Override
+    @Deprecated
     public boolean isArray() {
         return arrayDepth > 0; // should always be true...
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFieldDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFieldDeclaration.java
@@ -9,6 +9,7 @@ import java.util.Iterator;
 
 import net.sourceforge.pmd.lang.ast.SignedNode;
 import net.sourceforge.pmd.lang.java.multifile.signature.JavaFieldSignature;
+import net.sourceforge.pmd.lang.java.typeresolution.typedefinition.JavaTypeDefinition;
 
 
 /**
@@ -128,11 +129,13 @@ public class ASTFieldDeclaration extends AbstractJavaAccessTypeNode implements D
     }
 
     @Override
+    @Deprecated
     public boolean isArray() {
         return checkType() + checkDecl() > 0;
     }
 
     @Override
+    @Deprecated
     public int getArrayDepth() {
         if (!isArray()) {
             return 0;
@@ -159,8 +162,14 @@ public class ASTFieldDeclaration extends AbstractJavaAccessTypeNode implements D
      * VariableDeclartorId node and returns its image or <code>null</code> if
      * the child node is not found.
      *
+     *
+     * @deprecated FieldDeclaration may declare several variables, so this is not exhaustive
+     *             Iterate on the {@linkplain ASTVariableDeclaratorId VariableDeclaratorIds} instead
+     *
+     *
      * @return a String representing the name of the variable
      */
+    @Deprecated
     public String getVariableName() {
         ASTVariableDeclaratorId decl = getFirstDescendantOfType(ASTVariableDeclaratorId.class);
         if (decl != null) {
@@ -189,4 +198,26 @@ public class ASTFieldDeclaration extends AbstractJavaAccessTypeNode implements D
         return ASTVariableDeclarator.iterateIds(this);
     }
 
+
+    /**
+     * @deprecated FieldDeclaration may declare several variables with a different type
+     *             It won't implement TypeNode anymore come 7.0.0
+     */
+    @Override
+    @Deprecated
+    public Class<?> getType() {
+        return super.getType();
+    }
+
+
+    /**
+     *
+     * @deprecated FieldDeclaration may declare several variables with a different type
+     *             It won't implement TypeNode anymore come 7.0.0
+     */
+    @Override
+    @Deprecated
+    public JavaTypeDefinition getTypeDefinition() {
+        return super.getTypeDefinition();
+    }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFormalParameter.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFormalParameter.java
@@ -103,6 +103,7 @@ public class ASTFormalParameter extends AbstractJavaAccessTypeNode implements Di
      * This includes varargs parameters.
      */
     @Override
+    @Deprecated
     public boolean isArray() {
         return isVarargs()
                 || getTypeNode() != null && getTypeNode().isArray()
@@ -110,6 +111,7 @@ public class ASTFormalParameter extends AbstractJavaAccessTypeNode implements Di
     }
 
     @Override
+    @Deprecated
     public int getArrayDepth() {
         if (!isArray()) {
             return 0;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLocalVariableDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLocalVariableDeclaration.java
@@ -64,13 +64,13 @@ public class ASTLocalVariableDeclaration extends AbstractJavaAccessNode implemen
     }
 
     @Override
-    // TODO deprecate
+    @Deprecated
     public boolean isArray() {
         return getArrayDepth() > 0;
     }
 
     @Override
-    // TODO deprecate
+    @Deprecated
     public int getArrayDepth() {
         return getArrayDimensionOnType() + getArrayDimensionOnDeclaratorId();
     }
@@ -107,11 +107,14 @@ public class ASTLocalVariableDeclaration extends AbstractJavaAccessNode implemen
      * VariableDeclartorId node and returns it's image or <code>null</code> if
      * the child node is not found.
      *
+     * @deprecated LocalVariableDeclaration may declare several variables, so this is not exhaustive
+     *             Iterate on the {@linkplain ASTVariableDeclaratorId VariableDeclaratorIds} instead
+     *
      * @return a String representing the name of the variable
      */
-    // TODO deprecate.
     // It would be nice to have a way to inform XPath users of the intended replacement
     // for a deprecated attribute. We may use another annotation for that.
+    @Deprecated
     public String getVariableName() {
         ASTVariableDeclaratorId decl = getFirstDescendantOfType(ASTVariableDeclaratorId.class);
         if (decl != null) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPrimitiveType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPrimitiveType.java
@@ -38,16 +38,19 @@ public class ASTPrimitiveType extends AbstractJavaTypeNode implements Dimensiona
         return visitor.visit(this, data);
     }
 
+    @Deprecated
     public void bumpArrayDepth() {
         arrayDepth++;
     }
 
     @Override
+    @Deprecated
     public int getArrayDepth() {
         return arrayDepth;
     }
 
     @Override
+    @Deprecated
     public boolean isArray() {
         return arrayDepth > 0;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTReferenceType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTReferenceType.java
@@ -37,16 +37,19 @@ public class ASTReferenceType extends AbstractJavaTypeNode implements Dimensiona
         return visitor.visit(this, data);
     }
 
+    @Deprecated
     public void bumpArrayDepth() {
         arrayDepth++;
     }
 
     @Override
+    @Deprecated
     public int getArrayDepth() {
         return arrayDepth;
     }
 
     @Override
+    @Deprecated
     public boolean isArray() {
         return arrayDepth > 0;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTResource.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTResource.java
@@ -20,6 +20,9 @@ public class ASTResource extends ASTFormalParameter {
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
     }
+
+    // TODO Should we deprecate all methods from ASTFormalParameter?
+
 }
 /*
  * JavaCC - OriginalChecksum=92734fc70bba91fd9422150dbf87d5c4 (do not edit this

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTType.java
@@ -58,7 +58,7 @@ public class ASTType extends AbstractJavaTypeNode {
      */
     @Deprecated
     public boolean isArray() {
-        return getArrayDepth() > 0;
+        return isArrayType();
     }
 
 
@@ -67,6 +67,6 @@ public class ASTType extends AbstractJavaTypeNode {
      *
      */
     public boolean isArrayType() {
-        return isArray();
+        return getArrayDepth() > 0;
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTType.java
@@ -41,6 +41,8 @@ public class ASTType extends AbstractJavaTypeNode {
         return getFirstDescendantOfType(ASTPrimitiveType.class).getImage();
     }
 
+
+    @Deprecated
     public int getArrayDepth() {
         if (jjtGetNumChildren() != 0
                 && (jjtGetChild(0) instanceof ASTReferenceType || jjtGetChild(0) instanceof ASTPrimitiveType)) {
@@ -49,7 +51,22 @@ public class ASTType extends AbstractJavaTypeNode {
         return 0; // this is not an array
     }
 
+
+    /**
+     *
+     * @deprecated Use {@link #isArrayType()}
+     */
+    @Deprecated
     public boolean isArray() {
         return getArrayDepth() > 0;
+    }
+
+
+    /**
+     * Returns true if this type is an array type.
+     *
+     */
+    public boolean isArrayType() {
+        return isArray();
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclaratorId.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclaratorId.java
@@ -65,18 +65,19 @@ public class ASTVariableDeclaratorId extends AbstractJavaTypeNode implements Dim
         return getScope().getDeclarations(VariableNameDeclaration.class).get(nameDeclaration);
     }
 
-    // TODO Dimensionable will be deprecated
-
+    @Deprecated
     public void bumpArrayDepth() {
         arrayDepth++;
     }
 
     @Override
+    @Deprecated
     public int getArrayDepth() {
         return arrayDepth;
     }
 
     @Override
+    @Deprecated
     public boolean isArray() {
         return arrayDepth > 0;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclaratorId.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclaratorId.java
@@ -76,10 +76,23 @@ public class ASTVariableDeclaratorId extends AbstractJavaTypeNode implements Dim
         return arrayDepth;
     }
 
+
+    /**
+     * Returns true if the declared variable has an array type.
+     * @deprecated Use {@link #hasArrayType()}
+     */
     @Override
     @Deprecated
     public boolean isArray() {
         return arrayDepth > 0;
+    }
+
+
+    /**
+     * Returns true if the declared variable has an array type.
+     */
+    public boolean hasArrayType() {
+        return arrayDepth > 0 || !isTypeInferred() && getTypeNode().isArrayType();
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/Dimensionable.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/Dimensionable.java
@@ -4,8 +4,14 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+/**
+ * @deprecated Will be removed with 7.0.0. See https://github.com/pmd/pmd/issues/997 and https://github.com/pmd/pmd/issues/910
+ */
+@Deprecated
 public interface Dimensionable {
+    @Deprecated
     boolean isArray();
 
+    @Deprecated
     int getArrayDepth();
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolation.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolation.java
@@ -145,9 +145,9 @@ public class JavaRuleViolation extends ParametricRuleViolation<JavaNode> {
 
     private void setVariableNameIfExists(Node node) {
         if (node instanceof ASTFieldDeclaration) {
-            variableName = getVariableNames(((ASTFieldDeclaration) node));
+            variableName = getVariableNames((ASTFieldDeclaration) node);
         } else if (node instanceof ASTLocalVariableDeclaration) {
-            variableName = getVariableNames(((ASTLocalVariableDeclaration) node));
+            variableName = getVariableNames((ASTLocalVariableDeclaration) node);
         } else if (node instanceof ASTVariableDeclarator) {
             variableName = node.jjtGetChild(0).getImage();
         } else if (node instanceof ASTVariableDeclaratorId) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolation.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolation.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule;
 
+import java.util.Iterator;
 import java.util.Set;
 
 import net.sourceforge.pmd.Rule;
@@ -74,7 +75,7 @@ public class JavaRuleViolation extends ParametricRuleViolation<JavaNode> {
     /**
      * Check for suppression on this node, on parents, and on contained types
      * for ASTCompilationUnit
-     * 
+     *
      * @param node
      */
     public static boolean isSupressed(Node node, Rule rule) {
@@ -130,11 +131,23 @@ public class JavaRuleViolation extends ParametricRuleViolation<JavaNode> {
                 && ((CanSuppressWarnings) node).hasSuppressWarningsAnnotationFor(rule);
     }
 
+    private String getVariableNames(Iterable<ASTVariableDeclaratorId> iterable) {
+
+        Iterator<ASTVariableDeclaratorId> it = iterable.iterator();
+        StringBuilder builder = new StringBuilder();
+        builder.append(it.next());
+
+        while (it.hasNext()) {
+            builder.append(", ").append(it.next());
+        }
+        return builder.toString();
+    }
+
     private void setVariableNameIfExists(Node node) {
         if (node instanceof ASTFieldDeclaration) {
-            variableName = ((ASTFieldDeclaration) node).getVariableName();
+            variableName = getVariableNames(((ASTFieldDeclaration) node));
         } else if (node instanceof ASTLocalVariableDeclaration) {
-            variableName = ((ASTLocalVariableDeclaration) node).getVariableName();
+            variableName = getVariableNames(((ASTLocalVariableDeclaration) node));
         } else if (node instanceof ASTVariableDeclarator) {
             variableName = node.jjtGetChild(0).getImage();
         } else if (node instanceof ASTVariableDeclaratorId) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/PrematureDeclarationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/PrematureDeclarationRule.java
@@ -14,6 +14,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
 import net.sourceforge.pmd.lang.java.ast.ASTReturnStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTThrowStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
 /**
@@ -36,16 +37,19 @@ public class PrematureDeclarationRule extends AbstractJavaRule {
             return super.visit(node, data);
         }
 
-        for (ASTBlockStatement block : statementsAfter(node)) {
-            if (hasReferencesIn(block, node.getVariableName())) {
-                break;
-            }
-            
-            if (hasExit(block)) {
-                addViolation(data, node);
-                break;
+        for (ASTVariableDeclaratorId id : node) {
+            for (ASTBlockStatement block : statementsAfter(node)) {
+                if (hasReferencesIn(block, id.getVariableName())) {
+                    break;
+                }
+
+                if (hasExit(block)) {
+                    addViolation(data, node);
+                    break;
+                }
             }
         }
+
 
         return super.visit(node, data);
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/SingletonClassReturningNewInstanceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/SingletonClassReturningNewInstanceRule.java
@@ -15,6 +15,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTName;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
 import net.sourceforge.pmd.lang.java.ast.ASTReturnStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
 public class SingletonClassReturningNewInstanceRule extends AbstractJavaRule {
@@ -69,10 +70,12 @@ public class SingletonClassReturningNewInstanceRule extends AbstractJavaRule {
                                 .findDescendantsOfType(ASTLocalVariableDeclaration.class);
                         if (!lVarList.isEmpty()) {
                             for (ASTLocalVariableDeclaration localVar : lVarList) {
-                                localVarName = localVar.getVariableName();
-                                if (returnVariableName != null && returnVariableName.equals(localVarName)) {
-                                    violation = true;
-                                    break;
+                                for (ASTVariableDeclaratorId id : localVar) {
+                                    localVarName = id.getVariableName();
+                                    if (returnVariableName != null && returnVariableName.equals(localVarName)) {
+                                        violation = true;
+                                        break;
+                                    }
                                 }
                             }
                         }

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -1457,23 +1457,24 @@ having to deal with the creation of an array.
         </description>
         <priority>4</priority>
         <properties>
+            <property name="version" value="2.0" />
             <property name="xpath">
                 <value>
 <![CDATA[
 //FormalParameters/FormalParameter
     [position()=last()]
-    [@Array='true']
-    [@Varargs='false']
-    [not (./Type/ReferenceType[@Array='true'][PrimitiveType[@Image='byte']])]
+    [VariableDeclaratorId/@ArrayType=true()]
+    [@Varargs=false()]
+    [not (./Type[@ArrayType=true()]/ReferenceType[PrimitiveType[@Image='byte']])]
     [not (./Type/ReferenceType[ClassOrInterfaceType[@Image='Byte']])]
     [not (./Type/PrimitiveType[@Image='byte'])]
     [not (ancestor::MethodDeclaration/preceding-sibling::Annotation/*/Name[@Image='Override'])]
     [not(
         ancestor::MethodDeclaration
-            [@Public='true' and @Static='true']
-            [child::ResultType[@Void='true']] and
+            [@Public=true() and @Static=true()]
+            [child::ResultType[@Void=true()]] and
         ancestor::MethodDeclarator[@Image='main'] and
-        ..[@ParameterCount='1'] and
+        ..[@ParameterCount=1] and
         ./Type/ReferenceType[ClassOrInterfaceType[@Image='String']]
     )]
 ]]>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2628,7 +2628,7 @@ NullPointerExceptions.
 <![CDATA[
 //MethodDeclaration
 [
-(./ResultType/Type[@Array='true'])
+(./ResultType/Type[@ArrayType='true'])
 and
 (./Block/BlockStatement/Statement/ReturnStatement/Expression/PrimaryExpression/PrimaryPrefix/Literal/NullLiteral)
 ]

--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -862,9 +862,9 @@ You must use new ArrayList<>(Arrays.asList(...)) if that is inconvenient for you
    and
    PrimaryExpression/PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Name
    [
-     @Image = ancestor::MethodDeclaration//LocalVariableDeclaration[@Array="true"]/VariableDeclarator/VariableDeclaratorId/@Image
+     @Image = ancestor::MethodDeclaration[1]//LocalVariableDeclaration/VariableDeclarator/VariableDeclaratorId[@ArrayType="true"]/@Image
      or
-     @Image = ancestor::MethodDeclaration//FormalParameter/VariableDeclaratorId/@Image
+     @Image = ancestor::MethodDeclaration[1]//FormalParameter/VariableDeclaratorId/@Image
    ]
    /../..[count(.//PrimarySuffix)
    =1]/PrimarySuffix/Expression/PrimaryExpression/PrimaryPrefix


### PR DESCRIPTION
Deprecates Dimensionable so that we can remove it with 7.0.0. Adding a node for the dimensions to tackle #997 will replace its functionality