### PR TITLE
[java] Fix annotated module declaration

### DIFF
--- a/pmd-java/etc/grammar/Java.jjt
+++ b/pmd-java/etc/grammar/Java.jjt
@@ -1606,16 +1606,26 @@ ASTCompilationUnit CompilationUnit() :
 {
   [ LOOKAHEAD( ( Annotation() )* "package" ) PackageDeclaration() ( EmptyStatement() )* ]
   ( ImportDeclaration() ( EmptyStatement() )* )*
-  ( LOOKAHEAD(2) TypeDeclaration() ( EmptyStatement() )* )*
-  [ LOOKAHEAD({isKeyword("open") || isKeyword("module") || getToken(1).kind == AT}) ModuleDeclaration() ( EmptyStatement() )* ]
+  // the module decl lookahead needs to be before the type declaration branch,
+  // looking for annotations + "open" | "module" will fail faster if it's *not*
+  // a module (most common case)
+  [ LOOKAHEAD(ModuleDeclLahead()) ModuleDeclaration() ( EmptyStatement() )* ]
+  ( TypeDeclaration() ( EmptyStatement() )* )*
   ( < "\u001a" > )?
-  ( < "~[]" > )?
+  ( < "~[]" > )? // what's this for? Do you mean ( < ~[] > )*, i.e. "any character"?
   <EOF>
+  {
+     jjtThis.setComments(token_source.comments);
+     return jjtThis;
+  }
+}
+
+private void ModuleDeclLahead() #void:
+{}
 {
- jjtThis.setComments(token_source.comments);
- return jjtThis;
+  (Annotation())* LOOKAHEAD({isKeyword("open") || isKeyword("module")}) <IDENTIFIER>
 }
-}
+
 
 void PackageDeclaration() :
 {}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/JDKVersionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/JDKVersionTest.java
@@ -263,6 +263,11 @@ public class JDKVersionTest {
         parseJava9(loadSource("jdk9_module_info.java"));
     }
 
+    @Test
+    public void testAnnotatedModule() {
+        parseJava9(loadSource("jdk9_module_info_with_annot.java"));
+    }
+
     @Test(expected = ParseException.class)
     public final void jdk9TryWithResourcesInJava8() {
         parseJava18(loadSource("jdk9_try_with_resources.java"));

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/jdkversiontests/jdk9_module_info_with_annot.java
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/jdkversiontests/jdk9_module_info_with_annot.java
@@ -1,0 +1,6 @@
+/*
+ * See §7.7 Module Declarations in JLS
+ */
+@Deprecated(since = "11", forRemoval = true)
+module jdk.pack {
+}


### PR DESCRIPTION
Fixes #1842 

There's also this weird thing at the end of the CompilationUnit production:
```
( < "~[]" > )?
```

I think this is meant to allow any additionnal trailing characters, but in that case it should be written `( < ~[] > )*` (no quotes, a star). With the current grammar, an empty file with just the contents `~[]` is a valid compilation unit. 