### PR TITLE
[core] Configurable max loops in DAAPathFinder

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/dfa/pathfinder/DAAPathFinder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/dfa/pathfinder/DAAPathFinder.java
@@ -45,6 +45,7 @@ public class DAAPathFinder {
         this.maxPaths = maxPaths;
         this.maxLoops = MAX_LOOPS;
     }
+
     public DAAPathFinder(DataFlowNode rootNode, Executable shim, int maxPaths, int maxLoops) {
         this.rootNode = rootNode;
         this.shim = shim;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/dfa/pathfinder/DAAPathFinder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/dfa/pathfinder/DAAPathFinder.java
@@ -30,17 +30,26 @@ public class DAAPathFinder {
     private CurrentPath currentPath = new CurrentPath();
     private DefaultMutableTreeNode stack = new DefaultMutableTreeNode();
     private int maxPaths;
+    private int maxLoops;
 
     public DAAPathFinder(DataFlowNode rootNode, Executable shim) {
         this.rootNode = rootNode;
         this.shim = shim;
         this.maxPaths = MAX_PATHS;
+        this.maxLoops = MAX_LOOPS;
     }
 
     public DAAPathFinder(DataFlowNode rootNode, Executable shim, int maxPaths) {
         this.rootNode = rootNode;
         this.shim = shim;
         this.maxPaths = maxPaths;
+        this.maxLoops = MAX_LOOPS;
+    }
+    public DAAPathFinder(DataFlowNode rootNode, Executable shim, int maxPaths, int maxLoops) {
+        this.rootNode = rootNode;
+        this.shim = shim;
+        this.maxPaths = maxPaths;
+        this.maxLoops = maxLoops;
     }
 
     public void run() {
@@ -69,7 +78,7 @@ public class DAAPathFinder {
      */
     private void phase2(boolean flag) {
         int i = 0;
-        while (!currentPath.isEndNode() && i < MAX_LOOPS) {
+        while (!currentPath.isEndNode() && i < this.maxLoops) {
             i++;
             if (currentPath.isBranch() || currentPath.isFirstDoStatement()) {
                 if (flag) {


### PR DESCRIPTION
Make maxLoops configurable in DAAPathFinder.

With the fixed value of 100, we're limited to work on code blocks of about 100 lines.

Making it configurable allows the caller to decide to work with more lines (decide the balance between more lines or faster processing)

