### PR TITLE
[core] Upgrading System Rules dependency from 1.8.0 to 1.19.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -906,7 +906,7 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
             <dependency>
                 <groupId>com.github.stefanbirkner</groupId>
                 <artifactId>system-rules</artifactId>
-                <version>1.8.0</version>
+                <version>1.19.0</version>
             </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>


### PR DESCRIPTION
Upgrading System Rules dependency from 1.8.0 (released January 2015) to 1.19.0 (released November 2018).

`mvnw clean verify` passes.