### PR TITLE
[matlab] [cpd] Matlab comments

### DIFF
--- a/pmd-matlab/etc/grammar/matlab.jj
+++ b/pmd-matlab/etc/grammar/matlab.jj
@@ -41,10 +41,10 @@ PARSER_END(MatlabParser)
   "\n" : DEFAULT
 }
 
-MORE:
+<DEFAULT, TRANSPOSE> MORE:
 { "%{": IN_COMMENT }
 
-SPECIAL_TOKEN:
+<DEFAULT, TRANSPOSE> SPECIAL_TOKEN:
 { <SINGLE_LINE_COMMENT: "%"(~["\n","\r"])* ("\n"|"\r"|"\r\n")?> }
 
 <IN_COMMENT> SPECIAL_TOKEN:

--- a/pmd-matlab/etc/grammar/matlab.jj
+++ b/pmd-matlab/etc/grammar/matlab.jj
@@ -45,7 +45,7 @@ PARSER_END(MatlabParser)
 { "%{": IN_COMMENT }
 
 <DEFAULT, TRANSPOSE> SPECIAL_TOKEN:
-{ <SINGLE_LINE_COMMENT: "%"(~["\n","\r"])* ("\n"|"\r"|"\r\n")?> }
+{ <SINGLE_LINE_COMMENT: "%"~["{"](~["\n","\r"])* ("\n"|"\r"|"\r\n")?> }
 
 <IN_COMMENT> SPECIAL_TOKEN:
 { <MULTI_LINE_COMMENT: "%}">: DEFAULT }

--- a/pmd-matlab/src/test/java/net/sourceforge/pmd/cpd/MatlabTokenizerTest.java
+++ b/pmd-matlab/src/test/java/net/sourceforge/pmd/cpd/MatlabTokenizerTest.java
@@ -68,4 +68,22 @@ public class MatlabTokenizerTest extends AbstractTokenizerTest {
         TokenEntry.getEOF();
         assertEquals(28, tokens.size());
     }
+
+    @Test
+    public void testBlockComments() throws IOException {
+        SourceCode sourceCode = new SourceCode(new SourceCode.StringCodeLoader("%{" + PMD.EOL
+                + "  Name:     helloworld.m\n" + PMD.EOL
+                + "  Purpose:  Say \"Hello World!\" in two different ways" + PMD.EOL
+                + "%}" + PMD.EOL
+                + PMD.EOL
+                + "% Do it the good ol' fashioned way...command window" + PMD.EOL
+                + "disp('Hello World!');\n" + PMD.EOL
+                + "%" + PMD.EOL
+                + "% Do it the new hip GUI way...with a message box" + PMD.EOL
+                + "msgbox('Hello World!','Hello World!');"));
+        Tokens tokens = new Tokens();
+        tokenizer.tokenize(sourceCode, tokens); // should not result in parse error
+        TokenEntry.getEOF();
+        assertEquals(13, tokens.size());
+    }
 }

--- a/pmd-matlab/src/test/java/net/sourceforge/pmd/cpd/MatlabTokenizerTest.java
+++ b/pmd-matlab/src/test/java/net/sourceforge/pmd/cpd/MatlabTokenizerTest.java
@@ -54,4 +54,18 @@ public class MatlabTokenizerTest extends AbstractTokenizerTest {
         TokenEntry.getEOF();
         assertEquals(2, tokens.size()); // 2 tokens: "end" + EOF
     }
+
+    @Test
+    public void testComments() throws IOException {
+        SourceCode sourceCode = new SourceCode(new SourceCode.StringCodeLoader("classdef LC" + PMD.EOL
+                + "    methods" + PMD.EOL
+                + "        function [obj, c,t, s ] = Classification( obj,m,t, cm )%#codegen" + PMD.EOL
+                + "        end" + PMD.EOL
+                + "    end" + PMD.EOL
+                + "end"));
+        Tokens tokens = new Tokens();
+        tokenizer.tokenize(sourceCode, tokens); // should not result in parse error
+        TokenEntry.getEOF();
+        assertEquals(28, tokens.size());
+    }
 }


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
We encountered the follow construct in a Matlab file, which CPD fails to parse:
`function [obj, c,t, s ] = Classification( obj,m,t, cm )%#codegen`
This did work in early versions of PMD (5.3 specifically). I believe it's a regression that was introduced by commit cf9b768b90e11e022b2cbd4baad6419702abf532.