### PR TITLE
pmd-lang-test: Improvement to check node position

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
@@ -231,6 +231,8 @@ public abstract class AbstractNode implements Node {
 
     public void jjtSetFirstToken(final GenericToken token) {
         this.firstToken = token;
+        this.beginLine = token.getBeginLine();
+        this.beginColumn = token.getBeginColumn();
     }
 
     public GenericToken jjtGetLastToken() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchLabeledBlock.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchLabeledBlock.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import net.sourceforge.pmd.lang.ast.AbstractNode;
+
 public class ASTSwitchLabeledBlock extends AbstractJavaNode implements ASTSwitchLabeledRule {
 
     ASTSwitchLabeledBlock(int id) {
@@ -17,5 +19,14 @@ public class ASTSwitchLabeledBlock extends AbstractJavaNode implements ASTSwitch
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
+    }
+
+    @Override
+    public void jjtClose() {
+        super.jjtClose();
+        if (jjtGetNumChildren() > 0) {
+            AbstractNode firstChild = (AbstractNode) jjtGetChild(0);
+            jjtSetFirstToken(firstChild.jjtGetFirstToken());
+        }
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchLabeledExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchLabeledExpression.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import net.sourceforge.pmd.lang.ast.AbstractNode;
+
 public class ASTSwitchLabeledExpression extends AbstractJavaNode implements ASTSwitchLabeledRule {
 
     ASTSwitchLabeledExpression(int id) {
@@ -17,5 +19,14 @@ public class ASTSwitchLabeledExpression extends AbstractJavaNode implements ASTS
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
+    }
+
+    @Override
+    public void jjtClose() {
+        super.jjtClose();
+        if (jjtGetNumChildren() > 0) {
+            AbstractNode firstChild = (AbstractNode) jjtGetChild(0);
+            jjtSetFirstToken(firstChild.jjtGetFirstToken());
+        }
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchLabeledThrowStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchLabeledThrowStatement.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import net.sourceforge.pmd.lang.ast.AbstractNode;
+
 public class ASTSwitchLabeledThrowStatement extends AbstractJavaNode implements ASTSwitchLabeledRule {
 
     ASTSwitchLabeledThrowStatement(int id) {
@@ -17,5 +19,14 @@ public class ASTSwitchLabeledThrowStatement extends AbstractJavaNode implements 
     @Override
     public Object jjtAccept(JavaParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
+    }
+
+    @Override
+    public void jjtClose() {
+        super.jjtClose();
+        if (jjtGetNumChildren() > 0) {
+            AbstractNode firstChild = (AbstractNode) jjtGetChild(0);
+            jjtSetFirstToken(firstChild.jjtGetFirstToken());
+        }
     }
 }

--- a/pmd-lang-test/pom.xml
+++ b/pmd-lang-test/pom.xml
@@ -129,13 +129,5 @@
             <version>2.0.1</version>
             <scope>compile</scope>
         </dependency>
-
-        <!-- Use pmd-java for tests -->
-        <dependency>
-            <groupId>net.sourceforge.pmd</groupId>
-            <artifactId>pmd-java</artifactId>
-            <version>6.12.0</version>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 </project>

--- a/pmd-lang-test/pom.xml
+++ b/pmd-lang-test/pom.xml
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>com.github.oowekyala.treeutils</groupId>
             <artifactId>tree-matchers</artifactId>
-            <version>2.0.1</version>
+            <version>2.0.2</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/AstMatcherDslAdapter.kt
+++ b/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/AstMatcherDslAdapter.kt
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.ast.test
 
+import com.github.oowekyala.treeutils.DoublyLinkedTreeLikeAdapter
 import com.github.oowekyala.treeutils.TreeLikeAdapter
 import com.github.oowekyala.treeutils.matchers.MatchingConfig
 import com.github.oowekyala.treeutils.matchers.TreeNodeWrapper
@@ -12,10 +13,12 @@ import com.github.oowekyala.treeutils.printers.KotlintestBeanTreePrinter
 import net.sourceforge.pmd.lang.ast.Node
 
 /** An adapter for [baseShouldMatchSubtree]. */
-object NodeTreeLikeAdapter : TreeLikeAdapter<Node> {
+object NodeTreeLikeAdapter : DoublyLinkedTreeLikeAdapter<Node> {
     override fun getChildren(node: Node): List<Node> = node.findChildrenOfType(Node::class.java)
 
     override fun nodeName(type: Class<out Node>): String = type.simpleName.removePrefix("AST")
+
+    override fun getParent(node: Node): Node? = node.parent
 }
 
 /** A subtree matcher written in the DSL documented on [TreeNodeWrapper]. */
@@ -24,9 +27,11 @@ typealias NodeSpec<N> = TreeNodeWrapper<Node, N>.() -> Unit
 /** A function feedable to [io.kotlintest.should], which fails the test if an [AssertionError] is thrown. */
 typealias Assertions<M> = (M) -> Unit
 
+val DefaultMatchingConfig = MatchingConfig(adapter = NodeTreeLikeAdapter, errorPrinter = KotlintestBeanTreePrinter(NodeTreeLikeAdapter))
+
 /** A shorthand for [baseShouldMatchSubtree] providing the [NodeTreeLikeAdapter]. */
 inline fun <reified N : Node> Node?.shouldMatchNode(ignoreChildren: Boolean = false, noinline nodeSpec: NodeSpec<N>) {
-    this.baseShouldMatchSubtree(MatchingConfig(adapter = NodeTreeLikeAdapter, errorPrinter = KotlintestBeanTreePrinter(NodeTreeLikeAdapter)), ignoreChildren, nodeSpec)
+    this.baseShouldMatchSubtree(DefaultMatchingConfig, ignoreChildren, nodeSpec)
 }
 
 /**

--- a/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/AstMatcherDslAdapter.kt
+++ b/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/AstMatcherDslAdapter.kt
@@ -5,7 +5,6 @@
 package net.sourceforge.pmd.lang.ast.test
 
 import com.github.oowekyala.treeutils.DoublyLinkedTreeLikeAdapter
-import com.github.oowekyala.treeutils.TreeLikeAdapter
 import com.github.oowekyala.treeutils.matchers.MatchingConfig
 import com.github.oowekyala.treeutils.matchers.TreeNodeWrapper
 import com.github.oowekyala.treeutils.matchers.baseShouldMatchSubtree
@@ -27,7 +26,11 @@ typealias NodeSpec<N> = TreeNodeWrapper<Node, N>.() -> Unit
 /** A function feedable to [io.kotlintest.should], which fails the test if an [AssertionError] is thrown. */
 typealias Assertions<M> = (M) -> Unit
 
-val DefaultMatchingConfig = MatchingConfig(adapter = NodeTreeLikeAdapter, errorPrinter = KotlintestBeanTreePrinter(NodeTreeLikeAdapter))
+val DefaultMatchingConfig = MatchingConfig(
+        adapter = NodeTreeLikeAdapter,
+        errorPrinter = KotlintestBeanTreePrinter(NodeTreeLikeAdapter),
+        implicitAssertions = { it.assertTextRangeIsOk() }
+)
 
 /** A shorthand for [baseShouldMatchSubtree] providing the [NodeTreeLikeAdapter]. */
 inline fun <reified N : Node> Node?.shouldMatchNode(ignoreChildren: Boolean = false, noinline nodeSpec: NodeSpec<N>) {

--- a/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/NodeExtensions.kt
+++ b/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/NodeExtensions.kt
@@ -43,17 +43,19 @@ val Node.endPosition: TextPosition
 fun Node.assertTextRangeIsOk() {
 
     // they're defined
-    assert(beginLine >= 0)
-    assert(endLine >= 0)
-    assert(beginColumn >= 0)
-    assert(endColumn >= 0)
+    assert(beginLine >= 0) { "Begin line is not set" }
+    assert(endLine >= 0) { "End line is not set" }
+    assert(beginColumn >= 0) { "Begin column is not set" }
+    assert(endColumn >= 0) { "End column is not set" }
 
     // they're in the right order
     textRange.assertOrdered()
 
     val parent = parent ?: return
 
-    assert(textRange in parent.textRange)
+    assert(textRange in parent.textRange) {
+        "The text range is not a subrange of that of the parent"
+    }
 }
 
 

--- a/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/NodeExtensions.kt
+++ b/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/NodeExtensions.kt
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.ast.test
 
 import net.sourceforge.pmd.lang.ast.Node
+import java.util.*
 
 
 /** Extension methods to make the Node API more Kotlin-like */
@@ -29,3 +30,56 @@ fun Node.safeGetChild(i: Int): Node? = when {
     else -> null
 }
 
+val Node.textRange: TextRange
+    get() = TextRange(beginPosition, endPosition)
+
+val Node.beginPosition: TextPosition
+    get() = TextPosition(beginLine, beginColumn)
+
+val Node.endPosition: TextPosition
+    get() = TextPosition(endLine, endColumn)
+
+
+fun Node.assertTextRangeIsOk() {
+
+    // they're defined
+    assert(beginLine >= 0)
+    assert(endLine >= 0)
+    assert(beginColumn >= 0)
+    assert(endColumn >= 0)
+
+    // they're in the right order
+    textRange.assertOrdered()
+
+    val parent = parent ?: return
+
+    assert(textRange in parent.textRange)
+}
+
+
+data class TextPosition(val line: Int, val column: Int) : Comparable<TextPosition> {
+
+    override operator fun compareTo(other: TextPosition): Int = Comparator.compare(this, other)
+
+    companion object {
+        val Comparator: Comparator<TextPosition> =
+                java.util.Comparator.comparingInt<TextPosition> { o -> o.line }
+                        .thenComparingInt { o -> o.column }
+
+    }
+}
+
+data class TextRange(val beginPos: TextPosition, val endPos: TextPosition) {
+
+    fun assertOrdered() {
+        assert(beginPos <= endPos) {
+            "The begin position should be lower than the end position"
+        }
+    }
+
+    operator fun contains(position: TextPosition): Boolean = position in beginPos..endPos
+
+    /** Result makes no sense if either of those text bounds is not ordered. */
+    operator fun contains(other: TextRange): Boolean = other.beginPos in this && other.endPos in this
+
+}

--- a/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/NodeExtensions.kt
+++ b/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/NodeExtensions.kt
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.ast.test
 
+import net.sourceforge.pmd.lang.ast.AbstractNode
+import net.sourceforge.pmd.lang.ast.GenericToken
 import net.sourceforge.pmd.lang.ast.Node
 import java.util.*
 
@@ -21,6 +23,16 @@ val Node.childIndex: Int
 
 val Node.parent: Node?
     get() = this.jjtGetParent()
+
+val Node.containingFile: Node
+    get() = generateSequence(this) { it.parent }.last()
+
+
+val Node.firstToken: GenericToken
+    get() = (this as AbstractNode).jjtGetFirstToken()
+
+val Node.lastToken: GenericToken
+    get() = (this as AbstractNode).jjtGetLastToken()
 
 
 fun Node.getChild(i: Int) = jjtGetChild(i)

--- a/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/TestUtils.kt
+++ b/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/TestUtils.kt
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.ast.test
 
 import io.kotlintest.should
 import kotlin.reflect.KCallable
+import kotlin.reflect.jvm.isAccessible
 import io.kotlintest.shouldBe as ktShouldBe
 
 /**
@@ -21,6 +22,7 @@ private fun <N, V> assertWrapper(callable: KCallable<N>, right: V, asserter: (N,
     fun formatName() = "::" + callable.name.removePrefix("get").decapitalize()
 
     val value: N = try {
+        callable.isAccessible = true
         callable.call()
     } catch (e: Exception) {
         throw RuntimeException("Couldn't fetch value for property ${formatName()}", e)

--- a/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/TestUtils.kt
+++ b/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/TestUtils.kt
@@ -52,4 +52,3 @@ private fun <N, V> assertWrapper(callable: KCallable<N>, right: V, asserter: (N,
 infix fun <N, V : N> KCallable<N>.shouldBe(expected: V?) = this.shouldEqual(expected)
 
 infix fun <T> KCallable<T>.shouldMatch(expected: T.() -> Unit) = assertWrapper(this, expected) { n, v -> n should v }
-


### PR DESCRIPTION
* This PR is for PMD 7
* It's extracted from #1759 

Changes:
* adds the new `assertTextRangeIsOk`, that is executed on every node in the kotlin-based tests
* this ensures, that the position of the nodes in the AST is the same as they appear in the source code
* For the new switch labeled rules, we have the following grammar

```
void SwitchStatement():
{}
{
  "switch" "(" Expression() ")" SwitchBlock()
}

void SwitchBlock() #void :
{}
{
    "{"
        (
            SwitchLabel()
            (
                "->" SwitchLabeledRulePart() (SwitchLabeledRule())*
            |
                ":" (LOOKAHEAD(2) SwitchLabel() ":")* (BlockStatement())* (SwitchLabeledStatementGroup())*
            )
        )?
    "}"
}

void SwitchLabeledRulePart() #void:
{checkForSwitchRules();}
{
    (
        ( Expression() ";" ) #SwitchLabeledExpression(2)
      |
        ( Block() ) #SwitchLabeledBlock(2)
      |
        ( ThrowStatement() ) #SwitchLabeledThrowStatement(2)
    )
}
```

`#SwitchLabeledBlock(2)` takes the last two nodes (SwitchLabel + Block) and adds them as SwitchLabeledBlock to SwitchStatement. JavaCC sets the first token of SwitchLabeledBlock to be the Block node, but it should be the SwitchLabel node.

This is fixed in the `jjtClose` methods in the three related SwitchLabeled* nodes.

On the expression grammar PR, there is a better solution (you can mark the nodes via the interface `LeftRecursiveNode`).

* So, this actually fixes a bug, that is present in PMD 6.