### PR TITLE
[dart] [cpd] Dart escape sequences

### DIFF
--- a/pmd-dart/src/main/antlr4/net/sourceforge/pmd/lang/dart/antlr4/Dart2.g4
+++ b/pmd-dart/src/main/antlr4/net/sourceforge/pmd/lang/dart/antlr4/Dart2.g4
@@ -344,8 +344,8 @@ booleanLiteral
 stringLiteral: SingleLineString;
 //stringLiteral: SingleLineString;
 SingleLineString
-  : '"' (~["] | '\\"')* '"'
-  | '\'' (~['] | '\\\'')* '\''
+  : '"' (~[\\"] | '\\\\' | ESCAPE_SEQUENCE | '\\"')* '"'
+  | '\'' (~[\\'] | '\\\\' | ESCAPE_SEQUENCE | '\\\'')* '\''
 //  | 'r\'' (~('\'' | NEWLINE))* '\'' // TODO
 //  | 'r"' (~('\'' | NEWLINE))* '"'
   ;
@@ -369,6 +369,7 @@ ESCAPE_SEQUENCE
   | '\\x' HEX_DIGIT HEX_DIGIT
   | '\\u' HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT
   | '\\u{' HEX_DIGIT_SEQUENCE '}'
+  | '\\$'
   ;
 fragment
 HEX_DIGIT_SEQUENCE

--- a/pmd-dart/src/test/java/net/sourceforge/pmd/cpd/DartTokenizerTest.java
+++ b/pmd-dart/src/test/java/net/sourceforge/pmd/cpd/DartTokenizerTest.java
@@ -31,6 +31,8 @@ public class DartTokenizerTest extends AbstractTokenizerTest {
     public static Collection<Object[]> data() {
         return Arrays.asList(
                 new Object[] { "comment.dart", 5 },
+                new Object[] { "escape_sequences.dart", 13 },
+                new Object[] { "escaped_backslash.dart", 14 },
                 new Object[] { "escaped_string.dart", 17 },
                 new Object[] { "increment.dart", 185 },
                 new Object[] { "imports.dart", 1 }

--- a/pmd-dart/src/test/resources/net/sourceforge/pmd/cpd/escape_sequences.dart
+++ b/pmd-dart/src/test/resources/net/sourceforge/pmd/cpd/escape_sequences.dart
@@ -1,0 +1,3 @@
+var newline = '\n';
+var dollar = '$';
+var escaped_dollar = "\$";

--- a/pmd-dart/src/test/resources/net/sourceforge/pmd/cpd/escaped_backslash.dart
+++ b/pmd-dart/src/test/resources/net/sourceforge/pmd/cpd/escaped_backslash.dart
@@ -1,0 +1,2 @@
+var separator = '\\';
+var separators = const ['/', '\\'];


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
This is a fix for escape sequences in Dart. As a result of #1791, certain escape sequences resulted in parse errors. These have now been made explicit.