### PR TITLE
[core] Support NoAttribute for XPath

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/AttributeAxisIterator.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/AttributeAxisIterator.java
@@ -96,7 +96,7 @@ public class AttributeAxisIterator implements Iterator<Attribute> {
             Class declaration = method.getDeclaringClass();
             return annotation == NoAttrScope.ALL
                 || annotation == NoAttrScope.INHERITED
-                && declaration != nodeClass
+                && !declaration.equals(nodeClass)
                 && declaration != Node.class
                 && declaration != AbstractNode.class;
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/AttributeAxisIterator.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/AttributeAxisIterator.java
@@ -103,7 +103,7 @@ public class AttributeAxisIterator implements Iterator<Attribute> {
 
         if (localAnnot == null) {
             return false;
-        } else if (declaration != nodeClass) {
+        } else if (!declaration.equals(nodeClass)) {
             // then the node suppressed the attributes of its parent
             return localAnnot.scope() == NoAttrScope.INHERITED;
         } else {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/NoAttribute.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/NoAttribute.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -18,7 +18,7 @@ import net.sourceforge.pmd.lang.ast.Node;
  * @author Clément Fournier
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target( {ElementType.METHOD, ElementType.TYPE})
+@Target({ElementType.METHOD, ElementType.TYPE})
 public @interface NoAttribute {
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/NoAttribute.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/NoAttribute.java
@@ -1,0 +1,40 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.ast.xpath;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import net.sourceforge.pmd.lang.ast.AbstractNode;
+import net.sourceforge.pmd.lang.ast.Node;
+
+/**
+ * Filters out some methods from the XPath attributes of a node.
+ *
+ * @author Clément Fournier
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target( {ElementType.METHOD, ElementType.TYPE})
+public @interface NoAttribute {
+
+    /**
+     * When applied to a type declaration, this value determines which
+     * XPath attributes are filtered out.
+     */
+    NoAttrScope scope() default NoAttrScope.ALL;
+
+
+    enum NoAttrScope {
+        /**
+         * Only attributes inherited from superclasses or superinterfaces
+         * are filtered out (except those from {@link Node} and {@link AbstractNode}).
+         */
+        INHERITED,
+        /** All attributes are suppressed. */
+        ALL
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/NoAttribute.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/NoAttribute.java
@@ -23,7 +23,9 @@ public @interface NoAttribute {
 
     /**
      * When applied to a type declaration, this value determines which
-     * XPath attributes are filtered out.
+     * XPath attributes are filtered out. When applied to an attribute
+     * accessor this value has no effect and the annotation suppresses
+     * the attribute in any case.
      */
     NoAttrScope scope() default NoAttrScope.ALL;
 
@@ -32,9 +34,18 @@ public @interface NoAttribute {
         /**
          * Only attributes inherited from superclasses or superinterfaces
          * are filtered out (except those from {@link Node} and {@link AbstractNode}).
+         * Attributes defined here, or overridden, are kept. Attributes can
+         * be suppressed individually with a {@link NoAttribute} on their
+         * accessor.
          */
         INHERITED,
-        /** All attributes are suppressed. */
+        /**
+         * All attributes are suppressed, except those from {@link Node}
+         * and {@link AbstractNode}. This extends {@link #INHERITED} to
+         * the attributes defined in this class. Note that subclasses of
+         * the current class also will see those attributes suppressed
+         * unless they override them.
+         */
         ALL
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/xpath/NoAttributeTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/xpath/NoAttributeTest.java
@@ -1,0 +1,183 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.ast.xpath;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import net.sourceforge.pmd.internal.util.IteratorUtil;
+import net.sourceforge.pmd.lang.ast.DummyNode;
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.ast.xpath.NoAttribute.NoAttrScope;
+
+/**
+ * @author Clément Fournier
+ */
+public class NoAttributeTest {
+
+
+    @Test
+    public void testNoAttrInherited() {
+        Node child = new NodeNoInherited(12);
+
+        Set<String> attrNames = IteratorUtil.toList(child.getXPathAttributesIterator()).stream().map(Attribute::getName).collect(Collectors.toSet());
+
+        assertTrue(attrNames.contains("SomeInt"));
+        assertTrue(attrNames.contains("Child"));
+        // from Node
+        assertTrue(attrNames.contains("BeginLine"));
+
+        assertFalse(attrNames.contains("SomeLong"));
+        assertFalse(attrNames.contains("Image"));
+        assertFalse(attrNames.contains("SomeName"));
+    }
+
+
+    @Test
+    public void testNoAttrAll() {
+
+        assertTrue(0 < IteratorUtil.count(new NodeAllAttr(12).getXPathAttributesIterator()));
+
+        NodeNoAttrAll child = new NodeNoAttrAll(12);
+        Set<String> attrNames = IteratorUtil.toList(child.getXPathAttributesIterator()).stream().map(Attribute::getName).collect(Collectors.toSet());
+
+        // from Noded, so not suppressed
+        assertTrue(attrNames.contains("Image"));
+        assertFalse(attrNames.contains("MySuppressedAttr"));
+
+    }
+
+    @Test
+    public void testNoAttrAllIsNotInherited() {
+
+        NodeNoAttrAllChild child = new NodeNoAttrAllChild(12);
+
+        Set<String> attrNames = IteratorUtil.toList(child.getXPathAttributesIterator()).stream().map(Attribute::getName).collect(Collectors.toSet());
+
+        // suppressed because the parent has NoAttribute(scope = ALL)
+        assertFalse(attrNames.contains("MySuppressedAttr"));
+        // not suppressed because defined in the class, which has no annotation
+        assertTrue(attrNames.contains("NotSuppressedAttr"));
+    }
+
+
+    private static class DummyNodeParent extends DummyNode {
+
+        public DummyNodeParent(int id) {
+            super(id);
+        }
+
+        public DummyNodeParent(int id, boolean findBoundary) {
+            super(id, findBoundary);
+        }
+
+        public String getSomeName() {
+            return "Foo";
+        }
+
+        public int getSomeInt() {
+            return 42;
+        }
+
+        public long getSomeLong() {
+            return 42;
+        }
+
+        public long getSomeLong2() {
+            return 42;
+        }
+
+
+    }
+
+    @NoAttribute(scope = NoAttrScope.INHERITED)
+    private static class NodeNoInherited extends DummyNodeParent {
+
+        public NodeNoInherited(int id) {
+            super(id);
+        }
+
+        public NodeNoInherited(int id, boolean findBoundary) {
+            super(id, findBoundary);
+        }
+
+
+        // getSomeName is inherited and filtered out by NoAttrScope.INHERITED
+        // getSomeInt is inherited but overridden here, so NoAttrScope.INHERITED has no effect
+        // getSomeLong is inherited and overridden here,
+        //      and even with scope INHERITED its @NoAttribute takes precedence
+
+        // isChild overrides nothing so with INHERITED it's not filtered out
+
+
+        @Override
+        public int getSomeInt() {
+            return 43;
+        }
+
+        @NoAttribute // Notice
+        @Override
+        public long getSomeLong() {
+            return 43;
+        }
+
+
+        @NoAttribute(scope = NoAttrScope.INHERITED)
+        @Override
+        public String getImage() {
+            return super.getImage();
+        }
+
+        public boolean isChild() {
+            return true;
+        }
+
+
+    }
+
+    private static class NodeAllAttr extends DummyNodeParent {
+
+        public NodeAllAttr(int id) {
+            super(id);
+        }
+    }
+
+    @NoAttribute(scope = NoAttrScope.ALL)
+    private static class NodeNoAttrAll extends DummyNodeParent {
+
+
+        public NodeNoAttrAll(int id) {
+            super(id);
+        }
+
+        public int getMySuppressedAttr() {
+            return 12;
+        }
+
+    }
+
+
+    private static class NodeNoAttrAllChild extends NodeNoAttrAll {
+
+
+        public NodeNoAttrAllChild(int id) {
+            super(id);
+        }
+
+        public int getNotSuppressedAttr() {
+            return 12;
+        }
+
+
+    }
+
+
+}

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/xpath/NoAttributeTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/xpath/NoAttributeTest.java
@@ -4,7 +4,6 @@
 
 package net.sourceforge.pmd.lang.ast.xpath;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -71,11 +70,11 @@ public class NoAttributeTest {
 
     private static class DummyNodeParent extends DummyNode {
 
-        public DummyNodeParent(int id) {
+        DummyNodeParent(int id) {
             super(id);
         }
 
-        public DummyNodeParent(int id, boolean findBoundary) {
+        DummyNodeParent(int id, boolean findBoundary) {
             super(id, findBoundary);
         }
 
@@ -101,14 +100,9 @@ public class NoAttributeTest {
     @NoAttribute(scope = NoAttrScope.INHERITED)
     private static class NodeNoInherited extends DummyNodeParent {
 
-        public NodeNoInherited(int id) {
+        NodeNoInherited(int id) {
             super(id);
         }
-
-        public NodeNoInherited(int id, boolean findBoundary) {
-            super(id, findBoundary);
-        }
-
 
         // getSomeName is inherited and filtered out by NoAttrScope.INHERITED
         // getSomeInt is inherited but overridden here, so NoAttrScope.INHERITED has no effect
@@ -145,7 +139,7 @@ public class NoAttributeTest {
 
     private static class NodeAllAttr extends DummyNodeParent {
 
-        public NodeAllAttr(int id) {
+        NodeAllAttr(int id) {
             super(id);
         }
     }
@@ -154,7 +148,7 @@ public class NoAttributeTest {
     private static class NodeNoAttrAll extends DummyNodeParent {
 
 
-        public NodeNoAttrAll(int id) {
+        NodeNoAttrAll(int id) {
             super(id);
         }
 
@@ -168,7 +162,7 @@ public class NoAttributeTest {
     private static class NodeNoAttrAllChild extends NodeNoAttrAll {
 
 
-        public NodeNoAttrAllChild(int id) {
+        NodeNoAttrAllChild(int id) {
             super(id);
         }
 


### PR DESCRIPTION
* This PR is for PMD 7.
* It's extracted from #1759 

Changes:
* Adds the `@net.sourceforge.pmd.lang.ast.xpath.NoAttribute` annotation
* With that, you can annotate getters in AST nodes, that should not be exposed as XPath attributes and thus cannot be used for xpath expressions/queries.
* The annotation can also be applied to the whole AST class - then all methods are not exposed.

Todo:
* This feature needs to be documented somewhere... it seems to be part of the AST API -> https://github.com/pmd/pmd/wiki/PMD-7.0.0-API
* We need to add a unit test
