### PR TITLE
[doc] Add note which rules replace the deprecated rule.

### DIFF
--- a/docs/pages/next_major_development.md
+++ b/docs/pages/next_major_development.md
@@ -369,10 +369,10 @@ large projects, with many duplications, it was causing `OutOfMemoryError`s (see 
 *   The Java rule {% rule java/codestyle/AbstractNaming %} is deprecated
     in favour of {% rule java/codestyle/ClassNamingConventions %}.
 
-*   The Java rules {% rule java/codestyle/WhileLoopsMustUseBraces %}, {% rule java/codestyle/ForLoopMustUseBraces %}, {% rule java/codestyle/IfStmtMustUseBraces %}, and {% rule java/codestyle/IfElseStmtMustUseBraces %}
-    are deprecated. They will be replaced by the new rule {% rule java/codestyle/ControlStatementBraces %}
+*   The Java rules {% rule java/codestyle/WhileLoopsMustUseBraces %}, {% rule java/codestyle/ForLoopsMustUseBraces %}, {% rule java/codestyle/IfStmtsMustUseBraces %}, and {% rule java/codestyle/IfElseStmtsMustUseBraces %}
+    are deprecated. They will be replaced by the new rule {% rule java/codestyle/ControlStatementBraces %}.
 
-*   The Java rules {% rule java/codestyle/NcssConstructorCount %}, {% rule java/codestyle/NcssMethodCount %}, and {% rule java/codestyle/NcssTypeCount %} have been
+*   The Java rules {% rule java/design/NcssConstructorCount %}, {% rule java/design/NcssMethodCount %}, and {% rule java/design/NcssTypeCount %} have been
     deprecated. They will be replaced by the new rule {% rule java/design/NcssCount %} in the category `design`.
 
 *   The Java rule `LooseCoupling` in ruleset `java-typeresolution` is deprecated. Use the rule with the same name from category `bestpractices` instead.

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -17,7 +17,10 @@
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#abstractnaming">
         <description>
-            Abstract classes should be named 'AbstractXXX'.
+Abstract classes should be named 'AbstractXXX'.
+
+This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+by {% rule java/codestyle/ClassNamingConventions %}.
         </description>
         <priority>3</priority>
         <properties>
@@ -134,6 +137,9 @@ public class MyClass {
 Prefixing parameters by 'in' or 'out' pollutes the name of the parameters and reduces code readability.
 To indicate whether or not a parameter will be modify in a method, its better to document method
 behavior with Javadoc.
+
+This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+by the more general rule {% rule java/codestyle/FormalParameterNamingConventions %}.
         </description>
         <priority>4</priority>
         <properties>
@@ -772,6 +778,9 @@ public class Foo {
 Avoid using 'for' statements without using curly braces. If the code formatting or 
 indentation is lost then it becomes difficult to separate the code being controlled 
 from the rest.
+
+This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+by the rule {% rule java/codestyle/ControlStatementBraces %}.
         </description>
         <priority>3</priority>
         <properties>
@@ -914,6 +923,9 @@ try {
 Avoid using if..else statements without using surrounding braces. If the code formatting 
 or indentation is lost then it becomes difficult to separate the code being controlled 
 from the rest.
+
+This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+by the rule {% rule java/codestyle/ControlStatementBraces %}.
         </description>
         <priority>3</priority>
         <properties>
@@ -953,6 +965,9 @@ if (foo)
 Avoid using if statements without using braces to surround the code block. If the code 
 formatting or indentation is lost then it becomes difficult to separate the code being
 controlled from the rest.
+
+This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+by the rule {% rule java/codestyle/ControlStatementBraces %}.
         </description>
         <priority>3</priority>
         <properties>
@@ -1303,6 +1318,10 @@ public class Foo {
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#misleadingvariablename">
         <description>
 Detects when a non-field has a name starting with 'm_'.  This usually denotes a field and could be confusing.
+
+This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+by the more general rule
+{% rule java/codestyle/LocalVariableNamingConventions %}.
         </description>
         <priority>3</priority>
         <properties>
@@ -1681,6 +1700,9 @@ public class Something {
         <description>
 Field names using all uppercase characters - Sun's Java naming conventions indicating constants - should
 be declared as final.
+
+This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+by the more general rule {% rule java/codestyle/FieldNamingConventions %}.
         </description>
         <priority>3</priority>
         <properties>
@@ -2100,6 +2122,11 @@ public class Foo {
 A variable naming conventions rule - customize this to your liking.  Currently, it
 checks for final variables that should be fully capitalized and non-final variables
 that should not include underscores.
+
+This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+by the more general rules {% rule java/codestyle/FieldNamingConventions %},
+{% rule java/codestyle/FormalParameterNamingConventions %}, and
+{% rule java/codestyle/LocalVariableNamingConventions %}.
         </description>
         <priority>1</priority>
         <example>
@@ -2124,6 +2151,9 @@ public class Foo {
 Avoid using 'while' statements without using braces to surround the code block. If the code 
 formatting or indentation is lost then it becomes difficult to separate the code being
 controlled from the rest.
+
+This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+by the rule {% rule java/codestyle/ControlStatementBraces %}.
         </description>
         <priority>3</priority>
         <properties>

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -873,6 +873,9 @@ plus one for the method entry.  The decision points include 'if', 'while', 'for'
 Generally, numbers ranging from 1-4 denote low complexity, 5-7 denote moderate complexity, 8-10 denote
 high complexity, and 11+ is very high complexity. Modified complexity treats switch statements as a single
 decision point.
+
+This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+by the rule {% rule java/design/CyclomaticComplexity %}.
         </description>
         <priority>3</priority>
         <example>
@@ -927,6 +930,9 @@ public class Foo {    // This has a Cyclomatic Complexity = 9
 This rule uses the NCSS (Non-Commenting Source Statements) algorithm to determine the number of lines
 of code for a given constructor. NCSS ignores comments, and counts actual statements. Using this algorithm,
 lines of code that are split are counted as one.
+
+This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+by the rule {% rule java/design/NcssCount %}.
         </description>
         <priority>3</priority>
         <example>
@@ -1000,6 +1006,9 @@ class Foo {                         // +1, total Ncss = 12
 This rule uses the NCSS (Non-Commenting Source Statements) algorithm to determine the number of lines
 of code for a given method. NCSS ignores comments, and counts actual statements. Using this algorithm,
 lines of code that are split are counted as one.
+
+This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+by the rule {% rule java/design/NcssCount %}.
         </description>
         <priority>3</priority>
         <example>
@@ -1031,6 +1040,9 @@ public class Foo extends Bar {
 This rule uses the NCSS (Non-Commenting Source Statements) algorithm to determine the number of lines
 of code for a given type. NCSS ignores comments, and counts actual statements. Using this algorithm,
 lines of code that are split are counted as one.
+
+This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+by the rule {% rule java/design/NcssCount %}.
         </description>
         <priority>3</priority>
         <example>
@@ -1387,6 +1399,9 @@ Complexity directly affects maintenance costs is determined by the number of dec
 plus one for the method entry.  The decision points include 'if', 'while', 'for', and 'case labels' calls.  
 Generally, numbers ranging from 1-4 denote low complexity, 5-7 denote moderate complexity, 8-10 denote
 high complexity, and 11+ is very high complexity.
+
+This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+by the rule {% rule java/design/CyclomaticComplexity %}.
         </description>
         <priority>3</priority>
         <example>


### PR DESCRIPTION
Just enhances the documentation a bit and directly points to the rule, that should be used instead.