### PR TITLE
[doc] Generate property override examples in rule doc

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/stat/StatisticalRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/stat/StatisticalRule.java
@@ -29,13 +29,15 @@ public interface StatisticalRule extends Rule {
 
     /** @deprecated Not useful, will not be replaced. */
     @Deprecated
-    DoubleProperty SIGMA_DESCRIPTOR = new DoubleProperty("sigma", "Sigma value", -10000000d, 1000000d, null, 1.0f);
+    DoubleProperty SIGMA_DESCRIPTOR = new DoubleProperty("sigma", "deprecated! Sigma value", -10000000d, 1000000d, null,
+                                                         1.0f);
     // TODO we should have one such property descriptor pro rule, and *not* share it, to allow setting specific defaults
     DoubleProperty MINIMUM_DESCRIPTOR = new DoubleProperty("minimum", "Minimum reporting threshold", -10000000d, 1000000000d, null,
             2.0f);
     /** @deprecated Not useful, will not be replaced. */
     @Deprecated
-    IntegerProperty TOP_SCORE_DESCRIPTOR = new IntegerProperty("topscore", "Top score value", 1, 100, null, 3.0f);
+    IntegerProperty TOP_SCORE_DESCRIPTOR = new IntegerProperty("topscore", "deprecated! Top score value", 1, 100,
+                                                               null, 3.0f);
 
     void addDataPoint(DataPoint point);
 

--- a/pmd-doc/src/test/resources/expected/sample.md
+++ b/pmd-doc/src/test/resources/expected/sample.md
@@ -86,8 +86,7 @@ public class JumbledIncrementerRule1 {
 <rule ref="category/java/sample.xml/JumbledIncrementer">
     <properties>
         <property name="sampleAdditionalProperty" value="the value" />
-        <property name="sampleMultiStringProperty" value="Value1 | Value2" />
-        <property name="sampleDeprecatedProperty" value="test" />
+        <property name="sampleMultiStringProperty" value="Value1|Value2" />
         <property name="sampleRegexProperty1" value="\/\*\s+(default|package)\s+\*\/" />
         <property name="sampleRegexProperty2" value="[a-z]*" />
         <property name="sampleRegexProperty3" value="\s+" />
@@ -251,8 +250,7 @@ public class JumbledIncrementerRule1 {
 <rule ref="category/java/sample.xml/RenamedRule">
     <properties>
         <property name="sampleAdditionalProperty" value="the value" />
-        <property name="sampleMultiStringProperty" value="Value1 | Value2" />
-        <property name="sampleDeprecatedProperty" value="test" />
+        <property name="sampleMultiStringProperty" value="Value1|Value2" />
         <property name="sampleRegexProperty1" value="\/\*\s+(default|package)\s+\*\/" />
         <property name="sampleRegexProperty2" value="[a-z]*" />
         <property name="sampleRegexProperty3" value="\s+" />

--- a/pmd-doc/src/test/resources/expected/sample.md
+++ b/pmd-doc/src/test/resources/expected/sample.md
@@ -76,9 +76,27 @@ public class JumbledIncrementerRule1 {
 |sampleRegexProperty6|\\b|The property is of type regex|no|
 |sampleRegexProperty7|\\n|The property is of type regex|no|
 
-**Use this rule by referencing it:**
+**Use this rule with the default properties by just referencing it:**
 ``` xml
 <rule ref="category/java/sample.xml/JumbledIncrementer" />
+```
+
+**Use this rule and customize it:**
+``` xml
+<rule ref="category/java/sample.xml/JumbledIncrementer">
+    <properties>
+        <property name="sampleAdditionalProperty" value="the value" />
+        <property name="sampleMultiStringProperty" value="Value1 | Value2" />
+        <property name="sampleDeprecatedProperty" value="test" />
+        <property name="sampleRegexProperty1" value="\/\*\s+(default|package)\s+\*\/" />
+        <property name="sampleRegexProperty2" value="[a-z]*" />
+        <property name="sampleRegexProperty3" value="\s+" />
+        <property name="sampleRegexProperty4" value="_dd_" />
+        <property name="sampleRegexProperty5" value="[0-9]{1,3}" />
+        <property name="sampleRegexProperty6" value="\b" />
+        <property name="sampleRegexProperty7" value="\n" />
+    </properties>
+</rule>
 ```
 
 ## MovedRule
@@ -223,9 +241,27 @@ public class JumbledIncrementerRule1 {
 |sampleRegexProperty6|\\b|The property is of type regex|no|
 |sampleRegexProperty7|\\n|The property is of type regex|no|
 
-**Use this rule by referencing it:**
+**Use this rule with the default properties by just referencing it:**
 ``` xml
 <rule ref="category/java/sample.xml/RenamedRule" />
+```
+
+**Use this rule and customize it:**
+``` xml
+<rule ref="category/java/sample.xml/RenamedRule">
+    <properties>
+        <property name="sampleAdditionalProperty" value="the value" />
+        <property name="sampleMultiStringProperty" value="Value1 | Value2" />
+        <property name="sampleDeprecatedProperty" value="test" />
+        <property name="sampleRegexProperty1" value="\/\*\s+(default|package)\s+\*\/" />
+        <property name="sampleRegexProperty2" value="[a-z]*" />
+        <property name="sampleRegexProperty3" value="\s+" />
+        <property name="sampleRegexProperty4" value="_dd_" />
+        <property name="sampleRegexProperty5" value="[0-9]{1,3}" />
+        <property name="sampleRegexProperty6" value="\b" />
+        <property name="sampleRegexProperty7" value="\n" />
+    </properties>
+</rule>
 ```
 
 ## XSSInDocumentation
@@ -296,7 +332,18 @@ public class Bar {
 |XSSpropertyTest &lt;script&gt;alert('XSS');&lt;/script&gt;|&lt;script&gt;alert('XSS');&lt;/script&gt;|&lt;script&gt;alert('XSS');&lt;/script&gt;|no|
 |escapingNeeded|this is escaped: \||You should be able to use \| in the description|no|
 
-**Use this rule by referencing it:**
+**Use this rule with the default properties by just referencing it:**
 ``` xml
 <rule ref="category/java/sample.xml/XSSInDocumentation" />
+```
+
+**Use this rule and customize it:**
+``` xml
+<rule ref="category/java/sample.xml/XSSInDocumentation">
+    <properties>
+        <property name="sampleRegexProperty" value="\/\*\s+(default|package)\s+\*\/" />
+        <property name="XSSpropertyTest <script>alert('XSS');</script>" value="<script>alert('XSS');</script>" />
+        <property name="escapingNeeded" value="this is escaped: |" />
+    </properties>
+</rule>
 ```


### PR DESCRIPTION
Refs #1712

In case a rule has properties, we now generate additionally a section "Use this rule and customize it".

Example:
![grafik](https://user-images.githubusercontent.com/1573684/54073462-a6ebcc00-4287-11e9-9593-52955e2860ed.png)
