### PR TITLE
[core] Deprecate some more property types

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -76,9 +76,11 @@ interface, e.g. `PropertyDescriptor<Integer>` or `PropertyDescriptor<List<String
 from 7.0.0 on the only provider for property descriptor builders. Each current property type will be replaced
 by a corresponding method on `PropertyFactory`:
   * {% jdoc props::IntegerProperty %} is replaced by {% jdoc !c!:PF#intProperty(java.lang.String) %}
-  * {% jdoc props::IntegerMultiProperty %} is replaced by {% jdoc !c!:PF#intListProperty(java.lang.String) %}
+    * {% jdoc props::IntegerMultiProperty %} is replaced by {% jdoc !c!:PF#intListProperty(java.lang.String) %}
   * {% jdoc props::FloatProperty %} and {% jdoc props::DoubleProperty %} are both replaced by {% jdoc !c!:PF#doubleProperty(java.lang.String) %}.
     Having a separate property for floats wasn't that useful.
+    * Similarly, {% jdoc props::FloatMultiProperty %} and {% jdoc props::DoubleMultiProperty %} are replaced by {% jdoc !c!:PF#doubleListProperty(java.lang.String) %}.
+
   * {% jdoc props::MethodProperty %}, {% jdoc props::FileProperty %}, {% jdoc props::TypeProperty %} and their multi-valued counterparts
     are discontinued for lack of a use-case, and have no planned replacement in 7.0.0 for now.
     <!-- TODO complete that as we proceed. -->

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/metrics/impl/AbstractApexMetricTestRule.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/metrics/impl/AbstractApexMetricTestRule.java
@@ -18,8 +18,10 @@ import net.sourceforge.pmd.lang.metrics.MetricOption;
 import net.sourceforge.pmd.lang.metrics.MetricOptions;
 import net.sourceforge.pmd.lang.metrics.ResultOption;
 import net.sourceforge.pmd.properties.BooleanProperty;
-import net.sourceforge.pmd.properties.DoubleProperty;
 import net.sourceforge.pmd.properties.EnumeratedMultiProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
+
 
 /**
  * Abstract test rule for a metric. Tests of metrics use the standard framework for rule testing, using one dummy rule
@@ -36,8 +38,8 @@ public abstract class AbstractApexMetricTestRule extends AbstractApexRule {
         "reportClasses", "Add class violations to the report", isReportClasses(), 2.0f);
     private final BooleanProperty reportMethodsDescriptor = new BooleanProperty(
         "reportMethods", "Add method violations to the report", isReportMethods(), 3.0f);
-    private final DoubleProperty reportLevelDescriptor = new DoubleProperty(
-        "reportLevel", "Minimum value required to report", -1., Double.POSITIVE_INFINITY, defaultReportLevel(), 3.0f);
+    private final PropertyDescriptor<Double> reportLevelDescriptor =
+            PropertyFactory.doubleProperty("reportLevel").desc("Minimum value required to report").defaultValue(defaultReportLevel()).build();
 
     private MetricOptions metricOptions;
     private boolean reportClasses;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/DoubleMultiProperty.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/DoubleMultiProperty.java
@@ -16,7 +16,11 @@ import net.sourceforge.pmd.properties.builders.PropertyDescriptorBuilderConversi
  *
  * @author Brian Remedios
  * @version Refactored June 2017 (6.0.0)
+ *
+ * @deprecated Use a {@code PropertyDescriptor<List<Double>>} instead. A builder is available from {@link PropertyFactory#doubleListProperty(String)}.
+ *             This class will be removed in 7.0.0.
  */
+@Deprecated
 public final class DoubleMultiProperty extends AbstractMultiNumericProperty<Double> {
 
     /**
@@ -30,7 +34,9 @@ public final class DoubleMultiProperty extends AbstractMultiNumericProperty<Doub
      * @param theUIOrder     UI order
      *
      * @throws IllegalArgumentException if {@literal min > max} or one of the defaults is not between the bounds
+     * @deprecated use {@link PropertyFactory#doubleListProperty(String)}
      */
+    @Deprecated
     public DoubleMultiProperty(String theName, String theDescription, Double min, Double max,
                                Double[] defaultValues, float theUIOrder) {
         this(theName, theDescription, min, max, Arrays.asList(defaultValues), theUIOrder, false);
@@ -55,7 +61,9 @@ public final class DoubleMultiProperty extends AbstractMultiNumericProperty<Doub
      * @param theUIOrder     UI order
      *
      * @throws IllegalArgumentException if {@literal min > max} or one of the defaults is not between the bounds
+     * @deprecated use {@link PropertyFactory#doubleListProperty(String)}
      */
+    @Deprecated
     public DoubleMultiProperty(String theName, String theDescription, Double min, Double max,
                                List<Double> defaultValues, float theUIOrder) {
         this(theName, theDescription, min, max, defaultValues, theUIOrder, false);
@@ -83,12 +91,15 @@ public final class DoubleMultiProperty extends AbstractMultiNumericProperty<Doub
         };
     }
 
-
+    /** @deprecated use {@link PropertyFactory#doubleListProperty(String)} */
+    @Deprecated
     public static DoubleMultiPBuilder named(String name) {
         return new DoubleMultiPBuilder(name);
     }
 
 
+    /** @deprecated use {@link PropertyFactory#doubleListProperty(String)} */
+    @Deprecated
     public static final class DoubleMultiPBuilder extends MultiNumericPropertyBuilder<Double, DoubleMultiPBuilder> {
         private DoubleMultiPBuilder(String name) {
             super(name);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/DoubleProperty.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/DoubleProperty.java
@@ -15,7 +15,11 @@ import net.sourceforge.pmd.properties.builders.SingleNumericPropertyBuilder;
  *
  * @author Brian Remedios
  * @version Refactored June 2017 (6.0.0)
+ *
+ * @deprecated Use a {@code PropertyDescriptor<Double>} instead. A builder is available from {@link PropertyFactory#doubleProperty(String)}.
+ *             This class will be removed in 7.0.0.
  */
+@Deprecated
 public final class DoubleProperty extends AbstractNumericProperty<Double> {
 
 
@@ -31,8 +35,9 @@ public final class DoubleProperty extends AbstractNumericProperty<Double> {
      * @param theUIOrder     UI order
      *
      * @throws IllegalArgumentException if {@literal min > max} or one of the defaults is not between the bounds
-     * @deprecated will be removed in 7.0.0
+     * @deprecated Use {@link PropertyFactory#doubleProperty(String)}.
      */
+    @Deprecated
     public DoubleProperty(String theName, String theDescription, String minStr, String maxStr, String defaultStr,
                           float theUIOrder) {
         this(theName, theDescription, doubleFrom(minStr), doubleFrom(maxStr), doubleFrom(defaultStr), theUIOrder, false);
@@ -57,7 +62,9 @@ public final class DoubleProperty extends AbstractNumericProperty<Double> {
      * @param theUIOrder     UI order
      *
      * @throws IllegalArgumentException if {@literal min > max} or one of the defaults is not between the bounds
+     * @deprecated Use {@link PropertyFactory#doubleProperty(String)}.
      */
+    @Deprecated
     public DoubleProperty(String theName, String theDescription, Double min, Double max, Double theDefault,
                           float theUIOrder) {
         this(theName, theDescription, min, max, theDefault, theUIOrder, false);
@@ -98,11 +105,19 @@ public final class DoubleProperty extends AbstractNumericProperty<Double> {
     }
 
 
+    /**
+     * @deprecated Use {@link PropertyFactory#doubleProperty(String)}.
+     */
+    @Deprecated
     public static DoublePBuilder named(String name) {
         return new DoublePBuilder(name);
     }
 
 
+    /**
+     * @deprecated Use {@link PropertyFactory#doubleProperty(String)}.
+     */
+    @Deprecated
     public static final class DoublePBuilder extends SingleNumericPropertyBuilder<Double, DoublePBuilder> {
         private DoublePBuilder(String name) {
             super(name);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/FloatMultiProperty.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/FloatMultiProperty.java
@@ -16,7 +16,8 @@ import net.sourceforge.pmd.properties.builders.PropertyDescriptorBuilderConversi
  *
  * @author Brian Remedios
  * @version Refactored June 2017 (6.0.0)
- * @deprecated Will be removed with 7.0.0 with no scheduled replacement. Users should use {@link DoubleMultiProperty} instead
+ * @deprecated Use a {@code PropertyDescriptor<List<Double>>} instead. A builder is available from {@link PropertyFactory#doubleListProperty(String)}.
+ *             This class will be removed in 7.0.0.
  */
 @Deprecated
 public final class FloatMultiProperty extends AbstractMultiNumericProperty<Float> {
@@ -33,7 +34,9 @@ public final class FloatMultiProperty extends AbstractMultiNumericProperty<Float
      * @param theUIOrder     UI order
      *
      * @throws IllegalArgumentException if {@literal min > max} or one of the defaults is not between the bounds
+     * @deprecated use {@link PropertyFactory#doubleListProperty(String)}
      */
+    @Deprecated
     public FloatMultiProperty(String theName, String theDescription, Float min, Float max,
                               Float[] defaultValues, float theUIOrder) {
         this(theName, theDescription, min, max, Arrays.asList(defaultValues), theUIOrder, false);
@@ -58,7 +61,9 @@ public final class FloatMultiProperty extends AbstractMultiNumericProperty<Float
      * @param theUIOrder     UI order
      *
      * @throws IllegalArgumentException if {@literal min > max} or one of the defaults is not between the bounds
+     * @deprecated use {@link PropertyFactory#doubleListProperty(String)}
      */
+    @Deprecated
     public FloatMultiProperty(String theName, String theDescription, Float min, Float max,
                               List<Float> defaultValues, float theUIOrder) {
         this(theName, theDescription, min, max, defaultValues, theUIOrder, false);
@@ -87,11 +92,15 @@ public final class FloatMultiProperty extends AbstractMultiNumericProperty<Float
     }
 
 
+    /** @deprecated use {@link PropertyFactory#doubleListProperty(String)} */
+    @Deprecated
     public static FloatMultiPBuilder named(String name) {
         return new FloatMultiPBuilder(name);
     }
 
 
+    /** @deprecated use {@link PropertyFactory#doubleListProperty(String)} */
+    @Deprecated
     public static final class FloatMultiPBuilder extends MultiNumericPropertyBuilder<Float, FloatMultiPBuilder> {
         private FloatMultiPBuilder(String name) {
             super(name);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/FloatProperty.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/FloatProperty.java
@@ -14,7 +14,7 @@ import net.sourceforge.pmd.properties.builders.SingleNumericPropertyBuilder;
  * Defines a property type that supports single float property values within an upper and lower boundary.
  *
  *
- * @deprecated Will be removed with 7.0.0 with no scheduled replacement. Users should use {@link DoubleProperty} instead
+ * @deprecated Use {@link PropertyFactory#doubleProperty(String)} instead. This class will be removed with 7.0.0.
  * @author Brian Remedios
  */
 @Deprecated
@@ -33,8 +33,9 @@ public final class FloatProperty extends AbstractNumericProperty<Float> {
      * @param theUIOrder     UI order
      *
      * @throws IllegalArgumentException if {@literal min > max} or one of the defaults is not between the bounds
-     * @deprecated will be removed in 7.0.0
+     * @deprecated Use {@link PropertyFactory#doubleProperty(String)} instead.
      */
+    @Deprecated
     public FloatProperty(String theName, String theDescription, String minStr, String maxStr, String defaultStr,
                          float theUIOrder) {
         this(theName, theDescription, FLOAT_PARSER.valueOf(minStr),
@@ -60,7 +61,9 @@ public final class FloatProperty extends AbstractNumericProperty<Float> {
      * @param theUIOrder     UI order
      *
      * @throws IllegalArgumentException if {@literal min > max} or one of the defaults is not between the bounds
+     * @deprecated Use {@link PropertyFactory#doubleProperty(String)} instead.
      */
+    @Deprecated
     public FloatProperty(String theName, String theDescription, Float min, Float max, Float theDefault,
                          float theUIOrder) {
         this(theName, theDescription, min, max, theDefault, theUIOrder, false);
@@ -88,12 +91,17 @@ public final class FloatProperty extends AbstractNumericProperty<Float> {
         };
     }
 
-
+    /** @deprecated Use {@link PropertyFactory#doubleProperty(String)} instead. */
+    @Deprecated
     public static FloatPBuilder named(String name) {
         return new FloatPBuilder(name);
     }
 
 
+    /**
+     * @deprecated Use {@link PropertyFactory#doubleProperty(String)} instead.
+     */
+    @Deprecated
     public static final class FloatPBuilder extends SingleNumericPropertyBuilder<Float, FloatPBuilder> {
         private FloatPBuilder(String name) {
             super(name);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/IntegerMultiProperty.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/IntegerMultiProperty.java
@@ -16,7 +16,12 @@ import net.sourceforge.pmd.properties.builders.PropertyDescriptorBuilderConversi
  *
  * @author Brian Remedios
  * @version Refactored June 2017 (6.0.0)
+ *
+ *
+ * @deprecated Use a {@code PropertyDescriptor<List<Integer>>} instead. A builder is available from {@link PropertyFactory#intListProperty(String)}.
+ *             This class will be removed in 7.0.0.
  */
+@Deprecated
 public final class IntegerMultiProperty extends AbstractMultiNumericProperty<Integer> {
 
 
@@ -31,7 +36,9 @@ public final class IntegerMultiProperty extends AbstractMultiNumericProperty<Int
      * @param theUIOrder     UI order
      *
      * @throws IllegalArgumentException if {@literal min > max} or one of the defaults is not between the bounds
+     * @deprecated Use {@link PropertyFactory#intListProperty(String)}
      */
+    @Deprecated
     public IntegerMultiProperty(String theName, String theDescription, Integer min, Integer max,
                                 Integer[] defaultValues, float theUIOrder) {
         this(theName, theDescription, min, max, Arrays.asList(defaultValues), theUIOrder, false);
@@ -57,7 +64,9 @@ public final class IntegerMultiProperty extends AbstractMultiNumericProperty<Int
      * @param theUIOrder     UI order
      *
      * @throws IllegalArgumentException if {@literal min > max} or one of the defaults is not between the bounds
+     * @deprecated Use {@link PropertyFactory#intListProperty(String)}
      */
+    @Deprecated
     public IntegerMultiProperty(String theName, String theDescription, Integer min, Integer max,
                                 List<Integer> defaultValues, float theUIOrder) {
 
@@ -87,11 +96,19 @@ public final class IntegerMultiProperty extends AbstractMultiNumericProperty<Int
     }
 
 
+    /**
+     * @deprecated Use {@link PropertyFactory#intListProperty(String)}
+     */
+    @Deprecated
     public static IntegerMultiPBuilder named(String name) {
         return new IntegerMultiPBuilder(name);
     }
 
 
+    /**
+     * @deprecated Use {@link PropertyFactory#intListProperty(String)}
+     */
+    @Deprecated
     public static final class IntegerMultiPBuilder extends MultiNumericPropertyBuilder<Integer, IntegerMultiPBuilder> {
         private IntegerMultiPBuilder(String name) {
             super(name);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyBuilder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyBuilder.java
@@ -137,6 +137,8 @@ public abstract class PropertyBuilder<B extends PropertyBuilder<B, T>, T> {
      * @param constraint The constraint
      *
      * @return The same builder
+     *
+     * @see net.sourceforge.pmd.properties.constraints.NumericConstraints
      */
     @SuppressWarnings("unchecked")
     public B require(PropertyConstraint<? super T> constraint) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
@@ -129,6 +129,14 @@ public final class PropertyFactory {
     }
 
 
+    /**
+     * Returns a builder for a property having as value a list of decimal numbers. The
+     * format of the individual items is the same as for {@linkplain #doubleProperty(String) doubleProperty}.
+     *
+     * @param name Name of the property to build
+     *
+     * @return A new builder
+     */
     public static GenericCollectionPropertyBuilder<Double, List<Double>> doubleListProperty(String name) {
         return doubleProperty(name).toList().delim(MultiValuePropertyDescriptor.DEFAULT_NUMERIC_DELIMITER);
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
@@ -97,6 +97,14 @@ public final class PropertyFactory {
     }
 
 
+    /**
+     * Returns a builder for a property having as value a list of integers. The
+     * format of the individual items is the same as for {@linkplain #intProperty(String) intProperty}.
+     *
+     * @param name Name of the property to build
+     *
+     * @return A new builder
+     */
     public static GenericCollectionPropertyBuilder<Integer, List<Integer>> intListProperty(String name) {
         return intProperty(name).toList().delim(MultiValuePropertyDescriptor.DEFAULT_NUMERIC_DELIMITER);
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
@@ -110,6 +110,20 @@ public final class PropertyFactory {
     }
 
 
+    /**
+     * Returns a builder for a double property. The property descriptor
+     * will by default accept any value conforming to the format specified
+     * by {@link Double#valueOf(String)}, e.g. {@code 0}, {@code .93}, or {@code 1e-1}.
+     * Acceptable values may be further refined by {@linkplain PropertyBuilder#require(PropertyConstraint) adding constraints}.
+     * The class {@link NumericConstraints} provides some useful ready-made constraints
+     * for that purpose.
+     *
+     * @param name Name of the property to build
+     *
+     * @return A new builder
+     *
+     * @see NumericConstraints
+     */
     public static GenericPropertyBuilder<Double> doubleProperty(String name) {
         return new GenericPropertyBuilder<>(name, ValueParserConstants.DOUBLE_PARSER, Double.class);
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/properties/DoublePropertyTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/properties/DoublePropertyTest.java
@@ -14,6 +14,7 @@ import java.util.List;
  *
  * @author Brian Remedios
  */
+@Deprecated
 public class DoublePropertyTest extends AbstractNumericPropertyDescriptorTester<Double> {
 
     private static final double MIN = -10.0;

--- a/pmd-core/src/test/java/net/sourceforge/pmd/properties/NonRuleWithAllPropertyTypes.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/properties/NonRuleWithAllPropertyTypes.java
@@ -37,8 +37,8 @@ public class NonRuleWithAllPropertyTypes extends AbstractRule {
     public static final StringMultiProperty MULTI_STR = new StringMultiProperty("multiStr", "Multiple string values",
                                                                                 new String[] {"hello", "world"}, 5.0f, '|');
     public static final PropertyDescriptor<Integer> SINGLE_INT = PropertyFactory.intProperty("singleInt").desc("Single integer value").require(inRange(1, 10)).defaultValue(8).build();
-    public static final IntegerMultiProperty MULTI_INT = new IntegerMultiProperty("multiInt", "Multiple integer values",
-                                                                                  0, 10, new Integer[] {1, 2, 3, 4}, 5.0f);
+    public static final PropertyDescriptor<List<Integer>> MULTI_INT = PropertyFactory.intListProperty("multiInt").desc("Multiple integer values").requireEach(inRange(0, 10)).defaultValues(1, 2, 3, 4).build();
+
     public static final LongProperty SINGLE_LONG = new LongProperty("singleLong", "Single long value", 1L, 10L, 8L,
                                                                     3.0f);
     public static final LongMultiProperty MULTI_LONG = new LongMultiProperty("multiLong", "Multiple long values", 0L,

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NPathComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NPathComplexityRule.java
@@ -15,7 +15,6 @@ import net.sourceforge.pmd.lang.java.ast.MethodLikeNode;
 import net.sourceforge.pmd.lang.java.metrics.JavaMetrics;
 import net.sourceforge.pmd.lang.java.metrics.api.JavaOperationMetricKey;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaMetricsRule;
-import net.sourceforge.pmd.properties.DoubleProperty;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
 
@@ -31,9 +30,9 @@ public class NPathComplexityRule extends AbstractJavaMetricsRule {
     private static final Logger LOG = Logger.getLogger(NPathComplexityRule.class.getName());
 
     @Deprecated
-    private static final DoubleProperty MINIMUM_DESCRIPTOR
-        = DoubleProperty.named("minimum").desc("Deprecated! Minimum reporting threshold")
-                        .range(0d, 2000d).defaultValue(200d).uiOrder(2.0f).build();
+    private static final PropertyDescriptor<Double> MINIMUM_DESCRIPTOR
+            = PropertyFactory.doubleProperty("minimum").desc("Deprecated! Minimum reporting threshold")
+                             .require(positive()).defaultValue(200d).build();
 
 
     private static final PropertyDescriptor<Integer> REPORT_LEVEL_DESCRIPTOR

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/AbstractMetricTestRule.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/AbstractMetricTestRule.java
@@ -20,8 +20,10 @@ import net.sourceforge.pmd.lang.metrics.MetricOption;
 import net.sourceforge.pmd.lang.metrics.MetricOptions;
 import net.sourceforge.pmd.lang.metrics.ResultOption;
 import net.sourceforge.pmd.properties.BooleanProperty;
-import net.sourceforge.pmd.properties.DoubleProperty;
 import net.sourceforge.pmd.properties.EnumeratedMultiProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
+
 
 /**
  * Abstract test rule for a metric. Tests of metrics use the standard framework for rule testing, using one dummy rule
@@ -38,8 +40,8 @@ public abstract class AbstractMetricTestRule extends AbstractJavaMetricsRule {
         "reportClasses", "Add class violations to the report", isReportClasses(), 2.0f);
     private final BooleanProperty reportMethodsDescriptor = new BooleanProperty(
         "reportMethods", "Add method violations to the report", isReportMethods(), 3.0f);
-    private final DoubleProperty reportLevelDescriptor = new DoubleProperty(
-        "reportLevel", "Minimum value required to report", -1., Double.POSITIVE_INFINITY, defaultReportLevel(), 3.0f);
+    private final PropertyDescriptor<Double> reportLevelDescriptor =
+            PropertyFactory.doubleProperty("reportLevel").desc("Minimum value required to report").defaultValue(defaultReportLevel()).build();
 
     private MetricOptions metricOptions;
     private boolean reportClasses;


### PR DESCRIPTION
Takes care of
* IntegerMultiProperty
* DoubleProperty
* DoubleMultiProperty

They barely had any usages so I though doing them together was ok.

I also updated the deprecated notices on Float[Multi]Property. 

Refs #1432 


