### PR TITLE
[plsql] Support XMLTABLE functions

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -61,6 +61,8 @@ The designer will still be shipped with PMD's binaries.
     *   [#1701](https://github.com/pmd/pmd/issues/1701): \[java] UseTryWithResources does not handle multiple argument close methods
 *   java-codestyle
     *   [#1674](https://github.com/pmd/pmd/issues/1674): \[java] documentation of CommentDefaultAccessModifier is wrong
+*   plsql
+    *   [#1510](https://github.com/pmd/pmd/issues/1510): \[plsql] Support XMLTABLE functions
 
 ### API Changes
 

--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -27,6 +27,22 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 /**
+ * Added support for XMLTABLE, XMLEXISTS, XMLCAST, XMLQUERY, CAST, XMLFOREST
+ * and XMLELEMENT
+ *
+ * Andreas Dangel 03/2019
+ *====================================================================
+ * More complete support for UPDATE statements and subqueries and hierarchical
+ * queries in SELECT statements.
+ * Added support for analytic functions such as LISTAGG.
+ * Conditions in WHERE clauses support now REGEX_LIKE and multiset conditions.
+ *
+ * Andreas Dangel 02/2019
+ *====================================================================
+ * Added support for TableCollectionExpressions
+ *
+ * Andreas Dangel 01/2019
+ *====================================================================
  * Added support for DELETE Statements
  * Added support for UPDATE Statements
  * Fully parse the select statement in CursorForLoops.

--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -1552,7 +1552,7 @@ ASTFunctionCall FunctionCall() :
       | LOOKAHEAD({"XMLQUERY".equalsIgnoreCase(token.image)}) "(" StringLiteral() [ LOOKAHEAD({isKeyword("PASSING")}) XMLPassingClause() ] <RETURNING> KEYWORD("CONTENT") [ <NULL> <ON> <EMPTY> ] ")"
       | LOOKAHEAD({"CAST".equalsIgnoreCase(token.image)}) "(" ( <MULTISET> "(" Subquery() ")" | Expression() ) <AS> Datatype() ")"
       | LOOKAHEAD({"XMLFOREST".equalsIgnoreCase(token.image)}) "(" SqlExpression() [ <AS> ID() ] ( "," SqlExpression() [ <AS> ID() ] )* ")"
-      | LOOKAHEAD({"XMLELEMENT".equalsIgnoreCase(token.image)}) "(" XMLElement() ")"
+      | LOOKAHEAD({"XMLELEMENT".equalsIgnoreCase(token.image)}) XMLElement()
       | Arguments()
     )
 
@@ -1658,6 +1658,7 @@ ASTXMLExists XMLExists() :
 ASTXMLElement XMLElement() :
 {}
 {
+    "("
     [ LOOKAHEAD({isKeyword("ENTITYESCAPING") || isKeyword("NOENTITYESCAPING")}) <IDENTIFIER> ]
     (
         LOOKAHEAD({isKeyword("EVALNAME")}) KEYWORD("EVALNAME") Expression()
@@ -1673,6 +1674,7 @@ ASTXMLElement XMLElement() :
         )
     ]
     ( "," Expression() [ [ <AS> ] ColumnAlias() ] )*
+    ")"
     { return jjtThis; }
 }
 
@@ -1683,8 +1685,8 @@ ASTXMLAttributesClause XMLAttributesClause() :
         [ LOOKAHEAD({isKeyword("ENTITYESCAPING") || isKeyword("NOENTITYESCAPING")}) <IDENTIFIER> ]
         [ LOOKAHEAD({isKeyword("SCHEMACHECK") || isKeyword("NOSCHEMACHECK")}) <IDENTIFIER> ]
 
-             Expression() [ [ <AS> ] ( LOOKAHEAD({isKeyword("EVALNAME")}) KEYWORD("EVALNAME") Expression() | ColumnAlias() | Expression() ) ]
-        ("," Expression() [ [ <AS> ] ( LOOKAHEAD({isKeyword("EVALNAME")}) KEYWORD("EVALNAME") Expression() | ColumnAlias() | Expression() ) ] )*
+             Expression() [ [ <AS> ] ( LOOKAHEAD({isKeyword("EVALNAME")}) KEYWORD("EVALNAME") Expression() | LOOKAHEAD(2) ColumnAlias() | Expression() ) ]
+        ("," Expression() [ [ <AS> ] ( LOOKAHEAD({isKeyword("EVALNAME")}) KEYWORD("EVALNAME") Expression() | LOOKAHEAD(2) ColumnAlias() | Expression() ) ] )*
     ")"
     { return jjtThis; }
 }
@@ -6188,7 +6190,6 @@ ASTID ID(): {}
 		| <AND>  //SYNTAX  //RESERVED WORD
 		| <ANY>  //RESERVED WORD
 		| <ARRAY>
-		| <AS>  //SYNTAX  //RESERVED WORD
 		| <ASC>  //RESERVED WORD
 		//20120429 | <AT> | <AUTHID>
 		//| <AVG>

--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -1552,6 +1552,7 @@ ASTFunctionCall FunctionCall() :
       | LOOKAHEAD({"XMLQUERY".equalsIgnoreCase(token.image)}) "(" StringLiteral() [ LOOKAHEAD({isKeyword("PASSING")}) XMLPassingClause() ] <RETURNING> KEYWORD("CONTENT") [ <NULL> <ON> <EMPTY> ] ")"
       | LOOKAHEAD({"CAST".equalsIgnoreCase(token.image)}) "(" ( <MULTISET> "(" Subquery() ")" | Expression() ) <AS> Datatype() ")"
       | LOOKAHEAD({"XMLFOREST".equalsIgnoreCase(token.image)}) "(" SqlExpression() [ <AS> ID() ] ( "," SqlExpression() [ <AS> ID() ] )* ")"
+      | LOOKAHEAD({"XMLELEMENT".equalsIgnoreCase(token.image)}) "(" XMLElement() ")"
       | Arguments()
     )
 
@@ -1650,6 +1651,40 @@ ASTXMLExists XMLExists() :
     "("
         StringLiteral()
         [ LOOKAHEAD({isKeyword("PASSING")}) XMLPassingClause() ]
+    ")"
+    { return jjtThis; }
+}
+
+ASTXMLElement XMLElement() :
+{}
+{
+    [ LOOKAHEAD({isKeyword("ENTITYESCAPING") || isKeyword("NOENTITYESCAPING")}) <IDENTIFIER> ]
+    (
+        LOOKAHEAD({isKeyword("EVALNAME")}) KEYWORD("EVALNAME") Expression()
+        |
+        [ LOOKAHEAD({isKeyword("NAME")}) KEYWORD("NAME") ] ID()
+    )
+    [  LOOKAHEAD(1)
+        ","
+        (
+            LOOKAHEAD({isKeyword("XMLATTRIBUTES")}) XMLAttributesClause()
+        |
+            Expression() [ [ <AS> ] ColumnAlias() ]
+        )
+    ]
+    ( "," Expression() [ [ <AS> ] ColumnAlias() ] )*
+    { return jjtThis; }
+}
+
+ASTXMLAttributesClause XMLAttributesClause() :
+{}
+{
+    KEYWORD("XMLATTRIBUTES") "("
+        [ LOOKAHEAD({isKeyword("ENTITYESCAPING") || isKeyword("NOENTITYESCAPING")}) <IDENTIFIER> ]
+        [ LOOKAHEAD({isKeyword("SCHEMACHECK") || isKeyword("NOSCHEMACHECK")}) <IDENTIFIER> ]
+
+             Expression() [ [ <AS> ] ( LOOKAHEAD({isKeyword("EVALNAME")}) KEYWORD("EVALNAME") Expression() | ColumnAlias() | Expression() ) ]
+        ("," Expression() [ [ <AS> ] ( LOOKAHEAD({isKeyword("EVALNAME")}) KEYWORD("EVALNAME") Expression() | ColumnAlias() | Expression() ) ] )*
     ")"
     { return jjtThis; }
 }

--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -1548,6 +1548,9 @@ ASTFunctionCall FunctionCall() :
     name = FunctionName()
     (
         LOOKAHEAD({"TRIM".equalsIgnoreCase(token.image)}) TrimExpression()
+      | LOOKAHEAD({"XMLCAST".equalsIgnoreCase(token.image)}) "(" Expression() <AS> Datatype() ")"
+      | LOOKAHEAD({"XMLQUERY".equalsIgnoreCase(token.image)}) "(" StringLiteral() [ LOOKAHEAD({isKeyword("PASSING")}) XMLPassingClause() ] <RETURNING> KEYWORD("CONTENT") [ <NULL> <ON> <EMPTY> ] ")"
+      | LOOKAHEAD({"CAST".equalsIgnoreCase(token.image)}) "(" ( <MULTISET> "(" Subquery() ")" | Expression() ) <AS> Datatype() ")"
       | Arguments()
     )
 
@@ -1634,7 +1637,8 @@ ASTXMLPassingClause XMLPassingClause() :
 {
     KEYWORD("PASSING")
     [ <BY> "VALUE" ]
-    ( LOOKAHEAD(2) SqlExpression() [ LOOKAHEAD(2) <AS> ID() ] (",")? )+
+    ( SqlExpression() [ LOOKAHEAD(2) <AS> ID() ] )
+    ( "," SqlExpression() [ LOOKAHEAD(2) <AS> ID() ] )*
     { return jjtThis; }
 }
 
@@ -5189,7 +5193,6 @@ ASTKEYWORD_UNRESERVED KEYWORD_UNRESERVED (): {}
 //| <CONSTRAINTS>
 | <CONSTRUCTOR>
 //| <CONTAINER>
-//| <CONTENT>
 //| <CONTENTS>
 | <CONTEXT>
 | <CONTINUE>

--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -190,6 +190,14 @@ public class PLSQLParser {
     }
     return s.toString();
   }
+
+  /**
+   * Semantic lookahead to check if the next identifier is a
+   * specific keyword.
+   */
+  private boolean isKeyword(String keyword) {
+    return getToken(1).kind == IDENTIFIER && getToken(1).image.equalsIgnoreCase(keyword);
+  }
 }
 
 PARSER_END(PLSQLParser)
@@ -1503,14 +1511,14 @@ ASTSimpleExpression SimpleExpression() :
     LOOKAHEAD(6)
         SchemaName() { sb.append(token.image); } "." { sb.append(token.image); }
         TableName() { sb.append(token.image); } "." { sb.append(token.image); }
-        Column() { sb.append(token.image); }
+        ( "*" | Column() ) { sb.append(token.image); }
  |
     LOOKAHEAD(4)
         TableName() { sb.append(token.image); } "." { sb.append(token.image); }
-        Column() { sb.append(token.image); }
+        ( "*" | Column() ) { sb.append(token.image); }
  |
     LOOKAHEAD(2)
-        Column() { sb.append(token.image); }
+        ( "*" | Column() ) { sb.append(token.image); }
  )
  {
     jjtThis.setImage(sb.toString());
@@ -1537,9 +1545,8 @@ ASTFunctionCall FunctionCall() :
 {
     name = FunctionName()
     (
-      LOOKAHEAD({"TRIM".equalsIgnoreCase(token.image)}) TrimExpression()
-      |
-      Arguments()
+        LOOKAHEAD({"TRIM".equalsIgnoreCase(token.image)}) TrimExpression()
+      | Arguments()
     )
 
     {
@@ -1563,6 +1570,70 @@ ASTFunctionName FunctionName() :
         jjtThis.setImage(name.toString());
         return jjtThis;
     }
+}
+
+/**
+ * https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/XMLTABLE.html
+ */
+ASTXMLTable XMLTable() :
+{}
+{
+    KEYWORD("XMLTABLE")
+    "("
+        [ LOOKAHEAD({isKeyword("XMLNAMESPACES")}) XMLNamespacesClause() "," ]
+        StringLiteral()
+        XMLTableOptions()
+    ")"
+    { return jjtThis; }
+}
+
+ASTXMLNamespacesClause XMLNamespacesClause() :
+{}
+{
+    KEYWORD("XMLNAMESPACES") "("
+    (
+        ( StringLiteral() <AS> ID()
+         | <_DEFAULT> StringLiteral() )
+        (",")?
+    )+
+    ")"
+    { return jjtThis; }
+}
+
+ASTXMLTableOptions XMLTableOptions() :
+{}
+{
+    [ LOOKAHEAD({isKeyword("PASSING")}) XMLPassingClause() ]
+    [ <RETURNING> KEYWORD("SEQUENCE") <BY> "REF" ]
+    [ <COLUMNS> ( XMLTableColum() (",")? )+ ]
+    { return jjtThis; }
+}
+
+ASTXMLTableColum XMLTableColum() :
+{}
+{
+    Column()
+    (
+      <FOR> KEYWORD("ORDINALITY")
+        |
+      (
+        LOOKAHEAD({isKeyword("XMLTYPE")}) KEYWORD("XMLTYPE") [ "(" KEYWORD("SEQUENCE") ")" <BY> "REF" ]
+        |
+        Datatype()
+      )
+      [ LOOKAHEAD({isKeyword("PATH")}) KEYWORD("PATH") StringLiteral() ]
+      [ <_DEFAULT> SqlExpression() ]
+    )
+    { return jjtThis; }
+}
+
+ASTXMLPassingClause XMLPassingClause() :
+{}
+{
+    KEYWORD("PASSING")
+    [ <BY> "VALUE" ]
+    ( LOOKAHEAD(2) SqlExpression() [ LOOKAHEAD(2) <AS> ID() ] (",")? )+
+    { return jjtThis; }
 }
 
 /**
@@ -1656,6 +1727,8 @@ void FromClauseEntry() #void :
      // using lookahead to avoid misinterpreting the token after the identifier
      // as a table alias rather than as a keyword
      LOOKAHEAD(<IDENTIFIER> (<PARTITION>|<NATURAL>|<OUTER>|<JOIN>|<RIGHT>|<CROSS>|<FULL>)) JoinClause()
+ |
+     LOOKAHEAD(<IDENTIFIER> "(", {isKeyword("XMLTABLE")}) XMLTable() [ LOOKAHEAD(2) TableAlias() ]
  |
      LOOKAHEAD(3) TableReference()
  |

--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -1318,6 +1318,8 @@ void Condition2() #void :
  |
     LOOKAHEAD(<EXISTS>) ExistsCondition()
  |
+    LOOKAHEAD({isKeyword("XMLEXISTS")}) XMLExists()
+ |
     LOOKAHEAD(MultisetCondition()) MultisetCondition()
  |
     LOOKAHEAD(FloatingPointCondition()) FloatingPointCondition()
@@ -1633,6 +1635,17 @@ ASTXMLPassingClause XMLPassingClause() :
     KEYWORD("PASSING")
     [ <BY> "VALUE" ]
     ( LOOKAHEAD(2) SqlExpression() [ LOOKAHEAD(2) <AS> ID() ] (",")? )+
+    { return jjtThis; }
+}
+
+ASTXMLExists XMLExists() :
+{}
+{
+    KEYWORD("XMLEXISTS")
+    "("
+        StringLiteral()
+        [ LOOKAHEAD({isKeyword("PASSING")}) XMLPassingClause() ]
+    ")"
     { return jjtThis; }
 }
 

--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -1551,6 +1551,7 @@ ASTFunctionCall FunctionCall() :
       | LOOKAHEAD({"XMLCAST".equalsIgnoreCase(token.image)}) "(" Expression() <AS> Datatype() ")"
       | LOOKAHEAD({"XMLQUERY".equalsIgnoreCase(token.image)}) "(" StringLiteral() [ LOOKAHEAD({isKeyword("PASSING")}) XMLPassingClause() ] <RETURNING> KEYWORD("CONTENT") [ <NULL> <ON> <EMPTY> ] ")"
       | LOOKAHEAD({"CAST".equalsIgnoreCase(token.image)}) "(" ( <MULTISET> "(" Subquery() ")" | Expression() ) <AS> Datatype() ")"
+      | LOOKAHEAD({"XMLFOREST".equalsIgnoreCase(token.image)}) "(" SqlExpression() [ <AS> ID() ] ( "," SqlExpression() [ <AS> ID() ] )* ")"
       | Arguments()
     )
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLParserVisitorAdapter.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLParserVisitorAdapter.java
@@ -1056,4 +1056,29 @@ public class PLSQLParserVisitorAdapter implements PLSQLParserVisitor {
     public Object visit(ASTSimpleExpression node, Object data) {
         return visit((PLSQLNode) node, data);
     }
+
+    @Override
+    public Object visit(ASTXMLTable node, Object data) {
+        return visit((PLSQLNode) node, data);
+    }
+
+    @Override
+    public Object visit(ASTXMLNamespacesClause node, Object data) {
+        return visit((PLSQLNode) node, data);
+    }
+
+    @Override
+    public Object visit(ASTXMLTableOptions node, Object data) {
+        return visit((PLSQLNode) node, data);
+    }
+
+    @Override
+    public Object visit(ASTXMLPassingClause node, Object data) {
+        return visit((PLSQLNode) node, data);
+    }
+
+    @Override
+    public Object visit(ASTXMLTableColum node, Object data) {
+        return visit((PLSQLNode) node, data);
+    }
 }

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLParserVisitorAdapter.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLParserVisitorAdapter.java
@@ -1081,4 +1081,9 @@ public class PLSQLParserVisitorAdapter implements PLSQLParserVisitor {
     public Object visit(ASTXMLTableColum node, Object data) {
         return visit((PLSQLNode) node, data);
     }
+
+    @Override
+    public Object visit(ASTXMLExists node, Object data) {
+        return visit((PLSQLNode) node, data);
+    }
 }

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLParserVisitorAdapter.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLParserVisitorAdapter.java
@@ -1086,4 +1086,14 @@ public class PLSQLParserVisitorAdapter implements PLSQLParserVisitor {
     public Object visit(ASTXMLExists node, Object data) {
         return visit((PLSQLNode) node, data);
     }
+
+    @Override
+    public Object visit(ASTXMLAttributesClause node, Object data) {
+        return visit((PLSQLNode) node, data);
+    }
+
+    @Override
+    public Object visit(ASTXMLElement node, Object data) {
+        return visit((PLSQLNode) node, data);
+    }
 }

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractPLSQLRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractPLSQLRule.java
@@ -1175,6 +1175,11 @@ public abstract class AbstractPLSQLRule extends AbstractRule implements PLSQLPar
         return visit((PLSQLNode) node, data);
     }
 
+    @Override
+    public Object visit(ASTXMLExists node, Object data) {
+        return visit((PLSQLNode) node, data);
+    }
+
     /*
      * Treat all Executable Code
      */

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractPLSQLRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractPLSQLRule.java
@@ -1180,6 +1180,16 @@ public abstract class AbstractPLSQLRule extends AbstractRule implements PLSQLPar
         return visit((PLSQLNode) node, data);
     }
 
+    @Override
+    public Object visit(ASTXMLAttributesClause node, Object data) {
+        return visit((PLSQLNode) node, data);
+    }
+
+    @Override
+    public Object visit(ASTXMLElement node, Object data) {
+        return visit((PLSQLNode) node, data);
+    }
+
     /*
      * Treat all Executable Code
      */

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractPLSQLRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractPLSQLRule.java
@@ -1150,6 +1150,31 @@ public abstract class AbstractPLSQLRule extends AbstractRule implements PLSQLPar
         return visit((PLSQLNode) node, data);
     }
 
+    @Override
+    public Object visit(ASTXMLTable node, Object data) {
+        return visit((PLSQLNode) node, data);
+    }
+
+    @Override
+    public Object visit(ASTXMLNamespacesClause node, Object data) {
+        return visit((PLSQLNode) node, data);
+    }
+
+    @Override
+    public Object visit(ASTXMLTableOptions node, Object data) {
+        return visit((PLSQLNode) node, data);
+    }
+
+    @Override
+    public Object visit(ASTXMLPassingClause node, Object data) {
+        return visit((PLSQLNode) node, data);
+    }
+
+    @Override
+    public Object visit(ASTXMLTableColum node, Object data) {
+        return visit((PLSQLNode) node, data);
+    }
+
     /*
      * Treat all Executable Code
      */

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/XMLElementTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/XMLElementTest.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.plsql.ast;
 
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
@@ -19,5 +20,9 @@ public class XMLElementTest extends AbstractPLSQLParserTst {
         ASTInput input = parsePLSQL(IOUtils.toString(this.getClass().getResourceAsStream("XMLElement.pls"),
                 StandardCharsets.UTF_8));
         Assert.assertNotNull(input);
+        List<ASTXMLElement> xmlelements = input.findDescendantsOfType(ASTXMLElement.class);
+        Assert.assertEquals(10, xmlelements.size());
+        Assert.assertEquals("\"Emp\"", xmlelements.get(0).getFirstChildOfType(ASTID.class).getImage());
+        Assert.assertTrue(xmlelements.get(3).jjtGetChild(1) instanceof ASTXMLAttributesClause);
     }
 }

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/XMLElementTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/XMLElementTest.java
@@ -1,0 +1,23 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.plsql.ast;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.sourceforge.pmd.lang.plsql.AbstractPLSQLParserTst;
+
+public class XMLElementTest extends AbstractPLSQLParserTst {
+
+    @Test
+    public void testParseXMLElement() throws Exception {
+        ASTInput input = parsePLSQL(IOUtils.toString(this.getClass().getResourceAsStream("XMLElement.pls"),
+                StandardCharsets.UTF_8));
+        Assert.assertNotNull(input);
+    }
+}

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/XMLTableTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/XMLTableTest.java
@@ -1,0 +1,23 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.plsql.ast;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.sourceforge.pmd.lang.plsql.AbstractPLSQLParserTst;
+
+public class XMLTableTest extends AbstractPLSQLParserTst {
+
+    @Test
+    public void testParseXMLTable() throws Exception {
+        ASTInput input = parsePLSQL(IOUtils.toString(this.getClass().getResourceAsStream("XMLTable.pls"),
+                StandardCharsets.UTF_8));
+        Assert.assertNotNull(input);
+    }
+}

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/XMLElement.pls
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/XMLElement.pls
@@ -1,0 +1,27 @@
+--
+-- Examples from: https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/XMLELEMENT.html#GUID-DEA75423-00EA-4034-A246-4A774ADC988E
+--
+BEGIN
+
+SELECT XMLELEMENT("Emp", XMLELEMENT("Name", 
+   e.job_id||' '||e.last_name),
+   XMLELEMENT("Hiredate", e.hire_date)) as "Result"
+   FROM employees e WHERE employee_id > 200;
+
+SELECT XMLELEMENT("Emp",
+      XMLATTRIBUTES(e.employee_id AS "ID", e.last_name),
+      XMLELEMENT("Dept", e.department_id),
+      XMLELEMENT("Salary", e.salary)) AS "Emp Element"
+   FROM employees e
+   WHERE e.employee_id = 206;
+
+SELECT XMLELEMENT("Emp", XMLATTRIBUTES(e.employee_id, e.last_name),
+   XMLELEMENT("Dept", XMLATTRIBUTES(e.department_id,
+   (SELECT d.department_name FROM departments d
+   WHERE d.department_id = e.department_id) as "Dept_name")),
+   XMLELEMENT("salary", e.salary),
+   XMLELEMENT("Hiredate", e.hire_date)) AS "Emp Element"
+   FROM employees e
+   WHERE employee_id = 205;
+
+END;

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/XMLTable.pls
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/XMLTable.pls
@@ -98,4 +98,9 @@ SELECT XMLQuery('declare default element namespace
                 PASSING CFG AS "XML", 81 as "PORTNO" RETURNING CONTENT)
   FROM DUAL;
 
+SELECT XMLELEMENT("Emp", 
+   XMLFOREST(e.employee_id AS foo, e.last_name, e.salary))
+   "Emp Element"
+   FROM employees e WHERE employee_id = 204;
+
 END;

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/XMLTable.pls
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/XMLTable.pls
@@ -36,7 +36,7 @@ SELECT OBJECT_VALUE
   WHERE XMLExists('/PurchaseOrder[SpecialInstructions="Expedite"]'
                   PASSING OBJECT_VALUE);
 
-/*
+
 SELECT XMLCast(XMLQuery('/PurchaseOrder/Reference' PASSING OBJECT_VALUE
                                                    RETURNING CONTENT)
                AS VARCHAR2(100)) "REFERENCE"
@@ -97,6 +97,5 @@ SELECT XMLQuery('declare default element namespace
                                return $NEWXML}'
                 PASSING CFG AS "XML", 81 as "PORTNO" RETURNING CONTENT)
   FROM DUAL;
-*/
 
 END;

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/XMLTable.pls
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/XMLTable.pls
@@ -1,0 +1,101 @@
+--
+-- Samples from https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/XMLTABLE.html
+--
+
+BEGIN
+
+SELECT warehouse_name warehouse,
+   warehouse2."Water", warehouse2."Rail"
+   FROM warehouses,
+   XMLTABLE('/Warehouse'
+      PASSING warehouses.warehouse_spec
+      COLUMNS 
+         "Water" varchar2(6) PATH 'WaterAccess',
+         "Rail" varchar2(6) PATH 'RailAccess')
+      warehouse2;
+
+/*
+--
+-- Samples from https://docs.oracle.com/en/database/oracle/oracle-database/18/adxdb/xquery-and-XML-DB.html
+--
+ SELECT po.reference, li.*
+    FROM po_binaryxml p,
+         XMLTable('/PurchaseOrder' PASSING p.OBJECT_VALUE
+                  COLUMNS
+                    reference VARCHAR2(30) PATH 'Reference',
+                    lineitem  XMLType      PATH 'LineItems/LineItem') po,
+         XMLTable('/LineItem' PASSING po.lineitem
+                  COLUMNS
+                    itemno      NUMBER(38)    PATH '@ItemNumber',
+                    description VARCHAR2(256) PATH 'Description',
+                    partno      VARCHAR2(14)  PATH 'Part/@Id',
+                    quantity    NUMBER(12, 2) PATH 'Part/@Quantity',
+                    unitprice   NUMBER(8, 4)  PATH 'Part/@UnitPrice') li;
+
+SELECT OBJECT_VALUE
+  FROM purchaseorder
+  WHERE XMLExists('/PurchaseOrder[SpecialInstructions="Expedite"]'
+                  PASSING OBJECT_VALUE);
+SELECT XMLCast(XMLQuery('/PurchaseOrder/Reference' PASSING OBJECT_VALUE
+                                                   RETURNING CONTENT)
+               AS VARCHAR2(100)) "REFERENCE"
+  FROM purchaseorder
+  WHERE XMLExists('/PurchaseOrder[SpecialInstructions="Expedite"]'
+                  PASSING OBJECT_VALUE);
+
+
+UPDATE oe.purchaseorder p SET p.OBJECT_VALUE =
+  XMLQuery(
+    'copy $i :=
+       $p1 modify (for $j in $i/PurchaseOrder/LineItems
+                     return (#ora:child-element-name LineItem #)
+                            {insert node $p2 into $j)
+                  return $i'
+    PASSING p.OBJECT_VALUE AS "p1", :1 AS "p2" RETURNING CONTENT)
+  WHERE XMLQuery(
+          '/PurchaseOrder/Reference/text()'
+          PASSING p.OBJECT_VALUE RETURNING CONTENT).getStringVal() =
+            'EMPTY_LINES';
+
+SELECT XMLQuery('(#ora:invalid_path empty #)
+                 {exists($p/PurchaseOrder//NotInTheSchema)}'
+                PASSING OBJECT_VALUE AS "p" RETURNING CONTENT)
+  FROM oe.purchaseorder p;
+
+SELECT XMLQuery('(#ora:view_on_null empty #)
+                 {for $i in fn:collection("oradb:/PUBLIC/NULL_TEST")/ROW 
+                  return $i}'
+                RETURNING CONTENT)
+  FROM DUAL;
+
+SELECT XMLQuery('(#ora:view_on_null null #)
+                 {for $i in fn:collection("oradb:/PUBLIC/NULL_TEST")/ROW 
+                  return $i}'
+                RETURNING CONTENT)
+  FROM DUAL;
+
+SELECT XMLQuery('(#ora:no_xmlquery_rewrite#) (: Do not optimize expression :)
+                 {for $i in (#ora:xmlquery_rewrite#) (: Optimize subexp. :)
+                            {fn:collection("oradb:/HR/REGIONS")},
+                      $j in (#ora:xmlquery_rewrite#) (: Optimize subexpr. :)
+                            {fn:collection("oradb:/HR/COUNTRIES")}
+                  where $i/ROW/REGION_ID = $j/ROW/REGION_ID
+                    and $i/ROW/REGION_NAME = $regionname
+                  return $j}'
+         PASSING CAST('&REGION' AS VARCHAR2(40)) AS "regionname"
+           RETURNING CONTENT)
+  AS asian_countries FROM DUAL;
+
+SELECT XMLQuery('declare default element namespace
+                 "http://xmlns.oracle.com/xdb/xdbconfig.xsd"; (: :)
+                 (#ora:transform_keep_schema#)
+                 {copy $NEWXML :=
+                   $XML modify (for $CFG in $NEWXML/xdbconfig//httpconfig 
+                                  return (replace value of node
+                                          $CFG/http-port with xs:int($PORTNO)))
+                               return $NEWXML}'
+                PASSING CFG AS "XML", 81 as "PORTNO" RETURNING CONTENT)
+  FROM DUAL;
+*/
+
+END;

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/XMLTable.pls
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/XMLTable.pls
@@ -14,7 +14,6 @@ SELECT warehouse_name warehouse,
          "Rail" varchar2(6) PATH 'RailAccess')
       warehouse2;
 
-/*
 --
 -- Samples from https://docs.oracle.com/en/database/oracle/oracle-database/18/adxdb/xquery-and-XML-DB.html
 --
@@ -36,6 +35,8 @@ SELECT OBJECT_VALUE
   FROM purchaseorder
   WHERE XMLExists('/PurchaseOrder[SpecialInstructions="Expedite"]'
                   PASSING OBJECT_VALUE);
+
+/*
 SELECT XMLCast(XMLQuery('/PurchaseOrder/Reference' PASSING OBJECT_VALUE
                                                    RETURNING CONTENT)
                AS VARCHAR2(100)) "REFERENCE"


### PR DESCRIPTION
It fixes #1510, but only supports the minimal set of functions to be able to parse the example code from https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/XMLTABLE.html and https://docs.oracle.com/en/database/oracle/oracle-database/18/adxdb/xquery-and-XML-DB.html



