### PR TITLE
[java] UnsynchronizedStaticFormatter reports commons lang FastDateFormat

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/UnsynchronizedStaticFormatterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/UnsynchronizedStaticFormatterRule.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.java.rule.multithreading;
 
 import java.text.Format;
+import java.util.Arrays;
 
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
@@ -27,6 +28,9 @@ import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
  */
 public class UnsynchronizedStaticFormatterRule extends AbstractJavaRule {
     private Class<?> formatterClassToCheck = Format.class;
+    private String[] threadSafeFormatter = {
+        "org.apache.commons.lang3.time.FastDateFormat",
+    };
 
     public UnsynchronizedStaticFormatterRule() {
         addRuleChainVisit(ASTFieldDeclaration.class);
@@ -48,6 +52,9 @@ public class UnsynchronizedStaticFormatterRule extends AbstractJavaRule {
         }
 
         ASTVariableDeclaratorId var = node.getFirstDescendantOfType(ASTVariableDeclaratorId.class);
+        if (Arrays.asList(threadSafeFormatter).contains(var.getType().getName())) {
+            return data;
+        }
         for (NameOccurrence occ : var.getUsages()) {
             Node n = occ.getLocation();
             if (n.getFirstParentOfType(ASTSynchronizedStatement.class) != null) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/UnsynchronizedStaticFormatterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/UnsynchronizedStaticFormatterRule.java
@@ -52,7 +52,7 @@ public class UnsynchronizedStaticFormatterRule extends AbstractJavaRule {
         }
 
         ASTVariableDeclaratorId var = node.getFirstDescendantOfType(ASTVariableDeclaratorId.class);
-        if (Arrays.asList(threadSafeFormatter).contains(var.getType().getName())) {
+        if (var.getType() != null && Arrays.asList(threadSafeFormatter).contains(var.getType().getName())) {
             return data;
         }
         for (NameOccurrence occ : var.getUsages()) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/UnsynchronizedStaticFormatterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/UnsynchronizedStaticFormatterRule.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.java.rule.multithreading;
 
 import java.text.Format;
 import java.util.Arrays;
+import java.util.List;
 
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
@@ -28,9 +29,9 @@ import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
  */
 public class UnsynchronizedStaticFormatterRule extends AbstractJavaRule {
     private Class<?> formatterClassToCheck = Format.class;
-    private String[] threadSafeFormatter = {
-        "org.apache.commons.lang3.time.FastDateFormat",
-    };
+    private static final List<String> THREAD_SAFE_FORMATTER = Arrays.asList(
+        "org.apache.commons.lang3.time.FastDateFormat"
+    );
 
     public UnsynchronizedStaticFormatterRule() {
         addRuleChainVisit(ASTFieldDeclaration.class);
@@ -52,8 +53,10 @@ public class UnsynchronizedStaticFormatterRule extends AbstractJavaRule {
         }
 
         ASTVariableDeclaratorId var = node.getFirstDescendantOfType(ASTVariableDeclaratorId.class);
-        if (var.getType() != null && Arrays.asList(threadSafeFormatter).contains(var.getType().getName())) {
-            return data;
+        for (String formatter: THREAD_SAFE_FORMATTER) {
+            if (TypeHelper.isA(var, formatter)) {
+                return data;
+            }
         }
         for (NameOccurrence occ : var.getUsages()) {
             Node n = occ.getLocation();

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/UnsynchronizedStaticFormatter.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/UnsynchronizedStaticFormatter.xml
@@ -135,4 +135,18 @@ public class Foo {
 }
      ]]></code>
     </test-code>
+    <test-code>
+        <description>#1633 [java] UnsynchronizedStaticFormatter reports commons lang FastDateFormat</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.apache.commons.lang3.time.FastDateFormat;
+
+public class Foo {
+    private static final FastDateFormat FDF = FastDateFormat.getInstance("dd.MM.yyyy HH:mm:ss");
+    public void format() {
+        FDF.format(new Date());
+    }
+}
+     ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
**PR Description:**
Thread safe formatter org.apache.commons.lang3.time.FastDateFormat can now avoid UnsynchronizedStaticFormatterRule.

Fixes #1633 

