### PR TITLE
[core] Remove default implementation of getXPathNodeName

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
@@ -83,6 +83,7 @@ public abstract class AbstractNode implements Node {
         }
         children[index] = child;
         child.jjtSetChildIndex(index);
+        child.jjtSetParent(this);
     }
 
     @Override

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
@@ -5,19 +5,15 @@
 package net.sourceforge.pmd.lang.ast;
 
 import java.util.Objects;
-import java.util.logging.Logger;
 
 import org.apache.commons.lang3.ArrayUtils;
 
-import net.sourceforge.pmd.PMDVersion;
 import net.sourceforge.pmd.lang.dfa.DataFlowNode;
 
 /**
  * Base class for all implementations of the Node interface.
  */
 public abstract class AbstractNode implements Node {
-
-    private static final Logger LOG = Logger.getLogger(AbstractNode.class.getName());
 
     protected Node parent;
     protected Node[] children;
@@ -266,21 +262,8 @@ public abstract class AbstractNode implements Node {
         }
     }
 
-    /**
-     * {@inheritDoc}
-     * <p>
-     * <p>This default implementation adds compatibility with the previous
-     * way to get the xpath node name, which used {@link Object#toString()}.
-     * <p>
-     * <p>Please override it. It may be removed in a future major version.
-     */
     @Override
-    // @Deprecated // FUTURE 7.0.0 make abstract
-    public String getXPathNodeName() {
-        LOG.warning("getXPathNodeName should be overriden in classes derived from AbstractNode. "
-            + "The implementation is provided for compatibility with existing implementors,"
-            + "but could be declared abstract as soon as release " + PMDVersion.getNextMajorRelease()
-            + ".");
-        return toString();
+    public String toString() {
+        return getXPathNodeName();
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
@@ -236,6 +236,8 @@ public abstract class AbstractNode implements Node {
 
     public void jjtSetLastToken(final GenericToken token) {
         this.lastToken = token;
+        this.endLine = token.getEndLine();
+        this.endColumn = token.getEndColumn();
     }
 
     @Override

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/CommentTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/CommentTest.java
@@ -100,6 +100,10 @@ public class CommentTest {
         Token t = new Token();
         t.image = comment;
         Comment node = new Comment(t) {
+            @Override
+            public String getXPathNodeName() {
+                return "DummyComment";
+            }
         };
         return node.getFilteredComment();
     }


### PR DESCRIPTION
* This PR is for PMD 7
* It's extracted from #1759 

Changes:
* Ensures that a node has it's parent, when it is added as a child.
* Makes `getXPathNodeName()` abstract by removing the default implementation.

Todo:
* The default implementation of this method issued a warning. We have it mentioned in `next_major_development.md`, the we will remove it (under 6.1.0). Should we add it again (under 7.0.0?) that it has been removed?
