### PR TITLE
[java] InvalidSlf4jMessageFormatRule should not throw NPE for enums

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidSlf4jMessageFormatRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidSlf4jMessageFormatRule.java
@@ -20,6 +20,7 @@ import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBody;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
+import net.sourceforge.pmd.lang.java.ast.ASTEnumBody;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTInitializer;
@@ -175,7 +176,7 @@ public class InvalidSlf4jMessageFormatRule extends AbstractJavaRule {
 
             if (count == 0) {
                 // look if the message is defined in a field
-                final List<ASTFieldDeclaration> fieldlist = node.getFirstParentOfType(ASTClassOrInterfaceBody.class)
+                final List<ASTFieldDeclaration> fieldlist = node.getFirstParentOfAnyType(ASTClassOrInterfaceBody.class, ASTEnumBody.class)
                         .findDescendantsOfType(ASTFieldDeclaration.class);
                 // only look for ASTVariableDeclarator that are Fields
                 final List<ASTVariableDeclarator> fields = new ArrayList<>(fieldlist.size());

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidSlf4jMessageFormat.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidSlf4jMessageFormat.xml
@@ -335,4 +335,48 @@ public final class Main {
             }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>NPE in enums (see #1549)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            import org.slf4j.Logger;
+            import org.slf4j.LoggerFactory;
+
+            public enum LoggerHelper {
+                INSTANCE;
+
+                private final Logger log = LoggerFactory.getLogger(LoggerHelper.class);
+
+                public void sendMessage(String message) {
+                    log.info(message);
+                }
+
+                public static void main(String[] args) {
+                    LoggerHelper.INSTANCE.sendMessage("A message");
+                }
+            }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>missing argument in enum</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>11</expected-linenumbers>
+        <code><![CDATA[
+            import org.slf4j.Logger;
+            import org.slf4j.LoggerFactory;
+
+            public enum LoggerHelper {
+                INSTANCE;
+
+                public static void main(String[] args) {
+                    final Logger logger = LoggerFactory.getLogger(loggerName);
+                    final String pattern = "log: {}";
+
+                    logger.info(pattern, 1, 2);
+                }
+            }
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidSlf4jMessageFormat.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidSlf4jMessageFormat.xml
@@ -362,7 +362,7 @@ public final class Main {
     <test-code>
         <description>missing argument in enum</description>
         <expected-problems>1</expected-problems>
-        <expected-linenumbers>11</expected-linenumbers>
+        <expected-linenumbers>12</expected-linenumbers>
         <code><![CDATA[
             import org.slf4j.Logger;
             import org.slf4j.LoggerFactory;
@@ -370,8 +370,9 @@ public final class Main {
             public enum LoggerHelper {
                 INSTANCE;
 
+                private final Logger logger = LoggerFactory.getLogger(loggerName);
+
                 public static void main(String[] args) {
-                    final Logger logger = LoggerFactory.getLogger(loggerName);
                     final String pattern = "log: {}";
 
                     logger.info(pattern, 1, 2);

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidSlf4jMessageFormat.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidSlf4jMessageFormat.xml
@@ -370,10 +370,10 @@ public final class Main {
             public enum LoggerHelper {
                 INSTANCE;
 
-                private final Logger logger = LoggerFactory.getLogger(loggerName);
+                private static final String pattern = "log: {}";
 
                 public static void main(String[] args) {
-                    final String pattern = "log: {}";
+                    final Logger logger = LoggerFactory.getLogger(LoggerHelper.class);
 
                     logger.info(pattern, 1, 2);
                 }


### PR DESCRIPTION
InvalidSlf4jMessageFormatRule should support enums

Fixes #1549
