### PR TITLE
[plsql] Support hierarchical query clause

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -37,6 +37,8 @@ This is a {{ site.pmd.release_type }} release.
     *   [#1633](https://github.com/pmd/pmd/issues/1633): \[java] UnsynchronizedStaticFormatter reports commons lang FastDateFormat
 *   java-performance
     *   [#1632](https://github.com/pmd/pmd/issues/1632): \[java] ConsecutiveLiteralAppends false positive over catch
+*   plsql
+    *   [#1590](https://github.com/pmd/pmd/issues/1590): \[plsql] ParseException when using hierarchical query clause
 
 ### API Changes
 

--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -1421,19 +1421,44 @@ ASTSqlExpression SqlExpression() :
 }
 
 /**
- * Built-in function call
+ * Built-in function call or a user defined function call.
  * See https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/Functions.html#GUID-D079EFD3-C683-441F-977E-2C9503089982
+ * See https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/About-User-Defined-Functions.html#GUID-4EB3E236-8216-471C-BA44-23D87BDFEA67
+ *
+ * A function reference/name might be:
+ * function_name
+ * package.function_name
+ * package.schema.function_name
+ * optional: @ dblink
+ *
  */
 ASTFunctionCall FunctionCall() :
 {
-    ASTID id;
+    ASTFunctionName name;
 }
 {
-    id = ID()
+    name = FunctionName()
     Arguments()
 
     {
-        jjtThis.setImage(id.getImage());
+        jjtThis.setImage(name.getImage());
+        return jjtThis;
+    }
+}
+
+ASTFunctionName FunctionName() :
+{
+    ASTID id;
+    StringBuilder name = new StringBuilder();
+}
+{
+    id = ID() { name.append(id.getImage()); }
+    [ "." id = ID() { name.append('.').append(id.getImage()); }
+      [ "." id = ID() { name.append('.').append(id.getImage()); } ]
+    ]
+    [ "@" id = ID() { name.append('@').append(id.getImage()); } ]
+    {
+        jjtThis.setImage(name.toString());
         return jjtThis;
     }
 }
@@ -2797,14 +2822,6 @@ ASTIsOfTypeCondition IsOfTypeCondition() #IsOfTypeCondition(>1) :
  * 2006-05-23 - Matthias Hendler - Added lookahead otherwise warning encountered.
  *                                 Warning arised while adding methode triggerUnit().
  * 2011-04-27 - SRT - Add optional NEW Keyword to cope with Object Type constructors
- *
- * See also https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/About-User-Defined-Functions.html#GUID-4EB3E236-8216-471C-BA44-23D87BDFEA67
- *
- * A function reference might be:
- * function_name
- * package.function_name
- * package.schema.function_name
- * optional: @ dblink .
  */
 ASTPrimaryExpression PrimaryExpression() #PrimaryExpression(>1) :
 { Token thisToken ; PLSQLNode simpleNode = null; StringBuilder sb = new StringBuilder() ;
@@ -2835,9 +2852,8 @@ ASTPrimaryPrefix PrimaryPrefix() :
 }
 {
 (
-  LOOKAHEAD(2) (
-  LOOKAHEAD(2) simpleNode = FunctionCall() 
-| LOOKAHEAD(2) simpleNode = Literal() ) { sb.append(simpleNode.getImage()) ; }
+  LOOKAHEAD(FunctionName() "(") simpleNode = FunctionCall()
+| LOOKAHEAD(Literal()) simpleNode = Literal() { sb.append(simpleNode.getImage()) ; }
 | LOOKAHEAD(MultiSetCondition()) simpleNode = MultiSetCondition()
 | LOOKAHEAD(TrimExpression()) simpleNode = TrimExpression() //SRT 20110613.3
 | LOOKAHEAD(CaseExpression()) ( simpleNode =CaseExpression() ) { sb.append(simpleNode.getImage()) ; } //SRT 20110520

--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -357,7 +357,7 @@ ASTPackageSpecification PackageSpecification()  :
 }
 {
       (
-	[<CREATE> [<OR> <REPLACE>] [ <EDITIONABLE> | <NONEDITIONABLE> ] ]
+	[<CREATE> [<OR> "REPLACE"] [ <EDITIONABLE> | <NONEDITIONABLE> ] ]
 	<PACKAGE> simpleNode = ObjectNameDeclaration()
 
         (
@@ -388,7 +388,7 @@ ASTPackageBody PackageBody()  :
 }
 {
     (
-	[<CREATE> [<OR> <REPLACE>] [ <EDITIONABLE> | <NONEDITIONABLE> ] ]
+	[<CREATE> [<OR> "REPLACE"] [ <EDITIONABLE> | <NONEDITIONABLE> ] ]
 	( <PACKAGE> | <TYPE> ) <BODY> simpleNode = ObjectNameDeclaration()
 
 	(
@@ -490,7 +490,7 @@ ASTProgramUnit ProgramUnit()  :
 {
 	(
 
-	[<CREATE> [<OR> <REPLACE>] [ <EDITIONABLE> | <NONEDITIONABLE> ] ]
+	[<CREATE> [<OR> "REPLACE"] [ <EDITIONABLE> | <NONEDITIONABLE> ] ]
 
         MethodDeclarator()
 
@@ -684,7 +684,7 @@ ASTDatatype Datatype() :
 		LOOKAHEAD(2) simpleNode = ScalarDataTypeName() {sb.append(simpleNode.getImage());}
 		|
 		(
-		  ( [LOOKAHEAD(2) <REF>  {sb.append(token.image);}  ] simpleNode = QualifiedName() {sb.append(simpleNode.getImage());}
+		  ( [LOOKAHEAD(2) "REF"  {sb.append(token.image);}  ] simpleNode = QualifiedName() {sb.append(simpleNode.getImage());}
 		    //Bug 35352414 - datatype may include dblink
 		    ["@" simpleNode = QualifiedName() {sb.append("@"+simpleNode.getImage());}  ]
 		    ["%" (<TYPE>|<ROWTYPE>){sb.append("%"+token.image);} ]
@@ -796,7 +796,7 @@ ASTScalarDataTypeName ScalarDataTypeName() :
 
 	// reference types
   	<SYS_REFCURSOR> | //SRT Added to support pre-defined weak REF CURSOR
-  	(<REF><CURSOR> {name.append("REF CURSOR");}) |
+  	("REF" <CURSOR> {name.append("REF CURSOR");}) |
 	//<REF> object_type - defined elsewhere
 
 	// scalar types - date/time:
@@ -1145,6 +1145,7 @@ void RestOfStatement() #void :
 {
     FromClause()
     [ WhereClause() ]
+    [ HierarchicalQueryClause() ]
     [ GroupByClause() ]
     [ OrderByClause() ]
     [ RowLimitingClause() ]
@@ -1190,7 +1191,7 @@ void OrderByEntry() #void :
 {
     ( LOOKAHEAD(2) ColumnAlias() | LOOKAHEAD(2) SqlExpression() )
     [ <ASC> | <DESC> ]
-    [ LOOKAHEAD(2) <NULLS> <FIRST> | LOOKAHEAD(2) <NULLS> <LAST> ]
+    [ LOOKAHEAD(2) <NULLS> "FIRST" | LOOKAHEAD(2) <NULLS> "LAST" ]
 }
 
 /**
@@ -1202,7 +1203,7 @@ ASTRowLimitingClause RowLimitingClause() :
   (
     <OFFSET> NumericLiteral() ( <ROW> | <ROWS> )
   |
-    <FETCH> ( <FIRST> | <NEXT> ) [ NumericLiteral() [ <PERCENT> ] ] ( <ROW> | <ROWS> ) ( <ONLY> | <WITH> <TIES> )
+    <FETCH> ( "FIRST" | <NEXT> ) [ NumericLiteral() [ <PERCENT> ] ] ( <ROW> | <ROWS> ) ( <ONLY> | <WITH> <TIES> )
   )
     { return jjtThis; }
 }
@@ -1215,7 +1216,7 @@ ASTQueryBlock QueryBlock() :
     SelectList()
     FromClause()
     [ WhereClause() ]
-    // [ HierarchicalQueryClause() ]
+    [ HierarchicalQueryClause() ]
     [ GroupByClause() ]
     // [ ModelClause() ]
     { return jjtThis; }
@@ -1403,9 +1404,10 @@ ASTExpressionList ExpressionList() :
 ASTSqlExpression SqlExpression() :
 {}
 {
+ [ LOOKAHEAD(2) <PRIOR> ]
  // SimpleExpression
  (
-    LOOKAHEAD(FunctionCall()) FunctionCall()
+    LOOKAHEAD(3) AdditiveExpression() // this can be a literal or a simple expression, but no conditional
  |
     LOOKAHEAD(5) SchemaName() "." TableName() "." Column()
  |
@@ -1414,37 +1416,24 @@ ASTSqlExpression SqlExpression() :
     LOOKAHEAD(2) Column()
  |
     LOOKAHEAD(2) <ROWNUM>
- |
-    AdditiveExpression() // this can be a literal or a simple expression, but no conditional
  )
     { return jjtThis; }
 }
 
 /**
- * See also https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/About-User-Defined-Functions.html#GUID-4EB3E236-8216-471C-BA44-23D87BDFEA67
- *
- * A function reference might be:
- * function_name
- * package.function_name
- * package.schema.function_name
- * optional: @ dblink .
+ * Built-in function call
+ * See https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/Functions.html#GUID-D079EFD3-C683-441F-977E-2C9503089982
  */
 ASTFunctionCall FunctionCall() :
 {
     ASTID id;
-    StringBuilder name = new StringBuilder();
 }
 {
-    id = ID() { name.append(id.getImage()); }
-    [ "." id = ID() { name.append('.').append(id.getImage()); }
-        [ "." id = ID() { name.append('.').append(id.getImage()); } ]
-    ]
-    [ "@" id = ID() { name.append('@').append(id.getImage()); } ]
-
+    id = ID()
     Arguments()
 
     {
-        jjtThis.setImage(name.toString());
+        jjtThis.setImage(id.getImage());
         return jjtThis;
     }
 }
@@ -1453,6 +1442,20 @@ ASTColumn Column() :
 { ASTID id; }
 {
     id = ID() { jjtThis.setImage(id.getImage()); }
+    { return jjtThis; }
+}
+
+/**
+ * https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/SELECT.html#GUID-CFA006CA-6FF1-4972-821E-6996142A51C6__I2126079
+ */
+ASTHierarchicalQueryClause HierarchicalQueryClause() :
+{}
+{
+  (
+    ( <CONNECT> <BY> [ LOOKAHEAD(2) <NOCYCLE>] Condition() [ <START> <WITH> Condition() ] )
+    |
+    ( <START> <WITH> Condition() <CONNECT> <BY> [ LOOKAHEAD(2) <NOCYCLE>] Condition() )
+  )
     { return jjtThis; }
 }
 
@@ -1497,19 +1500,14 @@ ASTSelectList SelectList() :
 void SelectListEntry() #void :
 {}
 {
-  (
-    LOOKAHEAD(3) TableAlias() "." "*"
-  |
-    LOOKAHEAD(FunctionCall()) FunctionCall() [ [<AS>] ColumnAlias() ]
-  |
-    LOOKAHEAD(3) Expression() [ [<AS>] ColumnAlias() ]
-  )
+  [ LOOKAHEAD(2) <CONNECT_BY_ROOT> ]
+  SqlExpression() [LOOKAHEAD(2, {!(getToken(1).kind == BULK)}) [LOOKAHEAD(2) <AS>] ColumnAlias() ]
 }
 
 ASTColumnAlias ColumnAlias() :
-{}
+{ ASTID id; }
 {
-    ( <IDENTIFIER> | <QUOTED_LITERAL> ) { jjtThis.setImage(token.image); }
+    id = ID() {jjtThis.setImage(id.getImage());}
     { return jjtThis; }
 }
 
@@ -1957,7 +1955,7 @@ ASTMultiTableInsert MultiTableInsert() :
 ASTConditionalInsertClause ConditionalInsertClause() :
 {}
 {
-    [ <ALL> | <FIRST> ] ( <WHEN> Condition() <THEN> ( InsertIntoClause() [ ValuesClause() ] )+ )+
+    [ <ALL> | "FIRST" ] ( <WHEN> Condition() <THEN> ( InsertIntoClause() [ ValuesClause() ] )+ )+
         [ <ELSE> ( InsertIntoClause() [ ValuesClause() ] )+ ]
     { return jjtThis; }
 }
@@ -2231,7 +2229,7 @@ ASTSubTypeDefinition SubTypeDefinition()  :
 				((<TABLE> | <VARRAY> | <VARYING> <ARRAY>)["(" NumericLiteral() ")"]
 				<OF> Datatype() (<NOT> <NULL>)? (<INDEX> <BY> Datatype())?)
 				|
-				<REF> <CURSOR> [<RETURN> Datatype()]
+				"REF" <CURSOR> [<RETURN> Datatype()]
 				//Enumeration
 				| ( "("
 				      Expression()
@@ -2511,7 +2509,7 @@ ASTTrimExpression TrimExpression() :
 { Token thisToken;  PLSQLNode simpleNode = null; StringBuilder sb = new StringBuilder() ; }
 {
   (
-	(thisToken = <TRIM> ) { sb.append(thisToken.image);}
+	(thisToken = "TRIM" ) { sb.append(thisToken.image);}
 	"(" { sb.append("(");}
 	 [ ( <LEADING> | <TRAILING> | <BOTH> ){ sb.append(" "); sb.append(token.toString()); }  ]
 	 [ simpleNode = StringExpression() { sb.append(" "); sb.append(simpleNode.getImage()); } ]
@@ -2799,6 +2797,14 @@ ASTIsOfTypeCondition IsOfTypeCondition() #IsOfTypeCondition(>1) :
  * 2006-05-23 - Matthias Hendler - Added lookahead otherwise warning encountered.
  *                                 Warning arised while adding methode triggerUnit().
  * 2011-04-27 - SRT - Add optional NEW Keyword to cope with Object Type constructors
+ *
+ * See also https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/About-User-Defined-Functions.html#GUID-4EB3E236-8216-471C-BA44-23D87BDFEA67
+ *
+ * A function reference might be:
+ * function_name
+ * package.function_name
+ * package.schema.function_name
+ * optional: @ dblink .
  */
 ASTPrimaryExpression PrimaryExpression() #PrimaryExpression(>1) :
 { Token thisToken ; PLSQLNode simpleNode = null; StringBuilder sb = new StringBuilder() ;
@@ -2810,7 +2816,7 @@ ASTPrimaryExpression PrimaryExpression() #PrimaryExpression(>1) :
       )
     |
     (
-      LOOKAHEAD( <NEW>  PrimaryPrefix() ) // Lookahead so that we can recover and treat NEW as an identifier
+      LOOKAHEAD(<NEW>  PrimaryPrefix() ) // Lookahead so that we can recover and treat NEW as an identifier
         <NEW> { sb.append(" NEW "); } (simpleNode = PrimaryPrefix() ) {sb.append(simpleNode.getImage());}
       |       (simpleNode = PrimaryPrefix() ) {sb.append(simpleNode.getImage());}
 
@@ -2829,7 +2835,9 @@ ASTPrimaryPrefix PrimaryPrefix() :
 }
 {
 (
-  ( simpleNode = Literal() ) { sb.append(simpleNode.getImage()) ; }
+  LOOKAHEAD(2) (
+  LOOKAHEAD(2) simpleNode = FunctionCall() 
+| LOOKAHEAD(2) simpleNode = Literal() ) { sb.append(simpleNode.getImage()) ; }
 | LOOKAHEAD(MultiSetCondition()) simpleNode = MultiSetCondition()
 | LOOKAHEAD(TrimExpression()) simpleNode = TrimExpression() //SRT 20110613.3
 | LOOKAHEAD(CaseExpression()) ( simpleNode =CaseExpression() ) { sb.append(simpleNode.getImage()) ; } //SRT 20110520
@@ -3285,7 +3293,7 @@ ASTView View()  :
  PLSQLNode simpleNode = null;
 }
 {
-  <CREATE> [<OR> <REPLACE>]
+  <CREATE> [<OR> "REPLACE"]
   [[<NO>] <FORCE>]
   <VIEW> simpleNode = ObjectNameDeclaration()
   ["(" ViewColumn() ("," ViewColumn())* ")"]
@@ -3302,7 +3310,7 @@ ASTSynonym Synonym()  :
  PLSQLNode simpleNode = null;
 }
 {
-  <CREATE> [<OR> <REPLACE>]
+  <CREATE> [<OR> "REPLACE"]
   [<PUBLIC>] <SYNONYM>
   simpleNode = ObjectNameDeclaration()
   <FOR>
@@ -3317,7 +3325,7 @@ ASTDirectory Directory()  :
  PLSQLNode simpleNode = null;
 }
 {
-  <CREATE> [<OR> <REPLACE>]
+  <CREATE> [<OR> "REPLACE"]
    <DIRECTORY>
   simpleNode = ObjectNameDeclaration()
   <AS>
@@ -3434,7 +3442,7 @@ ASTTypeSpecification TypeSpecification()  :
  PLSQLNode simpleNode = null;
 }
 {
-	[<CREATE> [<OR> <REPLACE>] [ <EDITIONABLE> | <NONEDITIONABLE> ] ]
+	[<CREATE> [<OR> "REPLACE"] [ <EDITIONABLE> | <NONEDITIONABLE> ] ]
 	<TYPE> simpleNode = ObjectNameDeclaration()
 
 	[
@@ -3613,7 +3621,7 @@ ASTAlterTypeSpec AlterTypeSpec()  :
         |
 */
         [
-                <REPLACE>
+                "REPLACE"
                 (
 		LOOKAHEAD(2) //<AUTHID> (<CURRENT_USER> | <DEFINER>)
 				(
@@ -3825,7 +3833,7 @@ ASTTriggerUnit TriggerUnit()  :
  PLSQLNode simpleNode = null ;
 }
 {
-	[<CREATE> [<OR> <REPLACE>] [ <EDITIONABLE> | <NONEDITIONABLE> ] ]
+	[<CREATE> [<OR> "REPLACE"] [ <EDITIONABLE> | <NONEDITIONABLE> ] ]
 
 	(<TRIGGER>) simpleNode = ObjectNameDeclaration()
 
@@ -4071,7 +4079,6 @@ MORE :
 
 TOKEN [IGNORE_CASE]:
 {
-<REPLACE: "REPLACE"> |
 <DEFINER: "DEFINER"> |
 <CURRENT_USER: "CURRENT_USER"> |
 <SERIALLY_REUSABLE: "SERIALLY_REUSABLE"> |
@@ -4082,7 +4089,10 @@ TOKEN [IGNORE_CASE]:
 | <INLINE: "INLINE"> // PRAGMA INLINE
 }
 
-/* PL/SQL RESERVED WORDS */
+/**
+ * PL/SQL RESERVED WORDS
+ * https://docs.oracle.com/en/database/oracle/oracle-database/18/lnpls/plsql-reserved-words-keywords.html#GUID-9BAA3A99-41B1-45CB-A91E-1E482BC1F927
+ */
 /**
  * 2006-05-20 - Matthias Hendler - Removed: <COLUMN: "COLUMN">
  *                                 Added: <MERGE: "MERGE">, <AFTER: "AFTER">, <BEFORE: "BEFORE">,
@@ -4106,7 +4116,6 @@ TOKEN [IGNORE_CASE]:
 <AT: "AT"> |
 <ATTRIBUTE: "ATTRIBUTE"> |
 <AUTHID: "AUTHID"> |
-<AVG: "AVG"> |
 <BEGIN: "BEGIN"> |
 <BETWEEN: "BETWEEN"> |
 <BINARY_INTEGER: "BINARY_INTEGER"> |
@@ -4177,7 +4186,6 @@ TOKEN [IGNORE_CASE]:
 <FALSE: "FALSE"> |
 <FETCH: "FETCH"> |
 <FINAL: "FINAL"> |
-<FIRST: "FIRST"> |
 <FLOAT: "FLOAT"> |
 <FOR: "FOR"> |
 <FORALL: "FORALL"> |
@@ -4221,7 +4229,6 @@ TOKEN [IGNORE_CASE]:
 <JOIN: "JOIN"> |
 <KEY: "KEY"> |
 //<LANGUAGE: "LANGUAGE"> |
-<LAST: "LAST"> |
 <LEVEL: "LEVEL"> |
 <LIKE: "LIKE"> |
 <LIKEC: "LIKEC"> |
@@ -4233,11 +4240,9 @@ TOKEN [IGNORE_CASE]:
 <LONG: "LONG"> |
 <LOOP: "LOOP"> |
 <MAP: "MAP"> |
-<MAX: "MAX"> |
 <MEMBER: "MEMBER"> |
 <MERGE: "MERGE"> |
 <METADATA: "METADATA"> |
-<MIN: "MIN"> |
 <MINUS: "MINUS"> |
 <MINUTE: "MINUTE"> |
 <MLSLABEL: "MLSLABEL"> |
@@ -4311,7 +4316,6 @@ TOKEN [IGNORE_CASE]:
 <RAW: "RAW"> |
 <REAL: "REAL"> |
 <RECORD: "RECORD"> |
-<REF: "REF"> |
 <REFERENCES: "REFERENCES"> |
 <RELEASE: "RELEASE"> |
 <RELIES_ON: "RELIES_ON"> |
@@ -4351,11 +4355,9 @@ TOKEN [IGNORE_CASE]:
 <SQLERRM: "SQLERRM"> |
 <START: "START"> |
 <STATIC: "STATIC"> |
-<STDDEV: "STDDEV"> |
 <SUBTYPE: "SUBTYPE"> |
 <SUBSTITUTABLE: "SUBSTITUTABLE"> |
 <SUCCESSFUL: "SUCCESSFUL"> |
-<SUM: "SUM"> |
 <SYNONYM: "SYNONYM"> |
 <SYSDATE: "SYSDATE"> |
 <SYS_REFCURSOR: "SYS_REFCURSOR"> |
@@ -4489,7 +4491,6 @@ TOKEN [IGNORE_CASE]:
 | <ATTACH : "ATTACH">
 | <CAST : "CAST">
 | <TREAT : "TREAT">
-| <TRIM : "TRIM">
 | <LEFT : "LEFT">
 | <RIGHT : "RIGHT">
 | <BOTH : "BOTH">
@@ -4510,9 +4511,10 @@ TOKEN [IGNORE_CASE]:
 | <SHARED : "SHARED">
 | <DIRECTORY : "DIRECTORY">
 | <USER : "USER">
-
 | <READ : "READ">
 | <LATERAL : "LATERAL">
+| <NOCYCLE : "NOCYCLE">
+| <CONNECT_BY_ROOT : "CONNECT_BY_ROOT">
 }
 
 /**
@@ -4596,7 +4598,11 @@ TOKEN :
 <SQLPLUS_TERMINATOR: ( ";" | "/" ) >
 }
 
-//SRT 2011-04-17 - START
+/**
+ * PL/SQL Reserved words
+ *
+ * https://docs.oracle.com/en/database/oracle/oracle-database/18/lnpls/plsql-reserved-words-keywords.html#GUID-9BAA3A99-41B1-45CB-A91E-1E482BC1F927
+ */
 ASTKEYWORD_RESERVED KEYWORD_RESERVED (): {}
 {
 // PL/SQL RESERVED WORDS - V$RESERVED.RESERVED='Y'
@@ -4687,7 +4693,9 @@ ASTKEYWORD_RESERVED KEYWORD_RESERVED (): {}
 ASTKEYWORD_UNRESERVED KEYWORD_UNRESERVED (): {}
 {
 // PL/SQL UNRESERVED KEYWORDS - V$RESERVED.RESERVED='N'
-(<FALSE>
+(
+"FIRST" | "REPLACE" | "REF" | "LAST" | "TRIM" |
+<FALSE>
  | <TRUE>
  | <A>
 //| <ABORT>
@@ -4824,7 +4832,7 @@ ASTKEYWORD_UNRESERVED KEYWORD_UNRESERVED (): {}
 //| <CONNECT_BY_FILTERING>
 //| <CONNECT_BY_ISCYCLE>
 //| <CONNECT_BY_ISLEAF>
-//| <CONNECT_BY_ROOT>
+| <CONNECT_BY_ROOT>
 //| <CONNECT_TIME>
 //| <CONSIDER>
 //| <CONSISTENT>
@@ -4889,7 +4897,6 @@ ASTKEYWORD_UNRESERVED KEYWORD_UNRESERVED (): {}
 //| <DEMAND>
 //| <DENSE_RANK>
 //| <DEQUEUE>
-//| <DEREF>
 //| <DEREF_NO_REWRITE>
 //| <DETACHED>
 //| <DETERMINES>
@@ -4977,7 +4984,6 @@ ASTKEYWORD_UNRESERVED KEYWORD_UNRESERVED (): {}
 | <FINAL>
 //| <FINE>
 //| <FINISH>
-| <FIRST>
 //| <FIRST_ROWS>
 //| <FLAGGER>
 //| <FLASHBACK>
@@ -5098,7 +5104,6 @@ ASTKEYWORD_UNRESERVED KEYWORD_UNRESERVED (): {}
 //| <KEYSIZE>
 //| <KILL>
 | <LANGUAGE>
-| <LAST>
 | <LATERAL>
 //| <LAYER>
 //| <LDAP_REG_SYNC_INTERVAL>
@@ -5146,7 +5151,7 @@ ASTKEYWORD_UNRESERVED KEYWORD_UNRESERVED (): {}
 //| <MATCHED>
 //| <MATERIALIZE>
 //| <MATERIALIZED>
-| <MAX>
+//| <MAX>
 //| <MAXARCHLOGS>
 //| <MAXDATAFILES>
 //| <MAXEXTENTS>
@@ -5169,7 +5174,7 @@ ASTKEYWORD_UNRESERVED KEYWORD_UNRESERVED (): {}
 | <METADATA>
 //| <METHOD>
 //| <MIGRATE>
-| <MIN>
+//| <MIN>
 //| <MINEXTENTS>
 //| <MINIMIZE>
 //| <MINIMUM>
@@ -5289,7 +5294,7 @@ ASTKEYWORD_UNRESERVED KEYWORD_UNRESERVED (): {}
 | <NOAUDIT>
 //| <NOCACHE>
 //| <NOCPU_COSTING>
-//| <NOCYCLE>
+| <NOCYCLE>
 //| <NODELAY>
 //| <NOFORCE>
 //| <NOGUARANTEE>
@@ -5464,7 +5469,6 @@ ASTKEYWORD_UNRESERVED KEYWORD_UNRESERVED (): {}
 //| <RECYCLEBIN>
 //| <REDUCED>
 //| <REDUNDANCY>
-| <REF>
 //| <REF_CASCADE_CURSOR>
 //| <REFERENCE>
 //| <REFERENCED>
@@ -5481,7 +5485,6 @@ ASTKEYWORD_UNRESERVED KEYWORD_UNRESERVED (): {}
 | <REMARK>
 //| <REMOTE_MAPPED>
 //| <REPAIR>
-//| <REPLACE>
 //| <REQUIRED>
 //| <RESET>
 //| <RESETLOGS>
@@ -5674,7 +5677,6 @@ ASTKEYWORD_UNRESERVED KEYWORD_UNRESERVED (): {}
 //| <TRANSITIONAL>
 | <TREAT>
 //| <TRIGGERS>
-| <TRIM>
 | <TRUNCATE>
 //| <TRUSTED>
 //| <TUNING>
@@ -5732,7 +5734,6 @@ ASTKEYWORD_UNRESERVED KEYWORD_UNRESERVED (): {}
 | <USING>
 //| <VALIDATE>
 //| <VALIDATION>
-//| <VALUE>
 | <VARRAY>
 | <VARIABLE>
 | <VARYING>
@@ -5798,7 +5799,6 @@ ASTID ID(): {}
 		|<EXTRACT> | <FALSE> | <TRUE>  | <SECOND> | <MINUTE> | <HOUR> | <DAY> | <MONTH> | <YEAR>
 		 | <NO> |<ROW>  | <COMMENT> | <CURSOR>
 		*/
-		| <REPLACE> //SYNTAX
 		//20120501 | <DEFINER>
 		| <SERIALLY_REUSABLE> | <RESTRICT_REFERENCES>
 		| <EXCEPTION_INIT> | <AUTONOMOUS_TRANSACTION> // | <LANGUAGE>
@@ -5810,7 +5810,7 @@ ASTID ID(): {}
 		| <AS>  //SYNTAX  //RESERVED WORD
 		| <ASC>  //RESERVED WORD
 		//20120429 | <AT> | <AUTHID>
-		| <AVG>
+		//| <AVG>
 		//	<BEGIN> |
 		| <BETWEEN>  //RESERVED WORD
 		| <BINARY_INTEGER>
@@ -5827,7 +5827,7 @@ ASTID ID(): {}
 		| <CLUSTER> //-<COALESCE> |
 		//20120501 | <COLLECT>
 		| <COMPRESS>  //RESERVED WPRDS
-		| <CONNECT> //SYNTAX //RESERVED WORD
+		//| <CONNECT> //SYNTAX //RESERVED WORD
 		| <CONSTANT>
 		| <CREATE> //SYNTAX //RESERVED WORD
 		//20120501 | <CURRENT>
@@ -5835,17 +5835,17 @@ ASTID ID(): {}
 		| <DATE> //RESERVED WORD
 		| <DECLARE> //SYNTAX
 		| <DECIMAL> //RESERVED WORD
-		| <_DEFAULT> //RESERVED WORD
+		//| <_DEFAULT> //RESERVED WORD
 		| <DELETE>  //RESERVED WORD
 		| <DESC>  //RESERVED WORD
 		//| <DISTINCT>  //RESERVED WORD
 		| <DO>
 		| <DROP>  //RESERVED WORD
-		| <ELSE> //SYNTAX //RESERVED WORD
+		//| <ELSE> //SYNTAX //RESERVED WORD
 		| <ELSIF> //SYNTAX
 
 		//| <END> |<CURRENT_USER>
-		| <EXCEPTION> //SYNTAX
+		//| <EXCEPTION> //SYNTAX
 		| <EXCLUSIVE> //SYNTAX //RESERVED WORD
 		| <EXECUTE> //SYNTAX
 		| <EXISTS> //SYNTAX //RESERVED WORD
@@ -5855,7 +5855,7 @@ ASTID ID(): {}
 		| <FLOAT> //SYNTAX //RESERVED WORD
 		| <FOR>  //RESERVED WORD
 		| <FORALL> //SYNTAX
-		| <FROM>  //RESERVED WORD
+		//| <FROM>  //RESERVED WORD
 
 		// <COMMIT> | <FUNCTION> |	// this causes bug 643043 Procedure w/o params appears as variable
 		| <GOTO> //SYNTAX
@@ -5872,7 +5872,7 @@ ASTID ID(): {}
 		| <INTERFACE>
 		| <INTERSECT>  //RESERVED WORD
 		//20120501 | <INTERVAL>
-		| <INTO>  //RESERVED WORD
+		//| <INTO>  //RESERVED WORD
 		| <IS> //SYNTAX
 		//20120501 | <ISOLATION> | <JAVA> | <LEVEL>
 		| <LIKE>  //RESERVED WORD
@@ -5921,7 +5921,7 @@ ASTID ID(): {}
 		| <RAISE> //SYNTAX
 		| <RAW>  //RESERVED WORD
 		//20120501 | <REAL>
-		//<RECORD> | <RETURN> |  <SET> |<REF> |
+		//<RECORD> | <RETURN> |  <SET> |
 		//| <RELEASE>
 		//20120501 | <REVERSE>
 		//20120501 | <ROLLBACK> //SYNTAX
@@ -5935,10 +5935,10 @@ ASTID ID(): {}
 		| <SMALLINT>  //RESERVED WORD
 		| <SQL>
 		| <SQLCODE> | <SQLERRM>
-		| <START>  //RESERVED WORD
-		| <STDDEV> // <SUBTYPE> |
+		//| <START>  //RESERVED WORD
+		//| <STDDEV> // <SUBTYPE> |
 		//20120501 | <SUCCESSFUL>
-		| <SUM>
+		//| <SUM>
 		| <SYNONYM>  //RESERVED WORD
 		| <SYSDATE>
 		//| <TABLE>  //RESERVED WORD
@@ -6002,7 +6002,6 @@ ASTUnqualifiedID UnqualifiedID(): {}
 		| <OPERATOR>
 		| <PRIVATE>
 		| <RAW>
-		| <REPLACE>
 		| <STRING>
 		| <SQL>
 		| <SQLCODE>
@@ -6041,7 +6040,6 @@ ASTQualifiedID QualifiedID(): {}
 		| <YEAR> --Unreserved Key Word
 		| <NO> //SRT
 		*/
-		| <REPLACE>
 		//20120501 | <DEFINER>
 		//| <CURRENT_USER>
 		| <SERIALLY_REUSABLE>
@@ -6058,7 +6056,7 @@ ASTQualifiedID QualifiedID(): {}
 		//<ASC>
 		//<AT>
 		//20120429 | <AUTHID>
-		| <AVG>
+		//| <AVG>
 		//<BEGIN>
 		//<BETWEEN>
 		| <BINARY_INTEGER>
@@ -6183,7 +6181,6 @@ ASTQualifiedID QualifiedID(): {}
 		| <RAW>
 		//20120501 | <REAL>
 		//| <RECORD>
-		//| <REF>
 		//| <RELEASE>
 		//| <RETURN>
 		//20120501 | <REVERSE>
@@ -6203,10 +6200,10 @@ ASTQualifiedID QualifiedID(): {}
 		| <SQLCODE>
 		| <SQLERRM>
 		//<START>
-		| <STDDEV>
+		//| <STDDEV>
 		//| <SUBTYPE>
 		//20120501 | <SUCCESSFUL>
-		| <SUM>
+		//| <SUM>
 		| <SYNONYM>
 		| <SYSDATE>
 		//<TABLE>
@@ -6273,7 +6270,7 @@ ASTTypeKeyword TypeKeyword(): {}
 	<INTERVAL> |
 	<MONTH> |
 	<OCIROWID> |
-	<RECORD> | <REF> |
+	<RECORD> | "REF" |
 	<ROW> |
 	<ROWNUM> |
 	<ROWTYPE> | <SECOND> | <SET> |

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLParserVisitorAdapter.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLParserVisitorAdapter.java
@@ -991,4 +991,9 @@ public class PLSQLParserVisitorAdapter implements PLSQLParserVisitor {
     public Object visit(ASTHierarchicalQueryClause node, Object data) {
         return visit((PLSQLNode) node, data);
     }
+
+    @Override
+    public Object visit(ASTFunctionName node, Object data) {
+        return visit((PLSQLNode) node, data);
+    }
 }

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLParserVisitorAdapter.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLParserVisitorAdapter.java
@@ -986,4 +986,9 @@ public class PLSQLParserVisitorAdapter implements PLSQLParserVisitor {
     public Object visit(ASTValuesClause node, Object data) {
         return visit((PLSQLNode) node, data);
     }
+
+    @Override
+    public Object visit(ASTHierarchicalQueryClause node, Object data) {
+        return visit((PLSQLNode) node, data);
+    }
 }

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractPLSQLRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractPLSQLRule.java
@@ -1080,6 +1080,11 @@ public abstract class AbstractPLSQLRule extends AbstractRule implements PLSQLPar
         return visit((PLSQLNode) node, data);
     }
 
+    @Override
+    public Object visit(ASTHierarchicalQueryClause node, Object data) {
+        return visit((PLSQLNode) node, data);
+    }
+
     /*
      * Treat all Executable Code
      */

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractPLSQLRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractPLSQLRule.java
@@ -1085,6 +1085,11 @@ public abstract class AbstractPLSQLRule extends AbstractRule implements PLSQLPar
         return visit((PLSQLNode) node, data);
     }
 
+    @Override
+    public Object visit(ASTFunctionName node, Object data) {
+        return visit((PLSQLNode) node, data);
+    }
+
     /*
      * Treat all Executable Code
      */

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/CodeFormatRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/CodeFormatRule.java
@@ -125,10 +125,14 @@ public class CodeFormatRule extends AbstractPLSQLRule {
         int currentLine = firstLine;
         for (int i = 0; i < parent.jjtGetNumChildren(); i++) {
             Node child = parent.jjtGetChild(i);
+            String image = child.getImage();
+            if (image == null && child.jjtGetNumChildren() > 0) {
+                image = child.jjtGetChild(0).getImage();
+            }
             if (child.getBeginLine() != currentLine) {
-                addViolationWithMessage(data, child, child.getImage() + " should be on line " + currentLine);
+                addViolationWithMessage(data, child, image + " should be on line " + currentLine);
             } else if (i > 0 && child.getBeginColumn() != indentation) {
-                addViolationWithMessage(data, child, child.getImage() + " should begin at column " + indentation);
+                addViolationWithMessage(data, child, image + " should begin at column " + indentation);
             }
             // next entry needs to be on the next line
             currentLine++;

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectExpressionsTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectExpressionsTest.java
@@ -8,7 +8,6 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import net.sourceforge.pmd.lang.plsql.AbstractPLSQLParserTst;
@@ -16,7 +15,6 @@ import net.sourceforge.pmd.lang.plsql.AbstractPLSQLParserTst;
 public class SelectExpressionsTest extends AbstractPLSQLParserTst {
 
     @Test
-    @Ignore
     public void parseSelectExpression() throws Exception {
         String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectExpressions.pls"),
                 StandardCharsets.UTF_8);

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectHierarchicalTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SelectHierarchicalTest.java
@@ -1,0 +1,24 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.plsql.ast;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.sourceforge.pmd.lang.plsql.AbstractPLSQLParserTst;
+
+public class SelectHierarchicalTest extends AbstractPLSQLParserTst {
+
+    @Test
+    public void parseSelectHierarchicalQueries() throws Exception {
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("SelectHierarchical.pls"),
+                StandardCharsets.UTF_8);
+        ASTInput input = parsePLSQL(code);
+        Assert.assertNotNull(input);
+    }
+}

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/WhereClauseTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/WhereClauseTest.java
@@ -25,10 +25,9 @@ public class WhereClauseTest extends AbstractPLSQLParserTst {
 
         ASTFunctionCall functionCall = selectStatements.get(0).getFirstDescendantOfType(ASTFunctionCall.class);
         Assert.assertEquals("UPPER", functionCall.getImage());
-        
-        ASTPrimaryPrefix primaryPrefix = selectStatements.get(2).getFirstDescendantOfType(ASTWhereClause.class)
-                .findDescendantsOfType(ASTPrimaryPrefix.class).get(1);
-        Assert.assertEquals("utils.get_colname", primaryPrefix.getImage());
+
+        ASTFunctionCall functionCall2 = selectStatements.get(2).getFirstDescendantOfType(ASTFunctionCall.class);
+        Assert.assertEquals("utils.get_colname", functionCall2.getImage());
     }
 
     @Test

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/WhereClauseTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/WhereClauseTest.java
@@ -23,8 +23,12 @@ public class WhereClauseTest extends AbstractPLSQLParserTst {
         List<ASTSelectIntoStatement> selectStatements = input.findDescendantsOfType(ASTSelectIntoStatement.class);
         Assert.assertEquals(3, selectStatements.size());
 
-        ASTFunctionCall functionCall = selectStatements.get(2).getFirstDescendantOfType(ASTFunctionCall.class);
-        Assert.assertEquals("utils.get_colname", functionCall.getImage());
+        ASTFunctionCall functionCall = selectStatements.get(0).getFirstDescendantOfType(ASTFunctionCall.class);
+        Assert.assertEquals("UPPER", functionCall.getImage());
+        
+        ASTPrimaryPrefix primaryPrefix = selectStatements.get(2).getFirstDescendantOfType(ASTWhereClause.class)
+                .findDescendantsOfType(ASTPrimaryPrefix.class).get(1);
+        Assert.assertEquals("utils.get_colname", primaryPrefix.getImage());
     }
 
     @Test

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/SelectExpressions.pls
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/SelectExpressions.pls
@@ -4,6 +4,9 @@
 
 BEGIN
 
+SELECT AVG(sal)*2 INTO foo FROM bar;
+
+
 SELECT
     AVG(salary) * 12 "Average Sal"
   INTO some_record
@@ -13,6 +16,7 @@ SELECT
     TO_CHAR(sum(amount_sold) , '9,999,999,999') SALES$
   INTO some_record
   FROM some_table;
+
 
 END;
 /

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/SelectHierarchical.pls
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/SelectHierarchical.pls
@@ -1,0 +1,90 @@
+--
+-- Select statement with hierarchical queries
+--
+-- https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/SELECT.html#GUID-CFA006CA-6FF1-4972-821E-6996142A51C6
+-- https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/SELECT.html#GUID-CFA006CA-6FF1-4972-821E-6996142A51C6__I2130004
+-- https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/Hierarchical-Queries.html#GUID-0118DF1D-B9A9-41EB-8556-C6E7D6A5A84E
+--
+
+BEGIN
+
+SELECT id INTO v_id 
+  FROM (SELECT separator_in || string_in || separator_in AS token_list FROM DUAL)
+  CONNECT BY col_length <= LENGTH(string_in) - LENGTH(separator_in);
+
+SELECT last_name, employee_id, manager_id
+   INTO test
+   FROM employees
+   CONNECT BY employee_id = manager_id
+   ORDER BY last_name;
+
+SELECT last_name, employee_id, manager_id
+   INTO test
+   FROM employees
+   CONNECT BY PRIOR employee_id = manager_id
+   AND salary > commission_pct
+   ORDER BY last_name;
+
+SELECT employee_id, last_name, manager_id
+   INTO test
+   FROM employees
+   CONNECT BY PRIOR employee_id = manager_id;
+
+SELECT employee_id, last_name, manager_id, LEVEL
+   INTO test
+   FROM employees
+   CONNECT BY PRIOR employee_id = manager_id;
+
+SELECT last_name, employee_id, manager_id, LEVEL
+    INTO test
+    FROM employees
+    START WITH employee_id = 100
+    CONNECT BY PRIOR employee_id = manager_id
+    ORDER SIBLINGS BY last_name;
+
+SELECT last_name "Employee", 
+   LEVEL, SYS_CONNECT_BY_PATH(last_name, '/') "Path"
+   INTO test
+   FROM employees
+   WHERE level <= 3 AND department_id = 80
+   START WITH last_name = 'King'
+   CONNECT BY PRIOR employee_id = manager_id AND LEVEL <= 4;
+
+SELECT last_name "Employee", CONNECT_BY_ISCYCLE "Cycle",
+   LEVEL, SYS_CONNECT_BY_PATH(last_name, '/') "Path"
+   INTO test
+   FROM employees
+   WHERE level <= 3 AND department_id = 80
+   START WITH last_name = 'King'
+   CONNECT BY NOCYCLE PRIOR employee_id = manager_id AND LEVEL <= 4
+   ORDER BY "Employee", "Cycle", LEVEL, "Path";
+
+SELECT LTRIM(SYS_CONNECT_BY_PATH (warehouse_id,','),',')
+   INTO test
+   FROM
+   (SELECT ROWNUM r, warehouse_id FROM warehouses)
+   WHERE CONNECT_BY_ISLEAF = 1
+   START WITH r = 1
+   CONNECT BY r = PRIOR r + 1
+   ORDER BY warehouse_id;
+
+SELECT last_name "Employee", CONNECT_BY_ROOT last_name "Manager",
+   LEVEL-1 "Pathlen", SYS_CONNECT_BY_PATH(last_name, '/') "Path"
+   INTO test
+   FROM employees
+   WHERE LEVEL > 1 and department_id = 110
+   CONNECT BY PRIOR employee_id = manager_id
+   ORDER BY "Employee", "Manager", "Pathlen", "Path";
+
+SELECT name, SUM(salary) "Total_Salary"
+   INTO test
+   FROM (
+   SELECT CONNECT_BY_ROOT last_name as name, Salary
+      FROM employees
+      WHERE department_id = 110
+      CONNECT BY PRIOR employee_id = manager_id)
+      GROUP BY name
+   ORDER BY name, "Total_Salary";
+
+END;
+/


### PR DESCRIPTION
Fixes #1590 

This slightly changes the parse tree: In order to properly support function calls in select statements, I needed to move them down to PrimaryPrefix.

I also figured out, that we are hitting a limit here with the tokens: I first started out to define each built-in function name as a token and use these tokens to determine the function name, but it turns out, that the generated parser can't be compiled anymore (the compiler throws a stack overflow exception...) probably due to the big switch-case statements. So I tried to define not too many new tokens...
