### PR TITLE
deprecate: DumpFacade will be removed in PMD 7

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -33,7 +33,7 @@ This is a {{ site.pmd.release_type }} release.
     *   {% jdoc !q!vm::lang.vm.ast.AbstractVmNode#dump(String, boolean, Writer) %}
     *   {% jdoc !q!xml::lang.xml.ast.DumpFacade %}
 *   The method {% jdoc !c!core::lang.LanguageVersionHandler#getDumpFacade(Writer, String, boolean) %} will be
-    removed as well.
+    removed as well. It is deprecated, along with all its implementations in the subclasses of {% jdoc core::lang.LanguageVersionHandler %}.
 
 ### External Contributions
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -18,6 +18,23 @@ This is a {{ site.pmd.release_type }} release.
 
 ### API Changes
 
+#### Deprecated APIs
+
+##### For removal
+
+*   The `DumpFacades` in all languages, that could be used to transform a AST into a textual representation,
+    will be removed with PMD 7. The rule designer is a better way to inspect nodes.
+    *   {% jdoc !q!apex::lang.apex.ast.DumpFacade %}
+    *   {% jdoc !q!java::lang.java.ast.DumpFacade %}
+    *   {% jdoc !q!javascript::lang.ecmascript.ast.DumpFacade %}
+    *   {% jdoc !q!jsp::lang.jsp.ast.DumpFacade %}
+    *   {% jdoc !q!plsql::lang.plsql.ast.DumpFacade %}
+    *   {% jdoc !q!visualforce::lang.vf.ast.DumpFacade %}
+    *   {% jdoc !q!vm::lang.vm.ast.AbstractVmNode#dump(String, boolean, Writer) %}
+    *   {% jdoc !q!xml::lang.xml.ast.DumpFacade %}
+*   The method {% jdoc !c!core::lang.LanguageVersionHandler#getDumpFacade(Writer, String, boolean) %} will be
+    removed as well.
+
 ### External Contributions
 
 *   [#1803](https://github.com/pmd/pmd/pull/1803): \[dart] \[cpd] Dart escape sequences - [Maikel Steneker](https://github.com/maikelsteneker)

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ApexHandler.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ApexHandler.java
@@ -59,6 +59,7 @@ public class ApexHandler extends AbstractLanguageVersionHandler {
         return new ApexParser(parserOptions);
     }
 
+    @Deprecated
     @Override
     public VisitorStarter getDumpFacade(Writer writer, String prefix, boolean recurse) {
         return rootNode -> new DumpFacade().initializeWith(writer, prefix, recurse, (ApexNode<?>) rootNode);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/DumpFacade.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/DumpFacade.java
@@ -12,6 +12,11 @@ import java.util.List;
 
 import net.sourceforge.pmd.util.StringUtil;
 
+/**
+ *
+ * @deprecated This class will be removed with PMD 7. The rule designer is a better way to inspect nodes.
+ */
+@Deprecated
 public class DumpFacade {
 
     private PrintWriter writer;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/AbstractLanguageVersionHandler.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/AbstractLanguageVersionHandler.java
@@ -52,6 +52,7 @@ public abstract class AbstractLanguageVersionHandler implements LanguageVersionH
         return VisitorStarter.DUMMY;
     }
 
+    @Deprecated
     @Override
     public VisitorStarter getDumpFacade(final Writer writer, final String prefix, final boolean recurse) {
         return VisitorStarter.DUMMY;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/AbstractJavaHandler.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/AbstractJavaHandler.java
@@ -123,6 +123,7 @@ public abstract class AbstractJavaHandler extends AbstractLanguageVersionHandler
         };
     }
 
+    @Deprecated
     @Override
     public VisitorStarter getDumpFacade(final Writer writer, final String prefix, final boolean recurse) {
         return new VisitorStarter() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/DumpFacade.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/DumpFacade.java
@@ -10,6 +10,11 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ *
+ * @deprecated This class will be removed with PMD 7. The rule designer is a better way to inspect nodes.
+ */
+@Deprecated
 public class DumpFacade extends JavaParserVisitorAdapter {
 
     private PrintWriter writer;

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/Ecmascript3Handler.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/Ecmascript3Handler.java
@@ -43,6 +43,7 @@ public class Ecmascript3Handler extends AbstractLanguageVersionHandler {
         return new Ecmascript3Parser(parserOptions);
     }
 
+    @Deprecated
     @Override
     public VisitorStarter getDumpFacade(final Writer writer, final String prefix, final boolean recurse) {
         return new VisitorStarter() {

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/DumpFacade.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/DumpFacade.java
@@ -12,6 +12,11 @@ import java.util.List;
 
 import net.sourceforge.pmd.util.StringUtil;
 
+/**
+ *
+ * @deprecated This class will be removed with PMD 7. The rule designer is a better way to inspect nodes.
+ */
+@Deprecated
 public class DumpFacade {
 
     private PrintWriter writer;

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/JspHandler.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/JspHandler.java
@@ -40,6 +40,7 @@ public class JspHandler extends AbstractLanguageVersionHandler {
         return new JspParser(parserOptions);
     }
 
+    @Deprecated
     @Override
     public VisitorStarter getDumpFacade(final Writer writer, final String prefix, final boolean recurse) {
         return new VisitorStarter() {

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/DumpFacade.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/DumpFacade.java
@@ -12,6 +12,11 @@ import java.util.List;
 
 import net.sourceforge.pmd.lang.ast.Node;
 
+/**
+ *
+ * @deprecated This class will be removed with PMD 7. The rule designer is a better way to inspect nodes.
+ */
+@Deprecated
 public class DumpFacade extends JspParserVisitorAdapter {
 
     private PrintWriter writer;

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/PLSQLHandler.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/PLSQLHandler.java
@@ -72,6 +72,7 @@ public class PLSQLHandler extends AbstractLanguageVersionHandler {
         };
     }
 
+    @Deprecated
     @Override
     public VisitorStarter getDumpFacade(final Writer writer, final String prefix, final boolean recurse) {
         return new VisitorStarter() {

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/DumpFacade.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/DumpFacade.java
@@ -10,6 +10,11 @@ import java.io.Writer;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ *
+ * @deprecated This class will be removed with PMD 7. The rule designer is a better way to inspect nodes.
+ */
+@Deprecated
 public class DumpFacade extends PLSQLParserVisitorAdapter {
 
     private PrintWriter writer;

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/VfHandler.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/VfHandler.java
@@ -35,6 +35,7 @@ public class VfHandler extends AbstractLanguageVersionHandler {
         return new VfParser(parserOptions);
     }
 
+    @Deprecated
     @Override
     public VisitorStarter getDumpFacade(final Writer writer, final String prefix, final boolean recurse) {
         return new VisitorStarter() {

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/ast/DumpFacade.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/ast/DumpFacade.java
@@ -12,6 +12,11 @@ import java.util.List;
 
 import net.sourceforge.pmd.lang.ast.Node;
 
+/**
+ *
+ * @deprecated This class will be removed with PMD 7. The rule designer is a better way to inspect nodes.
+ */
+@Deprecated
 public class DumpFacade extends VfParserVisitorAdapter {
 
     private PrintWriter writer;

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/VmHandler.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/VmHandler.java
@@ -38,6 +38,7 @@ public class VmHandler extends AbstractLanguageVersionHandler {
         return new VmParser(parserOptions);
     }
 
+    @Deprecated
     @Override
     public VisitorStarter getDumpFacade(final Writer writer, final String prefix, final boolean recurse) {
         return new VisitorStarter() {

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/ast/AbstractVmNode.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/ast/AbstractVmNode.java
@@ -151,7 +151,9 @@ public class AbstractVmNode extends AbstractNode implements VmNode {
      * children.
      *
      * @param prefix
+     * @deprecated This method will be removed with PMD 7. The rule designer is a better way to inspect nodes.
      */
+    @Deprecated
     public void dump(final String prefix, final boolean recurse, final Writer writer) {
         final PrintWriter printWriter = writer instanceof PrintWriter ? (PrintWriter) writer : new PrintWriter(writer);
         printWriter.println(toString(prefix));

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/XmlHandler.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/XmlHandler.java
@@ -43,6 +43,7 @@ public class XmlHandler extends AbstractLanguageVersionHandler {
         return new XmlParser(parserOptions);
     }
 
+    @Deprecated
     @Override
     public VisitorStarter getDumpFacade(final Writer writer, final String prefix, final boolean recurse) {
         return new VisitorStarter() {

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/DumpFacade.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/DumpFacade.java
@@ -14,6 +14,11 @@ import java.util.List;
 import net.sourceforge.pmd.lang.ast.xpath.Attribute;
 import net.sourceforge.pmd.util.StringUtil;
 
+/**
+ *
+ * @deprecated This class will be removed with PMD 7. The rule designer is a better way to inspect nodes.
+ */
+@Deprecated
 public class DumpFacade {
 
     private PrintWriter writer;


### PR DESCRIPTION
Refs #1801

The method `LanguageVersionHandler#getDumpFacade(Writer, String, boolean)` was already deprecated. Looking at the implementations of this (we remove them in PMD 7), I don't see a direct warning in eclipse IDE... I see, the VisitorStarter is deprecated, but I don't see the method `getDumpFacade` is deprecated.
Should we add deprecations also in `AbstractLanguageVersionHandler` and every implementation?