### PR TITLE
[java] Deprecate containsComment

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTBlock.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTBlock.java
@@ -25,10 +25,12 @@ public class ASTBlock extends AbstractJavaNode {
         return visitor.visit(this, data);
     }
 
+    @Deprecated
     public boolean containsComment() {
         return this.containsComment;
     }
 
+    @Deprecated
     public void setContainsComment() {
         this.containsComment = true;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTConstructorDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTConstructorDeclaration.java
@@ -32,10 +32,12 @@ public class ASTConstructorDeclaration extends AbstractMethodOrConstructorDeclar
         return visitor.visit(this, data);
     }
 
+    @Deprecated
     public boolean containsComment() {
         return this.containsComment;
     }
 
+    @Deprecated
     public void setContainsComment() {
         this.containsComment = true;
     }


### PR DESCRIPTION
 - This is only present in constructors and blocks, and is only used to
pring "contains comment" on the dump facade. Moreover, we already have
ways to know if a comment is present.
 - The whole DumpFacade can probably be deprecated too, as it's only
used by the already deprecated Designer.
