### PR TITLE
[java] OneDeclarationPerLine: Don't report multiple variables in a for statement.

### DIFF
--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -812,6 +812,7 @@ can lead to quite messy code. This rule looks for several declarations on the sa
                 <value>
 <![CDATA[
 //LocalVariableDeclaration
+   [not(parent::ForInit)]
    [count(VariableDeclarator) > 1]
    [$strictMode or count(distinct-values(VariableDeclarator/@BeginLine)) != count(VariableDeclarator)]
 |

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/OneDeclarationPerLine.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/OneDeclarationPerLine.xml
@@ -89,4 +89,17 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Don't report multiple variables in a for statement, see #658</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        for (int i = 0, j = 0; i < 10; i++, j +=2) {
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
This PR fixes #658
- ignore local variable declarations inside a for-initializer
- test case with a multi-variable for statement