### PR TITLE
[java] New rule: ForLoopVariableCount: check the number of control variables in a for loop

### DIFF
--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -787,6 +787,33 @@ for (int i = 0; i < 42; i++)
         </example>
     </rule>
 
+    <rule name="ForLoopVariableCount"
+          language="java"
+          since="6.11.0"
+          message="Too many control variables in the 'for' statement"
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#forloopvariablecount">
+        <description>
+Having a lot of control variables in a 'for' loop makes it harder to see what range of values
+the loop iterates over. By default this rule allows a regular 'for' loop with only one variable.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="maximumVariables" type="Integer"
+                      description="A regular for statement will have 1 control variable" min="0" max="100" value="1"/>
+            <property name="xpath">
+                <value>//ForInit/LocalVariableDeclaration[count(VariableDeclarator) > $maximumVariables]</value>
+            </property>
+        </properties>
+        <example>
+<![CDATA[
+// this will be reported with the default setting of at most one control variable in a for loop
+for (int i = 0, j = 0; i < 10; i++, j += 2) {
+   foo();
+]]>
+        </example>
+    </rule>
+
 
     <rule name="FormalParameterNamingConventions"
           since="6.6.0"

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/ForLoopVariableCountTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/ForLoopVariableCountTest.java
@@ -1,0 +1,11 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.codestyle;
+
+import net.sourceforge.pmd.testframework.PmdRuleTst;
+
+public class ForLoopVariableCountTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ForLoopVariableCount.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ForLoopVariableCount.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+    <test-code>
+        <description>default: valid case</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class Foo {
+                void foo() {
+                    for (int i=0; i<42; i++) {
+                        foo();
+                    }
+                }
+            }
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>default: failing case</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+            public class Foo {
+                void foo() {
+                    for (int i=0, j=0; i<42; i++, j++) {
+                        foo();
+                    }
+                }
+            }
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>custom count: valid case</description>
+        <rule-property name="maximumVariables">2</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class Foo {
+                void foo() {
+                    for (int i=0, j=0; i<42; i++, j++) {
+                        foo();
+                    }
+                }
+            }
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>custom count: valid (but useless) case</description>
+        <rule-property name="maximumVariables">0</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class Foo {
+                void foo() {
+                    for (;;) {
+                        foo();
+                    }
+                }
+            }
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>custom count: failing case</description>
+        <rule-property name="maximumVariables">2</rule-property>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+            public class Foo {
+                void foo() {
+                    for (int i=0, j=0, k=0; i<42; i++, j++, k++) {
+                        foo();
+                    }
+                }
+            }
+        ]]></code>
+    </test-code>
+</test-data>


### PR DESCRIPTION
This PR fixes #1519
- new XPath rule "ForLoopVariableCount"
- test cases for the default configuration (one variable max) and a few custom configurations
