### PR TITLE
refactor: Make the children array never null

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNodeBase.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNodeBase.java
@@ -38,13 +38,12 @@ public abstract class AbstractApexNodeBase extends AbstractNode {
      * Accept the visitor. *
      */
     public Object childrenAccept(ApexParserVisitor visitor, Object data) {
-        if (children != null) {
-            for (int i = 0; i < children.length; ++i) {
-                // we know that the children here are all ApexNodes
-                AbstractApexNodeBase apexNode = (AbstractApexNodeBase) children[i];
-                apexNode.jjtAccept(visitor, data);
-            }
+        for (int i = 0; i < children.length; ++i) {
+            // we know that the children here are all ApexNodes
+            AbstractApexNodeBase apexNode = (AbstractApexNodeBase) children[i];
+            apexNode.jjtAccept(visitor, data);
         }
+
         return data;
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
@@ -19,8 +19,11 @@ public abstract class AbstractNode implements Node {
 
     private static final Logger LOG = Logger.getLogger(AbstractNode.class.getName());
 
+    private static final Node[] EMPTY_ARRAY = new Node[0];
+
     protected Node parent;
-    protected Node[] children;
+    // never null, never contains null elements
+    protected Node[] children = EMPTY_ARRAY;
     protected int childIndex;
     protected int id;
 
@@ -74,9 +77,7 @@ public abstract class AbstractNode implements Node {
 
     @Override
     public void jjtAddChild(final Node child, final int index) {
-        if (children == null) {
-            children = new Node[index + 1];
-        } else if (index >= children.length) {
+        if (index >= children.length) {
             final Node[] newChildren = new Node[index + 1];
             System.arraycopy(children, 0, newChildren, 0, children.length);
             children = newChildren;
@@ -102,7 +103,7 @@ public abstract class AbstractNode implements Node {
 
     @Override
     public int jjtGetNumChildren() {
-        return children == null ? 0 : children.length;
+        return children.length;
     }
 
     @Override
@@ -137,7 +138,7 @@ public abstract class AbstractNode implements Node {
     @Override
     public int getBeginColumn() {
         if (beginColumn == -1) {
-            if (children != null && children.length > 0) {
+            if (children.length > 0) {
                 return children[0].getBeginColumn();
             } else {
                 throw new RuntimeException("Unable to determine beginning line of Node.");

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/Node.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/Node.java
@@ -82,6 +82,8 @@ public interface Node {
      * This method returns a child node. The children are numbered from zero, left to right.
      *
      * @param index the child index. Must be nonnegative and less than {@link #jjtGetNumChildren}.
+     *
+     * @throws IndexOutOfBoundsException If the index is less than zero or greater or equal to {@link #jjtGetNumChildren()}
      */
     Node jjtGetChild(int index);
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractJavaNode.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractJavaNode.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.java.ast;
 
 import net.sourceforge.pmd.lang.ast.AbstractNode;
+import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.symboltable.Scope;
 
 public abstract class AbstractJavaNode extends AbstractNode implements JavaNode {
@@ -32,7 +33,7 @@ public abstract class AbstractJavaNode extends AbstractNode implements JavaNode 
 
     @Override
     public void jjtClose() {
-        if (beginLine == -1 && (children == null || children.length == 0)) {
+        if (beginLine == -1 && children.length == 0) {
             beginColumn = parser.token.beginColumn;
         }
         if (beginLine == -1) {
@@ -62,22 +63,20 @@ public abstract class AbstractJavaNode extends AbstractNode implements JavaNode 
      */
     @Override
     public Object childrenAccept(JavaParserVisitor visitor, Object data) {
-        if (children != null) {
-            for (int i = 0; i < children.length; ++i) {
-                ((JavaNode) children[i]).jjtAccept(visitor, data);
-            }
+        for (Node child : children) {
+            ((JavaNode) child).jjtAccept(visitor, data);
         }
+
         return data;
     }
 
 
     @Override
     public <T> void childrenAccept(SideEffectingVisitor<T> visitor, T data) {
-        if (children != null) {
-            for (int i = 0; i < children.length; i++) {
-                ((JavaNode) children[i]).jjtAccept(visitor, data);
-            }
+        for (Node child : children) {
+            ((JavaNode) child).jjtAccept(visitor, data);
         }
+
     }
 
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/AbstractEcmascriptNode.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/AbstractEcmascriptNode.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.ecmascript.ast;
 import org.mozilla.javascript.ast.AstNode;
 
 import net.sourceforge.pmd.lang.ast.AbstractNode;
+import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.ast.SourceCodePositioner;
 
 public abstract class AbstractEcmascriptNode<T extends AstNode> extends AbstractNode implements EcmascriptNode<T> {
@@ -46,14 +47,12 @@ public abstract class AbstractEcmascriptNode<T extends AstNode> extends Abstract
      */
     @Override
     public Object childrenAccept(EcmascriptParserVisitor visitor, Object data) {
-        if (children != null) {
-            for (int i = 0; i < children.length; ++i) {
-                // we know that the children here
-                // are all EcmascriptNodes
-                @SuppressWarnings("unchecked")
-                EcmascriptNode<T> ecmascriptNode = (EcmascriptNode<T>) children[i];
-                ecmascriptNode.jjtAccept(visitor, data);
-            }
+        for (Node child : children) {
+            // we know that the children here
+            // are all EcmascriptNodes
+            @SuppressWarnings("unchecked")
+            EcmascriptNode<T> ecmascriptNode = (EcmascriptNode<T>) child;
+            ecmascriptNode.jjtAccept(visitor, data);
         }
         return data;
     }

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/AbstractJspNode.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/AbstractJspNode.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.jsp.ast;
 
 import net.sourceforge.pmd.lang.ast.AbstractNode;
+import net.sourceforge.pmd.lang.ast.Node;
 
 public class AbstractJspNode extends AbstractNode implements JspNode {
 
@@ -29,7 +30,7 @@ public class AbstractJspNode extends AbstractNode implements JspNode {
 
     @Override
     public void jjtClose() {
-        if (beginLine == -1 && (children == null || children.length == 0)) {
+        if (beginLine == -1 && children.length == 0) {
             beginColumn = parser.token.beginColumn;
         }
         if (beginLine == -1) {
@@ -52,11 +53,10 @@ public class AbstractJspNode extends AbstractNode implements JspNode {
      */
     @Override
     public Object childrenAccept(JspParserVisitor visitor, Object data) {
-        if (children != null) {
-            for (int i = 0; i < children.length; ++i) {
-                ((JspNode) children[i]).jjtAccept(visitor, data);
-            }
+        for (Node child : children) {
+            ((JspNode) child).jjtAccept(visitor, data);
         }
+
         return data;
     }
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/AbstractPLSQLNode.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/AbstractPLSQLNode.java
@@ -7,6 +7,7 @@
 
 package net.sourceforge.pmd.lang.plsql.ast;
 
+import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.symboltable.Scope;
 
 public abstract class AbstractPLSQLNode extends net.sourceforge.pmd.lang.ast.AbstractNode implements PLSQLNode {
@@ -33,7 +34,7 @@ public abstract class AbstractPLSQLNode extends net.sourceforge.pmd.lang.ast.Abs
 
     @Override
     public void jjtClose() {
-        if (beginLine == -1 && (children == null || children.length == 0)) {
+        if (beginLine == -1 && children.length == 0) {
             beginColumn = parser.token.beginColumn;
         }
         if (beginLine == -1) {
@@ -92,12 +93,10 @@ public abstract class AbstractPLSQLNode extends net.sourceforge.pmd.lang.ast.Abs
 
     public void dump(String prefix) {
         System.out.println(toString(prefix));
-        if (children != null) {
-            for (int i = 0; i < children.length; ++i) {
-                AbstractPLSQLNode n = (AbstractPLSQLNode) children[i];
-                if (n != null) {
-                    n.dump(prefix + " ");
-                }
+        for (Node child : children) {
+            AbstractPLSQLNode n = (AbstractPLSQLNode) child;
+            if (n != null) {
+                n.dump(prefix + " ");
             }
         }
     }

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/ast/AbstractVFNode.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/ast/AbstractVFNode.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.vf.ast;
 
 import net.sourceforge.pmd.lang.ast.AbstractNode;
+import net.sourceforge.pmd.lang.ast.Node;
 
 public class AbstractVFNode extends AbstractNode implements VfNode {
 
@@ -29,7 +30,7 @@ public class AbstractVFNode extends AbstractNode implements VfNode {
 
     @Override
     public void jjtClose() {
-        if (beginLine == -1 && (children == null || children.length == 0)) {
+        if (beginLine == -1 && children.length == 0) {
             beginColumn = parser.token.beginColumn;
         }
         if (beginLine == -1) {
@@ -53,8 +54,8 @@ public class AbstractVFNode extends AbstractNode implements VfNode {
     @Override
     public Object childrenAccept(VfParserVisitor visitor, Object data) {
         if (children != null) {
-            for (int i = 0; i < children.length; ++i) {
-                ((VfNode) children[i]).jjtAccept(visitor, data);
+            for (Node child : children) {
+                ((VfNode) child).jjtAccept(visitor, data);
             }
         }
         return data;

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/ast/AbstractVmNode.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/ast/AbstractVmNode.java
@@ -26,6 +26,7 @@ import java.io.Writer;
 import org.apache.commons.lang3.text.StrBuilder;
 
 import net.sourceforge.pmd.lang.ast.AbstractNode;
+import net.sourceforge.pmd.lang.ast.Node;
 
 /**
  *
@@ -115,11 +116,10 @@ public class AbstractVmNode extends AbstractNode implements VmNode {
 
     @Override
     public Object childrenAccept(final VmParserVisitor visitor, final Object data) {
-        if (children != null) {
-            for (int i = 0; i < children.length; ++i) {
-                ((VmNode) children[i]).jjtAccept(visitor, data);
-            }
+        for (Node child : children) {
+            ((VmNode) child).jjtAccept(visitor, data);
         }
+
         return data;
     }
 
@@ -155,9 +155,9 @@ public class AbstractVmNode extends AbstractNode implements VmNode {
     public void dump(final String prefix, final boolean recurse, final Writer writer) {
         final PrintWriter printWriter = writer instanceof PrintWriter ? (PrintWriter) writer : new PrintWriter(writer);
         printWriter.println(toString(prefix));
-        if (children != null && recurse) {
-            for (int i = 0; i < children.length; ++i) {
-                final AbstractVmNode n = (AbstractVmNode) children[i];
+        if (recurse) {
+            for (Node child : children) {
+                final AbstractVmNode n = (AbstractVmNode) child;
                 if (n != null) {
                     n.dump(prefix + " ", recurse, printWriter);
                 }


### PR DESCRIPTION
* This PR is for PMD 7.
* It's extracted from #1759 

Changes:
* The children array in AbstractNode is now initialized with an empty array.
* This means, it is now never null, thus the null checks can be removed.
* The only change to the children array is, when adding a new child (`jjtAddChild`), or removing a child (`removeChildAtIndex`).

Future:
* the children array is protected. This means, sub classes could assign null to it... do we really need field available in subclasses? I'd assume, the already available methods are enough. -> this is something for defining a general AST API (which methods should be package private only, as they are only used by the parser, which methods define the API, when do we implement iterator, etc..)

