### PR TITLE
[doc] Generate docs for PMD 7

### DIFF
--- a/.travis/build-doc-pmd7.sh
+++ b/.travis/build-doc-pmd7.sh
@@ -39,6 +39,7 @@ upload_docs() {
 
 upload_javadocs() {
     upload_javadoc_module pmd-core
+    upload_javadoc_module pmd-java
 }
 
 upload_javadoc_module() {
@@ -46,7 +47,7 @@ upload_javadoc_module() {
     pushd $module/target
     scp "${module}-${VERSION}-javadoc.jar" pmd@pmd-code.org:/docs.pmd-code.org/
     ssh pmd@pmd-code.org "cd /docs.pmd-code.org && mkdir -p pmd-doc-${VERSION}/apidocs/${module} && \
-            unzip -qo -d pmd-doc-${VERSION}/apidocs/pmd-core pmd-core-7.0.0-SNAPSHOT-javadoc.jar && \
+            unzip -qo -d pmd-doc-${VERSION}/apidocs/${module} ${module}-${VERSION}-javadoc.jar && \
             rm ${module}-${VERSION}-javadoc.jar"
     log_info "JavaDoc for $module uploaded: https://docs.pmd-code.org/pmd-doc-${VERSION}/apidocs/${module}/"
     popd

--- a/.travis/build-doc-pmd7.sh
+++ b/.travis/build-doc-pmd7.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -e
+
+source .travis/logger.sh
+source .travis/common-functions.sh
+
+VERSION=$(./mvnw -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:1.5.0:exec)
+
+main() {
+    check_branch
+    setup_ssh
+    upload_docs
+    upload_javadocs
+    build_aggregate_javadoc
+}
+
+check_branch() {
+    if [[ "${VERSION}" != "7.0.0-SNAPSHOT" || "${TRAVIS_BRANCH}" != "pmd/7.0.x" ]]; then
+        log_info "Not on PMD 7 branch - exiting $0"
+        exit 0
+    fi
+    log_info "Building PMD Documentation ${VERSION} on branch ${TRAVIS_BRANCH}"
+}
+
+setup_ssh() {
+    mkdir -p "$HOME/.ssh"
+    echo "pmd-code.org ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDVsIeF6xU0oPb/bMbxG1nU1NDyBpR/cBEPZcm/PuJwdI9B0ydPHA6FysqAnt32fNFznC2SWisnWyY3iNsP3pa8RQJVwmnnv9OboGFlW2/61o3iRyydcpPbgl+ADdt8iU9fmMI7dC04UqgHGBoqOwVNna9VylTjp5709cK2qHnwU450F6YcOEiOKeZfJvV4PmpJCz/JcsUVqft6StviR31jKnqbnkZdP8qNoTbds6WmGKyXkhHdLSZE7X1CFQH28tk8XFqditX93ezeCiThFL7EleDexV/3+2+cs5878sDMUMzHS5KShTjkxzhHaodhtIEdNesinq/hOPbxAGkQ0FbD" >> $HOME/.ssh/known_hosts
+}
+
+upload_docs() {
+    if has_docs_change; then
+        scp docs/pmd-doc-${VERSION}.zip pmd@pmd-code.org:/docs.pmd-code.org/
+        ssh pmd@pmd-code.org "cd /docs.pmd-code.org && \
+            unzip -qo pmd-doc-${VERSION}.zip && \
+            rm pmd-doc-${VERSION}.zip"
+        log_info "Docs updated: https://docs.pmd-code.org/pmd-doc-${VERSION}/"
+    fi
+}
+
+upload_javadocs() {
+    upload_javadoc_module pmd-core
+}
+
+upload_javadoc_module() {
+    local module=$1
+    pushd $module/target
+    scp "${module}-${VERSION}-javadoc.jar" pmd@pmd-code.org:/docs.pmd-code.org/
+    ssh pmd@pmd-code.org "cd /docs.pmd-code.org && mkdir -p pmd-doc-${VERSION}/apidocs/${module} && \
+            unzip -qo -d pmd-doc-${VERSION}/apidocs/pmd-core pmd-core-7.0.0-SNAPSHOT-javadoc.jar && \
+            rm ${module}-${VERSION}-javadoc.jar"
+    log_info "JavaDoc for $module uploaded: https://docs.pmd-code.org/pmd-doc-${VERSION}/apidocs/${module}/"
+    popd
+}
+
+build_aggregate_javadoc() {
+    ./mvnw javadoc:aggregate-jar -Pjavadoc-aggregate
+    scp target/pmd-${VERSION}-javadoc.jar pmd@pmd-code.org:/docs.pmd-code.org/
+    ssh pmd@pmd-code.org "cd /docs.pmd-code.org && \
+        mkdir -p pmd-doc-${VERSION}/apidocs && \
+        unzip -qo -d pmd-doc-${VERSION}/apidocs pmd-${VERSION}-javadoc.jar && \
+        rm pmd-${VERSION}-javadoc.jar"
+    log_info "Aggregated JavaDoc: https://docs.pmd-code.org/pmd-doc-${VERSION}/apidocs/"
+}
+
+
+main

--- a/.travis/build-doc.sh
+++ b/.travis/build-doc.sh
@@ -59,8 +59,6 @@ ls -lh pmd-doc-${VERSION}.zip
     true
 )
 
-
-
 #
 # Push the generated site to gh-pages branch
 # only for snapshot builds from branch master
@@ -89,3 +87,5 @@ TRAVIS_COMMIT_RANGE=${TRAVIS_COMMIT_RANGE}"
 fi
 
 popd
+
+.travis/build-doc-pmd7.sh

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,9 +1,9 @@
 repository: pmd/pmd
 
 pmd:
-    version: 6.16.0
-    previous_version: 6.15.0
-    date: ??-June-2019
+    version: 7.0.0
+    previous_version: 6.??.0
+    date: ??-??-2019
     release_type: minor
 
 # release types: major, minor, bugfix

--- a/pom.xml
+++ b/pom.xml
@@ -1064,6 +1064,30 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
         </profile>
 
         <profile>
+            <id>javadoc-aggregate</id>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-javadoc-plugin</artifactId>
+                            <configuration>
+                                <additionalDependencies>
+                                    <additionalDependency>
+                                        <groupId>net.sourceforge.pmd</groupId>
+                                        <artifactId>pmd-apex-jorje</artifactId>
+                                        <version>${project.version}</version>
+                                        <classifier>lib</classifier>
+                                    </additionalDependency>
+                                </additionalDependencies>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+
+        <profile>
             <id>coveralls</id>
             <build>
                 <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -467,6 +467,7 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
                                 <version>${ant.version}</version>
                             </additionalDependency>
                         </additionalDependencies>
+                        <excludePackageNames>*.internal</excludePackageNames>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -1080,6 +1081,7 @@ Additionally it includes CPD, the copy-paste-detector. CPD finds duplicated code
                                         <classifier>lib</classifier>
                                     </additionalDependency>
                                 </additionalDependencies>
+                                <excludePackageNames>*.internal</excludePackageNames>
                             </configuration>
                         </plugin>
                     </plugins>


### PR DESCRIPTION
This adds a travis script, that uploads the documentation and javadoc to

* https://docs.pmd-code.org/pmd-doc-7.0.0-SNAPSHOT/
* https://docs.pmd-code.org/pmd-doc-7.0.0-SNAPSHOT/apidocs/
* https://docs.pmd-code.org/pmd-doc-7.0.0-SNAPSHOT/apidocs/pmd-core/
* https://docs.pmd-code.org/pmd-doc-7.0.0-SNAPSHOT/apidocs/pmd-java/

We could add more modules, I've now only added pmd-core and pmd-java separately.

(I've ran the script locally, so there is already documentation uploaded...)