### PR TITLE
[core] Add 'no error' return option, and assign it to the cli when the help command is invoked

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/cli/PMDCommandLineInterface.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cli/PMDCommandLineInterface.java
@@ -27,6 +27,7 @@ public final class PMDCommandLineInterface {
     public static final String NO_EXIT_AFTER_RUN = "net.sourceforge.pmd.cli.noExit";
     public static final String STATUS_CODE_PROPERTY = "net.sourceforge.pmd.cli.status";
 
+    public static final int NO_ERRORS_STATUS = 0;
     public static final int ERROR_STATUS = 1;
     public static final int VIOLATIONS_FOUND = 4;
 
@@ -41,7 +42,7 @@ public final class PMDCommandLineInterface {
             if (arguments.isHelp()) {
                 jcommander.usage();
                 System.out.println(buildUsageText(jcommander));
-                setStatusCodeOrExit(ERROR_STATUS);
+                setStatusCodeOrExit(NO_ERRORS_STATUS);
             }
         } catch (ParameterException e) {
             jcommander.usage();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDCommandLineInterface.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDCommandLineInterface.java
@@ -26,8 +26,9 @@ import com.beust.jcommander.ParameterException;
 public final class CPDCommandLineInterface {
     private static final Logger LOGGER = Logger.getLogger(CPDCommandLineInterface.class.getName());
 
-    private static final int DUPLICATE_CODE_FOUND = 4;
+    public static final int NO_ERRORS_STATUS = 0;
     private static final int ERROR_STATUS = 1;
+    private static final int DUPLICATE_CODE_FOUND = 4;
 
     public static final String NO_EXIT_AFTER_RUN = "net.sourceforge.pmd.cli.noExit";
     public static final String STATUS_CODE_PROPERTY = "net.sourceforge.pmd.cli.status";
@@ -66,7 +67,7 @@ public final class CPDCommandLineInterface {
             if (arguments.isHelp()) {
                 jcommander.usage();
                 System.out.println(buildUsageText());
-                setStatusCodeOrExit(ERROR_STATUS);
+                setStatusCodeOrExit(NO_ERRORS_STATUS);
                 return;
             }
         } catch (ParameterException e) {

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistributionIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistributionIT.java
@@ -111,8 +111,7 @@ public class BinaryDistributionIT {
         ExecutionResult result;
 
         result = CpdExecutor.runCpd(tempDir, "-h");
-
-        result.assertExecutionResult(1, "Supported languages: [apex, cpp, cs, dart, ecmascript, fortran, go, groovy, java, jsp, kotlin, lua, matlab, objectivec, perl, php, plsql, python, ruby, scala, swift, vf]");
+        result.assertExecutionResult(0, "Supported languages: [apex, cpp, cs, dart, ecmascript, fortran, go, groovy, java, jsp, kotlin, lua, matlab, objectivec, perl, php, plsql, python, ruby, scala, swift, vf]");
 
         result = CpdExecutor.runCpd(tempDir, "--minimum-tokens", "10", "--format", "text", "--files", srcDir);
         result.assertExecutionResult(4, "Found a 10 line (55 tokens) duplication in the following files:");

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistributionIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistributionIT.java
@@ -95,7 +95,7 @@ public class BinaryDistributionIT {
         ExecutionResult result;
 
         result = PMDExecutor.runPMD(tempDir, "-h");
-        result.assertExecutionResult(1, "apex, ecmascript, java, jsp, plsql, pom, vf, vm, wsdl, xml, xsl");
+        result.assertExecutionResult(0, "apex, ecmascript, java, jsp, plsql, pom, vf, vm, wsdl, xml, xsl");
 
         result = PMDExecutor.runPMDRules(tempDir, srcDir, "src/test/resources/rulesets/sample-ruleset.xml");
         result.assertExecutionResult(4, "JumbledIncrementer.java:8:");


### PR DESCRIPTION
…command is invoked.

<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

**PR Description:**

This fixes, in theory, the issue #1913 by creating a new status code in the PMDCommandLineInterface class with the value of zero, and makes the CLI return it when the help command is used.

Fixes #1913 