### PR TITLE
[plsql] Parse Exception when using '||' operator in where clause

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -28,6 +28,8 @@ This is a {{ site.pmd.release_type }} release.
     *   [#1513](https://github.com/pmd/pmd/issues/1513): \[java] LocalVariableCouldBeFinal: allow excluding the variable in a for-each loop
 *   java-errorprone
     *   [#1035](https://github.com/pmd/pmd/issues/1035): \[java] ReturnFromFinallyBlock: False positive on lambda expression in finally block
+*   plsql
+    *   [#1507](https://github.com/pmd/pmd/issues/1507): \[plsql] Parse Exception when using '||' operator in where clause
 
 ### API Changes
 

--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -1414,7 +1414,7 @@ ASTSqlExpression SqlExpression() :
  |
     LOOKAHEAD(2) <ROWNUM>
  |
-    LOOKAHEAD(2) Literal()
+    LOOKAHEAD(2) AdditiveExpression() // this can be a literal or a simple expression, but no conditional
  )
     { return jjtThis; }
 }

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/WhereClauseTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/WhereClauseTest.java
@@ -54,4 +54,11 @@ public class WhereClauseTest extends AbstractPLSQLParserTst {
                 StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
     }
+
+    @Test
+    public void testConcatenationOperator() throws Exception {
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("WhereClauseConcatenation.pls"),
+                StandardCharsets.UTF_8);
+        ASTInput input = parsePLSQL(code);
+    }
 }

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/WhereClauseConcatenation.pls
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/WhereClauseConcatenation.pls
@@ -1,0 +1,15 @@
+--
+-- BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+--
+-- See https://github.com/pmd/pmd/issues/1507
+--
+
+BEGIN
+
+SELECT *
+  INTO x
+  FROM y
+  WHERE a = 'a' || 'b';
+
+END;
+/


### PR DESCRIPTION
Fixes #1507

