### PR TITLE
[core] Update build-tools to 1.4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -282,7 +282,7 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
 
         <argLine>-Xmx512m -Dfile.encoding=${project.build.sourceEncoding}</argLine>
 
-        <pmd.build-tools.version>1.3.0</pmd.build-tools.version>
+        <pmd.build-tools.version>1.4.0</pmd.build-tools.version>
 
     </properties>
 


### PR DESCRIPTION
This fixes the build of #1576 because pmd/build-tools#12 is now included