### PR TITLE
[core] Deprecate IntegerProperty

### DIFF
--- a/docs/_plugins/javadoc_tag.rb
+++ b/docs/_plugins/javadoc_tag.rb
@@ -137,6 +137,7 @@ class JavadocTag < Liquid::Tag
 
     # Expand FQCN of arguments
     @member_suffix.gsub!(JDocNamespaceDeclaration::NAMESPACED_FQCN_REGEX) {|fqcn| JDocNamespaceDeclaration::parse_fqcn(fqcn, var_ctx)[1]}
+    @member_suffix.gsub!(JDocNamespaceDeclaration::SYM_REGEX) {|fqcn| JDocNamespaceDeclaration::parse_fqcn(fqcn, var_ctx)[1]}
 
     visible_name = JavadocTag::get_visible_name(@opts, @type_fqcn, @member_suffix, @is_package_ref)
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -50,42 +50,96 @@ This means, you can use CPD to find duplicated code in your Kotlin projects.
 
 #### Properties framework
 
-The properties framework is about to get a lifting, and for that reason, the following APIs are
-now deprecated until 7.0.0. The proposed changes to the API are described [on the wiki](https://github.com/pmd/pmd/wiki/Property-framework-7-0-0)
+{% jdoc_nspace :props core::properties %}
+{% jdoc_nspace :PDr props::PropertyDescriptor %}
+{% jdoc_nspace :PF props::PropertyFactory %}
 
-* Several classes and interfaces from the properties framework are now deprecated and will be removed with 7.0.0.
-  * `MethodProperty`, `FloatProperty`, `FileProperty`, `TypeProperty` and their multi-valued counterparts
-    are discontinued for lack of a use-case, and will probably not be replaced with 7.0.0.
-    Users of `FloatProperty` should consider using a `DoubleProperty`.
-  * `EnumeratedPropertyDescriptor`, `NumericPropertyDescriptor`, `PackagedPropertyDescriptor`, and the related builders
-    (in `net.sourceforge.pmd.properties.builders`) will be removed. In the future, these interfaces won't be around
-    but their functionality will, under another form. The related methods `PropertyTypeId#isPropertyNumeric` and
-    `PropertyTypeId#isPropertyPackaged` are also deprecated.
-  * All classes of net.sourceforge.pmd.properties.modules are deprecated and will be removed. They were
-    never intended as public api.
-  * The classes `PropertyDescriptorField`, `PropertyDescriptorBuilderConversionWrapper`, and the methods
-    `PropertyDescriptor#attributeValuesById`, `PropertyDescriptor#isDefinedExternally` and `PropertyTypeId#getFactory` are deprecated with no
-    intended replacement. These were used to read and write properties to and from XML, and were never
-    intended as public API.
-  * The class `ValueParserConstants` and the interface `ValueParser` are deprecated with no intended replacement,
-    they were not intended as public API.
-  * Methods from `PropertyDescriptor`:
-    * `preferredRowCount` is deprecated with no intended replacement. It was never implemented, and does not belong
-      in this interface. The methods `uiOrder` and `compareTo` are deprecated for the same reason. These methods mix presentation logic
-      with business logic and are not necessary for PropertyDescriptors to work. `PropertyDescriptor` will not
-      extend `Comparable<PropertyDescriptor>` anymore come 7.0.0.
-    * The method `PropertyDescriptor#propertyErrorFor` is deprecated and will be removed with no intended
-      replacement. It's really just a shortcut for `prop.errorFor(rule.getProperty(prop))`.
-    * `T valueFrom(String)` and `String asDelimitedString(T)` are deprecated and will be removed. These were
-      used to serialize and deserialize properties to/from a string, but 7.0.0 will introduce a more flexible
-      XML syntax which will make them obsolete.
-    * `isMultiValue` and `type` are deprecated and won't be replaced. The new XML syntax will remove the need
-      for a divide between multi- and single-value properties, and will allow arbitrary types to be represented.
-      Since arbitrary types may be represented, `type` will become obsolete as it can't represent generic types,
-      which will nevertheless be representable with the XML syntax. It was only used for documentation, but a
-      new way to document these properties exhaustively will be added with 7.0.0.
-    * `errorFor` is deprecated as its return type will be changed to `Optional<String>` with the shift to Java 8.
+The properties framework is about to get a lifting, and for that reason, we need to deprecate a lot of APIs
+to remove them in 7.0.0. The proposed changes to the API are described [on the wiki](https://github.com/pmd/pmd/wiki/Property-framework-7-0-0)
 
+##### Changes to how you define properties
+
+
+* Construction of property descriptors has been possible through builders since 6.0.0. The 7.0.0 API will only allow 
+construction through builders. The builder hierarchy, currently found in the package {% jdoc_package props::builders %},
+is being replaced by the simpler {% jdoc props::PropertyBuilder %}. Their APIs enjoy a high degree of source compatibility.
+
+* Concrete property classes like {% jdoc props::IntegerProperty %} and {% jdoc props::StringMultiProperty %} will gradually
+all be deprecated until 7.0.0. Their usages should be replaced by direct usage of the {% jdoc props::PropertyDescriptor %} 
+interface, e.g. `PropertyDescriptor<Integer>` or `PropertyDescriptor<List<String>>`.
+
+* Instead of spreading properties across countless classes, the utility class {% jdoc :PF %} will become
+from 7.0.0 on the only provider for property descriptor builders. Each current property type will be replaced
+by a corresponding method on `PropertyFactory`:
+  * {% jdoc props::IntegerProperty %} is replaced by {% jdoc !c!:PF#intProperty(java.lang.String) %}
+  * {% jdoc props::IntegerMultiProperty %} is replaced by {% jdoc !c!:PF#intListProperty(java.lang.String) %}
+  * {% jdoc props::FloatProperty %} and {% jdoc props::DoubleProperty %} are both replaced by {% jdoc !c!:PF#doubleProperty(java.lang.String) %}.
+    Having a separate property for floats wasn't that useful.
+  * {% jdoc props::MethodProperty %}, {% jdoc props::FileProperty %}, {% jdoc props::TypeProperty %} and their multi-valued counterparts
+    are discontinued for lack of a use-case, and have no planned replacement in 7.0.0 for now.
+    <!-- TODO complete that as we proceed. -->
+
+
+Here's an example: 
+```java
+// Before 7.0.0, these are equivalent:
+IntegerProperty myProperty = new IntegerProperty("score", "Top score value", 1, 100, 40, 3.0f);
+IntegerProperty myProperty = IntegerProperty.named("score").desc("Top score value").range(1, 100).defaultValue(40).uiOrder(3.0f);
+
+// They both map to the following in 7.0.0
+PropertyDescriptor<Integer> myProperty = PropertyFactory.intProperty("score").desc("Top score value").require(inRange(1, 100)).defaultValue(40);
+
+```
+
+You're highly encouraged to migrate to using this new API as soon as possible, to ease your migration to 7.0.0.
+
+
+
+##### Architectural simplifications
+
+* {% jdoc props::EnumeratedPropertyDescriptor %}, {% jdoc props::NumericPropertyDescriptor %}, {% jdoc props::PackagedPropertyDescriptor %},
+and the related builders (in {% jdoc_package props::builders %}) will be removed.
+These specialized interfaces allowed additionnal constraints to be enforced on the
+value of a property, but made the property class hierarchy very large and impractical
+to maintain. Their functionality will be mapped uniformly to {% jdoc props::constraints.PropertyConstraint %}s,
+which will allow virtually any constraint to be defined, and improve documentation and error reporting. The
+related methods {% jdoc !c!props::PropertyTypeId#isPropertyNumeric() %} and
+{% jdoc !c!props::PropertyTypeId#isPropertyPackaged() %} are also deprecated.
+
+* {% jdoc props::MultiValuePropertyDescriptor %} and {% jdoc props::SingleValuePropertyDescriptor %}
+are deprecated. 7.0.0 will introduce a new XML syntax which will remove the need for such a divide
+between single- and multi-valued properties. The method {% jdoc !c!:PDr#isMultiValue() %} will be removed
+accordingly.
+
+##### Changes to the PropertyDescriptor interface
+
+* {% jdoc :PDr#preferredRowCount() %} is deprecated with no intended replacement. It was never implemented, and does not belong
+  in this interface. The methods {% jdoc :PDr#uiOrder() %} and `compareTo(PropertyDescriptor)` are deprecated for the
+  same reason. These methods mix presentation logic with business logic and are not necessary for PropertyDescriptors to work.
+  `PropertyDescriptor` will not extend `Comparable<PropertyDescriptor>` anymore come 7.0.0.
+* The method {% jdoc :PDr#propertyErrorFor(core::Rule) %} is deprecated and will be removed with no intended
+  replacement. It's really just a shortcut for `prop.errorFor(rule.getProperty(prop))`.
+* `T `{% jdoc !a!:PDr#valueFrom(java.lang.String) %} and `String `{% jdoc :PDr#asDelimitedString(java.lang.Object) %}`(T)` are deprecated and will be removed. These were
+  used to serialize and deserialize properties to/from a string, but 7.0.0 will introduce a more flexible
+  XML syntax which will make them obsolete.
+* {% jdoc :PDr#isMultiValue() %} and {% jdoc :PDr#type() %} are deprecated and won't be replaced. The new XML syntax will remove the need
+  for a divide between multi- and single-value properties, and will allow arbitrary types to be represented.
+  Since arbitrary types may be represented, `type` will become obsolete as it can't represent generic types,
+  which will nevertheless be representable with the XML syntax. It was only used for documentation, but a
+  new way to document these properties exhaustively will be added with 7.0.0.
+* {% jdoc :PDr#errorFor(java.lang.Object) %} is deprecated as its return type will be changed to `Optional<String>` with the shift to Java 8.
+
+
+##### Internalized API
+
+The following APIs were never intended as public API and will be internalized or removed with 7.0.0.
+
+* All classes from {% jdoc_package props::modules %} are deprecated and will be removed. 
+* The classes {% jdoc props::PropertyDescriptorField %}, {% jdoc props::builders.PropertyDescriptorBuilderConversionWrapper %}, and the methods
+  {% jdoc !c!:PDr#attributeValuesById %}, {% jdoc !c!:PDr#isDefinedExternally() %} and {% jdoc !c!props::PropertyTypeId#getFactory() %}.
+  These were used to read and write properties to and from XML, but were not intended as public API.
+* The class {% jdoc props::ValueParserConstants %} and the interface {% jdoc props::ValueParser %}
+  
 #### Deprecated APIs
 
 {% jdoc_nspace :xpath core::lang.ast.xpath %}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/AvoidDeeplyNestedIfStmtsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/AvoidDeeplyNestedIfStmtsRule.java
@@ -4,20 +4,24 @@
 
 package net.sourceforge.pmd.lang.apex.rule.design;
 
+import static net.sourceforge.pmd.properties.constraints.NumericConstraints.positive;
+
 import net.sourceforge.pmd.lang.apex.ast.ASTIfBlockStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
-import net.sourceforge.pmd.properties.IntegerProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
+
 
 public class AvoidDeeplyNestedIfStmtsRule extends AbstractApexRule {
 
     private int depth;
     private int depthLimit;
 
-    private static final IntegerProperty PROBLEM_DEPTH_DESCRIPTOR
-            = IntegerProperty.named("problemDepth")
+    private static final PropertyDescriptor<Integer> PROBLEM_DEPTH_DESCRIPTOR
+            = PropertyFactory.intProperty("problemDepth")
                              .desc("The if statement depth reporting threshold")
-                             .range(1, 25).defaultValue(3).uiOrder(1.0f).build();
+                             .require(positive()).defaultValue(3).build();
 
     public AvoidDeeplyNestedIfStmtsRule() {
         definePropertyDescriptor(PROBLEM_DEPTH_DESCRIPTOR);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/StdCyclomaticComplexityRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/StdCyclomaticComplexityRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.apex.rule.design;
 
+import static net.sourceforge.pmd.properties.constraints.NumericConstraints.inRange;
+
 import java.util.Stack;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTBooleanExpression;
@@ -21,7 +23,9 @@ import net.sourceforge.pmd.lang.apex.ast.ASTUserTrigger;
 import net.sourceforge.pmd.lang.apex.ast.ASTWhileLoopStatement;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.properties.BooleanProperty;
-import net.sourceforge.pmd.properties.IntegerProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
+
 
 /**
  * Implements the standard cyclomatic complexity rule
@@ -36,10 +40,12 @@ import net.sourceforge.pmd.properties.IntegerProperty;
  */
 public class StdCyclomaticComplexityRule extends AbstractApexRule {
 
-    public static final IntegerProperty REPORT_LEVEL_DESCRIPTOR 
-            = IntegerProperty.named("reportLevel")
+    public static final PropertyDescriptor<Integer> REPORT_LEVEL_DESCRIPTOR
+            = PropertyFactory.intProperty("reportLevel")
                              .desc("Cyclomatic Complexity reporting threshold")
-                             .range(1, 30).defaultValue(10).uiOrder(1.0f).build();
+                             .require(inRange(1, 30))
+                             .defaultValue(10)
+                             .build();
 
     public static final BooleanProperty SHOW_CLASSES_COMPLEXITY_DESCRIPTOR = new BooleanProperty(
             "showClassesComplexity", "Add class average violations to the report", true, 2.0f);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/TooManyFieldsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/TooManyFieldsRule.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.apex.rule.design;
 
 import static apex.jorje.semantic.symbol.type.ModifierTypeInfos.FINAL;
 import static apex.jorje.semantic.symbol.type.ModifierTypeInfos.STATIC;
+import static net.sourceforge.pmd.properties.constraints.NumericConstraints.positive;
 
 import java.util.HashMap;
 import java.util.List;
@@ -15,7 +16,8 @@ import net.sourceforge.pmd.lang.apex.ast.ASTField;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.properties.IntegerProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
 import net.sourceforge.pmd.util.NumericConstants;
 
 public class TooManyFieldsRule extends AbstractApexRule {
@@ -25,8 +27,13 @@ public class TooManyFieldsRule extends AbstractApexRule {
     private Map<String, Integer> stats;
     private Map<String, ASTUserClass> nodes;
 
-    private static final IntegerProperty MAX_FIELDS_DESCRIPTOR = new IntegerProperty("maxfields",
-            "Max allowable fields", 1, 300, DEFAULT_MAXFIELDS, 1.0f);
+    private static final PropertyDescriptor<Integer> MAX_FIELDS_DESCRIPTOR
+            = PropertyFactory.intProperty("maxfields")
+                             .desc("Max allowable fields")
+                             .defaultValue(DEFAULT_MAXFIELDS)
+                             .require(positive())
+                             .build();
+
 
     public TooManyFieldsRule() {
         definePropertyDescriptor(MAX_FIELDS_DESCRIPTOR);
@@ -71,7 +78,7 @@ public class TooManyFieldsRule extends AbstractApexRule {
             stats.put(key, NumericConstants.ZERO);
             nodes.put(key, clazz);
         }
-        Integer i = Integer.valueOf(stats.get(key) + 1);
+        Integer i = stats.get(key) + 1;
         stats.put(key, i);
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/MockRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/MockRule.java
@@ -4,13 +4,16 @@
 
 package net.sourceforge.pmd.lang.rule;
 
+import static net.sourceforge.pmd.properties.constraints.NumericConstraints.inRange;
+
 import java.util.List;
 
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.RulePriority;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.properties.IntegerProperty;
+import net.sourceforge.pmd.properties.PropertyFactory;
+
 
 /**
  * This is a Rule implementation which can be used in scenarios where an actual
@@ -23,7 +26,7 @@ public class MockRule extends AbstractRule {
     public MockRule() {
         super();
         setLanguage(LanguageRegistry.getLanguage("Dummy"));
-        definePropertyDescriptor(IntegerProperty.named("testIntProperty").desc("testIntProperty").range(0, 100).defaultValue(1).uiOrder(0).build());
+        definePropertyDescriptor(PropertyFactory.intProperty("testIntProperty").desc("testIntProperty").require(inRange(1, 100)).defaultValue(1).build());
     }
 
     public MockRule(String name, String description, String message, String ruleSetName, RulePriority priority) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/GenericPropertyDescriptor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/GenericPropertyDescriptor.java
@@ -39,7 +39,7 @@ final class GenericPropertyDescriptor<T> extends AbstractSingleValueProperty<T> 
 
         String dftValueError = errorFor(defaultValue);
         if (dftValueError != null) {
-            throw new IllegalStateException(dftValueError);
+            throw new IllegalArgumentException(dftValueError);
         }
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/IntegerProperty.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/IntegerProperty.java
@@ -14,7 +14,11 @@ import net.sourceforge.pmd.properties.builders.SingleNumericPropertyBuilder;
  * Defines a datatype that supports single Integer property values within an upper and lower boundary.
  *
  * @author Brian Remedios
+ *
+ * @deprecated Use a {@code PropertyDescriptor<Integer>} instead. A builder is available from {@link PropertyFactory#intProperty(String)}.
+ *             Will be removed in 7.0.0.
  */
+@Deprecated
 public final class IntegerProperty extends AbstractNumericProperty<Integer> {
 
 
@@ -29,7 +33,10 @@ public final class IntegerProperty extends AbstractNumericProperty<Integer> {
      * @param theUIOrder     UI order
      *
      * @throws IllegalArgumentException if {@literal min > max} or one of the defaults is not between the bounds
+     *
+     * @deprecated Use {@link PropertyFactory#intProperty(String)}
      */
+    @Deprecated
     public IntegerProperty(String theName, String theDescription, Integer min, Integer max, Integer theDefault,
                            float theUIOrder) {
         this(theName, theDescription, min, max, theDefault, theUIOrder, false);
@@ -65,11 +72,19 @@ public final class IntegerProperty extends AbstractNumericProperty<Integer> {
     }
 
 
+    /**
+     * @deprecated Use {@link PropertyFactory#intProperty(String)}
+     */
+    @Deprecated
     public static IntegerPBuilder named(String name) {
         return new IntegerPBuilder(name);
     }
 
 
+    /**
+     * @deprecated Use {@link PropertyFactory#intProperty(String)}
+     */
+    @Deprecated
     public static final class IntegerPBuilder extends SingleNumericPropertyBuilder<Integer, IntegerPBuilder> {
         private IntegerPBuilder(String name) {
             super(name);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/IntegerProperty.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/IntegerProperty.java
@@ -16,7 +16,7 @@ import net.sourceforge.pmd.properties.builders.SingleNumericPropertyBuilder;
  * @author Brian Remedios
  *
  * @deprecated Use a {@code PropertyDescriptor<Integer>} instead. A builder is available from {@link PropertyFactory#intProperty(String)}.
- *             Will be removed in 7.0.0.
+ *             This class will be removed in 7.0.0.
  */
 @Deprecated
 public final class IntegerProperty extends AbstractNumericProperty<Integer> {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyBuilder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyBuilder.java
@@ -78,7 +78,7 @@ public abstract class PropertyBuilder<B extends PropertyBuilder<B, T>, T> {
     }
 
 
-    protected String getDescription() {
+    String getDescription() {
         if (StringUtils.isBlank(description)) {
             throw new IllegalArgumentException("Description must be provided");
         }
@@ -86,7 +86,7 @@ public abstract class PropertyBuilder<B extends PropertyBuilder<B, T>, T> {
     }
 
 
-    protected T getDefaultValue() {
+    T getDefaultValue() {
         if (defaultValue == null) {
             throw new IllegalArgumentException("The default value may not be null.");
         }
@@ -123,6 +123,7 @@ public abstract class PropertyBuilder<B extends PropertyBuilder<B, T>, T> {
     //     * constraint predicate will be executed, or in what order.
     //
     // This is superfluous right now bc users may not create their own constraints
+
 
     /**
      * Add a constraint on the values that this property may take.
@@ -349,7 +350,7 @@ public abstract class PropertyBuilder<B extends PropertyBuilder<B, T>, T> {
 
         /**
          * Require that the given constraint be fulfilled on each item of the
-         * value of this properties. This is a convenient shorthand for
+         * value of this property. This is a convenient shorthand for
          * {@code require(constraint.toCollectionConstraint())}.
          *
          * @param constraint Constraint to impose on the items of the collection value

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyBuilder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyBuilder.java
@@ -66,8 +66,6 @@ public abstract class PropertyBuilder<B extends PropertyBuilder<B, T>, T> {
     }
 
 
-    // will maybe be scrapped
-    @Deprecated
     void setDefinedExternally(boolean bool) {
         this.isDefinedExternally = bool;
     }
@@ -85,12 +83,17 @@ public abstract class PropertyBuilder<B extends PropertyBuilder<B, T>, T> {
         return description;
     }
 
-
+    /** Returns the value, asserting it has been set. */
     T getDefaultValue() {
-        if (defaultValue == null) {
-            throw new IllegalArgumentException("The default value may not be null.");
+        if (!isDefaultValueSet()) {
+            throw new IllegalArgumentException("A default value must be provided");
         }
         return defaultValue;
+    }
+
+
+    boolean isDefaultValueSet() {
+        return defaultValue != null;
     }
 
 
@@ -243,7 +246,7 @@ public abstract class PropertyBuilder<B extends PropertyBuilder<B, T>, T> {
 
         // TODO 7.0.0 this can be inlined
         private <C extends Collection<T>> GenericCollectionPropertyBuilder<T, C> toCollection(Supplier<C> emptyCollSupplier) {
-            if (getDefaultValue() != null) {
+            if (isDefaultValueSet()) {
                 throw new IllegalStateException("The default value is already set!");
             }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
@@ -9,6 +9,8 @@ import java.util.Map;
 
 import net.sourceforge.pmd.properties.PropertyBuilder.GenericCollectionPropertyBuilder;
 import net.sourceforge.pmd.properties.PropertyBuilder.GenericPropertyBuilder;
+import net.sourceforge.pmd.properties.constraints.NumericConstraints;
+import net.sourceforge.pmd.properties.constraints.PropertyConstraint;
 
 
 /**
@@ -28,6 +30,20 @@ public final class PropertyFactory {
     }
 
 
+    /**
+     * Returns a builder for an integer property. The property descriptor
+     * will by default accept any value conforming to the format specified
+     * by {@link Integer#parseInt(String)}, e.g. {@code 1234} or {@code -123}.
+     * Acceptable values may be further refined by {@linkplain PropertyBuilder#require(PropertyConstraint) adding constraints}.
+     * The class {@link NumericConstraints} provides some useful ready-made constraints
+     * for that purpose.
+     *
+     * @param name Name of the property to build
+     *
+     * @return A new builder
+     *
+     * @see NumericConstraints
+     */
     public static GenericPropertyBuilder<Integer> intProperty(String name) {
         return new GenericPropertyBuilder<>(name, ValueParserConstants.INTEGER_PARSER, Integer.class);
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
@@ -12,17 +12,65 @@ import net.sourceforge.pmd.properties.PropertyBuilder.GenericPropertyBuilder;
 import net.sourceforge.pmd.properties.constraints.NumericConstraints;
 import net.sourceforge.pmd.properties.constraints.PropertyConstraint;
 
-
+//@formatter:off
 /**
  * Provides factory methods for common property types.
  * Note: from 7.0.0 on, this will be the only way to
- * build property descriptors.
+ * build property descriptors. Concrete property classes
+ * and their constructors/ builders will be gradually
+ * deprecated before 7.0.0.
  *
- * TODO next PR add doc
+ * <h1>Usage</h1>
+ *
+ * Properties are a way to make your rule configurable by
+ * letting a user filling-in some config value in their
+ * ruleset XML.
+ *
+ * As a developer, to declare a property on your rule, you
+ * must:
+ * <ul>
+ *     <li>Build a {@link PropertyDescriptor} using one of
+ *     the factory methods of this class, and providing the
+ *     {@linkplain PropertyBuilder builder} with the required
+ *     info.
+ *     <li>Define the property on your rule using {@link PropertySource#definePropertyDescriptor(PropertyDescriptor)}.
+ *     This should be done in your rule's constructor.
+ * </ul>
+ *
+ * You can then retrieve the value configured by the user in your
+ * rule using {@link PropertySource#getProperty(PropertyDescriptor)}.
+ *
+ * <h1>Example</h1>
+ *
+ * <pre>
+ * class MyRule {
+ *   // The property descriptor may be static, it can be shared across threads.
+ *   private static final {@link PropertyDescriptor}&lt;Integer> myIntProperty
+ *     = PropertyFactory.{@linkplain #intProperty(String) intProperty}("myIntProperty")
+ *                      .{@linkplain PropertyBuilder#desc(String) desc}("This is my property")
+ *                      .{@linkplain PropertyBuilder#defaultValue(Object) defaultValue}(3)
+ *                      .{@linkplain PropertyBuilder#require(PropertyConstraint) require}(inRange(0, 100))   // constraints are checked before the rule is run
+ *                      .{@linkplain PropertyBuilder#build() build}();
+ *
+ *   // ..
+ *
+ *   public MyRule() {
+ *     {@linkplain PropertySource#definePropertyDescriptor(PropertyDescriptor) definePropertyDescriptor}(myIntProperty);
+ *   }
+ *
+ *     // ... somewhere in the rule
+ *
+ *     int myPropertyValue = {@linkplain PropertySource#getProperty(PropertyDescriptor) getProperty(myIntProperty)};
+ *     // use it.
+ *
+ * }
+ * </pre>
+ *
  *
  * @author Clément Fournier
  * @since 6.10.0
  */
+//@formatter:on
 public final class PropertyFactory {
 
     private PropertyFactory() {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
@@ -23,10 +23,10 @@ import net.sourceforge.pmd.properties.constraints.PropertyConstraint;
  * <h1>Usage</h1>
  *
  * Properties are a way to make your rule configurable by
- * letting a user filling-in some config value in their
+ * letting a user fill in some config value in their
  * ruleset XML.
  *
- * As a developer, to declare a property on your rule, you
+ * As a rule developer, to declare a property on your rule, you
  * must:
  * <ul>
  *     <li>Build a {@link PropertyDescriptor} using one of

--- a/pmd-core/src/test/java/net/sourceforge/pmd/AbstractRuleTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/AbstractRuleTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd;
 
+import static net.sourceforge.pmd.properties.constraints.NumericConstraints.inRange;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -20,9 +21,10 @@ import net.sourceforge.pmd.lang.ast.DummyNode;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.rule.AbstractRule;
 import net.sourceforge.pmd.lang.rule.ParametricRuleViolation;
-import net.sourceforge.pmd.properties.IntegerProperty;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
 import net.sourceforge.pmd.properties.StringProperty;
+
 
 public class AbstractRuleTest {
 
@@ -86,7 +88,7 @@ public class AbstractRuleTest {
         DummyNode s = new DummyNode(1);
         s.testingOnlySetBeginColumn(5);
         s.testingOnlySetBeginLine(5);
-        RuleViolation rv = new ParametricRuleViolation(r, ctx, s, "specificdescription");
+        RuleViolation rv = new ParametricRuleViolation<>(r, ctx, s, "specificdescription");
         assertEquals("Line number mismatch!", 5, rv.getBeginLine());
         assertEquals("Filename mismatch!", "filename", rv.getFilename());
         assertEquals("Rule object mismatch!", r, rv.getRule());
@@ -96,7 +98,7 @@ public class AbstractRuleTest {
     @Test
     public void testRuleWithVariableInMessage() {
         MyRule r = new MyRule();
-        r.definePropertyDescriptor(IntegerProperty.named("testInt").desc("description").range(0, 100).defaultValue(10).uiOrder(0).build());
+        r.definePropertyDescriptor(PropertyFactory.intProperty("testInt").desc("description").require(inRange(0, 100)).defaultValue(10).build());
         r.setMessage("Message ${packageName} ${className} ${methodName} ${variableName} ${testInt} ${noSuchProperty}");
         RuleContext ctx = new RuleContext();
         ctx.setLanguageVersion(LanguageRegistry.getLanguage(DummyLanguageModule.NAME).getDefaultVersion());
@@ -123,7 +125,7 @@ public class AbstractRuleTest {
         DummyNode n = new DummyNode(1);
         n.testingOnlySetBeginColumn(5);
         n.testingOnlySetBeginLine(5);
-        RuleViolation rv = new ParametricRuleViolation(r, ctx, n, "specificdescription");
+        RuleViolation rv = new ParametricRuleViolation<>(r, ctx, n, "specificdescription");
         ctx.getReport().addRuleViolation(rv);
         assertTrue(ctx.getReport().isEmpty());
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/properties/IntegerPropertyTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/properties/IntegerPropertyTest.java
@@ -15,6 +15,7 @@ import java.util.List;
  *
  * @author Brian Remedios
  */
+@Deprecated
 public class IntegerPropertyTest extends AbstractNumericPropertyDescriptorTester<Integer> {
 
     private static final int MIN = 1;

--- a/pmd-core/src/test/java/net/sourceforge/pmd/properties/NonRuleWithAllPropertyTypes.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/properties/NonRuleWithAllPropertyTypes.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.properties;
 
+import static net.sourceforge.pmd.properties.constraints.NumericConstraints.inRange;
+
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
@@ -34,7 +36,7 @@ public class NonRuleWithAllPropertyTypes extends AbstractRule {
     public static final StringProperty SINGLE_STR = new StringProperty("singleStr", "String value", "hello world", 3.0f);
     public static final StringMultiProperty MULTI_STR = new StringMultiProperty("multiStr", "Multiple string values",
                                                                                 new String[] {"hello", "world"}, 5.0f, '|');
-    public static final IntegerProperty SINGLE_INT = IntegerProperty.named("singleInt").desc("Single integer value").range(1, 10).defaultValue(8).uiOrder(3.0f).build();
+    public static final PropertyDescriptor<Integer> SINGLE_INT = PropertyFactory.intProperty("singleInt").desc("Single integer value").require(inRange(1, 10)).defaultValue(8).build();
     public static final IntegerMultiProperty MULTI_INT = new IntegerMultiProperty("multiInt", "Multiple integer values",
                                                                                   0, 10, new Integer[] {1, 2, 3, 4}, 5.0f);
     public static final LongProperty SINGLE_LONG = new LongProperty("singleLong", "Single long value", 1L, 10L, 8L,

--- a/pmd-core/src/test/java/net/sourceforge/pmd/properties/PropertyDescriptorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/properties/PropertyDescriptorTest.java
@@ -85,7 +85,7 @@ public class PropertyDescriptorTest {
     public void testDefaultValueConstraintViolationCausesFailure() {
         PropertyConstraint<Integer> constraint = inRange(1, 10);
 
-        thrown.expect(IllegalStateException.class);
+        thrown.expect(IllegalArgumentException.class);
         thrown.expectMessage(allOf(containsIgnoreCase("Constraint violat"/*-ed or -ion*/),
                                    containsIgnoreCase(constraint.getConstraintDescription())));
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AvoidDeeplyNestedIfStmtsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AvoidDeeplyNestedIfStmtsRule.java
@@ -4,20 +4,24 @@
 
 package net.sourceforge.pmd.lang.java.rule.design;
 
+import static net.sourceforge.pmd.properties.constraints.NumericConstraints.positive;
+
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
-import net.sourceforge.pmd.properties.IntegerProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
+
 
 public class AvoidDeeplyNestedIfStmtsRule extends AbstractJavaRule {
 
     private int depth;
     private int depthLimit;
 
-    private static final IntegerProperty PROBLEM_DEPTH_DESCRIPTOR
-            = IntegerProperty.named("problemDepth")
+    private static final PropertyDescriptor<Integer> PROBLEM_DEPTH_DESCRIPTOR
+            = PropertyFactory.intProperty("problemDepth")
                              .desc("The if statement depth reporting threshold")
-                             .range(1, 25).defaultValue(3).uiOrder(1.0f).build();
+                             .require(positive()).defaultValue(3).build();
 
     public AvoidDeeplyNestedIfStmtsRule() {
         definePropertyDescriptor(PROBLEM_DEPTH_DESCRIPTOR);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CouplingBetweenObjectsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CouplingBetweenObjectsRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.design;
 
+import static net.sourceforge.pmd.properties.constraints.NumericConstraints.positive;
+
 import java.util.HashSet;
 import java.util.Set;
 
@@ -20,7 +22,9 @@ import net.sourceforge.pmd.lang.java.ast.ASTType;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.symboltable.ClassScope;
-import net.sourceforge.pmd.properties.IntegerProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
+
 
 /**
  * CouplingBetweenObjects attempts to capture all unique Class attributes, local
@@ -36,10 +40,10 @@ public class CouplingBetweenObjectsRule extends AbstractJavaRule {
     private int couplingCount;
     private Set<String> typesFoundSoFar;
 
-    private static final IntegerProperty THRESHOLD_DESCRIPTOR 
-            = IntegerProperty.named("threshold")
+    private static final PropertyDescriptor<Integer> THRESHOLD_DESCRIPTOR
+            = PropertyFactory.intProperty("threshold")
                              .desc("Unique type reporting threshold")
-                             .range(2, 100).defaultValue(20).uiOrder(1.0f).build();
+                             .require(positive()).defaultValue(20).build();
 
     public CouplingBetweenObjectsRule() {
         definePropertyDescriptor(THRESHOLD_DESCRIPTOR);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CyclomaticComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CyclomaticComplexityRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.design;
 
+import static net.sourceforge.pmd.properties.constraints.NumericConstraints.positive;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -21,7 +23,8 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaMetricsRule;
 import net.sourceforge.pmd.lang.metrics.MetricOptions;
 import net.sourceforge.pmd.lang.metrics.ResultOption;
 import net.sourceforge.pmd.properties.EnumeratedMultiProperty;
-import net.sourceforge.pmd.properties.IntegerProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
 
 
 /**
@@ -37,21 +40,21 @@ public class CyclomaticComplexityRule extends AbstractJavaMetricsRule {
 
     // Deprecated, kept for backwards compatibility (6.0.0)
     @Deprecated
-    private static final IntegerProperty REPORT_LEVEL_DESCRIPTOR
-        = IntegerProperty.named("reportLevel")
+    private static final PropertyDescriptor<Integer> REPORT_LEVEL_DESCRIPTOR
+        = PropertyFactory.intProperty("reportLevel")
                          .desc("Deprecated! Cyclomatic Complexity reporting threshold")
-                         .range(1, 30).defaultValue(10).uiOrder(1.0f).build();
+                         .require(positive()).defaultValue(10).build();
 
 
-    private static final IntegerProperty CLASS_LEVEL_DESCRIPTOR
-        = IntegerProperty.named("classReportLevel")
+    private static final PropertyDescriptor<Integer> CLASS_LEVEL_DESCRIPTOR
+        = PropertyFactory.intProperty("classReportLevel")
                          .desc("Total class complexity reporting threshold")
-                         .range(1, 600).defaultValue(80).uiOrder(1.0f).build();
+                         .require(positive()).defaultValue(80).build();
 
-    private static final IntegerProperty METHOD_LEVEL_DESCRIPTOR
-        = IntegerProperty.named("methodReportLevel")
+    private static final PropertyDescriptor<Integer> METHOD_LEVEL_DESCRIPTOR
+        = PropertyFactory.intProperty("methodReportLevel")
                          .desc("Cyclomatic complexity reporting threshold")
-                         .range(1, 50).defaultValue(10).uiOrder(1.0f).build();
+                         .require(positive()).defaultValue(10).build();
 
     private static final Map<String, CycloOption> OPTION_MAP;
     

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NPathComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NPathComplexityRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.design;
 
+import static net.sourceforge.pmd.properties.constraints.NumericConstraints.positive;
+
 import java.util.logging.Logger;
 
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
@@ -14,7 +16,8 @@ import net.sourceforge.pmd.lang.java.metrics.JavaMetrics;
 import net.sourceforge.pmd.lang.java.metrics.api.JavaOperationMetricKey;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaMetricsRule;
 import net.sourceforge.pmd.properties.DoubleProperty;
-import net.sourceforge.pmd.properties.IntegerProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
 
 
 /**
@@ -33,9 +36,9 @@ public class NPathComplexityRule extends AbstractJavaMetricsRule {
                         .range(0d, 2000d).defaultValue(200d).uiOrder(2.0f).build();
 
 
-    private static final IntegerProperty REPORT_LEVEL_DESCRIPTOR
-        = IntegerProperty.named("reportLevel").desc("N-Path Complexity reporting threshold")
-                         .range(1, 2000).defaultValue(200).uiOrder(1.0f).build();
+    private static final PropertyDescriptor<Integer> REPORT_LEVEL_DESCRIPTOR
+        = PropertyFactory.intProperty("reportLevel").desc("N-Path Complexity reporting threshold")
+                         .require(positive()).defaultValue(200).build();
 
 
     private int reportLevel = 200;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NcssCountRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NcssCountRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.design;
 
+import static net.sourceforge.pmd.properties.constraints.NumericConstraints.positive;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Locale;
@@ -21,7 +23,9 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaMetricsRule;
 import net.sourceforge.pmd.lang.metrics.MetricOptions;
 import net.sourceforge.pmd.lang.metrics.ResultOption;
 import net.sourceforge.pmd.properties.EnumeratedMultiProperty;
-import net.sourceforge.pmd.properties.IntegerProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
+
 
 /**
  * Simple rule for Ncss. Maybe to be enriched with type specific thresholds.
@@ -31,17 +35,17 @@ import net.sourceforge.pmd.properties.IntegerProperty;
 public final class NcssCountRule extends AbstractJavaMetricsRule {
 
 
-    private static final IntegerProperty METHOD_REPORT_LEVEL_DESCRIPTOR =
-            IntegerProperty.named("methodReportLevel")
+    private static final PropertyDescriptor<Integer> METHOD_REPORT_LEVEL_DESCRIPTOR =
+            PropertyFactory.intProperty("methodReportLevel")
                            .desc("NCSS reporting threshold for methods")
-                           .range(1, 2000)
+                           .require(positive())
                            .defaultValue(60)
                            .build();
 
-    private static final IntegerProperty CLASS_REPORT_LEVEL_DESCRIPTOR =
-            IntegerProperty.named("classReportLevel")
+    private static final PropertyDescriptor<Integer> CLASS_REPORT_LEVEL_DESCRIPTOR =
+            PropertyFactory.intProperty("classReportLevel")
                            .desc("NCSS reporting threshold for classes")
-                           .range(1, 20000)
+                           .require(positive())
                            .defaultValue(1500)
                            .build();
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/StdCyclomaticComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/StdCyclomaticComplexityRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.design;
 
+import static net.sourceforge.pmd.properties.constraints.NumericConstraints.positive;
+
 import java.util.ArrayDeque;
 import java.util.Deque;
 
@@ -25,7 +27,9 @@ import net.sourceforge.pmd.lang.java.ast.ASTSwitchStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTWhileStatement;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.properties.BooleanProperty;
-import net.sourceforge.pmd.properties.IntegerProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
+
 
 /**
  * Implements the standard cyclomatic complexity rule
@@ -40,10 +44,10 @@ import net.sourceforge.pmd.properties.IntegerProperty;
 @Deprecated
 public class StdCyclomaticComplexityRule extends AbstractJavaRule {
 
-    public static final IntegerProperty REPORT_LEVEL_DESCRIPTOR 
-            = IntegerProperty.named("reportLevel")
+    public static final PropertyDescriptor<Integer> REPORT_LEVEL_DESCRIPTOR
+            = PropertyFactory.intProperty("reportLevel")
                              .desc("Cyclomatic Complexity reporting threshold")
-                             .range(1, 30).defaultValue(10).uiOrder(1.0f).build();
+                             .require(positive()).defaultValue(10).build();
 
     public static final BooleanProperty SHOW_CLASSES_COMPLEXITY_DESCRIPTOR = new BooleanProperty(
             "showClassesComplexity", "Add class average violations to the report", true, 2.0f);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/TooManyFieldsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/TooManyFieldsRule.java
@@ -4,19 +4,27 @@
 
 package net.sourceforge.pmd.lang.java.rule.design;
 
+import static net.sourceforge.pmd.properties.constraints.NumericConstraints.positive;
+
 import java.util.List;
 
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
-import net.sourceforge.pmd.properties.IntegerProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
+
 
 public class TooManyFieldsRule extends AbstractJavaRule {
 
     private static final int DEFAULT_MAXFIELDS = 15;
 
-    private static final IntegerProperty MAX_FIELDS_DESCRIPTOR = new IntegerProperty("maxfields",
-            "Max allowable fields", 1, 300, DEFAULT_MAXFIELDS, 1.0f);
+    private static final PropertyDescriptor<Integer> MAX_FIELDS_DESCRIPTOR
+            = PropertyFactory.intProperty("maxfields")
+                             .desc("Max allowable fields")
+                             .defaultValue(DEFAULT_MAXFIELDS)
+                             .require(positive())
+                             .build();
 
     public TooManyFieldsRule() {
         definePropertyDescriptor(MAX_FIELDS_DESCRIPTOR);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentSizeRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentSizeRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.documentation;
 
+import static net.sourceforge.pmd.properties.constraints.NumericConstraints.positive;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -11,7 +13,8 @@ import org.apache.commons.lang3.StringUtils;
 
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.Comment;
-import net.sourceforge.pmd.properties.IntegerProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
 import net.sourceforge.pmd.util.StringUtil;
 
 /**
@@ -21,15 +24,15 @@ import net.sourceforge.pmd.util.StringUtil;
  */
 public class CommentSizeRule extends AbstractCommentRule {
 
-    public static final IntegerProperty MAX_LINES
-            = IntegerProperty.named("maxLines")
+    public static final PropertyDescriptor<Integer> MAX_LINES
+            = PropertyFactory.intProperty("maxLines")
                              .desc("Maximum lines")
-                             .range(2, 200).defaultValue(6).uiOrder(2.0f).build();
+                             .require(positive()).defaultValue(6).build();
     
-    public static final IntegerProperty MAX_LINE_LENGTH
-            = IntegerProperty.named("maxLineLength")
+    public static final PropertyDescriptor<Integer> MAX_LINE_LENGTH
+            = PropertyFactory.intProperty("maxLineLength")
                              .desc("Maximum line length")
-                             .range(1, 200).defaultValue(80).uiOrder(2.0f).build();
+                             .require(positive()).defaultValue(80).build();
 
     private static final String CR = "\n";
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDuplicateLiteralsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDuplicateLiteralsRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 
+import static net.sourceforge.pmd.properties.constraints.NumericConstraints.positive;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.LineNumberReader;
@@ -25,19 +27,20 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.properties.BooleanProperty;
 import net.sourceforge.pmd.properties.CharacterProperty;
 import net.sourceforge.pmd.properties.FileProperty;
-import net.sourceforge.pmd.properties.IntegerProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
 import net.sourceforge.pmd.properties.PropertySource;
 import net.sourceforge.pmd.properties.StringProperty;
 
+
 public class AvoidDuplicateLiteralsRule extends AbstractJavaRule {
 
-    public static final IntegerProperty THRESHOLD_DESCRIPTOR 
-            = IntegerProperty.named("maxDuplicateLiterals")
+    public static final PropertyDescriptor<Integer> THRESHOLD_DESCRIPTOR
+            = PropertyFactory.intProperty("maxDuplicateLiterals")
                              .desc("Max duplicate literals")
-                             .range(1, 20).defaultValue(4).uiOrder(1.0f).build();
+                             .require(positive()).defaultValue(4).build();
 
-    public static final IntegerProperty MINIMUM_LENGTH_DESCRIPTOR = new IntegerProperty("minimumLength",
-            "Minimum string length to check", 1, Integer.MAX_VALUE, 3, 1.5f);
+    public static final PropertyDescriptor<Integer> MINIMUM_LENGTH_DESCRIPTOR = PropertyFactory.intProperty("minimumLength").desc("Minimum string length to check").require(positive()).defaultValue(3).build();
 
     public static final BooleanProperty SKIP_ANNOTATIONS_DESCRIPTOR = new BooleanProperty("skipAnnotations",
             "Skip literals within annotations", false, 2.0f);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/DataflowAnomalyAnalysisRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/DataflowAnomalyAnalysisRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 
+import static net.sourceforge.pmd.properties.constraints.NumericConstraints.inRange;
+
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -20,7 +22,9 @@ import net.sourceforge.pmd.lang.dfa.pathfinder.Executable;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
-import net.sourceforge.pmd.properties.IntegerProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
+
 
 /**
  * Starts path search for each method and runs code if found.
@@ -29,18 +33,18 @@ import net.sourceforge.pmd.properties.IntegerProperty;
  * @author Sven Jacob
  */
 public class DataflowAnomalyAnalysisRule extends AbstractJavaRule implements Executable {
-    private static final IntegerProperty MAX_PATH_DESCRIPTOR
-            = IntegerProperty.named("maxPaths")
+    private static final PropertyDescriptor<Integer> MAX_PATH_DESCRIPTOR
+            = PropertyFactory.intProperty("maxPaths")
                              .desc("Maximum number of checked paths per method. A lower value will increase the performance of the rule but may decrease anomalies found.")
-                             .range(100, 8000)
+                             .require(inRange(100, 8000))
                              .defaultValue(1000)
-                             .uiOrder(1.0f).build();
-    private static final IntegerProperty MAX_VIOLATIONS_DESCRIPTOR
-            = IntegerProperty.named("maxViolations")
+                             .build();
+    private static final PropertyDescriptor<Integer> MAX_VIOLATIONS_DESCRIPTOR
+            = PropertyFactory.intProperty("maxViolations")
                              .desc("Maximum number of anomalies per class")
-                             .range(1, 2000)
+                             .require(inRange(1, 2000))
                              .defaultValue(100)
-                             .uiOrder(2.0f).build();
+                             .build();
     private RuleContext rc;
     private List<DaaRuleViolation> daaRuleViolations;
     private int maxRuleViolations;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveLiteralAppendsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveLiteralAppendsRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.performance;
 
+import static net.sourceforge.pmd.properties.constraints.NumericConstraints.inRange;
+
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -33,7 +35,9 @@ import net.sourceforge.pmd.lang.java.symboltable.JavaNameOccurrence;
 import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
 import net.sourceforge.pmd.lang.java.typeresolution.TypeHelper;
 import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
-import net.sourceforge.pmd.properties.IntegerProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
+
 
 /**
  * This rule finds concurrent calls to StringBuffer/Builder.append where String
@@ -72,10 +76,10 @@ public class ConsecutiveLiteralAppendsRule extends AbstractJavaRule {
         BLOCK_PARENTS.add(ASTMethodDeclaration.class);
     }
 
-    private static final IntegerProperty THRESHOLD_DESCRIPTOR 
-            = IntegerProperty.named("threshold")
+    private static final PropertyDescriptor<Integer> THRESHOLD_DESCRIPTOR
+            = PropertyFactory.intProperty("threshold")
                              .desc("Max consecutive appends")
-                             .range(1, 10).defaultValue(1).uiOrder(1.0f).build();
+                             .require(inRange(1, 10)).defaultValue(1).build();
 
     private int threshold = 1;
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/CodeFormatRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/CodeFormatRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.plsql.rule.codestyle;
 
+import static net.sourceforge.pmd.properties.constraints.NumericConstraints.inRange;
+
 import java.util.List;
 
 import net.sourceforge.pmd.lang.ast.Node;
@@ -23,12 +25,14 @@ import net.sourceforge.pmd.lang.plsql.ast.ASTSubqueryOperation;
 import net.sourceforge.pmd.lang.plsql.ast.ASTUnqualifiedID;
 import net.sourceforge.pmd.lang.plsql.ast.ASTVariableOrConstantDeclarator;
 import net.sourceforge.pmd.lang.plsql.rule.AbstractPLSQLRule;
-import net.sourceforge.pmd.properties.IntegerProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
+
 
 public class CodeFormatRule extends AbstractPLSQLRule {
 
-    private static final IntegerProperty INDENTATION_PROPERTY = IntegerProperty.named("indentation")
-            .desc("Indentation to be used for blocks").defaultValue(2).range(0, 20).build();
+    private static final PropertyDescriptor<Integer> INDENTATION_PROPERTY = PropertyFactory.intProperty("indentation")
+                                                                                           .desc("Indentation to be used for blocks").defaultValue(2).require(inRange(0, 32)).build();
 
     private int indentation = INDENTATION_PROPERTY.defaultValue();
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/CyclomaticComplexityRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/CyclomaticComplexityRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.plsql.rule.design;
 
+import static net.sourceforge.pmd.properties.constraints.NumericConstraints.positive;
+
 import java.util.Stack;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -30,7 +32,9 @@ import net.sourceforge.pmd.lang.plsql.ast.ASTTypeSpecification;
 import net.sourceforge.pmd.lang.plsql.ast.ASTWhileStatement;
 import net.sourceforge.pmd.lang.plsql.rule.AbstractPLSQLRule;
 import net.sourceforge.pmd.properties.BooleanProperty;
-import net.sourceforge.pmd.properties.IntegerProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
+
 
 /**
  * @author Donald A. Leckie,
@@ -43,10 +47,10 @@ public class CyclomaticComplexityRule extends AbstractPLSQLRule {
     private static final Logger LOGGER = Logger.getLogger(CyclomaticComplexityRule.class.getName());
     private static final String CLASS_NAME = CyclomaticComplexityRule.class.getName();
 
-    public static final IntegerProperty REPORT_LEVEL_DESCRIPTOR 
-            = IntegerProperty.named("reportLevel")
+    public static final PropertyDescriptor<Integer> REPORT_LEVEL_DESCRIPTOR
+            = PropertyFactory.intProperty("reportLevel")
                              .desc("Cyclomatic Complexity reporting threshold")
-                             .range(1, 30).defaultValue(10).uiOrder(1.0f).build();
+                             .require(positive()).defaultValue(10).build();
 
     public static final BooleanProperty SHOW_CLASSES_COMPLEXITY_DESCRIPTOR = new BooleanProperty(
             "showClassesComplexity", "Add class average violations to the report", true, 2.0f);

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/TooManyFieldsRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/TooManyFieldsRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.plsql.rule.design;
 
+import static net.sourceforge.pmd.properties.constraints.NumericConstraints.positive;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,7 +17,8 @@ import net.sourceforge.pmd.lang.plsql.ast.ASTTypeSpecification;
 import net.sourceforge.pmd.lang.plsql.ast.ASTVariableOrConstantDeclaration;
 import net.sourceforge.pmd.lang.plsql.ast.PLSQLNode;
 import net.sourceforge.pmd.lang.plsql.rule.AbstractPLSQLRule;
-import net.sourceforge.pmd.properties.IntegerProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
 import net.sourceforge.pmd.util.NumericConstants;
 
 public class TooManyFieldsRule extends AbstractPLSQLRule {
@@ -25,8 +28,12 @@ public class TooManyFieldsRule extends AbstractPLSQLRule {
     private Map<String, Integer> stats;
     private Map<String, PLSQLNode> nodes;
 
-    private static final IntegerProperty MAX_FIELDS_DESCRIPTOR = new IntegerProperty("maxfields",
-            "Max allowable fields", 1, 300, DEFAULT_MAXFIELDS, 1.0f);
+    private static final PropertyDescriptor<Integer> MAX_FIELDS_DESCRIPTOR
+            = PropertyFactory.intProperty("maxfields")
+                             .desc("Max allowable fields")
+                             .defaultValue(DEFAULT_MAXFIELDS)
+                             .require(positive())
+                             .build();
 
     public TooManyFieldsRule() {
         definePropertyDescriptor(MAX_FIELDS_DESCRIPTOR);
@@ -87,7 +94,7 @@ public class TooManyFieldsRule extends AbstractPLSQLRule {
             stats.put(key, NumericConstants.ZERO);
             nodes.put(key, clazz);
         }
-        Integer i = Integer.valueOf(stats.get(key) + 1);
+        Integer i = stats.get(key) + 1;
         stats.put(key, i);
     }
 }

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/design/AvoidDeeplyNestedIfStmtsRule.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/design/AvoidDeeplyNestedIfStmtsRule.java
@@ -4,22 +4,26 @@
 
 package net.sourceforge.pmd.lang.vm.rule.design;
 
+import static net.sourceforge.pmd.properties.constraints.NumericConstraints.positive;
+
 import net.sourceforge.pmd.lang.vm.ast.ASTElseIfStatement;
 import net.sourceforge.pmd.lang.vm.ast.ASTIfStatement;
 import net.sourceforge.pmd.lang.vm.ast.ASTprocess;
 import net.sourceforge.pmd.lang.vm.ast.AbstractVmNode;
 import net.sourceforge.pmd.lang.vm.rule.AbstractVmRule;
-import net.sourceforge.pmd.properties.IntegerProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
+
 
 public class AvoidDeeplyNestedIfStmtsRule extends AbstractVmRule {
 
     private int depth;
     private int depthLimit;
 
-    private static final IntegerProperty PROBLEM_DEPTH_DESCRIPTOR
-            = IntegerProperty.named("problemDepth")
+    private static final PropertyDescriptor<Integer> PROBLEM_DEPTH_DESCRIPTOR
+            = PropertyFactory.intProperty("problemDepth")
                              .desc("The if statement depth reporting threshold")
-                             .range(1, 25).defaultValue(3).uiOrder(1.0f).build();
+                             .require(positive()).defaultValue(3).build();
 
     public AvoidDeeplyNestedIfStmtsRule() {
         definePropertyDescriptor(PROBLEM_DEPTH_DESCRIPTOR);


### PR DESCRIPTION
* I removed most internal usages, except where it was public (if it's public and in a concrete rule class I refactored it anyway).
* I intend to do one such PR for each property type (depending on number of usages) so it will take some time. But after this one they'll mostly be independent so I can maybe open the PRs in parallel
* I did the big documentation effort in this PR, next prs for other property types won't be as big

Refs #1432 