### PR TITLE
[matlab] [cpd] Double quoted string

### DIFF
--- a/pmd-matlab/etc/grammar/matlab.jj
+++ b/pmd-matlab/etc/grammar/matlab.jj
@@ -139,6 +139,7 @@ SPECIAL_TOKEN:
 <DEFAULT> TOKEN :
 {
     < STRING: "'" ( <ESC_SEQ> | "'" "'" | ~["\\","'","\n"] )* "'" >
+|   < DSTRING: "\"" ( "\\" | "\"" "\"" | ~["\\","\"","\n"] )* "\"" >
 |   < #ESC_SEQ:
       "\\" ( "b" | "t" | "n" | "f" | "r" | "\"" | "'" | "\\" )
     | <UNICODE_ESC>

--- a/pmd-matlab/src/test/java/net/sourceforge/pmd/cpd/MatlabTokenizerTest.java
+++ b/pmd-matlab/src/test/java/net/sourceforge/pmd/cpd/MatlabTokenizerTest.java
@@ -54,4 +54,14 @@ public class MatlabTokenizerTest extends AbstractTokenizerTest {
         TokenEntry.getEOF();
         assertEquals(2, tokens.size()); // 2 tokens: "end" + EOF
     }
+
+    @Test
+    public void testDoubleQuotedStrings() throws IOException {
+        SourceCode sourceCode = new SourceCode(new SourceCode.StringCodeLoader(
+                "error(\"This is a double-quoted string\");"));
+        Tokens tokens = new Tokens();
+        tokenizer.tokenize(sourceCode, tokens);
+        TokenEntry.getEOF();
+        assertEquals(6, tokens.size());
+    }
 }


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
This adds supports for double-quoted string to the Matlab tokenizer.

Traditionally, Matlab strings have looked as follows:
```c = 'Hello World'```
Starting from version R2017a, double quotes can be used as well:
```str = "Greetings friend"```
Refer to https://nl.mathworks.com/help/matlab/characters-and-strings.html for details.