### PR TITLE
[core] XMLRenderer: ProcessingErrors from exceptions without a messag…

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -30,6 +30,7 @@ This is a {{ site.pmd.release_type }} release.
     *   [#1284](https://github.com/pmd/pmd/issues/1284): \[doc] Keep record of every currently deprecated API
     *   [#1318](https://github.com/pmd/pmd/issues/1318): \[test] Kotlin DSL to ease test writing
     *   [#1341](https://github.com/pmd/pmd/issues/1341): \[doc] Documentation Error with Regex Properties
+    *   [#1471](https://github.com/pmd/pmd/issues/1471): \[core] XMLRenderer: ProcessingErrors from exceptions without a message missing
 *   java
     *   [#1460](https://github.com/pmd/pmd/issues/1460): \[java] Intermittent PMD failure : PMD processing errors while no violations reported
 *   java-codestyle

--- a/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
@@ -160,7 +160,7 @@ public class Report implements Iterable<RuleViolation> {
         }
 
         public String getMsg() {
-            return error.getMessage();
+            return error.getClass().getSimpleName() + ": " + error.getMessage();
         }
         
         public String getDetail() {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetTest.java
@@ -530,7 +530,7 @@ public class RuleSetTest {
         assertTrue("Report should have processing errors", context.getReport().hasErrors());
         List<ProcessingError> errors = CollectionUtil.toList(context.getReport().errors());
         assertEquals("Errors expected", 1, errors.size());
-        assertEquals("Wrong error message", "Test exception while applying rule", errors.get(0).getMsg());
+        assertEquals("Wrong error message", "RuntimeException: Test exception while applying rule", errors.get(0).getMsg());
         assertTrue("Should be a RuntimeException", errors.get(0).getError() instanceof RuntimeException);
     }
 
@@ -577,7 +577,7 @@ public class RuleSetTest {
         assertTrue("Report should have processing errors", context.getReport().hasErrors());
         List<ProcessingError> errors = CollectionUtil.toList(context.getReport().errors());
         assertEquals("Errors expected", 1, errors.size());
-        assertEquals("Wrong error message", "Test exception while applying rule", errors.get(0).getMsg());
+        assertEquals("Wrong error message", "RuntimeException: Test exception while applying rule", errors.get(0).getMsg());
         assertTrue("Should be a RuntimeException", errors.get(0).getError() instanceof RuntimeException);
 
         assertEquals("There should be a violation", 1, context.getReport().size());
@@ -617,7 +617,7 @@ public class RuleSetTest {
         assertTrue("Report should have processing errors", context.getReport().hasErrors());
         List<ProcessingError> errors = CollectionUtil.toList(context.getReport().errors());
         assertEquals("Errors expected", 1, errors.size());
-        assertEquals("Wrong error message", "Test exception while applying rule", errors.get(0).getMsg());
+        assertEquals("Wrong error message", "RuntimeException: Test exception while applying rule", errors.get(0).getMsg());
         assertTrue("Should be a RuntimeException", errors.get(0).getError() instanceof RuntimeException);
 
         assertEquals("There should be a violation", 1, context.getReport().size());

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/AbstractRendererTst.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/AbstractRendererTst.java
@@ -38,6 +38,10 @@ public abstract class AbstractRendererTst {
         return "";
     }
 
+    public String getExpectedErrorWithoutMessage(ProcessingError error) {
+        return getExpectedError(error);
+    }
+
     public String getExpectedError(ConfigurationError error) {
         return "";
     }
@@ -126,6 +130,15 @@ public abstract class AbstractRendererTst {
         rep.addError(err);
         String actual = ReportTest.render(getRenderer(), rep);
         assertEquals(filter(getExpectedError(err)), filter(actual));
+    }
+
+    @Test
+    public void testErrorWithoutMessage() throws Exception {
+        Report rep = new Report();
+        Report.ProcessingError err = new Report.ProcessingError(new NullPointerException(), "file");
+        rep.addError(err);
+        String actual = ReportTest.render(getRenderer(), rep);
+        assertEquals(filter(getExpectedErrorWithoutMessage(err)), filter(actual));
     }
 
     @Test

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/PapariTextRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/PapariTextRendererTest.java
@@ -56,7 +56,14 @@ public class PapariTextRendererTest extends AbstractRendererTst {
 
     @Override
     public String getExpectedError(ProcessingError error) {
-        return PMD.EOL + PMD.EOL + "Summary:" + PMD.EOL + PMD.EOL + "    err:  Error" + PMD.EOL
+        return PMD.EOL + PMD.EOL + "Summary:" + PMD.EOL + PMD.EOL + "    err:  RuntimeException: Error" + PMD.EOL
+                + error.getDetail() + PMD.EOL + PMD.EOL
+                + "* errors:   1" + PMD.EOL + "* warnings: 0" + PMD.EOL;
+    }
+
+    @Override
+    public String getExpectedErrorWithoutMessage(ProcessingError error) {
+        return PMD.EOL + PMD.EOL + "Summary:" + PMD.EOL + PMD.EOL + "    err:  NullPointerException: null" + PMD.EOL
                 + error.getDetail() + PMD.EOL + PMD.EOL
                 + "* errors:   1" + PMD.EOL + "* warnings: 0" + PMD.EOL;
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/TextRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/TextRendererTest.java
@@ -32,7 +32,12 @@ public class TextRendererTest extends AbstractRendererTst {
 
     @Override
     public String getExpectedError(ProcessingError error) {
-        return "file\t-\tError" + PMD.EOL;
+        return "file\t-\tRuntimeException: Error" + PMD.EOL;
+    }
+
+    @Override
+    public String getExpectedErrorWithoutMessage(ProcessingError error) {
+        return "file\t-\tNullPointerException: null" + PMD.EOL;
     }
 
     @Override

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
@@ -56,7 +56,13 @@ public class XMLRendererTest extends AbstractRendererTst {
 
     @Override
     public String getExpectedError(ProcessingError error) {
-        return getHeader() + "<error filename=\"file\" msg=\"Error\">"
+        return getHeader() + "<error filename=\"file\" msg=\"RuntimeException: Error\">"
+                + PMD.EOL + "<![CDATA[" + error.getDetail() + "]]>" + PMD.EOL + "</error>" + PMD.EOL + "</pmd>" + PMD.EOL;
+    }
+
+    @Override
+    public String getExpectedErrorWithoutMessage(ProcessingError error) {
+        return getHeader() + "<error filename=\"file\" msg=\"NullPointerException: null\">"
                 + PMD.EOL + "<![CDATA[" + error.getDetail() + "]]>" + PMD.EOL + "</error>" + PMD.EOL + "</pmd>" + PMD.EOL;
     }
 


### PR DESCRIPTION
…e missing

Fixes #1471

This also improves the message of the processing error by including
the exception name.
