### PR TITLE
[java] New rule: AvoidReassigningLoopVariables

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningLoopVariablesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningLoopVariablesRule.java
@@ -1,0 +1,250 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices;
+
+import static net.sourceforge.pmd.properties.PropertyFactory.enumProperty;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import net.sourceforge.pmd.lang.ast.AbstractNode;
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.java.ast.ASTAssignmentOperator;
+import net.sourceforge.pmd.lang.java.ast.ASTBlockStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTForInit;
+import net.sourceforge.pmd.lang.java.ast.ASTForStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTName;
+import net.sourceforge.pmd.lang.java.ast.ASTPostfixExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTPreDecrementExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTPreIncrementExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
+import net.sourceforge.pmd.lang.java.rule.performance.AbstractOptimizationRule;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+
+public class AvoidReassigningLoopVariablesRule extends AbstractOptimizationRule {
+
+    private static final Map<String, ForeachReassignOption> FOREACH_REASSIGN_VALUES;
+
+    static {
+        final Map<String, ForeachReassignOption> map = new HashMap<>();
+        map.put("deny", ForeachReassignOption.DENY);
+        map.put("firstOnly", ForeachReassignOption.FIRST_ONLY);
+        map.put("allow", ForeachReassignOption.ALLOW);
+        FOREACH_REASSIGN_VALUES = Collections.unmodifiableMap(map);
+    }
+
+    private static final PropertyDescriptor<ForeachReassignOption> FOREACH_REASSIGN
+            = enumProperty("foreachReassign", FOREACH_REASSIGN_VALUES)
+            .defaultValue(ForeachReassignOption.DENY)
+            .desc("how/if foreach control variables may be reassigned")
+            .build();
+
+    private static final Map<String, ForReassignOption> FOR_REASSIGN_VALUES;
+
+    static {
+        final Map<String, ForReassignOption> map = new HashMap<>();
+        map.put("deny", ForReassignOption.DENY);
+        map.put("skip", ForReassignOption.SKIP);
+        map.put("allow", ForReassignOption.ALLOW);
+        FOR_REASSIGN_VALUES = Collections.unmodifiableMap(map);
+    }
+
+    private static final PropertyDescriptor<ForReassignOption> FOR_REASSIGN
+            = enumProperty("forReassign", FOR_REASSIGN_VALUES)
+            .defaultValue(ForReassignOption.DENY)
+            .desc("how/if for control variables may be reassigned")
+            .build();
+
+    public AvoidReassigningLoopVariablesRule() {
+        definePropertyDescriptor(FOREACH_REASSIGN);
+        definePropertyDescriptor(FOR_REASSIGN);
+    }
+
+    @Override
+    public Object visit(ASTLocalVariableDeclaration node, Object data) {
+        final Set<String> loopVariables = new HashSet<>();
+        for (ASTVariableDeclaratorId declaratorId : node.findDescendantsOfType(ASTVariableDeclaratorId.class)) {
+            loopVariables.add(declaratorId.getImage());
+        }
+
+        if (node.jjtGetParent() instanceof ASTForInit) {
+            // regular for loop: LocalVariableDeclaration -> ForInit -> ForStatement
+            final ASTStatement loopBody = node.jjtGetParent().jjtGetParent().getFirstChildOfType(ASTStatement.class);
+            final ForReassignOption forReassign = getProperty(FOR_REASSIGN);
+
+            if (forReassign != ForReassignOption.ALLOW) {
+                // check assignments
+                checkAssignExceptIncrement(data, loopVariables, loopBody, false);
+
+                if (forReassign != ForReassignOption.SKIP) {
+                    // skipping not allowed -> also check increments
+                    checkIncrementAndDecrement(data, loopVariables, loopBody, false);
+                }
+            }
+
+        } else if (node.jjtGetParent() instanceof ASTForStatement) {
+            // for-each loop: LocalVariableDeclaration -> ForStatement
+            final ASTStatement loopBody = node.jjtGetParent().getFirstChildOfType(ASTStatement.class);
+            final ForeachReassignOption foreachReassign = getProperty(FOREACH_REASSIGN);
+
+            if (foreachReassign != ForeachReassignOption.ALLOW) {
+                final boolean ignoreFirst = foreachReassign == ForeachReassignOption.FIRST_ONLY;
+                checkAssignExceptIncrement(data, loopVariables, loopBody, ignoreFirst);
+                checkIncrementAndDecrement(data, loopVariables, loopBody, ignoreFirst);
+            }
+        }
+
+        return data;
+    }
+
+    /**
+     * Report usages of assignments except '+=' and '-='.
+     *
+     * @param ignoreFirst if the first statement in the loop body should be ignored
+     */
+    private void checkAssignExceptIncrement(Object data, Set<String> loopVariables, ASTStatement loopBody, boolean ignoreFirst) {
+        checkAssignments(data, loopVariables, loopBody, false, ignoreFirst);
+    }
+
+    /**
+     * Report usages of increments ('++', '--', '+=', '-=').
+     *
+     * @param ignoreFirst if the first statement in the loop body should be ignored
+     */
+    private void checkIncrementAndDecrement(Object data, Set<String> loopVariables, ASTStatement loopBody, boolean ignoreFirst) {
+
+        // foo ++ and foo --
+        for (ASTPostfixExpression expression : loopBody.findDescendantsOfType(ASTPostfixExpression.class)) {
+            if (ignoreFirst && isFirstStatementInBlock(expression, loopBody)) {
+                // ignore the first statement
+                continue;
+            }
+
+            checkVariable(data, loopVariables, expression.getFirstDescendantOfType(ASTName.class));
+        }
+
+        // ++ foo
+        for (ASTPreIncrementExpression expression : loopBody.findDescendantsOfType(ASTPreIncrementExpression.class)) {
+            if (ignoreFirst && isFirstStatementInBlock(expression, loopBody)) {
+                // ignore the first statement
+                continue;
+            }
+
+            checkVariable(data, loopVariables, expression.getFirstDescendantOfType(ASTName.class));
+        }
+
+        // -- foo
+        for (ASTPreDecrementExpression expression : loopBody.findDescendantsOfType(ASTPreDecrementExpression.class)) {
+            if (ignoreFirst && isFirstStatementInBlock(expression, loopBody)) {
+                // ignore the first statement
+                continue;
+            }
+
+            checkVariable(data, loopVariables, expression.getFirstDescendantOfType(ASTName.class));
+        }
+
+        // foo += x and foo -= x
+        checkAssignments(data, loopVariables, loopBody, true, ignoreFirst);
+    }
+
+    /**
+     * Report usages of assignments.
+     *
+     * @param checkIncrement true: check only '+=' and '-=',
+     *                       false: check all other assignments
+     * @param ignoreFirst    if the first statement in the loop body should be ignored
+     */
+    private void checkAssignments(Object data, Set<String> loopVariables, ASTStatement loopBody, boolean checkIncrement, boolean ignoreFirst) {
+        for (ASTAssignmentOperator operator : loopBody.findDescendantsOfType(ASTAssignmentOperator.class)) {
+            // check if the current operator is an assign-increment or assign-decrement operator
+            final String operatorImage = operator.getImage();
+            final boolean isIncrement = "+=".equals(operatorImage) || "-=".equals(operatorImage);
+
+            if (isIncrement != checkIncrement) {
+                // wrong type of operator
+                continue;
+            }
+
+            if (ignoreFirst && isFirstStatementInBlock(operator, loopBody)) {
+                // ignore the first statement
+                continue;
+            }
+
+            final ASTPrimaryExpression primaryExpression = operator.jjtGetParent().getFirstChildOfType(ASTPrimaryExpression.class);
+            final ASTName name = primaryExpression.getFirstDescendantOfType(ASTName.class);
+            if (name != null) {
+                checkVariable(data, loopVariables, name);
+            }
+
+        }
+    }
+
+    /**
+     * Check if the given node is the first statement in the block.
+     */
+    private boolean isFirstStatementInBlock(Node node, ASTStatement loopBody) {
+        // find the statement of the operation and the loop body block statement
+        final ASTStatement statement = node.getFirstParentOfType(ASTStatement.class);
+        final ASTBlockStatement block = loopBody.getFirstDescendantOfType(ASTBlockStatement.class);
+
+        if (statement == null || block == null) {
+            return false;
+        }
+
+        // is the first statement in the loop body?
+        return block.equals(statement.jjtGetParent()) && statement.jjtGetChildIndex() == 0;
+    }
+
+    /**
+     * Add a violation, if the node image is one of the loop variables.
+     */
+    private void checkVariable(Object data, Set<String> loopVariables, AbstractNode node) {
+        if (loopVariables.contains(node.getImage())) {
+            addViolation(data, node, node.getImage());
+        }
+    }
+
+    private enum ForeachReassignOption {
+        /**
+         * Deny reassigning the 'foreach' control variable
+         */
+        DENY,
+
+        /**
+         * Allow reassigning the 'foreach' control variable if it is the first statement in the loop body.
+         */
+        FIRST_ONLY,
+
+        /**
+         * Allow reassigning the 'foreach' control variable.
+         */
+        ALLOW,
+    }
+
+    private enum ForReassignOption {
+        /**
+         * Deny reassigning a 'for' control variable.
+         */
+        DENY,
+
+        /**
+         * Allow skipping elements by incrementing/decrementing the 'for' control variable.
+         */
+        SKIP,
+
+        /**
+         * Allow reassigning the 'for' control variable.
+         */
+        ALLOW,
+    }
+
+
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningLoopVariablesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningLoopVariablesRule.java
@@ -207,7 +207,7 @@ public class AvoidReassigningLoopVariablesRule extends AbstractOptimizationRule 
      * Add a violation, if the node image is one of the loop variables.
      */
     private void checkVariable(Object data, Set<String> loopVariables, AbstractNode node) {
-        if (loopVariables.contains(node.getImage())) {
+        if (node != null && loopVariables.contains(node.getImage())) {
             addViolation(data, node, node.getImage());
         }
     }

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -173,16 +173,41 @@ class Foo {
           class="net.sourceforge.pmd.lang.java.rule.bestpractices.AvoidReassigningLoopVariablesRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_bestpractices.html#avoidreassigningloopvariables">
         <description>
-Reassigning loop control variables can lead to hard-to-find bugs. Prevent or limit how these variables can be changed.
+Reassigning loop variables can lead to hard-to-find bugs. Prevent or limit how these variables can be changed.
+
+In foreach-loops, configured by the `foreachReassign` property:
+- `deny`: Report any reassignment of the loop variable in the loop body. _This is the default._
+- `allow`: Don't check the loop variable.
+- `firstOnly`: Report any reassignments of the loop variable, except as the first statement in the loop body.
+            _This is useful if some kind of normalization or clean-up of the value before using is permitted, but any other change of the variable is not._
+
+In for-loops, configured by the `forReassign` property:
+- `deny`: Report any reassignment of the control variable in the loop body. _This is the default._
+- `allow`: Don't check the control variable.
+- `skip`: Report any reassignments of the control variable, except conditional increments/decrements (`++`, `--`, `+=`, `-=`).
+            _This prevents accidental reassignments or unconditional increments of the control variable._
         </description>
         <priority>3</priority>
         <example>
 <![CDATA[
 public class Foo {
   private void foo() {
+    for (String s : listOfStrings()) {
+      s = s.trim(); // OK, when foreachReassign is "firstOnly" or "allow"
+      doSomethingWith(s);
+
+      s = s.toUpper(); // OK, when foreachReassign is "allow"
+      doSomethingElseWith(s);
+    }
+
     for (int i=0; i < 10; i++) {
+      if (check(i)) {
+        i++; // OK, when forReassign is "skip" or "allow"
+      }
+
+      i = 5;  // OK, when forReassign is "allow"
+
       doSomethingWith(i);
-      i = 5;
     }
   }
 }

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -167,6 +167,29 @@ class Foo {
         </example>
     </rule>
 
+    <rule name="AvoidReassigningLoopVariables"
+          since="6.11.0"
+          message="Avoid reassigning the loop control variable ''{0}''"
+          class="net.sourceforge.pmd.lang.java.rule.bestpractices.AvoidReassigningLoopVariablesRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_bestpractices.html#avoidreassigningloopvariables">
+        <description>
+Reassigning loop control variables can lead to hard-to-find bugs. Prevent or limit how these variables can be changed.
+        </description>
+        <priority>3</priority>
+        <example>
+<![CDATA[
+public class Foo {
+  private void foo() {
+    for (int i=0; i < 10; i++) {
+      doSomethingWith(i);
+      i = 5;
+    }
+  }
+}
+]]>
+        </example>
+    </rule>
+
     <rule name="AvoidReassigningParameters"
           since="1.0"
           message="Avoid reassigning parameters such as ''{0}''"

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningLoopVariablesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningLoopVariablesTest.java
@@ -1,0 +1,11 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices;
+
+import net.sourceforge.pmd.testframework.PmdRuleTst;
+
+public class AvoidReassigningLoopVariablesTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/AvoidReassigningLoopVariables.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/AvoidReassigningLoopVariables.xml
@@ -36,6 +36,21 @@ public class Foo {
     </test-code>
 
     <test-code>
+        <description>violation: incremented 'for' loop variable, inline</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i++);
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
         <description>no violation: incremented other variable</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
@@ -58,7 +73,7 @@ public class Foo {
     void foo(int bar) {
         for (int i=0; i < 10; i++) {
             doSomethingWith(i);
-            this.i++; // not OK
+            this.i++;
         }
     }
 }
@@ -82,7 +97,59 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>no violation: incremented 'for' loop variable</description>
+        <description>violation: unconditionally incremented 'for' loop variable</description>
+        <rule-property name="forReassign">skip</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            i++; // not OK
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>violation: unconditionally incremented 'for' loop variable, inline</description>
+        <rule-property name="forReassign">skip</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i++); // not OK
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>violation: unconditionally incremented 'for' loop variable</description>
+        <rule-property name="forReassign">skip</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        if (foo()) {
+            for (int i=0; i < 10; i++) {
+                doSomethingWith(i);
+                i++; // not OK
+            }
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>no violation: conditionally incremented 'for' loop variable</description>
         <rule-property name="forReassign">skip</rule-property>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
@@ -90,6 +157,102 @@ public class Foo {
     void foo(int bar) {
         for (int i=0; i < 10; i++) {
             doSomethingWith(i);
+            if (foo()) i += 1;
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>no violation: incremented 'for' loop variable inside if</description>
+        <rule-property name="forReassign">skip</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            if (foo()) i++;
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>no violation: incremented 'for' loop variable inline inside if</description>
+        <rule-property name="forReassign">skip</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            if (foo()) doSomethingWith(i++);
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>no violation: incremented 'for' loop variable inside while</description>
+        <rule-property name="forReassign">skip</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            while (foo()) i++;
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>no violation: incremented 'for' loop variable inside do-while</description>
+        <rule-property name="forReassign">skip</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            do i++; while(foo());
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>no violation: incremented 'for' loop variable inside nested for</description>
+        <rule-property name="forReassign">skip</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            for (int j=0; j < foo(); j++) i++;
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>no violation: incremented 'for' loop variable after continue</description>
+        <rule-property name="forReassign">skip</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            if (foo()) continue;
             i++;
         }
     }
@@ -98,15 +261,17 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>no violation: incremented 'for' loop variable</description>
+        <description>violation: incremented 'for' loop variable before continue</description>
         <rule-property name="forReassign">skip</rule-property>
-        <expected-problems>0</expected-problems>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     void foo(int bar) {
         for (int i=0; i < 10; i++) {
+            i++;
+            if (foo()) continue;
             doSomethingWith(i);
-            i += 1;
         }
     }
 }
@@ -123,8 +288,24 @@ public class Foo {
     void foo(int bar) {
         for (int i=0; i < 10; i++) {
             doSomethingWith(i);
-            i += 1;
-            i = 5;
+            if (foo()) i += 1;
+            if (foo()) i = 5;
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>violation: inline-reassign 'for' loop variable, only skip allowed</description>
+        <rule-property name="forReassign">skip</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i += 1);
         }
     }
 }
@@ -173,24 +354,28 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>violation: various reassignments of 'for' loop variable, skip allowed</description>
+        <description>violation: various conditional reassignments of 'for' loop variable, skip allowed</description>
         <rule-property name="forReassign">skip</rule-property>
-        <expected-problems>3</expected-problems>
-        <expected-linenumbers>11,12,13</expected-linenumbers>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>13,14,15,16</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     void foo(int bar) {
         for (int i=0; i < 10; i++) {
             doSomethingWith(i);
-            i++;
-            i--;
-            ++i;
-            --i;
-            i += 1;
-            i -= 1;
-            i *= 1; // not OK
-            i /= 1; // not OK
-            i = 5; // not OK
+            if (foo()) {
+                i++;
+                i--;
+                ++i;
+                --i;
+                i += 1;
+                i -= 1;
+                doSomethingWith(i++);
+                i *= 1; // not OK
+                i /= 1; // not OK
+                i = 5; // not OK
+                doSomethingWith(i = 5); // not OK
+            }
         }
     }
 }
@@ -204,10 +389,11 @@ public class Foo {
         <code><![CDATA[
 public class Foo {
     void foo(int bar) {
-        int[] ints = {1, 2, 3};
-        for (int i : ints) {
-            doSomethingWith(i);
-            i = 5; // not OK
+        String[] strings = getStrings();
+        for(String s : strings) {
+            doSomethingWith(s);
+            s = s.toUpper(); // not OK
+            doSomethingElseWith(s);
         }
     }
 }
@@ -215,17 +401,18 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>violation: increment 'foreach' loop variable, but not as first statement</description>
+        <description>violation: reassign 'foreach' loop variable, but not as first statement</description>
         <rule-property name="foreachReassign">firstOnly</rule-property>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>6</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     void foo(int bar) {
-        int[] ints = {1, 2, 3};
-        for (int i : ints) {
-            doSomethingWith(i);
-            i += 1; // not OK
+        String[] strings = getStrings();
+        for(String s : strings) {
+            doSomethingWith(s);
+            s = s.toUpper(); // not OK
+            doSomethingElseWith(s);
         }
     }
 }
@@ -233,16 +420,16 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>no violation: increment 'foreach' loop variable as first statement</description>
+        <description>no violation: reassign 'foreach' loop variable as first statement</description>
         <rule-property name="foreachReassign">firstOnly</rule-property>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
     void foo(int bar) {
-        int[] ints = {1, 2, 3};
-        for (int i : ints) {
-            i++;
-            doSomethingWith(i);
+        String[] strings = getStrings();
+        for(String s : strings) {
+            s = s.trim();
+            doSomethingWith(s);
         }
     }
 }
@@ -250,35 +437,19 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>no violation: assign-increment 'foreach' loop variable as first statement</description>
-        <rule-property name="foreachReassign">firstOnly</rule-property>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-public class Foo {
-    void foo(int bar) {
-        int[] ints = {1, 2, 3};
-        for (int i : ints) {
-            i += 1;
-            doSomethingWith(i);
-        }
-    }
-}
-     ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>violation: increment 'foreach' loop variable multiple times</description>
+        <description>violation: reassign 'foreach' loop variable multiple times, only first statement is allowed</description>
         <rule-property name="foreachReassign">firstOnly</rule-property>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>7</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     void foo(int bar) {
-        int[] ints = {1, 2, 3};
-        for (int i : ints) {
-            i++;
-            doSomethingWith(i);
-            i++; // not OK
+        String[] strings = getStrings();
+        for(String s : strings) {
+            s = s.trim();
+            doSomethingWith(s);
+            s = s.toUpper(); // not OK
+            doSomethingElseWith(s);
         }
     }
 }
@@ -286,55 +457,18 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>violation: pre-increment 'foreach' loop variable multiple times</description>
-        <rule-property name="foreachReassign">firstOnly</rule-property>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>7</expected-linenumbers>
-        <code><![CDATA[
-public class Foo {
-    void foo(int bar) {
-        int[] ints = {1, 2, 3};
-        for (int i : ints) {
-            ++i;
-            doSomethingWith(i);
-            ++i; // not OK
-        }
-    }
-}
-     ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>violation: assign-increment 'foreach' loop variable multiple times</description>
-        <rule-property name="foreachReassign">firstOnly</rule-property>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>7</expected-linenumbers>
-        <code><![CDATA[
-public class Foo {
-    void foo(int bar) {
-        int[] ints = {1, 2, 3};
-        for (int i : ints) {
-            i += 1;
-            doSomethingWith(i);
-            i += 1; // not OK
-        }
-    }
-}
-     ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>no violation: increment 'foreach' loop variable multiple times</description>
+        <description>no violation: reassign 'foreach' loop variable multiple times</description>
         <rule-property name="foreachReassign">allow</rule-property>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
     void foo(int bar) {
-        int[] ints = {1, 2, 3};
-        for (int i : ints) {
-            i += 1;
-            doSomethingWith(i);
-            i += 1; // not OK
+        String[] strings = getStrings();
+        for(String s : strings) {
+            s = s.trim();
+            doSomethingWith(s);
+            s = s.toUpper(); // not OK
+            doSomethingElseWith(s);
         }
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/AvoidReassigningLoopVariables.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/AvoidReassigningLoopVariables.xml
@@ -36,6 +36,36 @@ public class Foo {
     </test-code>
 
     <test-code>
+        <description>no violation: incremented other variable</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            x++;
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>no violation: incremented field</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            this.i++; // not OK
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
         <description>violation: add to 'for' loop variable</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>5</expected-linenumbers>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/AvoidReassigningLoopVariables.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/AvoidReassigningLoopVariables.xml
@@ -7,6 +7,9 @@
         <description>violation: reassigned 'for' loop variable</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>5</expected-linenumbers>
+        <expected-messages>
+            <message>Avoid reassigning the loop control variable 'i'</message>
+        </expected-messages>
         <code><![CDATA[
 public class Foo {
     void foo(int bar) {
@@ -29,6 +32,68 @@ public class Foo {
         for (int i=0; i < 10; i++) {
             doSomethingWith(i);
             i++; // not OK
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>no violation: assign to/increment array using variable as index</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    private int[] array = new int[10];
+
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            this.array[i] = 5;
+            array[i] = 5;
+            this.array[i]++;
+            array[i]++;
+            ++this.array[i];
+            ++array[i];
+            this.array[i] += 1;
+            array[i] += 1;
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>no violation: accessing array elements or fields of the loop variable</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void foo() {
+        for(String[] bar : bars()) {
+            bar[0] = "foo";
+            bar.length = 5; // let's assume that array.length is writable...
+            this.bar = 5;
+        }
+    }
+}
+
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>violation: assign to array using changed variable as index</description>
+        <expected-problems>6</expected-problems>
+        <expected-linenumbers>6,7,8,9,10,11</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    private String[] array = new String[10];
+
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            this.array[i++] = "Number " + i;
+            this.array[++i] = "Number " + i;
+            this.array[i = 5] = "Number " + i;
+            array[i++] = "Number " + i;
+            array[++i] = "Number " + i;
+            array[i = 5] = "Number " + i;
         }
     }
 }
@@ -66,7 +131,7 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>no violation: incremented field</description>
+        <description>no violation: incremented own field</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -74,6 +139,21 @@ public class Foo {
         for (int i=0; i < 10; i++) {
             doSomethingWith(i);
             this.i++;
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>no violation: incremented other field</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            otherObject.i++;
         }
     }
 }
@@ -149,7 +229,7 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>no violation: conditionally incremented 'for' loop variable</description>
+        <description>no violation: assign-increment 'for' loop variable inside if</description>
         <rule-property name="forReassign">skip</rule-property>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
@@ -188,7 +268,66 @@ public class Foo {
 public class Foo {
     void foo(int bar) {
         for (int i=0; i < 10; i++) {
-            if (foo()) doSomethingWith(i++);
+            if (foo())
+                doSomethingWith(i++);
+            else if (bar())
+                doSomethingElseWith(i--);
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>violation: incremented 'for' loop variable in if condition</description>
+        <rule-property name="forReassign">skip</rule-property>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>4,6</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            if (foo(i++))
+                doSomething();
+            else if (bar(i++))
+                doSomethingElse();
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>no violation: incremented 'for' loop variable inside switch-case</description>
+        <rule-property name="forReassign">skip</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            switch (foo()) {
+                case 1: i++;
+            }
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>violation: incremented 'for' loop variable inside switch expression</description>
+        <rule-property name="forReassign">skip</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            switch (foo(i++)) {
+                case 1: doSomething();
+            }
         }
     }
 }
@@ -212,6 +351,23 @@ public class Foo {
     </test-code>
 
     <test-code>
+        <description>violation: incremented 'for' loop variable inside while condition</description>
+        <rule-property name="forReassign">skip</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            while (foo(i++)) doSomething();
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
         <description>no violation: incremented 'for' loop variable inside do-while</description>
         <rule-property name="forReassign">skip</rule-property>
         <expected-problems>0</expected-problems>
@@ -228,6 +384,23 @@ public class Foo {
     </test-code>
 
     <test-code>
+        <description>violation: incremented 'for' loop variable inside do-while condition</description>
+        <rule-property name="forReassign">skip</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            do doSomething(); while(foo(i++));
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
         <description>no violation: incremented 'for' loop variable inside nested for</description>
         <rule-property name="forReassign">skip</rule-property>
         <expected-problems>0</expected-problems>
@@ -237,6 +410,57 @@ public class Foo {
         for (int i=0; i < 10; i++) {
             doSomethingWith(i);
             for (int j=0; j < foo(); j++) i++;
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>violation: incremented 'for' loop variable inside nested for declaration</description>
+        <rule-property name="forReassign">skip</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            for (int j=i++; j < foo(); j++) doSomething();
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>violation: incremented 'for' loop variable inside nested for expression</description>
+        <rule-property name="forReassign">skip</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            for (int j=0; j < foo(i++); j++) doSomething();
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>violation: incremented 'for' loop variable inside nested for update</description>
+        <rule-property name="forReassign">skip</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            for (int j=0; j < foo(); j=i++) doSomething();
         }
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/AvoidReassigningLoopVariables.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/AvoidReassigningLoopVariables.xml
@@ -1,0 +1,313 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+    <test-code>
+        <description>violation: reassigned 'for' loop variable</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            i = 5; // not OK
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>violation: incremented 'for' loop variable</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            i++; // not OK
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>violation: add to 'for' loop variable</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            i += 1; // not OK
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>no violation: incremented 'for' loop variable</description>
+        <rule-property name="forReassign">skip</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            i++;
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>no violation: incremented 'for' loop variable</description>
+        <rule-property name="forReassign">skip</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            i += 1;
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>violation: reassign 'for' loop variable, only skip allowed</description>
+        <rule-property name="forReassign">skip</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            i += 1;
+            i = 5;
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>no violation: reassign 'for' loop variable</description>
+        <rule-property name="forReassign">allow</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            i += 1;
+            i = 5;
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>violation: various reassignments of 'for' loop variable</description>
+        <expected-problems>9</expected-problems>
+        <expected-linenumbers>5,6,7,8,9,10,11,12,13</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            i++; // not OK
+            i--; // not OK
+            ++i; // not OK
+            --i; // not OK
+            i += 1; // not OK
+            i -= 1; // not OK
+            i *= 1; // not OK
+            i /= 1; // not OK
+            i = 5; // not OK
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>violation: various reassignments of 'for' loop variable, skip allowed</description>
+        <rule-property name="forReassign">skip</rule-property>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>11,12,13</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            i++;
+            i--;
+            ++i;
+            --i;
+            i += 1;
+            i -= 1;
+            i *= 1; // not OK
+            i /= 1; // not OK
+            i = 5; // not OK
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>violation: reassigned 'foreach' loop variable</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        int[] ints = {1, 2, 3};
+        for (int i : ints) {
+            doSomethingWith(i);
+            i = 5; // not OK
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>violation: increment 'foreach' loop variable, but not as first statement</description>
+        <rule-property name="foreachReassign">firstOnly</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        int[] ints = {1, 2, 3};
+        for (int i : ints) {
+            doSomethingWith(i);
+            i += 1; // not OK
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>no violation: increment 'foreach' loop variable as first statement</description>
+        <rule-property name="foreachReassign">firstOnly</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        int[] ints = {1, 2, 3};
+        for (int i : ints) {
+            i++;
+            doSomethingWith(i);
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>no violation: assign-increment 'foreach' loop variable as first statement</description>
+        <rule-property name="foreachReassign">firstOnly</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        int[] ints = {1, 2, 3};
+        for (int i : ints) {
+            i += 1;
+            doSomethingWith(i);
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>violation: increment 'foreach' loop variable multiple times</description>
+        <rule-property name="foreachReassign">firstOnly</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        int[] ints = {1, 2, 3};
+        for (int i : ints) {
+            i++;
+            doSomethingWith(i);
+            i++; // not OK
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>violation: pre-increment 'foreach' loop variable multiple times</description>
+        <rule-property name="foreachReassign">firstOnly</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        int[] ints = {1, 2, 3};
+        for (int i : ints) {
+            ++i;
+            doSomethingWith(i);
+            ++i; // not OK
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>violation: assign-increment 'foreach' loop variable multiple times</description>
+        <rule-property name="foreachReassign">firstOnly</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        int[] ints = {1, 2, 3};
+        for (int i : ints) {
+            i += 1;
+            doSomethingWith(i);
+            i += 1; // not OK
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>no violation: increment 'foreach' loop variable multiple times</description>
+        <rule-property name="foreachReassign">allow</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void foo(int bar) {
+        int[] ints = {1, 2, 3};
+        for (int i : ints) {
+            i += 1;
+            doSomethingWith(i);
+            i += 1; // not OK
+        }
+    }
+}
+     ]]></code>
+    </test-code>
+</test-data>


### PR DESCRIPTION
This implements the new AvoidReassigningLoopVariables rule proposed in #1518
- the rule checks for and foreach loops
- "for" loops: configuration to completely allow/deny changing the variable in the loop body or allow only incrementing/decrementing the variable
- "foreach" loops: configuration to completely allow/deny changing the variable in the loop body or allow changing it in the first statement
- test-cases to verify the allow, deny, and intermediate configuration options

**Rationale for the intermediate configuration options:**

Incrementing or decrementing a "for" loop variable is fairly common, e.g. when skipping/re-reading elements. Setting the variable directly is either a bug or an indicator that the loop is overly complicated. This ensures that the loop variable in general runs through the range of values as given in the header.

Changing the value of the "foreach" loop variable is usually done to clean up the values in the collection. This could also be done by changing/copying the values into a new collection or using a stream().map().forEach() construct; doing it inline is simply more efficient. Changing the variable later in the loop body can be confusing as it isn't immediately visible which part of the loop uses the original value and which part uses the changed value.