### PR TITLE
[fortran] Use diamond operator in impl

### DIFF
--- a/pmd-fortran/src/main/java/net/sourceforge/pmd/cpd/FortranTokenizer.java
+++ b/pmd-fortran/src/main/java/net/sourceforge/pmd/cpd/FortranTokenizer.java
@@ -19,16 +19,16 @@ public class FortranTokenizer extends AbstractTokenizer implements Tokenizer {
     public FortranTokenizer() {
         this.spanMultipleLinesString = false; // No such thing in Fortran !
         // setting markers for "string" in Fortran
-        this.stringToken = new ArrayList<String>();
+        this.stringToken = new ArrayList<>();
         this.stringToken.add("\'");
         // setting markers for 'ignorable character' in Fortran
-        this.ignorableCharacter = new ArrayList<String>();
+        this.ignorableCharacter = new ArrayList<>();
         this.ignorableCharacter.add("(");
         this.ignorableCharacter.add(")");
         this.ignorableCharacter.add(",");
 
         // setting markers for 'ignorable string' in Fortran
-        this.ignorableStmt = new ArrayList<String>();
+        this.ignorableStmt = new ArrayList<>();
         this.ignorableStmt.add("do");
         this.ignorableStmt.add("while");
         this.ignorableStmt.add("end");


### PR DESCRIPTION
This edit replaces type parameters to invoke the constructor of a generic class with an empty set (<>), diamond operator and allow inference of type parameters by the context. This edit ensures the use of generic instead of the deprecated raw types.

