### PR TITLE
[java] Location change in AssignmentToNonFinalStatic

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentToNonFinalStaticRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentToNonFinalStaticRule.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -33,15 +34,16 @@ public class AssignmentToNonFinalStaticRule extends AbstractJavaRule {
                 continue;
             }
 
-            final Node location = initializedInConstructor(entry.getValue());
-            if (location != null) {
+            final List<Node> locations = initializedInConstructor(entry.getValue());
+            for (final Node location : locations) {
                 addViolation(data, location, decl.getImage());
             }
         }
         return super.visit(node, data);
     }
 
-    private Node initializedInConstructor(List<NameOccurrence> usages) {
+    private List<Node> initializedInConstructor(List<NameOccurrence> usages) {
+        final List<Node> unsafeAssignments = new ArrayList<>();
         for (NameOccurrence occ : usages) {
             // specifically omitting prefix and postfix operators as there are
             // legitimate usages of these with static fields, e.g. typesafe enum pattern.
@@ -49,12 +51,12 @@ public class AssignmentToNonFinalStaticRule extends AbstractJavaRule {
                 Node node = occ.getLocation();
                 Node constructor = node.getFirstParentOfType(ASTConstructorDeclaration.class);
                 if (constructor != null) {
-                    return node;
+                    unsafeAssignments.add(node);
                 }
             }
         }
 
-        return null;
+        return unsafeAssignments;
     }
 
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentToNonFinalStaticRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentToNonFinalStaticRule.java
@@ -33,16 +33,15 @@ public class AssignmentToNonFinalStaticRule extends AbstractJavaRule {
                 continue;
             }
 
-            if (initializedInConstructor(entry.getValue())) {
-                addViolation(data, decl.getNode(), decl.getImage());
+            final Node location = initializedInConstructor(entry.getValue());
+            if (location != null) {
+                addViolation(data, location, decl.getImage());
             }
         }
         return super.visit(node, data);
     }
 
-    private boolean initializedInConstructor(List<NameOccurrence> usages) {
-        boolean initInConstructor = false;
-
+    private Node initializedInConstructor(List<NameOccurrence> usages) {
         for (NameOccurrence occ : usages) {
             // specifically omitting prefix and postfix operators as there are
             // legitimate usages of these with static fields, e.g. typesafe enum pattern.
@@ -50,12 +49,12 @@ public class AssignmentToNonFinalStaticRule extends AbstractJavaRule {
                 Node node = occ.getLocation();
                 Node constructor = node.getFirstParentOfType(ASTConstructorDeclaration.class);
                 if (constructor != null) {
-                    initInConstructor = true;
+                    return node;
                 }
             }
         }
 
-        return initInConstructor;
+        return null;
     }
 
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AssignmentToNonFinalStatic.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AssignmentToNonFinalStatic.xml
@@ -8,6 +8,7 @@
 clear rule violation
      ]]></description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
  static int x;
@@ -36,6 +37,7 @@ public class Foo {
 rule violated twice
      ]]></description>
         <expected-problems>2</expected-problems>
+        <expected-linenumbers>4,5</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
  static int x;

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AssignmentToNonFinalStatic.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AssignmentToNonFinalStatic.xml
@@ -31,4 +31,19 @@ public class Foo {
 }
      ]]></code>
     </test-code>
+    <test-code>
+        <description><![CDATA[
+rule violated twice
+     ]]></description>
+        <expected-problems>2</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ static int x;
+     Foo(int y) {
+         x = y;
+         x = y;
+     }
+}
+     ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
The rule AssignmentToNonFinalStatic reports violations when a static field is initialized in the constructor. Sometimes, people get confused about this, because they can't find the part when the variable is initialized.

I've adjusted the implementation to report the violations at the location of the initialization. In addition to this, violations are now reported for each initialization rather than once at the declaration.