### PR TITLE
[java] Update rule to prevent UnusedImport when using JavaDoc with array type

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
@@ -44,7 +44,7 @@ public class UnusedImportsRule extends AbstractJavaRule {
             .compile("@see\\s+(\\p{Alpha}?+\\w*)(?:#\\w*(?:\\(([\\w\\s,]*)\\))?)?");
 
     private static final Pattern LINK_PATTERNS = Pattern
-            .compile("\\{@link(?:plain)?\\s+(\\p{Alpha}\\w*)(?:#\\w*(?:\\(([.\\w\\s,]*)\\))?)?[\\s\\}]");
+            .compile("\\{@link(?:plain)?\\s+(\\p{Alpha}\\w*)(?:#\\w*(?:\\(([.\\w\\s,\\[\\]]*)\\))?)?[\\s\\}]");
 
     private static final Pattern VALUE_PATTERN = Pattern.compile("\\{@value\\s+(\\p{Alpha}\\w*)[\\s#\\}]");
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
@@ -41,7 +41,7 @@ public class UnusedImportsRule extends AbstractJavaRule {
      * @throws package.class label
      */
     private static final Pattern SEE_PATTERN = Pattern
-            .compile("@see\\s+(\\p{Alpha}?+\\w*)(?:#\\w*(?:\\(([\\w\\s,]*)\\))?)?");
+            .compile("@see\\s+(\\p{Alpha}?+\\w*)(?:#\\w*(?:\\(([\\w\\s,\\[\\]]*)\\))?)?");
 
     private static final Pattern LINK_PATTERNS = Pattern
             .compile("\\{@link(?:plain)?\\s+(\\p{Alpha}\\w*)(?:#\\w*(?:\\(([.\\w\\s,\\[\\]]*)\\))?)?[\\s\\}]");

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedImports.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedImports.xml
@@ -242,6 +242,22 @@ public class Foo {
     </test-code>
 
     <test-code>
+        <description>#1720 False Positive in UnusedImports for Javadoc link with array type</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import some.pack.SomeUtility;
+
+public class Foo {
+    /**
+     * The {@link SomeUtility#someHelperMethod(String, SomeObjectArray[])} method does something.
+     */
+    public void someMethod() {
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
          <description><![CDATA[
 Bug 2606609 : False "UnusedImports" positive in package-info.java
         ]]></description>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedImports.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedImports.xml
@@ -487,4 +487,20 @@ public class Derived extends FileInputStream {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#1720 False Positive in UnusedImports for Javadoc @see with array type</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+package net.sourceforge.pmd.lang.java.rule.bestpractices.unusedimports;
+
+import java.io.File;
+import java.io.FileInputStream;
+
+public class Derived extends FileInputStream {
+    /** @see #FileInputStream(File, File[]) */
+    void main() {}
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
This fixes #1720.

Allowing `[]` at the variable names of JavaDoc functions, when checking for unused imports.
  