### PR TITLE
[plsql] Parse Exception when functions are used with LIKE

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -78,6 +78,7 @@ This is a {{ site.pmd.release_type }} release.
     *   [#1509](https://github.com/pmd/pmd/issues/1509): \[plsql] Parse Exception with OUTER/INNER Joins
     *   [#1511](https://github.com/pmd/pmd/issues/1511): \[plsql] Parse Exception with IS NOT NULL
     *   [#1583](https://github.com/pmd/pmd/issues/1583): \[plsql] Update Set Clause should allow multiple columns
+    *   [#1586](https://github.com/pmd/pmd/issues/1586): \[plsql] Parse Exception when functions are used with LIKE
 
 ### API Changes
 

--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -1304,9 +1304,9 @@ void Condition2() #void :
  |
     LOOKAHEAD(9) FloatingPointCondition()
  |
-    LOOKAHEAD(4) InCondition()
+    LOOKAHEAD(9) InCondition()
  |
-    LOOKAHEAD(4) LikeCondition()
+    LOOKAHEAD(9) LikeCondition()
  |
     LOOKAHEAD(4) BetweenCondition()
  |
@@ -1341,11 +1341,11 @@ ASTCompoundCondition CompoundCondition() :
 {}
 {
  (
-    LOOKAHEAD(3) "(" Condition() ")" (LOOKAHEAD(2) ( <AND> | <OR> ) Condition() )*
+    LOOKAHEAD(3) "(" Condition() ")" (LOOKAHEAD(2) ( <AND> | <OR> ) { jjtThis.setType(token.getImage()); } Condition() )*
  |
-    LOOKAHEAD(3) <NOT> Condition()
+    LOOKAHEAD(3) <NOT> { jjtThis.setType(token.getImage()); } Condition()
  |
-    LOOKAHEAD(3) Condition2() (LOOKAHEAD(2) ( <AND> | <OR> ) Condition() )*
+    LOOKAHEAD(3) Condition2() (LOOKAHEAD(2) ( <AND> | <OR> ) { jjtThis.setType(token.getImage()); } Condition() )*
  )
     { return jjtThis; }
 }

--- a/pmd-plsql/src/main/ant/alljavacc.xml
+++ b/pmd-plsql/src/main/ant/alljavacc.xml
@@ -44,6 +44,7 @@
         <delete file="${target}/net/sourceforge/pmd/lang/plsql/ast/TokenMgrError.java" />
 
         <delete file="${target}/net/sourceforge/pmd/lang/plsql/ast/ASTArguments.java" />
+        <delete file="${target}/net/sourceforge/pmd/lang/plsql/ast/ASTCompoundCondition.java" />
         <delete file="${target}/net/sourceforge/pmd/lang/plsql/ast/ASTDatatype.java" />
         <delete file="${target}/net/sourceforge/pmd/lang/plsql/ast/ASTFormalParameter.java" />
         <delete file="${target}/net/sourceforge/pmd/lang/plsql/ast/ASTIfStatement.java" />

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTCompoundCondition.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTCompoundCondition.java
@@ -1,0 +1,36 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.plsql.ast;
+
+import java.util.Locale;
+
+public class ASTCompoundCondition extends net.sourceforge.pmd.lang.plsql.ast.AbstractPLSQLNode {
+    private String type;
+
+    public ASTCompoundCondition(int id) {
+        super(id);
+    }
+
+    public ASTCompoundCondition(PLSQLParser p, int id) {
+        super(p, id);
+    }
+
+    @Override
+    public Object jjtAccept(PLSQLParserVisitor visitor, Object data) {
+        return visitor.visit(this, data);
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    void setType(String type) {
+        this.type = type;
+        if (this.type != null) {
+            this.type = this.type.toUpperCase(Locale.ROOT);
+        }
+    }
+}
+/* JavaCC - OriginalChecksum=e16db32ec742f0a3836eafa8756cfbc2 (do not edit this line) */

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ASTCompoundConditionTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ASTCompoundConditionTest.java
@@ -1,0 +1,24 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.plsql.ast;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.sourceforge.pmd.lang.plsql.AbstractPLSQLParserTst;
+
+
+public class ASTCompoundConditionTest extends AbstractPLSQLParserTst {
+
+    @Test
+    public void testParseType() {
+        ASTInput input = parsePLSQL("BEGIN SELECT COUNT(1) INTO MY_TABLE FROM USERS_TABLE WHERE user_id = 1 AnD user_id = 2; END;");
+        List<ASTCompoundCondition> compoundConditions = input.findDescendantsOfType(ASTCompoundCondition.class);
+        Assert.assertFalse(compoundConditions.isEmpty());
+        Assert.assertEquals("AND", compoundConditions.get(0).getType());
+    }
+}

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/WhereClauseLike.pls
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/WhereClauseLike.pls
@@ -11,5 +11,17 @@ BEGIN
         WHERE last_name LIKE 'R%'
         ORDER BY salary;
 
+    select count(1)
+        into users
+        from users_table
+        where userid = 1
+            AND NVL(cmp_id,0) like NVL(other_cmp_id,0);
+
+    select count(1)
+        into users
+        from users_table
+        where userid = 1
+           AND LOWER (what) LIKE LOWER ('%' || name_in || '%');
+
 END;
 /


### PR DESCRIPTION
Fixes #1586
