### PR TITLE
[dart] [cpd] Dart escaped string

### DIFF
--- a/pmd-dart/src/main/antlr4/net/sourceforge/pmd/lang/dart/antlr4/Dart2.g4
+++ b/pmd-dart/src/main/antlr4/net/sourceforge/pmd/lang/dart/antlr4/Dart2.g4
@@ -344,8 +344,8 @@ booleanLiteral
 stringLiteral: SingleLineString;
 //stringLiteral: SingleLineString;
 SingleLineString
-  : '"' ~["]* '"'
-  | '\'' ~[']* '\''
+  : '"' (~["] | '\\"')* '"'
+  | '\'' (~['] | '\\\'')* '\''
 //  | 'r\'' (~('\'' | NEWLINE))* '\'' // TODO
 //  | 'r"' (~('\'' | NEWLINE))* '"'
   ;

--- a/pmd-dart/src/test/java/net/sourceforge/pmd/cpd/DartTokenizerTest.java
+++ b/pmd-dart/src/test/java/net/sourceforge/pmd/cpd/DartTokenizerTest.java
@@ -31,6 +31,7 @@ public class DartTokenizerTest extends AbstractTokenizerTest {
     public static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[] { "comment.dart", 5 },
+                new Object[] { "escaped_string.dart", 17 },
                 new Object[] { "increment.dart", 185 },
                 new Object[] { "imports.dart", 1 }
         );

--- a/pmd-dart/src/test/resources/net/sourceforge/pmd/cpd/escaped_string.dart
+++ b/pmd-dart/src/test/resources/net/sourceforge/pmd/cpd/escaped_string.dart
@@ -1,0 +1,4 @@
+var a = "a";
+var b = "b";
+var c = "c";
+var x = "$a(b: $b, c: \"$c\")";


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
This is a fix for strings containing escaped quotes in Dart. Without this fix, this results in a lexical error.

Example:
`"$a(b: $b, c: \"$c\")"`