### PR TITLE
[ui] Improved error reporting for the designer

### DIFF
--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/Designer.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/Designer.java
@@ -10,10 +10,13 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.ArrayUtils;
+
 import net.sourceforge.pmd.PMDVersion;
 import net.sourceforge.pmd.util.fxdesigner.app.DesignerRoot;
 import net.sourceforge.pmd.util.fxdesigner.util.DesignerUtil;
 
+import com.sun.javafx.fxml.builder.ProxyBuilder;
 import javafx.application.Application;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXMLLoader;
@@ -57,6 +60,19 @@ public class Designer extends Application {
         NodeInfoPanelController nodeInfoPanelController = new NodeInfoPanelController(mainController);
         XPathPanelController xpathPanelController = new XPathPanelController(mainController);
         SourceEditorController sourceEditorController = new SourceEditorController(mainController);
+
+        loader.setBuilderFactory(type -> {
+
+            boolean needsRoot = Arrays.stream(type.getConstructors()).anyMatch(it -> ArrayUtils.contains(it.getParameterTypes(), DesignerRoot.class));
+
+            if (needsRoot) {
+                ProxyBuilder<Object> builder = new ProxyBuilder<>(type);
+                builder.put("designerRoot", owner);
+                return builder;
+            } else {
+                return null; //use default
+            }
+        });
 
         loader.setControllerFactory(type -> {
             if (type == MainDesignerController.class) {

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/Designer.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/Designer.java
@@ -123,7 +123,9 @@ public class Designer extends Application {
         long initTime = System.currentTimeMillis() - initStartTimeMillis;
 
         System.out.println("done in " + initTime + "ms.");
-        System.out.println("Run with --verbose parameter to enable error output.");
+        if (!owner.isDeveloperMode()) {
+            System.out.println("Run with --verbose parameter to enable error output.");
+        }
     }
 
 

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/MainDesignerController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/MainDesignerController.java
@@ -165,7 +165,7 @@ public class MainDesignerController extends AbstractController<AbstractControlle
         if (root.isPresent()) {
             xpathPanelController.evaluateXPath(root.get(), getLanguageVersion());
         } else {
-            xpathPanelController.invalidateResults(true);
+            xpathPanelController.invalidateResultsExternal(true);
         }
     }
 
@@ -276,7 +276,7 @@ public class MainDesignerController extends AbstractController<AbstractControlle
      */
     public void invalidateAst() {
         nodeInfoPanelController.setFocusNode(null);
-        xpathPanelController.invalidateResults(false);
+        xpathPanelController.invalidateResultsExternal(false);
         getDesignerRoot().getNodeSelectionChannel().pushEvent(this, null);
     }
 

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/NodeInfoPanelController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/NodeInfoPanelController.java
@@ -101,18 +101,14 @@ public class NodeInfoPanelController extends AbstractController<MainDesignerCont
         // suppress as early as possible in the pipeline
         myScopeItemSelectionEvents = EventStreams.valuesOf(scopeHierarchyTreeView.getSelectionModel().selectedItemProperty()).suppressible();
 
-        initNodeSelectionHandling();
+        EventStream<Node> selectionEvents = myScopeItemSelectionEvents.filter(Objects::nonNull)
+                                                                      .map(TreeItem::getValue)
+                                                                      .filterMap(o -> o instanceof NameDeclaration, o -> (NameDeclaration) o)
+                                                                      .map(NameDeclaration::getNode);
+
+        initNodeSelectionHandling(getDesignerRoot(), selectionEvents);
     }
 
-
-    @Override
-    public EventStream<Node> getSelectionEvents() {
-        return myScopeItemSelectionEvents.filter(Objects::nonNull)
-                                         .map(TreeItem::getValue)
-                                         .filterMap(o -> o instanceof NameDeclaration, o -> (NameDeclaration) o)
-                                         .map(NameDeclaration::getNode);
-
-    }
 
 
     /**

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/NodeInfoPanelController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/NodeInfoPanelController.java
@@ -106,7 +106,8 @@ public class NodeInfoPanelController extends AbstractController<MainDesignerCont
                                                                       .filterMap(o -> o instanceof NameDeclaration, o -> (NameDeclaration) o)
                                                                       .map(NameDeclaration::getNode);
 
-        initNodeSelectionHandling(getDesignerRoot(), selectionEvents);
+        // TODO split this into independent NodeSelectionSources
+        initNodeSelectionHandling(getDesignerRoot(), selectionEvents, true);
     }
 
 

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/SourceEditorController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/SourceEditorController.java
@@ -78,16 +78,11 @@ public class SourceEditorController extends AbstractController<MainDesignerContr
     public SourceEditorController(MainDesignerController mainController) {
         super(mainController);
         astManager = new ASTManager(mainController.getDesignerRoot());
-
     }
 
 
     @Override
     protected void beforeParentInit() {
-
-        astTreeView.setDesignerRoot(getDesignerRoot());
-        nodeEditionCodeArea.setDesignerRoot(getDesignerRoot());
-
         initializeLanguageSelector(); // languageVersionProperty() must be initialized
 
         languageVersionProperty().values()

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/SourceEditorController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/SourceEditorController.java
@@ -5,7 +5,11 @@
 package net.sourceforge.pmd.util.fxdesigner;
 
 import static java.util.Collections.emptyList;
-import static net.sourceforge.pmd.util.fxdesigner.util.DesignerUtil.*;
+import static net.sourceforge.pmd.util.fxdesigner.util.DesignerUtil.defaultLanguageVersion;
+import static net.sourceforge.pmd.util.fxdesigner.util.DesignerUtil.getSupportedLanguageVersions;
+import static net.sourceforge.pmd.util.fxdesigner.util.DesignerUtil.mapToggleGroupToUserData;
+import static net.sourceforge.pmd.util.fxdesigner.util.DesignerUtil.rewire;
+import static net.sourceforge.pmd.util.fxdesigner.util.DesignerUtil.sanitizeExceptionMessage;
 
 import java.io.File;
 import java.io.IOException;

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/SourceEditorController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/SourceEditorController.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.util.fxdesigner;
 
 import static java.util.Collections.emptyList;
+import static net.sourceforge.pmd.util.fxdesigner.util.DesignerUtil.*;
 
 import java.io.File;
 import java.io.IOException;
@@ -112,7 +113,7 @@ public class SourceEditorController extends AbstractController<MainDesignerContr
 
     @Override
     protected void afterParentInit() {
-        DesignerUtil.rewire(astManager.languageVersionProperty(), languageVersionUIProperty);
+        rewire(astManager.languageVersionProperty(), languageVersionUIProperty);
         nodeEditionCodeArea.moveCaret(0, 0);
     }
 
@@ -121,7 +122,7 @@ public class SourceEditorController extends AbstractController<MainDesignerContr
 
         ToggleGroup languageToggleGroup = new ToggleGroup();
 
-        DesignerUtil.getSupportedLanguageVersions()
+        getSupportedLanguageVersions()
                     .stream()
                     .sorted(LanguageVersion::compareTo)
                     .map(lv -> {
@@ -134,9 +135,9 @@ public class SourceEditorController extends AbstractController<MainDesignerContr
                         languageSelectionMenuButton.getItems().add(item);
                     });
 
-        languageVersionUIProperty = DesignerUtil.mapToggleGroupToUserData(languageToggleGroup, DesignerUtil::defaultLanguageVersion);
+        languageVersionUIProperty = mapToggleGroupToUserData(languageToggleGroup, DesignerUtil::defaultLanguageVersion);
         // this will be overwritten by property restore if needed
-        languageVersionUIProperty.setValue(DesignerUtil.defaultLanguageVersion());
+        languageVersionUIProperty.setValue(defaultLanguageVersion());
     }
 
     /**
@@ -155,7 +156,7 @@ public class SourceEditorController extends AbstractController<MainDesignerContr
         try {
             current = astManager.updateIfChanged(source, auxclasspathClassLoader.getValue());
         } catch (ParseAbortedException e) {
-            astTitledPane.setTitle("Abstract syntax tree (error)");
+            editorTitledPane.errorMessageProperty().setValue(sanitizeExceptionMessage(e));
             return Optional.empty();
         }
 
@@ -171,7 +172,7 @@ public class SourceEditorController extends AbstractController<MainDesignerContr
 
     private void setUpToDateCompilationUnit(Node node) {
         parent.invalidateAst();
-        astTitledPane.setTitle("Abstract syntax tree");
+        editorTitledPane.errorMessageProperty().setValue("");
         ASTTreeItem root = ASTTreeItem.getRoot(node);
         astTreeView.setRoot(root);
     }

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/XPathPanelController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/XPathPanelController.java
@@ -18,7 +18,6 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.controlsfx.validation.ValidationSupport;
 import org.controlsfx.validation.Validator;
-import org.reactfx.EventStream;
 import org.reactfx.EventStreams;
 import org.reactfx.SuspendableEventStream;
 import org.reactfx.collection.LiveArrayList;
@@ -134,7 +133,8 @@ public class XPathPanelController extends AbstractController<MainDesignerControl
 
         selectionEvents = EventStreams.valuesOf(xpathResultListView.getSelectionModel().selectedItemProperty()).suppressible();
 
-        initNodeSelectionHandling();
+        initNodeSelectionHandling(getDesignerRoot(),
+                                  selectionEvents.filter(Objects::nonNull).map(TextAwareNodeWrapper::getNode));
     }
 
 
@@ -222,14 +222,6 @@ public class XPathPanelController extends AbstractController<MainDesignerControl
             }
         });
     }
-
-
-    @Override
-    public EventStream<Node> getSelectionEvents() {
-        return selectionEvents.filter(Objects::nonNull)
-                              .map(TextAwareNodeWrapper::getNode);
-    }
-
 
     @Override
     public void setFocusNode(Node node) {

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/XPathPanelController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/XPathPanelController.java
@@ -5,6 +5,8 @@
 package net.sourceforge.pmd.util.fxdesigner;
 
 
+import static net.sourceforge.pmd.util.fxdesigner.util.DesignerUtil.sanitizeExceptionMessage;
+
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -82,7 +84,6 @@ import javafx.stage.StageStyle;
  */
 public class XPathPanelController extends AbstractController<MainDesignerController> implements NodeSelectionSource {
 
-    private static final Pattern EXCEPTION_PREFIX_PATTERN = Pattern.compile("(?:(?:\\w+\\.)*\\w+:\\s*)*\\s*(.*)$", Pattern.DOTALL);
     private static final String NO_MATCH_MESSAGE = "No match in text";
     private static final Duration XPATH_REFRESH_DELAY = Duration.ofMillis(100);
     private final XPathEvaluator xpathEvaluator = new XPathEvaluator();
@@ -372,7 +373,7 @@ public class XPathPanelController extends AbstractController<MainDesignerControl
                                String emptyResultsPlaceholder) {
 
         Label emptyLabel = xpathError || otherError
-                           ? new Label(emptyResultsPlaceholder, new FontIcon("fas-exclamation"))
+                           ? new Label(emptyResultsPlaceholder, new FontIcon("fas-exclamation-triangle"))
                            : new Label(emptyResultsPlaceholder);
 
         xpathResultListView.setPlaceholder(emptyLabel);
@@ -384,9 +385,5 @@ public class XPathPanelController extends AbstractController<MainDesignerControl
     }
 
 
-    private static String sanitizeExceptionMessage(Throwable exception) {
-        Matcher matcher = EXCEPTION_PREFIX_PATTERN.matcher(exception.getMessage());
-        return matcher.matches() ? matcher.group(1) : exception.getMessage();
-    }
 
 }

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/XPathPanelController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/XPathPanelController.java
@@ -134,7 +134,7 @@ public class XPathPanelController extends AbstractController<MainDesignerControl
         selectionEvents = EventStreams.valuesOf(xpathResultListView.getSelectionModel().selectedItemProperty()).suppressible();
 
         initNodeSelectionHandling(getDesignerRoot(),
-                                  selectionEvents.filter(Objects::nonNull).map(TextAwareNodeWrapper::getNode));
+                                  selectionEvents.filter(Objects::nonNull).map(TextAwareNodeWrapper::getNode), false);
     }
 
 

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/XPathPanelController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/XPathPanelController.java
@@ -71,7 +71,6 @@ import javafx.scene.control.ToggleGroup;
 import javafx.scene.input.MouseButton;
 import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.HBox;
-import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.scene.text.Text;
 import javafx.stage.Modality;
@@ -136,12 +135,9 @@ public class XPathPanelController extends AbstractController<MainDesignerControl
 
         exportXpathToRuleButton.setOnAction(e -> showExportXPathToRuleWizard());
 
-        xpathExpressionArea.richChanges()
-                           .filter(t -> !t.isIdentity())
-                           .successionEnds(XPATH_REFRESH_DELAY)
-                           // Reevaluate XPath anytime the expression or the XPath version changes
-                           .or(xpathVersionProperty().changes())
-                           .subscribe(tick -> parent.refreshXPathResults());
+        getRuleBuilder().modificationsTicks()
+                        .successionEnds(XPATH_REFRESH_DELAY)
+                        .subscribe(tick -> parent.refreshXPathResults());
 
         selectionEvents = EventStreams.valuesOf(xpathResultListView.getSelectionModel().selectedItemProperty()).suppressible();
 

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/XPathPanelController.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/XPathPanelController.java
@@ -15,8 +15,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Supplier;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/app/MessageChannel.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/app/MessageChannel.java
@@ -58,8 +58,10 @@ public class MessageChannel<T> {
      *
      * @return A stream of messages
      */
-    public EventStream<T> messageStream(ApplicationComponent component) {
+    public EventStream<T> messageStream(boolean alwaysHandle,
+                                        ApplicationComponent component) {
         return distinct.hook(message -> component.logMessageTrace(message, () -> component.getDebugName() + " is handling message " + message))
+                       .filter(message -> alwaysHandle || !component.equals(message.getOrigin()))
                        .map(Message::getContent);
     }
 

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/app/NodeSelectionSource.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/app/NodeSelectionSource.java
@@ -24,19 +24,6 @@ public interface NodeSelectionSource extends ApplicationComponent {
 
 
     /**
-     * Returns a stream of events that should push an event each time
-     * this source or one of its sub components records a change in node
-     * selection. This one needs to be implemented in sub classes.
-     *
-     * <p>You can't trust that this method will return the same stream
-     * when called several times. In fact it's just called one time.
-     * That's why you can't abstract the suppressible behaviour here.
-     * You'd need Scala traits.
-     */
-    EventStream<Node> getSelectionEvents();
-
-
-    /**
      * Updates the UI to react to a change in focus node. This is called whenever some selection source
      * in the tree records a change.
      */
@@ -45,10 +32,17 @@ public interface NodeSelectionSource extends ApplicationComponent {
 
     /**
      * Initialises this component. Must be called by the component somewhere.
+     *
+     * @param root              Instance of the app. Should be the same as {@link #getDesignerRoot()},
+     *                          but a parameter here to make it clear that {@link #getDesignerRoot()}
+     *                          must be initialized before this method is called.
+     * @param mySelectionEvents Stream of nodes that should push an event each
+     *                          time this source records a change in node selection
      */
-    default void initNodeSelectionHandling() {
-        MessageChannel<Node> channel = getDesignerRoot().getNodeSelectionChannel();
-        getSelectionEvents().subscribe(n -> channel.pushEvent(this, n));
+    default void initNodeSelectionHandling(DesignerRoot root,
+                                           EventStream<? extends Node> mySelectionEvents) {
+        MessageChannel<Node> channel = root.getNodeSelectionChannel();
+        mySelectionEvents.subscribe(n -> channel.pushEvent(this, n));
         channel.messageStream(this).subscribe(this::setFocusNode);
     }
 

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/app/NodeSelectionSource.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/app/NodeSelectionSource.java
@@ -36,7 +36,8 @@ public interface NodeSelectionSource extends ApplicationComponent {
      * @param root                  Instance of the app. Should be the same as {@link #getDesignerRoot()},
      *                              but the parameter here is to make it clear that {@link #getDesignerRoot()}
      *                              must be initialized before this method is called.
-     * @param mySelectionEvents     Stream of nodes that should push an event each
+     * @param mySelectionEvents     Stream of nodes that should push an event each time the user selects a node
+     *                              from this control. The whole app will sync to this new selection.
      * @param alwaysHandleSelection Whether the component should handle selection events that originated from itself.
      *                              For now some must, because they aggregate several selection sources (the {@link net.sourceforge.pmd.util.fxdesigner.NodeInfoPanelController}).
      *                              Splitting it into separate controls will remove the need for that.

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/app/NodeSelectionSource.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/app/NodeSelectionSource.java
@@ -34,7 +34,7 @@ public interface NodeSelectionSource extends ApplicationComponent {
      * Initialises this component. Must be called by the component somewhere.
      *
      * @param root                  Instance of the app. Should be the same as {@link #getDesignerRoot()},
-     *                              but a parameter here to make it clear that {@link #getDesignerRoot()}
+     *                              but the parameter here is to make it clear that {@link #getDesignerRoot()}
      *                              must be initialized before this method is called.
      * @param mySelectionEvents     Stream of nodes that should push an event each
      * @param alwaysHandleSelection Whether the component should handle selection events that originated from itself.

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/app/NodeSelectionSource.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/app/NodeSelectionSource.java
@@ -33,17 +33,20 @@ public interface NodeSelectionSource extends ApplicationComponent {
     /**
      * Initialises this component. Must be called by the component somewhere.
      *
-     * @param root              Instance of the app. Should be the same as {@link #getDesignerRoot()},
-     *                          but a parameter here to make it clear that {@link #getDesignerRoot()}
-     *                          must be initialized before this method is called.
-     * @param mySelectionEvents Stream of nodes that should push an event each
-     *                          time this source records a change in node selection
+     * @param root                  Instance of the app. Should be the same as {@link #getDesignerRoot()},
+     *                              but a parameter here to make it clear that {@link #getDesignerRoot()}
+     *                              must be initialized before this method is called.
+     * @param mySelectionEvents     Stream of nodes that should push an event each
+     * @param alwaysHandleSelection Whether the component should handle selection events that originated from itself.
+     *                              For now some must, because they aggregate several selection sources (the {@link net.sourceforge.pmd.util.fxdesigner.NodeInfoPanelController}).
+     *                              Splitting it into separate controls will remove the need for that.
      */
     default void initNodeSelectionHandling(DesignerRoot root,
-                                           EventStream<? extends Node> mySelectionEvents) {
+                                           EventStream<? extends Node> mySelectionEvents,
+                                           boolean alwaysHandleSelection) {
         MessageChannel<Node> channel = root.getNodeSelectionChannel();
         mySelectionEvents.subscribe(n -> channel.pushEvent(this, n));
-        channel.messageStream(this).subscribe(this::setFocusNode);
+        channel.messageStream(alwaysHandleSelection, this).subscribe(this::setFocusNode);
     }
 
 }

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/model/ObservableXPathRuleBuilder.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/model/ObservableXPathRuleBuilder.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.util.fxdesigner.model;
 
+import org.reactfx.EventStream;
+import org.reactfx.collection.LiveList;
 import org.reactfx.value.Var;
 
 import net.sourceforge.pmd.util.fxdesigner.util.DesignerUtil;
@@ -52,6 +54,17 @@ public class ObservableXPathRuleBuilder extends ObservableRuleBuilder {
 
     public Var<String> xpathExpressionProperty() {
         return xpathExpression;
+    }
+
+
+    /**
+     * Pushes an event every time the rule needs to be re-evaluated.
+     */
+    public EventStream<?> modificationsTicks() {
+        return nameProperty().values()
+                             .or(xpathVersion.values())
+                             .or(xpathExpression.values())
+                             .or(LiveList.changesOf(rulePropertiesProperty()));
     }
 
     // TODO: Once the xpath expression changes, we'll need to rebuild the rule

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/model/PropertyDescriptorSpec.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/model/PropertyDescriptorSpec.java
@@ -8,6 +8,7 @@ package net.sourceforge.pmd.util.fxdesigner.model;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.reactfx.EventStream;
 import org.reactfx.value.Val;
 import org.reactfx.value.Var;
 
@@ -200,4 +201,15 @@ public class PropertyDescriptorSpec implements SettingsOwner {
     public static ObservableList<PropertyDescriptorSpec> observableList() {
         return FXCollections.observableArrayList(extractor());
     }
+
+
+    /**
+     * Pushes an event every time the rule owning this property needs to be re-evaluated.
+     */
+    public EventStream<?> modificationTicks() {
+        return nameProperty().values()
+                             .or(valueProperty().values())
+                             .or(typeIdProperty().values());
+    }
+
 }

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/DesignerUtil.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/DesignerUtil.java
@@ -70,6 +70,7 @@ import javafx.util.StringConverter;
  */
 public final class DesignerUtil {
 
+    private static final Pattern EXCEPTION_PREFIX_PATTERN = Pattern.compile("(?:(?:\\w+\\.)*\\w+:\\s*)*\\s*(.*)$", Pattern.DOTALL);
 
     private static final Path PMD_SETTINGS_DIR = Paths.get(System.getProperty("user.home"), ".pmd");
     private static final File DESIGNER_SETTINGS_FILE = PMD_SETTINGS_DIR.resolve("designer.xml").toFile();
@@ -287,6 +288,11 @@ public final class DesignerUtil {
         return lines.isEmpty() ? Optional.empty() : Optional.of("//" + String.join("/", lines));
     }
 
+
+    public static String sanitizeExceptionMessage(Throwable exception) {
+        Matcher matcher = EXCEPTION_PREFIX_PATTERN.matcher(exception.getMessage());
+        return matcher.matches() ? matcher.group(1) : exception.getMessage();
+    }
 
     /**
      * Works out an xpath query that matches the node

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/AstTreeView.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/AstTreeView.java
@@ -21,6 +21,7 @@ import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.util.fxdesigner.app.DesignerRoot;
 import net.sourceforge.pmd.util.fxdesigner.app.NodeSelectionSource;
 
+import javafx.beans.NamedArg;
 import javafx.scene.control.SelectionModel;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeView;
@@ -41,7 +42,9 @@ public class AstTreeView extends TreeView<Node> implements NodeSelectionSource {
     private DesignerRoot designerRoot;
 
 
-    public AstTreeView() {
+    public AstTreeView(@NamedArg("designerRoot") DesignerRoot root) {
+        designerRoot = root;
+
         EventSource<Node> eventSink = new EventSource<>();
         selectionEvents = eventSink.suppressible();
 
@@ -58,6 +61,8 @@ public class AstTreeView extends TreeView<Node> implements NodeSelectionSource {
                 eventSink.push(n);
             }
         }));
+
+        initNodeSelectionHandling();
     }
 
 
@@ -141,8 +146,4 @@ public class AstTreeView extends TreeView<Node> implements NodeSelectionSource {
     }
 
 
-    public void setDesignerRoot(DesignerRoot designerRoot) {
-        this.designerRoot = designerRoot;
-        initNodeSelectionHandling();
-    }
 }

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/AstTreeView.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/AstTreeView.java
@@ -35,7 +35,14 @@ public class AstTreeView extends TreeView<Node> implements NodeSelectionSource {
 
     private ASTTreeItem selectedTreeItem;
     private final SuspendableEventStream<Node> selectionEvents;
-    private DesignerRoot designerRoot;
+    private final DesignerRoot designerRoot;
+
+
+    /** Only provided for scenebuilder, not used at runtime. */
+    public AstTreeView() {
+        designerRoot = null;
+        selectionEvents = null;
+    }
 
 
     public AstTreeView(@NamedArg("designerRoot") DesignerRoot root) {

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/AstTreeView.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/AstTreeView.java
@@ -12,7 +12,6 @@ import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import org.reactfx.EventSource;
-import org.reactfx.EventStream;
 import org.reactfx.EventStreams;
 import org.reactfx.SuspendableEventStream;
 import org.reactfx.value.Var;
@@ -48,7 +47,7 @@ public class AstTreeView extends TreeView<Node> implements NodeSelectionSource {
         EventSource<Node> eventSink = new EventSource<>();
         selectionEvents = eventSink.suppressible();
 
-        initNodeSelectionHandling(root, selectionEvents);
+        initNodeSelectionHandling(root, selectionEvents, false);
 
         // push a node selection event whenever...
         //  * The selection changes
@@ -81,6 +80,11 @@ public class AstTreeView extends TreeView<Node> implements NodeSelectionSource {
             // && node is not null
 
             ASTTreeItem found = ((ASTTreeItem) getRoot()).findItem(node);
+
+            if (found != null && found.equals(selectedTreeItem)) {
+                return;
+            }
+
             if (found != null) {
                 // don't fire any selection event while itself setting the selected item
                 selectionEvents.suspendWhile(() -> selectionModel.select(found));

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/AstTreeView.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/AstTreeView.java
@@ -9,12 +9,10 @@ import static net.sourceforge.pmd.util.fxdesigner.util.DesignerIteratorUtil.pare
 
 import java.util.Objects;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 
 import org.reactfx.EventSource;
 import org.reactfx.EventStreams;
 import org.reactfx.SuspendableEventStream;
-import org.reactfx.value.Var;
 
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.util.fxdesigner.app.DesignerRoot;
@@ -33,7 +31,6 @@ import javafx.scene.control.TreeView;
 public class AstTreeView extends TreeView<Node> implements NodeSelectionSource {
 
 
-    private final Var<Consumer<Node>> onNodeClickedHandler = Var.newSimpleVar(n -> {});
     private final TreeViewWrapper<Node> myWrapper = new TreeViewWrapper<>(this);
 
     private ASTTreeItem selectedTreeItem;
@@ -48,6 +45,10 @@ public class AstTreeView extends TreeView<Node> implements NodeSelectionSource {
         selectionEvents = eventSink.suppressible();
 
         initNodeSelectionHandling(root, selectionEvents, false);
+
+        // this needs to be done even if the selection originates from this node
+        EventStreams.changesOf(getSelectionModel().selectedItemProperty())
+                    .subscribe(item -> highlightFocusNodeParents((ASTTreeItem) item.getOldValue(), (ASTTreeItem) item.getNewValue()));
 
         // push a node selection event whenever...
         //  * The selection changes
@@ -90,8 +91,6 @@ public class AstTreeView extends TreeView<Node> implements NodeSelectionSource {
                 selectionEvents.suspendWhile(() -> selectionModel.select(found));
             }
 
-            highlightFocusNodeParents(selectedTreeItem, found);
-
             selectedTreeItem = found;
 
             getFocusModel().focus(selectionModel.getSelectedIndex());
@@ -132,11 +131,6 @@ public class AstTreeView extends TreeView<Node> implements NodeSelectionSource {
      */
     private boolean isIndexVisible(int index) {
         return myWrapper.isIndexVisible(index);
-    }
-
-
-    public Var<Consumer<Node>> onNodeClickedHandlerProperty() {
-        return onNodeClickedHandler;
     }
 
 

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/AstTreeView.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/AstTreeView.java
@@ -48,6 +48,8 @@ public class AstTreeView extends TreeView<Node> implements NodeSelectionSource {
         EventSource<Node> eventSink = new EventSource<>();
         selectionEvents = eventSink.suppressible();
 
+        initNodeSelectionHandling(root, selectionEvents);
+
         // push a node selection event whenever...
         //  * The selection changes
         EventStreams.valuesOf(getSelectionModel().selectedItemProperty())
@@ -62,14 +64,8 @@ public class AstTreeView extends TreeView<Node> implements NodeSelectionSource {
             }
         }));
 
-        initNodeSelectionHandling();
     }
 
-
-    @Override
-    public EventStream<Node> getSelectionEvents() {
-        return selectionEvents;
-    }
 
 
     /**

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/NodeEditionCodeArea.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/NodeEditionCodeArea.java
@@ -192,7 +192,7 @@ public class NodeEditionCodeArea extends HighlightLayerCodeArea<StyleLayerIds> i
 
 
     /** Style layers for the code area. */
-    enum StyleLayerIds implements LayerId {
+    enum StyleLayerIds implements HighlightLayerCodeArea.LayerId {
         // caution, the name of the constants are used as style classes
 
         /** For the currently selected node. */

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/NodeEditionCodeArea.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/NodeEditionCodeArea.java
@@ -31,10 +31,10 @@ import net.sourceforge.pmd.util.fxdesigner.app.NodeSelectionSource;
 import net.sourceforge.pmd.util.fxdesigner.util.DesignerUtil;
 import net.sourceforge.pmd.util.fxdesigner.util.codearea.AvailableSyntaxHighlighters;
 import net.sourceforge.pmd.util.fxdesigner.util.codearea.HighlightLayerCodeArea;
-import net.sourceforge.pmd.util.fxdesigner.util.codearea.HighlightLayerCodeArea.LayerId;
 import net.sourceforge.pmd.util.fxdesigner.util.controls.NodeEditionCodeArea.StyleLayerIds;
 
 import javafx.application.Platform;
+import javafx.beans.NamedArg;
 import javafx.css.PseudoClass;
 
 
@@ -52,14 +52,18 @@ public class NodeEditionCodeArea extends HighlightLayerCodeArea<StyleLayerIds> i
     private DesignerRoot designerRoot;
 
 
-    public NodeEditionCodeArea() {
+    public NodeEditionCodeArea(@NamedArg("designerRoot") DesignerRoot root) {
         super(StyleLayerIds.class);
+
+        this.designerRoot = root;
 
         setParagraphGraphicFactory(lineNumberFactory());
 
         currentRuleResultsProperty().values().subscribe(this::highlightXPathResults);
         currentErrorNodesProperty().values().subscribe(this::highlightErrorNodes);
         currentNameOccurrences.values().subscribe(this::highlightNameOccurrences);
+
+        initNodeSelectionHandling();
     }
 
     /** Scroll the editor to a node and makes it visible. */
@@ -181,12 +185,6 @@ public class NodeEditionCodeArea extends HighlightLayerCodeArea<StyleLayerIds> i
     @Override
     public DesignerRoot getDesignerRoot() {
         return designerRoot;
-    }
-
-
-    public void setDesignerRoot(DesignerRoot designerRoot) {
-        this.designerRoot = designerRoot;
-        initNodeSelectionHandling();
     }
 
 

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/NodeEditionCodeArea.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/NodeEditionCodeArea.java
@@ -16,7 +16,6 @@ import java.util.function.IntFunction;
 import java.util.stream.Collectors;
 
 import org.fxmisc.richtext.LineNumberFactory;
-import org.reactfx.EventStream;
 import org.reactfx.EventStreams;
 import org.reactfx.value.Val;
 import org.reactfx.value.Var;
@@ -57,13 +56,14 @@ public class NodeEditionCodeArea extends HighlightLayerCodeArea<StyleLayerIds> i
 
         this.designerRoot = root;
 
+        // never emits selection events itself for now, but handles events from other sources
+        initNodeSelectionHandling(root, EventStreams.never());
+
         setParagraphGraphicFactory(lineNumberFactory());
 
         currentRuleResultsProperty().values().subscribe(this::highlightXPathResults);
         currentErrorNodesProperty().values().subscribe(this::highlightErrorNodes);
         currentNameOccurrences.values().subscribe(this::highlightNameOccurrences);
-
-        initNodeSelectionHandling();
     }
 
     /** Scroll the editor to a node and makes it visible. */
@@ -149,13 +149,6 @@ public class NodeEditionCodeArea extends HighlightLayerCodeArea<StyleLayerIds> i
     public void moveCaret(int line, int column) {
         moveTo(line, column);
         requestFollowCaret();
-    }
-
-
-    @Override
-    public EventStream<Node> getSelectionEvents() {
-        // never emits selection events itself for now
-        return EventStreams.never();
     }
 
 

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/NodeEditionCodeArea.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/NodeEditionCodeArea.java
@@ -48,8 +48,13 @@ public class NodeEditionCodeArea extends HighlightLayerCodeArea<StyleLayerIds> i
     private final Var<List<Node>> currentRuleResults = Var.newSimpleVar(Collections.emptyList());
     private final Var<List<Node>> currentErrorNodes = Var.newSimpleVar(Collections.emptyList());
     private final Var<List<NameOccurrence>> currentNameOccurrences = Var.newSimpleVar(Collections.emptyList());
-    private DesignerRoot designerRoot;
+    private final DesignerRoot designerRoot;
 
+    /** Only provided for scenebuilder, not used at runtime. */
+    public NodeEditionCodeArea() {
+        super(StyleLayerIds.class);
+        designerRoot = null;
+    }
 
     public NodeEditionCodeArea(@NamedArg("designerRoot") DesignerRoot root) {
         super(StyleLayerIds.class);

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/NodeEditionCodeArea.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/NodeEditionCodeArea.java
@@ -57,7 +57,7 @@ public class NodeEditionCodeArea extends HighlightLayerCodeArea<StyleLayerIds> i
         this.designerRoot = root;
 
         // never emits selection events itself for now, but handles events from other sources
-        initNodeSelectionHandling(root, EventStreams.never());
+        initNodeSelectionHandling(root, EventStreams.never(), false);
 
         setParagraphGraphicFactory(lineNumberFactory());
 

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/PropertyTableView.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/PropertyTableView.java
@@ -100,14 +100,14 @@ public class PropertyTableView extends TableView<PropertyDescriptorSpec> {
         });
 
         MenuItem addItem = new MenuItem("Add property...");
-        addItem.setOnAction(e -> onAddPropertyClicked());
+        addItem.setOnAction(e -> onAddPropertyClicked("name"));
 
         ContextMenu fullMenu = new ContextMenu();
         fullMenu.getItems().addAll(editItem, removeItem, new SeparatorMenuItem(), addItem);
 
         // Reduced context menu, for when there are no properties or none is selected
         MenuItem addItem2 = new MenuItem("Add property...");
-        addItem2.setOnAction(e -> onAddPropertyClicked());
+        addItem2.setOnAction(e -> onAddPropertyClicked("name"));
 
         ContextMenu smallMenu = new ContextMenu();
         smallMenu.getItems().add(addItem2);
@@ -129,8 +129,12 @@ public class PropertyTableView extends TableView<PropertyDescriptorSpec> {
     }
 
 
-    private void onAddPropertyClicked() {
+    /**
+     * Call this to pop the "new property" popup.
+     */
+    public void onAddPropertyClicked(String name) {
         PropertyDescriptorSpec spec = new PropertyDescriptorSpec();
+        spec.setName(name);
         this.getItems().add(spec);
         popEditPropertyDialog(spec);
     }

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/ToolbarTitledPane.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/ToolbarTitledPane.java
@@ -4,9 +4,10 @@
 
 package net.sourceforge.pmd.util.fxdesigner.util.controls;
 
-import java.util.Collection;
 import java.util.Objects;
 
+import org.apache.commons.lang3.StringUtils;
+import org.kordamp.ikonli.javafx.FontIcon;
 import org.reactfx.value.Val;
 import org.reactfx.value.Var;
 
@@ -18,6 +19,7 @@ import javafx.scene.Node;
 import javafx.scene.control.Label;
 import javafx.scene.control.TitledPane;
 import javafx.scene.control.ToolBar;
+import javafx.scene.control.Tooltip;
 import javafx.scene.layout.StackPane;
 
 
@@ -33,9 +35,21 @@ public final class ToolbarTitledPane extends TitledPane {
 
     private final ToolBar toolBar = new ToolBar();
     private final Var<String> title = Var.newSimpleVar("Title");
+    private final Var<String> errorMessage = Var.newSimpleVar("");
 
 
     public ToolbarTitledPane() {
+
+        Label errorLabel = new Label();
+
+        FontIcon errorIcon = new FontIcon("fas-exclamation-triangle");
+        errorLabel.setGraphic(errorIcon);
+        errorLabel.tooltipProperty().bind(errorMessage.map(message -> StringUtils.isBlank(message) ? null : new Tooltip(message)));
+        errorLabel.visibleProperty().bind(errorMessage.map(StringUtils::isNotBlank));
+        // makes the label zero-width when it's not visible
+        errorLabel.managedProperty().bind(errorLabel.visibleProperty());
+
+        toolBar.getItems().add(errorLabel);
 
         getStyleClass().add("tool-bar-title");
 
@@ -79,11 +93,6 @@ public final class ToolbarTitledPane extends TitledPane {
     }
 
 
-    public void setToolbarItems(Collection<? extends Node> nodes) {
-        toolBar.getItems().setAll(nodes);
-    }
-
-
     public String getTitle() {
         return title.getValue();
     }
@@ -93,6 +102,10 @@ public final class ToolbarTitledPane extends TitledPane {
         this.title.setValue(title);
     }
 
+
+    public Var<String> errorMessageProperty() {
+        return errorMessage;
+    }
 
     /** Title of the pane, not equivalent to {@link #textProperty()}. */
     public Var<String> titleProperty() {

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/ToolbarTitledPane.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/ToolbarTitledPane.java
@@ -103,6 +103,10 @@ public final class ToolbarTitledPane extends TitledPane {
     }
 
 
+    /**
+     * If non-blank, an error icon with this message as the tooltip
+     * will appear.
+     */
     public Var<String> errorMessageProperty() {
         return errorMessage;
     }

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/ToolbarTitledPane.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/ToolbarTitledPane.java
@@ -10,6 +10,8 @@ import java.util.Objects;
 import org.reactfx.value.Val;
 import org.reactfx.value.Var;
 
+import net.sourceforge.pmd.util.fxdesigner.util.DesignerUtil;
+
 import javafx.collections.ObservableList;
 import javafx.geometry.Insets;
 import javafx.scene.Node;
@@ -24,7 +26,7 @@ import javafx.scene.layout.StackPane;
  * Supported by some CSS in designer.less.
  *
  * @author Clément Fournier
- * @since 7.0.0
+ * @since 6.11.0
  */
 public final class ToolbarTitledPane extends TitledPane {
 
@@ -63,12 +65,10 @@ public final class ToolbarTitledPane extends TitledPane {
                 // The title region is provided by the skin,
                 // this is the only way to access it outside of css
                 StackPane titleRegion = (StackPane) parent;
-                toolBar.maxHeightProperty().unbind();
-                toolBar.maxHeightProperty().bind(titleRegion.heightProperty());
-                toolBar.minHeightProperty().unbind();
-                toolBar.minHeightProperty().bind(titleRegion.heightProperty());
-                toolBar.prefHeightProperty().unbind();
-                toolBar.prefHeightProperty().bind(titleRegion.heightProperty());
+
+                DesignerUtil.rewire(toolBar.maxHeightProperty(), titleRegion.heightProperty());
+                DesignerUtil.rewire(toolBar.minHeightProperty(), titleRegion.heightProperty());
+                DesignerUtil.rewire(toolBar.prefHeightProperty(), titleRegion.heightProperty());
             });
 
     }

--- a/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/TreeViewWrapper.java
+++ b/pmd-ui/src/main/java/net/sourceforge/pmd/util/fxdesigner/util/controls/TreeViewWrapper.java
@@ -143,12 +143,12 @@ class TreeViewWrapper<T> {
                 // that exception was introduced for Jigsaw (JRE 9)
                 // so we can't refer to it without breaking compat with Java 8
 
-                // TODO log that properly, System.err is closed when not in developer mode
+                // TODO find a way to report errors in the app directly, System.out is too shitty
 
-                System.err.println();
-                System.err.println("On JRE 9+, the following VM argument makes the controls smarter:");
-                System.err.println("--add-opens javafx.controls/javafx.scene.control.skin=ALL-UNNAMED");
-                System.err.println("Please consider adding it to the command-line.");
+                System.out.println();
+                System.out.println("On JRE 9+, the following VM argument makes the controls smarter:");
+                System.out.println("--add-opens javafx.controls/javafx.scene.control.skin=ALL-UNNAMED");
+                System.out.println("Please consider adding it to your command-line or using the launch script bundled with PMD's binary distribution.");
 
                 reflectionImpossibleWarning = true;
             } else {


### PR DESCRIPTION
Inspired by the discussion on #1672 

User-facing:
* If the VM parameters have been forgotten on JRE 9+, a warning is output on `System.out` and it doesn't cause the app to crash (the treeview just can't estimate visibility of items nicely). I'll try to find a way to displays those errors in-app instead of using System.out.
* System.err is not closed until after the end of the initialisation sequence, so as not to hide fatal errors
* XPath syntax errors and other reasons why XPath can't be evaluated are now displayed very prominently in the XPath results area

![peek 22-02-2019 16-28](https://user-images.githubusercontent.com/24524930/53252370-03af8a00-36bf-11e9-8f14-df4e9c452c44.gif)


Internal:

* NodeSelectionSource has been simplified to a more basic form. In particular the selection events are only used by the initialisation method, so they were converted from an interface method to a method parameter. Same can be really said for `setFocusNode`, but I think there the interface method make implementing classes clearer.
* The designer root is injected into controls that need it directly by the FXMLLoader, meaning we don't need to use a setter and worry about initialization order. There's an extra no-arg constructor that builds the controls in an invalid state, but which are provided for Scenebuilder to load the FXML correctly. Refactoring the app to use that injection system consistently for all controllers is still TODO and will wait until controllers are decoupled from their parent.

This can be pushed to 6.12.0 if there's still time for a review, otherwise we can schedule it for 6.13.0. 