### PR TITLE
[apex] Include the documentation category

### DIFF
--- a/pmd-apex/src/main/resources/category/apex/categories.properties
+++ b/pmd-apex/src/main/resources/category/apex/categories.properties
@@ -6,6 +6,7 @@ rulesets.filenames=\
     category/apex/bestpractices.xml,\
     category/apex/codestyle.xml,\
     category/apex/design.xml,\
+    category/apex/documentation.xml,\
     category/apex/errorprone.xml,\
     category/apex/performance.xml,\
     category/apex/security.xml


### PR DESCRIPTION
We are currently not generating documentation for the `ApexDoc` rule, included in the documentation category.