### PR TITLE
[doc] Adds Liquid tags to link to javadoc

### DIFF
--- a/.travis/render_release_notes.rb
+++ b/.travis/render_release_notes.rb
@@ -12,9 +12,7 @@ require "liquid"
 require "safe_yaml"
 
 # include some custom liquid extensions
-require_relative "../docs/_plugins/rule_tag"
-require_relative "../docs/_plugins/tocmaker_block"
-require_relative "../docs/_plugins/custom_filters"
+require_relative "../docs/_plugins/all_extensions"
 
 # explicitly setting safe mode to get rid of the warning
 SafeYAML::OPTIONS[:default_mode] = :safe
@@ -22,15 +20,18 @@ SafeYAML::OPTIONS[:default_mode] = :safe
 # START OF THE SCRIPT
 
 unless ARGV.length == 1 && File.exists?(ARGV[0])
-  print "\e[31m[ERROR] In #{$0}: The first arg must be a valid file name\e[0m"
+  print "\e[31m[ERROR] In #{$0}: The first arg must be a valid file name\e[0m\n"
   exit 1
 end
 
 release_notes_file = ARGV[0]
 
+# Make the script execute wherever we are
+travis_dir = File.expand_path File.dirname(__FILE__)
+
 liquid_env = {
     # wrap the config under a "site." namespace because that's how jekyll does it
-    'site' => YAML.load_file("docs/_config.yml"),
+    'site' => YAML.load_file(travis_dir + "/../docs/_config.yml"),
     # This signals the links in {% rule %} tags that they should be rendered as absolute
     'is_release_notes_processor' => true
 }

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,7 @@
 repository: pmd/pmd
 
 pmd:
-    version: 6.10.0
+    version: 6.9.0
     previous_version: 6.9.0
     date: ??-????-2018
     release_type: minor

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,7 +1,7 @@
 repository: pmd/pmd
 
 pmd:
-    version: 6.9.0
+    version: 6.10.0
     previous_version: 6.9.0
     date: ??-????-2018
     release_type: minor

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,6 +2,7 @@ repository: pmd/pmd
 
 pmd:
     version: 6.10.0
+    previous_version: 6.9.0
     date: ??-????-2018
     release_type: minor
 

--- a/docs/_plugins/all_extensions.rb
+++ b/docs/_plugins/all_extensions.rb
@@ -1,0 +1,3 @@
+# This file requires all the defined Liquid extensions for ease of reference
+# Thanks stackoverflow <3
+Dir[File.join(File.dirname(__FILE__), "*.rb")].reject {|file| file == __FILE__}.each {|file| require file}

--- a/docs/_plugins/javadoc_tag.rb
+++ b/docs/_plugins/javadoc_tag.rb
@@ -1,3 +1,4 @@
+
 # Tags to reference a javadoc page or package summary.
 #
 # Provides several tags, which should not be mixed up:
@@ -5,7 +6,7 @@
 # * The tag "jdoc_package" is used for a package summary reference
 #
 # Both of these link to the latest version of the API so when editing the site,
-# since it concerns an unpublished API version, the links don't work. When releasing
+# since it refers to an unpublished API version, the links don't work. When releasing
 # though, links on the published jekyll site will work.
 # To refer to the previous API version, e.g. to refer to a type or member that was removed,
 # the tag "jdoc_old" may be used. This tag is used exactly the same way as "jdoc". There's
@@ -15,50 +16,89 @@
 # Usage (don't miss the DO NOT section at the bottom):
 #
 # * Simple type reference: {% jdoc core net.sourceforge.pmd.properties.PropertyDescriptor %}
-#   * First arg must be the name of the module, without the "pmd-" prefix, eg  "core" will be expanded to "pmd-core"
+#   * First arg must be the name of the artifact, without the "pmd-" prefix, eg  "core" will be expanded to "pmd-core"
 #   * After a space, the fqcn of the type to reference is mentioned
 #   * This will be expanded to [`PropertyDescriptor`](https://javadoc.io/page/net.sourceforge.pmd/pmd-core/latest/net/sourceforge/pmd/properties/PropertyDescriptor.html)
 #     * Only the simple name of the type is visible by default
-#     * If you want to make the visible text expand to the FQCN like so [`net.sourceforge.pmd.properties.PropertyDescriptor`](...),
-#       then prefix the type name with a double bang (!!), e.g. {% jdoc core !!net.sourceforge.pmd.properties.PropertyDescriptor %}
+#     * Prefixing the reference with a double bang ("!!") displays the FQCN instead of the simple name
+#       * E.g. {% jdoc core !!net.sourceforge.pmd.properties.PropertyDescriptor %} -> [`net.sourceforge.pmd.properties.PropertyDescriptor`](...),
 #
 # * Using context:
-#   * The variable javadoc_context may be used to shorten references
-#     * You can assign it like so:
-#       * {% assign javadoc_context = "core @.properties" %}
-#         * The "@" symbol in the initializer is expanded to "net.sourceforge.pmd", the artifact id is not optional though
-#         * So this assignment sets the context to pmd-core/net.sourceforge.pmd.properties
-#         * Then the symbol "@" in a javadoc tag will be expanded to "core net.sourceforge.pmd.properties"
+#   * A context block may be used to shorten references
+#     * {% jdoc %} tags and such may be surrounded by a {% jdoc_context %} ... {% endjdoc_context %} block
+#     * You can open it like so:
+#       * {% jdoc_context core @.properties %}
+#         * The first word is the artifact id, the second is the name of e.g. a package or type
+#           * The "@" symbol *in the second word* is expanded to "net.sourceforge.pmd" regardless of the enclosing context
+#         * So inside the block, the context will be set to "pmd-core net.sourceforge.pmd.properties"
+#         * Then the symbol "@" in a jdoc tag will be expanded to "core net.sourceforge.pmd.properties"
 #         * E.g. the reference {% jdoc @.PropertyDescriptor %} is expanded to the same as {% jdoc core net.sourceforge.pmd.properties.PropertyDescriptor %}
 #         * Again, you may use "!!" to show the FQCN, like {% jdoc !!@.PropertyDescriptor %}
-#     * If the variable is not set, then "@" in a javadoc tag means "core net.sourceforge.pmd", eg
-#       {% jdoc @.properties.PropertyDescriptor %} works.
+#     * If a jdoc link occurs outside of a context block, then "@" in a javadoc tag means "core net.sourceforge.pmd", eg
+#       {% jdoc @.properties.PropertyDescriptor %} works anywhere.
 #     * The artifact can be overridden from the context, eg with the default context "core net.sourceforge.pmd"
 #       {% jdoc java @.lang.java.JavaLanguageModule %} will be linked correctly to pmd-java, and @ will be expanded to
 #       "net.sourceforge.pmd"
 #
-# * To reference a method or field: {% jdoc core @.Rule#addRuleChainVisit(java.lang.Class) %}
-#   * The suffix # is followed by the name of the method
-#   * The (erased) types of method arguments must be fully qualified!! This is the same
-#   convention as in javadoc {@link} tags
+# * To reference a method or field: {% jdoc @.Rule#addRuleChainVisit(java.lang.Class) %}
+#   * The suffix # is followed by the name of the method or field
+#   * The (erased) types of method arguments must be fully qualified. This is the same
+#     convention as in javadoc {@link} tags, so you can use you're IDE's javadoc auto-
+#     complete and copy-paste. The "@" can still be used to reference the context package
+#     to shorten FQCNs.
 #
-# * To reference a package: {% jdoc_package @.properties %}, or {% jdoc-package @ %}
-#   * The "!!" is implicit, the full package name is always displayed
+# * To reference a package: {% jdoc_package @.properties %}, or {% jdoc-package @ %}, context works the same
+#
+# * Bang options:
+#   * Rendering may be customized by prefixing the reference to the linked member or type with some options.
+#   * Option syntax is "!name", and the options, if any, must be separated from the reference by another bang ("!")
+#   * Available options:
+#     * No options -> just the member name:
+#         * {% jdoc @.Rule %} -> [`Rule`](...)
+#         * {% jdoc @.Rule#setName(java.lang.String) %} -> [`setName`](...)
+#         * {% jdoc @.AbstractRule#children %} -> [`children`](...)
+#     * args -> adds the simple name of the argument types for method references, noop for other references
+#         *  {% jdoc !args!@.Rule#setName(java.lang.String) %} -> [`setName(String)`](...)
+#     * qualify -> prefix with the fqcn of the class, noop for package references
+#         *  {% jdoc !qualify!@.Rule %} -> [`net.sourceforge.pmd.Rule`](...)
+#         *  {% jdoc !qualify!@.Rule#setName(java.lang.String) %} -> [`net.sourceforge.pmd.Rule#setName`](...)
+#     * class -> prefix the class name for member references, noop for type and package references, or if "qualify" is specified
+#         *  {% jdoc !class!@.Rule#setName(java.lang.String) %} -> [`Rule#setName`](...)
+#
+# * Double-bang shorthands:
+#     * For field or method references, "!!" is the "class" option
+#       * {% jdoc !!@.Rule#setName(java.lang.String) %} -> [`Rule#setName`](...)
+#     * For type references, "!!" is the "qualify" option
+#       *  {% jdoc !!@.Rule %} -> [`net.sourceforge.pmd.Rule`](...)
+#     * For package references, "!!" is a noop, they're always fully qualified
+#   * Options may be concatenated:
+#     * {% jdoc !args!!@.Rule#setName(java.lang.String) %} -> [`Rule#setName(String)`](...)
+#     * {% jdoc !args!qualify!@.Rule#setName(java.lang.String) %} -> [`net.sourceforge.pmd.Rule#setName(String)`](...)
+#
 #
 # * DO NOT:
 #   - Include spaces between dots, or anywhere except between the artifact reference and the page reference
-#   - Forget to use an artifact id whenever setting javadoc_context
+#   - Forget to use an artifact id whenever opening a jdoc_context block
 #   - Use double or single quotes around the arguments
 #   - Use the "#" suffix to reference a nested type, instead, use a dot "." and reference it like a normal type name
 #
 class JavadocTag < Liquid::Tag
+
+  FQCN_OPTION = "qualify"
+  ARGS_OPTION = "args"
+  CLASS_OPTION = "class"
+  DOUBLE_BANG_OPTION = "shorthand"
+
   def initialize(tag_name, doc_ref, tokens)
     super
 
-    if %r/(\w+\s+)?(!!)?(@(?:\.\w+)*)(#.*)?/ =~ doc_ref
+    options_str = ""
+
+    if %r/^"?(\w+\s+)?((?:!\w+)*!?!)?(@(?:\.\w+)*)(#.*)?"?$/ =~ doc_ref.strip
 
       @artifact_name = $1 && ("pmd-" + $1.strip) # is nil if not mentioned
-      @show_full_name = !!$2
+      options_str = $2 || ""
+      @display_options = [] # empty
       @type_fqcn = $3 # may be just "@"
       @member_suffix = $4 || "" # default to empty string instead of nil
 
@@ -66,42 +106,81 @@ class JavadocTag < Liquid::Tag
       fail "Invalid javadoc reference format, see doc on javadoc_tag.rb"
     end
 
+    if options_str.end_with?("!!")
+      @display_options.push(DOUBLE_BANG_OPTION)
+    end
+
+    @display_options += options_str.split("!").compact.reject {|s| s.empty?} # filter out empty
 
     if tag_name == "jdoc_package"
       @is_package_ref = true
-      @show_full_name = true
+      @display_options.push("qualify")
     elsif tag_name == "jdoc_old"
       @use_previous_api_version = true
     end
 
-  end
-
-  def render(context)
-
-
-    doc_ctx = context["javadoc_context"] || "core net.sourceforge.pmd"
-    doc_ctx = doc_ctx.sub("@", "net.sourceforge.pmd") # Allows to use @ as shortcut when assigning javadoc_context
-    doc_ctx = doc_ctx.split(" ") # first is module, snd is package
-
-    if @type_fqcn.include?("@") # Expand using the context
-      if doc_ctx.length == 2 # if it's two words then the first is the module name
-        # if the artifact was mentioned in the tag, it takes precedence
-        @artifact_name = @artifact_name || ("pmd-" + doc_ctx.first)
-        @type_fqcn = @type_fqcn.sub("@", doc_ctx.last)
-      else
-        fail "Invalid javadoc context format, you must specify artifact + package prefix in exactly two words"
+    @display_options.each do |opt|
+      if opt != FQCN_OPTION && opt != ARGS_OPTION && opt != CLASS_OPTION && opt != DOUBLE_BANG_OPTION
+        fail "Unknown display option '#{opt}'"
       end
     end
+  end
 
-    unless @artifact_name
-      fail "No artifact id was mentioned either in the tag or in the context"
+  def get_visible_name
+
+
+    # method or field
+    if @member_suffix && /#(\w+)(\((\s*[\w.]+(?:\[\])*(?:,\s*[\w.]+(?:\[\])*)*)\s*\))?/ =~ @member_suffix
+
+
+      suffix = $1 # method or field name
+
+      if @display_options.include?(ARGS_OPTION) && $2 && !$2.empty? # is method
+
+        p $3
+
+
+        args = ($3 || "").split(",").map {|a| a.gsub(/\w+\./, "").strip} # map to simple names
+
+        p args
+
+        suffix = "#{suffix}(#{args.join(", ")})"
+      end
+
+      visible_name = if @display_options.include?(FQCN_OPTION)
+                       @type_fqcn + "#" + suffix
+                     elsif @display_options.include?(CLASS_OPTION) || @display_options.include?(DOUBLE_BANG_OPTION)
+                       @type_fqcn.split("\.").last + "#" + suffix # type simple name
+                     else
+                       suffix
+                     end
+
+      return visible_name
     end
 
-    if @show_full_name # !! was mentioned
-      visible_name = @type_fqcn
+    # else package or type, for packages the FQCN_OPTION is present
+
+    if @display_options.include? FQCN_OPTION || @display_options.include?(DOUBLE_BANG_OPTION)
+      @type_fqcn
     else
-      visible_name = @type_fqcn.split("\.").last # simple name
+      @type_fqcn.split("\.").last
     end
+  end
+
+  def render(rendering_context)
+
+
+
+    if @type_fqcn.include?("@") # Expand using the context
+
+      doc_ctx = JDocContextBlock.get_jdoc_context(rendering_context)
+
+      @artifact_name = @artifact_name || doc_ctx.first # if the artifact was mentioned in the tag, it takes precedence
+      @type_fqcn = @type_fqcn.sub("@", doc_ctx.last)
+      @member_suffix = @member_suffix.gsub("@", doc_ctx.last)
+    end
+
+    visible_name = get_visible_name
 
     # Hack to reference the package summary
     # Has to be done after finding the visible_name
@@ -114,9 +193,9 @@ class JavadocTag < Liquid::Tag
     api_version =
         if @use_previous_api_version
         then
-          context["site.pmd.previous_version"]
+          rendering_context["site.pmd.previous_version"]
         else
-          context["site.pmd.version"]
+          rendering_context["site.pmd.version"]
         end
 
 
@@ -126,7 +205,7 @@ class JavadocTag < Liquid::Tag
   private
 
   def doclink(artifact, api_version, type_name, member_suffix)
-    "https://javadoc.io/page/net.sourceforge.pmd/#{artifact}/#{api_version}/#{type_name.gsub("\.", "/")}.html#{member_suffix}"
+    "https://javadoc.io/page/net.sourceforge.pmd/#{artifact}/#{api_version}/#{type_name.gsub("\.", "/")}.html#{member_suffix.gsub(/\s+/, "")}"
   end
 
   def markup_link(rname, link)
@@ -135,6 +214,76 @@ class JavadocTag < Liquid::Tag
 
 end
 
+
+# Block used to set the javadoc context
+#
+# Usage:
+#
+# {% jdoc_context java @.lang.java.ast}
+#
+#   Links here in here use the context "java net.sourceforge.pmd.lang.java.ast" as context
+#
+# {% endjdoc_context %}
+#
+# Context is reset to the previous value
+#
+# If no arg is provided to the opening tag, context is reset to the default
+#
+#
+class JDocContextBlock < Liquid::Block
+
+  DEFAULT_JDOC_CONTEXT = "core net.sourceforge.pmd"
+  JDOC_CONTEXT_VARNAME = "javadoc_context"
+
+
+  def initialize(tag_name, arg, tokens)
+    super
+
+    @this_context = JDocContextBlock.build_ctx(arg || DEFAULT_JDOC_CONTEXT).join(" ") #just a syntax check
+
+    @body = tokens
+  end
+
+  def render(context)
+
+    ctx_sfg = context[JDOC_CONTEXT_VARNAME] || DEFAULT_JDOC_CONTEXT
+
+    context[JDOC_CONTEXT_VARNAME] = @this_context
+
+    contents = @body.render(context)
+
+    context[JDOC_CONTEXT_VARNAME] = ctx_sfg
+
+    contents
+  end
+
+
+  def self.build_ctx(ctx_str)
+    # Allows to use @ as shortcut when assigning javadoc_context
+    ctx_str = ctx_str.to_s.sub("@", "net.sourceforge.pmd").gsub("\"", "")
+    res = ctx_str.split(" ")
+
+    if res.length != 2
+      fail "Invalid javadoc context format, you must specify artifact + package prefix in exactly two words"
+    end
+
+    unless res[0].strip.start_with?("pmd-")
+      res[0] = "pmd-#{res[0].strip}"
+    end
+
+    res
+  end
+
+  def self.get_jdoc_context(context)
+    build_ctx(context[JDOC_CONTEXT_VARNAME] || DEFAULT_JDOC_CONTEXT)
+  end
+
+end
+
+Liquid::Template.register_tag('jdoc_context', JDocContextBlock)
 Liquid::Template.register_tag('jdoc', JavadocTag)
 Liquid::Template.register_tag('jdoc_package', JavadocTag)
 Liquid::Template.register_tag('jdoc_old', JavadocTag)
+
+
+

--- a/docs/_plugins/javadoc_tag.rb
+++ b/docs/_plugins/javadoc_tag.rb
@@ -1,0 +1,131 @@
+# Tag to reference a javadoc page or package summary.
+#
+# * The tag "jdoc" is used for a type or member reference
+# * The tag "jdoc_package" is used for a package reference
+# * DO NOT confuse the two
+#
+# Usage (don't miss the DO NOT section at the bottom):
+#
+# * Simple type reference: {% jdoc core net.sourceforge.pmd.properties.PropertyDescriptor %}
+#   * First arg must be the name of the module, without the "pmd-" prefix, eg  "core" will be expanded to "pmd-core"
+#   * After a space, the fqcn of the type to reference is mentioned
+#   * This will be expanded to [`PropertyDescriptor`](https://javadoc.io/page/net.sourceforge.pmd/pmd-core/latest/net/sourceforge/pmd/properties/PropertyDescriptor.html)
+#     * Only the simple name of the type is visible by default
+#     * If you want to make the visible text expand to the FQCN like so [`net.sourceforge.pmd.properties.PropertyDescriptor`](...),
+#       then prefix the type name with a double bang (!!), e.g. {% jdoc core !!net.sourceforge.pmd.properties.PropertyDescriptor %}
+#
+# * Using context:
+#   * The variable javadoc_context may be used to shorten references
+#     * You can assign it like so:
+#       * {% assign javadoc_context = "core @.properties" %}
+#         * The "@" symbol in the initializer is expanded to "net.sourceforge.pmd"
+#         * So this assignment sets the context to pmd-core/net.sourceforge.pmd.properties
+#         * Then the symbol "@" in a javadoc tag will be expanded to "core net.sourceforge.pmd.properties"
+#         * E.g. the reference {% jdoc @.PropertyDescriptor %} is expanded to the same as {% jdoc core net.sourceforge.pmd.properties.PropertyDescriptor %}
+#         * Again, you may use "!!" to show the FQCN, like {% jdoc !!@.PropertyDescriptor %}
+#     * If the variable is not set, then "@" in a javadoc tag means "core net.sourceforge.pmd", eg
+#       {% jdoc @.properties.PropertyDescriptor %} works.
+#     * The artifact can be overridden from the context, eg with the default context "core net.sourceforge.pmd"
+#       {% jdoc java @.lang.java.JavaLanguageModule %} will be linked correctly to pmd-java, and @ will be expanded to
+#       "net.sourceforge.pmd"
+#
+# * To reference a method or field: {% jdoc core @.Rule#addRuleChainVisit(java.lang.Class) %}
+#   * The suffix # is followed by the name of the method
+#   * The (erased) types of method arguments must be fully qualified!! This is the same
+#   convention as in javadoc {@link} tags
+#
+# * To reference a package: {% jdoc_package @.properties %}, or {% jdoc-package @ %}
+#   * The "!!" is implicit, the full package name is always displayed
+#
+# * DO NOT:
+#   - Include spaces between dots, or anywhere except between the artifact reference and the page reference
+#   - Use double or single quotes around the arguments
+#   - Use the "#" suffix to reference a nested type, instead, use a dot "." and reference it like a normal type name
+#
+class JavadocTag < Liquid::Tag
+  def initialize(tag_name, doc_ref, tokens)
+    super
+
+    if %r/(\w+\s+)?(!!)?(@(?:\.\w+)*)(#.*)?/ =~ doc_ref
+
+      @artifact_name = $1 && ("pmd-" + $1.strip) # is nil if not mentioned
+      @show_full_name = !!$2
+      @type_fqcn = $3 # may be just "@"
+      @member_suffix = $4 || "" # default to empty string instead of nil
+
+    else
+      fail "Invalid javadoc reference format, see doc on javadoc_tag.rb"
+    end
+
+
+    if tag_name == "jdoc_package"
+      @is_package_ref = true
+      @show_full_name = true
+    end
+
+  end
+
+  def render(context)
+
+
+    doc_ctx = context["javadoc_context"] || "core net.sourceforge.pmd"
+    doc_ctx = doc_ctx.sub("@", "net.sourceforge.pmd") # Allows to use @ as shortcut when assigning javadoc_context
+    doc_ctx = doc_ctx.split(" ") # first is module, snd is package
+
+    p doc_ctx
+
+    if @type_fqcn.include?("@") # Expand using the context
+      if doc_ctx.length == 2 # if it's two words then the first is the module name
+        # if the artifact was mentioned in the tag, it takes precedence
+        @artifact_name = @artifact_name || ("pmd-" + doc_ctx.first)
+        @type_fqcn = @type_fqcn.sub("@", doc_ctx.last)
+      elsif doc_ctx.length == 1
+        p @type_fqcn
+        @type_fqcn = @type_fqcn.sub("@", doc_ctx.last)
+        p @type_fqcn
+      else
+        fail "Invalid javadoc context format (spaces), use either one word for a package prefix, or two words for module + package prefix"
+      end
+    end
+
+    unless @artifact_name
+      fail "No artifact id was mentioned either in the tag or in the context"
+    end
+
+
+    p @type_fqcn
+
+    if @show_full_name # !! was mentioned
+      visible_name = @type_fqcn
+    else
+      visible_name = @type_fqcn.split("\.").last # simple name
+    end
+
+
+    # Hack to reference the package summary
+    # Has to be done after finding the visible_name
+    if @is_package_ref
+      @type_fqcn = @type_fqcn + ".package-summary"
+    end
+
+
+    # Always hardcode the artifact version instead of using "latest"
+    api_version = context["site.pmd.version"]
+
+    markup_link(visible_name, doclink(@artifact_name, api_version, @type_fqcn, @member_suffix))
+  end
+
+  private
+
+  def doclink(artifact, api_version, type_name, member_suffix)
+    "https://javadoc.io/page/net.sourceforge.pmd/#{artifact}/#{api_version}/#{type_name.gsub("\.", "/")}.html#{member_suffix}"
+  end
+
+  def markup_link(rname, link)
+    "[`#{rname}`](#{link})"
+  end
+
+end
+
+Liquid::Template.register_tag('jdoc', JavadocTag)
+Liquid::Template.register_tag('jdoc_package', JavadocTag)

--- a/docs/_plugins/javadoc_tag.rb
+++ b/docs/_plugins/javadoc_tag.rb
@@ -28,6 +28,16 @@ require_relative 'jdoc_namespace_tag'
 #       'properties.PropertyDescriptor' is expanded to 'net.sourceforge.pmd.properties.PropertyDescriptor'
 #       This is rendered as [`PropertyDescriptor`](https://javadoc.io/page/net.sourceforge.pmd/pmd-core/6.10.0/net/sourceforge/pmd/properties/PropertyDescriptor.html)
 #
+#
+# * To reference a package: eg {% jdoc_package core::properties %} -> points to pmd-core, expanded to 'net.sourceforge.pmd.properties'
+#
+# * To reference a method or field: {% jdoc core::Rule#addRuleChainVisit(java.lang.Class) %}
+#   * The suffix # is followed by the name of the method or field
+#   * The (erased) types of method arguments must be fully qualified. This is the same
+#     convention as in javadoc {@link} tags, so you can use you're IDE's javadoc auto-
+#     complete and copy-paste. Namespaces also can be used for method arguments if they're from PMD.
+#
+#
 # * Defining custom namespaces
 #   * you can define a namespace pointing to a package name relevant to what
 #     you're documenting to save some keystrokes.
@@ -42,18 +52,13 @@ require_relative 'jdoc_namespace_tag'
 #     jdoc tags or other jdoc_nspace tags. E.g.
 #      {% jdoc coreast::Node %} -> points to pmd-core, expanded to 'net.sourceforge.pmd.lang.ast.Node'
 #      {% jdoc jmx::impl.NcssVisitor %} -> points to pmd-java, expanded to 'net.sourceforge.pmd.lang.java.metrics.impl.NcssVisitor'
-#
-# * To reference a method or field: {% jdoc core::Rule#addRuleChainVisit(java.lang.Class) %}
-#   * The suffix # is followed by the name of the method or field
-#   * The (erased) types of method arguments must be fully qualified. This is the same
-#     convention as in javadoc {@link} tags, so you can use you're IDE's javadoc auto-
-#     complete and copy-paste. Namespaces also can be used for method arguments if they're from PMD.
-#
-# * To reference a package: eg {% jdoc_package core::properties %}
 #   * If you want to reference the package prefix of a namespace, you can do so
 #     by using the syntax ':nspace', e.g.
-#     {% jdoc_package :jmx %} -> points to pmd-java, expanded to 'net.sourceforge.pmd.lang.ast.Node'
-#     {% jdoc_package :coreast %} -> points to pmd-core, expanded to 'net.sourceforge.pmd.lang.java.metrics'
+#     {% jdoc_package :jmx %} -> points to pmd-java, expanded to 'net.sourceforge.pmd.lang.java.metrics'
+#     {% jdoc_package :coreast %} -> points to pmd-core, expanded to 'net.sourceforge.pmd.lang.ast'
+#     * This is especially cool because it allows you to assign a namespace to a type name and then add a method suffix, eg
+#       {% jdoc_nspace :PrD core::properties.PropertyDescriptor %}
+#       {% jdoc :PrD#description() %}
 #
 # * Bang options:
 #   * The visible text of the link may be customized by prefixing the reference to the
@@ -61,25 +66,25 @@ require_relative 'jdoc_namespace_tag'
 #   * Option syntax is "!opts!", and prefixes the namespace. Options are one-character switches.
 #   * Available options:
 #     * No options -> just the member name:
-#         * {% jdoc @.Rule %} -> [`Rule`](...)
-#         * {% jdoc @.Rule#setName(java.lang.String) %} -> [`setName`](...)
-#         * {% jdoc @.AbstractRule#children %} -> [`children`](...)
+#         * {% jdoc core::Rule %} -> [`Rule`](...)
+#         * {% jdoc core::Rule#setName(java.lang.String) %} -> [`setName`](...)
+#         * {% jdoc core::AbstractRule#children %} -> [`children`](...)
 #     * a (args) -> adds the simple name of the argument types for method references, noop for other references
-#         *  {% jdoc !a!@.Rule#setName(java.lang.String) %} -> [`setName(String)`](...)
+#         *  {% jdoc !a!core::Rule#setName(java.lang.String) %} -> [`setName(String)`](...)
 #     * q (qualify) -> prefix with the fqcn of the class, noop for package references
-#         *  {% jdoc !q!@.Rule %} -> [`net.sourceforge.pmd.Rule`](...)
-#         *  {% jdoc !q!@.Rule#setName(java.lang.String) %} -> [`net.sourceforge.pmd.Rule#setName`](...)
+#         *  {% jdoc !q!core::Rule %} -> [`net.sourceforge.pmd.Rule`](...)
+#         *  {% jdoc !q!core::Rule#setName(java.lang.String) %} -> [`net.sourceforge.pmd.Rule#setName`](...)
 #     * c (class) -> prefix the class name for member references, noop for type and package references, or if "qualify" is specified
-#         *  {% jdoc !c!@.Rule#setName(java.lang.String) %} -> [`Rule#setName`](...)
+#         *  {% jdoc !c!core::Rule#setName(java.lang.String) %} -> [`Rule#setName`](...)
 #     * Empty options ("!!") - > shorthand to a commonly relevant option
 #         * For field or method references, "!!" is the "c" option
-#           * {% jdoc !!@.Rule#setName(java.lang.String) %} -> [`Rule#setName`](...)
+#           * {% jdoc !!core::Rule#setName(java.lang.String) %} -> [`Rule#setName`](...)
 #         * For type references, "!!" is the "q" option
-#           *  {% jdoc !!@.Rule %} -> [`net.sourceforge.pmd.Rule`](...)
+#           *  {% jdoc !!core::Rule %} -> [`net.sourceforge.pmd.Rule`](...)
 #         * For package references, "!!" is a noop, they're always fully qualified
 #     * Several options may be used at once, though this is only useful for method references:
-#         * {% jdoc !ac!@.Rule#setName(java.lang.String) %} -> [`Rule#setName(String)`](...)
-#         * {% jdoc !aq!@.Rule#setName(java.lang.String) %} -> [`net.sourceforge.pmd.Rule#setName(String)`](...)
+#         * {% jdoc !ac!core::Rule#setName(java.lang.String) %} -> [`Rule#setName(String)`](...)
+#         * {% jdoc !aq!core::Rule#setName(java.lang.String) %} -> [`net.sourceforge.pmd.Rule#setName(String)`](...)
 #
 # * DO NOT:
 #   - Include spaces in any part of the reference
@@ -106,8 +111,8 @@ class JavadocTag < Liquid::Tag
     @type_fqcn = arr[0]
     @member_suffix = arr[1] || "" # default to empty string
 
-    unless Regexp.new('(!\w*!)?' + JDocNamespaceDeclaration::NAMESPACED_FQCN_REGEX.source) =~ @type_fqcn
-      "Wrong syntax for type reference, expected eg nspace::a.b.C, !!nspace::a.b.C, or !opts!nspace::a.b.C"
+    unless Regexp.new('(!\w*!)?' + Regexp.union(JDocNamespaceDeclaration::NAMESPACED_FQCN_REGEX, JDocNamespaceDeclaration::SYM_REGEX).source ) =~ @type_fqcn
+      fail "Wrong syntax for type reference, expected eg nspace::a.b.C, !opts!nspace::a.b.C, or :nspace"
     end
 
     # If no options, then split produces [@type_fqcn]
@@ -166,7 +171,7 @@ class JavadocTag < Liquid::Tag
 
       if opts.show_args? && $2 && !$2.empty? # is method
 
-        args = $3.split(",").map {|a| a.gsub(/\w+\./, "").strip} # map to simple names
+        args = ($3 || "").split(",").map {|a| a.gsub(/\w+\./, "").strip} # map to simple names
 
         suffix = "#{suffix}(#{args.join(", ")})"
       end

--- a/docs/_plugins/jdoc_namespace_tag.rb
+++ b/docs/_plugins/jdoc_namespace_tag.rb
@@ -1,0 +1,110 @@
+# Tag used to declare a javadoc namespace to shorten javadoc references.
+#
+# Usage:
+# {% jdoc_nspace :coreast core::lang.ast %}
+# {% jdoc_nspace :jast java::lang.java.ast %}
+#
+# * The first argument is the name of the namespace, it can be prefixed with a ":" for readability
+# * The second argument is the package prefix of the namespace, which itself must use an already declared namespace
+# Base namespaces are declared for most of the modules of PMD, with the "net.sourceforge.pmd" package prefix.
+# E.g. "core::" and "pmd-core::" (aliased) point to pmd-core's "net.sourceforge.pmd" package.
+#
+# After those tags have been declared, the handle is used with the "name::" syntax, eg {% jdoc jast::ASTType %}
+# To refer to only the package prefix defined by the namespace, use instead the ":name" syntax, e.g. {% jdoc_package :jast %}
+#
+class JDocNamespaceDeclaration < Liquid::Tag
+
+  # a namespace is a pair [artifactId, base package]
+
+  def initialize(tag_name, arg, tokens)
+    super
+
+    all_args = arg.split(" ")
+
+    if all_args.size != 2
+      "Invalid arguments for jdoc namespace declaration, expected ':name baseNSpace::package.prefix'"
+    end
+
+
+    @nspace_name = all_args.first.delete(":")
+
+    if RESERVED_NSPACES.include?(@nspace_name)
+      fail "Javadoc namespace #{@nspace_name} is reserved and cannot be redefined"
+    end
+
+    @this_fqcn_unresolved = all_args.last
+
+  end
+
+  def render(var_ctx)
+
+    unless var_ctx[JDOC_NAMESPACE_MAP]
+      var_ctx[JDOC_NAMESPACE_MAP] = JDocNamespaceDeclaration::make_base_namespaces #base namespace map
+    end
+
+    # Add the resolved QName to the map
+    var_ctx[JDOC_NAMESPACE_MAP][@nspace_name] = JDocNamespaceDeclaration::parse_fqcn(@this_fqcn_unresolved, var_ctx)
+
+    ""
+  end
+
+  # Regex to match a prefixed fqcn, used for method arguments
+  NAMESPACED_FQCN_REGEX = /(\w[\w-]*)::((?:\w+\.)*\w+)/
+  SYM_REGEX = /:(\w[\w-]*)/
+
+  # Parses a namespaced fqcn of the form nspace::a.b.c.Class into a tuple [artifactId, expandedFQCN]
+  # If allow_sym is true, then the syntax :nspace is allowed as well
+  def self.parse_fqcn(fqcn, var_ctx, allow_sym = true)
+
+    nspace = nil
+    fqcn_suffix = ""
+
+    if NAMESPACED_FQCN_REGEX =~ fqcn
+      nspace = $1
+      fqcn_suffix = $2
+    elsif allow_sym && SYM_REGEX =~ fqcn
+      nspace = $1
+      fqcn_suffix = ""
+    else
+      fail "Invalid javadoc fqcn format, expected nspace::a.b.c.Class" + (allow_sym ? " or :nspace" : "") + ", but was " + fqcn
+    end
+
+    resolved_nspace = []
+
+    unless var_ctx[JDOC_NAMESPACE_MAP] && (resolved_nspace = var_ctx[JDOC_NAMESPACE_MAP][nspace])
+      fail "Undeclared javadoc namespace #{nspace}"
+    end
+
+    unless resolved_nspace.size == 2
+      fail "Badly registered namespace (implementation bug)" # just to be safe
+    end
+
+    expanded_fqcn = resolved_nspace.last
+    unless fqcn_suffix.empty?
+      expanded_fqcn += "." + fqcn_suffix
+    end
+
+
+    # Return the resolved artifactId + the expanded FQCN
+    [resolved_nspace.first, expanded_fqcn]
+  end
+
+  private
+
+  JDOC_NAMESPACE_MAP = "jdoc_nspaces"
+  RESERVED_NSPACES = ['core', 'java', 'apex', 'dist', 'doc', 'xml', 'visualforce', 'ui', 'test'].flat_map {|m| [m, "pmd-" + m]}
+
+  def self.make_base_namespaces
+    res = {}
+    RESERVED_NSPACES.each do |mod|
+      pmd_prefixed = mod.start_with?("pmd") ? mod : ("pmd-" + mod)
+
+      # Each is aliased, eg core:: is equivalent to pmd-core::
+      res[mod] = [pmd_prefixed, "net.sourceforge.pmd"]
+      res[pmd_prefixed] = [pmd_prefixed, "net.sourceforge.pmd"]
+    end
+
+    res
+  end
+
+end

--- a/docs/pages/pmd/userdocs/extending/defining_properties.md
+++ b/docs/pages/pmd/userdocs/extending/defining_properties.md
@@ -8,6 +8,7 @@ permalink: pmd_userdocs_extending_defining_properties.html
 author: Hooper Bloob <hooperbloob@users.sourceforge.net>, Romain Pelisse <rpelisse@users.sourceforge.net>, Clément Fournier <clement.fournier76@gmail.com>
 ---
 
+{% jdoc_context core @.properties %}
 
 ## Defining properties
 
@@ -52,9 +53,9 @@ Note that RegexProperty doesn't have a multivalued variant, since the delimiters
 
 The procedure to define a property is quite straightforward:
 * Create a property descriptor of the type you want, using its builder;
-* Call `definePropertyDescriptor(<your descriptor>)` in the rule's noarg constructor.
+* Call {% jdoc !args!@.PropertySource#definePropertyDescriptor(@.PropertyDescriptor) %}` in the rule's noarg constructor.
 
-You can then retrieve the value of the property at any time using `getProperty(<your descriptor>)`.
+You can then retrieve the value of the property at any time using {% jdoc !args!@.PropertySource#getProperty(@.PropertyDescriptor) %}.
 
 #### Creating a descriptor
 
@@ -171,3 +172,5 @@ Multivalued properties are also allowed and their `type` attribute has the form 
 ```
 
 Notice that in the example above, `@Image = $reportedIdentifiers` doesn't test `@Image` for equality with the whole sequence `('foo', 'bar')`, it tests whether the sequence *contains* `@Image`. That is, the above rule will report all variables named `foo` or `bar`. All other XPath 2.0 [functions operating on sequences](https://www.w3.org/TR/xpath-functions/#sequence-functions) are supported.
+
+{% endjdoc_context %}

--- a/docs/pages/pmd/userdocs/extending/defining_properties.md
+++ b/docs/pages/pmd/userdocs/extending/defining_properties.md
@@ -8,7 +8,7 @@ permalink: pmd_userdocs_extending_defining_properties.html
 author: Hooper Bloob <hooperbloob@users.sourceforge.net>, Romain Pelisse <rpelisse@users.sourceforge.net>, Clément Fournier <clement.fournier76@gmail.com>
 ---
 
-{% jdoc_context core @.properties %}
+{% jdoc_nspace :props core::properties %}
 
 ## Defining properties
 
@@ -53,9 +53,9 @@ Note that RegexProperty doesn't have a multivalued variant, since the delimiters
 
 The procedure to define a property is quite straightforward:
 * Create a property descriptor of the type you want, using its builder;
-* Call {% jdoc !args!@.PropertySource#definePropertyDescriptor(@.PropertyDescriptor) %}` in the rule's noarg constructor.
+* Call {% jdoc !a!props::PropertySource#definePropertyDescriptor(props::PropertyDescriptor) %}` in the rule's noarg constructor.
 
-You can then retrieve the value of the property at any time using {% jdoc !args!@.PropertySource#getProperty(@.PropertyDescriptor) %}.
+You can then retrieve the value of the property at any time using {% jdoc !a!props::PropertySource#getProperty(props::PropertyDescriptor) %}.
 
 #### Creating a descriptor
 
@@ -173,4 +173,3 @@ Multivalued properties are also allowed and their `type` attribute has the form 
 
 Notice that in the example above, `@Image = $reportedIdentifiers` doesn't test `@Image` for equality with the whole sequence `('foo', 'bar')`, it tests whether the sequence *contains* `@Image`. That is, the above rule will report all variables named `foo` or `bar`. All other XPath 2.0 [functions operating on sequences](https://www.w3.org/TR/xpath-functions/#sequence-functions) are supported.
 
-{% endjdoc_context %}

--- a/docs/pages/pmd/userdocs/extending/metrics_howto.md
+++ b/docs/pages/pmd/userdocs/extending/metrics_howto.md
@@ -9,10 +9,10 @@ permalink: pmd_userdocs_extending_metrics_howto.html
 author: Clément Fournier <clement.fournier76@gmail.com>
 ---
 
-{% jdoc_handle @{coremx} core @.lang.metrics %}
-{% jdoc_handle @{coreast} core @.lang.ast %}
-{% jdoc_handle @{jmx} java @.lang.java.metrics %}
-{% jdoc_handle @{jast} java @.lang.java.ast %}
+{% jdoc_nspace :coremx core::lang.metrics %}
+{% jdoc_nspace :coreast core::lang.ast %}
+{% jdoc_nspace :jmx java::lang.java.metrics %}
+{% jdoc_nspace :jast java::lang.java.ast %}
 
 
 ## Using the metrics framework
@@ -25,8 +25,8 @@ a numeric result. In the Java framework, metrics can be computed on operation de
 method declaration), and type declaration nodes (class, interface, enum, and annotation declarations). A metric
 object in the framework can only handle either types or operations, but not both.
 
-PMD ships with a library of already implemented metrics. These metrics are referenced by {% jdoc @{coremx}.MetricKey %} objects,
-which are listed in two public enums: {% jdoc @{jmx}.api.JavaClassMetricKey %} and {% jdoc @{jmx}.api.JavaOperationMetricKey %}.
+PMD ships with a library of already implemented metrics. These metrics are referenced by {% jdoc coremx::MetricKey %} objects,
+which are listed in two public enums: {% jdoc jmx::api.JavaClassMetricKey %} and {% jdoc jmx::api.JavaOperationMetricKey %}.
 Metric keys wrap a metric, and know which type of node their metric can be computed on. That way, you cannot compute an operation metric on a class
 declaration node. Metrics that can be computed on both operation and type declarations (e.g. NCSS) have one metric key in
 each enum.
@@ -38,7 +38,7 @@ which is the name of the metric key as defined in  `JavaClassMetricKey` or `Java
  will be **computed on the context node**.
 
 The function will throw an exception in the following cases:
-* The context node is neither an instance of {% jdoc @{jast}.ASTAnyTypeDeclaration %} or {% jdoc @{jast}.MethodLikeNode %}, that is,
+* The context node is neither an instance of {% jdoc jast::ASTAnyTypeDeclaration %} or {% jdoc jast::MethodLikeNode %}, that is,
 it's not one of `ClassOrInterfaceDeclaration`, `EnumDeclaration`, `AnnotationDeclaration`, `MethodDeclaration`,
 `ConstructorDeclaration`, or `LambdaExpression`.
 * The metric key does not exist (the name is case insensitive) or is not defined for the type of the context node.
@@ -56,7 +56,7 @@ it's not one of `ClassOrInterfaceDeclaration`, `EnumDeclaration`, `AnnotationDec
 
 ## For Java Rules
 
-The static façade class {% jdoc @{jmx}.JavaMetrics %} is the single entry point to compute metrics in the Java framework.
+The static façade class {% jdoc jmx::JavaMetrics %} is the single entry point to compute metrics in the Java framework.
 
 This class provides the method `get` and its overloads. The following sections describes the interface of this class.
 
@@ -86,7 +86,7 @@ to `JavaMetrics.get`.
 ### Capability checking
 
 Metrics are not necessarily computable on any node of the type they handle. For example, Cyclo cannot be computed on
-abstract methods. Metric keys provides a {% jdoc !args!@{coremx}.MetricKey#supports(@{coreast}.Node) %} boolean method
+abstract methods. Metric keys provides a {% jdoc !a!coremx::MetricKey#supports(coreast::Node) %} boolean method
 to find out if the metric can be computed on
 the specified node. **If the metric cannot be computed on the given node, `JavaMetrics.get` will return `Double.NaN` .**
 If you're concerned about that, you can condition your call on whether the node is supported or not:
@@ -108,7 +108,7 @@ Some metrics define options that can be used to slightly modify the computation.
 gathered inside an enum in the implementation class of the metric, for example `CycloMetric.CycloOption`. They're
 also documented on the [index of metrics](pmd_java_metrics_index.html).
 
-To use options with a metric, you must first bundle them into a {% jdoc @.<<.<<.metrics.MetricOptions %} object. `MetricOptions` provides the
+To use options with a metric, you must first bundle them into a {% jdoc coremx::MetricOptions %} object. `MetricOptions` provides the
 utility method `ofOptions` to get a `MetricOptions` bundle from a collection or with varargs parameters. You can then
 pass this bundle as a parameter to `JavaMetrics.get`:
 ```java

--- a/docs/pages/pmd/userdocs/extending/metrics_howto.md
+++ b/docs/pages/pmd/userdocs/extending/metrics_howto.md
@@ -9,6 +9,9 @@ permalink: pmd_userdocs_extending_metrics_howto.html
 author: Clément Fournier <clement.fournier76@gmail.com>
 ---
 
+{% jdoc_context java @.lang.java.metrics %}
+
+
 ## Using the metrics framework
 
 {%include note.html content="The following explains how to use the Java metrics framework. The Apex framework 
@@ -19,9 +22,9 @@ a numeric result. In the Java framework, metrics can be computed on operation de
 method declaration), and type declaration nodes (class, interface, enum, and annotation declarations). A metric
 object in the framework can only handle either types or operations, but not both.
 
-PMD ships with a library of already implemented metrics. These metrics are referenced by `MetricKey` objects,
-which are listed in two public enums: `JavaClassMetricKey` and `JavaOperationMetricKey`. Metric keys wrap a metric, and
-know which type of node their metric can be computed on. That way, you cannot compute an operation metric on a class 
+PMD ships with a library of already implemented metrics. These metrics are referenced by {% jdoc @.<<.<<.metrics.MetricKey %} objects,
+which are listed in two public enums: {% jdoc @.api.JavaClassMetricKey %} and {% jdoc @.api.JavaOperationMetricKey %}.
+Metric keys wrap a metric, and know which type of node their metric can be computed on. That way, you cannot compute an operation metric on a class
 declaration node. Metrics that can be computed on both operation and type declarations (e.g. NCSS) have one metric key in
 each enum.
 
@@ -32,9 +35,9 @@ which is the name of the metric key as defined in  `JavaClassMetricKey` or `Java
  will be **computed on the context node**.
 
 The function will throw an exception in the following cases:
-* The context node is neither an instance of `ASTAnyTypeDeclaration` or `ASTMethodOrConstructorDeclaration`, that is,
+* The context node is neither an instance of {% jdoc @.<<.ast.ASTAnyTypeDeclaration %} or {% jdoc @.<<.ast.MethodLikeNode %}, that is,
 it's not one of `ClassOrInterfaceDeclaration`, `EnumDeclaration`, `AnnotationDeclaration`, `MethodDeclaration`,
-or `ConstructorDeclaration`.
+`ConstructorDeclaration`, or `LambdaExpression`.
 * The metric key does not exist (the name is case insensitive) or is not defined for the type of the context node.
 
 {%include note.html
@@ -50,7 +53,7 @@ or `ConstructorDeclaration`.
 
 ## For Java Rules
 
-The static façade class `JavaMetrics` is the single entry point to compute metrics in the Java framework. 
+The static façade class {% jdoc @.JavaMetrics %} is the single entry point to compute metrics in the Java framework.
 
 This class provides the method `get` and its overloads. The following sections describes the interface of this class.
 
@@ -80,7 +83,8 @@ to `JavaMetrics.get`.
 ### Capability checking
 
 Metrics are not necessarily computable on any node of the type they handle. For example, Cyclo cannot be computed on
-abstract methods. Metric keys provides a `supports(Node)` boolean method to find out if the metric can be computed on
+abstract methods. Metric keys provides a {% jdoc core @.<<.<<.metrics.MetricKey#supports(@.<<.<<.ast.Node) %} boolean method
+to find out if the metric can be computed on
 the specified node. **If the metric cannot be computed on the given node, `JavaMetrics.get` will return `Double.NaN` .**
 If you're concerned about that, you can condition your call on whether the node is supported or not:
 ```java
@@ -101,7 +105,7 @@ Some metrics define options that can be used to slightly modify the computation.
 gathered inside an enum in the implementation class of the metric, for example `CycloMetric.CycloOption`. They're
 also documented on the [index of metrics](pmd_java_metrics_index.html).
 
-To use options with a metric, you must first bundle them into a `MetricOptions` object. `MetricOptions` provides the
+To use options with a metric, you must first bundle them into a {% jdoc @.<<.<<.metrics.MetricOptions %} object. `MetricOptions` provides the
 utility method `ofOptions` to get a `MetricOptions` bundle from a collection or with varargs parameters. You can then
 pass this bundle as a parameter to `JavaMetrics.get`:
 ```java
@@ -295,3 +299,5 @@ Language   | Java | Apex |
 -----------|------|------|
 Operation metrics| supports constructors and non abstract methods| supports any non abstract method (including triggers), except `<init>`, `<clinit>`, and `clone`
 Type declaration|supports classes and enums|supports classes
+
+{% endjdoc_context %}

--- a/docs/pages/pmd/userdocs/extending/metrics_howto.md
+++ b/docs/pages/pmd/userdocs/extending/metrics_howto.md
@@ -9,7 +9,10 @@ permalink: pmd_userdocs_extending_metrics_howto.html
 author: Clément Fournier <clement.fournier76@gmail.com>
 ---
 
-{% jdoc_context java @.lang.java.metrics %}
+{% jdoc_handle @{coremx} core @.lang.metrics %}
+{% jdoc_handle @{coreast} core @.lang.ast %}
+{% jdoc_handle @{jmx} java @.lang.java.metrics %}
+{% jdoc_handle @{jast} java @.lang.java.ast %}
 
 
 ## Using the metrics framework
@@ -22,8 +25,8 @@ a numeric result. In the Java framework, metrics can be computed on operation de
 method declaration), and type declaration nodes (class, interface, enum, and annotation declarations). A metric
 object in the framework can only handle either types or operations, but not both.
 
-PMD ships with a library of already implemented metrics. These metrics are referenced by {% jdoc @.<<.<<.metrics.MetricKey %} objects,
-which are listed in two public enums: {% jdoc @.api.JavaClassMetricKey %} and {% jdoc @.api.JavaOperationMetricKey %}.
+PMD ships with a library of already implemented metrics. These metrics are referenced by {% jdoc @{coremx}.MetricKey %} objects,
+which are listed in two public enums: {% jdoc @{jmx}.api.JavaClassMetricKey %} and {% jdoc @{jmx}.api.JavaOperationMetricKey %}.
 Metric keys wrap a metric, and know which type of node their metric can be computed on. That way, you cannot compute an operation metric on a class
 declaration node. Metrics that can be computed on both operation and type declarations (e.g. NCSS) have one metric key in
 each enum.
@@ -35,7 +38,7 @@ which is the name of the metric key as defined in  `JavaClassMetricKey` or `Java
  will be **computed on the context node**.
 
 The function will throw an exception in the following cases:
-* The context node is neither an instance of {% jdoc @.<<.ast.ASTAnyTypeDeclaration %} or {% jdoc @.<<.ast.MethodLikeNode %}, that is,
+* The context node is neither an instance of {% jdoc @{jast}.ASTAnyTypeDeclaration %} or {% jdoc @{jast}.MethodLikeNode %}, that is,
 it's not one of `ClassOrInterfaceDeclaration`, `EnumDeclaration`, `AnnotationDeclaration`, `MethodDeclaration`,
 `ConstructorDeclaration`, or `LambdaExpression`.
 * The metric key does not exist (the name is case insensitive) or is not defined for the type of the context node.
@@ -53,7 +56,7 @@ it's not one of `ClassOrInterfaceDeclaration`, `EnumDeclaration`, `AnnotationDec
 
 ## For Java Rules
 
-The static façade class {% jdoc @.JavaMetrics %} is the single entry point to compute metrics in the Java framework.
+The static façade class {% jdoc @{jmx}.JavaMetrics %} is the single entry point to compute metrics in the Java framework.
 
 This class provides the method `get` and its overloads. The following sections describes the interface of this class.
 
@@ -83,7 +86,7 @@ to `JavaMetrics.get`.
 ### Capability checking
 
 Metrics are not necessarily computable on any node of the type they handle. For example, Cyclo cannot be computed on
-abstract methods. Metric keys provides a {% jdoc core @.<<.<<.metrics.MetricKey#supports(@.<<.<<.ast.Node) %} boolean method
+abstract methods. Metric keys provides a {% jdoc !args!@{coremx}.MetricKey#supports(@{coreast}.Node) %} boolean method
 to find out if the metric can be computed on
 the specified node. **If the metric cannot be computed on the given node, `JavaMetrics.get` will return `Double.NaN` .**
 If you're concerned about that, you can condition your call on whether the node is supported or not:
@@ -300,4 +303,3 @@ Language   | Java | Apex |
 Operation metrics| supports constructors and non abstract methods| supports any non abstract method (including triggers), except `<init>`, `<clinit>`, and `clone`
 Type declaration|supports classes and enums|supports classes
 
-{% endjdoc_context %}

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -38,8 +38,6 @@ This is a {{ site.pmd.release_type }} release.
 * The implementation of the adapters for the XPath engines Saxon and Jaxen (package {% jdoc_package :xpath %})
   are now deprecated. They'll be moved to an internal package come 7.0.0. Only {% jdoc xpath::Attribute %} remains public API.
 
-{% jdoc !aq!core::lang.rule.stat.StatisticalRule#SIGMA_DESCRIPTOR %}
-
 
 ### External Contributions
 
@@ -50,5 +48,7 @@ This is a {{ site.pmd.release_type }} release.
 
 {% endtocmaker %}
 
-{% include note.html content="The release notes of previous versions are available [here](pmd_release_notes_old.html)" %}
+{% unless is_release_notes_processor %}
+    {% include note.html content="The release notes of previous versions are available [here](pmd_release_notes_old.html)" %}
+{% endunless %}
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -33,12 +33,13 @@ This is a {{ site.pmd.release_type }} release.
 
 ### API Changes
 
-{% jdoc_context "core @.lang.ast.xpath" %}
+{% jdoc_nspace :xpath core::lang.ast.xpath %}
 
-* The implementation of the adapters for the XPath engines Saxon and Jaxen (package {% jdoc_package @ %})
-  are now deprecated. They'll be moved to an internal package come 7.0.0. Only {% jdoc @.Attribute %} remains public API.
+* The implementation of the adapters for the XPath engines Saxon and Jaxen (package {% jdoc_package :xpath %})
+  are now deprecated. They'll be moved to an internal package come 7.0.0. Only {% jdoc xpath::Attribute %} remains public API.
 
-{% endjdoc_context %}
+{% jdoc !aq!core::lang.rule.stat.StatisticalRule#SIGMA_DESCRIPTOR %}
+
 
 ### External Contributions
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -32,10 +32,13 @@ This is a {{ site.pmd.release_type }} release.
     *   [#1372](https://github.com/pmd/pmd/issues/1372): \[java] false positive for UselessQualifiedThis
 
 ### API Changes
-{% assign javadoc_context = "core @.lang.ast.xpath" %}
+
+{% jdoc_context "core @.lang.ast.xpath" %}
 
 * The implementation of the adapters for the XPath engines Saxon and Jaxen (package {% jdoc_package @ %})
   are now deprecated. They'll be moved to an internal package come 7.0.0. Only {% jdoc @.Attribute %} remains public API.
+
+{% endjdoc_context %}
 
 ### External Contributions
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -32,9 +32,10 @@ This is a {{ site.pmd.release_type }} release.
     *   [#1372](https://github.com/pmd/pmd/issues/1372): \[java] false positive for UselessQualifiedThis
 
 ### API Changes
+{% assign javadoc_context = "core @.lang.ast.xpath" %}
 
-* The implementation of the adapters for the XPath engines Saxon and Jaxen (package `net.sourceforge.pmd.lang.ast.xpath`)
-  are now deprecated. They'll be moved to an internal package come 7.0.0. Only `Attribute` remains public API.
+* The implementation of the adapters for the XPath engines Saxon and Jaxen (package {% jdoc_package @ %})
+  are now deprecated. They'll be moved to an internal package come 7.0.0. Only {% jdoc @.Attribute %} remains public API.
 
 ### External Contributions
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/LongMultiProperty.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/LongMultiProperty.java
@@ -6,7 +6,9 @@ package net.sourceforge.pmd.properties;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 
+import net.sourceforge.pmd.PMDConfiguration;
 import net.sourceforge.pmd.properties.builders.MultiNumericPropertyBuilder;
 import net.sourceforge.pmd.properties.builders.PropertyDescriptorBuilderConversionWrapper;
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/LongMultiProperty.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/LongMultiProperty.java
@@ -6,9 +6,7 @@ package net.sourceforge.pmd.properties;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Set;
 
-import net.sourceforge.pmd.PMDConfiguration;
 import net.sourceforge.pmd.properties.builders.MultiNumericPropertyBuilder;
 import net.sourceforge.pmd.properties.builders.PropertyDescriptorBuilderConversionWrapper;
 


### PR DESCRIPTION
Adds Liquid tags to link to a javadoc page.
* Links point to javadoc.io
* There's a provision to refer to a member that was removed in a previous API version (jdoc_old tag)
* There's a nice way to keep doc references short ("namespaces")
* It's well documented and tested for all documented inputs
* It plays well with the release notes preprocessor, and it'll probably be most useful in the release notes

Test it with `.travis/render_release_notes.rb docs/pages/release_notes.md` or on a local instance of the site.

Note that on a local site or snapshot site the links are 404 because they point to an unreleased version of the API (6.10.0), which makes sense because it's the site for 6.10.0. The links in the examples below are generated for 6.9.0 for them to work. You can edit _config.yml and change `site.version` to 6.9.0 to get working links temporarily

* Bonus: the alert at the bottom of the release notes is now not rendered unless we're generating for the site, since github wouldn't have rendered the include tag properly on the release page

Examples: 



| Liquid                                                                                             | Rendered as                                                                                                                                                   |
|----------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `{% jdoc core::Rule %}`                                                                            | [`Rule`](https://javadoc.io/page/net.sourceforge.pmd/pmd-core/6.9.0/net/sourceforge/pmd/Rule.html)                                                            |
| `{% jdoc !q!core::Rule %}`                                                                         | [`net.sourceforge.pmd.Rule`](https://javadoc.io/page/net.sourceforge.pmd/pmd-core/6.9.0/net/sourceforge/pmd/Rule.html#)                                       |
| `{% jdoc core::Rule#setName(java.lang.String) %}`                                                  | [`setName`](https://javadoc.io/page/net.sourceforge.pmd/pmd-core/6.9.0/net/sourceforge/pmd/Rule.html#setName(java.lang.String))                               |
| `{% jdoc !c!core::Rule#setName(java.lang.String) %}`                                               | [`Rule#setName`](https://javadoc.io/page/net.sourceforge.pmd/pmd-core/6.9.0/net/sourceforge/pmd/Rule.html#setName(java.lang.String))                          |
| `{% jdoc !a!core::Rule#setName(java.lang.String) %}`                                               | [`setName(String)`](https://javadoc.io/page/net.sourceforge.pmd/pmd-core/6.9.0/net/sourceforge/pmd/Rule.html#setName(java.lang.String))                       |
| `{% jdoc !ac!core::Rule#setName(java.lang.String) %}`                                              | [`Rule#setName(String)`](https://javadoc.io/page/net.sourceforge.pmd/pmd-core/6.9.0/net/sourceforge/pmd/Rule.html#setName(java.lang.String))                  |
| `{% jdoc core::properties.PropertyDescriptor %}`                                                   | [`PropertyDescriptor`](https://javadoc.io/page/net.sourceforge.pmd/pmd-core/6.9.0/net/sourceforge/pmd/properties/PropertyDescriptor.html)                     |
| `{% jdoc_nspace :jast java::lang.java.ast %}` <br/> `{% jdoc jast::ASTAnyTypeDeclaration %}`       | [`ASTAnyTypeDeclaration`](https://javadoc.io/page/net.sourceforge.pmd/pmd-java/6.9.0/net/sourceforge/pmd/lang/java/ast/ASTAnyTypeDeclaration.html#)           |
| `{% jdoc_nspace :jast java::lang.java.ast %}` <br/> `{% jdoc_package :jast %}`                     | [`net.sourceforge.pmd.lang.java.ast`](https://javadoc.io/page/net.sourceforge.pmd/pmd-java/6.9.0/net/sourceforge/pmd/lang/java/ast/package-summary.html#)     |
| `{% jdoc_nspace :PrD core::properties.PropertyDescriptor %}` <br/> `{% jdoc !ac!:PrD#uiOrder() %}` | [`PropertyDescriptor#uiOrder()`](https://javadoc.io/page/net.sourceforge.pmd/pmd-core/6.9.0/net/sourceforge/pmd/properties/PropertyDescriptor.html#uiOrder()) |


