### PR TITLE
[cpp] [cpd] Add support for digit separators

### DIFF
--- a/pmd-cpp/etc/grammar/cpp.jj
+++ b/pmd-cpp/etc/grammar/cpp.jj
@@ -284,27 +284,31 @@ TOKEN :
 
 TOKEN [IGNORE_CASE] :
 {
-  <  OCTALINT : "0" (["0"-"7"])* >
+  <  OCTALINT : "0" (["'", "0"-"7"])* >
 | <  OCTALLONG : <OCTALINT> "l" >
 | <  UNSIGNED_OCTALINT : <OCTALINT> "u" >
 | <  UNSIGNED_OCTALLONG : <OCTALINT> ("ul" | "lu") >
 
-| <  DECIMALINT : ["1"-"9"] (["0"-"9"])* >
+| < #DECIMALDIGIT : ["'", "0"-"9"] >
+
+| <  DECIMALINT : ["1"-"9"] (<DECIMALDIGIT>)* >
 | <  DECIMALLONG : <DECIMALINT> ["u","l"] >
 | <  UNSIGNED_DECIMALINT : <DECIMALINT> "u" >
 | <  UNSIGNED_DECIMALLONG : <DECIMALINT> ("ul" | "lu") >
 
 
-| <  HEXADECIMALINT : "0x" (["0"-"9","a"-"f"])+ >
+| <  HEXADECIMALINT : "0x" (<DECIMALDIGIT> | ["a"-"f"])+ >
 | <  HEXADECIMALLONG : <HEXADECIMALINT> (["u","l"])? >
 | <  UNSIGNED_HEXADECIMALINT : <HEXADECIMALINT> "u" >
 | <  UNSIGNED_HEXADECIMALLONG : <HEXADECIMALINT> ("ul" | "lu") >
 
 
-| <  FLOATONE : ((["0"-"9"])+ "." (["0"-"9"])* | (["0"-"9"])* "." (["0"-"9"])+)
-              ("e" (["-","+"])? (["0"-"9"])+)? (["f","l"])? >
+| <  FLOATONE : (["0"-"9"](<DECIMALDIGIT>)* "."
+              | "." (<DECIMALDIGIT>)+
+              | ["0"-"9"](<DECIMALDIGIT>)* "." (<DECIMALDIGIT>)+)
+              ("e" (["-","+"])? (<DECIMALDIGIT>)+)? (["f","l"])? >
 
-| <  FLOATTWO : (["0"-"9"])+ "e" (["-","+"])?  (["0"-"9"])+ (["f","l"])? >
+| <  FLOATTWO : ["0"-"9"](<DECIMALDIGIT>)* "e" (["-","+"])? (<DECIMALDIGIT>)+ (["f","l"])? >
 }
 
 TOKEN :

--- a/pmd-cpp/src/test/java/net/sourceforge/pmd/cpd/CPPTokenizerTest.java
+++ b/pmd-cpp/src/test/java/net/sourceforge/pmd/cpd/CPPTokenizerTest.java
@@ -159,6 +159,18 @@ public class CPPTokenizerTest {
         tokenizer.tokenize(code, new Tokens());
     }
 
+    @Test
+    public void testDigitSeparators() {
+        final String code = "auto integer_literal = 1'000'000;" + PMD.EOL
+                + "auto floating_point_literal = 0.000'015'3;" + PMD.EOL
+                + "auto hex_literal = 0x0F00'abcd'6f3d;" + PMD.EOL
+                + "auto silly_example = 1'0'0'000'00;";
+        Tokens tokens = parse(code);
+        System.out.println(tokens.getTokens());
+        assertTrue(TokenEntry.getEOF() != tokens.getTokens().get(0));
+        assertEquals(21, tokens.size());
+    }
+
     private Tokens parse(String snippet) {
         try {
             return parse(snippet, false, new Tokens());


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
This adds support for digit separators in C++. This is a C++14 feature.
Example: `auto integer_literal = 1'000'000;`
The single quotes can be used to add some structure to large numbers.