### PR TITLE
[plsql] New rules which use the plsql source directly

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -47,12 +47,20 @@ The designer will still be shipped with PMD's binaries.
     Do-While-Loops and While-Loops that can be simplified since they use simply `true` or `false` as their
     loop condition.
 
+*   The new PLSQL rule {% rule "plsql/codestyle/AvoidTabCharacter" %} (`plsql-codestyle`) checks, that there are
+    no tab characters ("\t") in the source file.
+
+*   The new PLSQL rule {% rule "plsql/codestyle/LineLength" %} (`plsql-codestyle`) helps to enforce a maximum
+    line length.
+
 ### Fixed Issues
 
 *   doc
     *   [#1721](https://github.com/pmd/pmd/issues/1721): \[doc] Documentation provides an invalid property configuration example
 *   java-bestpractices
     *   [#1701](https://github.com/pmd/pmd/issues/1701): \[java] UseTryWithResources does not handle multiple argument close methods
+*   plsql
+    *   [#1716](https://github.com/pmd/pmd/issues/1716): \[plsql] Support access to whole plsql code
 
 ### API Changes
 

--- a/pmd-core/src/main/resources/rulesets/releases/6130.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6130.xml
@@ -12,5 +12,8 @@ This ruleset contains links to rules that are new in PMD v6.13.0
     <rule ref="category/java/design.xml/AvoidUncheckedExceptionsInSignatures"/>
     <rule ref="category/java/errorprone.xml/DetachedTestCase"/>
 
+    <rule ref="category/plsql/codestyle.xml/AvoidTabCharacter"/>
+    <rule ref="category/plsql/codestyle.xml/LineLength"/>
+
 </ruleset>
 

--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -135,7 +135,7 @@ public class PLSQLParser {
       throws ParseException {
 
     PLSQLParser parser = new PLSQLParser(System.in);
-    PLSQLNode node = parser.Input();
+    PLSQLNode node = parser.Input("");
 
     String s;
     s = "qwerty";
@@ -203,7 +203,7 @@ PARSER_END(PLSQLParser)
 /**
  * 2006-05-22 - Matthias Hendler - added globalBody()
  */
-ASTInput Input() : {}
+ASTInput Input(String sourcecode) : {}
 {
 	// SRT 2011-04-17 This syntax breaks the parser when fields of record.attach* are referenced (attachLibrary())*
 	(
@@ -229,7 +229,7 @@ ASTInput Input() : {}
 	 ("/")*
 	)*
 	<EOF>
-      { return jjtThis ; }
+      { jjtThis.setSourcecode(sourcecode); return jjtThis ; }
 }
 
 ASTDDLCommand DDLCommand() :

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/PLSQLParser.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/PLSQLParser.java
@@ -4,9 +4,13 @@
 
 package net.sourceforge.pmd.lang.plsql;
 
+import java.io.IOException;
 import java.io.Reader;
+import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.apache.commons.io.IOUtils;
 
 import net.sourceforge.pmd.lang.AbstractParser;
 import net.sourceforge.pmd.lang.ParserOptions;
@@ -45,8 +49,13 @@ public class PLSQLParser extends AbstractParser {
 
     @Override
     public Node parse(String fileName, Reader source) throws ParseException {
-        AbstractTokenManager.setFileName(fileName);
-        return createPLSQLParser(source).Input();
+        try {
+            String sourcecode = IOUtils.toString(source);
+            AbstractTokenManager.setFileName(fileName);
+            return createPLSQLParser(new StringReader(sourcecode)).Input(sourcecode);
+        } catch (IOException e) {
+            throw new ParseException(e);
+        }
     }
 
     @Override

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTInput.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTInput.java
@@ -9,6 +9,8 @@ package net.sourceforge.pmd.lang.plsql.ast;
 import net.sourceforge.pmd.lang.ast.RootNode;
 
 public class ASTInput extends net.sourceforge.pmd.lang.plsql.ast.AbstractPLSQLNode implements RootNode {
+    private String sourcecode;
+
     public ASTInput(int id) {
         super(id);
     }
@@ -21,6 +23,14 @@ public class ASTInput extends net.sourceforge.pmd.lang.plsql.ast.AbstractPLSQLNo
     @Override
     public Object jjtAccept(PLSQLParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
+    }
+
+    void setSourcecode(String sourcecode) {
+        this.sourcecode = sourcecode;
+    }
+
+    public String getSourcecode() {
+        return sourcecode;
     }
 }
 /*

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/AvoidTabCharacterRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/AvoidTabCharacterRule.java
@@ -10,24 +10,37 @@ import java.io.StringReader;
 
 import net.sourceforge.pmd.lang.plsql.ast.ASTInput;
 import net.sourceforge.pmd.lang.plsql.rule.AbstractPLSQLRule;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
 
 public class AvoidTabCharacterRule extends AbstractPLSQLRule {
 
+    private static final PropertyDescriptor<Boolean> EACH_LINE = PropertyFactory.booleanProperty("eachLine")
+            .desc("Whether to report each line with a tab character or only the first line")
+            .defaultValue(false)
+            .build();
+
     public AvoidTabCharacterRule() {
+        definePropertyDescriptor(EACH_LINE);
         addRuleChainVisit(ASTInput.class);
     }
 
     @Override
     public Object visit(ASTInput node, Object data) {
+        boolean eachLine = getProperty(EACH_LINE);
+
         try (BufferedReader in = new BufferedReader(new StringReader(node.getSourcecode()))) {
             String line;
             int lineNumber = 0;
             while ((line = in.readLine()) != null) {
                 lineNumber++;
                 if (line.indexOf('\t') != -1) {
-                    addViolationWithMessage(data, null, "Tab characters are not allowed. Use spaces for intendation",
+                    addViolationWithMessage(data, null, "Tab characters are not allowed. Use spaces for indentation",
                             lineNumber, lineNumber);
-                    break;
+
+                    if (!eachLine) {
+                        break;
+                    }
                 }
             }
         } catch (IOException e) {

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/AvoidTabCharacterRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/AvoidTabCharacterRule.java
@@ -1,0 +1,38 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.plsql.rule.codestyle;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+
+import net.sourceforge.pmd.lang.plsql.ast.ASTInput;
+import net.sourceforge.pmd.lang.plsql.rule.AbstractPLSQLRule;
+
+public class AvoidTabCharacterRule extends AbstractPLSQLRule {
+
+    public AvoidTabCharacterRule() {
+        addRuleChainVisit(ASTInput.class);
+    }
+
+    @Override
+    public Object visit(ASTInput node, Object data) {
+        try (BufferedReader in = new BufferedReader(new StringReader(node.getSourcecode()))) {
+            String line;
+            int lineNumber = 0;
+            while ((line = in.readLine()) != null) {
+                lineNumber++;
+                if (line.indexOf('\t') != -1) {
+                    addViolationWithMessage(data, null, "Tab characters are not allowed. Use spaces for intendation",
+                            lineNumber, lineNumber);
+                    break;
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Error while executing rule AvoidTabCharacter", e);
+        }
+        return data;
+    }
+}

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/LineLengthRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/LineLengthRule.java
@@ -1,0 +1,59 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.plsql.rule.codestyle;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.StringReader;
+
+import net.sourceforge.pmd.lang.plsql.ast.ASTInput;
+import net.sourceforge.pmd.lang.plsql.rule.AbstractPLSQLRule;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.properties.constraints.NumericConstraints;
+
+public class LineLengthRule extends AbstractPLSQLRule {
+
+    private static final PropertyDescriptor<Integer> MAX_LINE_LENGTH = PropertyFactory.intProperty("maxLineLength")
+            .desc("The maximum allowed line length")
+            .defaultValue(80)
+            .require(NumericConstraints.inRange(10, 200))
+            .build();
+    private static final PropertyDescriptor<Boolean> EACH_LINE = PropertyFactory.booleanProperty("eachLine")
+            .desc("Whether to report each line that is longer only the first line")
+            .defaultValue(false)
+            .build();
+
+    public LineLengthRule() {
+        definePropertyDescriptor(MAX_LINE_LENGTH);
+        definePropertyDescriptor(EACH_LINE);
+        addRuleChainVisit(ASTInput.class);
+    }
+
+    @Override
+    public Object visit(ASTInput node, Object data) {
+        boolean eachLine = getProperty(EACH_LINE);
+        int maxLineLength = getProperty(MAX_LINE_LENGTH);
+
+        try (BufferedReader in = new BufferedReader(new StringReader(node.getSourcecode()))) {
+            String line;
+            int lineNumber = 0;
+            while ((line = in.readLine()) != null) {
+                lineNumber++;
+                if (line.length() > maxLineLength) {
+                    addViolationWithMessage(data, null, "The line is too long. Only " + maxLineLength + " characters are allowed.",
+                            lineNumber, lineNumber);
+
+                    if (!eachLine) {
+                        break;
+                    }
+                }
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("Error while executing rule LineLengthRule", e);
+        }
+        return data;
+    }
+}

--- a/pmd-plsql/src/main/resources/category/plsql/codestyle.xml
+++ b/pmd-plsql/src/main/resources/category/plsql/codestyle.xml
@@ -9,6 +9,24 @@
 Rules which enforce a specific coding style.
     </description>
 
+    <rule name="AvoidTabCharacter"
+          language="plsql"
+          since="6.13.0"
+          message="Avoid tab characters for indentation. Use spaces instead."
+          class="net.sourceforge.pmd.lang.plsql.rule.codestyle.AvoidTabCharacterRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_plsql_codestyle.html#avoidtabcharacter">
+        <description>
+This rule checks, that there are no tab characters (`\t`) in the source file.
+It reports only the first occurrence per file.
+
+Using tab characters for indentation is not recommended, since this requires that every developer
+uses the same tab with in their editor.
+
+This rule is the PMD equivalent of checkstyle's [FileTabCharacter](http://checkstyle.sourceforge.net/config_whitespace.html#FileTabCharacter) check.
+        </description>
+        <priority>3</priority>
+    </rule>
+
     <rule name="CodeFormat"
           language="plsql"
           since="6.9.0"

--- a/pmd-plsql/src/main/resources/category/plsql/codestyle.xml
+++ b/pmd-plsql/src/main/resources/category/plsql/codestyle.xml
@@ -195,4 +195,19 @@ END;
 ]]>
         </example>
     </rule>
+
+    <rule name="LineLength"
+          language="plsql"
+          since="6.13.0"
+          message="The line is too long."
+          class="net.sourceforge.pmd.lang.plsql.rule.codestyle.LineLengthRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_plsql_codestyle.html#linelength">
+        <description>
+This rule checks for long lines. Please note that comments are not ignored.
+
+This rule is the PMD equivalent of checkstyle's [LineLength](http://checkstyle.sourceforge.net/config_sizes.html#LineLength) check.
+        </description>
+        <priority>3</priority>
+    </rule>
+
 </ruleset>

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/AvoidTabCharacterTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/AvoidTabCharacterTest.java
@@ -1,0 +1,11 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.plsql.rule.codestyle;
+
+import net.sourceforge.pmd.testframework.PmdRuleTst;
+
+public class AvoidTabCharacterTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/LineLengthTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/LineLengthTest.java
@@ -1,0 +1,11 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.plsql.rule.codestyle;
+
+import net.sourceforge.pmd.testframework.PmdRuleTst;
+
+public class LineLengthTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/rule/codestyle/xml/AvoidTabCharacter.xml
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/rule/codestyle/xml/AvoidTabCharacter.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+    <test-code>
+        <description>Using tabs - only the first tab character is reported</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>2</expected-linenumbers>
+        <code><![CDATA[
+BEGIN
+	SELECT cmer_id
+		,version
+		,cmp_id
+	BULK COLLECT INTO v_cmer_ids
+		,v_versions
+		,v_cmp_ids
+	FROM cmer;
+END;
+/
+        ]]></code>
+        <source-type>plsql</source-type>
+    </test-code>
+
+    <test-code>
+        <description>No tabs</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+BEGIN
+    SELECT cmer_id
+        ,version
+        ,cmp_id
+    BULK COLLECT INTO v_cmer_ids
+        ,v_versions
+        ,v_cmp_ids
+    FROM cmer;
+END;
+/
+        ]]></code>
+        <source-type>plsql</source-type>
+    </test-code>
+</test-data>

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/rule/codestyle/xml/AvoidTabCharacter.xml
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/rule/codestyle/xml/AvoidTabCharacter.xml
@@ -24,6 +24,26 @@ END;
     </test-code>
 
     <test-code>
+        <description>Using tabs - all lines are reported</description>
+        <rule-property name="eachLine">true</rule-property>
+        <expected-problems>6</expected-problems>
+        <expected-linenumbers>2,3,4,6,7,8</expected-linenumbers>
+        <code><![CDATA[
+BEGIN
+	SELECT cmer_id
+		,version
+		,cmp_id
+    BULK COLLECT INTO v_cmer_ids
+		,v_versions
+		,v_cmp_ids
+	FROM cmer;
+END;
+/
+        ]]></code>
+        <source-type>plsql</source-type>
+    </test-code>
+
+    <test-code>
         <description>No tabs</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/rule/codestyle/xml/LineLength.xml
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/rule/codestyle/xml/LineLength.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+    <test-code>
+        <description>All lines are fine - default line length</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+BEGIN
+    SELECT cmer_id
+        ,version
+        ,cmp_id
+    BULK COLLECT INTO v_cmer_ids
+        ,v_versions
+        ,v_cmp_ids
+    FROM cmer;
+END;
+/
+        ]]></code>
+        <source-type>plsql</source-type>
+    </test-code>
+
+    <test-code>
+        <description>One line is too long</description>
+        <rule-property name="maxLineLength">30</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <expected-messages>
+            <message>The line is too long. Only 30 characters are allowed.</message>
+        </expected-messages>
+        <code><![CDATA[
+BEGIN
+    SELECT cmer_id
+        ,version
+        ,cmp_id
+    BULK COLLECT INTO v_cmer_ids
+        ,v_versions
+        ,v_cmp_ids
+    FROM cmer;
+END;
+/
+        ]]></code>
+        <source-type>plsql</source-type>
+    </test-code>
+
+    <test-code>
+        <description>Multiple lines are too long - only first is reported</description>
+        <rule-property name="maxLineLength">30</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>2</expected-linenumbers>
+        <expected-messages>
+            <message>The line is too long. Only 30 characters are allowed.</message>
+        </expected-messages>
+        <code><![CDATA[
+BEGIN
+                                SELECT cmer_id
+                                    ,version
+                                    ,cmp_id
+                                BULK COLLECT INTO v_cmer_ids
+                                    ,v_versions
+                                    ,v_cmp_ids
+                                FROM cmer;
+END;
+/
+        ]]></code>
+        <source-type>plsql</source-type>
+    </test-code>
+
+    <test-code>
+        <description>Multiple lines are too long - report all</description>
+        <rule-property name="maxLineLength">30</rule-property>
+        <rule-property name="eachLine">true</rule-property>
+        <expected-problems>7</expected-problems>
+        <expected-linenumbers>2,3,4,5,6,7,8</expected-linenumbers>
+        <code><![CDATA[
+BEGIN
+                                SELECT cmer_id
+                                    ,version
+                                    ,cmp_id
+                                BULK COLLECT INTO v_cmer_ids
+                                    ,v_versions
+                                    ,v_cmp_ids
+                                FROM cmer;
+END;
+/
+        ]]></code>
+        <source-type>plsql</source-type>
+    </test-code>
+</test-data>


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

This adds 2 new sample rules for PLSQL, which make use of the plsql source directly.

I think, that's an interesting idea that we should consider in PMD 7 for "official" support in all languages (this PR only adds it for PLSQL).

This PR fixes #1716 