### PR TITLE
[core] Deprecate string property and string multi property

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -229,14 +229,8 @@ removal:
 
 #### Modified rules
 
-* The properties of the {% rule java/errorprone/AvoidDuplicateLiterals %} have been reworked a little
-to prepare for 7.0.0.
-  * The property `exceptionfile` is now deprecated. Please use `exceptionList` instead
-  * The property `separator` is now deprecated. Please avoid overriding its value and
-    instead use the default (a comma) separator. This is because delimiter logic will
-    be scrapped from property descriptors. Multi-valued properties will use a dedicated syntax,
-    which doesn't rely on a delimiter, to avoid ambiguity around the delimiter.
-  * These properties will be removed with 7.0.0
+* The property `exceptionfile` of the rule {% rule java/errorprone/AvoidDuplicateLiterals %} has been
+  deprecated and will be removed with 7.0.0. Please use `exceptionList` instead.
 
 ### External Contributions
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -78,9 +78,15 @@ from 7.0.0 on the only provider for property descriptor builders. Each current p
 by a corresponding method on `PropertyFactory`:
   * {% jdoc props::IntegerProperty %} is replaced by {% jdoc !c!:PF#intProperty(java.lang.String) %}
     * {% jdoc props::IntegerMultiProperty %} is replaced by {% jdoc !c!:PF#intListProperty(java.lang.String) %}
+
   * {% jdoc props::FloatProperty %} and {% jdoc props::DoubleProperty %} are both replaced by {% jdoc !c!:PF#doubleProperty(java.lang.String) %}.
     Having a separate property for floats wasn't that useful.
     * Similarly, {% jdoc props::FloatMultiProperty %} and {% jdoc props::DoubleMultiProperty %} are replaced by {% jdoc !c!:PF#doubleListProperty(java.lang.String) %}.
+
+  * {% jdoc props::StringProperty %} is replaced by {% jdoc !c!:PF#stringProperty(java.lang.String) %}
+    * {% jdoc props::StringMultiProperty %} is replaced by {% jdoc !c!:PF#stringListProperty(java.lang.String) %}
+
+  * {% jdoc props::RegexProperty %} is replaced by {% jdoc !c!:PF#regexProperty(java.lang.String) %}
 
   * {% jdoc props::MethodProperty %}, {% jdoc props::FileProperty %}, {% jdoc props::TypeProperty %} and their multi-valued counterparts
     are discontinued for lack of a use-case, and have no planned replacement in 7.0.0 for now.

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -227,7 +227,14 @@ removal:
   * In {% jdoc :lvh %}: {% jdoc !a!:lvh#getDataFlowFacade() %}, {% jdoc !a!:lvh#getSymbolFacade() %}, {% jdoc !a!:lvh#getSymbolFacade(java.lang.ClassLoader) %},
     {% jdoc !a!:lvh#getTypeResolutionFacade(java.lang.ClassLoader) %}, {% jdoc !a!:lvh#getQualifiedNameResolutionFacade(java.lang.ClassLoader) %}
 
+#### Modified rules
 
+* The properties of the {% rule java/errorprone/AvoidDuplicateLiterals %} have been reworked a little
+to prepare for 7.0.0.
+  * The properties `exceptionfile`, `exceptionList` and `separator` are now deprecated and will be removed with 7.0.0
+  * The new property `ignoredLiterals` works the same as exceptionList, except its delimiter is not
+    selected by the `separator` property. The delimiter is invariably `,`. If you didn't override `separator`,
+    then updating only involves changing the name `exceptionList` to `ignoredLiterals`
 
 
 ### External Contributions

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -231,11 +231,12 @@ removal:
 
 * The properties of the {% rule java/errorprone/AvoidDuplicateLiterals %} have been reworked a little
 to prepare for 7.0.0.
-  * The properties `exceptionfile`, `exceptionList` and `separator` are now deprecated and will be removed with 7.0.0
-  * The new property `ignoredLiterals` works the same as exceptionList, except its delimiter is not
-    selected by the `separator` property. The delimiter is invariably `,`. If you didn't override `separator`,
-    then updating only involves changing the name `exceptionList` to `ignoredLiterals`
-
+  * The property `exceptionfile` is now deprecated. Please use `exceptionList` instead
+  * The property `separator` is now deprecated. Please avoid overriding its value and
+    instead use the default (a comma) separator. This is because delimiter logic will
+    be scrapped from property descriptors. Multi-valued properties will use a dedicated syntax,
+    which doesn't rely on a delimiter, to avoid ambiguity around the delimiter.
+  * These properties will be removed with 7.0.0
 
 ### External Contributions
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/VariableNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/VariableNamingConventionsRule.java
@@ -6,7 +6,9 @@ package net.sourceforge.pmd.lang.apex.rule.codestyle;
 
 import static apex.jorje.semantic.symbol.type.ModifierTypeInfos.FINAL;
 import static apex.jorje.semantic.symbol.type.ModifierTypeInfos.STATIC;
+import static net.sourceforge.pmd.properties.PropertyFactory.stringListProperty;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
@@ -19,7 +21,6 @@ import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.properties.BooleanProperty;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
-import net.sourceforge.pmd.properties.StringMultiProperty;
 
 public class VariableNamingConventionsRule extends AbstractApexRule {
 
@@ -44,47 +45,47 @@ public class VariableNamingConventionsRule extends AbstractApexRule {
     private static final BooleanProperty CHECK_PARAMETERS_DESCRIPTOR = new BooleanProperty("checkParameters",
             "Check constructor and method parameter variables", true, 3.0f);
 
-    private static final StringMultiProperty STATIC_PREFIXES_DESCRIPTOR = new StringMultiProperty("staticPrefix",
-            "Static variable prefixes", new String[] { "" }, 4.0f, ',');
+    private static final PropertyDescriptor<List<String>> STATIC_PREFIXES_DESCRIPTOR = stringListProperty("staticPrefix").desc("Static variable prefixes").defaultValues("").delim(',').build();
 
-    private static final StringMultiProperty STATIC_SUFFIXES_DESCRIPTOR = new StringMultiProperty("staticSuffix",
-            "Static variable suffixes", new String[] { "" }, 5.0f, ',');
+    private static final PropertyDescriptor<List<String>> STATIC_SUFFIXES_DESCRIPTOR = stringListProperty("staticSuffix").desc("Static variable suffixes").defaultValues("").delim(',').build();
 
-    private static final StringMultiProperty MEMBER_PREFIXES_DESCRIPTOR = new StringMultiProperty("memberPrefix",
-            "Member variable prefixes", new String[] { "" }, 6.0f, ',');
+    private static final PropertyDescriptor<List<String>> MEMBER_PREFIXES_DESCRIPTOR = stringListProperty("memberPrefix").desc("Member variable prefixes").defaultValues("").delim(',').build();
 
-    private static final StringMultiProperty MEMBER_SUFFIXES_DESCRIPTOR = new StringMultiProperty("memberSuffix",
-            "Member variable suffixes", new String[] { "" }, 7.0f, ',');
+    private static final PropertyDescriptor<List<String>> MEMBER_SUFFIXES_DESCRIPTOR = stringListProperty("memberSuffix").desc("Member variable suffixes").defaultValues("").delim(',').build();
 
-    private static final StringMultiProperty LOCAL_PREFIXES_DESCRIPTOR = new StringMultiProperty("localPrefix",
-            "Local variable prefixes", new String[] { "" }, 8.0f, ',');
+    private static final PropertyDescriptor<List<String>> LOCAL_PREFIXES_DESCRIPTOR = stringListProperty("localPrefix").desc("Local variable prefixes").defaultValues("").delim(',').build();
 
-    private static final StringMultiProperty LOCAL_SUFFIXES_DESCRIPTOR = new StringMultiProperty("localSuffix",
-            "Local variable suffixes", new String[] { "" }, 9.0f, ',');
+    private static final PropertyDescriptor<List<String>> LOCAL_SUFFIXES_DESCRIPTOR = stringListProperty("localSuffix").desc("Local variable suffixes").defaultValues("").delim(',').build();
 
-    private static final StringMultiProperty PARAMETER_PREFIXES_DESCRIPTOR = new StringMultiProperty("parameterPrefix",
-            "Method parameter variable prefixes", new String[] { "" }, 10.0f, ',');
+    private static final PropertyDescriptor<List<String>> PARAMETER_PREFIXES_DESCRIPTOR = stringListProperty("parameterPrefix").desc("Method parameter variable prefixes").defaultValues("").delim(',').build();
 
-    private static final StringMultiProperty PARAMETER_SUFFIXES_DESCRIPTOR = new StringMultiProperty("parameterSuffix",
-            "Method parameter variable suffixes", new String[] { "" }, 11.0f, ',');
+    private static final PropertyDescriptor<List<String>> PARAMETER_SUFFIXES_DESCRIPTOR = stringListProperty("parameterSuffix").desc("Method parameter variable suffixes").defaultValues("").delim(',').build();
 
     public VariableNamingConventionsRule() {
         definePropertyDescriptor(CHECK_MEMBERS_DESCRIPTOR);
         definePropertyDescriptor(CHECK_LOCALS_DESCRIPTOR);
         definePropertyDescriptor(CHECK_PARAMETERS_DESCRIPTOR);
-        definePropertyDescriptor(STATIC_PREFIXES_DESCRIPTOR);
-        definePropertyDescriptor(STATIC_SUFFIXES_DESCRIPTOR);
-        definePropertyDescriptor(MEMBER_PREFIXES_DESCRIPTOR);
-        definePropertyDescriptor(MEMBER_SUFFIXES_DESCRIPTOR);
-        definePropertyDescriptor(LOCAL_PREFIXES_DESCRIPTOR);
-        definePropertyDescriptor(LOCAL_SUFFIXES_DESCRIPTOR);
-        definePropertyDescriptor(PARAMETER_PREFIXES_DESCRIPTOR);
-        definePropertyDescriptor(PARAMETER_SUFFIXES_DESCRIPTOR);
+        for (PropertyDescriptor<List<String>> property : suffixOrPrefixProperties()) {
+            definePropertyDescriptor(property);
+        }
 
         setProperty(CODECLIMATE_CATEGORIES, "Style");
         // Note: x10 as Apex has not automatic refactoring
         setProperty(CODECLIMATE_REMEDIATION_MULTIPLIER, 5);
         setProperty(CODECLIMATE_BLOCK_HIGHLIGHTING, false);
+    }
+
+    private static List<PropertyDescriptor<List<String>>> suffixOrPrefixProperties() {
+        List<PropertyDescriptor<List<String>>> res = new ArrayList<>();
+        res.add(STATIC_PREFIXES_DESCRIPTOR);
+        res.add(STATIC_SUFFIXES_DESCRIPTOR);
+        res.add(MEMBER_PREFIXES_DESCRIPTOR);
+        res.add(MEMBER_SUFFIXES_DESCRIPTOR);
+        res.add(LOCAL_PREFIXES_DESCRIPTOR);
+        res.add(LOCAL_SUFFIXES_DESCRIPTOR);
+        res.add(PARAMETER_PREFIXES_DESCRIPTOR);
+        res.add(PARAMETER_SUFFIXES_DESCRIPTOR);
+        return res;
     }
 
     @Override
@@ -209,13 +210,9 @@ public class VariableNamingConventionsRule extends AbstractApexRule {
     }
 
     public boolean hasPrefixesOrSuffixes() {
-
-        for (PropertyDescriptor<?> desc : getPropertyDescriptors()) {
-            if (desc instanceof StringMultiProperty) {
-                List<String> values = getProperty((StringMultiProperty) desc);
-                if (!values.isEmpty()) {
-                    return true;
-                }
+        for (PropertyDescriptor<List<String>> desc : suffixOrPrefixProperties()) {
+            if (!getProperty(desc).isEmpty()) {
+                return true;
             }
         }
         return false;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/Rule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/Rule.java
@@ -28,6 +28,7 @@ public interface Rule extends PropertySource {
      * The property descriptor to universally suppress violations with messages
      * matching a regular expression.
      */
+    // TODO 7.0.0 use PropertyDescriptor<Pattern>
     StringProperty VIOLATION_SUPPRESS_REGEX_DESCRIPTOR = new StringProperty("violationSuppressRegex",
             "Suppress violations with messages matching a regular expression", null, Integer.MAX_VALUE - 1);
 
@@ -35,6 +36,7 @@ public interface Rule extends PropertySource {
      * Name of the property to universally suppress violations on nodes which
      * match a given relative XPath expression.
      */
+    // TODO 7.0.0 use PropertyDescriptor<String>
     StringProperty VIOLATION_SUPPRESS_XPATH_DESCRIPTOR = new StringProperty("violationSuppressXPath",
             "Suppress violations on nodes which match a given relative XPath expression.", null, Integer.MAX_VALUE - 2);
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/XPathRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/XPathRule.java
@@ -30,6 +30,7 @@ import net.sourceforge.pmd.properties.StringProperty;
  */
 public class XPathRule extends AbstractRule {
 
+    // TODO 7.0.0 use PropertyDescriptor<String>
     public static final StringProperty XPATH_DESCRIPTOR = StringProperty.named("xpath")
             .desc("XPath expression")
             .defaultValue("")

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyBuilder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyBuilder.java
@@ -363,7 +363,7 @@ public abstract class PropertyBuilder<B extends PropertyBuilder<B, T>, T> {
         private final ValueParser<V> parser;
         private final Supplier<C> emptyCollSupplier;
         private final Class<V> type;
-        private char multiValueDelimiter;
+        private char multiValueDelimiter = MultiValuePropertyDescriptor.DEFAULT_DELIMITER;
 
 
         /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyBuilder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyBuilder.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.properties;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -150,7 +151,7 @@ public abstract class PropertyBuilder<B extends PropertyBuilder<B, T>, T> {
 
     /**
      * Specify a default value. Some subclasses provide convenient
-     * related methods, see e.g. {@link GenericCollectionPropertyBuilder#defaultValues(Object[])}.
+     * related methods, see e.g. {@link GenericCollectionPropertyBuilder#defaultValues(Object, Object[])}.
      * Using the null value is prohibited.
      *
      * <p>Calling this method is required for {@link #build()} to succeed.
@@ -345,8 +346,8 @@ public abstract class PropertyBuilder<B extends PropertyBuilder<B, T>, T> {
 
     /**
      * Generic builder for a collection-valued property.
-     * This class adds overloads to {@linkplain #defaultValues(Object[])}
-     * to make its use more flexible.
+     * This class adds methods related to {@link #defaultValue(Collection)}
+     * to make its use more flexible. See e.g. {@link #defaultValues(Object, Object[])}.
      *
      * <p>Note: this is designed to support arbitrary collections.
      * Pre-7.0.0, the only collections available from the {@link PropertyFactory}
@@ -401,15 +402,30 @@ public abstract class PropertyBuilder<B extends PropertyBuilder<B, T>, T> {
 
 
         /**
-         * Specify default values.
+         * Specify default values. To specify an empty
+         * default value, use {@link #emptyDefaultValue()}.
          *
-         * @param val List of values
+         * @param head First value
+         * @param tail Rest of the values
          *
          * @return The same builder
          */
         @SuppressWarnings("unchecked")
-        public GenericCollectionPropertyBuilder<V, C> defaultValues(V... val) {
-            return super.defaultValue(getDefaultValue(Arrays.asList(val)));
+        public GenericCollectionPropertyBuilder<V, C> defaultValues(V head, V... tail) {
+            List<V> tmp = new ArrayList<>(tail.length + 1);
+            tmp.add(head);
+            tmp.addAll(Arrays.asList(tail));
+            return super.defaultValue(getDefaultValue(tmp));
+        }
+
+
+        /**
+         * Specify that the default value is an empty collection.
+         *
+         * @return The same builder
+         */
+        public GenericCollectionPropertyBuilder<V, C> emptyDefaultValue() {
+            return super.defaultValue(getDefaultValue(Collections.<V>emptyList()));
         }
 
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
@@ -164,7 +164,7 @@ public final class PropertyFactory {
 
     /**
      * Returns a builder for a string property. The property descriptor
-     * will accept any string for now, and performs no expansion of escape
+     * will accept any string, and performs no expansion of escape
      * sequences (e.g. {@code \n} in the XML will be represented as the
      * character sequence '\' 'n' and not the line-feed character '\n'). This
      * behaviour could be changed with PMD 7.0.0.
@@ -180,14 +180,14 @@ public final class PropertyFactory {
 
     /**
      * Returns a builder for a property having as value a list of strings. The
-     * format of the individual items is the same as for {@linkplain #stringProperty(String)} stringProperty}.
+     * format of the individual items is the same as for {@linkplain #stringProperty(String) stringProperty}.
      *
      * @param name Name of the property to build
      *
      * @return A new builder
      */
     public static GenericCollectionPropertyBuilder<String, List<String>> stringListProperty(String name) {
-        return stringProperty(name).toList().delim(MultiValuePropertyDescriptor.DEFAULT_DELIMITER);
+        return stringProperty(name).toList();
     }
 
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
@@ -166,8 +166,8 @@ public final class PropertyFactory {
      * Returns a builder for a string property. The property descriptor
      * will accept any string for now, and performs no expansion of escape
      * sequences (e.g. {@code \n} in the XML will be represented as the
-     * character sequence '\' 'n' and not the character '\u000A'). This
-     * behaviour will probably be changed with PMD 7.0.0.
+     * character sequence '\' 'n' and not the line-feed character '\n'). This
+     * behaviour could be changed with PMD 7.0.0.
      *
      * @param name Name of the property to build
      *

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
@@ -162,11 +162,30 @@ public final class PropertyFactory {
     }
 
 
+    /**
+     * Returns a builder for a string property. The property descriptor
+     * will accept any string for now, and performs no expansion of escape
+     * sequences (e.g. {@code \n} in the XML will be represented as the
+     * character sequence '\' 'n' and not the character '\u000A'). This
+     * behaviour will probably be changed with PMD 7.0.0.
+     *
+     * @param name Name of the property to build
+     *
+     * @return A new builder
+     */
     public static GenericPropertyBuilder<String> stringProperty(String name) {
         return new GenericPropertyBuilder<>(name, ValueParserConstants.STRING_PARSER, String.class);
     }
 
 
+    /**
+     * Returns a builder for a property having as value a list of strings. The
+     * format of the individual items is the same as for {@linkplain #stringProperty(String)} stringProperty}.
+     *
+     * @param name Name of the property to build
+     *
+     * @return A new builder
+     */
     public static GenericCollectionPropertyBuilder<String, List<String>> stringListProperty(String name) {
         return stringProperty(name).toList().delim(MultiValuePropertyDescriptor.DEFAULT_DELIMITER);
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/StringMultiProperty.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/StringMultiProperty.java
@@ -19,7 +19,10 @@ import net.sourceforge.pmd.properties.builders.PropertyDescriptorBuilderConversi
  *
  * @author Brian Remedios
  * @version Refactored June 2017 (6.0.0)
+ * @deprecated Use a {@code PropertyDescriptor<List<String>>}. A builder is available from {@link PropertyFactory#stringListProperty(String)}.
+ * This class will be removed in 7.0.0.
  */
+@Deprecated
 public final class StringMultiProperty extends AbstractMultiValueProperty<String> {
 
 
@@ -34,7 +37,9 @@ public final class StringMultiProperty extends AbstractMultiValueProperty<String
      *
      * @throws IllegalArgumentException if a default value contains the delimiter
      * @throws NullPointerException     if the defaults array is null
+     * @deprecated Use {@link PropertyFactory#stringListProperty(String)}
      */
+    @Deprecated
     public StringMultiProperty(String theName, String theDescription, String[] defaultValues, float theUIOrder,
                                char delimiter) {
         this(theName, theDescription, Arrays.asList(defaultValues), theUIOrder, delimiter);
@@ -52,7 +57,9 @@ public final class StringMultiProperty extends AbstractMultiValueProperty<String
      *
      * @throws IllegalArgumentException if a default value contains the delimiter
      * @throws NullPointerException     if the defaults array is null
+     * @deprecated Use {@link PropertyFactory#stringListProperty(String)}
      */
+    @Deprecated
     public StringMultiProperty(String theName, String theDescription, List<String> defaultValues, float theUIOrder,
                                char delimiter) {
         this(theName, theDescription, defaultValues, theUIOrder, delimiter, false);
@@ -147,11 +154,19 @@ public final class StringMultiProperty extends AbstractMultiValueProperty<String
     }
 
 
+    /**
+     * @deprecated Use {@link PropertyFactory#stringListProperty(String)}
+     */
+    @Deprecated
     public static StringMultiPBuilder named(String name) {
         return new StringMultiPBuilder(name);
     }
 
 
+    /**
+     * @deprecated Use {@link PropertyFactory#stringListProperty(String)}
+     */
+    @Deprecated
     public static final class StringMultiPBuilder extends MultiValuePropertyBuilder<String, StringMultiPBuilder> {
         private StringMultiPBuilder(String name) {
             super(name);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/StringProperty.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/StringProperty.java
@@ -13,7 +13,10 @@ import net.sourceforge.pmd.properties.builders.SingleValuePropertyBuilder;
  *
  * @author Brian Remedios
  * @version Refactored June 2017 (6.0.0)
+ * @deprecated Use a {@code PropertyDescriptor<String>}. A builder is available from {@link PropertyFactory#stringProperty(String)}.
+ * This class will be removed in 7.0.0.
  */
+@Deprecated
 public final class StringProperty extends AbstractSingleValueProperty<String> {
 
     /**
@@ -23,7 +26,10 @@ public final class StringProperty extends AbstractSingleValueProperty<String> {
      * @param theDescription Description
      * @param defaultValue   Default value
      * @param theUIOrder     UI order
+     *
+     * @deprecated Use {@link PropertyFactory#stringProperty(String)}
      */
+    @Deprecated
     public StringProperty(String theName, String theDescription, String defaultValue, float theUIOrder) {
         this(theName, theDescription, defaultValue, theUIOrder, false);
     }
@@ -31,7 +37,7 @@ public final class StringProperty extends AbstractSingleValueProperty<String> {
 
     /** Master constructor. */
     private StringProperty(String theName, String theDescription, String defaultValue, float theUIOrder, boolean
-        isDefinedExternally) {
+            isDefinedExternally) {
         super(theName, theDescription, defaultValue, theUIOrder, isDefinedExternally);
     }
 
@@ -58,11 +64,19 @@ public final class StringProperty extends AbstractSingleValueProperty<String> {
     }
 
 
+    /**
+     * @deprecated Use {@link PropertyFactory#stringProperty(String)}
+     */
+    @Deprecated
     public static StringPBuilder named(String name) {
         return new StringPBuilder(name);
     }
 
 
+    /**
+     * @deprecated Use {@link PropertyFactory#stringProperty(String)}
+     */
+    @Deprecated
     public static final class StringPBuilder extends SingleValuePropertyBuilder<String, StringPBuilder> {
         private StringPBuilder(String name) {
             super(name);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/HTMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/HTMLRenderer.java
@@ -28,6 +28,7 @@ public class HTMLRenderer extends AbstractIncrementingRenderer {
 
     public static final String NAME = "html";
 
+    // TODO 7.0.0 use PropertyDescriptor<String>
     public static final StringProperty LINE_PREFIX = new StringProperty("linePrefix",
             "Prefix for line number anchor in the source file.", null, 1);
     public static final StringProperty LINK_PREFIX = new StringProperty("linkPrefix", "Path to HTML source.", null, 0);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/IDEAJRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/IDEAJRenderer.java
@@ -25,6 +25,7 @@ public class IDEAJRenderer extends AbstractIncrementingRenderer {
 
     public static final String NAME = "ideaj";
 
+    // TODO 7.0.0 use PropertyDescriptor<String>
     public static final StringProperty FILE_NAME = new StringProperty("fileName", "File name.", "", 0);
     public static final StringProperty SOURCE_PATH = new StringProperty("sourcePath", "Source path.", "", 1);
     public static final StringProperty CLASS_AND_METHOD_NAME = new StringProperty("classAndMethodName",

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextColorRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextColorRenderer.java
@@ -53,6 +53,7 @@ public class TextColorRenderer extends AbstractAccumulatingRenderer {
 
     public static final String NAME = "textcolor";
 
+    // What? TODO 7.0.0 Use a boolean property
     public static final StringProperty COLOR = new StringProperty("color",
             "Enables colors with anything other than 'false' or '0'.", "yes", 0);
     private static final String SYSTEM_PROPERTY_PMD_COLOR = "pmd.color";

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XMLRenderer.java
@@ -24,6 +24,7 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
 
     public static final String NAME = "xml";
 
+    // TODO 7.0.0 use PropertyDescriptor<String> or something more specialized
     public static final StringProperty ENCODING = new StringProperty("encoding",
             "XML encoding format, defaults to UTF-8.", "UTF-8", 0);
     private boolean useUTF8 = false;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XSLTRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XSLTRenderer.java
@@ -38,6 +38,7 @@ public class XSLTRenderer extends XMLRenderer {
 
     public static final String NAME = "xslt";
 
+    // TODO 7.0.0 use PropertyDescriptor<Optional<File>>
     public static final StringProperty XSLT_FILENAME = new StringProperty("xsltFilename", "The XSLT file name.", null,
             0);
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/YAHTMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/YAHTMLRenderer.java
@@ -26,8 +26,7 @@ import net.sourceforge.pmd.properties.StringProperty;
 public class YAHTMLRenderer extends AbstractAccumulatingRenderer {
 
     public static final String NAME = "yahtml";
-    // TODO 7.0.0 use PropertyDescriptor<Optional<File>>
-    // Why does this one define an output dir property, shouldn't this be available to all renderers?
+    // TODO 7.0.0 use PropertyDescriptor<Optional<File>> with a constraint that the file is an existing directory
     public static final StringProperty OUTPUT_DIR = new StringProperty("outputDir", "Output directory.", null, 0);
 
     private SortedMap<String, ReportNode> reportNodesByPackage = new TreeMap<>();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/YAHTMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/YAHTMLRenderer.java
@@ -26,6 +26,8 @@ import net.sourceforge.pmd.properties.StringProperty;
 public class YAHTMLRenderer extends AbstractAccumulatingRenderer {
 
     public static final String NAME = "yahtml";
+    // TODO 7.0.0 use PropertyDescriptor<Optional<File>>
+    // Why does this one define an output dir property, shouldn't this be available to all renderers?
     public static final StringProperty OUTPUT_DIR = new StringProperty("outputDir", "Output directory.", null, 0);
 
     private SortedMap<String, ReportNode> reportNodesByPackage = new TreeMap<>();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractIgnoredAnnotationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractIgnoredAnnotationRule.java
@@ -4,18 +4,21 @@
 
 package net.sourceforge.pmd.lang.java.rule;
 
+import static net.sourceforge.pmd.properties.PropertyFactory.stringListProperty;
+
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 
 import net.sourceforge.pmd.lang.java.ast.Annotatable;
-import net.sourceforge.pmd.properties.StringMultiProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
 
 public abstract class AbstractIgnoredAnnotationRule extends AbstractJavaRule {
 
-    private final StringMultiProperty ignoredAnnotationsDescriptor
-        = StringMultiProperty.named("ignoredAnnotations")
+    private final PropertyDescriptor<List<String>> ignoredAnnotationsDescriptor
+        = stringListProperty("ignoredAnnotations")
         .desc("Fully qualified names of the annotation types that should be ignored by this rule")
-        .defaultValues(defaultSuppressionAnnotations())
+        .defaultValue(defaultSuppressionAnnotations())
         .build();
 
     protected Collection<String> defaultSuppressionAnnotations() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/GenericLiteralCheckerRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/GenericLiteralCheckerRule.java
@@ -24,6 +24,7 @@ public class GenericLiteralCheckerRule extends AbstractJavaRule {
 
     private static final String PROPERTY_NAME = "regexPattern";
 
+    // The rule is unused
     private static final StringProperty REGEX_PROPERTY = new StringProperty(PROPERTY_NAME, "Regular expression", "",
             1.0f);
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
+import static net.sourceforge.pmd.properties.PropertyFactory.stringListProperty;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -24,29 +26,29 @@ import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
 import net.sourceforge.pmd.lang.java.ast.ASTStatementExpression;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
-import net.sourceforge.pmd.properties.StringMultiProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
 
 /**
  * Check that log.debug, log.trace, log.error, etc... statements are guarded by
  * some test expression on log.isDebugEnabled() or log.isTraceEnabled().
- * 
+ *
  * @author Romain Pelisse - &lt;belaran@gmail.com&gt;
  * @author Heiko Rupp - &lt;hwr@pilhuhn.de&gt;
  * @author Tammo van Lessen - provided original XPath expression
- * 
+ *
  */
 public class GuardLogStatementRule extends AbstractJavaRule implements Rule {
     /*
      * guard methods and log levels:
-     * 
+     *
      * log4j + apache commons logging (jakarta):
      * trace -> isTraceEnabled
      * debug -> isDebugEnabled
      * info  -> isInfoEnabled
      * warn  -> isWarnEnabled
      * error -> isErrorEnabled
-     * 
-     * 
+     *
+     *
      * java util:
      * log(Level.FINE) ->  isLoggable
      * finest ->  isLoggable
@@ -56,14 +58,19 @@ public class GuardLogStatementRule extends AbstractJavaRule implements Rule {
      * warning -> isLoggable
      * severe  -> isLoggable
      */
-    private static final StringMultiProperty LOG_LEVELS = new StringMultiProperty("logLevels", "LogLevels to guard",
-            new String[] {"trace", "debug", "info", "warn", "error",
-                "log", "finest", "finer", "fine", "info", "warning", "severe", }, 1.0f, ',');
+    private static final PropertyDescriptor<List<String>> LOG_LEVELS =
+            stringListProperty("logLevels")
+                    .desc("LogLevels to guard")
+                    .defaultValues("trace", "debug", "info", "warn", "error",
+                                   "log", "finest", "finer", "fine", "info", "warning", "severe")
+                    .delim(',')
+                    .build();
 
-    private static final StringMultiProperty GUARD_METHODS = new StringMultiProperty("guardsMethods",
-            "method use to guard the log statement",
-            new String[] {"isTraceEnabled", "isDebugEnabled", "isInfoEnabled", "isWarnEnabled", "isErrorEnabled",
-                "isLoggable", }, 2.0f, ',');
+    private static final PropertyDescriptor<List<String>> GUARD_METHODS =
+            stringListProperty("guardsMethods")
+                    .desc("Method use to guard the log statement")
+                    .defaultValues("isTraceEnabled", "isDebugEnabled", "isInfoEnabled", "isWarnEnabled", "isErrorEnabled", "isLoggable")
+                    .delim(',').build();
 
     private Map<String, String> guardStmtByLogLevel = new HashMap<>(12);
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LinguisticNamingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LinguisticNamingRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
+import static net.sourceforge.pmd.properties.PropertyFactory.stringListProperty;
+
 import java.util.List;
 import java.util.Locale;
 
@@ -18,7 +20,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.typeresolution.TypeHelper;
 import net.sourceforge.pmd.properties.BooleanProperty;
-import net.sourceforge.pmd.properties.StringMultiProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
 
 public class LinguisticNamingRule extends AbstractJavaRule {
     private static final BooleanProperty CHECK_BOOLEAN_METHODS = BooleanProperty.named("checkBooleanMethod")
@@ -35,20 +37,25 @@ public class LinguisticNamingRule extends AbstractJavaRule {
             .defaultValue(false)
             .desc("Check return type of methods which contain the configured infix in their name (see transformMethodNames property).")
             .uiOrder(4.0f).build();
-    private static final StringMultiProperty BOOLEAN_METHOD_PREFIXES_PROPERTY = StringMultiProperty
-            .named("booleanMethodPrefixes").defaultValues("is", "has", "can", "have", "will", "should")
-            .desc("The prefixes of methods that return boolean.").uiOrder(5.0f).build();
-    private static final StringMultiProperty TRANSFORM_METHOD_NAMES_PROPERTY = StringMultiProperty
-            .named("transformMethodNames").defaultValues("to", "as")
-            .desc("The prefixes and infixes that indicate a transform method.").uiOrder(6.0f).build();
 
     private static final BooleanProperty CHECK_FIELDS = BooleanProperty.named("checkFields").defaultValue(true)
             .desc("Check field names and types for inconsistent naming.").uiOrder(7.0f).build();
     private static final BooleanProperty CHECK_VARIABLES = BooleanProperty.named("checkVariables").defaultValue(true)
             .desc("Check local variable names and types for inconsistent naming.").uiOrder(8.0f).build();
-    private static final StringMultiProperty BOOLEAN_FIELD_PREFIXES_PROPERTY = StringMultiProperty
-            .named("booleanFieldPrefixes").defaultValues("is", "has", "can", "have", "will", "should")
-            .desc("The prefixes of fields and variables that indicate boolean.").uiOrder(9.0f).build();
+
+    private static final PropertyDescriptor<List<String>> BOOLEAN_METHOD_PREFIXES_PROPERTY =
+            stringListProperty("booleanMethodPrefixes")
+                    .desc("The prefixes of methods that return boolean.")
+                    .defaultValues("is", "has", "can", "have", "will", "should").build();
+    private static final PropertyDescriptor<List<String>> TRANSFORM_METHOD_NAMES_PROPERTY =
+            stringListProperty("transformMethodNames")
+                    .desc("The prefixes and infixes that indicate a transform method.")
+                    .defaultValues("to", "as").build();
+    private static final PropertyDescriptor<List<String>> BOOLEAN_FIELD_PREFIXES_PROPERTY =
+            stringListProperty("booleanFieldPrefixes")
+                    .desc("The prefixes of fields and variables that indicate boolean.")
+                    .defaultValues("is", "has", "can", "have", "will", "should").build();
+
 
     public LinguisticNamingRule() {
         definePropertyDescriptor(CHECK_BOOLEAN_METHODS);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/VariableNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/VariableNamingConventionsRule.java
@@ -39,6 +39,7 @@ public class VariableNamingConventionsRule extends AbstractJavaRule {
     private List<String> parameterPrefixes;
     private List<String> parameterSuffixes;
 
+    // the rule is deprecated and will be removed so its properties won't be converted
     private static final BooleanProperty CHECK_MEMBERS_DESCRIPTOR = new BooleanProperty("checkMembers",
             "Check member variables", true, 1.0f);
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/GenericClassCounterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/GenericClassCounterRule.java
@@ -51,6 +51,7 @@ import net.sourceforge.pmd.properties.StringProperty;
  */
 public class GenericClassCounterRule extends AbstractJavaRule {
 
+    // Class is unused
     private static final StringMultiProperty NAME_MATCH_DESCRIPTOR = new StringMultiProperty("nameMatch",
             "A series of regex, separated by ',' to match on the classname", new String[] { "" }, 1.0f, ',');
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/GenericClassCounterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/GenericClassCounterRule.java
@@ -51,7 +51,7 @@ import net.sourceforge.pmd.properties.StringProperty;
  */
 public class GenericClassCounterRule extends AbstractJavaRule {
 
-    // Class is unused
+    // Class is unused, properties won't be converted
     private static final StringMultiProperty NAME_MATCH_DESCRIPTOR = new StringMultiProperty("nameMatch",
             "A series of regex, separated by ',' to match on the classname", new String[] { "" }, 1.0f, ',');
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LoosePackageCouplingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LoosePackageCouplingRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.design;
 
+import static net.sourceforge.pmd.properties.PropertyFactory.stringListProperty;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -12,6 +14,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTPackageDeclaration;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertySource;
 import net.sourceforge.pmd.properties.StringMultiProperty;
 
@@ -36,11 +39,11 @@ import net.sourceforge.pmd.properties.StringMultiProperty;
  */
 public class LoosePackageCouplingRule extends AbstractJavaRule {
 
-    public static final StringMultiProperty PACKAGES_DESCRIPTOR = new StringMultiProperty("packages",
-            "Restricted packages", new String[] {}, 1.0f, ',');
+    public static final PropertyDescriptor<List<String>> PACKAGES_DESCRIPTOR =
+            stringListProperty("packages").desc("Restricted packages").emptyDefaultValue().delim(',').build();
 
-    public static final StringMultiProperty CLASSES_DESCRIPTOR = new StringMultiProperty("classes", "Allowed classes",
-            new String[] {}, 2.0f, ',');
+    public static final PropertyDescriptor<List<String>> CLASSES_DESCRIPTOR =
+            stringListProperty("classes").desc("Allowed classes").emptyDefaultValue().delim(',').build();
 
     // The package of this source file
     private String thisPackage;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentContentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentContentRule.java
@@ -36,9 +36,6 @@ public class CommentContentRule extends AbstractCommentRule {
     private List<String> originalBadWords;
     private List<String> currentBadWords;
 
-    // FIXME need some better defaults (or none?)
-    private static final String[] BAD_WORDS = {"idiot", "jerk" };
-
     // ignored when property above == True
     public static final BooleanProperty CASE_SENSITIVE_DESCRIPTOR = new BooleanProperty("caseSensitive",
             "Case sensitive", false, 2.0f);
@@ -70,6 +67,10 @@ public class CommentContentRule extends AbstractCommentRule {
         if (caseSensitive) {
             currentBadWords = originalBadWords;
         } else {
+            // TODO this only accounts for the original word
+            // + the all uppercase version
+            // but not eg a capitalized version
+            // (hardly a case insensitive comparison)
             currentBadWords = new ArrayList<>();
             for (String badWord : originalBadWords) {
                 currentBadWords.add(badWord.toUpperCase(Locale.ROOT));

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentContentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentContentRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.documentation;
 
+import static net.sourceforge.pmd.properties.PropertyFactory.stringListProperty;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -20,7 +22,6 @@ import net.sourceforge.pmd.lang.java.ast.Comment;
 import net.sourceforge.pmd.properties.BooleanProperty;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertySource;
-import net.sourceforge.pmd.properties.StringMultiProperty;
 
 /**
  * A rule that checks for illegal words in the comment text.
@@ -42,8 +43,10 @@ public class CommentContentRule extends AbstractCommentRule {
     public static final BooleanProperty CASE_SENSITIVE_DESCRIPTOR = new BooleanProperty("caseSensitive",
             "Case sensitive", false, 2.0f);
 
-    public static final StringMultiProperty DISSALLOWED_TERMS_DESCRIPTOR = new StringMultiProperty("disallowedTerms",
-            "Illegal terms or phrases", BAD_WORDS, 3.0f, '|');
+    public static final PropertyDescriptor<List<String>> DISSALLOWED_TERMS_DESCRIPTOR =
+            stringListProperty("disallowedTerms")
+                    .desc("Illegal terms or phrases")
+                    .defaultValues("idiot", "jerk").build(); // TODO make blank property? or add more defaults?
 
     private static final Set<PropertyDescriptor<?>> NON_REGEX_PROPERTIES;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/HeaderCommentsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/HeaderCommentsRule.java
@@ -15,6 +15,8 @@ import net.sourceforge.pmd.properties.StringMultiProperty;
  */
 public class HeaderCommentsRule extends AbstractCommentRule {
 
+    // Rule is not used and not implemented, properties won't be converted
+
     private static final String[] REQUIRED_WORKDS = new String[] { "copyright" };
     private static final String[] REQUIRED_TAGS = new String[] { "author", "version" };
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDuplicateLiteralsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDuplicateLiteralsRule.java
@@ -54,7 +54,7 @@ public class AvoidDuplicateLiteralsRule extends AbstractJavaRule {
     // TODO 7.0.0:
     // EXCEPTION_LIST_DESCRIPTOR -> PropertyDescriptor<Set<String>>
     // delete SEPARATOR_DESCRIPTOR, EXCEPTION_FILE_DESCRIPTOR
-    // Try hard to convert the properties to the seq syntax
+    // Try hard to convert the properties to the seq syntax, using the separator descriptor
 
     // TODO We use the old builders here, bc of the null default value
     public static final StringProperty EXCEPTION_LIST_DESCRIPTOR
@@ -65,9 +65,8 @@ public class AvoidDuplicateLiteralsRule extends AbstractJavaRule {
                             .defaultValue(null)
                             .build();
 
-    @Deprecated
     public static final CharacterProperty SEPARATOR_DESCRIPTOR = new CharacterProperty("separator",
-            "deprecated!(Avoid setting this property, use the comma) Ignore list separator", ',', 4.0f);
+            "Ignore list separator", ',', 4.0f);
 
     @Deprecated
     public static final FileProperty EXCEPTION_FILE_DESCRIPTOR = new FileProperty("exceptionfile",

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/BeanMembersShouldSerializeRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/BeanMembersShouldSerializeRule.java
@@ -4,11 +4,14 @@
 
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 
+import static net.sourceforge.pmd.properties.PropertyFactory.stringProperty;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
 
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
@@ -23,14 +26,14 @@ import net.sourceforge.pmd.lang.java.symboltable.ClassScope;
 import net.sourceforge.pmd.lang.java.symboltable.MethodNameDeclaration;
 import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
 import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
-import net.sourceforge.pmd.properties.StringProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
 
 public class BeanMembersShouldSerializeRule extends AbstractJavaRule {
 
     private String prefixProperty;
 
-    private static final StringProperty PREFIX_DESCRIPTOR = new StringProperty("prefix",
-            "A variable prefix to skip, i.e., m_", "", 1.0f);
+    private static final PropertyDescriptor<String> PREFIX_DESCRIPTOR = stringProperty("prefix").desc("A variable prefix to skip, i.e., m_").defaultValue("").build();
+
 
     public BeanMembersShouldSerializeRule() {
         definePropertyDescriptor(PREFIX_DESCRIPTOR);
@@ -81,8 +84,7 @@ public class BeanMembersShouldSerializeRule extends AbstractJavaRule {
             if (entry.getValue().isEmpty() || accessNodeParent.isTransient() || accessNodeParent.isStatic()) {
                 continue;
             }
-            String varName = trimIfPrefix(decl.getImage());
-            varName = varName.substring(0, 1).toUpperCase(Locale.ROOT) + varName.substring(1, varName.length());
+            String varName = StringUtils.capitalize(trimIfPrefix(decl.getImage()));
             boolean hasGetMethod = Arrays.binarySearch(methNameArray, "get" + varName) >= 0
                     || Arrays.binarySearch(methNameArray, "is" + varName) >= 0;
             boolean hasSetMethod = Arrays.binarySearch(methNameArray, "set" + varName) >= 0;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 
+import static net.sourceforge.pmd.properties.PropertyFactory.stringListProperty;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -34,12 +36,12 @@ import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableInitializer;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.properties.BooleanProperty;
-import net.sourceforge.pmd.properties.StringMultiProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
 
 /**
  * Makes sure you close your database connections. It does this by looking for
  * code patterned like this:
- * 
+ *
  * <pre>
  *  Connection c = X;
  *  try {
@@ -48,7 +50,7 @@ import net.sourceforge.pmd.properties.StringMultiProperty;
  *   c.close();
  *  }
  * </pre>
- * 
+ *
  *  @author original author unknown
  *  @author Contribution from Pierre Mathien
  */
@@ -58,11 +60,17 @@ public class CloseResourceRule extends AbstractJavaRule {
     private Set<String> simpleTypes = new HashSet<>();
 
     private Set<String> closeTargets = new HashSet<>();
-    private static final StringMultiProperty CLOSE_TARGETS_DESCRIPTOR = new StringMultiProperty("closeTargets",
-            "Methods which may close this resource", new String[] {}, 1.0f, ',');
+    private static final PropertyDescriptor<List<String>> CLOSE_TARGETS_DESCRIPTOR =
+            stringListProperty("closeTargets")
+                           .desc("Methods which may close this resource")
+                           .emptyDefaultValue()
+                           .delim(',').build();
 
-    private static final StringMultiProperty TYPES_DESCRIPTOR = new StringMultiProperty("types", "Affected types",
-            new String[] { "java.sql.Connection", "java.sql.Statement", "java.sql.ResultSet" }, 2.0f, ',');
+    private static final PropertyDescriptor<List<String>> TYPES_DESCRIPTOR =
+            stringListProperty("types")
+                    .desc("Affected types")
+                    .defaultValues("java.sql.Connection", "java.sql.Statement", "java.sql.ResultSet")
+                    .delim(',').build();
 
     private static final BooleanProperty USE_CLOSE_AS_DEFAULT_TARGET = new BooleanProperty("closeAsDefaultTarget",
             "Consider 'close' as a target by default", true, 3.0f);

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -320,14 +320,11 @@ BigDecimal bd = new BigDecimal(12);          // preferred approach, ok for integ
 
     <rule name="AvoidDuplicateLiterals"
           since="1.0"
-          message="The String literal {0} appears {1} times in this file"
+          message="The String literal {0} appears {1} times in this file; the first occurrence is on line {2}"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.AvoidDuplicateLiteralsRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#avoidduplicateliterals">
         <description>
-            Code containing duplicate String literals can usually be improved by declaring the String as a constant field.
-
-            The minimum number of occurrences needed to report a violation is configurable via a property.
-            Exceptions can also be configured via the property `ignoredImages`.
+Code containing duplicate String literals can usually be improved by declaring the String as a constant field.
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -320,11 +320,14 @@ BigDecimal bd = new BigDecimal(12);          // preferred approach, ok for integ
 
     <rule name="AvoidDuplicateLiterals"
           since="1.0"
-          message="The String literal {0} appears {1} times in this file; the first occurrence is on line {2}"
+          message="The String literal {0} appears {1} times in this file"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.AvoidDuplicateLiteralsRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#avoidduplicateliterals">
         <description>
-Code containing duplicate String literals can usually be improved by declaring the String as a constant field.
+            Code containing duplicate String literals can usually be improved by declaring the String as a constant field.
+
+            The minimum number of occurrences needed to report a violation is configurable via a property.
+            Exceptions can also be configured via the property `ignoredImages`.
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidDuplicateLiterals.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidDuplicateLiterals.xml
@@ -173,7 +173,7 @@ public class Foo {
         <description>#1425 Invalid XML Characters in Output</description>
         <expected-problems>1</expected-problems>
         <expected-messages>
-            <message>The String literal "Tokenizer \ud801\udc1ctest" appears 4 times in this file</message>
+            <message>The String literal "Tokenizer \ud801\udc1ctest" appears 4 times in this file; the first occurrence is on line 2</message>
         </expected-messages>
         <code><![CDATA[
 public class Duplicate {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidDuplicateLiterals.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidDuplicateLiterals.xml
@@ -173,7 +173,7 @@ public class Foo {
         <description>#1425 Invalid XML Characters in Output</description>
         <expected-problems>1</expected-problems>
         <expected-messages>
-            <message>The String literal "Tokenizer \ud801\udc1ctest" appears 4 times in this file; the first occurrence is on line 2</message>
+            <message>The String literal "Tokenizer \ud801\udc1ctest" appears 4 times in this file</message>
         </expected-messages>
         <code><![CDATA[
 public class Duplicate {
@@ -185,5 +185,34 @@ public class Duplicate {
     char c\u0030 = 'a';
 }
         ]]></code>
+    </test-code>
+    <test-code>
+        <description>Test ignoredLiterals takes precedence over exceptionList</description>
+        <rule-property name="ignoredLiterals">Hodor,foo</rule-property>
+        <rule-property name="exceptionList">Howdy:foo</rule-property>
+        <rule-property name="separator">:</rule-property>
+        <rule-property name="maxDuplicateLiterals">2</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <!-- We test here that howdy is not ignored, whereas Hodor is -->
+            <message>The String literal "Howdy" appears 4 times in this file</message>
+        </expected-messages>
+        <code><![CDATA[
+            public class Foo {
+                private void bar() {
+                    buz("Howdy");
+                    buz("Howdy");
+                    buz("Howdy");
+                    buz("Howdy");
+                    buz("Hodor");
+                    buz("Hodor");
+                    buz("Hodor");
+                    buz("foo");
+                    buz("foo");
+                    buz("foo");
+                    buz("foo");
+                }
+            }
+            ]]></code>
     </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidDuplicateLiterals.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidDuplicateLiterals.xml
@@ -186,33 +186,4 @@ public class Duplicate {
 }
         ]]></code>
     </test-code>
-    <test-code>
-        <description>Test ignoredLiterals takes precedence over exceptionList</description>
-        <rule-property name="ignoredLiterals">Hodor,foo</rule-property>
-        <rule-property name="exceptionList">Howdy:foo</rule-property>
-        <rule-property name="separator">:</rule-property>
-        <rule-property name="maxDuplicateLiterals">2</rule-property>
-        <expected-problems>1</expected-problems>
-        <expected-messages>
-            <!-- We test here that howdy is not ignored, whereas Hodor is -->
-            <message>The String literal "Howdy" appears 4 times in this file</message>
-        </expected-messages>
-        <code><![CDATA[
-            public class Foo {
-                private void bar() {
-                    buz("Howdy");
-                    buz("Howdy");
-                    buz("Howdy");
-                    buz("Howdy");
-                    buz("Hodor");
-                    buz("Hodor");
-                    buz("Hodor");
-                    buz("foo");
-                    buz("foo");
-                    buz("foo");
-                    buz("foo");
-                }
-            }
-            ]]></code>
-    </test-code>
 </test-data>


### PR DESCRIPTION
Refs #1432 

Many usages cannot be replaced just yet, because they are published API. Interestingly, AvoidDuplicateLiterals tried to implement its own StringMultiProperty based on a StringProperty, which makes it really hard to refactor. I think it's better to leave it like that until 7.0.0.

There's surprisingly nearly nothing to do for #1027, and all of it will have to wait for 7.0.0.  I suppose we don't use so many regexes.