### PR TITLE
[doc] Update ruleset filename from deprecated basic.xml to quickstart.xml

### DIFF
--- a/docs/pages/pmd/userdocs/installation.md
+++ b/docs/pages/pmd/userdocs/installation.md
@@ -79,7 +79,7 @@ Additionally, the following options, are specified most of the time even though 
   <div class="tab-content">
     <div role="tabpanel" class="tab-pane active" id="linux">
 <figure class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="gp">~ $ </span><span class="s2">cd</span> ~/bin/pmd-bin-{{site.pmd.version}}/bin
-<span class="gp">~/.../bin $ </span><span class="s2">./run.sh</span> pmd -d ../../../src/main/java/ -f text -R rulesets/java/basic.xml
+<span class="gp">~/.../bin $ </span><span class="s2">./run.sh</span> pmd -d ../../../src/main/java/ -f text -R rulesets/java/quickstart.xml
   
   .../src/main/java/com/me/RuleSet.java:123  These nested if statements could be combined
   .../src/main/java/com/me/RuleSet.java:231  Useless parentheses.
@@ -89,7 +89,7 @@ Additionally, the following options, are specified most of the time even though 
     </div>
     <div role="tabpanel" class="tab-pane" id="windows">
 <figure class="highlight"><pre><code class="language-bash" data-lang="bash"><span class="gp">C:\ &gt; </span><span class="s2">cd</span> C:\pmd-bin-{{site.pmd.version}}\bin
-<span class="gp">C:\...\bin > </span><span class="s2">.\pmd.bat</span> -d ..\..\src\main\java\ -f text -R rulesets/java/basic.xml
+<span class="gp">C:\...\bin > </span><span class="s2">.\pmd.bat</span> -d ..\..\src\main\java\ -f text -R rulesets/java/quickstart.xml
       
   .../src/main/java/com/me/RuleSet.java:123  These nested if statements could be combined
   .../src/main/java/com/me/RuleSet.java:231  Useless parentheses.


### PR DESCRIPTION
Frontpage (https://pmd.github.io/) uses ruleset quickstart.xml but https://pmd.github.io/pmd-6.16.0/pmd_userdocs_installation.html#sample-usage uses deprecated ruleset basic.xml 
(page https://pmd.github.io/pmd-6.16.0/pmd_rules_java.html shows status of both rulesets)

<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [ ] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

Fixes #1909 