### PR TITLE
[core] Deprecate StatisticalRule

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -55,6 +55,15 @@ This is a {{ site.pmd.release_type }} release.
 
 ### API Changes
 
+#### Deprecated API
+
+* {% jdoc core::lang.rule.stat.StatisticalRule %} and the related helper classes and base rule classes
+are deprecated for removal in 7.0.0. This includes all of {% jdoc_package core::stat %} and {% jdoc_package core::lang.rule.stat %},
+and also {% jdoc java::lang.java.rule.AbstractStatisticalJavaRule %}, {% jdoc apex::lang.apex.rule.AbstractStatisticalApexRule %} and the like.
+The methods {% jdoc !c!core::Report#addMetric(core::stat.Metric) %} and {% jdoc core::ThreadSafeReportListener#metricAdded(core::stat.Metric) %}
+will also be removed.
+
+
 ### External Contributions
 
 *   [#1503](https://github.com/pmd/pmd/pull/1503): \[java] Fix for ReturnFromFinallyBlock false-positives - [RishabhDeep Singh](https://github.com/rishabhdeepsingh)

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/AbstractStatisticalApexRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/AbstractStatisticalApexRule.java
@@ -12,6 +12,11 @@ import net.sourceforge.pmd.lang.rule.stat.StatisticalRule;
 import net.sourceforge.pmd.lang.rule.stat.StatisticalRuleHelper;
 import net.sourceforge.pmd.stat.DataPoint;
 
+
+/**
+ * @deprecated see {@link StatisticalRule}
+ */
+@Deprecated
 public abstract class AbstractStatisticalApexRule extends AbstractApexRule implements StatisticalRule {
 
     private final StatisticalRuleHelper helper = new StatisticalRuleHelper(this);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
@@ -20,6 +20,7 @@ import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 
 import net.sourceforge.pmd.lang.dfa.report.ReportTree;
+import net.sourceforge.pmd.lang.rule.stat.StatisticalRule;
 import net.sourceforge.pmd.renderers.AbstractAccumulatingRenderer;
 import net.sourceforge.pmd.stat.Metric;
 import net.sourceforge.pmd.util.DateTimeUtil;
@@ -340,7 +341,10 @@ public class Report implements Iterable<RuleViolation> {
      *
      * @param metric
      *            the metric to add
+     *
+     * @deprecated see {@link StatisticalRule}
      */
+    @Deprecated
     public void addMetric(Metric metric) {
         metrics.add(metric);
         for (ThreadSafeReportListener listener : listeners) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ThreadSafeReportListener.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ThreadSafeReportListener.java
@@ -27,6 +27,8 @@ public interface ThreadSafeReportListener {
      *
      * @param metric
      *            the metric
+     * @deprecated see {@link net.sourceforge.pmd.lang.rule.stat.StatisticalRule}
      */
+    @Deprecated
     void metricAdded(Metric metric);
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/stat/StatisticalRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/stat/StatisticalRule.java
@@ -17,12 +17,24 @@ import net.sourceforge.pmd.stat.Metric;
  * @see DataPoint
  * @see Metric
  * @see StatisticalRuleHelper
+ * @deprecated Statistical rules can be implemented much more easily with plain
+ * rules, and this framework is confusing and under-documented. All interfaces
+ * and classes related to this rule will be removed by 7.0.0. See also <a href="https://github.com/pmd/pmd/issues/483">#483</a>.
  */
+@Deprecated
 public interface StatisticalRule extends Rule {
 
+    // These property descriptors can't map to the new properties framework and
+    // should be removed before removing the concrete property classes as part of #1432
+
+    /** @deprecated Not useful, will not be replaced. */
+    @Deprecated
     DoubleProperty SIGMA_DESCRIPTOR = new DoubleProperty("sigma", "Sigma value", -10000000d, 1000000d, null, 1.0f);
+    // TODO we should have one such property descriptor pro rule, and *not* share it, to allow setting specific defaults
     DoubleProperty MINIMUM_DESCRIPTOR = new DoubleProperty("minimum", "Minimum reporting threshold", -10000000d, 1000000000d, null,
             2.0f);
+    /** @deprecated Not useful, will not be replaced. */
+    @Deprecated
     IntegerProperty TOP_SCORE_DESCRIPTOR = new IntegerProperty("topscore", "Top score value", 1, 100, null, 3.0f);
 
     void addDataPoint(DataPoint point);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/stat/StatisticalRuleHelper.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/stat/StatisticalRuleHelper.java
@@ -22,7 +22,9 @@ import net.sourceforge.pmd.stat.Metric;
  * Rule implementations should delegate to an instance of this class.
  *
  * @author David Dixon-Peugh Aug 8, 2002 StatisticalRule.java
+ * @deprecated see {@link StatisticalRule}
  */
+@Deprecated
 public class StatisticalRuleHelper {
 
     public static final double DELTA = 0.000005; // Within this range. . .

--- a/pmd-core/src/main/java/net/sourceforge/pmd/stat/DataPoint.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/stat/DataPoint.java
@@ -7,13 +7,17 @@ package net.sourceforge.pmd.stat;
 import java.util.Random;
 
 import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.rule.stat.StatisticalRule;
+
 
 /**
  * Datapoint used for rules that deal with metrics.
  *
  * @author David Dixon-Peugh
  * @since Aug 8, 2002
+ * @deprecated see {@link StatisticalRule}
  */
+@Deprecated
 public class DataPoint implements Comparable<DataPoint> {
 
     private Node node;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/stat/Metric.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/stat/Metric.java
@@ -4,11 +4,16 @@
 
 package net.sourceforge.pmd.stat;
 
+import net.sourceforge.pmd.lang.rule.stat.StatisticalRule;
+
+
 /**
  * This class holds all sorts of statistical information.
  *
  * @author David Dixon-Peugh
+ * @deprecated see {@link StatisticalRule}
  */
+@Deprecated
 public class Metric {
     private String metricName = null;
     private int count = 0;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractStatisticalJavaRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractStatisticalJavaRule.java
@@ -12,6 +12,11 @@ import net.sourceforge.pmd.lang.rule.stat.StatisticalRule;
 import net.sourceforge.pmd.lang.rule.stat.StatisticalRuleHelper;
 import net.sourceforge.pmd.stat.DataPoint;
 
+
+/**
+ * @deprecated see {@link StatisticalRule}
+ */
+@Deprecated
 public abstract class AbstractStatisticalJavaRule extends AbstractJavaRule implements StatisticalRule {
 
     private final StatisticalRuleHelper helper = new StatisticalRuleHelper(this);

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractStatisticalPLSQLRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractStatisticalPLSQLRule.java
@@ -12,6 +12,11 @@ import net.sourceforge.pmd.lang.rule.stat.StatisticalRule;
 import net.sourceforge.pmd.lang.rule.stat.StatisticalRuleHelper;
 import net.sourceforge.pmd.stat.DataPoint;
 
+
+/**
+ * @deprecated see {@link StatisticalRule}
+ */
+@Deprecated
 public abstract class AbstractStatisticalPLSQLRule extends AbstractPLSQLRule implements StatisticalRule {
 
     private final StatisticalRuleHelper helper = new StatisticalRuleHelper(this);

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/AbstractStatisticalVmRule.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/AbstractStatisticalVmRule.java
@@ -12,6 +12,11 @@ import net.sourceforge.pmd.lang.rule.stat.StatisticalRule;
 import net.sourceforge.pmd.lang.rule.stat.StatisticalRuleHelper;
 import net.sourceforge.pmd.stat.DataPoint;
 
+
+/**
+ * @deprecated see {@link StatisticalRule}
+ */
+@Deprecated
 public abstract class AbstractStatisticalVmRule extends AbstractVmRule implements StatisticalRule {
 
     private final StatisticalRuleHelper helper = new StatisticalRuleHelper(this);


### PR DESCRIPTION
This relates to #483. The concrete rule classes can't be refactored for now without breaking the API, because of the properties declared by StatisticalRule. Statistical rules also need to be removed before #1432 can proceed on the 7.0.x branch