### PR TITLE
[core] Dogfood - AvoidFileStream

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/Formatter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/Formatter.java
@@ -7,7 +7,6 @@ package net.sourceforge.pmd.ant;
 import java.io.BufferedWriter;
 import java.io.Console;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
@@ -16,6 +15,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -181,7 +181,7 @@ public class Formatter {
         Writer writer = null;
         boolean isOnError = true;
         try {
-            output = new FileOutputStream(file);
+            output = Files.newOutputStream(file.toPath());
             writer = new OutputStreamWriter(output, charset);
             writer = new BufferedWriter(writer);
             isOnError = false;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/AnalysisResult.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/AnalysisResult.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.cache;
 
 import java.io.BufferedInputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/FileAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/FileAnalysisCache.java
@@ -10,7 +10,6 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/FileAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/FileAnalysisCache.java
@@ -10,7 +10,6 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
@@ -106,7 +105,7 @@ public class FileAnalysisCache extends AbstractAnalysisCache {
 
         try (
             DataOutputStream outputStream = new DataOutputStream(
-                new BufferedOutputStream(new FileOutputStream(cacheFile)))
+                new BufferedOutputStream(Files.newOutputStream(cacheFile.toPath())))
         ) {
             outputStream.writeUTF(pmdVersion);
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDTask.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDTask.java
@@ -6,11 +6,11 @@ package net.sourceforge.pmd.cpd;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -137,9 +137,9 @@ public class CPDTask extends Task {
             if (outputFile == null) {
                 os = System.out;
             } else if (outputFile.isAbsolute()) {
-                os = new FileOutputStream(outputFile);
+                os = Files.newOutputStream(outputFile.toPath());
             } else {
-                os = new FileOutputStream(new File(getProject().getBaseDir(), outputFile.toString()));
+                os = Files.newOutputStream(new File(getProject().getBaseDir(), outputFile.toString()).toPath());
             }
             
             if (encoding == null) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/FileReporter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/FileReporter.java
@@ -6,12 +6,11 @@ package net.sourceforge.pmd.cpd;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
+import java.nio.file.Files;
 
 import net.sourceforge.pmd.cpd.renderer.CPDRenderer;
 
@@ -45,7 +44,7 @@ public class FileReporter {
         }
     }
 
-    private OutputStream getOutputStream() throws FileNotFoundException {
-        return reportFile == null ? System.out : new FileOutputStream(reportFile);
+    private OutputStream getOutputStream() throws IOException {
+        return reportFile == null ? System.out : Files.newOutputStream(reportFile.toPath());
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/GUI.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/GUI.java
@@ -18,10 +18,10 @@ import java.awt.event.KeyEvent;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -269,7 +269,7 @@ public class GUI implements CPDListener {
             }
 
             if (!f.canWrite()) {
-                try (PrintWriter pw = new PrintWriter(new FileOutputStream(f))) {
+                try (PrintWriter pw = new PrintWriter(Files.newOutputStream(f.toPath()))) {
                     renderer.render(matches.iterator(), pw);
                     pw.flush();
                     JOptionPane.showMessageDialog(frame, "Saved " + matches.size() + " matches");

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/SourceCode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/SourceCode.java
@@ -6,11 +6,11 @@ package net.sourceforge.pmd.cpd;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
 import java.lang.ref.SoftReference;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -102,7 +102,7 @@ public class SourceCode {
 
         @Override
         public Reader getReader() throws Exception {
-            BOMInputStream inputStream = new BOMInputStream(new FileInputStream(file), ByteOrderMark.UTF_8,
+            BOMInputStream inputStream = new BOMInputStream(Files.newInputStream(file.toPath()), ByteOrderMark.UTF_8,
                     ByteOrderMark.UTF_16BE, ByteOrderMark.UTF_16LE);
 
             if (inputStream.hasBOM()) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/dfa/report/ReportHTMLPrintVisitor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/dfa/report/ReportHTMLPrintVisitor.java
@@ -6,8 +6,9 @@ package net.sourceforge.pmd.lang.dfa.report;
 
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -44,7 +45,8 @@ public class ReportHTMLPrintVisitor extends ReportVisitor {
      * Writes the buffer to file.
      */
     private void write(String filename, StringBuilder buf) throws IOException {
-        try (BufferedWriter bw = new BufferedWriter(new FileWriter(new File(baseDir + FILE_SEPARATOR + filename)))) {
+        try (BufferedWriter bw = Files.newBufferedWriter(new File(baseDir + FILE_SEPARATOR + filename).toPath(),
+                StandardCharsets.UTF_8)) {
             bw.write(buf.toString(), 0, buf.length());
         }
     }
@@ -92,7 +94,9 @@ public class ReportHTMLPrintVisitor extends ReportVisitor {
          */
         if (node.getParent() == null) {
             packageBuf.insert(0,
-                    "<html>" + " <head>" + "   <title>PMD</title>" + " </head>" + " <body>" + PMD.EOL
+                    "<!DOCTYPE html>" + PMD.EOL
+                    + "<html>" + " <head>" + PMD.EOL + "    <meta charset=\"UTF-8\">" + PMD.EOL
+                            + "   <title>PMD</title>" + " </head>" + " <body>" + PMD.EOL
                             + "<h2>Package View</h2>"
                             + "<table border=\"1\" align=\"center\" cellspacing=\"0\" cellpadding=\"3\">" + " <tr>"
                             + PMD.EOL + "<th>Package</th>" + "<th>Class</th>" + "<th>#</th>" + " </tr>" + PMD.EOL);
@@ -152,7 +156,8 @@ public class ReportHTMLPrintVisitor extends ReportVisitor {
         String str = cnode.getClassName();
 
         classBuf.insert(0,
-                "<html><head><title>PMD - " + str + "</title></head><body>" + PMD.EOL + "<h2>Class View</h2>"
+                "<!DOCTYPE html>" + PMD.EOL
+                + "<html><head><meta charset=\"UTF-8\"><title>PMD - " + str + "</title></head><body>" + PMD.EOL + "<h2>Class View</h2>"
                         + "<h3 align=\"center\">Class: " + str + "</h3>"
                         + "<table border=\"\" align=\"center\" cellspacing=\"0\" cellpadding=\"3\">" + " <tr>" + PMD.EOL
                         + "<th>Method</th>" + "<th>Violation</th>" + " </tr>" + PMD.EOL);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextColorRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextColorRenderer.java
@@ -7,9 +7,10 @@ package net.sourceforge.pmd.renderers;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -201,7 +202,13 @@ public class TextColorRenderer extends AbstractAccumulatingRenderer {
     }
 
     protected Reader getReader(String sourceFile) throws FileNotFoundException {
-        return new FileReader(new File(sourceFile));
+        try {
+            return Files.newBufferedReader(new File(sourceFile).toPath(), Charset.defaultCharset());
+        } catch (IOException e) {
+            FileNotFoundException ex = new FileNotFoundException(sourceFile);
+            ex.initCause(e);
+            throw ex;
+        }
     }
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XSLTRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XSLTRenderer.java
@@ -5,7 +5,6 @@
 package net.sourceforge.pmd.renderers;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -13,7 +12,6 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.file.Files;
-
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -84,7 +82,7 @@ public class XSLTRenderer extends XMLRenderer {
             xslt = this.getClass().getResourceAsStream(this.xsltFilename);
         }
         if (xslt == null) {
-            throw new FileNotFoundException("Can't file XSLT sheet :" + this.xsltFilename);
+            throw new FileNotFoundException("Can't find XSLT file: " + this.xsltFilename);
         }
         this.prepareTransformer(xslt);
         // Now we build the XML file

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/YAHTMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/YAHTMLRenderer.java
@@ -5,9 +5,10 @@
 package net.sourceforge.pmd.renderers;
 
 import java.io.File;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -98,9 +99,11 @@ public class YAHTMLRenderer extends AbstractAccumulatingRenderer {
     }
 
     private void renderIndex(String outputDir) throws IOException {
-        try (PrintWriter out = new PrintWriter(new FileWriter(new File(outputDir, "index.html")))) {
+        try (PrintWriter out = new PrintWriter(Files.newBufferedWriter(new File(outputDir, "index.html").toPath(), StandardCharsets.UTF_8))) {
+            out.println("<!DOCTYPE html>");
             out.println("<html>");
             out.println("    <head>");
+            out.println("        <meta charset=\"UTF-8\">");
             out.println("        <title>PMD</title>");
             out.println("    </head>");
             out.println("    <body>");
@@ -137,9 +140,11 @@ public class YAHTMLRenderer extends AbstractAccumulatingRenderer {
     private void renderClasses(String outputDir) throws IOException {
         for (ReportNode node : reportNodesByPackage.values()) {
             if (node.hasViolations()) {
-                try (PrintWriter out = new PrintWriter(new FileWriter(new File(outputDir, node.getClassName() + ".html")))) {
+                try (PrintWriter out = new PrintWriter(Files.newBufferedWriter(new File(outputDir, node.getClassName() + ".html").toPath(), StandardCharsets.UTF_8))) {
+                    out.println("<!DOCTYPE html>");
                     out.println("<html>");
                     out.println("    <head>");
+                    out.println("        <meta charset=\"UTF-8\">");
                     out.print("        <title>PMD - ");
                     out.print(node.getClassName());
                     out.println("</title>");

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/FileIterable.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/FileIterable.java
@@ -5,10 +5,10 @@
 package net.sourceforge.pmd.util;
 
 import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.LineNumberReader;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.util.Iterator;
 
 /**
@@ -26,10 +26,9 @@ public class FileIterable implements Iterable<String> {
     private LineNumberReader lineReader = null;
 
     public FileIterable(File file) {
-
         try {
-            lineReader = new LineNumberReader(new FileReader(file));
-        } catch (FileNotFoundException e) {
+            lineReader = new LineNumberReader(Files.newBufferedReader(file.toPath(), Charset.defaultCharset()));
+        } catch (IOException e) {
             throw new IllegalStateException(e);
         }
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/IOUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/IOUtil.java
@@ -5,13 +5,14 @@
 package net.sourceforge.pmd.util;
 
 import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.Closeable;
-import java.io.FileWriter;
+import java.io.File;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -31,7 +32,8 @@ public final class IOUtil {
 
     public static Writer createWriter(String reportFile) {
         try {
-            return StringUtils.isBlank(reportFile) ? createWriter() : new BufferedWriter(new FileWriter(reportFile));
+            return StringUtils.isBlank(reportFile) ? createWriter()
+                    : Files.newBufferedWriter(new File(reportFile).toPath(), Charset.defaultCharset());
         } catch (IOException e) {
             throw new IllegalArgumentException(e);
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/ResourceLoader.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/ResourceLoader.java
@@ -5,13 +5,12 @@
 package net.sourceforge.pmd.util;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
+import java.nio.file.Files;
 import java.util.Objects;
 
 import net.sourceforge.pmd.RuleSetNotFoundException;
@@ -60,8 +59,8 @@ public class ResourceLoader {
         final File file = new File(name);
         if (file.exists()) {
             try {
-                return new FileInputStream(file);
-            } catch (final FileNotFoundException e) {
+                return Files.newInputStream(file.toPath());
+            } catch (final IOException e) {
                 // if the file didn't exist, we wouldn't be here
                 throw new RuntimeException(e); // somehow the file vanished between checking for existence and opening
             }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/database/DBType.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/database/DBType.java
@@ -5,11 +5,10 @@
 package net.sourceforge.pmd.util.database;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.util.Properties;
 import java.util.PropertyResourceBundle;
 import java.util.ResourceBundle;
@@ -176,17 +175,17 @@ public class DBType {
             resourceBundle = new PropertyResourceBundle(stream);
             propertiesSource = propertiesFile.getAbsolutePath();
             LOGGER.finest("FileSystemWithoutExtension");
-        } catch (FileNotFoundException notFoundOnFilesystemWithoutExtension) {
+        } catch (NoSuchFileException notFoundOnFilesystemWithoutExtension) {
             if (LOGGER.isLoggable(Level.FINEST)) {
                 LOGGER.finest("notFoundOnFilesystemWithoutExtension");
                 LOGGER.finest("Attempting File with added file suffix: " + matchString + ".properties");
             }
+            propertiesFile = new File(matchString + ".properties");
             try (InputStream stream = Files.newInputStream(propertiesFile.toPath())) {
-                propertiesFile = new File(matchString + ".properties");
                 resourceBundle = new PropertyResourceBundle(stream);
                 propertiesSource = propertiesFile.getAbsolutePath();
                 LOGGER.finest("FileSystemWithExtension");
-            } catch (FileNotFoundException notFoundOnFilesystemWithExtensionTackedOn) {
+            } catch (NoSuchFileException notFoundOnFilesystemWithExtensionTackedOn) {
                 if (LOGGER.isLoggable(Level.FINEST)) {
                     LOGGER.finest("Attempting JARWithoutClassPrefix: " + matchString);
                 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/datasource/FileDataSource.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/datasource/FileDataSource.java
@@ -5,9 +5,9 @@
 package net.sourceforge.pmd.util.datasource;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -30,7 +30,7 @@ public class FileDataSource implements DataSource {
 
     @Override
     public InputStream getInputStream() throws IOException {
-        return new FileInputStream(file);
+        return Files.newInputStream(file.toPath());
     }
 
     @Override

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/designer/Designer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/designer/Designer.java
@@ -20,13 +20,13 @@ import java.awt.event.ComponentEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.lang.reflect.Proxy;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -993,7 +993,7 @@ public class Designer implements ClipboardOwner {
     private void loadSettings() {
         File file = new File(SETTINGS_FILE_NAME);
         if (file.exists()) {
-            try (InputStream stream = new FileInputStream(file)) {
+            try (InputStream stream = Files.newInputStream(file.toPath())) {
                 DocumentBuilder builder = DocumentBuilderFactory.newInstance().newDocumentBuilder();
                 Document document = builder.parse(stream);
                 Element settingsElement = document.getDocumentElement();
@@ -1050,7 +1050,8 @@ public class Designer implements ClipboardOwner {
             transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
 
             Source source = new DOMSource(document);
-            Result result = new StreamResult(new FileWriter(new File(SETTINGS_FILE_NAME)));
+            Result result = new StreamResult(Files.newBufferedWriter(new File(SETTINGS_FILE_NAME).toPath(),
+                    StandardCharsets.UTF_8));
             transformer.transform(source, result);
         } catch (ParserConfigurationException | IOException | TransformerException e) {
             e.printStackTrace();

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/yahtml/YAHTMLSampleClass1.html
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/yahtml/YAHTMLSampleClass1.html
@@ -1,5 +1,7 @@
+<!DOCTYPE html>
 <html>
     <head>
+        <meta charset="UTF-8">
         <title>PMD - YAHTMLSampleClass1</title>
     </head>
     <body>

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/yahtml/YAHTMLSampleClass2.html
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/yahtml/YAHTMLSampleClass2.html
@@ -1,5 +1,7 @@
+<!DOCTYPE html>
 <html>
     <head>
+        <meta charset="UTF-8">
         <title>PMD - YAHTMLSampleClass2</title>
     </head>
     <body>

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/yahtml/index.html
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/yahtml/index.html
@@ -1,5 +1,7 @@
+<!DOCTYPE html>
 <html>
     <head>
+        <meta charset="UTF-8">
         <title>PMD</title>
     </head>
     <body>

--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -120,14 +120,22 @@ public class Test {
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_performance.html#avoidfilestream">
         <description>
-The FileInputStream and FileOutputStream classes contains a finalizer method which will cause garbage collection pauses. See [JDK-8080225](https://bugs.openjdk.java.net/browse/JDK-8080225) for details.
+The FileInputStream and FileOutputStream classes contains a finalizer method which will cause garbage
+collection pauses.
+See [JDK-8080225](https://bugs.openjdk.java.net/browse/JDK-8080225) for details.
 
-The FileReader and FileWriter constructors instantiate FileInputStream and FileOutputStream, again causing garbage collection issues while finalizer methods are called.
+The FileReader and FileWriter constructors instantiate FileInputStream and FileOutputStream,
+again causing garbage collection issues while finalizer methods are called.
 
 * Use `Files.newInputStream(Paths.get(fileName))` instead of `new FileInputStream(fileName)`.
 * Use `Files.newOutputStream(Paths.get(fileName))` instead of `new FileOutputStream(fileName)`.
 * Use `Files.newBufferedReader(Paths.get(fileName))` instead of `new FileReader(fileName)`.
 * Use `Files.newBufferedWriter(Paths.get(fileName))` instead of `new FileWriter(fileName)`.
+
+Please note, that the `java.nio` API does not throw a `FileNotFoundException` anymore, instead
+it throws a `NoSuchFileException`. If your code dealt explicitly with a `FileNotFoundException`,
+then this needs to be adjusted. Both exceptions are subclasses of `IOException`, so catching
+that one covers both.
         </description>
         <priority>1</priority>
         <properties>


### PR DESCRIPTION
This is a follow-up on #1439.

It includes the following fixes (not sure, if they need to be mentioned explicitly):
* Using a charset explicitly, where possible. E.g. ReportHTMLPrintVisitor and YAHTMLRenderer now use UTF-8
* DBType tried to read twice from the same file in case the file doesn't exist. The comments clearly showed the original intentation to try the second time with a *different* file name... so, I moved that line above...

After this is merged, we can raise the priority of AvoidFileStream in our dogfood ruleset.