### PR TITLE
[ui] Fix package exploration in jars

### DIFF
--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/XPathPanelController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/XPathPanelController.java
@@ -236,9 +236,6 @@ public class XPathPanelController implements Initializable, SettingsOwner {
             designerRoot.getLogger().logEvent(new LogEntry(e, Category.XPATH_EVALUATION_EXCEPTION));
         }
 
-        xpathResultListView.refresh();
-
-
     }
 
 

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/autocomplete/XPathAutocompleteProvider.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/autocomplete/XPathAutocompleteProvider.java
@@ -66,6 +66,7 @@ public final class XPathAutocompleteProvider {
         Set<String> completionTriggers = new HashSet<>(Arrays.asList("\r", "\r\n", "\n", "\t"));
 
         // allows tab/enter completion
+        // FIXME doesn't work on java 9
         autoCompletePopup.addEventHandler(KeyEvent.KEY_TYPED, e -> {
 
             // for some reason using KeyEvent.KEY_PRESSED didn't work with the ENTER key,

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/autocomplete/XPathAutocompleteProvider.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/autocomplete/XPathAutocompleteProvider.java
@@ -5,11 +5,8 @@
 package net.sourceforge.pmd.util.fxdesigner.util.autocomplete;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -63,27 +60,32 @@ public final class XPathAutocompleteProvider {
 
     public void initialiseAutoCompletion() {
 
-        Set<String> completionTriggers = new HashSet<>(Arrays.asList("\r", "\r\n", "\n", "\t"));
-
         // allows tab/enter completion
-        // FIXME doesn't work on java 9
-        autoCompletePopup.addEventHandler(KeyEvent.KEY_TYPED, e -> {
+        EventStreams.eventsOf(autoCompletePopup, KeyEvent.ANY)
+                    .filter(e -> !e.isConsumed())
+                    .filter(e ->
+                                // For some reason this has to be asymmetric
+                                // Delivered events vary between JREs, as well as their properties
+                                // This is the common denominator I found for JREs 8..10
 
-            // for some reason using KeyEvent.KEY_PRESSED didn't work with the ENTER key,
-            // which is why we use KeyEvent.KEY_TYPED
-            if (!e.isConsumed() && completionTriggers.contains(e.getCharacter())) {
-                int focusIdx = getFocusIdx();
-                if (focusIdx == -1) {
-                    focusIdx = 0;
-                }
+                                // Only KEY_RELEASED events are delivered for ENTER
+                                e.getEventType().equals(KeyEvent.KEY_RELEASED) && e.getCode() == KeyCode.ENTER
+                                    // All KEY_TYPED, KEY_PRESSED, and KEY_RELEASED are delivered for TAB,
+                                    // but we have to handle it before it inserts a \t so we catch KEY_PRESSED
+                                    || e.getEventType().equals(KeyEvent.KEY_PRESSED) && e.getCode() == KeyCode.TAB
 
-                if (focusIdx < autoCompletePopup.getItems().size()) {
-                    autoCompletePopup.getItems().get(focusIdx).getOnAction().handle(new ActionEvent());
-                }
-                e.consume();
-            }
+                    )
+                    .subscribe(e -> {
+                        int focusIdx = getFocusIdx();
+                        if (focusIdx == -1) {
+                            focusIdx = 0;
+                        }
 
-        });
+                        if (focusIdx < autoCompletePopup.getItems().size()) {
+                            autoCompletePopup.getItems().get(focusIdx).getOnAction().handle(new ActionEvent());
+                        }
+                        e.consume();
+                    });
 
         EventStream<Integer> changesEventStream = myCodeArea.plainTextChanges()
                                                             .map(characterChanges -> {


### PR DESCRIPTION
The refactoring of AstPackageExplorer done in #1577 didn't work properly --Files.walkFileTree doesn't work inside of a jar file. I tried to revert the change but for some reason I found that that didn't work anymore. I took ideas from [this SO post](https://stackoverflow.com/a/28057735/6245827) and made something that should work both when the libraries are inside a jar and when they're unpacked (so that it works when running inside an IDE). Without that the autocompletion doesn't find any suggestions.

Please test it works on your systems by bundling a zip distribution and checking that the autocomplete works without exception, eg with `mvn install -pl pmd-ui,pmd-dist`