### PR TITLE
[core] Fixes 1196: inconsistencies of clones returned by different CPD executions for the same files 

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/FileFinder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/FileFinder.java
@@ -7,9 +7,10 @@ package net.sourceforge.pmd.util;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
+import java.util.Arrays;
 import java.util.List;
+
+import org.apache.commons.io.comparator.PathFileComparator;
 
 /**
  * A utility class for finding files within a directory.
@@ -17,27 +18,20 @@ import java.util.List;
 public class FileFinder {
 
     private FilenameFilter filter;
-    private static final String FILE_SEP = System.getProperty("file.separator");
 
     /**
      * Searches for files in a given directory.
-     * The returned files are sorted alphabetically by path, ignoring the case.
      *
      * @param dir     the directory to search files
      * @param filter  the filename filter that can optionally be passed to get files that match this filter
      * @param recurse search for files recursively or not
-     * @return list of the found files sorted alphabetically by path, ignoring the case
+     * @return list of files from the given directory
      */
     public List<File> findFilesFrom(File dir, FilenameFilter filter, boolean recurse) {
         this.filter = filter;
         List<File> files = new ArrayList<>();
         scanDirectory(dir, files, recurse);
-        Collections.sort(files, new Comparator<File>() {
-            @Override
-            public int compare(File o1, File o2) {
-                return o1.getPath().compareToIgnoreCase(o2.getPath());
-            }
-        });
+
         return files;
     }
 
@@ -45,18 +39,20 @@ public class FileFinder {
      * Implements a tail recursive file scanner
      */
     private void scanDirectory(File dir, List<File> list, boolean recurse) {
-        String[] candidates = dir.list(filter);
+        File[] candidates = dir.listFiles(filter);
         if (candidates == null) {
             return;
         }
-        for (int i = 0; i < candidates.length; i++) {
-            File tmp = new File(dir + FILE_SEP + candidates[i]);
+
+        Arrays.sort(candidates, PathFileComparator.PATH_INSENSITIVE_COMPARATOR);
+
+        for (File tmp : candidates) {
             if (tmp.isDirectory()) {
                 if (recurse) {
                     scanDirectory(tmp, list, true);
                 }
             } else {
-                list.add(new File(dir + FILE_SEP + candidates[i]));
+                list.add(tmp);
             }
         }
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/FileFinder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/FileFinder.java
@@ -7,6 +7,8 @@ package net.sourceforge.pmd.util;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -17,10 +19,25 @@ public class FileFinder {
     private FilenameFilter filter;
     private static final String FILE_SEP = System.getProperty("file.separator");
 
+    /**
+     * Searches for files in a given directory.
+     * The returned files are sorted alphabetically by path, ignoring the case.
+     *
+     * @param dir     the directory to search files
+     * @param filter  the filename filter that can optionally be passed to get files that match this filter
+     * @param recurse search for files recursively or not
+     * @return list of the found files sorted alphabetically by path, ignoring the case
+     */
     public List<File> findFilesFrom(File dir, FilenameFilter filter, boolean recurse) {
         this.filter = filter;
         List<File> files = new ArrayList<>();
         scanDirectory(dir, files, recurse);
+        Collections.sort(files, new Comparator<File>() {
+            @Override
+            public int compare(File o1, File o2) {
+                return o1.getPath().compareToIgnoreCase(o2.getPath());
+            }
+        });
         return files;
     }
 


### PR DESCRIPTION
Sorts the listed files by path in order to avoid inconsistencies since the listing on directories provided by the java api does not guarantee always the same order. Therefore, sorting the files by path (ignoring the case), we can guarantee that the files will be iterated always by the same order, avoiding returning different clones for the same files in different CPD executions.