### PR TITLE
[java] LocalVariableCouldBeFinal: allow excluding the variable in a for-each loop

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableCouldBeFinalRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableCouldBeFinalRule.java
@@ -4,20 +4,34 @@
 
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
+import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
+
 import java.util.List;
 import java.util.Map;
 
+import net.sourceforge.pmd.lang.java.ast.ASTForStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
 import net.sourceforge.pmd.lang.java.rule.performance.AbstractOptimizationRule;
 import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
 import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
 import net.sourceforge.pmd.lang.symboltable.Scope;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
 
 public class LocalVariableCouldBeFinalRule extends AbstractOptimizationRule {
+
+    private static final PropertyDescriptor<Boolean> IGNORE_FOR_EACH =
+            booleanProperty("ignoreForEachDecl").defaultValue(false).desc("Ignore non-final loop variables in a for-each statement.").build();
+
+    public LocalVariableCouldBeFinalRule() {
+        definePropertyDescriptor(IGNORE_FOR_EACH);
+    }
 
     @Override
     public Object visit(ASTLocalVariableDeclaration node, Object data) {
         if (node.isFinal()) {
+            return data;
+        }
+        if (getProperty(IGNORE_FOR_EACH) && node.jjtGetParent() instanceof ASTForStatement) {
             return data;
         }
         Scope s = node.getScope();

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1127,6 +1127,9 @@ public interface MissingProperSuffix extends javax.ejb.EJBLocalObject {}    // n
 A local variable assigned only once can be declared final.
         </description>
         <priority>3</priority>
+        <properties>
+            <property name="ignoreForEachDecl" type="Boolean" description="Ignore non-final loop variables in a for-each statement." value="false"/>
+        </properties>
         <example>
 <![CDATA[
 public class Bar {

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1127,9 +1127,6 @@ public interface MissingProperSuffix extends javax.ejb.EJBLocalObject {}    // n
 A local variable assigned only once can be declared final.
         </description>
         <priority>3</priority>
-        <properties>
-            <property name="ignoreForEachDecl" type="Boolean" description="Ignore non-final loop variables in a for-each statement." value="false"/>
-        </properties>
         <example>
 <![CDATA[
 public class Bar {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableCouldBeFinal.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableCouldBeFinal.xml
@@ -175,4 +175,18 @@ public class Test {
 }
        ]]></code>
    </test-code>
+    <test-code>
+        <description>Parameter to ignore non-final variables in for each loops (see #1513).</description>
+        <rule-property name="ignoreForEachDecl">true</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ public void bar() {
+  for ( String c : strings ) {
+   System.out.println(c); // use c
+  }
+ }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
This PR fixes #1513 

- a new property to exclude the for-each variable (it is "false" by default, so existing rule definitions don't change)
- a test case to check the new property