### PR TITLE
[core] Port deprecations from the AST processing stages PR

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -136,24 +136,37 @@ accordingly.
   new way to document these properties exhaustively will be added with 7.0.0.
 * {% jdoc :PDr#errorFor(java.lang.Object) %} is deprecated as its return type will be changed to `Optional<String>` with the shift to Java 8.
 
-
-##### Internalized API
-
-The following APIs were never intended as public API and will be internalized or removed with 7.0.0.
-
-* All classes from {% jdoc_package props::modules %} are deprecated and will be removed.
-* The classes {% jdoc props::PropertyDescriptorField %}, {% jdoc props::builders.PropertyDescriptorBuilderConversionWrapper %}, and the methods
-  {% jdoc !c!:PDr#attributeValuesById %}, {% jdoc !c!:PDr#isDefinedExternally() %} and {% jdoc !c!props::PropertyTypeId#getFactory() %}.
-  These were used to read and write properties to and from XML, but were not intended as public API.
-* The class {% jdoc props::ValueParserConstants %} and the interface {% jdoc props::ValueParser %}.
-
 #### Deprecated APIs
 
 {% jdoc_nspace :xpath core::lang.ast.xpath %}
 {% jdoc_nspace :jast java::lang.java.ast %}
+{% jdoc_nspace :rule core::Rule %}
+{% jdoc_nspace :lvh core::lang.LanguageVersionHandler %}
+{% jdoc_nspace :rset core::RuleSet %}
+{% jdoc_nspace :rsets core::RuleSets %}
+
+##### For internalization
 
 *   The implementation of the adapters for the XPath engines Saxon and Jaxen (package {% jdoc_package :xpath %})
     are now deprecated. They'll be moved to an internal package come 7.0.0. Only {% jdoc xpath::Attribute %} remains public API.
+
+*   The classes {% jdoc props::PropertyDescriptorField %}, {% jdoc props::builders.PropertyDescriptorBuilderConversionWrapper %}, and the methods
+    {% jdoc !c!:PDr#attributeValuesById %}, {% jdoc !c!:PDr#isDefinedExternally() %} and {% jdoc !c!props::PropertyTypeId#getFactory() %}.
+    These were used to read and write properties to and from XML, but were not intended as public API.
+
+*   The class {% jdoc props::ValueParserConstants %} and the interface {% jdoc props::ValueParser %}.
+
+*   All classes from {% jdoc_package java::lang.java.metrics.impl.visitors %} are now considered internal API. They're deprecated
+    and will be moved into an internal package with 7.0.0. To implement your own metrics visitors,
+    {% jdoc jast::JavaParserVisitorAdapter %} should be directly subclassed.
+
+*   {% jdoc !ac!:lvh#getDataFlowHandler() %}, {% jdoc !ac!:lvh#getDFAGraphRule() %}
+
+*   {% jdoc core::lang.VisitorStarter %}
+
+##### For removal
+
+*   All classes from {% jdoc_package props::modules %} will be removed.
 
 *   The interface {% jdoc jast::Dimensionable %} has been deprecated.
     It gets in the way of a grammar change for 7.0.0 and won't be needed anymore (see [#997](https://github.com/pmd/pmd/issues/997)).
@@ -176,10 +189,6 @@ The following APIs were never intended as public API and will be internalized or
 
     *   In {% jdoc_package :jast %}: {% jdoc jast::JavaParserDecoratedVisitor %}, {% jdoc jast::JavaParserControllessVisitor %},
         {% jdoc jast::JavaParserControllessVisitorAdapter %}, and {% jdoc jast::JavaParserVisitorDecorator %} are deprecated with no intended replacement.
-
-*   All classes from {% jdoc_package java::lang.java.metrics.impl.visitors %} are now considered internal API. They're deprecated
-    and will be moved into an internal package with 7.0.0. To implement your own metrics visitors,
-    {% jdoc jast::JavaParserVisitorAdapter %} should be directly subclassed.
 
 
 *   The LanguageModules of several languages, that only support CPD execution, have been deprecated. These languages
@@ -205,6 +214,21 @@ The following APIs were never intended as public API and will be internalized or
     *   {% jdoc ruby::lang.ruby.RubyLanguageModule %}
     *   {% jdoc scala::lang.scala.ScalaLanguageModule %}
     *   {% jdoc swift::lang.swift.SwiftLanguageModule %}
+
+
+* Optional AST processing stages like symbol table, type resolution or data-flow analysis will be reified
+in 7.0.0 to factorise common logic and make them extensible. Further explanations about this change can be
+found on [#1426](https://github.com/pmd/pmd/pull/1426). Consequently, the following APIs are deprecated for
+removal:
+  * In {% jdoc :rule %}: {% jdoc !a!:rule#isDfa() %}, {% jdoc !a!:rule#isTypeResolution() %}, {% jdoc !a!:rule#isMultifile() %} and their
+    respective setters.
+  * In {% jdoc :rset %}: {% jdoc !a!:rset#usesDFA(core::lang.Language) %}, {% jdoc !a!:rset#usesTypeResolution(core::lang.Language) %}, {% jdoc !a!:rset#usesMultifile(core::lang.Language) %}
+  * In {% jdoc :rsets %}: {% jdoc !a!:rsets#usesDFA(core::lang.Language) %}, {% jdoc !a!:rsets#usesTypeResolution(core::lang.Language) %}, {% jdoc !a!:rsets#usesMultifile(core::lang.Language) %}
+  * In {% jdoc :lvh %}: {% jdoc !a!:lvh#getDataFlowFacade() %}, {% jdoc !a!:lvh#getSymbolFacade() %}, {% jdoc !a!:lvh#getSymbolFacade(java.lang.ClassLoader) %},
+    {% jdoc !a!:lvh#getTypeResolutionFacade(java.lang.ClassLoader) %}, {% jdoc !a!:lvh#getQualifiedNameResolutionFacade(java.lang.ClassLoader) %}
+
+
+
 
 ### External Contributions
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/Rule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/Rule.java
@@ -258,21 +258,23 @@ public interface Rule extends PropertySource {
 
     /**
      * Sets whether this Rule uses Data Flow Analysis.
-     * @deprecated Use {@link #setDfa(boolean)} instead.
+     * @deprecated See {@link #isDfa()}
      */
     @Deprecated // To be removed in PMD 7.0.0
     void setUsesDFA();
 
     /**
      * Sets whether this Rule uses Data Flow Analysis.
+     * @deprecated See {@link #isDfa()}
      */
+    @Deprecated
     void setDfa(boolean isDfa);
 
     /**
      * Gets whether this Rule uses Data Flow Analysis.
      *
      * @return <code>true</code> if Data Flow Analysis is used.
-     * @deprecated Use {@link #isDfa()} instead.
+     * @deprecated See {@link #isDfa()}
      */
     @Deprecated // To be removed in PMD 7.0.0
     boolean usesDFA();
@@ -281,19 +283,24 @@ public interface Rule extends PropertySource {
      * Gets whether this Rule uses Data Flow Analysis.
      *
      * @return <code>true</code> if Data Flow Analysis is used.
+     * @deprecated Optional AST processing stages will be reified in 7.0.0 to factorise common logic.
+     *             This method and the similar methods will be removed.
      */
+    @Deprecated
     boolean isDfa();
 
     /**
      * Sets whether this Rule uses Type Resolution.
-     * @deprecated Use {@link #setTypeResolution(boolean)} instead.
+     * @deprecated See {@link #isTypeResolution()}
      */
     @Deprecated // To be removed in PMD 7.0.0
     void setUsesTypeResolution();
 
     /**
      * Sets whether this Rule uses Type Resolution.
+     * @deprecated See {@link #isTypeResolution()}
      */
+    @Deprecated
     void setTypeResolution(boolean usingTypeResolution);
 
     /**
@@ -301,7 +308,7 @@ public interface Rule extends PropertySource {
      *
      * @return <code>true</code> if Type Resolution is used.
      *
-     * @deprecated Use {@link #isTypeResolution()} instead
+     * @deprecated See {@link #isTypeResolution()}
      */
     @Deprecated // To be removed in PMD 7.0.0
     boolean usesTypeResolution();
@@ -310,19 +317,24 @@ public interface Rule extends PropertySource {
      * Gets whether this Rule uses Type Resolution.
      *
      * @return <code>true</code> if Type Resolution is used.
+     * @deprecated Optional AST processing stages will be reified in 7.0.0 to factorise common logic.
+     *             This method and the similar methods will be removed.
      */
+    @Deprecated
     boolean isTypeResolution();
 
     /**
      * Sets whether this Rule uses multi-file analysis.
-     * @deprecated use {@link #setMultifile(boolean)} instead.
+     * @deprecated See {@link #isMultifile()}
      */
     @Deprecated // To be removed in PMD 7.0.0
     void setUsesMultifile();
 
     /**
      * Sets whether this Rule uses multi-file analysis.
+     * @deprecated See {@link #isMultifile()}
      */
+    @Deprecated
     void setMultifile(boolean multifile);
 
     /**
@@ -330,7 +342,7 @@ public interface Rule extends PropertySource {
      *
      * @return <code>true</code> if the multi file analysis is used.
      *
-     * @deprecated Use {@link #isMultifile()} instead.
+     * @deprecated See {@link #isMultifile()}
      */
     @Deprecated // To be removed in PMD 7.0.0
     boolean usesMultifile();
@@ -339,7 +351,10 @@ public interface Rule extends PropertySource {
      * Gets whether this Rule uses multi-file analysis.
      *
      * @return <code>true</code> if the multi file analysis is used.
+     * @deprecated Logic for multifile analysis is not implemented yet and probably
+     *             won't be implemented this way. Will be removed in 7.0.0.
      */
+    @Deprecated
     boolean isMultifile();
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
@@ -603,7 +603,9 @@ public class RuleSet implements ChecksumAware {
      *            The Language.
      * @return <code>true</code> if a Rule for the Language uses the DFA layer,
      *         <code>false</code> otherwise.
+     * @deprecated See {@link Rule#isDfa()}
      */
+    @Deprecated
     public boolean usesDFA(Language language) {
         for (Rule r : rules) {
             if (r.getLanguage().equals(language) && r.isDfa()) {
@@ -620,7 +622,9 @@ public class RuleSet implements ChecksumAware {
      *            The Language.
      * @return <code>true</code> if a Rule for the Language uses Type
      *         Resolution, <code>false</code> otherwise.
+     * @deprecated See {@link Rule#isTypeResolution()}
      */
+    @Deprecated
     public boolean usesTypeResolution(Language language) {
         for (Rule r : rules) {
             if (r.getLanguage().equals(language) && r.isTypeResolution()) {
@@ -639,7 +643,9 @@ public class RuleSet implements ChecksumAware {
      *
      * @return {@code true} if a Rule for the Language uses multi file analysis,
      *         {@code false} otherwise.
+     * @deprecated See {@link Rule#isMultifile()}
      */
+    @Deprecated
     public boolean usesMultifile(Language language) {
         for (Rule r : rules) {
             if (r.getLanguage().equals(language) && r.isMultifile()) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSets.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSets.java
@@ -160,7 +160,9 @@ public class RuleSets {
      * @param language
      *            the language of a source
      * @return true if any rule in the RuleSet needs the DFA layer
+     * @deprecated See {@link Rule#isDfa()}
      */
+    @Deprecated
     public boolean usesDFA(Language language) {
         for (RuleSet ruleSet : ruleSets) {
             if (ruleSet.usesDFA(language)) {
@@ -209,7 +211,9 @@ public class RuleSets {
      *            The Language.
      * @return <code>true</code> if a Rule for the Language uses Type
      *         Resolution, <code>false</code> otherwise.
+     * @deprecated See {@link Rule#isTypeResolution()}
      */
+    @Deprecated
     public boolean usesTypeResolution(Language language) {
         for (RuleSet ruleSet : ruleSets) {
             if (ruleSet.usesTypeResolution(language)) {
@@ -227,7 +231,9 @@ public class RuleSets {
      *
      * @return {@code true} if a Rule for the Language uses multi file analysis,
      *         {@code false} otherwise.
+     * @deprecated See {@link Rule#isMultifile()}
      */
+    @Deprecated
     public boolean usesMultifile(Language language) {
         for (RuleSet ruleSet : ruleSets) {
             if (ruleSet.usesMultifile(language)) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/DataFlowHandler.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/DataFlowHandler.java
@@ -6,9 +6,16 @@ package net.sourceforge.pmd.lang;
 
 import java.util.List;
 
+import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.dfa.DataFlowNode;
 
+
+/**
+ * @deprecated This is internal API
+ */
+@Deprecated
+@InternalApi
 public interface DataFlowHandler {
 
     DataFlowHandler DUMMY = new DataFlowHandler() {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageVersionHandler.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageVersionHandler.java
@@ -6,12 +6,17 @@ package net.sourceforge.pmd.lang;
 
 import java.io.Writer;
 
+import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.lang.dfa.DFAGraphRule;
 import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
 
 /**
  * Interface for obtaining the classes necessary for checking source files of a
  * specific language.
+ *
+ * Note: "façade" getters like {@link #getSymbolFacade()} will be removed with 7.0.0
+ * and replaced with a more extensible mechanism. They're now deprecated. See also
+ * https://github.com/pmd/pmd/pull/1426
  *
  * @author pieter_van_raemdonck - Application Engineers NV/SA - www.ae.be
  */
@@ -50,14 +55,18 @@ public interface LanguageVersionHandler {
      * Get the DataFlowFacade.
      *
      * @return VisitorStarter
+     * @deprecated see note in the class description
      */
+    @Deprecated
     VisitorStarter getDataFlowFacade();
 
     /**
      * Get the SymbolFacade.
      *
      * @return VisitorStarter
+     * @deprecated see note in the class description
      */
+    @Deprecated
     VisitorStarter getSymbolFacade();
 
     /**
@@ -66,7 +75,9 @@ public interface LanguageVersionHandler {
      * @param classLoader
      *            A ClassLoader to use for resolving Types.
      * @return VisitorStarter
+     * @deprecated see note in the class description
      */
+    @Deprecated
     VisitorStarter getSymbolFacade(ClassLoader classLoader);
 
     /**
@@ -75,7 +86,9 @@ public interface LanguageVersionHandler {
      * @param classLoader
      *            A ClassLoader to use for resolving Types.
      * @return VisitorStarter
+     * @deprecated see note in the class description
      */
+    @Deprecated
     VisitorStarter getTypeResolutionFacade(ClassLoader classLoader);
 
     /**
@@ -84,7 +97,9 @@ public interface LanguageVersionHandler {
      * @param writer
      *            The writer to dump to.
      * @return VisitorStarter
+     * @deprecated The dump façade is not that useful and will be completely scrapped with PMD 7.0.0
      */
+    @Deprecated
     VisitorStarter getDumpFacade(Writer writer, String prefix, boolean recurse);
 
 
@@ -92,7 +107,9 @@ public interface LanguageVersionHandler {
      * Gets the visitor that performs multifile data gathering.
      *
      * @return The visitor starter
+     * @deprecated see note in the class description
      */
+    @Deprecated
     VisitorStarter getMultifileFacade();
 
 
@@ -103,7 +120,9 @@ public interface LanguageVersionHandler {
      * @param classLoader The classloader to use to resolve the types of type qualified names
      *
      * @return The visitor starter
+     * @deprecated see note in the class description
      */
+    @Deprecated
     VisitorStarter getQualifiedNameResolutionFacade(ClassLoader classLoader);
 
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageVersionHandler.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageVersionHandler.java
@@ -6,7 +6,7 @@ package net.sourceforge.pmd.lang;
 
 import java.io.Writer;
 
-import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.dfa.DFAGraphRule;
 import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
 
@@ -24,7 +24,10 @@ public interface LanguageVersionHandler {
 
     /**
      * Get the DataFlowHandler.
+     * @deprecated This is internal API
      */
+    @Deprecated
+    @InternalApi
     DataFlowHandler getDataFlowHandler();
 
     /**
@@ -126,5 +129,10 @@ public interface LanguageVersionHandler {
     VisitorStarter getQualifiedNameResolutionFacade(ClassLoader classLoader);
 
 
+    /**
+     * @deprecated This is internal API
+     */
+    @Deprecated
+    @InternalApi
     DFAGraphRule getDFAGraphRule();
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/VisitorStarter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/VisitorStarter.java
@@ -4,13 +4,18 @@
 
 package net.sourceforge.pmd.lang;
 
+import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.ast.Node;
 
 /**
  * Interface for starting an implementation of the visitors for ASTs.
  *
  * @author pieter_van_raemdonck - Application Engineers NV/SA - www.ae.be
+ *
+ * @deprecated Is internal API, and is now only used on methods deprecated for removal.
  */
+@Deprecated
+@InternalApi
 public interface VisitorStarter {
 
     /**


### PR DESCRIPTION
This PR ports deprecations from #1426 to master.

I added a few `@InternalApi` annotations on the data-flow related methods of LanguageVersionHandler. Perhaps all data-flow related methods and classes should be downgraded to `@Experimental` API and not relied upon outside of PMD, until someday we improve them enough to be stable API again. Wdyt?

Also, maybe the jdoc tag should display by default the arguments of a method. The most common case is that `!a!` is specified 