### PR TITLE
[java] False positive on Java rule: CompareObjectsWithEqualsRule

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CompareObjectsWithEqualsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CompareObjectsWithEqualsRule.java
@@ -90,7 +90,21 @@ public class CompareObjectsWithEqualsRule extends AbstractJavaRule {
                     && (type0.getType().isEnum() || type0.getType() == java.lang.Enum.class)) {
                     return data;
                 }
-
+		// skip, if it is an Object
+                if (type0.getType() != null && type0.getType().equals(type1.getType())
+                    && type0.getType() == java.lang.Object.class) {
+                    return data;
+                }
+                // skip, if it is an Exception
+                if (type0.getType() != null && type0.getType().equals(type1.getType())
+                    && type0.getType() == java.lang.Exception.class) {
+                    return data;
+                }
+                // skip, if it is an List
+                if (type0.getType() != null && type0.getType().equals(type1.getType())
+                    && type0.getType() == java.util.List.class) {
+                    return data;
+                }
                 addViolation(data, node);
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CompareObjectsWithEqualsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CompareObjectsWithEqualsRule.java
@@ -100,11 +100,6 @@ public class CompareObjectsWithEqualsRule extends AbstractJavaRule {
                     && type0.getType() == java.lang.Exception.class) {
                     return data;
                 }
-                // skip, if it is an List
-                if (type0.getType() != null && type0.getType().equals(type1.getType())
-                    && type0.getType() == java.util.List.class) {
-                    return data;
-                }
                 addViolation(data, node);
             }
         }


### PR DESCRIPTION
Fixes #1642
Because Object, Exception, List types trigger False Positives, have to skip those types.

<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

