### PR TITLE
[java]  Adding the fix for #1440. Showing correct message for CommentDefaultAccessmodifier.

### DIFF
--- a/pmd-java/etc/grammar/Java.jjt
+++ b/pmd-java/etc/grammar/Java.jjt
@@ -1854,7 +1854,7 @@ void ConstructorDeclaration(int modifiers) :
 Token t;}
 {
     [ TypeParameters() ]
-  t=<IDENTIFIER> {jjtThis.setImage(t.image);} FormalParameters() [ "throws" NameList() ]
+   <IDENTIFIER>  {jjtThis.setImage(getToken(0).getImage());} FormalParameters() [ "throws" NameList() ]
   "{"
     [ LOOKAHEAD(ExplicitConstructorInvocation()) ExplicitConstructorInvocation() ]
     ( BlockStatement() )*

--- a/pmd-java/etc/grammar/Java.jjt
+++ b/pmd-java/etc/grammar/Java.jjt
@@ -1854,7 +1854,7 @@ void ConstructorDeclaration(int modifiers) :
 Token t;}
 {
     [ TypeParameters() ]
-  <IDENTIFIER> FormalParameters() [ "throws" NameList() ]
+  t=<IDENTIFIER> {jjtThis.setImage(t.image);} FormalParameters() [ "throws" NameList() ]
   "{"
     [ LOOKAHEAD(ExplicitConstructorInvocation()) ExplicitConstructorInvocation() ]
     ( BlockStatement() )*

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/CommentDefaultAccessModifier.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/CommentDefaultAccessModifier.xml
@@ -254,4 +254,25 @@ public class CommentDefaultAccessModifier {
 }
         ]]></code>
     </test-code>
+
+    <code-fragment id="constructor-with-default-access-modifier-rule"><![CDATA[
+public class Foo {
+   Foo() {} // should be reported
+
+   Foo(final String str) {} // should be reported
+
+   /* default */ Foo(final String str1, final String str2) {}  // should not be reported
+}
+    ]]>
+    </code-fragment>
+    <test-code>
+        <description>Add a comment to the constructors with default access modifiers to avoid mistakes</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>2,4</expected-linenumbers>
+        <expected-messages>
+            <message>To avoid mistakes add a comment at the beginning of the Foo constructor if you want a default access modifier</message>
+                <message>To avoid mistakes add a comment at the beginning of the Foo constructor if you want a default access modifier</message>
+            </expected-messages>
+        <code-ref id="constructor-with-default-access-modifier-rule"/>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Fixes #1440. Changed the grammar to set the image for the node, thereby resulting in the name of the constructor to be appearing in the error message.