### PR TITLE
[java] LinguisticNaming should ignore overriden methods

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LinguisticNamingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LinguisticNamingRule.java
@@ -80,26 +80,28 @@ public class LinguisticNamingRule extends AbstractIgnoredAnnotationRule {
 
     @Override
     public Object visit(ASTMethodDeclaration node, Object data) {
-        String nameOfMethod = node.getMethodName();
+        if (!hasIgnoredAnnotation(node)) {
+            String nameOfMethod = node.getMethodName();
 
-        if (getProperty(CHECK_BOOLEAN_METHODS)) {
-            checkBooleanMethods(node, data, nameOfMethod);
-        }
-
-        if (getProperty(CHECK_SETTERS)) {
-            checkSetters(node, data, nameOfMethod);
-        }
-
-        if (getProperty(CHECK_GETTERS)) {
-            checkGetters(node, data, nameOfMethod);
-        }
-
-        if (getProperty(CHECK_PREFIXED_TRANSFORM_METHODS)) {
-            checkPrefixedTransformMethods(node, data, nameOfMethod);
-        }
-
-        if (getProperty(CHECK_TRANSFORM_METHODS)) {
-            checkTransformMethods(node, data, nameOfMethod);
+            if (getProperty(CHECK_BOOLEAN_METHODS)) {
+                checkBooleanMethods(node, data, nameOfMethod);
+            }
+    
+            if (getProperty(CHECK_SETTERS)) {
+                checkSetters(node, data, nameOfMethod);
+            }
+    
+            if (getProperty(CHECK_GETTERS)) {
+                checkGetters(node, data, nameOfMethod);
+            }
+    
+            if (getProperty(CHECK_PREFIXED_TRANSFORM_METHODS)) {
+                checkPrefixedTransformMethods(node, data, nameOfMethod);
+            }
+    
+            if (getProperty(CHECK_TRANSFORM_METHODS)) {
+                checkTransformMethods(node, data, nameOfMethod);
+            }
         }
 
         return data;
@@ -140,12 +142,10 @@ public class LinguisticNamingRule extends AbstractIgnoredAnnotationRule {
     }
 
     private void checkSetters(ASTMethodDeclaration node, Object data, String nameOfMethod) {
-        if (!hasIgnoredAnnotation(node)) {
-            ASTResultType resultType = node.getResultType();
-            if (hasPrefix(nameOfMethod, "set") && !resultType.isVoid()) {
-                addViolationWithMessage(data, node, "Linguistics Antipattern - The setter ''{0}'' should not return any type except void linguistically",
-                        new Object[] { nameOfMethod });
-            }
+        ASTResultType resultType = node.getResultType();
+        if (hasPrefix(nameOfMethod, "set") && !resultType.isVoid()) {
+            addViolationWithMessage(data, node, "Linguistics Antipattern - The setter ''{0}'' should not return any type except void linguistically",
+                    new Object[] { nameOfMethod });
         }
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LinguisticNamingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LinguisticNamingRule.java
@@ -7,6 +7,9 @@ package net.sourceforge.pmd.lang.java.rule.codestyle;
 import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
 import static net.sourceforge.pmd.properties.PropertyFactory.stringListProperty;
 
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
 
@@ -18,11 +21,11 @@ import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTResultType;
 import net.sourceforge.pmd.lang.java.ast.ASTType;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
-import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
+import net.sourceforge.pmd.lang.java.rule.AbstractIgnoredAnnotationRule;
 import net.sourceforge.pmd.lang.java.typeresolution.TypeHelper;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 
-public class LinguisticNamingRule extends AbstractJavaRule {
+public class LinguisticNamingRule extends AbstractIgnoredAnnotationRule {
     private static final PropertyDescriptor<Boolean> CHECK_BOOLEAN_METHODS =
             booleanProperty("checkBooleanMethod").defaultValue(true).desc("Check method names and types for inconsistent naming.").build();
     private static final PropertyDescriptor<Boolean> CHECK_GETTERS =
@@ -68,6 +71,11 @@ public class LinguisticNamingRule extends AbstractJavaRule {
         addRuleChainVisit(ASTMethodDeclaration.class);
         addRuleChainVisit(ASTFieldDeclaration.class);
         addRuleChainVisit(ASTLocalVariableDeclaration.class);
+    }
+
+    @Override
+    protected Collection<String> defaultSuppressionAnnotations() {
+        return Collections.checkedList(Arrays.asList("java.lang.Override"), String.class);
     }
 
     @Override
@@ -132,10 +140,12 @@ public class LinguisticNamingRule extends AbstractJavaRule {
     }
 
     private void checkSetters(ASTMethodDeclaration node, Object data, String nameOfMethod) {
-        ASTResultType resultType = node.getResultType();
-        if (hasPrefix(nameOfMethod, "set") && !resultType.isVoid()) {
-            addViolationWithMessage(data, node, "Linguistics Antipattern - The setter ''{0}'' should not return any type except void linguistically",
-                    new Object[] { nameOfMethod });
+        if (!hasIgnoredAnnotation(node)) {
+            ASTResultType resultType = node.getResultType();
+            if (hasPrefix(nameOfMethod, "set") && !resultType.isVoid()) {
+                addViolationWithMessage(data, node, "Linguistics Antipattern - The setter ''{0}'' should not return any type except void linguistically",
+                        new Object[] { nameOfMethod });
+            }
         }
     }
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LinguisticNaming.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LinguisticNaming.xml
@@ -555,6 +555,7 @@ public class AtomicBooleanFN {
     <test-code>
         <description>#1543 [java] LinguisticNaming should ignore overriden methods</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
         <code><![CDATA[
 class Foo {
     private int value;

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LinguisticNaming.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LinguisticNaming.xml
@@ -552,4 +552,27 @@ public class AtomicBooleanFN {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>#1543 [java] LinguisticNaming should ignore overriden methods</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+class Foo {
+    private int value;
+
+    public int setValue(int value) {
+        this.value = value;
+        return value;
+    }
+}
+public class Bar extends Foo {
+    private int value;
+
+    @Override
+    public int setValue(int value) {
+        this.value = value;
+        return value;
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
**PR Description:**
Overriden methods are ignored from LinguisticNamingRule.

fixes #1543 