### PR TITLE
[apex] Add property to allow apex test methods to contain underscores

### DIFF
--- a/docs/pages/pmd/rules/apex/codestyle.md
+++ b/docs/pages/pmd/rules/apex/codestyle.md
@@ -187,6 +187,7 @@ public class Foo {
 |cc\_categories|Style|Code Climate Categories|yes. Delimiter is '\|'.|
 |cc\_remediation\_points\_multiplier|1|Code Climate Remediation Points multiplier|no|
 |cc\_block\_highlighting|false|Code Climate Block Highlighting|no|
+|skipTestMethodUnderscores|false|Skip underscores in test methods|no|
 
 **Use this rule by referencing it:**
 ``` xml

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/MethodNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/MethodNamingConventionsRule.java
@@ -5,15 +5,26 @@
 package net.sourceforge.pmd.lang.apex.rule.codestyle;
 
 import static apex.jorje.semantic.symbol.type.ModifierTypeInfos.OVERRIDE;
+import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
+import net.sourceforge.pmd.lang.apex.ast.ASTModifierNode;
 import net.sourceforge.pmd.lang.apex.ast.ASTProperty;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
 
 public class MethodNamingConventionsRule extends AbstractApexRule {
 
+    private static final PropertyDescriptor<Boolean> SKIP_TEST_METHOD_UNDERSCORES_DESCRIPTOR
+        = booleanProperty("skipTestMethodUnderscores")
+              .desc("Skip underscores in test methods")
+              .defaultValue(false)
+              .build();
+    
     public MethodNamingConventionsRule() {
+        definePropertyDescriptor(SKIP_TEST_METHOD_UNDERSCORES_DESCRIPTOR);
+
         setProperty(CODECLIMATE_CATEGORIES, "Style");
         // Note: x10 as Apex has not automatic refactoring
         setProperty(CODECLIMATE_REMEDIATION_MULTIPLIER, 1);
@@ -28,6 +39,9 @@ public class MethodNamingConventionsRule extends AbstractApexRule {
     @Override
     public Object visit(ASTMethod node, Object data) {
         if (isOverriddenMethod(node) || isPropertyAccessor(node) || isConstructor(node)) {
+            return data;
+        }
+        if (isTestMethod(node) && getProperty(SKIP_TEST_METHOD_UNDERSCORES_DESCRIPTOR)) {
             return data;
         }
 
@@ -52,5 +66,10 @@ public class MethodNamingConventionsRule extends AbstractApexRule {
 
     private boolean isConstructor(ASTMethod node) {
         return node.getNode().getMethodInfo().isConstructor();
+    }
+
+    private boolean isTestMethod(ASTMethod node) {
+        final ASTModifierNode modifierNode = node.getFirstChildOfType(ASTModifierNode.class);
+        return modifierNode != null && modifierNode.getNode().getModifiers().isTest();
     }
 }

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/MethodNamingConventions.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/MethodNamingConventions.xml
@@ -67,15 +67,37 @@ public class Foo {
     </test-code>
     
     <test-code>
-        <description>#1573 method names should not contain underscores, but skip test methods</description>
+        <description>#1573 method names should not contain underscores, but skip test methods 1</description>
         <expected-problems>0</expected-problems>
         <rule-property name="skipTestMethodUnderscores">true</rule-property>
         <code><![CDATA[
 public class Foo {
     @isTest
-	void test_barFoo() {}
+    void test_barFoo() {}
 }
 		]]></code>
     </test-code>
 
+    <test-code>
+        <description>#1573 method names should not contain underscores, but skip test methods 2</description>
+        <expected-problems>0</expected-problems>
+        <rule-property name="skipTestMethodUnderscores">true</rule-property>
+        <code><![CDATA[
+public class Foo {
+    void testMethod test_barFoo() {}
+}
+		]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#1573 method names should not contain underscores, but skip test methods 3</description>
+        <expected-problems>1</expected-problems>
+        <rule-property name="skipTestMethodUnderscores">false</rule-property>
+        <code><![CDATA[
+public class Foo {
+    @isTest
+    void test_barFoo() {}
+}
+		]]></code>
+    </test-code>
 </test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/MethodNamingConventions.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/MethodNamingConventions.xml
@@ -66,4 +66,16 @@ public class Foo {
         ]]></code>
     </test-code>
     
+    <test-code>
+        <description>#1573 method names should not contain underscores, but skip test methods</description>
+        <expected-problems>0</expected-problems>
+        <rule-property name="skipTestMethodUnderscores">true</rule-property>
+        <code><![CDATA[
+public class Foo {
+    @isTest
+	void test_barFoo() {}
+}
+		]]></code>
+    </test-code>
+
 </test-data>


### PR DESCRIPTION
Add a 'skipTestMethodUnderscore' boolean property that allows an
annotated Apex test method (@isTest or testMethod) to contain underscores
Fixes #1573

<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)