### PR TITLE
[core] Declare fn namespace on Saxon 

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQuery.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQuery.java
@@ -18,6 +18,7 @@ import net.sourceforge.pmd.lang.xpath.Initializer;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 
 import net.sf.saxon.om.Item;
+import net.sf.saxon.om.NamespaceConstant;
 import net.sf.saxon.om.ValueRepresentation;
 import net.sf.saxon.sxpath.AbstractStaticContext;
 import net.sf.saxon.sxpath.IndependentContext;
@@ -192,6 +193,8 @@ public class SaxonXPathRuleQuery extends AbstractXPathRuleQuery {
             if (XPATH_1_0_COMPATIBILITY.equals(version)) {
                 ((AbstractStaticContext) xpathStaticContext).setBackwardsCompatibilityMode(true);
             }
+
+            ((IndependentContext) xpathEvaluator.getStaticContext()).declareNamespace("fn", NamespaceConstant.FN);
 
             // Register PMD functions
             Initializer.initialize((IndependentContext) xpathStaticContext);

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/XPathRuleTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/XPathRuleTest.java
@@ -99,6 +99,24 @@ public class XPathRuleTest extends RuleTst {
         assertEquals(3, rv.getBeginLine());
     }
 
+    @Test
+    public void testFnPrefixOnSaxon() throws Exception {
+        rule.setXPath("//VariableDeclaratorId[fn:matches(@Image, 'fiddle')]");
+        rule.setVersion(XPathRuleQuery.XPATH_2_0);
+        Report report = getReportForTestString(rule, TEST2);
+        RuleViolation rv = report.iterator().next();
+        assertEquals(3, rv.getBeginLine());
+    }
+
+    @Test
+    public void testNoFnPrefixOnSaxon() throws Exception {
+        rule.setXPath("//VariableDeclaratorId[matches(@Image, 'fiddle')]");
+        rule.setVersion(XPathRuleQuery.XPATH_2_0);
+        Report report = getReportForTestString(rule, TEST2);
+        RuleViolation rv = report.iterator().next();
+        assertEquals(3, rv.getBeginLine());
+    }
+
 
     /**
      * Test for problem reported in bug #1219 PrimarySuffix/@Image does not work


### PR DESCRIPTION
This removes one incompatibility between Jaxen- and Saxon-flavoured XPath queries. In Jaxen you need the `fn:` prefix for standard function calls, now in Saxon it's allowed, but not necessary, instead of causing failure.

Refs #1687, #1770 