### PR TITLE
[ui] make the language dependencies optional

### DIFF
--- a/pmd-ui/pom.xml
+++ b/pmd-ui/pom.xml
@@ -70,11 +70,6 @@
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-core</artifactId>
         </dependency>
-        <dependency>
-            <groupId>net.sourceforge.pmd</groupId>
-            <artifactId>pmd-java</artifactId>
-            <version>${project.version}</version>
-        </dependency>
 
         <!-- OpenJFX dependencies are provided. OpenJFX needs to be installed separately. -->
         <dependency>
@@ -147,36 +142,49 @@
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-apex</artifactId>
             <version>${project.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.pmd</groupId>
-            <artifactId>pmd-jsp</artifactId>
+            <artifactId>pmd-java</artifactId>
             <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>net.sourceforge.pmd</groupId>
-            <artifactId>pmd-plsql</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>net.sourceforge.pmd</groupId>
-            <artifactId>pmd-visualforce</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>net.sourceforge.pmd</groupId>
-            <artifactId>pmd-xml</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>net.sourceforge.pmd</groupId>
-            <artifactId>pmd-vm</artifactId>
-            <version>${project.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-javascript</artifactId>
             <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.pmd</groupId>
+            <artifactId>pmd-jsp</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.pmd</groupId>
+            <artifactId>pmd-plsql</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.pmd</groupId>
+            <artifactId>pmd-visualforce</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.pmd</groupId>
+            <artifactId>pmd-vm</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.pmd</groupId>
+            <artifactId>pmd-xml</artifactId>
+            <version>${project.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
* This makes it easier to create a customized and tailored
  PMD distribution.
* Also sort the languages alphabetically


*Example usage:*

The [sample project for plsql](https://github.com/pmd/pmd-examples/tree/plsql) creates a tailored pmd distribution, which only contains plsql support. All other languages are irrelevant.
Currently, these other languages need to be excluded:

https://github.com/pmd/pmd-examples/blob/c8a1e5bf5d39440482e5ee0ab8571393ca4c6dec/pom.xml#L36-L65

With this change, you would create your own PMD distribution by packaging your language (pmd-plsql) and the ui tools (pmd-ui) together.

Note: we currently declare all modules explicitly in our main distribution file - https://github.com/pmd/pmd/blob/master/pmd-dist/pom.xml#L75 - so, this change should not affect the main distribution.