### PR TITLE
[java] Fix false positive in useTryWithResources when using a custom close method with multiple arguments

### DIFF
--- a/docs/pages/pmd/rules/java/bestpractices.md
+++ b/docs/pages/pmd/rules/java/bestpractices.md
@@ -1657,7 +1657,7 @@ preserved.
 ][
     pmd-java:typeIs('java.lang.AutoCloseable')
     or
-    ../../PrimarySuffix/Arguments[@ArgumentCount = 1]//PrimaryPrefix[pmd-java:typeIs('java.lang.AutoCloseable')]
+    ../../PrimarySuffix/Arguments//PrimaryPrefix[pmd-java:typeIs('java.lang.AutoCloseable')]
 ]]
 ```
 

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -1546,7 +1546,7 @@ preserved.
 ][
     pmd-java:typeIs('java.lang.AutoCloseable')
     or
-    ../../PrimarySuffix/Arguments[@ArgumentCount = 1]//PrimaryPrefix[pmd-java:typeIs('java.lang.AutoCloseable')]
+    ../../PrimarySuffix/Arguments//PrimaryPrefix[pmd-java:typeIs('java.lang.AutoCloseable')]
 ]]
 ]]>
                 </value>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UseTryWithResources.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UseTryWithResources.xml
@@ -189,4 +189,28 @@ public class TryWithResources {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>Custom close methods with multiple arguments</description>
+        <rule-property name="closeMethods">myClose2,myClose</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code><![CDATA[
+import java.io.*;
+
+public class TryWithResources {
+    public void run() {
+        InputStream in = null, in2 = null;
+        try {
+            in = openInputStream();
+            in2 = openInputStream();
+            int i = in.read(), j = in2.read();
+        } catch (IOException e) {
+            e.printStackTrace();
+        } finally {
+            myClose(in, in2);
+        }
+    }
+}
+     ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Fixes #1701 
<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [ ] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [ ] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

