### PR TITLE
[core] [swift] Antlr Base Parser adapter and Swift Implementation

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/antlr/AntlrBaseParser.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/antlr/AntlrBaseParser.java
@@ -6,8 +6,6 @@ package net.sourceforge.pmd.lang.antlr;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -49,21 +47,17 @@ public abstract class AntlrBaseParser implements Parser {
     public Node parse(final String fileName, final Reader source) throws ParseException {
         try {
             return getRootNode(getParser(getLexer(source)));
-        } catch (final IOException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+        } catch (final IOException e) {
             throw new ParseException(e);
         }
-    }
-
-    private AntlrBaseNode getRootNode(final org.antlr.v4.runtime.Parser parser)
-            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        final Method rootMethod = parser.getClass().getMethod(parser.getRuleNames()[0]);
-        return (AntlrBaseNode) rootMethod.invoke(parser);
     }
 
     @Override
     public Map<Integer, String> getSuppressMap() {
         return new HashMap<>();
     }
+
+    protected abstract AntlrBaseNode getRootNode(org.antlr.v4.runtime.Parser parser);
 
     protected abstract Lexer getLexer(Reader source) throws IOException;
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/antlr/AntlrBaseParser.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/antlr/AntlrBaseParser.java
@@ -41,20 +41,17 @@ public abstract class AntlrBaseParser implements Parser {
         try {
             return new AntlrTokenManager(getLexer(source), fileName);
         } catch (final IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-        return null;
     }
 
     @Override
     public Node parse(final String fileName, final Reader source) throws ParseException {
-        AntlrBaseNode rootNode = null;
         try {
-            rootNode = getRootNode(getParser(getLexer(source)));
+            return getRootNode(getParser(getLexer(source)));
         } catch (final IOException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-            e.printStackTrace();
+            throw new ParseException(e);
         }
-        return rootNode;
     }
 
     private AntlrBaseNode getRootNode(final org.antlr.v4.runtime.Parser parser)

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/antlr/AntlrBaseParser.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/antlr/AntlrBaseParser.java
@@ -1,0 +1,74 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.antlr;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.antlr.v4.runtime.Lexer;
+
+import net.sourceforge.pmd.lang.Parser;
+import net.sourceforge.pmd.lang.ParserOptions;
+import net.sourceforge.pmd.lang.TokenManager;
+import net.sourceforge.pmd.lang.ast.AntlrBaseNode;
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.ast.ParseException;
+
+/**
+ * Generic Antlr parser adapter for all Antlr parsers.
+ */
+public abstract class AntlrBaseParser implements Parser {
+
+    protected final ParserOptions parserOptions;
+
+    public AntlrBaseParser(final ParserOptions parserOptions) {
+        this.parserOptions = parserOptions;
+    }
+
+    @Override
+    public ParserOptions getParserOptions() {
+        return parserOptions;
+    }
+
+    @Override
+    public TokenManager getTokenManager(final String fileName, final Reader source) {
+        try {
+            return new AntlrTokenManager(getLexer(source), fileName);
+        } catch (final IOException e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    @Override
+    public Node parse(final String fileName, final Reader source) throws ParseException {
+        AntlrBaseNode rootNode = null;
+        try {
+            rootNode = getRootNode(getParser(getLexer(source)));
+        } catch (final IOException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
+        }
+        return rootNode;
+    }
+
+    private AntlrBaseNode getRootNode(final org.antlr.v4.runtime.Parser parser)
+            throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        final Method rootMethod = parser.getClass().getMethod(parser.getRuleNames()[0]);
+        return (AntlrBaseNode) rootMethod.invoke(parser);
+    }
+
+    @Override
+    public Map<Integer, String> getSuppressMap() {
+        return new HashMap<>();
+    }
+
+    protected abstract Lexer getLexer(Reader source) throws IOException;
+
+    protected abstract org.antlr.v4.runtime.Parser getParser(Lexer lexer);
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/antlr/AntlrBaseParser.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/antlr/AntlrBaseParser.java
@@ -21,7 +21,7 @@ import net.sourceforge.pmd.lang.ast.ParseException;
 /**
  * Generic Antlr parser adapter for all Antlr parsers.
  */
-public abstract class AntlrBaseParser implements Parser {
+public abstract class AntlrBaseParser<T extends org.antlr.v4.runtime.Parser> implements Parser {
 
     protected final ParserOptions parserOptions;
 
@@ -57,9 +57,9 @@ public abstract class AntlrBaseParser implements Parser {
         return new HashMap<>();
     }
 
-    protected abstract AntlrBaseNode getRootNode(org.antlr.v4.runtime.Parser parser);
+    protected abstract AntlrBaseNode getRootNode(T parser);
 
     protected abstract Lexer getLexer(Reader source) throws IOException;
 
-    protected abstract org.antlr.v4.runtime.Parser getParser(Lexer lexer);
+    protected abstract T getParser(Lexer lexer);
 }

--- a/pmd-swift/pom.xml
+++ b/pmd-swift/pom.xml
@@ -10,8 +10,33 @@
         <version>7.0.0-SNAPSHOT</version>
     </parent>
 
+    <properties>
+        <antlr4.visitor>true</antlr4.visitor>
+    </properties>
+
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <inherited>true</inherited>
+                <executions>
+                    <execution>
+                        <id>process-sources</id>
+                        <phase>process-sources</phase>
+                        <configuration>
+                            <target>
+                                <ant antfile="src/main/ant/antlr4.xml">
+                                    <property name="target" value="${project.build.directory}/generated-sources/antlr4" />
+                                </ant>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>

--- a/pmd-swift/src/main/ant/antlr4.xml
+++ b/pmd-swift/src/main/ant/antlr4.xml
@@ -1,0 +1,10 @@
+<project name="pmd" default="antlr4" basedir="../../../../">
+
+    <property name="target-package-dir" value="${target}/net/sourceforge/pmd/lang/swift/antlr4" />
+
+    <target name="antlr4" description="Generates all Antlr4 aspects within PMD">
+        <replace file="${target-package-dir}/SwiftParser.java"
+                 token="extends ParserRuleContext"
+                 value="extends net.sourceforge.pmd.lang.ast.AntlrBaseNode" />
+    </target>
+</project>

--- a/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/SwiftParserAdapter.java
+++ b/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/SwiftParserAdapter.java
@@ -1,0 +1,43 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.swift;
+
+import java.io.IOException;
+import java.io.Reader;
+
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+import org.antlr.v4.runtime.Lexer;
+import org.antlr.v4.runtime.Parser;
+
+import net.sourceforge.pmd.lang.ParserOptions;
+import net.sourceforge.pmd.lang.antlr.AntlrBaseParser;
+import net.sourceforge.pmd.lang.swift.antlr4.SwiftLexer;
+import net.sourceforge.pmd.lang.swift.antlr4.SwiftParser;
+
+/**
+ * Adapter for the SwiftParser.
+ */
+public class SwiftParserAdapter extends AntlrBaseParser {
+
+    public SwiftParserAdapter(final ParserOptions parserOptions) {
+        super(parserOptions);
+    }
+
+    @Override
+    protected Lexer getLexer(final Reader source) throws IOException {
+        return new SwiftLexer(CharStreams.fromReader(source));
+    }
+
+    @Override
+    protected Parser getParser(final Lexer lexer) {
+        return new SwiftParser(new CommonTokenStream(lexer));
+    }
+
+    @Override
+    public boolean canParse() {
+        return true;
+    }
+}

--- a/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/SwiftParserAdapter.java
+++ b/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/SwiftParserAdapter.java
@@ -10,7 +10,6 @@ import java.io.Reader;
 import org.antlr.v4.runtime.CharStreams;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.antlr.v4.runtime.Lexer;
-import org.antlr.v4.runtime.Parser;
 
 import net.sourceforge.pmd.lang.ParserOptions;
 import net.sourceforge.pmd.lang.antlr.AntlrBaseParser;
@@ -21,15 +20,15 @@ import net.sourceforge.pmd.lang.swift.antlr4.SwiftParser;
 /**
  * Adapter for the SwiftParser.
  */
-public class SwiftParserAdapter extends AntlrBaseParser {
+public class SwiftParserAdapter extends AntlrBaseParser<SwiftParser> {
 
     public SwiftParserAdapter(final ParserOptions parserOptions) {
         super(parserOptions);
     }
 
     @Override
-    protected AntlrBaseNode getRootNode(final Parser parser) {
-        return ((SwiftParser) parser).topLevel();
+    protected AntlrBaseNode getRootNode(final SwiftParser parser) {
+        return parser.topLevel();
     }
 
     @Override
@@ -38,7 +37,7 @@ public class SwiftParserAdapter extends AntlrBaseParser {
     }
 
     @Override
-    protected Parser getParser(final Lexer lexer) {
+    protected SwiftParser getParser(final Lexer lexer) {
         return new SwiftParser(new CommonTokenStream(lexer));
     }
 

--- a/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/SwiftParserAdapter.java
+++ b/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/SwiftParserAdapter.java
@@ -14,6 +14,7 @@ import org.antlr.v4.runtime.Parser;
 
 import net.sourceforge.pmd.lang.ParserOptions;
 import net.sourceforge.pmd.lang.antlr.AntlrBaseParser;
+import net.sourceforge.pmd.lang.ast.AntlrBaseNode;
 import net.sourceforge.pmd.lang.swift.antlr4.SwiftLexer;
 import net.sourceforge.pmd.lang.swift.antlr4.SwiftParser;
 
@@ -24,6 +25,11 @@ public class SwiftParserAdapter extends AntlrBaseParser {
 
     public SwiftParserAdapter(final ParserOptions parserOptions) {
         super(parserOptions);
+    }
+
+    @Override
+    protected AntlrBaseNode getRootNode(final Parser parser) {
+        return ((SwiftParser) parser).topLevel();
     }
 
     @Override


### PR DESCRIPTION
This pull request depends on #1658.

Before submitting a PR, please check that:
 - [ ] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [X] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

We added an ant-file to make all Antlr4 autogenerated nodes extend `AntlrBaseNode` for swift, a base parser adapter for all Antlr4 autogenerated parsers and it's implementation for swift. 

Team Raptor.