### PR TITLE
[Java] Avoid FileInputStream and FileOutputStream.

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/AnalysisResult.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/AnalysisResult.java
@@ -8,6 +8,7 @@ import java.io.BufferedInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.zip.Adler32;
@@ -38,7 +39,7 @@ public class AnalysisResult {
     private static long computeFileChecksum(final File sourceFile) {
         try (
             CheckedInputStream stream = new CheckedInputStream(
-                new BufferedInputStream(new FileInputStream(sourceFile)), new Adler32());
+                new BufferedInputStream(Files.newInputStream(sourceFile.toPath())), new Adler32());
         ) {
             // Just read it, the CheckedInputStream will update the checksum on it's own
             IOUtils.skipFully(stream, sourceFile.length());

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/FileAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/FileAnalysisCache.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -46,7 +47,7 @@ public class FileAnalysisCache extends AbstractAnalysisCache {
         if (cacheExists()) {
             try (
                 DataInputStream inputStream = new DataInputStream(
-                    new BufferedInputStream(new FileInputStream(cacheFile)));
+                    new BufferedInputStream(Files.newInputStream(cacheFile.toPath())));
             ) {
                 final String cacheVersion = inputStream.readUTF();
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XSLTRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XSLTRenderer.java
@@ -12,6 +12,8 @@ import java.io.InputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.nio.file.Files;
+
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -77,7 +79,7 @@ public class XSLTRenderer extends XMLRenderer {
         InputStream xslt = null;
         File file = new File(this.xsltFilename);
         if (file.exists() && file.canRead()) {
-            xslt = new FileInputStream(file);
+            xslt = Files.newInputStream(file.toPath());
         } else {
             xslt = this.getClass().getResourceAsStream(this.xsltFilename);
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/database/DBType.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/database/DBType.java
@@ -9,6 +9,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.util.Properties;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
@@ -171,7 +172,7 @@ public class DBType {
         if (LOGGER.isLoggable(Level.FINEST)) {
             LOGGER.finest("Attempting File no file suffix: " + matchString);
         }
-        try (InputStream stream = new FileInputStream(propertiesFile)) {
+        try (InputStream stream = Files.newInputStream(propertiesFile.toPath())) {
             resourceBundle = new PropertyResourceBundle(stream);
             propertiesSource = propertiesFile.getAbsolutePath();
             LOGGER.finest("FileSystemWithoutExtension");
@@ -180,7 +181,7 @@ public class DBType {
                 LOGGER.finest("notFoundOnFilesystemWithoutExtension");
                 LOGGER.finest("Attempting File with added file suffix: " + matchString + ".properties");
             }
-            try (InputStream stream = new FileInputStream(propertiesFile)) {
+            try (InputStream stream = Files.newInputStream(propertiesFile.toPath())) {
                 propertiesFile = new File(matchString + ".properties");
                 resourceBundle = new PropertyResourceBundle(stream);
                 propertiesSource = propertiesFile.getAbsolutePath();


### PR DESCRIPTION
Avoid FileInputStream and FileOutputStream. These classes override the finalize method. As a result, their objects are only cleaned when the garbage collector performs a sweep. Since Java 7, programmers can use Files.newInputStream and Files.newOutputStream instead of FileInputStream and FileOutputStream to improve performance.

