### PR TITLE
[java] Upgrade to ASM7 for JDK 11 support

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/visitors/PMDASMVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/visitors/PMDASMVisitor.java
@@ -36,7 +36,7 @@ public class PMDASMVisitor extends ClassVisitor {
     public List<String> innerClasses;
 
     public PMDASMVisitor(String outerName) {
-        super(Opcodes.ASM7_EXPERIMENTAL);
+        super(Opcodes.ASM7);
         this.outerName = outerName;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -819,7 +819,7 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
             <dependency>
                 <groupId>org.ow2.asm</groupId>
                 <artifactId>asm</artifactId>
-                <version>6.2.1</version>
+                <version>7.0</version>
             </dependency>
             <dependency>
                 <groupId>net.sourceforge.pmd</groupId>


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

Remove ASM7_EXPERIMENTAL flag since ASM7 has been released.

PMD 6.10.0 passes the `ASM7_EXPERIMENTAL` flag to asm, which fails on asm 6.2.1 - `ClassVisitor` enforces only stable ASM per https://gitlab.ow2.org/asm/asm/blob/master/asm/src/main/java/org/objectweb/asm/ClassVisitor.java#L69

Upgrading PMD to use the recently released ASM 7.0 library and replacing `ASM7_EXPERIMENTAL` with `ASM7` works.