### PR TITLE
[core] Deprecate boolean properties

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -85,6 +85,9 @@ by a corresponding method on `PropertyFactory`:
     Having a separate property for floats wasn't that useful.
     * Similarly, {% jdoc props::FloatMultiProperty %} and {% jdoc props::DoubleMultiProperty %} are replaced by {% jdoc !c!:PF#doubleListProperty(java.lang.String) %}.
 
+  * {% jdoc props::BooleanProperty %} is replaced by {% jdoc !c!:PF#booleanProperty(java.lang.String) %}
+    * Its multi-valued counterpart, {% jdoc props::BooleanMultiProperty %}, is not replaced, because it doesn't have a use case.
+
   * {% jdoc props::MethodProperty %}, {% jdoc props::FileProperty %}, {% jdoc props::TypeProperty %} and their multi-valued counterparts
     are discontinued for lack of a use-case, and have no planned replacement in 7.0.0 for now.
     <!-- TODO complete that as we proceed. -->

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/VariableNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/VariableNamingConventionsRule.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.apex.rule.codestyle;
 
 import static apex.jorje.semantic.symbol.type.ModifierTypeInfos.FINAL;
 import static apex.jorje.semantic.symbol.type.ModifierTypeInfos.STATIC;
+import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
 
 import java.util.List;
 import java.util.Locale;
@@ -17,7 +18,6 @@ import net.sourceforge.pmd.lang.apex.ast.ASTUserInterface;
 import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
-import net.sourceforge.pmd.properties.BooleanProperty;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.StringMultiProperty;
 
@@ -35,14 +35,11 @@ public class VariableNamingConventionsRule extends AbstractApexRule {
     private List<String> parameterPrefixes;
     private List<String> parameterSuffixes;
 
-    private static final BooleanProperty CHECK_MEMBERS_DESCRIPTOR = new BooleanProperty("checkMembers",
-            "Check member variables", true, 1.0f);
+    private static final PropertyDescriptor<Boolean> CHECK_MEMBERS_DESCRIPTOR = booleanProperty("checkMembers").desc("Check member variables").defaultValue(true).build();
 
-    private static final BooleanProperty CHECK_LOCALS_DESCRIPTOR = new BooleanProperty("checkLocals",
-            "Check local variables", true, 2.0f);
+    private static final PropertyDescriptor<Boolean> CHECK_LOCALS_DESCRIPTOR = booleanProperty("checkLocals").desc("Check local variables").defaultValue(true).build();
 
-    private static final BooleanProperty CHECK_PARAMETERS_DESCRIPTOR = new BooleanProperty("checkParameters",
-            "Check constructor and method parameter variables", true, 3.0f);
+    private static final PropertyDescriptor<Boolean> CHECK_PARAMETERS_DESCRIPTOR = booleanProperty("checkParameters").desc("Check constructor and method parameter variables").defaultValue(true).build();
 
     private static final StringMultiProperty STATIC_PREFIXES_DESCRIPTOR = new StringMultiProperty("staticPrefix",
             "Static variable prefixes", new String[] { "" }, 4.0f, ',');

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/StdCyclomaticComplexityRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/StdCyclomaticComplexityRule.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.apex.rule.design;
 
+import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
 import static net.sourceforge.pmd.properties.constraints.NumericConstraints.inRange;
 
 import java.util.Stack;
@@ -22,7 +23,6 @@ import net.sourceforge.pmd.lang.apex.ast.ASTUserInterface;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserTrigger;
 import net.sourceforge.pmd.lang.apex.ast.ASTWhileLoopStatement;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
-import net.sourceforge.pmd.properties.BooleanProperty;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
 
@@ -47,11 +47,9 @@ public class StdCyclomaticComplexityRule extends AbstractApexRule {
                              .defaultValue(10)
                              .build();
 
-    public static final BooleanProperty SHOW_CLASSES_COMPLEXITY_DESCRIPTOR = new BooleanProperty(
-            "showClassesComplexity", "Add class average violations to the report", true, 2.0f);
+    public static final PropertyDescriptor<Boolean> SHOW_CLASSES_COMPLEXITY_DESCRIPTOR = booleanProperty("showClassesComplexity").desc("Add class average violations to the report").defaultValue(true).build();
 
-    public static final BooleanProperty SHOW_METHODS_COMPLEXITY_DESCRIPTOR = new BooleanProperty(
-            "showMethodsComplexity", "Add method average violations to the report", true, 3.0f);
+    public static final PropertyDescriptor<Boolean> SHOW_METHODS_COMPLEXITY_DESCRIPTOR = booleanProperty("showMethodsComplexity").desc("Add method average violations to the report").defaultValue(true).build();
 
     private int reportLevel;
     private boolean showClassesComplexity = true;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/BooleanMultiProperty.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/BooleanMultiProperty.java
@@ -17,7 +17,9 @@ import net.sourceforge.pmd.properties.builders.PropertyDescriptorBuilderConversi
  * Defines a property type that supports multiple Boolean values.
  *
  * @author Brian Remedios
+ * @deprecated Not useful, will be removed with 7.0.0
  */
+@Deprecated
 public final class BooleanMultiProperty extends AbstractMultiValueProperty<Boolean> {
 
 
@@ -28,7 +30,10 @@ public final class BooleanMultiProperty extends AbstractMultiValueProperty<Boole
      * @param theDescription Description
      * @param defaultValues  List of defaults
      * @param theUIOrder     UI order
+     *
+     * @deprecated Not useful, will be removed with 7.0.0
      */
+    @Deprecated
     public BooleanMultiProperty(String theName, String theDescription, Boolean[] defaultValues, float theUIOrder) {
         this(theName, theDescription, Arrays.asList(defaultValues), theUIOrder, false);
     }
@@ -48,7 +53,10 @@ public final class BooleanMultiProperty extends AbstractMultiValueProperty<Boole
      * @param theDescription Description
      * @param defaultValues  List of defaults
      * @param theUIOrder     UI order
+     *
+     * @deprecated Not useful, will be removed with 7.0.0
      */
+    @Deprecated
     public BooleanMultiProperty(String theName, String theDescription, List<Boolean> defaultValues, float theUIOrder) {
         this(theName, theDescription, defaultValues, theUIOrder, false);
     }
@@ -76,11 +84,19 @@ public final class BooleanMultiProperty extends AbstractMultiValueProperty<Boole
     }
 
 
+    /**
+     * @deprecated Not useful, will be removed with 7.0.0
+     */
+    @Deprecated
     public static BooleanMultiPBuilder named(String name) {
         return new BooleanMultiPBuilder(name);
     }
 
 
+    /**
+     * @deprecated Not useful, will be removed with 7.0.0
+     */
+    @Deprecated
     public static final class BooleanMultiPBuilder extends MultiValuePropertyBuilder<Boolean, BooleanMultiPBuilder> {
         private BooleanMultiPBuilder(String name) {
             super(name);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/BooleanProperty.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/BooleanProperty.java
@@ -15,7 +15,10 @@ import net.sourceforge.pmd.properties.builders.SingleValuePropertyBuilder;
  *
  * @author Brian Remedios
  * @version Refactored June 2017 (6.0.0)
+ * @deprecated Use a {@code PropertyDescriptor<Boolean>} instead. A builder is available from {@link PropertyFactory#booleanProperty(String)} and its overloads.
+ *             This class will be removed in 7.0.0.
  */
+@Deprecated
 public final class BooleanProperty extends AbstractSingleValueProperty<Boolean> {
 
     /**
@@ -26,8 +29,9 @@ public final class BooleanProperty extends AbstractSingleValueProperty<Boolean> 
      * @param defaultBoolStr String representing the default value.
      * @param theUIOrder     UI order
      *
-     * @deprecated will be removed in 7.0.0
+     * @deprecated Use {@link PropertyFactory#booleanProperty(String)} or its overloads.
      */
+    @Deprecated
     public BooleanProperty(String theName, String theDescription, String defaultBoolStr, float theUIOrder) {
         this(theName, theDescription, Boolean.valueOf(defaultBoolStr), theUIOrder, false);
     }
@@ -46,7 +50,10 @@ public final class BooleanProperty extends AbstractSingleValueProperty<Boolean> 
      * @param theDescription Description
      * @param defaultValue   Default value
      * @param theUIOrder     UI order
+     *
+     * @deprecated Use {@link PropertyFactory#booleanProperty(String)} or its overloads.
      */
+    @Deprecated
     public BooleanProperty(String theName, String theDescription, boolean defaultValue, float theUIOrder) {
         this(theName, theDescription, defaultValue, theUIOrder, false);
     }
@@ -74,11 +81,19 @@ public final class BooleanProperty extends AbstractSingleValueProperty<Boolean> 
     }
 
 
+    /**
+     * @deprecated Use {@link PropertyFactory#booleanProperty(String)} or its overloads.
+     */
+    @Deprecated
     public static BooleanPBuilder named(String name) {
         return new BooleanPBuilder(name);
     }
 
 
+    /**
+     * @deprecated Use {@link PropertyFactory#booleanProperty(String)} or its overloads.
+     */
+    @Deprecated
     public static final class BooleanPBuilder extends SingleValuePropertyBuilder<Boolean, BooleanPBuilder> {
         private BooleanPBuilder(String name) {
             super(name);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
@@ -180,6 +180,8 @@ public final class PropertyFactory {
      * @param name Name of the property to build
      *
      * @return A new builder
+     *
+     * @see #booleanProperty(String, boolean)
      */
     public static GenericPropertyBuilder<Boolean> booleanProperty(String name) {
         return new GenericPropertyBuilder<>(name, ValueParserConstants.BOOLEAN_PARSER, Boolean.class);
@@ -194,6 +196,8 @@ public final class PropertyFactory {
      * @param defaultValue Default value of the property
      *
      * @return A new builder
+     *
+     * @see #booleanProperty(String)
      */
     public static GenericPropertyBuilder<Boolean> booleanProperty(String name, boolean defaultValue) {
         return booleanProperty(name).defaultValue(defaultValue);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
@@ -186,6 +186,20 @@ public final class PropertyFactory {
     }
 
 
+    /**
+     * Returns a builder for a boolean property, with a default value
+     * already specified. This is shorthand for {@code booleanProperty(name).defaultValue(defaultValue)}
+     *
+     * @param name         Name of the property to build
+     * @param defaultValue Default value of the property
+     *
+     * @return A new builder
+     */
+    public static GenericPropertyBuilder<Boolean> booleanProperty(String name, boolean defaultValue) {
+        return booleanProperty(name).defaultValue(defaultValue);
+    }
+
+
     public static <T> GenericPropertyBuilder<T> enumProperty(String name, Map<String, T> nameToValue) {
         // TODO find solution to document the set of possible values
         // At best, map that requirement to a constraint (eg make parser return null if not found, and

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
@@ -172,6 +172,20 @@ public final class PropertyFactory {
     }
 
 
+    /**
+     * Returns a builder for a boolean property. The boolean is parsed from
+     * the XML using {@link Boolean#valueOf(String)}, i.e. the only truthy
+     * value is the string "true", and all other string values are falsy.
+     *
+     * @param name Name of the property to build
+     *
+     * @return A new builder
+     */
+    public static GenericPropertyBuilder<Boolean> booleanProperty(String name) {
+        return new GenericPropertyBuilder<>(name, ValueParserConstants.BOOLEAN_PARSER, Boolean.class);
+    }
+
+
     public static <T> GenericPropertyBuilder<T> enumProperty(String name, Map<String, T> nameToValue) {
         // TODO find solution to document the set of possible values
         // At best, map that requirement to a constraint (eg make parser return null if not found, and

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyTypeId.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyTypeId.java
@@ -34,6 +34,8 @@ public enum PropertyTypeId {
     // e.g. the Class type), including the mnemonics (eg. xs:integer instead of Integer)
 
     BOOLEAN("Boolean", BooleanProperty.extractor(), ValueParserConstants.BOOLEAN_PARSER),
+    /** @deprecated see {@link BooleanMultiProperty} */
+    @Deprecated
     BOOLEAN_LIST("List[Boolean]", BooleanMultiProperty.extractor(), ValueParserConstants.BOOLEAN_PARSER),
 
     STRING("String", StringProperty.extractor(), ValueParserConstants.STRING_PARSER),

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/CSVRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/CSVRenderer.java
@@ -15,9 +15,11 @@ import org.apache.commons.lang3.StringUtils;
 
 import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.RuleViolation;
-import net.sourceforge.pmd.properties.BooleanProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
 import net.sourceforge.pmd.properties.PropertySource;
 import net.sourceforge.pmd.renderers.ColumnDescriptor.Accessor;
+
 
 /**
  * Renderer the results to a comma-delimited text format. All available columns
@@ -33,7 +35,7 @@ public class CSVRenderer extends AbstractIncrementingRenderer {
 
     private static final String DEFAULT_SEPARATOR = ",";
 
-    private static final Map<String, BooleanProperty> PROPERTY_DESCRIPTORS_BY_ID = new HashMap<>();
+    private static final Map<String, PropertyDescriptor<Boolean>> PROPERTY_DESCRIPTORS_BY_ID = new HashMap<>();
 
     public static final String NAME = "csv";
 
@@ -96,14 +98,14 @@ public class CSVRenderer extends AbstractIncrementingRenderer {
         this(ALL_COLUMNS, DEFAULT_SEPARATOR, PMD.EOL);
     }
 
-    private static BooleanProperty booleanPropertyFor(String id, String label) {
+    private static PropertyDescriptor<Boolean> booleanPropertyFor(String id, String label) {
 
-        BooleanProperty prop = PROPERTY_DESCRIPTORS_BY_ID.get(id);
+        PropertyDescriptor<Boolean> prop = PROPERTY_DESCRIPTORS_BY_ID.get(id);
         if (prop != null) {
             return prop;
         }
 
-        prop = new BooleanProperty(id, "Include " + label + " column", true, 1.0f);
+        prop = PropertyFactory.booleanProperty(id, true).desc("Include " + label + " column").build();
         PROPERTY_DESCRIPTORS_BY_ID.put(id, prop);
         return prop;
     }
@@ -113,12 +115,11 @@ public class CSVRenderer extends AbstractIncrementingRenderer {
         List<ColumnDescriptor<RuleViolation>> actives = new ArrayList<>();
 
         for (ColumnDescriptor<RuleViolation> desc : ALL_COLUMNS) {
-            BooleanProperty prop = booleanPropertyFor(desc.id, null);
+            PropertyDescriptor<Boolean> prop = booleanPropertyFor(desc.id, null);
             if (getProperty(prop)) {
                 actives.add(desc);
-            } else {
-                // System.out.println("disabled: " + prop);
             }
+
         }
         return actives;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedFormalParameterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedFormalParameterRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
+import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
+
 import java.io.InvalidObjectException;
 import java.io.ObjectInputStream;
 import java.util.List;
@@ -25,12 +27,12 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.symboltable.JavaNameOccurrence;
 import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
 import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
-import net.sourceforge.pmd.properties.BooleanProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+
 
 public class UnusedFormalParameterRule extends AbstractJavaRule {
 
-    private static final BooleanProperty CHECKALL_DESCRIPTOR = new BooleanProperty("checkAll",
-            "Check all methods, including non-private ones", false, 1.0f);
+    private static final PropertyDescriptor<Boolean> CHECKALL_DESCRIPTOR = booleanProperty("checkAll").desc("Check all methods, including non-private ones").defaultValue(false).build();
 
     public UnusedFormalParameterRule() {
         definePropertyDescriptor(CHECKALL_DESCRIPTOR);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ConfusingTernaryRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ConfusingTernaryRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
+import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
+
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTConditionalAndExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTConditionalExpression;
@@ -15,7 +17,8 @@ import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
 import net.sourceforge.pmd.lang.java.ast.ASTUnaryExpressionNotPlusMinus;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
-import net.sourceforge.pmd.properties.BooleanProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+
 
 /**
  * <code>if (x != y) { diff(); } else { same(); }</code> and<br>
@@ -51,8 +54,7 @@ import net.sourceforge.pmd.properties.BooleanProperty;
  * </pre>
  */
 public class ConfusingTernaryRule extends AbstractJavaRule {
-    private static BooleanProperty ignoreElseIfProperty = new BooleanProperty("ignoreElseIf",
-            "Ignore conditions with an else-if case", Boolean.FALSE, 0);
+    private static PropertyDescriptor<Boolean> ignoreElseIfProperty = booleanProperty("ignoreElseIf").desc("Ignore conditions with an else-if case").defaultValue(false).build();
 
     public ConfusingTernaryRule() {
         super();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldDeclarationsShouldBeAtStartOfClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldDeclarationsShouldBeAtStartOfClassRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
+import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
+
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotationTypeDeclaration;
@@ -14,7 +16,8 @@ import net.sourceforge.pmd.lang.java.ast.ASTEnumDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
-import net.sourceforge.pmd.properties.BooleanProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+
 
 /**
  * Detects fields that are declared after methods, constructors, etc. It was a
@@ -36,12 +39,9 @@ import net.sourceforge.pmd.properties.BooleanProperty;
  */
 public class FieldDeclarationsShouldBeAtStartOfClassRule extends AbstractJavaRule {
 
-    private BooleanProperty ignoreEnumDeclarations = new BooleanProperty("ignoreEnumDeclarations",
-            "Ignore Enum Declarations that precede fields.", true, 1.0f);
-    private BooleanProperty ignoreAnonymousClassDeclarations = new BooleanProperty("ignoreAnonymousClassDeclarations",
-            "Ignore Field Declarations, that are initialized with anonymous class declarations", true, 2.0f);
-    private BooleanProperty ignoreInterfaceDeclarations = new BooleanProperty("ignoreInterfaceDeclarations",
-            "Ignore Interface Declarations that precede fields.", false, 3.0f);
+    private PropertyDescriptor<Boolean> ignoreEnumDeclarations = booleanProperty("ignoreEnumDeclarations").desc("Ignore Enum Declarations that precede fields.").defaultValue(true).build();
+    private PropertyDescriptor<Boolean> ignoreAnonymousClassDeclarations = booleanProperty("ignoreAnonymousClassDeclarations").desc("Ignore Field Declarations, that are initialized with anonymous class declarations").defaultValue(true).build();
+    private PropertyDescriptor<Boolean> ignoreInterfaceDeclarations = booleanProperty("ignoreInterfaceDeclarations").desc("Ignore Interface Declarations that precede fields.").defaultValue(false).build();
 
     /**
      * Initializes the rule {@link FieldDeclarationsShouldBeAtStartOfClassRule}.

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LinguisticNamingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LinguisticNamingRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
+import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
+
 import java.util.List;
 import java.util.Locale;
 
@@ -17,38 +19,35 @@ import net.sourceforge.pmd.lang.java.ast.ASTType;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.typeresolution.TypeHelper;
-import net.sourceforge.pmd.properties.BooleanProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.StringMultiProperty;
 
 public class LinguisticNamingRule extends AbstractJavaRule {
-    private static final BooleanProperty CHECK_BOOLEAN_METHODS = BooleanProperty.named("checkBooleanMethod")
-            .defaultValue(true).desc("Check method names and types for inconsistent naming.").uiOrder(1.0f).build();
-    private static final BooleanProperty CHECK_GETTERS = BooleanProperty.named("checkGetters").defaultValue(true)
-            .desc("Check return type of getters.").uiOrder(2.0f).build();
-    private static final BooleanProperty CHECK_SETTERS = BooleanProperty.named("checkSetters").defaultValue(true)
-            .desc("Check return type of setters.").uiOrder(3.0f).build();
-    private static final BooleanProperty CHECK_PREFIXED_TRANSFORM_METHODS = BooleanProperty
-            .named("checkPrefixedTransformMethods").defaultValue(true)
-            .desc("Check return type of methods whose names start with the configured prefix (see transformMethodNames property).")
-            .uiOrder(4.0f).build();
-    private static final BooleanProperty CHECK_TRANSFORM_METHODS = BooleanProperty.named("checkTransformMethods")
-            .defaultValue(false)
-            .desc("Check return type of methods which contain the configured infix in their name (see transformMethodNames property).")
-            .uiOrder(4.0f).build();
+    private static final PropertyDescriptor<Boolean> CHECK_BOOLEAN_METHODS =
+            booleanProperty("checkBooleanMethod", true).desc("Check method names and types for inconsistent naming.").build();
+    private static final PropertyDescriptor<Boolean> CHECK_GETTERS =
+            booleanProperty("checkGetters").defaultValue(true).desc("Check return type of getters.").build();
+    private static final PropertyDescriptor<Boolean> CHECK_SETTERS =
+            booleanProperty("checkSetters", true).desc("Check return type of setters.").build();
+    private static final PropertyDescriptor<Boolean> CHECK_PREFIXED_TRANSFORM_METHODS =
+            booleanProperty("checkPrefixedTransformMethods", true).desc("Check return type of methods whose names start with the configured prefix (see transformMethodNames property).").build();
+    private static final PropertyDescriptor<Boolean> CHECK_TRANSFORM_METHODS =
+            booleanProperty("checkTransformMethods", false)
+            .desc("Check return type of methods which contain the configured infix in their name (see transformMethodNames property).").build();
     private static final StringMultiProperty BOOLEAN_METHOD_PREFIXES_PROPERTY = StringMultiProperty
             .named("booleanMethodPrefixes").defaultValues("is", "has", "can", "have", "will", "should")
-            .desc("The prefixes of methods that return boolean.").uiOrder(5.0f).build();
+            .desc("The prefixes of methods that return boolean.").build();
     private static final StringMultiProperty TRANSFORM_METHOD_NAMES_PROPERTY = StringMultiProperty
             .named("transformMethodNames").defaultValues("to", "as")
-            .desc("The prefixes and infixes that indicate a transform method.").uiOrder(6.0f).build();
+            .desc("The prefixes and infixes that indicate a transform method.").build();
 
-    private static final BooleanProperty CHECK_FIELDS = BooleanProperty.named("checkFields").defaultValue(true)
-            .desc("Check field names and types for inconsistent naming.").uiOrder(7.0f).build();
-    private static final BooleanProperty CHECK_VARIABLES = BooleanProperty.named("checkVariables").defaultValue(true)
-            .desc("Check local variable names and types for inconsistent naming.").uiOrder(8.0f).build();
+    private static final PropertyDescriptor<Boolean> CHECK_FIELDS =
+            booleanProperty("checkFields", true).desc("Check field names and types for inconsistent naming.").build();
+    private static final PropertyDescriptor<Boolean> CHECK_VARIABLES =
+            booleanProperty("checkVariables", true).desc("Check local variable names and types for inconsistent naming.").build();
     private static final StringMultiProperty BOOLEAN_FIELD_PREFIXES_PROPERTY = StringMultiProperty
             .named("booleanFieldPrefixes").defaultValues("is", "has", "can", "have", "will", "should")
-            .desc("The prefixes of fields and variables that indicate boolean.").uiOrder(9.0f).build();
+            .desc("The prefixes of fields and variables that indicate boolean.").build();
 
     public LinguisticNamingRule() {
         definePropertyDescriptor(CHECK_BOOLEAN_METHODS);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryLocalBeforeReturnRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryLocalBeforeReturnRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
+import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
+
 import java.util.List;
 import java.util.Map;
 
@@ -23,14 +25,12 @@ import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
 import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
 import net.sourceforge.pmd.lang.symboltable.Scope;
 import net.sourceforge.pmd.lang.symboltable.ScopedNode;
-import net.sourceforge.pmd.properties.BooleanProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+
 
 public class UnnecessaryLocalBeforeReturnRule extends AbstractJavaRule {
 
-    private static final BooleanProperty STATEMENT_ORDER_MATTERS = new BooleanProperty("statementOrderMatters",
-            "If set to false this rule no longer requires the variable declaration and return statement to be "
-            + "on consecutive lines. Any variable that is used solely in a return statement will be reported.",
-            true, 1.0f);
+    private static final PropertyDescriptor<Boolean> STATEMENT_ORDER_MATTERS = booleanProperty("statementOrderMatters", true).desc("If set to false this rule no longer requires the variable declaration and return statement to be on consecutive lines. Any variable that is used solely in a return statement will be reported.").build();
 
     public UnnecessaryLocalBeforeReturnRule() {
         definePropertyDescriptor(STATEMENT_ORDER_MATTERS);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/VariableNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/VariableNamingConventionsRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
+import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
+
 import java.util.List;
 import java.util.Locale;
 
@@ -19,7 +21,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
-import net.sourceforge.pmd.properties.BooleanProperty;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.StringMultiProperty;
 
@@ -39,17 +40,13 @@ public class VariableNamingConventionsRule extends AbstractJavaRule {
     private List<String> parameterPrefixes;
     private List<String> parameterSuffixes;
 
-    private static final BooleanProperty CHECK_MEMBERS_DESCRIPTOR = new BooleanProperty("checkMembers",
-            "Check member variables", true, 1.0f);
+    private static final PropertyDescriptor<Boolean> CHECK_MEMBERS_DESCRIPTOR = booleanProperty("checkMembers", true).desc("Check member variables").build();
 
-    private static final BooleanProperty CHECK_LOCALS_DESCRIPTOR = new BooleanProperty("checkLocals",
-            "Check local variables", true, 2.0f);
+    private static final PropertyDescriptor<Boolean> CHECK_LOCALS_DESCRIPTOR = booleanProperty("checkLocals", true).desc("Check local variables").build();
 
-    private static final BooleanProperty CHECK_PARAMETERS_DESCRIPTOR = new BooleanProperty("checkParameters",
-            "Check constructor and method parameter variables", true, 3.0f);
+    private static final PropertyDescriptor<Boolean> CHECK_PARAMETERS_DESCRIPTOR = booleanProperty("checkParameters", true).desc("Check constructor and method parameter variables").build();
 
-    private static final BooleanProperty CHECK_NATIVE_METHOD_PARAMETERS_DESCRIPTOR = new BooleanProperty(
-            "checkNativeMethodParameters", "Check method parameter of native methods", true, 3.5f);
+    private static final PropertyDescriptor<Boolean> CHECK_NATIVE_METHOD_PARAMETERS_DESCRIPTOR = booleanProperty("checkNativeMethodParameters", true).desc("Check method parameter of native methods").build();
 
     private static final StringMultiProperty STATIC_PREFIXES_DESCRIPTOR = new StringMultiProperty("staticPrefix",
             "Static variable prefixes", new String[] { "" }, 4.0f, ',');

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SignatureDeclareThrowsExceptionRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SignatureDeclareThrowsExceptionRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.design;
 
+import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
+
 import java.util.Collections;
 import java.util.List;
 
@@ -18,7 +20,8 @@ import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
 import net.sourceforge.pmd.lang.java.ast.ASTNameList;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
-import net.sourceforge.pmd.properties.BooleanProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+
 
 /**
  * A method/constructor shouldn't explicitly throw java.lang.Exception, since it
@@ -36,8 +39,7 @@ import net.sourceforge.pmd.properties.BooleanProperty;
 
 public class SignatureDeclareThrowsExceptionRule extends AbstractJavaRule {
 
-    private static final BooleanProperty IGNORE_JUNIT_COMPLETELY_DESCRIPTOR = new BooleanProperty(
-            "IgnoreJUnitCompletely", "Allow all methods in a JUnit testcase to throw Exceptions", false, 1.0f);
+    private static final PropertyDescriptor<Boolean> IGNORE_JUNIT_COMPLETELY_DESCRIPTOR = booleanProperty("IgnoreJUnitCompletely", false).desc("Allow all methods in a JUnit testcase to throw Exceptions").build();
 
     // Set to true when the class is determined to be a JUnit testcase
     private boolean junitImported = false;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SingularFieldRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SingularFieldRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.design;
 
+import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
+
 import java.util.List;
 
 import net.sourceforge.pmd.lang.ast.Node;
@@ -22,7 +24,8 @@ import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 import net.sourceforge.pmd.lang.java.rule.AbstractLombokAwareRule;
 import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
-import net.sourceforge.pmd.properties.BooleanProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+
 
 /**
  * @author Eric Olander
@@ -35,10 +38,8 @@ public class SingularFieldRule extends AbstractLombokAwareRule {
      * Restore old behavior by setting both properties to true, which will
      * result in many false positives
      */
-    private static final BooleanProperty CHECK_INNER_CLASSES = new BooleanProperty("checkInnerClasses",
-            "Check inner classes", false, 1.0f);
-    private static final BooleanProperty DISALLOW_NOT_ASSIGNMENT = new BooleanProperty("disallowNotAssignment",
-            "Disallow violations where the first usage is not an assignment", false, 2.0f);
+    private static final PropertyDescriptor<Boolean> CHECK_INNER_CLASSES = booleanProperty("checkInnerClasses", false).desc("Check inner classes").build();
+    private static final PropertyDescriptor<Boolean> DISALLOW_NOT_ASSIGNMENT = booleanProperty("disallowNotAssignment", false).desc("Disallow violations where the first usage is not an assignment").build();
 
     public SingularFieldRule() {
         definePropertyDescriptor(CHECK_INNER_CLASSES);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UselessOverridingMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UselessOverridingMethodRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.design;
 
+import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -29,7 +31,8 @@ import net.sourceforge.pmd.lang.java.ast.ASTResultType;
 import net.sourceforge.pmd.lang.java.ast.ASTStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
-import net.sourceforge.pmd.properties.BooleanProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+
 
 /**
  * @author Romain Pelisse, bugfix for [ 1522517 ] False +:
@@ -41,8 +44,9 @@ public class UselessOverridingMethodRule extends AbstractJavaRule {
     private static final String CLONE = "clone";
     private static final String OBJECT = "Object";
 
-    private static final BooleanProperty IGNORE_ANNOTATIONS_DESCRIPTOR = new BooleanProperty("ignoreAnnotations",
-            "Ignore annotations", false, 1.0f);
+    // TODO extend AbstractIgnoredAnnotationsRule node
+    // TODO ignore if there is javadoc
+    private static final PropertyDescriptor<Boolean> IGNORE_ANNOTATIONS_DESCRIPTOR = booleanProperty("ignoreAnnotations", false).desc("Ignore annotations").build();
 
     public UselessOverridingMethodRule() {
         definePropertyDescriptor(IGNORE_ANNOTATIONS_DESCRIPTOR);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentContentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentContentRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.documentation;
 
+import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -17,7 +19,6 @@ import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.Comment;
-import net.sourceforge.pmd.properties.BooleanProperty;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertySource;
 import net.sourceforge.pmd.properties.StringMultiProperty;
@@ -39,8 +40,7 @@ public class CommentContentRule extends AbstractCommentRule {
     private static final String[] BAD_WORDS = {"idiot", "jerk" };
 
     // ignored when property above == True
-    public static final BooleanProperty CASE_SENSITIVE_DESCRIPTOR = new BooleanProperty("caseSensitive",
-            "Case sensitive", false, 2.0f);
+    public static final PropertyDescriptor<Boolean> CASE_SENSITIVE_DESCRIPTOR = booleanProperty("caseSensitive", false).desc("Case sensitive").build();
 
     public static final StringMultiProperty DISSALLOWED_TERMS_DESCRIPTOR = new StringMultiProperty("disallowedTerms",
             "Illegal terms or phrases", BAD_WORDS, 3.0f, '|');

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentInOperandRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentInOperandRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 
+import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
+
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignmentOperator;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
@@ -14,7 +16,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTPreDecrementExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTPreIncrementExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTWhileStatement;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
-import net.sourceforge.pmd.properties.BooleanProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertySource;
 
 /**
@@ -23,19 +25,13 @@ import net.sourceforge.pmd.properties.PropertySource;
  */
 public class AssignmentInOperandRule extends AbstractJavaRule {
 
-    private static final BooleanProperty ALLOW_IF_DESCRIPTOR = new BooleanProperty("allowIf",
-            "Allow assignment within the conditional expression of an if statement", false, 1.0f);
+    private static final PropertyDescriptor<Boolean> ALLOW_IF_DESCRIPTOR = booleanProperty("allowIf", false).desc("Allow assignment within the conditional expression of an if statement").build();
 
-    private static final BooleanProperty ALLOW_FOR_DESCRIPTOR = new BooleanProperty("allowFor",
-            "Allow assignment within the conditional expression of a for statement", false, 2.0f);
+    private static final PropertyDescriptor<Boolean> ALLOW_FOR_DESCRIPTOR = booleanProperty("allowFor", false).desc("Allow assignment within the conditional expression of a for statement").build();
 
-    private static final BooleanProperty ALLOW_WHILE_DESCRIPTOR = new BooleanProperty("allowWhile",
-            "Allow assignment within the conditional expression of a while statement", false, 3.0f);
+    private static final PropertyDescriptor<Boolean> ALLOW_WHILE_DESCRIPTOR = booleanProperty("allowWhile", false).desc("Allow assignment within the conditional expression of a while statement").build();
 
-    private static final BooleanProperty ALLOW_INCREMENT_DECREMENT_DESCRIPTOR = new BooleanProperty(
-            "allowIncrementDecrement",
-            "Allow increment or decrement operators within the conditional expression of an if, for, or while statement",
-            false, 4.0f);
+    private static final PropertyDescriptor<Boolean> ALLOW_INCREMENT_DECREMENT_DESCRIPTOR = booleanProperty("allowIncrementDecrement", false).desc("Allow increment or decrement operators within the conditional expression of an if, for, or while statement").build();
 
     public AssignmentInOperandRule() {
         definePropertyDescriptor(ALLOW_IF_DESCRIPTOR);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDuplicateLiteralsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDuplicateLiteralsRule.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 
+import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
 import static net.sourceforge.pmd.properties.constraints.NumericConstraints.positive;
 
 import java.io.File;
@@ -24,7 +25,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTLiteral;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
-import net.sourceforge.pmd.properties.BooleanProperty;
 import net.sourceforge.pmd.properties.CharacterProperty;
 import net.sourceforge.pmd.properties.FileProperty;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
@@ -42,8 +42,7 @@ public class AvoidDuplicateLiteralsRule extends AbstractJavaRule {
 
     public static final PropertyDescriptor<Integer> MINIMUM_LENGTH_DESCRIPTOR = PropertyFactory.intProperty("minimumLength").desc("Minimum string length to check").require(positive()).defaultValue(3).build();
 
-    public static final BooleanProperty SKIP_ANNOTATIONS_DESCRIPTOR = new BooleanProperty("skipAnnotations",
-            "Skip literals within annotations", false, 2.0f);
+    public static final PropertyDescriptor<Boolean> SKIP_ANNOTATIONS_DESCRIPTOR = booleanProperty("skipAnnotations", false).desc("Skip literals within annotations").build();
 
     public static final StringProperty EXCEPTION_LIST_DESCRIPTOR = new StringProperty("exceptionList",
             "Strings to ignore", null, 3.0f);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidUsingOctalValuesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidUsingOctalValuesRule.java
@@ -4,11 +4,14 @@
 
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 
+import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
+
 import java.util.regex.Pattern;
 
 import net.sourceforge.pmd.lang.java.ast.ASTLiteral;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
-import net.sourceforge.pmd.properties.BooleanProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+
 
 public class AvoidUsingOctalValuesRule extends AbstractJavaRule {
 
@@ -16,10 +19,10 @@ public class AvoidUsingOctalValuesRule extends AbstractJavaRule {
 
     public static final Pattern STRICT_OCTAL_PATTERN = Pattern.compile("0[0-7]+[lL]?");
 
-    private static final BooleanProperty STRICT_METHODS_DESCRIPTOR = BooleanProperty.named("strict")
+    private static final PropertyDescriptor<Boolean> STRICT_METHODS_DESCRIPTOR = booleanProperty("strict")
                                                                                     .desc("Detect violations between 00 and 07")
                                                                                     .defaultValue(false)
-                                                                                    .uiOrder(1.0f).build();
+                                                                                    .build();
 
 
     public AvoidUsingOctalValuesRule() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 
+import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
+
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -33,7 +35,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTType;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableInitializer;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
-import net.sourceforge.pmd.properties.BooleanProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.StringMultiProperty;
 
 /**
@@ -64,8 +66,7 @@ public class CloseResourceRule extends AbstractJavaRule {
     private static final StringMultiProperty TYPES_DESCRIPTOR = new StringMultiProperty("types", "Affected types",
             new String[] { "java.sql.Connection", "java.sql.Statement", "java.sql.ResultSet" }, 2.0f, ',');
 
-    private static final BooleanProperty USE_CLOSE_AS_DEFAULT_TARGET = new BooleanProperty("closeAsDefaultTarget",
-            "Consider 'close' as a target by default", true, 3.0f);
+    private static final PropertyDescriptor<Boolean> USE_CLOSE_AS_DEFAULT_TARGET = booleanProperty("closeAsDefaultTarget", true).desc("Consider 'close' as a target by default").build();
 
     public CloseResourceRule() {
         definePropertyDescriptor(CLOSE_TARGETS_DESCRIPTOR);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/NonThreadSafeSingletonRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/NonThreadSafeSingletonRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.multithreading;
 
+import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -21,7 +23,8 @@ import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
 import net.sourceforge.pmd.lang.java.ast.ASTStatementExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTSynchronizedStatement;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
-import net.sourceforge.pmd.properties.BooleanProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+
 
 public class NonThreadSafeSingletonRule extends AbstractJavaRule {
 
@@ -30,12 +33,8 @@ public class NonThreadSafeSingletonRule extends AbstractJavaRule {
     private boolean checkNonStaticMethods = true;
     private boolean checkNonStaticFields = true;
 
-    private static final BooleanProperty CHECK_NON_STATIC_METHODS_DESCRIPTOR = new BooleanProperty(
-            "checkNonStaticMethods",
-            "Check for non-static methods.  Do not set this to false and checkNonStaticFields to true.", true, 1.0f);
-    private static final BooleanProperty CHECK_NON_STATIC_FIELDS_DESCRIPTOR = new BooleanProperty(
-            "checkNonStaticFields",
-            "Check for non-static fields.  Do not set this to true and checkNonStaticMethods to false.", false, 2.0f);
+    private static final PropertyDescriptor<Boolean> CHECK_NON_STATIC_METHODS_DESCRIPTOR = booleanProperty("checkNonStaticMethods", true).desc("Check for non-static methods.  Do not set this to false and checkNonStaticFields to true.").build();
+    private static final PropertyDescriptor<Boolean> CHECK_NON_STATIC_FIELDS_DESCRIPTOR = booleanProperty("checkNonStaticFields", false).desc("Check for non-static fields.  Do not set this to true and checkNonStaticMethods to false.").build();
 
     public NonThreadSafeSingletonRule() {
         definePropertyDescriptor(CHECK_NON_STATIC_METHODS_DESCRIPTOR);

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/EcmascriptParserOptions.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/EcmascriptParserOptions.java
@@ -13,6 +13,7 @@ import net.sourceforge.pmd.lang.ParserOptions;
 import net.sourceforge.pmd.properties.BooleanProperty;
 import net.sourceforge.pmd.properties.EnumeratedProperty;
 
+
 public class EcmascriptParserOptions extends ParserOptions {
 
     public enum Version {

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/rule/AbstractEcmascriptRule.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/rule/AbstractEcmascriptRule.java
@@ -65,14 +65,15 @@ import net.sourceforge.pmd.lang.ecmascript.ast.EcmascriptNode;
 import net.sourceforge.pmd.lang.ecmascript.ast.EcmascriptParserVisitor;
 import net.sourceforge.pmd.lang.rule.AbstractRule;
 import net.sourceforge.pmd.lang.rule.ImmutableLanguage;
-import net.sourceforge.pmd.properties.BooleanProperty;
 import net.sourceforge.pmd.properties.EnumeratedProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+
 
 public abstract class AbstractEcmascriptRule extends AbstractRule
         implements EcmascriptParserVisitor, ImmutableLanguage {
 
-    private static final BooleanProperty RECORDING_COMMENTS_DESCRIPTOR = EcmascriptParserOptions.RECORDING_COMMENTS_DESCRIPTOR;
-    private static final BooleanProperty RECORDING_LOCAL_JSDOC_COMMENTS_DESCRIPTOR = EcmascriptParserOptions.RECORDING_LOCAL_JSDOC_COMMENTS_DESCRIPTOR;
+    private static final PropertyDescriptor<Boolean> RECORDING_COMMENTS_DESCRIPTOR = EcmascriptParserOptions.RECORDING_COMMENTS_DESCRIPTOR;
+    private static final PropertyDescriptor<Boolean> RECORDING_LOCAL_JSDOC_COMMENTS_DESCRIPTOR = EcmascriptParserOptions.RECORDING_LOCAL_JSDOC_COMMENTS_DESCRIPTOR;
     private static final EnumeratedProperty<EcmascriptParserOptions.Version> RHINO_LANGUAGE_VERSION = EcmascriptParserOptions.RHINO_LANGUAGE_VERSION;
 
     public AbstractEcmascriptRule() {

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/rule/EcmascriptXPathRule.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/rule/EcmascriptXPathRule.java
@@ -9,13 +9,14 @@ import net.sourceforge.pmd.lang.ParserOptions;
 import net.sourceforge.pmd.lang.ecmascript.EcmascriptLanguageModule;
 import net.sourceforge.pmd.lang.ecmascript.EcmascriptParserOptions;
 import net.sourceforge.pmd.lang.rule.XPathRule;
-import net.sourceforge.pmd.properties.BooleanProperty;
 import net.sourceforge.pmd.properties.EnumeratedProperty;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+
 
 public class EcmascriptXPathRule extends XPathRule {
 
-    private static final BooleanProperty RECORDING_COMMENTS_DESCRIPTOR = EcmascriptParserOptions.RECORDING_COMMENTS_DESCRIPTOR;
-    private static final BooleanProperty RECORDING_LOCAL_JSDOC_COMMENTS_DESCRIPTOR = EcmascriptParserOptions.RECORDING_LOCAL_JSDOC_COMMENTS_DESCRIPTOR;
+    private static final PropertyDescriptor<Boolean> RECORDING_COMMENTS_DESCRIPTOR = EcmascriptParserOptions.RECORDING_COMMENTS_DESCRIPTOR;
+    private static final PropertyDescriptor<Boolean> RECORDING_LOCAL_JSDOC_COMMENTS_DESCRIPTOR = EcmascriptParserOptions.RECORDING_LOCAL_JSDOC_COMMENTS_DESCRIPTOR;
     private static final EnumeratedProperty<EcmascriptParserOptions.Version> RHINO_LANGUAGE_VERSION = EcmascriptParserOptions.RHINO_LANGUAGE_VERSION;
 
     public EcmascriptXPathRule() {


### PR DESCRIPTION
BooleanMultiProperty doesn't appear to have a use case (how could one use a list of booleans?) so I didn't replace it.