### PR TITLE
[core] Deprecate char and long properties

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -94,6 +94,12 @@ by a corresponding method on `PropertyFactory`:
   * {% jdoc props::BooleanProperty %} is replaced by {% jdoc !c!:PF#booleanProperty(java.lang.String) %}
     * Its multi-valued counterpart, {% jdoc props::BooleanMultiProperty %}, is not replaced, because it doesn't have a use case.
 
+  * {% jdoc props::CharacterProperty %} is replaced by {% jdoc !c!:PF#charProperty(java.lang.String) %}
+    * {% jdoc props::CharacterMultiProperty %} is replaced by {% jdoc !c!:PF#charListProperty(java.lang.String) %}
+
+  * {% jdoc props::LongProperty %} is replaced by {% jdoc !c!:PF#longIntProperty(java.lang.String) %}
+    * {% jdoc props::LongMultiProperty %} is replaced by {% jdoc !c!:PF#longIntListProperty(java.lang.String) %}
+
   * {% jdoc props::MethodProperty %}, {% jdoc props::FileProperty %}, {% jdoc props::TypeProperty %} and their multi-valued counterparts
     are discontinued for lack of a use-case, and have no planned replacement in 7.0.0 for now.
     <!-- TODO complete that as we proceed. -->

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/CharacterMultiProperty.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/CharacterMultiProperty.java
@@ -19,7 +19,10 @@ import net.sourceforge.pmd.properties.builders.PropertyDescriptorBuilderConversi
  *
  * @author Brian Remedios
  * @version Refactored June 2017 (6.0.0)
+ * @deprecated Use a {@code PropertyDescriptor<List<Character>>}. A builder is available from {@link PropertyFactory#charListProperty(String)}.
+ * This class will be removed in 7.0.0.
  */
+@Deprecated
 public final class CharacterMultiProperty extends AbstractMultiValueProperty<Character> {
 
 
@@ -33,7 +36,9 @@ public final class CharacterMultiProperty extends AbstractMultiValueProperty<Cha
      * @param delimiter      The delimiter to use
      *
      * @throws IllegalArgumentException if the delimiter is in the default values
+     * @deprecated Use {@link PropertyFactory#charListProperty(String)}
      */
+    @Deprecated
     public CharacterMultiProperty(String theName, String theDescription, Character[] defaultValues, float theUIOrder, char delimiter) {
         this(theName, theDescription, Arrays.asList(defaultValues), theUIOrder, delimiter, false);
     }
@@ -64,7 +69,9 @@ public final class CharacterMultiProperty extends AbstractMultiValueProperty<Cha
      * @param delimiter      The delimiter to use
      *
      * @throws IllegalArgumentException if the delimiter is in the default values
+     * @deprecated Use {@link PropertyFactory#charListProperty(String)}
      */
+    @Deprecated
     public CharacterMultiProperty(String theName, String theDescription, List<Character> defaultValues, float theUIOrder, char delimiter) {
         this(theName, theDescription, defaultValues, theUIOrder, delimiter, false);
     }
@@ -104,11 +111,19 @@ public final class CharacterMultiProperty extends AbstractMultiValueProperty<Cha
     }
 
 
+    /**
+     * @deprecated Use {@link PropertyFactory#charListProperty(String)}
+     */
+    @Deprecated
     public static CharacterMultiPBuilder named(String name) {
         return new CharacterMultiPBuilder(name);
     }
 
 
+    /**
+     * @deprecated Use {@link PropertyFactory#charListProperty(String)}
+     */
+    @Deprecated
     public static final class CharacterMultiPBuilder extends MultiValuePropertyBuilder<Character, CharacterMultiPBuilder> {
         private CharacterMultiPBuilder(String name) {
             super(name);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/CharacterProperty.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/CharacterProperty.java
@@ -15,7 +15,10 @@ import net.sourceforge.pmd.properties.builders.SingleValuePropertyBuilder;
  *
  * @author Brian Remedios
  * @version Refactored June 2017 (6.0.0)
+ * @deprecated Use a {@code PropertyDescriptor<Character>}. A builder is available from {@link PropertyFactory#charProperty(String)}.
+ * This class will be removed in 7.0.0.
  */
+@Deprecated
 public final class CharacterProperty extends AbstractSingleValueProperty<Character> {
 
     /**
@@ -27,8 +30,9 @@ public final class CharacterProperty extends AbstractSingleValueProperty<Charact
      * @param theUIOrder     float
      *
      * @throws IllegalArgumentException
-     * @deprecated will be removed in 7.0.0
+     * @deprecated Use {@link PropertyFactory#charProperty(String)}
      */
+    @Deprecated
     public CharacterProperty(String theName, String theDescription, String defaultStr, float theUIOrder) {
         this(theName, theDescription, charFrom(defaultStr), theUIOrder, false);
     }
@@ -47,7 +51,9 @@ public final class CharacterProperty extends AbstractSingleValueProperty<Charact
      * @param theDescription Description
      * @param theDefault     Default value
      * @param theUIOrder     UI order
+     * @deprecated Use {@link PropertyFactory#charProperty(String)}
      */
+    @Deprecated
     public CharacterProperty(String theName, String theDescription, Character theDefault, float theUIOrder) {
         this(theName, theDescription, theDefault, theUIOrder, false);
     }
@@ -88,11 +94,19 @@ public final class CharacterProperty extends AbstractSingleValueProperty<Charact
     }
 
 
+    /**
+     * @deprecated Use {@link PropertyFactory#charProperty(String)}
+     */
+    @Deprecated
     public static CharacterPBuilder named(String name) {
         return new CharacterPBuilder(name);
     }
 
 
+    /**
+     * @deprecated Use {@link PropertyFactory#charProperty(String)}
+     */
+    @Deprecated
     public static final class CharacterPBuilder extends SingleValuePropertyBuilder<Character, CharacterPBuilder> {
         private CharacterPBuilder(String name) {
             super(name);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/LongMultiProperty.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/LongMultiProperty.java
@@ -16,7 +16,11 @@ import net.sourceforge.pmd.properties.builders.PropertyDescriptorBuilderConversi
  *
  * @author Brian Remedios
  * @version Refactored June 2017 (6.0.0)
+ *
+ * @deprecated Use a {@code PropertyDescriptor<List<Long>>} instead. A builder is available from {@link PropertyFactory#longIntListProperty(String)}.
+ *             This class will be removed in 7.0.0.
  */
+@Deprecated
 public final class LongMultiProperty extends AbstractMultiNumericProperty<Long> {
 
 
@@ -31,7 +35,9 @@ public final class LongMultiProperty extends AbstractMultiNumericProperty<Long> 
      * @param theUIOrder     UI order
      *
      * @throws IllegalArgumentException if {@literal min > max} or one of the defaults is not between the bounds
+     * @deprecated Use {@link PropertyFactory#longIntListProperty(String)}
      */
+    @Deprecated
     public LongMultiProperty(String theName, String theDescription, Long min, Long max,
                              Long[] defaultValues, float theUIOrder) {
         this(theName, theDescription, min, max, Arrays.asList(defaultValues), theUIOrder, false);
@@ -56,7 +62,9 @@ public final class LongMultiProperty extends AbstractMultiNumericProperty<Long> 
      * @param theUIOrder     UI order
      *
      * @throws IllegalArgumentException if {@literal min > max} or one of the defaults is not between the bounds
+     * @deprecated Use {@link PropertyFactory#longIntListProperty(String)}
      */
+    @Deprecated
     public LongMultiProperty(String theName, String theDescription, Long min, Long max,
                              List<Long> defaultValues, float theUIOrder) {
         this(theName, theDescription, min, max, defaultValues, theUIOrder, false);
@@ -85,11 +93,15 @@ public final class LongMultiProperty extends AbstractMultiNumericProperty<Long> 
     }
 
 
+    /** @deprecated Use {@link PropertyFactory#longIntListProperty(String)} */
+    @Deprecated
     public static LongMultiPBuilder named(String name) {
         return new LongMultiPBuilder(name);
     }
 
 
+    /** @deprecated Use {@link PropertyFactory#longIntListProperty(String)} */
+    @Deprecated
     public static final class LongMultiPBuilder
         extends MultiNumericPropertyBuilder<Long, LongMultiPBuilder> {
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/LongProperty.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/LongProperty.java
@@ -14,7 +14,11 @@ import net.sourceforge.pmd.properties.builders.SingleNumericPropertyBuilder;
  * @author Brian Remedios
  * @author Clément Fournier
  * @version Refactored June 2017 (6.0.0)
+ *
+ * @deprecated Use a {@code PropertyDescriptor<Long>} instead. A builder is available from {@link PropertyFactory#longIntProperty(String)}.
+ *             This class will be removed in 7.0.0.
  */
+@Deprecated
 public final class LongProperty extends AbstractNumericProperty<Long> {
 
 
@@ -30,8 +34,9 @@ public final class LongProperty extends AbstractNumericProperty<Long> {
      * @param theUIOrder     UI order
      *
      * @throws IllegalArgumentException if {@literal min > max} or one of the defaults is not between the bounds
-     * @deprecated will be removed in 7.0.0
+     * @deprecated Use {@link PropertyFactory#longIntProperty(String)}
      */
+    @Deprecated
     public LongProperty(String theName, String theDescription, String minStr, String maxStr, String defaultStr,
                         float theUIOrder) {
         this(theName, theDescription, Long.valueOf(minStr), Long.valueOf(maxStr),
@@ -57,7 +62,9 @@ public final class LongProperty extends AbstractNumericProperty<Long> {
      * @param theUIOrder     UI order
      *
      * @throws IllegalArgumentException if {@literal min > max} or one of the defaults is not between the bounds
+     * @deprecated Use {@link PropertyFactory#longIntProperty(String)}
      */
+    @Deprecated
     public LongProperty(String theName, String theDescription, Long min, Long max, Long theDefault, float theUIOrder) {
         this(theName, theDescription, min, max, theDefault, theUIOrder, false);
     }
@@ -85,11 +92,15 @@ public final class LongProperty extends AbstractNumericProperty<Long> {
     }
 
 
+    /** @deprecated Use {@link PropertyFactory#longIntProperty(String)} */
+    @Deprecated
     public static LongPBuilder named(String name) {
         return new LongPBuilder(name);
     }
 
 
+    /** @deprecated Use {@link PropertyFactory#longIntProperty(String)} */
+    @Deprecated
     public static final class LongPBuilder extends SingleNumericPropertyBuilder<Long, LongPBuilder> {
         private LongPBuilder(String name) {
             super(name);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
@@ -46,7 +46,7 @@ import net.sourceforge.pmd.properties.constraints.PropertyConstraint;
  * <pre>
  * class MyRule {
  *   // The property descriptor may be static, it can be shared across threads.
- *   private static final {@link PropertyDescriptor}&lt;Integer> myIntProperty
+ *   private static final {@link PropertyDescriptor}&lt;Integer&gt; myIntProperty
  *     = PropertyFactory.{@linkplain #intProperty(String) intProperty}("myIntProperty")
  *                      .{@linkplain PropertyBuilder#desc(String) desc}("This is my property")
  *                      .{@linkplain PropertyBuilder#defaultValue(Object) defaultValue}(3)
@@ -235,10 +235,10 @@ public final class PropertyFactory {
      * Returns a builder for a character property. The property descriptor
      * will accept any single character string. No unescaping is performed
      * other than what the XML parser does itself. That means that Java
-     * escape sequences are not expanded: "\n", will be represented as the
+     * escape sequences are not expanded: e.g. "\n", will be represented as the
      * character sequence '\' 'n', so it's not a valid value for this type
      * of property. On the other hand, XML character references are expanded,
-     * like {@literal &amp;} ('&') or {@literal &lt;} ('<').
+     * like {@literal &amp;} ('&amp;') or {@literal &lt;} ('&lt;').
      *
      * @param name Name of the property to build
      *

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
@@ -166,8 +166,8 @@ public final class PropertyFactory {
      * Returns a builder for a string property. The property descriptor
      * will accept any string, and performs no expansion of escape
      * sequences (e.g. {@code \n} in the XML will be represented as the
-     * character sequence '\' 'n' and not the line-feed character '\n'). This
-     * behaviour could be changed with PMD 7.0.0.
+     * character sequence '\' 'n' and not the line-feed character '\n').
+     * This behaviour could be changed with PMD 7.0.0.
      *
      * @param name Name of the property to build
      *
@@ -188,6 +188,37 @@ public final class PropertyFactory {
      */
     public static GenericCollectionPropertyBuilder<String, List<String>> stringListProperty(String name) {
         return stringProperty(name).toList();
+    }
+
+    
+    /**
+     * Returns a builder for a character property. The property descriptor
+     * will accept any single character string. No unescaping is performed
+     * other than what the XML parser does itself. That means that Java
+     * escape sequences are not expanded: "\n", will be represented as the
+     * character sequence '\' 'n', so it's not a valid value for this type
+     * of property. On the other hand, XML character references are expanded,
+     * like {@literal &amp;} ('&') or {@literal &lt;} ('<').
+     *
+     * @param name Name of the property to build
+     *
+     * @return A new builder
+     */
+    public static GenericPropertyBuilder<Character> charProperty(String name) {
+        return new GenericPropertyBuilder<>(name, ValueParserConstants.CHARACTER_PARSER, Character.class);
+    }
+
+
+    /**
+     * Returns a builder for a property having as value a list of characters. The
+     * format of the individual items is the same as for {@linkplain #charProperty(String) charProperty}.
+     *
+     * @param name Name of the property to build
+     *
+     * @return A new builder
+     */
+    public static GenericCollectionPropertyBuilder<Character, List<Character>> charListProperty(String name) {
+        return charProperty(name).toList();
     }
 
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
@@ -83,7 +83,10 @@ public final class PropertyFactory {
      * Returns a builder for an integer property. The property descriptor
      * will by default accept any value conforming to the format specified
      * by {@link Integer#parseInt(String)}, e.g. {@code 1234} or {@code -123}.
-     * Acceptable values may be further refined by {@linkplain PropertyBuilder#require(PropertyConstraint) adding constraints}.
+     *
+     * <p>Note that that parser only supports decimal representations.
+     *
+     * <p>Acceptable values may be further refined by {@linkplain PropertyBuilder#require(PropertyConstraint) adding constraints}.
      * The class {@link NumericConstraints} provides some useful ready-made constraints
      * for that purpose.
      *
@@ -108,6 +111,43 @@ public final class PropertyFactory {
      */
     public static GenericCollectionPropertyBuilder<Integer, List<Integer>> intListProperty(String name) {
         return intProperty(name).toList().delim(MultiValuePropertyDescriptor.DEFAULT_NUMERIC_DELIMITER);
+    }
+
+
+    /**
+     * Returns a builder for a long integer property. The property descriptor
+     * will by default accept any value conforming to the format specified
+     * by {@link Long#parseLong(String)}, e.g. {@code 1234455678854}.
+     *
+     * <p>Note that that parser only supports decimal representations, and that neither
+     * the character L nor l is permitted to appear at the end of the string as a type
+     * indicator, as would be permitted in Java source.
+     *
+     * <p>Acceptable values may be further refined by {@linkplain PropertyBuilder#require(PropertyConstraint) adding constraints}.
+     * The class {@link NumericConstraints} provides some useful ready-made constraints
+     * for that purpose.
+     *
+     * @param name Name of the property to build
+     *
+     * @return A new builder
+     *
+     * @see NumericConstraints
+     */
+    public static GenericPropertyBuilder<Long> longIntProperty(String name) {
+        return new GenericPropertyBuilder<>(name, ValueParserConstants.LONG_PARSER, Long.class);
+    }
+
+
+    /**
+     * Returns a builder for a property having as value a list of long integers. The
+     * format of the individual items is the same as for {@linkplain #longIntProperty(String)} longIntProperty}.
+     *
+     * @param name Name of the property to build
+     *
+     * @return A new builder
+     */
+    public static GenericCollectionPropertyBuilder<Long, List<Long>> longIntListProperty(String name) {
+        return longIntProperty(name).toList().delim(MultiValuePropertyDescriptor.DEFAULT_NUMERIC_DELIMITER);
     }
 
 
@@ -190,7 +230,7 @@ public final class PropertyFactory {
         return stringProperty(name).toList();
     }
 
-    
+
     /**
      * Returns a builder for a character property. The property descriptor
      * will accept any single character string. No unescaping is performed

--- a/pmd-core/src/test/java/net/sourceforge/pmd/properties/CharacterPropertyTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/properties/CharacterPropertyTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
  *
  * @author Brian Remedios
  */
+@Deprecated
 public class CharacterPropertyTest extends AbstractPropertyDescriptorTester<Character> {
 
     private static final char DELIMITER = '|';

--- a/pmd-core/src/test/java/net/sourceforge/pmd/properties/LongPropertyTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/properties/LongPropertyTest.java
@@ -10,6 +10,7 @@ import java.util.List;
 /**
  * @author Clément Fournier
  */
+@Deprecated
 public class LongPropertyTest extends AbstractNumericPropertyDescriptorTester<Long> {
 
     private static final long MIN = 10L;


### PR DESCRIPTION
Last item on the checklist #1432 for 6.10.0 :smile: 

Those properties were not used at all... but supporting them is practically free as we can use the standard library to parse them