### PR TITLE
[java] Fix for ReturnFromFinallyBlock false-positives

### DIFF
--- a/docs/pages/pmd/rules/java/errorprone.md
+++ b/docs/pages/pmd/rules/java/errorprone.md
@@ -2790,7 +2790,7 @@ Avoid returning from a finally block, this can discard exceptions.
 
 **This rule is defined by the following XPath expression:**
 ``` xpath
-//FinallyStatement//ReturnStatement
+//FinallyStatement//ReturnStatement except //FinallyStatement//(MethodDeclaration|LambdaExpression)//ReturnStatement
 ```
 
 **Example(s):**

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2666,8 +2666,9 @@ Avoid returning from a finally block, this can discard exceptions.
         </description>
         <priority>3</priority>
         <properties>
+            <property name="version" value="2.0"/>
             <property name="xpath">
-                <value>//FinallyStatement//ReturnStatement</value>
+                <value>//FinallyStatement//ReturnStatement except //FinallyStatement//(MethodDeclaration|LambdaExpression)//ReturnStatement</value>
             </property>
         </properties>
         <example>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReturnFromFinallyBlock.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReturnFromFinallyBlock.xml
@@ -120,4 +120,24 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>Return from anonyous class should not give any error</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void printSomething() {
+        try {
+            System.out.println("Integers: ");
+        } finally {
+            Arrays.asList(0, 1, 2).map(new Function<Integer, Integer>() {
+               @Override
+               public Integer apply(Integer i) {
+                   return i + 1;
+               }
+           }).forEach(i -> System.out.println(i));
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReturnFromFinallyBlock.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReturnFromFinallyBlock.xml
@@ -4,9 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
     <test-code>
-        <description><![CDATA[
-throw exception but return from finally
-     ]]></description>
+        <description>throw exception but return from finally</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -23,9 +21,7 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-lots of returns
-     ]]></description>
+        <description>lots of returns</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -42,9 +38,7 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-ok
-     ]]></description>
+        <description>ok</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -58,9 +52,7 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-Return from a Class in Finally
-    ]]></description>
+        <description>#1035 [java] ReturnFromFinallyBlock: False positive on lambda expression in finally block</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -79,9 +71,7 @@ public class Foo {
         ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-Return from Lambda in Finally
-     ]]></description>
+        <description>Return from Lambda in Finally</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -100,9 +90,7 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
-return from a lambda should not cause issues
-        ]]></description>
+        <description>return from a lambda should not cause issues</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -111,6 +99,22 @@ public class Foo {
             System.out.println("Integers: ");
         } finally {
             Arrays.asList(0, 1, 2).map(i -> { return i + 1; }).forEach(i -> System.out.println(i));
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Return in finally should give error but not in lambda</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    String printSomething() {
+        try {
+            System.out.println("Integers: ");
+        } finally {
+            Arrays.asList(0, 1, 2).map(i -> { return i + 1; }).forEach(i -> System.out.println(i));
+            return "foo";
         }
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReturnFromFinallyBlock.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReturnFromFinallyBlock.xml
@@ -57,4 +57,63 @@ public class Foo {
 }
      ]]></code>
     </test-code>
+    <test-code>
+        <description><![CDATA[
+Return from a Class in Finally
+    ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    String bar() {
+    try {
+    } finally {
+        Object o = new Object() {
+            @Override
+            public String toString() {
+                return "";
+            }
+        };
+    }
+  }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+Return from Lambda in Finally
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+  String getBar() {
+   try {
+   } finally {
+    Collection<ServiceExecutionEntry> untracked = serviceExecutionTracker.untrackMatchingEntries(e -> {
+        ServiceExecutionIdentifiers ids = e.getIdentifiers();
+        Long execBqiId = (ids == null) ? null : ids.getBqiId();
+        return Objects.equals(bqiId, execBqiId);
+    });
+    untracked.forEach(e -> logger.info("overwriteLastBqi(bqId={}, bqiId={}) untracked {}", bqId, bqiId, e));
+  }
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+return from a lambda should not cause issues
+        ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void printSomething() {
+        try {
+            System.out.println("Integers: ");
+        } finally {
+            Arrays.asList(0, 1, 2).map(i -> { return i + 1; }).forEach(i -> System.out.println(i));
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [X] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [X] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
ReturnFromFinallyBlock was giving wrong results for Lambdas or Class return statements.
Added new Tests also.

Fixes #1035 