### PR TITLE
[apex] Expose more information on the nodes

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -33,6 +33,30 @@ will be developed at [pmd/pmd-designer](https://github.com/pmd/pmd-designer)
 from now on. The maven coordinates will stay the same for the time being.
 The designer will still be shipped with PMD's binaries.
 
+#### Improved Apex Support
+
+*   Many AST nodes now expose more information which makes it easier to write XPath-based rules for Apex. Here are
+    some examples:
+    *   `Annotation[@Resolved = false()]` finds unsupported annotations.
+    *   `AnnotationParameter[@Name='RestResource'][@Value='/myurl']` gives access to
+        annotation parameters.
+    *   `CatchBlockStatement[@ExceptionType='Exception'][@VariableName='e']` finds catch
+        block for specific exception types.
+    *   `Field[@Type='String']` find all String fields, `Field[string-length(@Name) < 5]`
+        finds all fields with short names and `Field[@Value='a']` find alls fields, that are
+        initialized with a specific value.
+    *   `LiteralExpression[@String = true()]` finds all String literals. There are attributes
+        for each type: `@Boolean`, `@Integer`, `@Double`, `@Long`, `@Decimal`, `@Null`.
+    *   `Method[@Constructor = true()]` selects all constructors. `Method[@ReturnType = 'String']`
+        selects all methods that return a String.
+    *   The `ModifierNode` node has a couple of attributes to check for the existence of specific
+        modifiers: `@Test`, `@TestOrTestSetup`, `@WithSharing`, `@WithoutSharing`, `@InheritedSharing`,
+        `@WebService`, `@Global`, `@Override`.
+    *   Many nodes now expose their type. E.g. with `Parameter[@Type='Integer']` you can find all
+        method parameters of type Integer. The same attribute `Type` exists as well for:
+        `NewObjectExpression`, `Property`, `VariableDeclaration`.
+    *   `VariableExpression[@Image='i']` finds all variable usages of the variable "i".
+
 #### New Rules
 
 *   The new Java rule {% rule "java/design/AvoidUncheckedExceptionsInSignatures" %} (`java-design`) finds methods or constructors

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotation.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotation.java
@@ -47,4 +47,8 @@ public class ASTAnnotation extends AbstractApexNode<Annotation> {
 
         return false;
     }
+
+    public boolean isResolved() {
+        return node.getType().isResolved();
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotationParameter.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotationParameter.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import apex.jorje.semantic.ast.modifier.AnnotationParameter;
 
 public class ASTAnnotationParameter extends AbstractApexNode<AnnotationParameter> {
+    public static final String SEE_ALL_DATA = "seeAllData";
 
     public ASTAnnotationParameter(AnnotationParameter annotationParameter) {
         super(annotationParameter);
@@ -17,11 +18,26 @@ public class ASTAnnotationParameter extends AbstractApexNode<AnnotationParameter
         return visitor.visit(this, data);
     }
 
-    @Override
-    public String getImage() {
+    public String getName() {
+        if (node.getProperty() != null) {
+            return node.getProperty().getName();
+        }
+        return null;
+    }
+
+    public String getValue() {
         if (node.getValue() != null) {
             return node.getValueAsString();
         }
         return null;
+    }
+
+    public Boolean getBooleanValue() {
+        return node.getBooleanValue();
+    }
+
+    @Override
+    public String getImage() {
+        return getValue();
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTCatchBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTCatchBlockStatement.java
@@ -16,4 +16,15 @@ public class ASTCatchBlockStatement extends AbstractApexNode<CatchBlockStatement
     public Object jjtAccept(ApexParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
     }
+
+    public String getExceptionTypeName() {
+        return String.valueOf(node.getTypeRef());
+    }
+
+    public String getVariableName() {
+        if (node.getVariable() != null) {
+            return node.getVariable().getName();
+        }
+        return null;
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTCatchBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTCatchBlockStatement.java
@@ -17,7 +17,7 @@ public class ASTCatchBlockStatement extends AbstractApexNode<CatchBlockStatement
         return visitor.visit(this, data);
     }
 
-    public String getExceptionTypeName() {
+    public String getExceptionType() {
         return String.valueOf(node.getTypeRef());
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTField.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTField.java
@@ -21,7 +21,7 @@ public class ASTField extends AbstractApexNode<Field> implements CanSuppressWarn
 
     @Override
     public String getImage() {
-        return node.getFieldInfo().getName();
+        return getName();
     }
 
     @Override
@@ -42,6 +42,10 @@ public class ASTField extends AbstractApexNode<Field> implements CanSuppressWarn
 
     public ASTModifierNode getModifiers() {
         return getFirstChildOfType(ASTModifierNode.class);
+    }
+
+    public String getName() {
+        return node.getFieldInfo().getName();
     }
 
     public String getValue() {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTField.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTField.java
@@ -21,10 +21,7 @@ public class ASTField extends AbstractApexNode<Field> implements CanSuppressWarn
 
     @Override
     public String getImage() {
-        if (node.getFieldInfo() != null) {
-            return node.getFieldInfo().getName();
-        }
-        return null;
+        return node.getFieldInfo().getName();
     }
 
     @Override
@@ -39,11 +36,18 @@ public class ASTField extends AbstractApexNode<Field> implements CanSuppressWarn
         return false;
     }
 
-    public String getTypeRef() {
-        return String.valueOf(node.getTypeRef());
+    public String getType() {
+        return node.getFieldInfo().getType().getApexName();
     }
 
     public ASTModifierNode getModifiers() {
         return getFirstChildOfType(ASTModifierNode.class);
+    }
+
+    public String getValue() {
+        if (node.getFieldInfo().getValue() != null) {
+            return String.valueOf(node.getFieldInfo().getValue());
+        }
+        return null;
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTField.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTField.java
@@ -42,4 +42,8 @@ public class ASTField extends AbstractApexNode<Field> implements CanSuppressWarn
     public String getTypeRef() {
         return String.valueOf(node.getTypeRef());
     }
+
+    public ASTModifierNode getModifiers() {
+        return getFirstChildOfType(ASTModifierNode.class);
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTField.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTField.java
@@ -21,7 +21,10 @@ public class ASTField extends AbstractApexNode<Field> implements CanSuppressWarn
 
     @Override
     public String getImage() {
-        return node.getFieldInfo().getName();
+        if (node.getFieldInfo() != null) {
+            return node.getFieldInfo().getName();
+        }
+        return null;
     }
 
     @Override
@@ -34,5 +37,9 @@ public class ASTField extends AbstractApexNode<Field> implements CanSuppressWarn
             }
         }
         return false;
+    }
+
+    public String getTypeRef() {
+        return String.valueOf(node.getTypeRef());
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclaration.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclaration.java
@@ -16,4 +16,16 @@ public class ASTFieldDeclaration extends AbstractApexNode<FieldDeclaration> {
     public Object jjtAccept(ApexParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
     }
+
+    @Override
+    public String getImage() {
+        if (node.getFieldInfo() != null) {
+            return node.getFieldInfo().getName();
+        }
+        ASTVariableExpression variable = getFirstChildOfType(ASTVariableExpression.class);
+        if (variable != null) {
+            return variable.getImage();
+        }
+        return null;
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclaration.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclaration.java
@@ -19,6 +19,10 @@ public class ASTFieldDeclaration extends AbstractApexNode<FieldDeclaration> {
 
     @Override
     public String getImage() {
+        return getName();
+    }
+
+    public String getName() {
         if (node.getFieldInfo() != null) {
             return node.getFieldInfo().getName();
         }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclarationStatements.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclarationStatements.java
@@ -31,4 +31,8 @@ public class ASTFieldDeclarationStatements extends AbstractApexNode<FieldDeclara
         }
         return false;
     }
+
+    public ASTModifierNode getModifiers() {
+        return getFirstChildOfType(ASTModifierNode.class);
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFormalComment.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFormalComment.java
@@ -17,6 +17,11 @@ public class ASTFormalComment extends AbstractApexNodeBase {
         return visitor.visit(this, data);
     }
 
+    @Override
+    public String getImage() {
+        return token;
+    }
+
     public String getToken() {
         return token;
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralExpression.java
@@ -24,4 +24,9 @@ public class ASTLiteralExpression extends AbstractApexNode<LiteralExpression> {
     public LiteralType getLiteralType() {
         return node.getLiteralType();
     }
+
+    @Override
+    public String getImage() {
+        return String.valueOf(node.getLiteral());
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralExpression.java
@@ -20,17 +20,43 @@ public class ASTLiteralExpression extends AbstractApexNode<LiteralExpression> {
         return visitor.visit(this, data);
     }
 
-
     public LiteralType getLiteralType() {
         return node.getLiteralType();
     }
 
     public boolean isString() {
-        return getLiteralType() == LiteralType.STRING;
+        return node.getLiteralType() == LiteralType.STRING;
+    }
+
+    public boolean isBoolean() {
+        return node.getLiteralType() == LiteralType.TRUE || node.getLiteralType() == LiteralType.FALSE;
+    }
+
+    public boolean isInteger() {
+        return node.getLiteralType() == LiteralType.INTEGER;
+    }
+
+    public boolean isDouble() {
+        return node.getLiteralType() == LiteralType.DOUBLE;
+    }
+
+    public boolean isLong() {
+        return node.getLiteralType() == LiteralType.LONG;
+    }
+
+    public boolean isDecimal() {
+        return node.getLiteralType() == LiteralType.DECIMAL;
+    }
+
+    public boolean isNull() {
+        return node.getLiteralType() == LiteralType.NULL;
     }
 
     @Override
     public String getImage() {
-        return String.valueOf(node.getLiteral());
+        if (node.getLiteral() != null) {
+            return String.valueOf(node.getLiteral());
+        }
+        return null;
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralExpression.java
@@ -25,6 +25,10 @@ public class ASTLiteralExpression extends AbstractApexNode<LiteralExpression> {
         return node.getLiteralType();
     }
 
+    public boolean isString() {
+        return getLiteralType() == LiteralType.STRING;
+    }
+
     @Override
     public String getImage() {
         return String.valueOf(node.getLiteral());

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethod.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethod.java
@@ -69,4 +69,16 @@ public class ASTMethod extends AbstractApexNode<Method> implements ApexQualifiab
         }
         return false;
     }
+
+    public boolean isConstructor() {
+        return node.getMethodInfo().isConstructor();
+    }
+
+    public ASTModifierNode getModifiers() {
+        return getFirstChildOfType(ASTModifierNode.class);
+    }
+
+    public String getReturnType() {
+        return node.getReturnTypeRef().toString();
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodCallExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodCallExpression.java
@@ -21,13 +21,13 @@ public class ASTMethodCallExpression extends AbstractApexNode<MethodCallExpressi
     }
 
     public String getMethodName() {
-        return getNode().getMethodName();
+        return node.getMethodName();
     }
 
     public String getFullMethodName() {
         final String methodName = getMethodName();
         StringBuilder typeName = new StringBuilder();
-        for (Iterator<Identifier> it = getNode().getReferenceContext().getNames().iterator(); it.hasNext();) {
+        for (Iterator<Identifier> it = node.getReferenceContext().getNames().iterator(); it.hasNext();) {
             typeName.append(it.next().getValue()).append('.');
         }
         return typeName.toString() + methodName;

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTModifierNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTModifierNode.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.apex.ast;
 
 import apex.jorje.semantic.ast.modifier.ModifierNode;
+import apex.jorje.semantic.symbol.type.ModifierTypeInfos;
 
 public class ASTModifierNode extends AbstractApexNode<ModifierNode> implements AccessNode {
 
@@ -55,5 +56,37 @@ public class ASTModifierNode extends AbstractApexNode<ModifierNode> implements A
     @Override
     public boolean isTransient() {
         return (node.getModifiers().getJavaModifiers() & TRANSIENT) == TRANSIENT;
+    }
+
+    public boolean isTest() {
+        return node.getModifiers().isTest();
+    }
+
+    public boolean isTestOrTestSetup() {
+        return node.getModifiers().isTestOrTestSetup();
+    }
+
+    public boolean isWithSharing() {
+        return node.getModifiers().has(ModifierTypeInfos.WITH_SHARING);
+    }
+
+    public boolean isWithoutSharing() {
+        return node.getModifiers().has(ModifierTypeInfos.WITHOUT_SHARING);
+    }
+
+    public boolean isInheritedSharing() {
+        return node.getModifiers().has(ModifierTypeInfos.INHERITED_SHARING);
+    }
+
+    public boolean isWebService() {
+        return node.getModifiers().has(ModifierTypeInfos.WEB_SERVICE);
+    }
+
+    public boolean isGlobal() {
+        return node.getModifiers().has(ModifierTypeInfos.GLOBAL);
+    }
+
+    public boolean hasOverride() {
+        return node.getModifiers().has(ModifierTypeInfos.OVERRIDE);
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTModifierNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTModifierNode.java
@@ -86,7 +86,7 @@ public class ASTModifierNode extends AbstractApexNode<ModifierNode> implements A
         return node.getModifiers().has(ModifierTypeInfos.GLOBAL);
     }
 
-    public boolean hasOverride() {
+    public boolean isOverride() {
         return node.getModifiers().has(ModifierTypeInfos.OVERRIDE);
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewKeyValueObjectExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewKeyValueObjectExpression.java
@@ -16,4 +16,12 @@ public class ASTNewKeyValueObjectExpression extends AbstractApexNode<NewKeyValue
     public Object jjtAccept(ApexParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
     }
+
+    public String getType() {
+        return node.getTypeRef().getNames().get(0).getValue();
+    }
+
+    public int getParameterCount() {
+        return node.getParameters().size();
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewObjectExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewObjectExpression.java
@@ -17,7 +17,7 @@ public class ASTNewObjectExpression extends AbstractApexNode<NewObjectExpression
         return visitor.visit(this, data);
     }
 
-    public String getTypeRef() {
+    public String getType() {
         return String.valueOf(node.getTypeRef());
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewObjectExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewObjectExpression.java
@@ -16,4 +16,8 @@ public class ASTNewObjectExpression extends AbstractApexNode<NewObjectExpression
     public Object jjtAccept(ApexParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
     }
+
+    public String getTypeRef() {
+        return String.valueOf(node.getTypeRef());
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTParameter.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTParameter.java
@@ -39,4 +39,8 @@ public class ASTParameter extends AbstractApexNode<Parameter> implements CanSupp
     public ASTModifierNode getModifiers() {
         return getFirstChildOfType(ASTModifierNode.class);
     }
+
+    public String getType() {
+        return node.getType().getApexName();
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTParameter.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTParameter.java
@@ -35,4 +35,8 @@ public class ASTParameter extends AbstractApexNode<Parameter> implements CanSupp
         }
         return false;
     }
+
+    public ASTModifierNode getModifiers() {
+        return getFirstChildOfType(ASTModifierNode.class);
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTProperty.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTProperty.java
@@ -17,11 +17,8 @@ public class ASTProperty extends AbstractApexNode<Property> {
         return visitor.visit(this, data);
     }
 
-    public String getTypeName() {
-        if (node.getFieldInfo() != null) {
-            return node.getFieldInfo().getType().getApexName();
-        }
-        return null;
+    public String getType() {
+        return node.getFieldInfo().getType().getApexName();
     }
 
     public ASTModifierNode getModifiers() {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTProperty.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTProperty.java
@@ -23,4 +23,8 @@ public class ASTProperty extends AbstractApexNode<Property> {
         }
         return null;
     }
+
+    public ASTModifierNode getModifiers() {
+        return getFirstChildOfType(ASTModifierNode.class);
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTProperty.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTProperty.java
@@ -16,4 +16,11 @@ public class ASTProperty extends AbstractApexNode<Property> {
     public Object jjtAccept(ApexParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
     }
+
+    public String getTypeName() {
+        if (node.getFieldInfo() != null) {
+            return node.getFieldInfo().getType().getApexName();
+        }
+        return null;
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTReferenceExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTReferenceExpression.java
@@ -30,4 +30,12 @@ public class ASTReferenceExpression extends AbstractApexNode<ReferenceExpression
     public ReferenceType getReferenceType() {
         return node.getReferenceType();
     }
+
+    @Override
+    public String getImage() {
+        if (node.getNames() != null && !node.getNames().isEmpty()) {
+            return node.getNames().get(0).getValue();
+        }
+        return null;
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClass.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClass.java
@@ -72,4 +72,8 @@ public class ASTUserClass extends ApexRootNode<UserClass> implements ASTUserClas
         }
         return false;
     }
+
+    public ASTModifierNode getModifiers() {
+        return getFirstChildOfType(ASTModifierNode.class);
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserEnum.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserEnum.java
@@ -21,4 +21,8 @@ public class ASTUserEnum extends ApexRootNode<UserEnum> {
     public String getImage() {
         return node.getClass().getName();
     }
+
+    public ASTModifierNode getModifiers() {
+        return getFirstChildOfType(ASTModifierNode.class);
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserInterface.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserInterface.java
@@ -69,4 +69,8 @@ public class ASTUserInterface extends ApexRootNode<UserInterface> implements AST
         }
         return false;
     }
+
+    public ASTModifierNode getModifiers() {
+        return getFirstChildOfType(ASTModifierNode.class);
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserTrigger.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserTrigger.java
@@ -31,4 +31,8 @@ public class ASTUserTrigger extends ApexRootNode<UserTrigger> {
             throw new RuntimeException(e);
         }
     }
+
+    public ASTModifierNode getModifiers() {
+        return getFirstChildOfType(ASTModifierNode.class);
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableDeclaration.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableDeclaration.java
@@ -21,7 +21,10 @@ public class ASTVariableDeclaration extends AbstractApexNode<VariableDeclaration
 
     @Override
     public String getImage() {
-        return node.getLocalInfo().getName();
+        if (node.getLocalInfo() != null) {
+            return node.getLocalInfo().getName();
+        }
+        return null;
     }
 
     @Override
@@ -38,7 +41,10 @@ public class ASTVariableDeclaration extends AbstractApexNode<VariableDeclaration
         return false;
     }
 
-    public String getTypeName() {
-        return String.valueOf(node.getTypeNameUsed());
+    public String getType() {
+        if (node.getLocalInfo() != null) {
+            return node.getLocalInfo().getType().getApexName();
+        }
+        return null;
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableDeclaration.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableDeclaration.java
@@ -37,4 +37,8 @@ public class ASTVariableDeclaration extends AbstractApexNode<VariableDeclaration
         }
         return false;
     }
+
+    public String getTypeName() {
+        return String.valueOf(node.getTypeNameUsed());
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableDeclarationStatements.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableDeclarationStatements.java
@@ -16,4 +16,8 @@ public class ASTVariableDeclarationStatements extends AbstractApexNode<VariableD
     public Object jjtAccept(ApexParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
     }
+
+    public ASTModifierNode getModifiers() {
+        return getFirstChildOfType(ASTModifierNode.class);
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableExpression.java
@@ -16,4 +16,12 @@ public class ASTVariableExpression extends AbstractApexNode<VariableExpression> 
     public Object jjtAccept(ApexParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
     }
+
+    @Override
+    public String getImage() {
+        if (node.getIdentifier() != null) {
+            return node.getIdentifier().getValue();
+        }
+        return null;
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNode.java
@@ -38,7 +38,7 @@ public abstract class AbstractApexNode<T extends AstNode> extends AbstractApexNo
         return node;
     }
 
-    protected boolean hasRealLoc() {
+    public boolean hasRealLoc() {
         try {
             Location loc = node.getLoc();
             return loc != null && Locations.isReal(loc);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexRootNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexRootNode.java
@@ -21,4 +21,8 @@ public abstract class ApexRootNode<T extends AstNode> extends AbstractApexNode<T
         this.endLine = positioner.getLastLine();
         this.endColumn = positioner.getLastLineColumn();
     }
+
+    public double getApexVersion() {
+        return getNode().getDefiningType().getCodeUnitDetails().getVersion().getExternal();
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexRootNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexRootNode.java
@@ -8,6 +8,7 @@ import net.sourceforge.pmd.lang.ast.RootNode;
 import net.sourceforge.pmd.lang.ast.SourceCodePositioner;
 
 import apex.jorje.semantic.ast.AstNode;
+import apex.jorje.services.Version;
 
 public abstract class ApexRootNode<T extends AstNode> extends AbstractApexNode<T> implements RootNode {
     public ApexRootNode(T node) {
@@ -22,6 +23,12 @@ public abstract class ApexRootNode<T extends AstNode> extends AbstractApexNode<T
         this.endColumn = positioner.getLastLineColumn();
     }
 
+    /**
+     * Gets the apex version this class has been compiled with.
+     * Use {@link Version} to compare, e.g.
+     * {@code node.getApexVersion() >= Version.V176.getExternal()}
+     * @return the apex version
+     */
     public double getApexVersion() {
         return getNode().getDefiningType().getCodeUnitDetails().getVersion().getExternal();
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/CycloMetric.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/CycloMetric.java
@@ -44,7 +44,7 @@ public class CycloMetric extends AbstractApexOperationMetric {
         int complexity = 0;
 
         for (ASTBooleanExpression sub : subs) {
-            BooleanOp op = sub.getNode().getOp();
+            BooleanOp op = sub.getOperator();
             if (op != null && (op == BooleanOp.AND || op == BooleanOp.OR)) {
                 complexity++;
             }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexUnitTestRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexUnitTestRule.java
@@ -25,12 +25,11 @@ public abstract class AbstractApexUnitTestRule extends AbstractApexRule {
 
     /**
      * Don't bother visiting this class if it's not a class with @isTest and
-     * newer than API v24
+     * newer than API v24 (V176 internal).
      */
     @Override
     public Object visit(final ASTUserClass node, final Object data) {
-        final Version classApiVersion = node.getNode().getDefiningType().getCodeUnitDetails().getVersion();
-        if (!isTestMethodOrClass(node) && classApiVersion.isGreaterThan(Version.V174)) {
+        if (!isTestMethodOrClass(node) && node.getApexVersion() >= Version.V176.getExternal()) {
             return data;
         }
         return super.visit(node, data);
@@ -38,6 +37,6 @@ public abstract class AbstractApexUnitTestRule extends AbstractApexRule {
 
     protected boolean isTestMethodOrClass(final ApexNode<?> node) {
         final ASTModifierNode modifierNode = node.getFirstChildOfType(ASTModifierNode.class);
-        return modifierNode != null && modifierNode.getNode().getModifiers().isTest();
+        return modifierNode != null && modifierNode.isTest();
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/AvoidGlobalModifierRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/AvoidGlobalModifierRule.java
@@ -14,8 +14,6 @@ import net.sourceforge.pmd.lang.apex.ast.ASTUserInterface;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 
-import apex.jorje.semantic.symbol.type.ModifierTypeInfos;
-
 public class AvoidGlobalModifierRule extends AbstractApexRule {
 
     public AvoidGlobalModifierRule() {
@@ -56,11 +54,11 @@ public class AvoidGlobalModifierRule extends AbstractApexRule {
     }
 
     private boolean isWebService(ASTModifierNode modifierNode) {
-        return modifierNode != null && modifierNode.getNode().getModifiers().has(ModifierTypeInfos.WEB_SERVICE);
+        return modifierNode != null && modifierNode.isWebService();
     }
 
     private boolean isGlobal(ASTModifierNode modifierNode) {
-        return modifierNode != null && modifierNode.getNode().getModifiers().has(ModifierTypeInfos.GLOBAL);
+        return modifierNode != null && modifierNode.isGlobal();
     }
 
     private boolean hasRestAnnotation(ASTModifierNode modifierNode) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/AvoidLogicInTriggerRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/AvoidLogicInTriggerRule.java
@@ -16,6 +16,7 @@ public class AvoidLogicInTriggerRule extends AbstractApexRule {
         setProperty(CODECLIMATE_CATEGORIES, "Style");
         setProperty(CODECLIMATE_REMEDIATION_MULTIPLIER, 200);
         setProperty(CODECLIMATE_BLOCK_HIGHLIGHTING, false);
+        addRuleChainVisit(ASTUserTrigger.class);
     }
 
     @Override

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/MethodNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/MethodNamingConventionsRule.java
@@ -70,6 +70,6 @@ public class MethodNamingConventionsRule extends AbstractApexRule {
 
     private boolean isTestMethod(ASTMethod node) {
         final ASTModifierNode modifierNode = node.getFirstChildOfType(ASTModifierNode.class);
-        return modifierNode != null && modifierNode.getNode().getModifiers().isTest();
+        return modifierNode != null && modifierNode.isTest();
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/MethodNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/MethodNamingConventionsRule.java
@@ -4,13 +4,10 @@
 
 package net.sourceforge.pmd.lang.apex.rule.codestyle;
 
-import static apex.jorje.semantic.symbol.type.ModifierTypeInfos.OVERRIDE;
 import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
-import net.sourceforge.pmd.lang.apex.ast.ASTModifierNode;
 import net.sourceforge.pmd.lang.apex.ast.ASTProperty;
-import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 
@@ -29,11 +26,8 @@ public class MethodNamingConventionsRule extends AbstractApexRule {
         // Note: x10 as Apex has not automatic refactoring
         setProperty(CODECLIMATE_REMEDIATION_MULTIPLIER, 1);
         setProperty(CODECLIMATE_BLOCK_HIGHLIGHTING, false);
-    }
 
-    @Override
-    public Object visit(ASTUserClass node, Object data) {
-        return super.visit(node, data);
+        addRuleChainVisit(ASTMethod.class);
     }
 
     @Override
@@ -57,7 +51,7 @@ public class MethodNamingConventionsRule extends AbstractApexRule {
     }
 
     private boolean isOverriddenMethod(ASTMethod node) {
-        return node.getNode().getModifiers().has(OVERRIDE);
+        return node.getModifiers().isOverride();
     }
 
     private boolean isPropertyAccessor(ASTMethod node) {
@@ -65,11 +59,10 @@ public class MethodNamingConventionsRule extends AbstractApexRule {
     }
 
     private boolean isConstructor(ASTMethod node) {
-        return node.getNode().getMethodInfo().isConstructor();
+        return node.isConstructor();
     }
 
     private boolean isTestMethod(ASTMethod node) {
-        final ASTModifierNode modifierNode = node.getFirstChildOfType(ASTModifierNode.class);
-        return modifierNode != null && modifierNode.isTest();
+        return node.getModifiers().isTest();
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/VariableNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/VariableNamingConventionsRule.java
@@ -4,8 +4,6 @@
 
 package net.sourceforge.pmd.lang.apex.rule.codestyle;
 
-import static apex.jorje.semantic.symbol.type.ModifierTypeInfos.FINAL;
-import static apex.jorje.semantic.symbol.type.ModifierTypeInfos.STATIC;
 import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
 import static net.sourceforge.pmd.properties.PropertyFactory.stringListProperty;
 
@@ -18,6 +16,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTParameter;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserInterface;
 import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration;
+import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclarationStatements;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
@@ -141,8 +140,8 @@ public class VariableNamingConventionsRule extends AbstractApexRule {
         if (!checkMembers) {
             return data;
         }
-        boolean isStatic = node.getNode().getFieldInfo().getModifiers().has(STATIC);
-        boolean isFinal = node.getNode().getFieldInfo().getModifiers().has(FINAL);
+        boolean isStatic = node.getModifiers().isStatic();
+        boolean isFinal = node.getModifiers().isFinal();
 
         return checkName(isStatic ? staticPrefixes : memberPrefixes, isStatic ? staticSuffixes : memberSuffixes, node,
                 isStatic, isFinal, data);
@@ -155,7 +154,7 @@ public class VariableNamingConventionsRule extends AbstractApexRule {
             return data;
         }
 
-        boolean isFinal = node.getNode().getLocalInfo().getModifiers().has(FINAL);
+        boolean isFinal = node.getFirstParentOfType(ASTVariableDeclarationStatements.class).getModifiers().isFinal();
         return checkName(localPrefixes, localSuffixes, node, false, isFinal, data);
     }
 
@@ -165,7 +164,7 @@ public class VariableNamingConventionsRule extends AbstractApexRule {
             return data;
         }
 
-        boolean isFinal = node.getNode().getModifierInfo().has(FINAL);
+        boolean isFinal = node.getModifiers().isFinal();
         return checkName(parameterPrefixes, parameterSuffixes, node, false, isFinal, data);
     }
 
@@ -212,8 +211,7 @@ public class VariableNamingConventionsRule extends AbstractApexRule {
         if (suffixes != null) {
             for (String suffix : suffixes) {
                 if (varName.endsWith(suffix)) {
-                    varName = varName.substring(0, varName.length() - suffix.length());
-                    break;
+                    return varName.substring(0, varName.length() - suffix.length());
                 }
             }
         }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessiveClassLengthRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessiveClassLengthRule.java
@@ -4,8 +4,6 @@
 
 package net.sourceforge.pmd.lang.apex.rule.design;
 
-import static apex.jorje.semantic.symbol.type.AnnotationTypeInfos.IS_TEST;
-
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 
 /**
@@ -24,7 +22,7 @@ public class ExcessiveClassLengthRule extends ExcessiveLengthRule {
 
     @Override
     public Object visit(ASTUserClass node, Object data) {
-        if (node.getNode().getModifiers().getModifiers().not(IS_TEST)) {
+        if (!node.getModifiers().isTest()) {
             return super.visit(node, data);
         }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessivePublicCountRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessivePublicCountRule.java
@@ -4,9 +4,6 @@
 
 package net.sourceforge.pmd.lang.apex.rule.design;
 
-import static apex.jorje.semantic.symbol.type.ModifierTypeInfos.PUBLIC;
-import static apex.jorje.semantic.symbol.type.ModifierTypeInfos.STATIC;
-
 import net.sourceforge.pmd.lang.apex.ast.ASTFieldDeclarationStatements;
 import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
@@ -38,7 +35,7 @@ public class ExcessivePublicCountRule extends ExcessiveNodeCountRule {
 
     @Override
     public Object visit(ASTMethod node, Object data) {
-        if (node.getNode().getModifiers().has(PUBLIC) && !node.getImage().matches("<clinit>|<init>|clone")) {
+        if (node.getModifiers().isPublic() && !node.getImage().matches("<clinit>|<init>|clone")) {
             return NumericConstants.ONE;
         }
         return NumericConstants.ZERO;
@@ -46,7 +43,7 @@ public class ExcessivePublicCountRule extends ExcessiveNodeCountRule {
 
     @Override
     public Object visit(ASTFieldDeclarationStatements node, Object data) {
-        if (node.getNode().getModifiers().has(PUBLIC) && !node.getNode().getModifiers().has(STATIC)) {
+        if (node.getModifiers().isPublic() && !node.getModifiers().isStatic()) {
             return NumericConstants.ONE;
         }
         return NumericConstants.ZERO;

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/NcssConstructorCountRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/NcssConstructorCountRule.java
@@ -28,7 +28,7 @@ public class NcssConstructorCountRule extends AbstractNcssCountRule {
 
     @Override
     public Object visit(ASTMethod node, Object data) {
-        if (node.getNode().getMethodInfo().isConstructor()) {
+        if (node.isConstructor()) {
             return super.visit(node, data);
         }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/NcssMethodCountRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/NcssMethodCountRule.java
@@ -28,7 +28,7 @@ public class NcssMethodCountRule extends AbstractNcssCountRule {
 
     @Override
     public Object visit(ASTMethod node, Object data) {
-        if (!node.getNode().getMethodInfo().isConstructor()) {
+        if (!node.isConstructor()) {
             return super.visit(node, data);
         }
 
@@ -37,7 +37,7 @@ public class NcssMethodCountRule extends AbstractNcssCountRule {
 
     @Override
     public Object[] getViolationParameters(DataPoint point) {
-        return new String[] { ((ASTMethod) point.getNode()).getNode().getMethodInfo().getName(),
+        return new String[] { ((ASTMethod) point.getNode()).getImage(),
             String.valueOf((int) point.getScore()), };
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/StdCyclomaticComplexityRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/StdCyclomaticComplexityRule.java
@@ -155,7 +155,7 @@ public class StdCyclomaticComplexityRule extends AbstractApexRule {
             }
 
             if (showMethodsComplexity && methodEntry.decisionPoints >= reportLevel) {
-                String methodType = node.getNode().getMethodInfo().isConstructor() ? "constructor" : "method";
+                String methodType = node.isConstructor() ? "constructor" : "method";
                 addViolation(data, node,
                         new String[] { methodType, node.getImage(), String.valueOf(methodEntry.decisionPoints) });
             }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/TooManyFieldsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/TooManyFieldsRule.java
@@ -4,8 +4,6 @@
 
 package net.sourceforge.pmd.lang.apex.rule.design;
 
-import static apex.jorje.semantic.symbol.type.ModifierTypeInfos.FINAL;
-import static apex.jorje.semantic.symbol.type.ModifierTypeInfos.STATIC;
 import static net.sourceforge.pmd.properties.constraints.NumericConstraints.positive;
 
 import java.util.HashMap;
@@ -51,13 +49,13 @@ public class TooManyFieldsRule extends AbstractApexRule {
         stats = new HashMap<>(5);
         nodes = new HashMap<>(5);
 
-        List<ASTField> l = node.findDescendantsOfType(ASTField.class);
+        List<ASTField> fields = node.findDescendantsOfType(ASTField.class);
 
-        for (ASTField fd : l) {
-            if (fd.getNode().getModifierInfo().all(FINAL, STATIC)) {
+        for (ASTField field : fields) {
+            if (field.getModifiers().isFinal() && field.getModifiers().isStatic()) {
                 continue;
             }
-            ASTUserClass clazz = fd.getFirstParentOfType(ASTUserClass.class);
+            ASTUserClass clazz = field.getFirstParentOfType(ASTUserClass.class);
             if (clazz != null) {
                 bumpCounterFor(clazz);
             }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidHardcodingIdRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidHardcodingIdRule.java
@@ -37,9 +37,8 @@ public class AvoidHardcodingIdRule extends AbstractApexRule {
 
     @Override
     public Object visit(ASTLiteralExpression node, Object data) {
-        Object o = node.getNode().getLiteral();
-        if (o instanceof String) {
-            String literal = (String) o;
+        if (node.isString()) {
+            String literal = node.getImage();
             if (PATTERN.matcher(literal).matches()) {
                 // 18-digit ids are just 15 digit ids + checksums, validate it  or it's not an id
                 if (literal.length() == 18 && !validateChecksum(literal)) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidNonExistentAnnotationsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidNonExistentAnnotationsRule.java
@@ -4,28 +4,16 @@
 
 package net.sourceforge.pmd.lang.apex.rule.errorprone;
 
-import java.util.HashSet;
-import java.util.Set;
-
+import net.sourceforge.pmd.lang.apex.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.apex.ast.ASTField;
 import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
+import net.sourceforge.pmd.lang.apex.ast.ASTModifierNode;
 import net.sourceforge.pmd.lang.apex.ast.ASTProperty;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserEnum;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserInterface;
 import net.sourceforge.pmd.lang.apex.ast.AbstractApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
-
-import apex.jorje.semantic.ast.compilation.UserClass;
-import apex.jorje.semantic.ast.compilation.UserEnum;
-import apex.jorje.semantic.ast.compilation.UserInterface;
-import apex.jorje.semantic.ast.member.Field;
-import apex.jorje.semantic.ast.member.Method;
-import apex.jorje.semantic.ast.member.Property;
-import apex.jorje.semantic.ast.modifier.Annotation;
-import apex.jorje.semantic.ast.modifier.ModifierNode;
-import apex.jorje.semantic.symbol.type.AnnotationTypeInfos;
-import apex.jorje.semantic.symbol.type.StandardAnnotationTypeInfo;
 
 /**
  * Apex supported non existent annotations for legacy reasons.
@@ -36,71 +24,46 @@ import apex.jorje.semantic.symbol.type.StandardAnnotationTypeInfo;
  * @author a.subramanian
  */
 public class AvoidNonExistentAnnotationsRule extends AbstractApexRule {
-
-    private static final Set<StandardAnnotationTypeInfo> SUPPORTED_APEX_ANNOTATIONS = getSupportedApexAnnotations();
-
     @Override
     public Object visit(final ASTUserClass node, final Object data) {
-        final UserClass userClass = node.getNode();
-        checkForNonExistentAnnotation(node, userClass.getModifiers(), data);
+        checkForNonExistentAnnotation(node, node.getModifiers(), data);
         return super.visit(node, data);
     }
 
     @Override
-    public final Object visit(ASTUserInterface node, final Object data) {
-        final UserInterface userInterface = node.getNode();
-        checkForNonExistentAnnotation(node, userInterface.getModifiers(), data);
+    public Object visit(final ASTUserInterface node, final Object data) {
+        checkForNonExistentAnnotation(node, node.getModifiers(), data);
         return super.visit(node, data);
     }
 
     @Override
     public Object visit(final ASTUserEnum node, final Object data) {
-        final UserEnum userEnum = node.getNode();
-        checkForNonExistentAnnotation(node, userEnum.getModifiers(), data);
+        checkForNonExistentAnnotation(node, node.getModifiers(), data);
         return super.visit(node, data);
     }
 
     @Override
     public Object visit(final ASTMethod node, final Object data) {
-        final Method method = node.getNode();
-        return checkForNonExistentAnnotation(node, method.getModifiersNode(), data);
+        return checkForNonExistentAnnotation(node, node.getModifiers(), data);
     }
 
     @Override
     public Object visit(final ASTProperty node, final Object data) {
-        final Property property = node.getNode();
         // may have nested methods, don't visit children
-        return checkForNonExistentAnnotation(node, property.getModifiersNode(), data);
+        return checkForNonExistentAnnotation(node, node.getModifiers(), data);
     }
 
     @Override
     public Object visit(final ASTField node, final Object data) {
-        final Field field = node.getNode();
-        return checkForNonExistentAnnotation(node, field.getModifiers(), data);
+        return checkForNonExistentAnnotation(node, node.getModifiers(), data);
     }
 
-    private Object checkForNonExistentAnnotation(final AbstractApexNode<?> node, final ModifierNode modifierNode, final Object data) {
-        for (final Annotation annotation : modifierNode.getModifiers().getAnnotations()) {
-            if (!SUPPORTED_APEX_ANNOTATIONS.contains(annotation.getType())) {
+    private Object checkForNonExistentAnnotation(final AbstractApexNode<?> node, final ASTModifierNode modifierNode, final Object data) {
+        for (ASTAnnotation annotation : modifierNode.findChildrenOfType(ASTAnnotation.class)) {
+            if (!annotation.isResolved()) {
                 addViolationWithMessage(data, node, "Use of non existent annotations will lead to broken Apex code which will not compile in the future.");
             }
         }
         return data;
-    }
-
-    private static Set<StandardAnnotationTypeInfo> getSupportedApexAnnotations() {
-        final java.lang.reflect.Field[] fields = AnnotationTypeInfos.class.getFields();
-        final Set<StandardAnnotationTypeInfo> annotationTypeInfos = new HashSet<>();
-        for (final java.lang.reflect.Field field : fields) {
-            if (field.getType().isAssignableFrom(StandardAnnotationTypeInfo.class)) {
-                field.setAccessible(true);
-                try {
-                    annotationTypeInfos.add((StandardAnnotationTypeInfo) field.get(null));
-                } catch (final Exception illegalAccessException) {
-                    continue;
-                }
-            }
-        }
-        return annotationTypeInfos;
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/MethodWithSameNameAsEnclosingClassRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/MethodWithSameNameAsEnclosingClassRule.java
@@ -17,6 +17,8 @@ public class MethodWithSameNameAsEnclosingClassRule extends AbstractApexRule {
         // Note: x10 as Apex has not automatic refactoring
         setProperty(CODECLIMATE_REMEDIATION_MULTIPLIER, 50);
         setProperty(CODECLIMATE_BLOCK_HIGHLIGHTING, false);
+
+        addRuleChainVisit(ASTUserClass.class);
     }
 
     @Override
@@ -28,11 +30,11 @@ public class MethodWithSameNameAsEnclosingClassRule extends AbstractApexRule {
         for (ASTMethod m : methods) {
             String methodName = m.getImage();
 
-            if (!m.getNode().getMethodInfo().isConstructor() && methodName.equalsIgnoreCase(className)) {
+            if (!m.isConstructor() && methodName.equalsIgnoreCase(className)) {
                 addViolation(data, m);
             }
         }
 
-        return super.visit(node, data);
+        return data;
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCSRFRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCSRFRule.java
@@ -46,14 +46,14 @@ public class ApexCSRFRule extends AbstractApexRule {
      * @param data
      */
     private void checkForCSRF(ASTMethod node, Object data) {
-        if (node.getNode().getMethodInfo().isConstructor()) {
+        if (node.isConstructor()) {
             if (Helper.foundAnyDML(node)) {
                 addViolation(data, node);
             }
 
         }
 
-        String name = node.getNode().getMethodInfo().getName();
+        String name = node.getImage();
         if (name.equalsIgnoreCase(INIT)) {
             if (Helper.foundAnyDML(node)) {
                 addViolation(data, node);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexDangerousMethodsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexDangerousMethodsRule.java
@@ -73,7 +73,7 @@ public class ApexDangerousMethodsRule extends AbstractApexRule {
     private void collectBenignVariables(ASTUserClass node) {
         List<ASTField> fields = node.findDescendantsOfType(ASTField.class);
         for (ASTField field : fields) {
-            if (BOOLEAN.equalsIgnoreCase(field.getNode().getFieldInfo().getType().getApexName())) {
+            if (BOOLEAN.equalsIgnoreCase(field.getTypeRef())) {
                 whiteListedVariables.add(Helper.getFQVariableName(field));
             }
 
@@ -81,7 +81,7 @@ public class ApexDangerousMethodsRule extends AbstractApexRule {
 
         List<ASTVariableDeclaration> declarations = node.findDescendantsOfType(ASTVariableDeclaration.class);
         for (ASTVariableDeclaration decl : declarations) {
-            if (BOOLEAN.equalsIgnoreCase(decl.getNode().getLocalInfo().getType().getApexName())) {
+            if (BOOLEAN.equalsIgnoreCase(decl.getTypeName())) {
                 whiteListedVariables.add(Helper.getFQVariableName(decl));
             }
         }
@@ -91,7 +91,7 @@ public class ApexDangerousMethodsRule extends AbstractApexRule {
     private void validateParameters(ASTMethodCallExpression methodCall, Object data) {
         List<ASTVariableExpression> variables = methodCall.findDescendantsOfType(ASTVariableExpression.class);
         for (ASTVariableExpression var : variables) {
-            if (REGEXP.matcher(var.getNode().getIdentifier().getValue()).matches()) {
+            if (REGEXP.matcher(var.getImage()).matches()) {
                 if (!whiteListedVariables.contains(Helper.getFQVariableName(var))) {
                     addViolation(data, methodCall);
                 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexDangerousMethodsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexDangerousMethodsRule.java
@@ -73,7 +73,7 @@ public class ApexDangerousMethodsRule extends AbstractApexRule {
     private void collectBenignVariables(ASTUserClass node) {
         List<ASTField> fields = node.findDescendantsOfType(ASTField.class);
         for (ASTField field : fields) {
-            if (BOOLEAN.equalsIgnoreCase(field.getTypeRef())) {
+            if (BOOLEAN.equalsIgnoreCase(field.getType())) {
                 whiteListedVariables.add(Helper.getFQVariableName(field));
             }
 
@@ -81,7 +81,7 @@ public class ApexDangerousMethodsRule extends AbstractApexRule {
 
         List<ASTVariableDeclaration> declarations = node.findDescendantsOfType(ASTVariableDeclaration.class);
         for (ASTVariableDeclaration decl : declarations) {
-            if (BOOLEAN.equalsIgnoreCase(decl.getTypeName())) {
+            if (BOOLEAN.equalsIgnoreCase(decl.getType())) {
                 whiteListedVariables.add(Helper.getFQVariableName(decl));
             }
         }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexInsecureEndpointRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexInsecureEndpointRule.java
@@ -70,9 +70,8 @@ public class ApexInsecureEndpointRule extends AbstractApexRule {
         ASTLiteralExpression literalNode = node.getFirstChildOfType(ASTLiteralExpression.class);
 
         if (literalNode != null && variableNode != null) {
-            Object o = literalNode.getNode().getLiteral();
-            if (o instanceof String) {
-                String literal = (String) o;
+            if (literalNode.isString()) {
+                String literal = literalNode.getImage();
                 if (PATTERN.matcher(literal).matches()) {
                     httpEndpointStrings.add(Helper.getFQVariableName(variableNode));
                 }
@@ -102,13 +101,10 @@ public class ApexInsecureEndpointRule extends AbstractApexRule {
 
     private void runChecks(AbstractApexNode<?> node, Object data) {
         ASTLiteralExpression literalNode = node.getFirstChildOfType(ASTLiteralExpression.class);
-        if (literalNode != null) {
-            Object o = literalNode.getNode().getLiteral();
-            if (o instanceof String) {
-                String literal = (String) o;
-                if (PATTERN.matcher(literal).matches()) {
-                    addViolation(data, literalNode);
-                }
+        if (literalNode != null && literalNode.isString()) {
+            String literal = literalNode.getImage();
+            if (PATTERN.matcher(literal).matches()) {
+                addViolation(data, literalNode);
             }
         }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexOpenRedirectRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexOpenRedirectRule.java
@@ -132,7 +132,7 @@ public class ApexOpenRedirectRule extends AbstractApexRule {
             return;
         }
 
-        if (node.getTypeRef().equalsIgnoreCase(PAGEREFERENCE)) {
+        if (node.getType().equalsIgnoreCase(PAGEREFERENCE)) {
             getObjectValue(node, data);
         }
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexOpenRedirectRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexOpenRedirectRule.java
@@ -21,8 +21,6 @@ import net.sourceforge.pmd.lang.apex.ast.AbstractApexNode;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 
-import apex.jorje.semantic.symbol.member.variable.StandardFieldInfo;
-
 /**
  * Looking for potential Open redirect via PageReference variable input
  * 
@@ -100,21 +98,13 @@ public class ApexOpenRedirectRule extends AbstractApexRule {
         } else {
             if (node instanceof ASTField) {
                 ASTField field = (ASTField) node;
-                if ("String".equalsIgnoreCase(field.getTypeRef())) {
-                    StandardFieldInfo fieldInfo = (StandardFieldInfo) field.getNode().getFieldInfo();
-                    if (fieldInfo.getValue() != null) {
-                        addVariable(fieldInfo);
+                if ("String".equalsIgnoreCase(field.getType())) {
+                    if (field.getValue() != null) {
+                        listOfStringLiteralVariables.add(Helper.getFQVariableName(field));
                     }
                 }
             }
         }
-
-    }
-
-    private void addVariable(StandardFieldInfo fieldInfo) {
-        StringBuilder sb = new StringBuilder().append(fieldInfo.getDefiningType().getApexName()).append(":")
-                .append(fieldInfo.getName());
-        listOfStringLiteralVariables.add(sb.toString());
 
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSharingViolationsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSharingViolationsRule.java
@@ -13,9 +13,6 @@ import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 
-import apex.jorje.semantic.ast.modifier.OldModifiers.ModifierType;
-import apex.jorje.semantic.symbol.type.ModifierOrAnnotationTypeInfo;
-
 /**
  * Finds Apex class that do not define sharing
  * 
@@ -98,21 +95,8 @@ public class ApexSharingViolationsRule extends AbstractApexRule {
      * @param node
      * @return
      */
-    private boolean isSharingPresent(ApexNode<?> node) {
-        boolean sharingFound = false;
-
-        for (ModifierOrAnnotationTypeInfo type : node.getNode().getDefiningType().getModifiers().all()) {
-            if (type.getBytecodeName().equalsIgnoreCase(ModifierType.WithoutSharing.toString())) {
-                sharingFound = true;
-                break;
-            }
-            if (type.getBytecodeName().equalsIgnoreCase(ModifierType.WithSharing.toString())) {
-                sharingFound = true;
-                break;
-            }
-
-        }
-        return sharingFound;
+    private boolean isSharingPresent(ASTUserClass node) {
+        return node.getModifiers().isWithoutSharing() || node.getModifiers().isWithSharing();
     }
 
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSuggestUsingNamedCredRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSuggestUsingNamedCredRule.java
@@ -66,12 +66,8 @@ public class ApexSuggestUsingNamedCredRule extends AbstractApexRule {
     }
 
     private void findFieldLiterals(final ASTField fDecl) {
-        Object f = fDecl.getNode().getFieldInfo().getValue();
-        if (f instanceof String) {
-            final String fieldValue = (String) f;
-            if (AUTHORIZATION.equalsIgnoreCase(fieldValue)) {
-                listOfAuthorizationVariables.add(Helper.getFQVariableName(fDecl));
-            }
+        if ("String".equals(fDecl.getType()) && AUTHORIZATION.equalsIgnoreCase(fDecl.getValue())) {
+            listOfAuthorizationVariables.add(Helper.getFQVariableName(fDecl));
         }
     }
 
@@ -118,9 +114,8 @@ public class ApexSuggestUsingNamedCredRule extends AbstractApexRule {
     }
 
     private boolean isAuthorizationLiteral(final ASTLiteralExpression literal) {
-        Object o = literal.getNode().getLiteral();
-        if (o instanceof String) {
-            String lit = (String) o;
+        if (literal.isString()) {
+            String lit = literal.getImage();
             if (lit.equalsIgnoreCase(AUTHORIZATION)) {
                 return true;
             }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromEscapeFalseRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromEscapeFalseRule.java
@@ -48,10 +48,9 @@ public class ApexXSSFromEscapeFalseRule extends AbstractApexRule {
             Object potentialLiteral = methodCall.jjtGetChild(2);
             if (potentialLiteral instanceof ASTLiteralExpression) {
                 ASTLiteralExpression parameter = (ASTLiteralExpression) potentialLiteral;
-                Object o = parameter.getNode().getLiteral();
-                if (o instanceof Boolean) {
-                    Boolean paramValue = (Boolean) o;
-                    if (paramValue.equals(Boolean.FALSE)) {
+                if (parameter.isBoolean()) {
+                    boolean paramValue = Boolean.parseBoolean(parameter.getImage());
+                    if (!paramValue) {
                         validateLiteralPresence(methodCall, data);
                     }
                 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromURLParamRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromURLParamRule.java
@@ -175,7 +175,7 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
                 String varType = null;
 
                 if (node instanceof ASTVariableDeclaration) {
-                    varType = ((ASTVariableDeclaration) node).getTypeName();
+                    varType = ((ASTVariableDeclaration) node).getType();
 
                 }
 
@@ -214,7 +214,7 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
 
             String varType = null;
             if (node instanceof ASTVariableDeclaration) {
-                varType = ((ASTVariableDeclaration) node).getTypeName();
+                varType = ((ASTVariableDeclaration) node).getType();
             }
 
             if (varType == null || !"id".equalsIgnoreCase(varType)) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromURLParamRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromURLParamRule.java
@@ -120,7 +120,7 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
     private String getReturnType(ASTReturnStatement node) {
         ASTMethod method = node.getFirstParentOfType(ASTMethod.class);
         if (method != null) {
-            return method.getNode().getMethodInfo().getReturnType().getApexName();
+            return method.getReturnType();
         }
 
         return "";
@@ -175,7 +175,7 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
                 String varType = null;
 
                 if (node instanceof ASTVariableDeclaration) {
-                    varType = ((ASTVariableDeclaration) node).getNode().getLocalInfo().getType().getApexName();
+                    varType = ((ASTVariableDeclaration) node).getTypeName();
 
                 }
 
@@ -214,7 +214,7 @@ public class ApexXSSFromURLParamRule extends AbstractApexRule {
 
             String varType = null;
             if (node instanceof ASTVariableDeclaration) {
-                varType = ((ASTVariableDeclaration) node).getNode().getLocalInfo().getType().getApexName();
+                varType = ((ASTVariableDeclaration) node).getTypeName();
             }
 
             if (varType == null || !"id".equalsIgnoreCase(varType)) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
@@ -19,6 +19,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTModifierNode;
 import net.sourceforge.pmd.lang.apex.ast.ASTNewKeyValueObjectExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTParameter;
 import net.sourceforge.pmd.lang.apex.ast.ASTReferenceExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTSoqlExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTSoslExpression;
@@ -229,6 +230,12 @@ public final class Helper {
     public static String getFQVariableName(Parameter p) {
         StringBuffer sb = new StringBuffer();
         sb.append(p.getDefiningType()).append(":").append(p.getName().getValue());
+        return sb.toString();
+    }
+
+    static String getFQVariableName(ASTParameter p) {
+        StringBuffer sb = new StringBuffer();
+        sb.append(p.getNode().getDefiningType()).append(":").append(p.getImage());
         return sb.toString();
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
@@ -31,11 +31,9 @@ import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import apex.jorje.data.Identifier;
 import apex.jorje.data.ast.TypeRef;
 import apex.jorje.semantic.ast.expression.MethodCallExpression;
-import apex.jorje.semantic.ast.expression.NewKeyValueObjectExpression;
 import apex.jorje.semantic.ast.expression.VariableExpression;
 import apex.jorje.semantic.ast.member.Field;
 import apex.jorje.semantic.ast.member.Parameter;
-import apex.jorje.semantic.ast.statement.FieldDeclaration;
 import apex.jorje.semantic.ast.statement.VariableDeclaration;
 
 /**
@@ -154,7 +152,8 @@ public final class Helper {
 
     static String getFQVariableName(final ASTField variable) {
         Field n = variable.getNode();
-        StringBuilder sb = new StringBuilder().append(n.getDefiningType().getApexName()).append(":")
+        StringBuilder sb = new StringBuilder()
+                .append(n.getDefiningType().getApexName()).append(":")
                 .append(n.getFieldInfo().getName());
         return sb.toString();
     }
@@ -167,29 +166,16 @@ public final class Helper {
     }
     
     static String getFQVariableName(final ASTFieldDeclaration variable) {
-        FieldDeclaration n = variable.getNode();
-        String name = "";
-
-        try {
-            java.lang.reflect.Field f = n.getClass().getDeclaredField("name");
-            f.setAccessible(true);
-            Identifier nameField = (Identifier) f.get(n);
-            name = nameField.getValue();
-
-        } catch (NoSuchFieldException | SecurityException | IllegalArgumentException | IllegalAccessException e) {
-            throw new RuntimeException(e);
-        }
-
-        StringBuilder sb = new StringBuilder().append(n.getDefiningType().getApexName()).append(":").append(name);
+        StringBuilder sb = new StringBuilder()
+                .append(variable.getNode().getDefiningType().getApexName()).append(":")
+                .append(variable.getImage());
         return sb.toString();
     }
 
     static String getFQVariableName(final ASTNewKeyValueObjectExpression variable) {
-        NewKeyValueObjectExpression n = variable.getNode();
-        TypeRef typeRef = n.getTypeRef();
-        String objType = typeRef.getNames().get(0).getValue();
-
-        StringBuilder sb = new StringBuilder().append(n.getDefiningType().getApexName()).append(":").append(objType);
+        StringBuilder sb = new StringBuilder()
+                .append(variable.getNode().getDefiningType().getApexName()).append(":")
+                .append(variable.getType());
         return sb.toString();
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
@@ -53,7 +53,7 @@ public final class Helper {
     static boolean isTestMethodOrClass(final ApexNode<?> node) {
         final List<ASTModifierNode> modifierNode = node.findChildrenOfType(ASTModifierNode.class);
         for (final ASTModifierNode m : modifierNode) {
-            if (m.getNode().getModifiers().isTest()) {
+            if (m.isTest()) {
                 return true;
             }
         }

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldTest.java
@@ -15,10 +15,27 @@ public class ASTFieldTest {
 
     @Test
     public void testGetType() {
-        ApexNode<Compilation> node = parse("public class Foo { private String myField = \"a\"; }");
+        ApexNode<Compilation> node = parse("public class Foo { private String myField = 'a'; }");
         ASTField field = node.getFirstDescendantOfType(ASTField.class);
 
         Assert.assertEquals("myField", field.getImage());
-        Assert.assertEquals("String", field.getTypeRef());
+        Assert.assertEquals("String", field.getType());
+        Assert.assertEquals("a", field.getValue());
+    }
+
+    @Test
+    public void testGetValue() {
+        ApexNode<Compilation> node = parse("public class Foo { private String myField = 'a'; }");
+        ASTField field = node.getFirstDescendantOfType(ASTField.class);
+
+        Assert.assertEquals("a", field.getValue());
+    }
+
+    @Test
+    public void testGetNoValue() {
+        ApexNode<Compilation> node = parse("public class Foo { private String myField; }");
+        ASTField field = node.getFirstDescendantOfType(ASTField.class);
+
+        Assert.assertNull(field.getValue());
     }
 }

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldTest.java
@@ -1,0 +1,24 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.ast;
+
+import static net.sourceforge.pmd.lang.apex.ast.ApexParserTestHelpers.parse;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import apex.jorje.semantic.ast.compilation.Compilation;
+
+public class ASTFieldTest {
+
+    @Test
+    public void testGetType() {
+        ApexNode<Compilation> node = parse("public class Foo { private String myField = \"a\"; }");
+        ASTField field = node.getFirstDescendantOfType(ASTField.class);
+
+        Assert.assertEquals("myField", field.getImage());
+        Assert.assertEquals("String", field.getTypeRef());
+    }
+}

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTNewKeyValueObjectExpressionTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTNewKeyValueObjectExpressionTest.java
@@ -1,0 +1,36 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.ast;
+
+import static net.sourceforge.pmd.lang.apex.ast.ApexParserTestHelpers.parse;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import apex.jorje.semantic.ast.compilation.Compilation;
+
+public class ASTNewKeyValueObjectExpressionTest {
+
+    @Test
+    public void testParameterName() {
+        ApexNode<Compilation> node = parse("public class Foo { \n"
+                + "    public void foo(String newName, String tempID) { \n"
+                + "        if (Contact.sObjectType.getDescribe().isCreateable() && Contact.sObjectType.getDescribe().isUpdateable()) {\n"
+                + "            upsert new Contact(FirstName = 'First', LastName = 'Last', Phone = '414-414-4414');\n"
+                + "        }\n" + "    } \n" + "}");
+
+        ASTNewKeyValueObjectExpression keyValueExpr = node.getFirstDescendantOfType(ASTNewKeyValueObjectExpression.class);
+        Assert.assertEquals(3, keyValueExpr.getParameterCount());
+
+        List<ASTLiteralExpression> literals = keyValueExpr.findDescendantsOfType(ASTLiteralExpression.class);
+        Assert.assertEquals(3, literals.size());
+        Assert.assertEquals("FirstName", literals.get(0).getName());
+        Assert.assertEquals("LastName", literals.get(1).getName());
+        Assert.assertEquals("Phone", literals.get(2).getName());
+    }
+
+}


### PR DESCRIPTION
Like variable names, type names, apex version

This is a first suggestions. Feedback is welcome.
I've seen, that we have a helper class: https://github.com/pmd/pmd/blob/master/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java from which many parts could be moved into the AST Nodes.

After that, we should review the rules to use the information available on the nodes, rather than let them dig into jorje.
