### PR TITLE
[core] Add checker-qual dependency

### DIFF
--- a/pmd-core/pom.xml
+++ b/pmd-core/pom.xml
@@ -143,6 +143,12 @@
             <version>2.8.5</version>
         </dependency>
 
+        <dependency>
+            <groupId>org.checkerframework</groupId>
+            <artifactId>checker-qual</artifactId>
+            <version>2.5.2</version>
+        </dependency>
+
 
         <dependency>
             <groupId>net.sourceforge.saxon</groupId>


### PR DESCRIPTION
* This PR is for PMD 7
* It's extracted from #1759 

This only adds the dependency (compile time), and does not make use of it yet.
I've added a section in the wiki: https://github.com/pmd/pmd/wiki/PMD-7.0.0-API
We'll need to flesh out the details over time and verify our APIs, that we have properly annotated them (if we all agree, that we use `@Nullable`).
