### PR TITLE
[java] JUnitTestsShouldIncludeAssertRule should support `this.exception` as well as just `exception`

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -41,6 +41,7 @@ This means, you can use CPD to find duplicated code in your Kotlin projects.
 *   java
     *   [#1460](https://github.com/pmd/pmd/issues/1460): \[java] Intermittent PMD failure : PMD processing errors while no violations reported
 *   java-bestpractices
+    *   [#647](https://github.com/pmd/pmd/issues/647): \[java] JUnitTestsShouldIncludeAssertRule should support `this.exception` as well as just `exception`
     *   [#1435](https://github.com/pmd/pmd/issues/1435): \[java] JUnitTestsShouldIncludeAssert: Support AssertJ soft assertions
 *   java-codestyle
     *   [#1232](https://github.com/pmd/pmd/issues/1232): \[java] Detector for large numbers not separated by _

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnitTestsShouldIncludeAssert.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnitTestsShouldIncludeAssert.xml
@@ -496,4 +496,20 @@ public class FooTest {
     }
 }]]></code>
     </test-code>
+    <test-code>
+        <description>#647 JUnitTestsShouldIncludeAssertRule should support `this.exception` as well as just `exception`</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.junit.*;
+public class DigitalAssetManagerTest {
+  @Rule
+  public final ExpectedException exception = ExpectedException.none();
+  @Test
+  public void throwsIllegalArgumentExceptionIfIconIsNull() {
+    this.exception.expect(IllegalArgumentException.class);
+    this.exception.expectMessage("Icon is null, not a file, or doesn't exist.");
+    new DigitalAssetManager(null, null);
+  }
+}]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
This fixes #647 .
It uses the test from PR #1457.