### PR TITLE
[core] Fix bug with maven incremental compilation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -367,6 +367,9 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.7.0</version>
                     <configuration>
+                        <!-- Bug with incremental compilation -->
+                        <!-- https://issues.apache.org/jira/browse/MCOMPILER-209 -->
+                        <useIncrementalCompilation>false</useIncrementalCompilation>
                         <release>${java.version}</release>
                     </configuration>
                     <executions>


### PR DESCRIPTION
There's a bug with the `useIncrementalCompilation` flag of the maven compiler plugin: https://issues.apache.org/jira/browse/MCOMPILER-209

Basically the flag must be explicitly set to false to get incremental compilation, otherwise maven always picks up changes and recompiles everything.