### PR TITLE
[cpd] [core] Use current classloader instead of Thread's classloader

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -49,6 +49,8 @@ Being based on a proper Antlr grammar, CPD can:
     *   [#1782](https://github.com/pmd/pmd/issues/1782): \[java] NoPackage: False Negative for enums
 *   java-design
     *   [#1760](https://github.com/pmd/pmd/issues/1760): \[java] UseObjectForClearerAPI flags private methods
+*   cpd-core
+    *   [#1788](https://github.com/pmd/pmd/issues/1788): \[cpd] \[core] Use better `ClassLoader` for `ServiceLoader` in `LanguageFactory`
 
 ### API Changes
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/LanguageFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/LanguageFactory.java
@@ -33,7 +33,8 @@ public final class LanguageFactory {
 
     private LanguageFactory() {
         List<Language> languagesList = new ArrayList<>();
-        ServiceLoader<Language> languageLoader = ServiceLoader.load(Language.class);
+        // Use current class' classloader instead of the threads context classloader, see https://github.com/pmd/pmd/issues/1788
+        ServiceLoader<Language> languageLoader = ServiceLoader.load(Language.class, getClass().getClassLoader());
         Iterator<Language> iterator = languageLoader.iterator();
         while (iterator.hasNext()) {
             try {


### PR DESCRIPTION
**PR Description:**

This fixes #1788 by using the current's classloader instead of the current Thread's ones. This is required if executing CPD in a separate worker.

Also adjusts the release notes.


As discussed in #1788, here is the desired PR. Orientates on #1387.