### PR TITLE
[java] Exclude Autowired and Inject for MissingStaticMethodInNonInstantiatableClass

### DIFF
--- a/docs/pages/pmd/rules/java/errorprone.md
+++ b/docs/pages/pmd/rules/java/errorprone.md
@@ -2628,6 +2628,9 @@ A class that has private constructors and does not have any static methods or fi
     ./ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/ConstructorDeclaration
     and
     count(./ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/ConstructorDeclaration) = count(./ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/ConstructorDeclaration[@Private='true'])
+    and
+    not(./ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/ConstructorDeclaration/
+        ../Annotation/MarkerAnnotation/Name[pmd-java:typeIs('org.springframework.beans.factory.annotation.Autowired') or pmd-java:typeIs('javax.inject.Inject')])
   )
   and
   not(.//MethodDeclaration[@Static='true'])

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2420,6 +2420,9 @@ A class that has private constructors and does not have any static methods or fi
     ./ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/ConstructorDeclaration
     and
     count(./ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/ConstructorDeclaration) = count(./ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/ConstructorDeclaration[@Private='true'])
+    and
+    not(./ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/ConstructorDeclaration/
+        ../Annotation/MarkerAnnotation/Name[pmd-java:typeIs('org.springframework.beans.factory.annotation.Autowired') or pmd-java:typeIs('javax.inject.Inject')])
   )
   and
   not(.//MethodDeclaration[@Static='true'])

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/MissingStaticMethodInNonInstantiatableClass.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/MissingStaticMethodInNonInstantiatableClass.xml
@@ -247,4 +247,77 @@ public final class BacklogElementParameters {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#1832 Check constructor injection with @Autowired or @Inject </description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import javax.inject.Inject;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class Foo {
+
+ private String arg;
+
+ @Autowired
+ private Foo() {}
+
+ @Inject
+ private Foo(String arg) {
+    this.arg = arg;
+ }
+
+ public void bar() {}
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#1832 fine with a least one constructor annotated with "Autowired</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.annotation.PersistenceConstructor;
+
+public class Foo {
+
+ private String arg;
+
+ @PersistenceConstructor
+ private Foo() {}
+
+ @Autowired
+ private Foo(String arg) {
+    this.arg = arg;
+ }
+
+ public void bar() {}
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#1832 but fail with both private constructors annotated with @PersistenceConstructor</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import org.springframework.data.annotation.PersistenceConstructor;
+
+public class Foo {
+
+ private String arg;
+
+ @PersistenceConstructor
+ private Foo() {}
+
+ @PersistenceConstructor
+ private Foo(String arg) {
+    this.arg = arg;
+ }
+
+ public void bar() {}
+}
+     ]]></code>
+    </test-code>
+
+
 </test-data>


### PR DESCRIPTION
<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
I added exclusion from MissingStaticMethodInNonInstantiatableClass rule for private annotated constructors handled by DI framework. I also considered to add suggested @ApplicationScoped, @Dependent, @RequestScopedm but them to specific from my perspective.

And thank you for great project!


Fixes #1832 