### PR TITLE
[java] Compile time constants initialized by literals avoided by AccessorMethodGenerationRule

### DIFF
--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/AccessorMethodGeneration.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/AccessorMethodGeneration.xml
@@ -196,8 +196,8 @@ public class Foo implements Parcelable {
     </test-code>
     <test-code>
         <description>#808 - [java] AccessorMethodGeneration false positives with compile time constants</description>
-        <expected-problems>3</expected-problems>
-        <expected-linenumbers>24,27,28</expected-linenumbers>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>25,26,27,28</expected-linenumbers>
         <code><![CDATA[
 @SuppressWarnings("unused")
 class Outer {
@@ -205,11 +205,11 @@ class Outer {
   private static final String CALCULATED_STRING = "value" + 0;
   private static final int LITERAL = 0;
   private static final int CALCULATED = LITERAL * 2;
-  private static final int REFERENCED = Thread.MIN_PRIORITY;
   private static final int CAST = (int) 0L;
   private static final long NON_CONSTANT = java.util.concurrent.TimeUnit.SECONDS.toMillis(10);
   private static final String NON_CONSTANT_STR = NON_CONSTANT + "foo";
   private static final int LATE_INIT;
+  private static String STATIC_STRING = "value";
   static {
   	LATE_INIT = 0;
   }
@@ -222,11 +222,11 @@ class Outer {
            + CALCULATED_STRING
            + LITERAL
            + CALCULATED
-           + LATE_INIT        // valid violation
-           + REFERENCED
            + CAST
            + NON_CONSTANT     // valid violation
            + NON_CONSTANT_STR // valid violation
+           + LATE_INIT        // valid violation
+           + STATIC_STRING    // valid violation
       ;
     }
   }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/AccessorMethodGeneration.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/AccessorMethodGeneration.xml
@@ -194,4 +194,37 @@ public class Foo implements Parcelable {
      ]]></code>
      <source-type>java 10</source-type>
     </test-code>
+    <test-code>
+        <description>#808 - [java] AccessorMethodGeneration false positives with compile time constants - literals</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+@SuppressWarnings("unused")
+class Outer {
+  private static final String CONST_STRING = "value";
+  private static final String CALCULATED_STRING = "value" + 0;
+  private static final int LITERAL = 0;
+  private static final int CALCULATED = LITERAL * 2;
+  private static final int CAST = (int) 0L;
+  private static final int LATE_INIT;
+  static {
+  	LATE_INIT = 0;
+  }
+
+  class Inner {
+    @Override
+    public String toString() {
+      return "" // separate lines so the rule violations show up better
+           + CONST_STRING
+           + CALCULATED_STRING
+           + LITERAL
+           + CALCULATED
+           + LATE_INIT    // valid violation
+           + CAST
+      ;
+    }
+  }
+}
+     ]]></code>
+     <source-type>java 10</source-type>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/AccessorMethodGeneration.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/AccessorMethodGeneration.xml
@@ -195,8 +195,9 @@ public class Foo implements Parcelable {
      <source-type>java 10</source-type>
     </test-code>
     <test-code>
-        <description>#808 - [java] AccessorMethodGeneration false positives with compile time constants - literals</description>
-        <expected-problems>1</expected-problems>
+        <description>#808 - [java] AccessorMethodGeneration false positives with compile time constants</description>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>24,27,28</expected-linenumbers>
         <code><![CDATA[
 @SuppressWarnings("unused")
 class Outer {
@@ -204,7 +205,10 @@ class Outer {
   private static final String CALCULATED_STRING = "value" + 0;
   private static final int LITERAL = 0;
   private static final int CALCULATED = LITERAL * 2;
+  private static final int REFERENCED = Thread.MIN_PRIORITY;
   private static final int CAST = (int) 0L;
+  private static final long NON_CONSTANT = java.util.concurrent.TimeUnit.SECONDS.toMillis(10);
+  private static final String NON_CONSTANT_STR = NON_CONSTANT + "foo";
   private static final int LATE_INIT;
   static {
   	LATE_INIT = 0;
@@ -218,8 +222,11 @@ class Outer {
            + CALCULATED_STRING
            + LITERAL
            + CALCULATED
-           + LATE_INIT    // valid violation
+           + LATE_INIT        // valid violation
+           + REFERENCED
            + CAST
+           + NON_CONSTANT     // valid violation
+           + NON_CONSTANT_STR // valid violation
       ;
     }
   }


### PR DESCRIPTION
**PR Description:**
Compile time constants with literals only expression avoiding AccessorMethodGenerationRule.
Fixes #808 

