### PR TITLE
[core] Upgrading Google Gson from 2.5 to 2.8.5

### DIFF
--- a/pmd-core/pom.xml
+++ b/pmd-core/pom.xml
@@ -140,7 +140,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.5</version>
+            <version>2.8.5</version>
         </dependency>
 
 


### PR DESCRIPTION
Upgrading Google Gson from 2.5 (released November 2015) to 2.8.5 (released May 2018).

`mvnw clean verify` passes.