### PR TITLE
[java] fix escaping of CommentDefaultAccessModifier documentation

### DIFF
--- a/docs/pages/pmd/rules/java/codestyle.md
+++ b/docs/pages/pmd/rules/java/codestyle.md
@@ -475,7 +475,7 @@ public class Éléphant {}
 
 To avoid mistakes if we want that a Method, Constructor, Field or Nested class have a default access modifier
 we must add a comment at the beginning of it's declaration.
-By default the comment must be /* default */ or /* package */, if you want another, you have to provide a regular expression.
+By default the comment must be `/* default */` or `/* package */`, if you want another, you have to provide a regular expression.
 This rule ignores by default all cases that have a @VisibleForTesting annotation. Use the
 property &quot;ignoredAnnotations&quot; to customize the recognized annotations.
 

--- a/docs/pages/pmd/rules/java/codestyle.md
+++ b/docs/pages/pmd/rules/java/codestyle.md
@@ -475,7 +475,7 @@ public class Éléphant {}
 
 To avoid mistakes if we want that a Method, Constructor, Field or Nested class have a default access modifier
 we must add a comment at the beginning of it's declaration.
-By default the comment must be `/* default */` or `/* package */`, if you want another, you have to provide a regular expression.
+By default the comment must be /* default */ or /* package */, if you want another, you have to provide a regular expression.
 This rule ignores by default all cases that have a @VisibleForTesting annotation. Use the
 property &quot;ignoredAnnotations&quot; to customize the recognized annotations.
 

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -404,7 +404,7 @@ public class Éléphant {}
         <description>
 To avoid mistakes if we want that a Method, Constructor, Field or Nested class have a default access modifier
 we must add a comment at the beginning of it's declaration.
-By default the comment must be /* default */ or /* package */, if you want another, you have to provide a regular expression.
+By default the comment must be `/* default */` or `/* package */`, if you want another, you have to provide a regular expression.
 This rule ignores by default all cases that have a @VisibleForTesting annotation. Use the
 property "ignoredAnnotations" to customize the recognized annotations.
         </description>


### PR DESCRIPTION
This fixes #1674.

Documentation of CommentDefaultAccessModifier used `/` which renders as italic font, and disappears.
Instead, using ` to mark these symbols as code, as it should be.
 