### PR TITLE
[java] BeanMembersShouldSerializeRule does not recognize lombok accessors

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/BeanMembersShouldSerializeRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/BeanMembersShouldSerializeRule.java
@@ -21,14 +21,15 @@ import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclarator;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimitiveType;
 import net.sourceforge.pmd.lang.java.ast.ASTResultType;
 import net.sourceforge.pmd.lang.java.ast.AccessNode;
-import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
+import net.sourceforge.pmd.lang.java.ast.Annotatable;
+import net.sourceforge.pmd.lang.java.rule.AbstractLombokAwareRule;
 import net.sourceforge.pmd.lang.java.symboltable.ClassScope;
 import net.sourceforge.pmd.lang.java.symboltable.MethodNameDeclaration;
 import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
 import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 
-public class BeanMembersShouldSerializeRule extends AbstractJavaRule {
+public class BeanMembersShouldSerializeRule extends AbstractLombokAwareRule {
 
     private String prefixProperty;
 
@@ -62,6 +63,8 @@ public class BeanMembersShouldSerializeRule extends AbstractJavaRule {
             return data;
         }
 
+        boolean classHasLombok = hasLombokAnnotation(node);
+
         Map<MethodNameDeclaration, List<NameOccurrence>> methods = node.getScope().getEnclosingScope(ClassScope.class)
                 .getMethodDeclarations();
         List<ASTMethodDeclarator> getSetMethList = new ArrayList<>(methods.size());
@@ -81,7 +84,8 @@ public class BeanMembersShouldSerializeRule extends AbstractJavaRule {
         for (Map.Entry<VariableNameDeclaration, List<NameOccurrence>> entry : vars.entrySet()) {
             VariableNameDeclaration decl = entry.getKey();
             AccessNode accessNodeParent = decl.getAccessNodeParent();
-            if (entry.getValue().isEmpty() || accessNodeParent.isTransient() || accessNodeParent.isStatic()) {
+            if (entry.getValue().isEmpty() || accessNodeParent.isTransient() || accessNodeParent.isStatic() 
+                    || classHasLombok || hasIgnoredAnnotation((Annotatable) accessNodeParent)) {
                 continue;
             }
             String varName = StringUtils.capitalize(trimIfPrefix(decl.getImage()));

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/BeanMembersShouldSerialize.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/BeanMembersShouldSerialize.xml
@@ -188,4 +188,82 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>#780 [java] BeanMembersShouldSerializeRule does not recognize lombok accessors - 1</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import lombok.Data;
+
+@Data
+public class Buzz {
+    private String foo;
+
+    public Buzz(String s) {
+        foo = s;
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>#780 [java] BeanMembersShouldSerializeRule does not recognize lombok accessors - 2</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+@lombok.Data
+public class Foo {
+    private String bar;
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>#780 [java] BeanMembersShouldSerializeRule does not recognize lombok accessors - 3</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import lombok.*;
+@Data
+public class Foo {
+    private String bar;
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>#780 [java] BeanMembersShouldSerializeRule does not recognize lombok accessors - 4</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import lombok.Getter;
+@Getter
+public class Foo {
+    private String bar;
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>#780 [java] BeanMembersShouldSerializeRule does not recognize lombok accessors - 5</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import lombok.Getter;
+public class Foo {
+    @Getter private String bar;
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>#780 [java] BeanMembersShouldSerializeRule does not recognize lombok accessors - 6</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import lombok.Getter;
+public class Foo {
+    @Getter(lazy=true) private String bar;
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>#780 [java] BeanMembersShouldSerializeRule does not recognize lombok accessors - 7</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+@Data
+public class Foo {
+    private String bar;
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
**PR Description:**
Extended **AbstractLombokAwareRule** to make **BeanMembersShouldSerializeRule** aware of lombok annotations. Checking if class or any of the variables have lombok annotations and avoiding BeanMembersShouldSerializeRule on these variables & class.

Fixes #780 


