### PR TITLE
[java] JUnitTestContainsTooManyAsserts uses XPath 2

### DIFF
--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -699,7 +699,7 @@ This rule checks for JUnit4, JUnit5 and TestNG Tests, as well as methods startin
             <property name="xpath">
                 <value>
 <![CDATA[
-//MethodDeclarator[@Image[fn:matches(.,'^test')] or ../../Annotation/MarkerAnnotation/Name[
+//MethodDeclarator[@Image[matches(.,'^test')] or ../../Annotation/MarkerAnnotation/Name[
            pmd-java:typeIs('org.junit.Test')
         or pmd-java:typeIs('org.junit.jupiter.api.Test')
         or pmd-java:typeIs('org.junit.jupiter.api.RepeatedTest')
@@ -708,10 +708,11 @@ This rule checks for JUnit4, JUnit5 and TestNG Tests, as well as methods startin
         or pmd-java:typeIs('org.junit.jupiter.params.ParameterizedTest')
         or pmd-java:typeIs('org.testng.annotations.Test')
     ]]
-    [count(..//PrimaryPrefix/Name[@Image[fn:matches(.,'^assert')]]) > $maximumAsserts]
+    [count(..//PrimaryPrefix/Name[@Image[matches(.,'^assert')]]) > $maximumAsserts]
 ]]>
                 </value>
             </property>
+            <property name="version" value="2.0"/>
         </properties>
         <example>
 <![CDATA[


### PR DESCRIPTION
 - We are already using `pmd-java:typeIs`, so it's the correct thing to do.
 - Plus, this way it's 6X faster