### PR TITLE
[python] [cpd] Add support for Python 2 backticks

### DIFF
--- a/pmd-python/etc/grammar/python.jj
+++ b/pmd-python/etc/grammar/python.jj
@@ -52,6 +52,7 @@ TOKEN : /* SEPARATORS */
 |   < COMMA: "," >
 |   < DOT: "." >
 |   < COLON: ":" >
+|   < BACKTICK: "`" >
 }
 
 

--- a/pmd-python/src/test/java/net/sourceforge/pmd/cpd/PythonTokenizerTest.java
+++ b/pmd-python/src/test/java/net/sourceforge/pmd/cpd/PythonTokenizerTest.java
@@ -53,4 +53,16 @@ public class PythonTokenizerTest extends AbstractTokenizerTest {
         TokenEntry.getEOF();
         assertEquals(3, tokens.size()); // 3 tokens: "import" + "logging" + EOF
     }
+
+    @Test
+    public void testBackticks() throws IOException {
+        SourceCode sourceCode = new SourceCode(new SourceCode.StringCodeLoader("test = 'hello'" + PMD.EOL
+                + "quoted = `test`" + PMD.EOL
+                + "print quoted" + PMD.EOL
+        ));
+        Tokens tokens = new Tokens();
+        tokenizer.tokenize(sourceCode, tokens); // should not result in parse error
+        TokenEntry.getEOF();
+        assertEquals(3, tokens.getTokens().get(tokens.getTokens().size() - 2).getBeginLine());
+    }
 }


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
This pull request adds backticks (\`) to the Python grammar. Backticks are an alternative for the `repr` function in Python 2.