### PR TITLE
[dart] [cpd] Improved string tokenization

### DIFF
--- a/pmd-dart/src/main/antlr4/net/sourceforge/pmd/lang/dart/antlr4/Dart2.g4
+++ b/pmd-dart/src/main/antlr4/net/sourceforge/pmd/lang/dart/antlr4/Dart2.g4
@@ -340,58 +340,49 @@ booleanLiteral
   | 'false'
   ;
 
-//stringLiteral: (MultilineString | SingleLineString)+;
-stringLiteral: SingleLineString;
-//stringLiteral: SingleLineString;
+stringLiteral: (MultiLineString | SingleLineString)+;
+
 SingleLineString
-  : '"' (~[\\"] | '\\\\' | ESCAPE_SEQUENCE | '\\"')* '"'
-  | '\'' (~[\\'] | '\\\\' | ESCAPE_SEQUENCE | '\\\'')* '\''
-//  | 'r\'' (~('\'' | NEWLINE))* '\'' // TODO
-//  | 'r"' (~('\'' | NEWLINE))* '"'
+  : '"' StringContentDQ* '"'
+  | '\'' StringContentSQ* '\''
+  | 'r\'' (~('\'' | '\n' | '\r'))* '\''
+  | 'r"' (~('"' | '\n' | '\r'))* '"'
   ;
 
-//MultilineString
-//  : '"""' StringContentTDQ* '"""'
-//  | '\'\'\'' StringContentTDQ* '\'\'\''
-//  | 'r"""' (~'"""')* '"""' // TODO
-//  | 'r\'\'\'' (~'\'\'\'')* '\'\'\''
-//  ;
-//StringContentSQ: .;// TODO
-//StringContentTDQ: .;// TODO
 fragment
-ESCAPE_SEQUENCE
-  : '\\n'
-  | '\\r'
-  | '\\f'
-  | '\\b'
-  | '\\t'
-  | '\\v'
-  | '\\x' HEX_DIGIT HEX_DIGIT
-  | '\\u' HEX_DIGIT HEX_DIGIT HEX_DIGIT HEX_DIGIT
-  | '\\u{' HEX_DIGIT_SEQUENCE '}'
-  | '\\$'
+StringContentDQ
+  : ~('\\' | '"' /*| '$'*/ | '\n' | '\r')
+  | '\\' ~('\n' | '\r')
+  //| stringInterpolation
   ;
+
 fragment
-HEX_DIGIT_SEQUENCE
-  : HEX_DIGIT HEX_DIGIT? HEX_DIGIT?
-    HEX_DIGIT? HEX_DIGIT? HEX_DIGIT?
+StringContentSQ
+  : ~('\\' | '\'' /*| '$'*/ | '\n' | '\r')
+  | '\\' ~('\n' | '\r')
+  //| stringInterpolation
   ;
-/*TODO
-<stringContentDQ> ::= \~{}( `\\' | `"' | `$' | <NEWLINE> )
-  \alt `\\' \~{}( <NEWLINE> )
-  \alt <stringInterpolation>
 
-<stringContentSQ> ::= \~{}( `\\' | `\'' | `$' | <NEWLINE> )
-  \alt `\\' \~{}( <NEWLINE> )
-  \alt <stringInterpolation>
-<stringContentTDQ> ::= \~{}( `\\' | `"""' | `$')
-  \alt `\\' \~{}( <NEWLINE> )
-  \alt <stringInterpolation>
+MultiLineString
+  : '"""' StringContentTDQ* '"""'
+  | '\'\'\'' StringContentTSQ* '\'\'\''
+  | 'r"""' (~'"' | '"' ~'"' | '""' ~'"')* '"""'
+  | 'r\'\'\'' (~'\'' | '\'' ~'\'' | '\'\'' ~'\'')* '\'\'\''
+  ;
 
-<stringContentTSQ> ::= \~{}( `\\' | `\'\'\'' | `$')
-  \alt `\\' \~{}( <NEWLINE> )
-  \alt <stringInterpolation>
-*/
+fragment
+StringContentTDQ
+  : ~('\\' | '"' /*| '$'*/)
+  | '"' ~'"' | '""' ~'"'
+  //| stringInterpolation
+  ;
+
+fragment StringContentTSQ
+  : ~('\\' | '\'' /*| '$'*/)
+  | '\'' ~'\'' | '\'\'' ~'\''
+  //| stringInterpolation
+  ;
+
 NEWLINE
   : '\n'
   | '\r'

--- a/pmd-dart/src/test/java/net/sourceforge/pmd/cpd/DartTokenizerTest.java
+++ b/pmd-dart/src/test/java/net/sourceforge/pmd/cpd/DartTokenizerTest.java
@@ -35,7 +35,11 @@ public class DartTokenizerTest extends AbstractTokenizerTest {
                 new Object[] { "escaped_backslash.dart", 14 },
                 new Object[] { "escaped_string.dart", 17 },
                 new Object[] { "increment.dart", 185 },
-                new Object[] { "imports.dart", 1 }
+                new Object[] { "imports.dart", 1 },
+                new Object[] { "regex.dart", 13 },
+                new Object[] { "regex2.dart", 13 },
+                new Object[] { "regex3.dart", 13 },
+                new Object[] { "string_with_backslashes.dart", 9 }
         );
     }
 

--- a/pmd-dart/src/test/resources/net/sourceforge/pmd/cpd/regex.dart
+++ b/pmd-dart/src/test/resources/net/sourceforge/pmd/cpd/regex.dart
@@ -1,0 +1,3 @@
+class MyClass {
+  final regex = new RegExp(r'^--([a-zA-Z\-_0-9]+)(=(.*))?$');
+}

--- a/pmd-dart/src/test/resources/net/sourceforge/pmd/cpd/regex2.dart
+++ b/pmd-dart/src/test/resources/net/sourceforge/pmd/cpd/regex2.dart
@@ -1,0 +1,3 @@
+class MyClass {
+  final regex = new RegExp(r"(^[a-zA-Z][-+.a-zA-Z\d]*://|[^/])$");
+}

--- a/pmd-dart/src/test/resources/net/sourceforge/pmd/cpd/regex3.dart
+++ b/pmd-dart/src/test/resources/net/sourceforge/pmd/cpd/regex3.dart
@@ -1,0 +1,3 @@
+class MyClass {
+  final regex = new RegExp(r'''[ \t\r\n"'\\/]''');
+}

--- a/pmd-dart/src/test/resources/net/sourceforge/pmd/cpd/string_with_backslashes.dart
+++ b/pmd-dart/src/test/resources/net/sourceforge/pmd/cpd/string_with_backslashes.dart
@@ -1,0 +1,3 @@
+class MyClass {
+  final stringWithBackslashes = "Escaping\ spaces\ should work";
+}


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
This is yet another improvement on the Dart grammar for CPD. I found some other cases that weren't tokenized correctly. This time, the grammar is much more closely aligned to the official specification (see https://github.com/chalin/dart-spec-and-grammar/blob/master/doc/grammar-AUTOGENERATED-DO-NOT-EDIT.txt).

One aspect that is not taken into account are interpolated strings. These are strings with a $ character followed by a character in them. These could, in principle, be tokenized differently (with identifiers being separate tokens). However, this is more difficult, and it won't help too much for duplicated code analysis, since an interpolated string including all interpolated variables will typically result in the same result.