### PR TITLE
[java] AvoidDuplicateLiterals warning about deprecated separator property when not used

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -61,6 +61,8 @@ The designer will still be shipped with PMD's binaries.
     *   [#1701](https://github.com/pmd/pmd/issues/1701): \[java] UseTryWithResources does not handle multiple argument close methods
 *   java-codestyle
     *   [#1674](https://github.com/pmd/pmd/issues/1674): \[java] documentation of CommentDefaultAccessModifier is wrong
+*   java-errorprone
+    *   [#1570](https://github.com/pmd/pmd/issues/1570): \[java] AvoidDuplicateLiterals warning about deprecated separator property when not used
 
 ### API Changes
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
@@ -468,10 +468,11 @@ public abstract class AbstractRule extends AbstractPropertySource implements Rul
             if (rule.getPropertyDescriptor(prop.name()) == null) {
                 rule.definePropertyDescriptor(prop); // Property descriptors are immutable, and can be freely shared
             }
-            
-            rule.setProperty((PropertyDescriptor<Object>) prop, getProperty((PropertyDescriptor<Object>) prop));
+
+            if (isPropertyOverridden(prop)) {
+                rule.setProperty((PropertyDescriptor<Object>) prop, getProperty((PropertyDescriptor<Object>) prop));
+            }
         }
-        
         return rule;
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/AbstractRuleTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/AbstractRuleTest.java
@@ -30,12 +30,17 @@ public class AbstractRuleTest {
 
     public static class MyRule extends AbstractRule {
         private static final StringProperty FOO_PROPERTY = new StringProperty("foo", "foo property", "x", 1.0f);
+        private static final PropertyDescriptor<String> FOO_DEFAULT_PROPERTY = PropertyFactory.stringProperty("fooDefault")
+                .defaultValue("bar")
+                .desc("Property without value uses default value")
+                .build();
 
         private static final StringProperty XPATH_PROPERTY = new StringProperty("xpath", "xpath property", "", 2.0f);
 
         public MyRule() {
             definePropertyDescriptor(FOO_PROPERTY);
             definePropertyDescriptor(XPATH_PROPERTY);
+            definePropertyDescriptor(FOO_DEFAULT_PROPERTY);
             setName("MyRule");
             setMessage("my rule msg");
             setPriority(RulePriority.MEDIUM);
@@ -223,9 +228,8 @@ public class AbstractRuleTest {
         assertEquals(r1.getRuleClass(), r2.getRuleClass());
         assertEquals(r1.getRuleSetName(), r2.getRuleSetName());
         assertEquals(r1.getSince(), r2.getSince());
-    }
 
-    public static junit.framework.Test suite() {
-        return new junit.framework.JUnit4TestAdapter(AbstractRuleTest.class);
+        assertEquals(r1.isPropertyOverridden(MyRule.FOO_DEFAULT_PROPERTY),
+                r2.isPropertyOverridden(MyRule.FOO_DEFAULT_PROPERTY));
     }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDuplicateLiteralsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDuplicateLiteralsTest.java
@@ -9,8 +9,10 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Set;
 
+import org.junit.Assert;
 import org.junit.Test;
 
+import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.testframework.PmdRuleTst;
 
 public class AvoidDuplicateLiteralsTest extends PmdRuleTst {
@@ -49,5 +51,14 @@ public class AvoidDuplicateLiteralsTest extends PmdRuleTst {
         assertTrue(res.contains("a"));
         assertTrue(res.contains("b"));
         assertTrue(res.contains("\\"));
+    }
+
+    @Test
+    public void testSeparatorPropertyWarning() throws Exception {
+        AvoidDuplicateLiteralsRule rule = new AvoidDuplicateLiteralsRule();
+        Assert.assertFalse(rule.isPropertyOverridden(AvoidDuplicateLiteralsRule.SEPARATOR_DESCRIPTOR));
+
+        Rule copy = rule.deepCopy();
+        Assert.assertFalse(copy.isPropertyOverridden(AvoidDuplicateLiteralsRule.SEPARATOR_DESCRIPTOR));
     }
 }


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
Fixes #1570

