### PR TITLE
[doc] Correct property override example

### DIFF
--- a/docs/pages/pmd/userdocs/configuring_rules.md
+++ b/docs/pages/pmd/userdocs/configuring_rules.md
@@ -41,7 +41,9 @@ Properties make it easy to customise the behaviour of a rule directly from the x
 ```xml
 <rule ref="category/java/design.xml/NPathComplexity">
     <properties>
-        <property name="reportLevel">150</property>
+        <property name="reportLevel">
+              <value>150</value>
+        </property>
     </properties>
 </rule>
 ```


### PR DESCRIPTION
**PR Description:**
The example for how to set a custom value to a property of a rule is incorrect. This PR corrects the example.

Fixes #1721.
