### PR TITLE
[java] Fix lombok.AllArgsConstructor support

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/AtLeastOneConstructorRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/AtLeastOneConstructorRule.java
@@ -33,7 +33,7 @@ public class AtLeastOneConstructorRule extends AbstractIgnoredAnnotationRule {
                 "lombok.Builder",
                 "lombok.NoArgsConstructor",
                 "lombok.RequiredArgsConstructor",
-                "lombok.AllArgsConstructorAtLeastOneConstructor");
+                "lombok.AllArgsConstructor");
     }
 
     @Override

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/AtLeastOneConstructor.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/AtLeastOneConstructor.xml
@@ -117,12 +117,56 @@ public class TestAtLeastOneConstructor {
         ]]></code>
     </test-code>
     <test-code>
-        <description>Ignore classes with lombok-generated constructors</description>
+        <description>Ignore classes with lombok-generated constructors (Value)</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 import lombok.Value;
 
 @Value
+public class TestAtLeastOneConstructor {
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Ignore classes with lombok-generated constructors (Required)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class TestAtLeastOneConstructor {
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Ignore classes with lombok-generated constructors (No)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class TestAtLeastOneConstructor {
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Ignore classes with lombok-generated constructors (All)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class TestAtLeastOneConstructor {
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Ignore classes with lombok-generated constructors (Builder)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import lombok.Builder;
+
+@Builder
 public class TestAtLeastOneConstructor {
 }
         ]]></code>


### PR DESCRIPTION
<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)
This didn't pass, but it failed in a module I didn't touch (core). `./mvnw clean verify -pl pmd-java` passes.

**PR Description:**
Fixes a copy/paste error that caused lombok.AllArgsConstructor to not count as a constructor. Fixes #1547.