### PR TITLE
[java] Update quickstart ruleset 

### DIFF
--- a/pmd-apex/pom.xml
+++ b/pmd-apex/pom.xml
@@ -74,6 +74,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>net.sourceforge.pmd</groupId>
       <artifactId>pmd-test</artifactId>
       <scope>test</scope>

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/DefaultRulesetTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/DefaultRulesetTest.java
@@ -4,26 +4,32 @@
 
 package net.sourceforge.pmd.lang.apex;
 
-import static org.junit.Assert.assertNotNull;
-
+import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.SystemErrRule;
 
+import net.sourceforge.pmd.RulePriority;
 import net.sourceforge.pmd.RuleSet;
 import net.sourceforge.pmd.RuleSetFactory;
+import net.sourceforge.pmd.util.ResourceLoader;
 
 public class DefaultRulesetTest {
+    @Rule
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
 
-    private RuleSetFactory factory = new RuleSetFactory();
+    private RuleSetFactory factory = new RuleSetFactory(new ResourceLoader(), RulePriority.LOW, true, false);
 
     @Test
     public void loadDefaultRuleset() throws Exception {
         RuleSet ruleset = factory.createRuleSet("rulesets/apex/ruleset.xml");
-        assertNotNull(ruleset);
+        Assert.assertNotNull(ruleset);
     }
 
     @Test
     public void loadQuickstartRuleset() throws Exception {
         RuleSet ruleset = factory.createRuleSet("rulesets/apex/quickstart.xml");
-        assertNotNull(ruleset);
+        Assert.assertNotNull(ruleset);
+        Assert.assertTrue(systemErrRule.getLog().isEmpty());
     }
 }

--- a/pmd-java/src/main/resources/rulesets/java/quickstart.xml
+++ b/pmd-java/src/main/resources/rulesets/java/quickstart.xml
@@ -10,6 +10,7 @@
     <!-- <rule ref="category/java/bestpractices.xml/AccessorMethodGeneration" /> -->
     <!-- <rule ref="category/java/bestpractices.xml/ArrayIsStoredDirectly" /> -->
     <!-- <rule ref="category/java/bestpractices.xml/AvoidPrintStackTrace" /> -->
+    <!-- <rule ref="category/java/bestpractices.xml/AvoidReassigningLoopVariables" /> -->
     <!-- <rule ref="category/java/bestpractices.xml/AvoidReassigningParameters" /> -->
     <rule ref="category/java/bestpractices.xml/AvoidStringBufferField"/>
     <rule ref="category/java/bestpractices.xml/AvoidUsingHardCodedIP"/>
@@ -17,6 +18,7 @@
     <rule ref="category/java/bestpractices.xml/ConstantsInInterface"/>
     <rule ref="category/java/bestpractices.xml/DefaultLabelNotLastInSwitchStmt"/>
     <rule ref="category/java/bestpractices.xml/ForLoopCanBeForeach"/>
+    <!-- <rule ref="category/java/bestpractices.xml/ForLoopVariableCount" /> -->
     <rule ref="category/java/bestpractices.xml/GuardLogStatement"/>
     <!-- <rule ref="category/java/bestpractices.xml/JUnit4SuitesShouldUseSuiteAnnotation" /> -->
     <!-- <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseAfterAnnotation" /> -->
@@ -29,64 +31,56 @@
     <rule ref="category/java/bestpractices.xml/LooseCoupling"/>
     <!-- <rule ref="category/java/bestpractices.xml/MethodReturnsInternalArray" /> -->
     <rule ref="category/java/bestpractices.xml/MissingOverride"/>
-
     <rule ref="category/java/bestpractices.xml/OneDeclarationPerLine"/>
     <rule ref="category/java/bestpractices.xml/PositionLiteralsFirstInCaseInsensitiveComparisons"/>
     <rule ref="category/java/bestpractices.xml/PositionLiteralsFirstInComparisons"/>
     <rule ref="category/java/bestpractices.xml/PreserveStackTrace"/>
-
     <!-- <rule ref="category/java/bestpractices.xml/ReplaceEnumerationWithIterator" /> -->
     <!-- <rule ref="category/java/bestpractices.xml/ReplaceHashtableWithMap" /> -->
     <!-- <rule ref="category/java/bestpractices.xml/ReplaceVectorWithList" /> -->
-
     <rule ref="category/java/bestpractices.xml/SwitchStmtsShouldHaveDefault"/>
-
     <!-- <rule ref="category/java/bestpractices.xml/SystemPrintln" /> -->
-
     <rule ref="category/java/bestpractices.xml/UnusedFormalParameter"/>
-
     <rule ref="category/java/bestpractices.xml/UnusedImports"/>
-    <rule ref="category/java/errorprone.xml/ImportFromSamePackage"/>
-
     <rule ref="category/java/bestpractices.xml/UnusedLocalVariable"/>
     <rule ref="category/java/bestpractices.xml/UnusedPrivateField"/>
     <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod"/>
-
     <rule ref="category/java/bestpractices.xml/UseAssertEqualsInsteadOfAssertTrue"/>
     <rule ref="category/java/bestpractices.xml/UseAssertNullInsteadOfAssertTrue"/>
     <rule ref="category/java/bestpractices.xml/UseAssertSameInsteadOfAssertTrue"/>
     <rule ref="category/java/bestpractices.xml/UseAssertTrueInsteadOfAssertEquals"/>
-
     <rule ref="category/java/bestpractices.xml/UseCollectionIsEmpty"/>
+    <!-- <rule ref="category/java/bestpractices.xml/UseTryWithResources" /> -->
     <!-- <rule ref="category/java/bestpractices.xml/UseVarargs" /> -->
+    <!-- <rule ref="category/java/bestpractices.xml/WhileLoopWithLiteralBoolean" /> -->
 
-    <!-- <rule ref="category/java/codestyle.xml/AtLeastOneConstructor" /> -->
-    <rule ref="category/java/codestyle.xml/AvoidDollarSigns"/>
-    <!-- <rule ref="category/java/codestyle.xml/AvoidFinalLocalVariable" /> -->
-
-    <rule ref="category/java/codestyle.xml/AvoidProtectedFieldInFinalClass"/>
-
-    <rule ref="category/java/codestyle.xml/AvoidProtectedMethodInFinalClassNotExtending"/>
 
     <!-- NAMING CONVENTIONS -->
-
-    <rule ref="category/java/codestyle.xml/FormalParameterNamingConventions"/>
     <rule ref="category/java/codestyle.xml/ClassNamingConventions"/>
+    <!--<rule ref="category/java/codestyle.xml/FieldNamingConventions" />-->
+    <rule ref="category/java/codestyle.xml/FormalParameterNamingConventions"/>
+    <rule ref="category/java/codestyle.xml/GenericsNaming"/>
+    <!-- <rule ref="category/java/codestyle.xml/LinguisticNaming" /> -->
     <rule ref="category/java/codestyle.xml/LocalVariableNamingConventions"/>
+    <!-- <rule ref="category/java/codestyle.xml/LongVariable" /> -->
     <rule ref="category/java/codestyle.xml/MethodNamingConventions"/>
     <rule ref="category/java/codestyle.xml/PackageCase"/>
-
-    <!-- Unimplemented !-->
-    <!--<rule ref="category/java/codestyle.xml/FieldNamingConventions" />-->
-    <rule ref="category/java/codestyle.xml/GenericsNaming"/>
-
-    <!-- <rule ref="category/java/codestyle.xml/LongVariable" /> -->
     <!-- <rule ref="category/java/codestyle.xml/ShortClassName" /> -->
     <!-- <rule ref="category/java/codestyle.xml/ShortMethodName" /> -->
     <!-- <rule ref="category/java/codestyle.xml/ShortVariable" /> -->
 
-    <!-- OTHER -->
+    <!-- <rule ref="category/java/codestyle.xml/LocalHomeNamingConvention" /> -->
+    <!-- <rule ref="category/java/codestyle.xml/LocalInterfaceSessionNamingConvention" /> -->
+    <!-- <rule ref="category/java/codestyle.xml/MDBAndSessionBeanNamingConvention" /> -->
+    <!-- <rule ref="category/java/codestyle.xml/RemoteInterfaceNamingConvention" /> -->
+    <!-- <rule ref="category/java/codestyle.xml/RemoteSessionInterfaceNamingConvention" /> -->
 
+    <!-- OTHER -->
+    <!-- <rule ref="category/java/codestyle.xml/AtLeastOneConstructor" /> -->
+    <rule ref="category/java/codestyle.xml/AvoidDollarSigns"/>
+    <!-- <rule ref="category/java/codestyle.xml/AvoidFinalLocalVariable" /> -->
+    <rule ref="category/java/codestyle.xml/AvoidProtectedFieldInFinalClass"/>
+    <rule ref="category/java/codestyle.xml/AvoidProtectedMethodInFinalClassNotExtending"/>
     <!-- <rule ref="category/java/codestyle.xml/AvoidUsingNativeCode"/>-->
     <!-- <rule ref="category/java/codestyle.xml/BooleanGetMethodName" /> -->
     <!-- <rule ref="category/java/codestyle.xml/CallSuperInConstructor" /> -->
@@ -94,27 +88,19 @@
     <!-- <rule ref="category/java/codestyle.xml/ConfusingTernary" /> -->
     <rule ref="category/java/codestyle.xml/ControlStatementBraces"/>
     <!--<rule ref="category/java/codestyle.xml/DefaultPackage"/>-->
-
     <rule ref="category/java/codestyle.xml/DontImportJavaLang"/>
     <rule ref="category/java/codestyle.xml/DuplicateImports"/>
-
     <!-- <rule ref="category/java/codestyle.xml/EmptyMethodInAbstractClassShouldBeAbstract" /> -->
-
     <rule ref="category/java/codestyle.xml/ExtendsObject"/>
-
     <!-- <rule ref="category/java/codestyle.xml/FieldDeclarationsShouldBeAtStartOfClass" /> -->
     <rule ref="category/java/codestyle.xml/ForLoopShouldBeWhileLoop"/>
-
     <rule ref="category/java/codestyle.xml/IdenticalCatchBranches"/>
-
     <!-- <rule ref="category/java/codestyle.xml/LocalVariableCouldBeFinal" /> -->
     <!-- <rule ref="category/java/codestyle.xml/MethodArgumentCouldBeFinal" /> -->
-
-    <!-- <rule ref="category/java/codestyle.xml/MIsLeadingVariableName" /> -->
     <rule ref="category/java/codestyle.xml/NoPackage"/>
+    <!-- <rule ref="category/java/codestyle.xml/UseUnderscoresInNumericLiterals" /> -->
     <!-- <rule ref="category/java/codestyle.xml/OnlyOneReturn" /> -->
     <!-- <rule ref="category/java/codestyle.xml/PrematureDeclaration" /> -->
-
     <!-- <rule ref="category/java/codestyle.xml/SuspiciousConstantFieldName" /> -->
     <!-- <rule ref="category/java/codestyle.xml/TooManyStaticImports" /> -->
     <rule ref="category/java/codestyle.xml/UnnecessaryAnnotationValueElement"/>
@@ -123,8 +109,10 @@
     <rule ref="category/java/codestyle.xml/UnnecessaryLocalBeforeReturn"/>
     <rule ref="category/java/codestyle.xml/UnnecessaryModifier"/>
     <rule ref="category/java/codestyle.xml/UnnecessaryReturn"/>
+    <!-- <rule ref="category/java/codestyle.xml/UseDiamondOperator" /> -->
     <rule ref="category/java/codestyle.xml/UselessParentheses"/>
     <rule ref="category/java/codestyle.xml/UselessQualifiedThis"/>
+
 
     <rule ref="category/java/design.xml/AbstractClassWithoutAnyMethod"/>
     <!-- <rule ref="category/java/design.xml/AvoidCatchingGenericException" /> -->
@@ -133,11 +121,13 @@
     <!-- <rule ref="category/java/design.xml/AvoidThrowingNewInstanceOfSameException" /> -->
     <!-- <rule ref="category/java/design.xml/AvoidThrowingNullPointerException" /> -->
     <!-- <rule ref="category/java/design.xml/AvoidThrowingRawExceptionTypes" /> -->
+    <!-- <rule ref="category/java/design.xml/AvoidUncheckedExceptionsInSignatures" /> -->
     <rule ref="category/java/design.xml/ClassWithOnlyPrivateConstructorsShouldBeFinal"/>
-    <!--<rule ref="category/java/design.xml/CollapsibleIfStatements"/>-->
+    <!-- <rule ref="category/java/design.xml/CollapsibleIfStatements"/>-->
     <!-- <rule ref="category/java/design.xml/CouplingBetweenObjects" /> -->
+    <!-- <rule ref="category/java/design.xml/CyclomaticComplexity" /> -->
     <!-- <rule ref="category/java/design.xml/DataClass" /> -->
-    <!-- <rule ref="category/java/design.xml/DoNotExtendJavaLangError" /> -->
+    <rule ref="category/java/design.xml/DoNotExtendJavaLangError" />
     <!-- <rule ref="category/java/design.xml/ExceptionAsFlowControl" /> -->
     <!-- <rule ref="category/java/design.xml/ExcessiveClassLength" /> -->
     <!-- <rule ref="category/java/design.xml/ExcessiveImports" /> -->
@@ -149,18 +139,18 @@
     <!-- <rule ref="category/java/design.xml/ImmutableField" /> -->
     <!-- <rule ref="category/java/design.xml/LawOfDemeter" /> -->
     <rule ref="category/java/design.xml/LogicInversion"/>
-
-    <!-- <rule ref="category/java/design.xml/CyclomaticComplexity" /> -->
+    <!-- <rule ref="category/java/design.xml/LoosePackageCouling"> -->
+    <!--     <properties> -->
+    <!--         <property name="packages" value="org.sample,org.sample2" /> -->
+    <!--         <property name="classes" value="org.sample.SampleInterface,org.sample2.SampleInterface" /> -->
+    <!--     </properties> -->
+    <!-- </rule> -->
     <!-- <rule ref="category/java/design.xml/NcssCount" /> -->
     <!-- <rule ref="category/java/design.xml/NPathComplexity" /> -->
-
     <!-- <rule ref="category/java/design.xml/SignatureDeclareThrowsException" /> -->
-
     <rule ref="category/java/design.xml/SimplifiedTernary"/>
-
     <!-- <rule ref="category/java/design.xml/SimplifyBooleanAssertion" /> -->
     <!-- <rule ref="category/java/design.xml/SimplifyBooleanExpressions" /> -->
-
     <rule ref="category/java/design.xml/SimplifyBooleanReturns"/>
     <rule ref="category/java/design.xml/SimplifyConditional"/>
     <rule ref="category/java/design.xml/SingularField"/>
@@ -171,11 +161,14 @@
     <!-- <rule ref="category/java/design.xml/UseObjectForClearerAPI" /> -->
     <rule ref="category/java/design.xml/UseUtilityClass"/>
 
+
     <!-- <rule ref="category/java/documentation.xml/CommentContent" /> -->
     <!-- <rule ref="category/java/documentation.xml/CommentRequired" /> -->
     <!-- <rule ref="category/java/documentation.xml/CommentSize" /> -->
     <rule ref="category/java/documentation.xml/UncommentedEmptyConstructor"/>
     <rule ref="category/java/documentation.xml/UncommentedEmptyMethodBody"/>
+
+
 
     <rule ref="category/java/errorprone.xml/AssignmentInOperand">
         <properties>
@@ -214,40 +207,21 @@
     <rule ref="category/java/errorprone.xml/CompareObjectsWithEquals"/>
     <!-- <rule ref="category/java/errorprone.xml/ConstructorCallsOverridableMethod" /> -->
     <!-- <rule ref="category/java/errorprone.xml/DataflowAnomalyAnalysis" /> -->
+    <!-- <rule ref="category/java/errorprone.xml/DetachedTestCase" /> -->
     <rule ref="category/java/errorprone.xml/DoNotCallGarbageCollectionExplicitly"/>
     <!-- <rule ref="category/java/errorprone.xml/DoNotCallSystemExit" /> -->
-
     <rule ref="category/java/errorprone.xml/DoNotExtendJavaLangThrowable"/>
-    <rule ref="category/java/design.xml/DoNotExtendJavaLangError"/>
-         
     <!-- <rule ref="category/java/errorprone.xml/DoNotHardCodeSDCard" /> -->
     <!-- <rule ref="category/java/errorprone.xml/DoNotThrowExceptionInFinally" /> -->
-
     <!--<rule ref="category/java/errorprone.xml/DontImportSun" />-->
-
     <rule ref="category/java/errorprone.xml/DontUseFloatTypeForLoopIndices"/>
-    <rule ref="category/java/errorprone.xml/EmptyCatchBlock"/>
-
-    <!-- Empty rules -->
-         
-    <rule ref="category/java/errorprone.xml/EmptyFinalizer"/>
-    <rule ref="category/java/errorprone.xml/EmptyFinallyBlock"/>
-    <rule ref="category/java/errorprone.xml/EmptyIfStmt"/>
-    <rule ref="category/java/errorprone.xml/EmptyInitializer"/>
-    <rule ref="category/java/errorprone.xml/EmptyStatementBlock"/>
-    <rule ref="category/java/errorprone.xml/EmptyStatementNotInLoop"/>
-    <rule ref="category/java/errorprone.xml/EmptySwitchStatements"/>
-    <rule ref="category/java/errorprone.xml/EmptySynchronizedBlock"/>
-    <rule ref="category/java/errorprone.xml/EmptyTryBlock"/> 
-    <rule ref="category/java/errorprone.xml/EmptyWhileStmt"/>
-
     <rule ref="category/java/errorprone.xml/EqualsNull"/>
-
     <!-- <rule ref="category/java/errorprone.xml/FinalizeDoesNotCallSuperFinalize" /> -->
     <!-- <rule ref="category/java/errorprone.xml/FinalizeOnlyCallsSuperFinalize" /> -->
     <!-- <rule ref="category/java/errorprone.xml/FinalizeOverloaded" /> -->
     <!-- <rule ref="category/java/errorprone.xml/FinalizeShouldBeProtected" /> -->
     <rule ref="category/java/errorprone.xml/IdempotentOperations"/>
+    <rule ref="category/java/errorprone.xml/ImportFromSamePackage"/>
     <rule ref="category/java/errorprone.xml/InstantiationToGetClass"/>
     <!-- <rule ref="category/java/errorprone.xml/InvalidSlf4jMessageFormat" /> -->
     <rule ref="category/java/errorprone.xml/JumbledIncrementer"/>
@@ -288,6 +262,20 @@
     <rule ref="category/java/errorprone.xml/UseLocaleWithCaseConversions"/>
     <!-- <rule ref="category/java/errorprone.xml/UseProperClassLoader" /> -->
 
+    <!-- Empty rules -->
+    <rule ref="category/java/errorprone.xml/EmptyCatchBlock"/>
+    <rule ref="category/java/errorprone.xml/EmptyFinalizer"/>
+    <rule ref="category/java/errorprone.xml/EmptyFinallyBlock"/>
+    <rule ref="category/java/errorprone.xml/EmptyIfStmt"/>
+    <rule ref="category/java/errorprone.xml/EmptyInitializer"/>
+    <rule ref="category/java/errorprone.xml/EmptyStatementBlock"/>
+    <rule ref="category/java/errorprone.xml/EmptyStatementNotInLoop"/>
+    <rule ref="category/java/errorprone.xml/EmptySwitchStatements"/>
+    <rule ref="category/java/errorprone.xml/EmptySynchronizedBlock"/>
+    <rule ref="category/java/errorprone.xml/EmptyTryBlock"/> 
+    <rule ref="category/java/errorprone.xml/EmptyWhileStmt"/>
+
+
     <!-- <rule ref="category/java/multithreading.xml/AvoidSynchronizedAtMethodLevel" /> -->
     <rule ref="category/java/multithreading.xml/AvoidThreadGroup"/>
     <rule ref="category/java/multithreading.xml/AvoidUsingVolatile"/>
@@ -295,9 +283,10 @@
     <rule ref="category/java/multithreading.xml/DontCallThreadRun"/>
     <rule ref="category/java/multithreading.xml/DoubleCheckedLocking"/>
     <rule ref="category/java/multithreading.xml/NonThreadSafeSingleton"/>
-    <rule ref="category/java/multithreading.xml/UnsynchronizedStaticDateFormatter"/>
+    <rule ref="category/java/multithreading.xml/UnsynchronizedStaticFormatter"/>
     <!-- <rule ref="category/java/multithreading.xml/UseConcurrentHashMap" /> -->
     <rule ref="category/java/multithreading.xml/UseNotifyAllInsteadOfNotify"/>
+
 
     <!-- <rule ref="category/java/performance.xml/AddEmptyString" /> -->
     <!-- <rule ref="category/java/performance.xml/AppendCharacterWithChar" /> -->
@@ -330,4 +319,7 @@
     <!-- <rule ref="category/java/performance.xml/UseStringBufferForStringAppends" /> -->
     <!-- <rule ref="category/java/performance.xml/UseStringBufferLength" /> -->
 
+
+    <!-- <rule ref="category/java/security.xml/HardCodedCryptoKey" /> -->
+    <!-- <rule ref="category/java/security.xml/InsecureCryptoIv" /> -->
 </ruleset>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/QuickstartRulesetTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/QuickstartRulesetTest.java
@@ -1,0 +1,31 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.SystemErrRule;
+
+import net.sourceforge.pmd.RulePriority;
+import net.sourceforge.pmd.RuleSet;
+import net.sourceforge.pmd.RuleSetFactory;
+import net.sourceforge.pmd.RuleSetNotFoundException;
+import net.sourceforge.pmd.util.ResourceLoader;
+
+public class QuickstartRulesetTest {
+
+    @Rule
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog();
+
+    @Test
+    public void noDeprecations() throws RuleSetNotFoundException {
+        RuleSetFactory ruleSetFactory = new RuleSetFactory(new ResourceLoader(), RulePriority.LOW, true, false);
+        RuleSet quickstart = ruleSetFactory.createRuleSet("rulesets/java/quickstart.xml");
+        Assert.assertFalse(quickstart.getRules().isEmpty());
+
+        Assert.assertTrue(systemErrRule.getLog().isEmpty());
+    }
+}


### PR DESCRIPTION
I noticed, that we get a deprecation warning about UnsynchronizedStaticDateFormatter …

So, I updated it, added a unit test, that we detect such cases earlier and took the chance to add the templates for any new rule, we added since we initially created the quickstart ruleset.
No new rules are activated, I only reordered them.

