### PR TITLE
[java] UseObjectForClearerAPI Only For Public

### DIFF
--- a/docs/pages/pmd/rules/java/design.md
+++ b/docs/pages/pmd/rules/java/design.md
@@ -2090,7 +2090,7 @@ your API.
 
 **This rule is defined by the following XPath expression:**
 ``` xpath
-//MethodDeclaration[@Public]/MethodDeclarator/FormalParameters[
+//MethodDeclaration[@Public = 'true']/MethodDeclarator/FormalParameters[
      count(FormalParameter/Type/ReferenceType/ClassOrInterfaceType[@Image = 'String']) > 3
 ]
 ```

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -1639,7 +1639,7 @@ your API.
                 <value>
 <![CDATA[
 //MethodDeclaration[@Public = 'true']/MethodDeclarator/FormalParameters[
-     count(FormalParameter/Type/ReferenceType/ClassOrInterfaceType[@Image = 'String']) > 3
+     count(FormalParameter/Type/ReferenceType/ClassOrInterfaceType[@Image = 'String' and @Array = 'false']) > 3
 ]
 ]]>
                 </value>

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -1638,7 +1638,7 @@ your API.
             <property name="xpath">
                 <value>
 <![CDATA[
-//MethodDeclaration[@Public]/MethodDeclarator/FormalParameters[
+//MethodDeclaration[@Public = 'true']/MethodDeclarator/FormalParameters[
      count(FormalParameter/Type/ReferenceType/ClassOrInterfaceType[@Image = 'String']) > 3
 ]
 ]]>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UseObjectForClearerAPI.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UseObjectForClearerAPI.xml
@@ -58,4 +58,36 @@ public class MyClass {
 		     ]]>
 		</code>
     </test-code>
+    <test-code>
+        <description>
+            <![CDATA[
+non-public methods should not have findings
+            ]]>
+        </description>
+        <expected-problems>0</expected-problems>
+        <code>
+            <![CDATA[
+public class MyClass {
+  protected void connectProtected(String username,
+    String pssd,
+    String databaseName,
+    String databaseAdress)
+  {
+  }
+  void connectPackagePrivate(String username,
+    String pssd,
+    String databaseName,
+    String databaseAdress)
+  {
+  }
+  private void connectPrivate(String username,
+    String pssd,
+    String databaseName,
+    String databaseAdress)
+  {
+  }
+}
+           ]]>
+       </code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UseObjectForClearerAPI.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UseObjectForClearerAPI.xml
@@ -90,4 +90,24 @@ public class MyClass {
            ]]>
        </code>
     </test-code>
+    <test-code>
+        <description>
+            <![CDATA[
+String[] should not be treated as String
+            ]]>
+        </description>
+        <expected-problems>0</expected-problems>
+        <code>
+            <![CDATA[
+public class MyClass {
+  public void connectProtected(String username,
+    String[] pssd,
+    String databaseName,
+    String databaseAdress)
+  {
+  }
+}
+           ]]>
+       </code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
The description and implementation of the rule suggest that is should only apply
to public methods, but it is effective against all methods as for the existence
of the `@Public` attribute is tested instead of the value, so the condition is
always true.

With this fix, only public methods are considered like intended.

Fixes #1760 