### PR TITLE
Change method name 'desc' to 'setDescription', 'size' to 'getNumViolations'

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/AbstractNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/AbstractNamingConventionsRule.java
@@ -41,6 +41,6 @@ abstract class AbstractNamingConventionsRule extends AbstractApexRule {
 
     protected static PropertyBuilder.RegexPropertyBuilder prop(String name, String displayName, Map<String, String> descriptorToDisplayNames) {
         descriptorToDisplayNames.put(name, displayName);
-        return regexProperty(name).desc("Regex which applies to " + displayName + " names");
+        return regexProperty(name).setDescription("Regex which applies to " + displayName + " names");
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/MethodNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/MethodNamingConventionsRule.java
@@ -29,7 +29,7 @@ public class MethodNamingConventionsRule extends AbstractNamingConventionsRule {
 
     private static final PropertyDescriptor<Boolean> SKIP_TEST_METHOD_UNDERSCORES_DESCRIPTOR
         = booleanProperty("skipTestMethodUnderscores")
-              .desc("deprecated! Skip underscores in test methods")
+              .setDescription("deprecated! Skip underscores in test methods")
               .defaultValue(false)
               .build();
     

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/VariableNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/VariableNamingConventionsRule.java
@@ -38,48 +38,48 @@ public class VariableNamingConventionsRule extends AbstractApexRule {
 
     private static final PropertyDescriptor<Boolean> CHECK_MEMBERS_DESCRIPTOR =
             booleanProperty("checkMembers")
-                .desc("Check member variables").defaultValue(true).build();
+                .setDescription("Check member variables").defaultValue(true).build();
 
     private static final PropertyDescriptor<Boolean> CHECK_LOCALS_DESCRIPTOR =
             booleanProperty("checkLocals")
-                .desc("Check local variables").defaultValue(true).build();
+                .setDescription("Check local variables").defaultValue(true).build();
 
     private static final PropertyDescriptor<Boolean> CHECK_PARAMETERS_DESCRIPTOR =
             booleanProperty("checkParameters")
-                .desc("Check constructor and method parameter variables").defaultValue(true).build();
+                .setDescription("Check constructor and method parameter variables").defaultValue(true).build();
 
     private static final PropertyDescriptor<List<String>> STATIC_PREFIXES_DESCRIPTOR =
             stringListProperty("staticPrefix")
-                    .desc("Static variable prefixes").defaultValues("").delim(',').build();
+                    .setDescription("Static variable prefixes").defaultValues("").delim(',').build();
 
     private static final PropertyDescriptor<List<String>> STATIC_SUFFIXES_DESCRIPTOR =
             stringListProperty("staticSuffix")
-                    .desc("Static variable suffixes").defaultValues("").delim(',').build();
+                    .setDescription("Static variable suffixes").defaultValues("").delim(',').build();
 
     private static final PropertyDescriptor<List<String>> MEMBER_PREFIXES_DESCRIPTOR =
             stringListProperty("memberPrefix")
-                    .desc("Member variable prefixes").defaultValues("").delim(',').build();
+                    .setDescription("Member variable prefixes").defaultValues("").delim(',').build();
 
     private static final PropertyDescriptor<List<String>> MEMBER_SUFFIXES_DESCRIPTOR =
             stringListProperty("memberSuffix")
-                    .desc("Member variable suffixes").defaultValues("").delim(',').build();
+                    .setDescription("Member variable suffixes").defaultValues("").delim(',').build();
 
     private static final PropertyDescriptor<List<String>> LOCAL_PREFIXES_DESCRIPTOR =
             stringListProperty("localPrefix")
-                    .desc("Local variable prefixes").defaultValues("").delim(',').build();
+                    .setDescription("Local variable prefixes").defaultValues("").delim(',').build();
 
     private static final PropertyDescriptor<List<String>> LOCAL_SUFFIXES_DESCRIPTOR =
             stringListProperty("localSuffix")
-                    .desc("Local variable suffixes").defaultValues("").delim(',').build();
+                    .setDescription("Local variable suffixes").defaultValues("").delim(',').build();
 
     private static final PropertyDescriptor<List<String>> PARAMETER_PREFIXES_DESCRIPTOR =
             stringListProperty("parameterPrefix")
-                    .desc("Method parameter variable prefixes")
+                    .setDescription("Method parameter variable prefixes")
                     .defaultValues("").delim(',').build();
 
     private static final PropertyDescriptor<List<String>> PARAMETER_SUFFIXES_DESCRIPTOR =
             stringListProperty("parameterSuffix")
-                    .desc("Method parameter variable suffixes")
+                    .setDescription("Method parameter variable suffixes")
                     .defaultValues("").delim(',').build();
 
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/AvoidDeeplyNestedIfStmtsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/AvoidDeeplyNestedIfStmtsRule.java
@@ -20,7 +20,7 @@ public class AvoidDeeplyNestedIfStmtsRule extends AbstractApexRule {
 
     private static final PropertyDescriptor<Integer> PROBLEM_DEPTH_DESCRIPTOR
             = PropertyFactory.intProperty("problemDepth")
-                             .desc("The if statement depth reporting threshold")
+                             .setDescription("The if statement depth reporting threshold")
                              .require(positive()).defaultValue(3).build();
 
     public AvoidDeeplyNestedIfStmtsRule() {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/CyclomaticComplexityRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/CyclomaticComplexityRule.java
@@ -30,14 +30,14 @@ public class CyclomaticComplexityRule extends AbstractApexRule {
 
     private static final PropertyDescriptor<Integer> CLASS_LEVEL_DESCRIPTOR
         = PropertyFactory.intProperty("classReportLevel")
-                         .desc("Total class complexity reporting threshold")
+                         .setDescription("Total class complexity reporting threshold")
                          .require(positive())
                          .defaultValue(40)
                          .build();
 
     private static final PropertyDescriptor<Integer> METHOD_LEVEL_DESCRIPTOR
         = PropertyFactory.intProperty("methodReportLevel")
-                         .desc("Cyclomatic complexity reporting threshold")
+                         .setDescription("Cyclomatic complexity reporting threshold")
                          .require(positive())
                          .defaultValue(10)
                          .build();

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/StdCyclomaticComplexityRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/StdCyclomaticComplexityRule.java
@@ -42,14 +42,14 @@ public class StdCyclomaticComplexityRule extends AbstractApexRule {
 
     public static final PropertyDescriptor<Integer> REPORT_LEVEL_DESCRIPTOR
             = PropertyFactory.intProperty("reportLevel")
-                             .desc("Cyclomatic Complexity reporting threshold")
+                             .setDescription("Cyclomatic Complexity reporting threshold")
                              .require(inRange(1, 30))
                              .defaultValue(10)
                              .build();
 
-    public static final PropertyDescriptor<Boolean> SHOW_CLASSES_COMPLEXITY_DESCRIPTOR = booleanProperty("showClassesComplexity").desc("Add class average violations to the report").defaultValue(true).build();
+    public static final PropertyDescriptor<Boolean> SHOW_CLASSES_COMPLEXITY_DESCRIPTOR = booleanProperty("showClassesComplexity").setDescription("Add class average violations to the report").defaultValue(true).build();
 
-    public static final PropertyDescriptor<Boolean> SHOW_METHODS_COMPLEXITY_DESCRIPTOR = booleanProperty("showMethodsComplexity").desc("Add method average violations to the report").defaultValue(true).build();
+    public static final PropertyDescriptor<Boolean> SHOW_METHODS_COMPLEXITY_DESCRIPTOR = booleanProperty("showMethodsComplexity").setDescription("Add method average violations to the report").defaultValue(true).build();
 
     private int reportLevel;
     private boolean showClassesComplexity = true;

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/TooManyFieldsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/TooManyFieldsRule.java
@@ -27,7 +27,7 @@ public class TooManyFieldsRule extends AbstractApexRule {
 
     private static final PropertyDescriptor<Integer> MAX_FIELDS_DESCRIPTOR
             = PropertyFactory.intProperty("maxfields")
-                             .desc("Max allowable fields")
+                             .setDescription("Max allowable fields")
                              .defaultValue(DEFAULT_MAXFIELDS)
                              .require(positive())
                              .build();

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/SuppressWarningsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/SuppressWarningsTest.java
@@ -37,10 +37,10 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST1, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
         runTestFromString(TEST2, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     @Test
@@ -48,7 +48,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST3, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     @Test
@@ -56,7 +56,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST4, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -64,7 +64,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST5, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     @Test
@@ -72,7 +72,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST6, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -80,7 +80,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST7, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -88,7 +88,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST8, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -96,7 +96,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST9, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -104,7 +104,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST9_MULTIPLE_VALUES, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     @Test
@@ -112,7 +112,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST10, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(2, rpt.size());
+        assertEquals(2, rpt.getNumViolations());
     }
 
     @Test
@@ -120,7 +120,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST11, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(2, rpt.size());
+        assertEquals(2, rpt.getNumViolations());
     }
 
     @Test
@@ -128,7 +128,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST12, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     @Test
@@ -136,7 +136,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST13, new BarRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     private static final String TEST1 = "@SuppressWarnings('PMD')" + PMD.EOL + "public class Foo {}";

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/metrics/impl/AbstractApexMetricTestRule.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/metrics/impl/AbstractApexMetricTestRule.java
@@ -31,22 +31,22 @@ public abstract class AbstractApexMetricTestRule extends AbstractApexRule {
 
     private final PropertyDescriptor<List<MetricOption>> optionsDescriptor =
             PropertyFactory.enumListProperty("metricOptions", optionMappings())
-                           .desc("Choose a variant of the metric or the standard")
+                           .setDescription("Choose a variant of the metric or the standard")
                            .emptyDefaultValue().build();
 
     private final PropertyDescriptor<Boolean> reportClassesDescriptor =
             PropertyFactory.booleanProperty("reportClasses")
-                           .desc("Add class violations to the report")
+                           .setDescription("Add class violations to the report")
                            .defaultValue(isReportClasses()).build();
 
     private final PropertyDescriptor<Boolean> reportMethodsDescriptor =
             PropertyFactory.booleanProperty("reportMethods")
-                           .desc("Add method violations to the report")
+                           .setDescription("Add method violations to the report")
                            .defaultValue(isReportMethods()).build();
 
     private final PropertyDescriptor<Double> reportLevelDescriptor =
             PropertyFactory.doubleProperty("reportLevel")
-                           .desc("Minimum value required to report")
+                           .setDescription("Minimum value required to report")
                            .defaultValue(defaultReportLevel()).build();
 
     private MetricOptions metricOptions;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
@@ -512,7 +512,7 @@ public class Report implements Iterable<RuleViolation> {
      *
      * @return number of violations.
      */
-    public int size() {
+    public int getNumViolations() {
         return violations.size();
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
@@ -165,7 +165,7 @@ public class PMDTaskImpl {
 
                 @Override
                 public void renderFileReport(Report r) {
-                    int size = r.size();
+                    int size = r.getNumViolations();
                     if (size > 0) {
                         reportSize.addAndGet(size);
                     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/MockRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/MockRule.java
@@ -26,7 +26,7 @@ public class MockRule extends AbstractRule {
     public MockRule() {
         super();
         setLanguage(LanguageRegistry.getLanguage("Dummy"));
-        definePropertyDescriptor(PropertyFactory.intProperty("testIntProperty").desc("testIntProperty").require(inRange(1, 100)).defaultValue(1).build());
+        definePropertyDescriptor(PropertyFactory.intProperty("testIntProperty").setDescription("testIntProperty").require(inRange(1, 100)).defaultValue(1).build());
     }
 
     public MockRule(String name, String description, String message, String ruleSetName, RulePriority priority) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyBuilder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyBuilder.java
@@ -29,7 +29,7 @@ import net.sourceforge.pmd.properties.constraints.PropertyConstraint;
  * properly:
  * <ul>
  *   <li>A name: filled-in when obtaining the builder
- *   <li>A description: see {@link #desc(String)}
+ *   <li>A description: see {@link #setDescription(String)}
  *   <li>A default value: see {@link #defaultValue(Object)}
  * </ul>
  *
@@ -117,7 +117,7 @@ public abstract class PropertyBuilder<B extends PropertyBuilder<B, T>, T> {
      * @throws IllegalArgumentException If the description is null or whitespace
      */
     @SuppressWarnings("unchecked")
-    public B desc(String desc) {
+    public B setDescription(String desc) {
         if (StringUtils.isBlank(desc)) {
             throw new IllegalArgumentException("Description must be provided");
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyFactory.java
@@ -48,7 +48,7 @@ import net.sourceforge.pmd.properties.constraints.PropertyConstraint;
  *   // The property descriptor may be static, it can be shared across threads.
  *   private static final {@link PropertyDescriptor}&lt;Integer&gt; myIntProperty
  *     = PropertyFactory.{@linkplain #intProperty(String) intProperty}("myIntProperty")
- *                      .{@linkplain PropertyBuilder#desc(String) desc}("This is my property")
+ *                      .{@linkplain PropertyBuilder#setDescription(String) desc}("This is my property")
  *                      .{@linkplain PropertyBuilder#defaultValue(Object) defaultValue}(3)
  *                      .{@linkplain PropertyBuilder#require(PropertyConstraint) require}(inRange(0, 100))   // constraints are checked before the rule is run
  *                      .{@linkplain PropertyBuilder#build() build}();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/CSVRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/CSVRenderer.java
@@ -105,7 +105,7 @@ public class CSVRenderer extends AbstractIncrementingRenderer {
             return prop;
         }
 
-        prop = PropertyFactory.booleanProperty(id).defaultValue(true).desc("Include " + label + " column").build();
+        prop = PropertyFactory.booleanProperty(id).defaultValue(true).setDescription("Include " + label + " column").build();
         PROPERTY_DESCRIPTORS_BY_ID.put(id, prop);
         return prop;
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/AbstractRuleTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/AbstractRuleTest.java
@@ -32,7 +32,7 @@ public class AbstractRuleTest {
         private static final StringProperty FOO_PROPERTY = new StringProperty("foo", "foo property", "x", 1.0f);
         private static final PropertyDescriptor<String> FOO_DEFAULT_PROPERTY = PropertyFactory.stringProperty("fooDefault")
                 .defaultValue("bar")
-                .desc("Property without value uses default value")
+                .setDescription("Property without value uses default value")
                 .build();
 
         private static final StringProperty XPATH_PROPERTY = new StringProperty("xpath", "xpath property", "", 2.0f);
@@ -103,7 +103,7 @@ public class AbstractRuleTest {
     @Test
     public void testRuleWithVariableInMessage() {
         MyRule r = new MyRule();
-        r.definePropertyDescriptor(PropertyFactory.intProperty("testInt").desc("description").require(inRange(0, 100)).defaultValue(10).build());
+        r.definePropertyDescriptor(PropertyFactory.intProperty("testInt").setDescription("description").require(inRange(0, 100)).defaultValue(10).build());
         r.setMessage("Message ${packageName} ${className} ${methodName} ${variableName} ${testInt} ${noSuchProperty}");
         RuleContext ctx = new RuleContext();
         ctx.setLanguageVersion(LanguageRegistry.getLanguage(DummyLanguageModule.NAME).getDefaultVersion());

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleContextTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleContextTest.java
@@ -22,7 +22,7 @@ public class RuleContextTest {
     @Test
     public void testReport() {
         RuleContext ctx = new RuleContext();
-        assertEquals(0, ctx.getReport().size());
+        assertEquals(0, ctx.getReport().getNumViolations());
         Report r = new Report();
         ctx.setReport(r);
         Report r2 = ctx.getReport();

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetTest.java
@@ -440,7 +440,7 @@ public class RuleSetTest {
         ctx.setSourceCodeFile(file);
         ctx.setLanguageVersion(LanguageRegistry.getLanguage(DummyLanguageModule.NAME).getDefaultVersion());
         ruleSets.apply(makeCompilationUnits(), ctx, LanguageRegistry.getLanguage(DummyLanguageModule.NAME));
-        assertEquals("Violations", 2, r.size());
+        assertEquals("Violations", 2, r.getNumViolations());
 
         // One violation
         ruleSet1 = createRuleSetBuilder("RuleSet1")
@@ -455,7 +455,7 @@ public class RuleSetTest {
         r = new Report();
         ctx.setReport(r);
         ruleSets.apply(makeCompilationUnits(), ctx, LanguageRegistry.getLanguage(DummyLanguageModule.NAME));
-        assertEquals("Violations", 1, r.size());
+        assertEquals("Violations", 1, r.getNumViolations());
     }
     
     @Test
@@ -483,7 +483,7 @@ public class RuleSetTest {
         context.setReport(new Report());
         ruleset.apply(makeCompilationUnits(), context);
 
-        assertEquals("Invalid number of Violations Reported", size, context.getReport().size());
+        assertEquals("Invalid number of Violations Reported", size, context.getReport().getNumViolations());
 
         Iterator<RuleViolation> violations = context.getReport().iterator();
         while (violations.hasNext()) {
@@ -580,7 +580,7 @@ public class RuleSetTest {
         assertEquals("Wrong error message", "RuntimeException: Test exception while applying rule", errors.get(0).getMsg());
         assertTrue("Should be a RuntimeException", errors.get(0).getError() instanceof RuntimeException);
 
-        assertEquals("There should be a violation", 1, context.getReport().size());
+        assertEquals("There should be a violation", 1, context.getReport().getNumViolations());
     }
 
     @Test
@@ -620,7 +620,7 @@ public class RuleSetTest {
         assertEquals("Wrong error message", "RuntimeException: Test exception while applying rule", errors.get(0).getMsg());
         assertTrue("Should be a RuntimeException", errors.get(0).getError() instanceof RuntimeException);
 
-        assertEquals("There should be a violation", 1, context.getReport().size());
+        assertEquals("There should be a violation", 1, context.getReport().getNumViolations());
     }
 
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/properties/PropertyDescriptorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/properties/PropertyDescriptorTest.java
@@ -49,7 +49,7 @@ public class PropertyDescriptorTest {
     @Test
     public void testConstraintViolationCausesDysfunctionalRule() {
         PropertyDescriptor<Integer> intProperty = PropertyFactory.intProperty("fooProp")
-                                                                 .desc("hello")
+                                                                 .setDescription("hello")
                                                                  .defaultValue(4)
                                                                  .require(inRange(1, 10))
                                                                  .build();
@@ -70,7 +70,7 @@ public class PropertyDescriptorTest {
     @Test
     public void testConstraintViolationCausesDysfunctionalRuleMulti() {
         PropertyDescriptor<List<Double>> descriptor = PropertyFactory.doubleListProperty("fooProp")
-                                                                     .desc("hello")
+                                                                     .setDescription("hello")
                                                                      .defaultValues(2., 11.) // 11. is in range
                                                                      .requireEach(inRange(1d, 20d))
                                                                      .build();
@@ -96,7 +96,7 @@ public class PropertyDescriptorTest {
                                    containsIgnoreCase(constraint.getConstraintDescription())));
 
         PropertyFactory.intProperty("fooProp")
-                       .desc("hello")
+                       .setDescription("hello")
                        .defaultValue(1000)
                        .require(constraint)
                        .build();
@@ -112,7 +112,7 @@ public class PropertyDescriptorTest {
                                    containsIgnoreCase(constraint.getConstraintDescription())));
 
         PropertyFactory.doubleListProperty("fooProp")
-                       .desc("hello")
+                       .setDescription("hello")
                        .defaultValues(2., 11.) // 11. is out of range
                        .requireEach(constraint)
                        .build();
@@ -123,7 +123,7 @@ public class PropertyDescriptorTest {
     public void testNoConstraintViolationCausesIsOkMulti() {
 
         PropertyDescriptor<List<Double>> descriptor = PropertyFactory.doubleListProperty("fooProp")
-                                                                     .desc("hello")
+                                                                     .setDescription("hello")
                                                                      .defaultValues(2., 11.) // 11. is in range
                                                                      .requireEach(inRange(1d, 20d))
                                                                      .build();
@@ -139,7 +139,7 @@ public class PropertyDescriptorTest {
     public void testNoConstraintViolationCausesIsOk() {
 
         PropertyDescriptor<String> descriptor = PropertyFactory.stringProperty("fooProp")
-                                                                     .desc("hello")
+                                                                     .setDescription("hello")
                                                                      .defaultValue("bazooli")
                                                                      .build();
 
@@ -151,7 +151,7 @@ public class PropertyDescriptorTest {
     @Test
     public void testIntProperty() {
         PropertyDescriptor<Integer> descriptor = PropertyFactory.intProperty("intProp")
-                .desc("hello")
+                .setDescription("hello")
                 .defaultValue(1)
                 .build();
         assertEquals("intProp", descriptor.name());
@@ -160,7 +160,7 @@ public class PropertyDescriptorTest {
         assertEquals(Integer.valueOf(5), descriptor.valueFrom("5"));
 
         PropertyDescriptor<List<Integer>> listDescriptor = PropertyFactory.intListProperty("intListProp")
-                .desc("hello")
+                .setDescription("hello")
                 .defaultValues(1, 2)
                 .build();
         assertEquals("intListProp", listDescriptor.name());
@@ -172,7 +172,7 @@ public class PropertyDescriptorTest {
     @Test
     public void testIntPropertyInvalidValue() {
         PropertyDescriptor<Integer> descriptor = PropertyFactory.intProperty("intProp")
-                .desc("hello")
+                .setDescription("hello")
                 .defaultValue(1)
                 .build();
         thrown.expect(NumberFormatException.class);
@@ -183,7 +183,7 @@ public class PropertyDescriptorTest {
     @Test
     public void testDoubleProperty() {
         PropertyDescriptor<Double> descriptor = PropertyFactory.doubleProperty("doubleProp")
-                .desc("hello")
+                .setDescription("hello")
                 .defaultValue(1.0)
                 .build();
         assertEquals("doubleProp", descriptor.name());
@@ -192,7 +192,7 @@ public class PropertyDescriptorTest {
         assertEquals(Double.valueOf(2.0), descriptor.valueFrom("2.0"));
 
         PropertyDescriptor<List<Double>> listDescriptor = PropertyFactory.doubleListProperty("doubleListProp")
-                .desc("hello")
+                .setDescription("hello")
                 .defaultValues(1.0, 2.0)
                 .build();
         assertEquals("doubleListProp", listDescriptor.name());
@@ -204,7 +204,7 @@ public class PropertyDescriptorTest {
     @Test
     public void testDoublePropertyInvalidValue() {
         PropertyDescriptor<Double> descriptor = PropertyFactory.doubleProperty("doubleProp")
-                .desc("hello")
+                .setDescription("hello")
                 .defaultValue(1.0)
                 .build();
         thrown.expect(NumberFormatException.class);
@@ -215,7 +215,7 @@ public class PropertyDescriptorTest {
     @Test
     public void testStringProperty() {
         PropertyDescriptor<String> descriptor = PropertyFactory.stringProperty("stringProp")
-                .desc("hello")
+                .setDescription("hello")
                 .defaultValue("default value")
                 .build();
         assertEquals("stringProp", descriptor.name());
@@ -224,7 +224,7 @@ public class PropertyDescriptorTest {
         assertEquals("foo", descriptor.valueFrom("foo"));
 
         PropertyDescriptor<List<String>> listDescriptor = PropertyFactory.stringListProperty("stringListProp")
-                .desc("hello")
+                .setDescription("hello")
                 .defaultValues("v1", "v2")
                 .build();
         assertEquals("stringListProp", listDescriptor.name());
@@ -246,7 +246,7 @@ public class PropertyDescriptorTest {
     @Test
     public void testEnumProperty() {
         PropertyDescriptor<SampleEnum> descriptor = PropertyFactory.enumProperty("enumProp", nameMap)
-                .desc("hello")
+                .setDescription("hello")
                 .defaultValue(SampleEnum.B)
                 .build();
         assertEquals("enumProp", descriptor.name());
@@ -255,7 +255,7 @@ public class PropertyDescriptorTest {
         assertEquals(SampleEnum.C, descriptor.valueFrom("TEST_C"));
 
         PropertyDescriptor<List<SampleEnum>> listDescriptor = PropertyFactory.enumListProperty("enumListProp", nameMap)
-                .desc("hello")
+                .setDescription("hello")
                 .defaultValues(SampleEnum.A, SampleEnum.B)
                 .build();
         assertEquals("enumListProp", listDescriptor.name());
@@ -292,7 +292,7 @@ public class PropertyDescriptorTest {
     @Test
     public void testEnumPropertyInvalidValue() {
         PropertyDescriptor<SampleEnum> descriptor = PropertyFactory.enumProperty("enumProp", nameMap)
-                .desc("hello")
+                .setDescription("hello")
                 .defaultValue(SampleEnum.B)
                 .build();
         thrown.expect(IllegalArgumentException.class);
@@ -303,7 +303,7 @@ public class PropertyDescriptorTest {
     @Test
     public void testRegexProperty() {
         PropertyDescriptor<Pattern> descriptor = PropertyFactory.regexProperty("regexProp")
-                .desc("hello")
+                .setDescription("hello")
                 .defaultValue("^[A-Z].*$")
                 .build();
         assertEquals("regexProp", descriptor.name());
@@ -315,7 +315,7 @@ public class PropertyDescriptorTest {
     @Test
     public void testRegexPropertyInvalidValue() {
         PropertyDescriptor<Pattern> descriptor = PropertyFactory.regexProperty("regexProp")
-                .desc("hello")
+                .setDescription("hello")
                 .defaultValue("^[A-Z].*$")
                 .build();
         thrown.expect(PatternSyntaxException.class);
@@ -328,7 +328,7 @@ public class PropertyDescriptorTest {
         thrown.expect(PatternSyntaxException.class);
         thrown.expectMessage("Unclosed character class");
         PropertyDescriptor<Pattern> descriptor = PropertyFactory.regexProperty("regexProp")
-                .desc("hello")
+                .setDescription("hello")
                 .defaultValue("[open class")
                 .build();
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/stat/StatisticalRuleTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/stat/StatisticalRuleTest.java
@@ -288,7 +288,7 @@ public class StatisticalRuleTest {
 
         Report report = makeReport(rule);
 
-        assertEquals("Expecting only one result", 1, report.size());
+        assertEquals("Expecting only one result", 1, report.getNumViolations());
     }
 
     // Okay, we have three properties we need to
@@ -819,15 +819,15 @@ public class StatisticalRuleTest {
                 assertEquals(
                         "Unexpected number of results: sigma= " + Double.toString(sigma) + " min= "
                                 + Double.toString(minimum) + " topscore= " + Integer.toString(topScore),
-                        expected, report.size());
+                        expected, report.getNumViolations());
             } else {
                 String assertStr = "Unexpected number of results: sigma= " + Double.toString(sigma) + " min= "
                         + Double.toString(minimum) + " topscore= " + Integer.toString(topScore) + " expected= "
                         + Integer.toString(expected) + " +/- " + Integer.toString(delta) + " actual-result= "
-                        + report.size();
+                        + report.getNumViolations();
 
-                assertTrue(assertStr, report.size() >= (expected - delta));
-                assertTrue(assertStr, report.size() <= (expected + delta));
+                assertTrue(assertStr, report.getNumViolations() >= (expected - delta));
+                assertTrue(assertStr, report.getNumViolations() <= (expected + delta));
             }
         } catch (AssertionFailedError afe) {
             System.err.println("******** " + testName + " ***********");

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractIgnoredAnnotationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractIgnoredAnnotationRule.java
@@ -17,7 +17,7 @@ public abstract class AbstractIgnoredAnnotationRule extends AbstractJavaRule {
 
     private final PropertyDescriptor<List<String>> ignoredAnnotationsDescriptor
         = stringListProperty("ignoredAnnotations")
-        .desc("Fully qualified names of the annotation types that should be ignored by this rule")
+        .setDescription("Fully qualified names of the annotation types that should be ignored by this rule")
         .defaultValue(defaultSuppressionAnnotations())
         .build();
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningLoopVariablesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningLoopVariablesRule.java
@@ -56,7 +56,7 @@ public class AvoidReassigningLoopVariablesRule extends AbstractOptimizationRule 
     private static final PropertyDescriptor<ForeachReassignOption> FOREACH_REASSIGN
             = enumProperty("foreachReassign", FOREACH_REASSIGN_VALUES)
             .defaultValue(ForeachReassignOption.DENY)
-            .desc("how/if foreach control variables may be reassigned")
+            .setDescription("how/if foreach control variables may be reassigned")
             .build();
 
     private static final Map<String, ForReassignOption> FOR_REASSIGN_VALUES;
@@ -72,7 +72,7 @@ public class AvoidReassigningLoopVariablesRule extends AbstractOptimizationRule 
     private static final PropertyDescriptor<ForReassignOption> FOR_REASSIGN
             = enumProperty("forReassign", FOR_REASSIGN_VALUES)
             .defaultValue(ForReassignOption.DENY)
-            .desc("how/if for control variables may be reassigned")
+            .setDescription("how/if for control variables may be reassigned")
             .build();
 
     public AvoidReassigningLoopVariablesRule() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidUsingHardCodedIPRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidUsingHardCodedIPRule.java
@@ -41,7 +41,7 @@ public class AvoidUsingHardCodedIPRule extends AbstractJavaRule {
 
     public static final PropertyDescriptor<List<String>> CHECK_ADDRESS_TYPES_DESCRIPTOR =
             PropertyFactory.enumListProperty("checkAddressTypes", ADDRESSES_TO_CHECK)
-                           .desc("Check for IP address types.")
+                           .setDescription("Check for IP address types.")
                            .defaultValue(ADDRESSES_TO_CHECK.keySet()).build();
 
     // Provides 4 capture groups that can be used for additional validation

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
@@ -60,7 +60,7 @@ public class GuardLogStatementRule extends AbstractJavaRule implements Rule {
      */
     private static final PropertyDescriptor<List<String>> LOG_LEVELS =
             stringListProperty("logLevels")
-                    .desc("LogLevels to guard")
+                    .setDescription("LogLevels to guard")
                     .defaultValues("trace", "debug", "info", "warn", "error",
                                    "log", "finest", "finer", "fine", "info", "warning", "severe")
                     .delim(',')
@@ -68,7 +68,7 @@ public class GuardLogStatementRule extends AbstractJavaRule implements Rule {
 
     private static final PropertyDescriptor<List<String>> GUARD_METHODS =
             stringListProperty("guardsMethods")
-                    .desc("Method use to guard the log statement")
+                    .setDescription("Method use to guard the log statement")
                     .defaultValues("isTraceEnabled", "isDebugEnabled", "isInfoEnabled", "isWarnEnabled", "isErrorEnabled", "isLoggable")
                     .delim(',').build();
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedFormalParameterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedFormalParameterRule.java
@@ -32,7 +32,7 @@ import net.sourceforge.pmd.properties.PropertyDescriptor;
 
 public class UnusedFormalParameterRule extends AbstractJavaRule {
 
-    private static final PropertyDescriptor<Boolean> CHECKALL_DESCRIPTOR = booleanProperty("checkAll").desc("Check all methods, including non-private ones").defaultValue(false).build();
+    private static final PropertyDescriptor<Boolean> CHECKALL_DESCRIPTOR = booleanProperty("checkAll").setDescription("Check all methods, including non-private ones").defaultValue(false).build();
 
     public UnusedFormalParameterRule() {
         definePropertyDescriptor(CHECKALL_DESCRIPTOR);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/AbstractNamingConventionRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/AbstractNamingConventionRule.java
@@ -37,7 +37,7 @@ abstract class AbstractNamingConventionRule<T extends JavaNode> extends Abstract
     /** Returns a pre-filled builder with the given name and display name (for the description). */
     RegexPropertyBuilder defaultProp(String name, String displayName) {
         return PropertyFactory.regexProperty(name + "Pattern")
-                              .desc("Regex which applies to " + displayName.trim() + " names")
+                              .setDescription("Regex which applies to " + displayName.trim() + " names")
                               .defaultValue(defaultConvention());
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/CommentDefaultAccessModifierRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/CommentDefaultAccessModifierRule.java
@@ -39,9 +39,9 @@ import net.sourceforge.pmd.properties.PropertyFactory;
 public class CommentDefaultAccessModifierRule extends AbstractIgnoredAnnotationRule {
 
     private static final PropertyDescriptor<Pattern> REGEX_DESCRIPTOR = PropertyFactory.regexProperty("regex")
-            .desc("Regular expression").defaultValue("\\/\\*\\s+(default|package)\\s+\\*\\/").build();
+            .setDescription("Regular expression").defaultValue("\\/\\*\\s+(default|package)\\s+\\*\\/").build();
     private static final PropertyDescriptor<Boolean> TOP_LEVEL_TYPES = PropertyFactory.booleanProperty("checkTopLevelTypes")
-            .desc("Check for default access modifier in top-level classes, annotations, and enums")
+            .setDescription("Check for default access modifier in top-level classes, annotations, and enums")
             .defaultValue(false).build();
     private static final String MESSAGE = "To avoid mistakes add a comment "
             + "at the beginning of the %s %s if you want a default access modifier";

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ConfusingTernaryRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ConfusingTernaryRule.java
@@ -54,7 +54,7 @@ import net.sourceforge.pmd.properties.PropertyDescriptor;
  * </pre>
  */
 public class ConfusingTernaryRule extends AbstractJavaRule {
-    private static PropertyDescriptor<Boolean> ignoreElseIfProperty = booleanProperty("ignoreElseIf").desc("Ignore conditions with an else-if case").defaultValue(false).build();
+    private static PropertyDescriptor<Boolean> ignoreElseIfProperty = booleanProperty("ignoreElseIf").setDescription("Ignore conditions with an else-if case").defaultValue(false).build();
 
     public ConfusingTernaryRule() {
         super();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldDeclarationsShouldBeAtStartOfClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldDeclarationsShouldBeAtStartOfClassRule.java
@@ -39,9 +39,9 @@ import net.sourceforge.pmd.properties.PropertyDescriptor;
  */
 public class FieldDeclarationsShouldBeAtStartOfClassRule extends AbstractJavaRule {
 
-    private final PropertyDescriptor<Boolean> ignoreEnumDeclarations = booleanProperty("ignoreEnumDeclarations").defaultValue(true).desc("Ignore Enum Declarations that precede fields.").build();
-    private final PropertyDescriptor<Boolean> ignoreAnonymousClassDeclarations = booleanProperty("ignoreAnonymousClassDeclarations").defaultValue(true).desc("Ignore Field Declarations, that are initialized with anonymous class declarations").build();
-    private final PropertyDescriptor<Boolean> ignoreInterfaceDeclarations = booleanProperty("ignoreInterfaceDeclarations").defaultValue(false).desc("Ignore Interface Declarations that precede fields.").build();
+    private final PropertyDescriptor<Boolean> ignoreEnumDeclarations = booleanProperty("ignoreEnumDeclarations").defaultValue(true).setDescription("Ignore Enum Declarations that precede fields.").build();
+    private final PropertyDescriptor<Boolean> ignoreAnonymousClassDeclarations = booleanProperty("ignoreAnonymousClassDeclarations").defaultValue(true).setDescription("Ignore Field Declarations, that are initialized with anonymous class declarations").build();
+    private final PropertyDescriptor<Boolean> ignoreInterfaceDeclarations = booleanProperty("ignoreInterfaceDeclarations").defaultValue(false).setDescription("Ignore Interface Declarations that precede fields.").build();
 
 
     public FieldDeclarationsShouldBeAtStartOfClassRule() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldNamingConventionsRule.java
@@ -25,13 +25,13 @@ public class FieldNamingConventionsRule extends AbstractNamingConventionRule<AST
     // We could define a new property, but specifying property values as a single string doesn't scale
     private static final PropertyDescriptor<List<String>> EXCLUDED_NAMES =
             PropertyFactory.stringListProperty("exclusions")
-                           .desc("Names of fields to whitelist.")
+                           .setDescription("Names of fields to whitelist.")
                            .defaultValues("serialVersionUID", "serialPersistentFields")
                            .build();
 
 
     private final PropertyDescriptor<Pattern> publicConstantFieldRegex = defaultProp("public constant").defaultValue("[A-Z][A-Z_0-9]*").build();
-    private final PropertyDescriptor<Pattern> constantFieldRegex = defaultProp("constant").desc("Regex which applies to non-public static final field names").defaultValue("[A-Z][A-Z_0-9]*").build();
+    private final PropertyDescriptor<Pattern> constantFieldRegex = defaultProp("constant").setDescription("Regex which applies to non-public static final field names").defaultValue("[A-Z][A-Z_0-9]*").build();
     private final PropertyDescriptor<Pattern> enumConstantRegex = defaultProp("enum constant").defaultValue("[A-Z][A-Z_0-9]*").build();
     private final PropertyDescriptor<Pattern> finalFieldRegex = defaultProp("final field").build();
     private final PropertyDescriptor<Pattern> staticFieldRegex = defaultProp("static field").build();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LinguisticNamingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LinguisticNamingRule.java
@@ -27,34 +27,34 @@ import net.sourceforge.pmd.properties.PropertyDescriptor;
 
 public class LinguisticNamingRule extends AbstractIgnoredAnnotationRule {
     private static final PropertyDescriptor<Boolean> CHECK_BOOLEAN_METHODS =
-            booleanProperty("checkBooleanMethod").defaultValue(true).desc("Check method names and types for inconsistent naming.").build();
+            booleanProperty("checkBooleanMethod").defaultValue(true).setDescription("Check method names and types for inconsistent naming.").build();
     private static final PropertyDescriptor<Boolean> CHECK_GETTERS =
-            booleanProperty("checkGetters").defaultValue(true).desc("Check return type of getters.").build();
+            booleanProperty("checkGetters").defaultValue(true).setDescription("Check return type of getters.").build();
     private static final PropertyDescriptor<Boolean> CHECK_SETTERS =
-            booleanProperty("checkSetters").defaultValue(true).desc("Check return type of setters.").build();
+            booleanProperty("checkSetters").defaultValue(true).setDescription("Check return type of setters.").build();
     private static final PropertyDescriptor<Boolean> CHECK_PREFIXED_TRANSFORM_METHODS =
             booleanProperty("checkPrefixedTransformMethods")
-                    .desc("Check return type of methods whose names start with the configured prefix (see transformMethodNames property).")
+                    .setDescription("Check return type of methods whose names start with the configured prefix (see transformMethodNames property).")
                     .defaultValue(true).build();
     private static final PropertyDescriptor<Boolean> CHECK_TRANSFORM_METHODS =
             booleanProperty("checkTransformMethods")
-                    .desc("Check return type of methods which contain the configured infix in their name (see transformMethodNames property).")
+                    .setDescription("Check return type of methods which contain the configured infix in their name (see transformMethodNames property).")
                     .defaultValue(false).build();
     private static final PropertyDescriptor<Boolean> CHECK_FIELDS =
-            booleanProperty("checkFields").defaultValue(true).desc("Check field names and types for inconsistent naming.").build();
+            booleanProperty("checkFields").defaultValue(true).setDescription("Check field names and types for inconsistent naming.").build();
     private static final PropertyDescriptor<Boolean> CHECK_VARIABLES =
-            booleanProperty("checkVariables").defaultValue(true).desc("Check local variable names and types for inconsistent naming.").build();
+            booleanProperty("checkVariables").defaultValue(true).setDescription("Check local variable names and types for inconsistent naming.").build();
     private static final PropertyDescriptor<List<String>> BOOLEAN_METHOD_PREFIXES_PROPERTY =
             stringListProperty("booleanMethodPrefixes")
-                    .desc("The prefixes of methods that return boolean.")
+                    .setDescription("The prefixes of methods that return boolean.")
                     .defaultValues("is", "has", "can", "have", "will", "should").build();
     private static final PropertyDescriptor<List<String>> TRANSFORM_METHOD_NAMES_PROPERTY =
             stringListProperty("transformMethodNames")
-                    .desc("The prefixes and infixes that indicate a transform method.")
+                    .setDescription("The prefixes and infixes that indicate a transform method.")
                     .defaultValues("to", "as").build();
     private static final PropertyDescriptor<List<String>> BOOLEAN_FIELD_PREFIXES_PROPERTY =
             stringListProperty("booleanFieldPrefixes")
-                    .desc("The prefixes of fields and variables that indicate boolean.")
+                    .setDescription("The prefixes of fields and variables that indicate boolean.")
                     .defaultValues("is", "has", "can", "have", "will", "should").build();
 
     public LinguisticNamingRule() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableCouldBeFinalRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableCouldBeFinalRule.java
@@ -20,7 +20,7 @@ import net.sourceforge.pmd.properties.PropertyDescriptor;
 public class LocalVariableCouldBeFinalRule extends AbstractOptimizationRule {
 
     private static final PropertyDescriptor<Boolean> IGNORE_FOR_EACH =
-            booleanProperty("ignoreForEachDecl").defaultValue(false).desc("Ignore non-final loop variables in a for-each statement.").build();
+            booleanProperty("ignoreForEachDecl").defaultValue(false).setDescription("Ignore non-final loop variables in a for-each statement.").build();
 
     public LocalVariableCouldBeFinalRule() {
         definePropertyDescriptor(IGNORE_FOR_EACH);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryLocalBeforeReturnRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryLocalBeforeReturnRule.java
@@ -29,7 +29,7 @@ import net.sourceforge.pmd.properties.PropertyDescriptor;
 
 public class UnnecessaryLocalBeforeReturnRule extends AbstractJavaRule {
 
-    private static final PropertyDescriptor<Boolean> STATEMENT_ORDER_MATTERS = booleanProperty("statementOrderMatters").defaultValue(true).desc("If set to false this rule no longer requires the variable declaration and return statement to be on consecutive lines. Any variable that is used solely in a return statement will be reported.").build();
+    private static final PropertyDescriptor<Boolean> STATEMENT_ORDER_MATTERS = booleanProperty("statementOrderMatters").defaultValue(true).setDescription("If set to false this rule no longer requires the variable declaration and return statement to be on consecutive lines. Any variable that is used solely in a return statement will be reported.").build();
 
 
     public UnnecessaryLocalBeforeReturnRule() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/VariableNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/VariableNamingConventionsRule.java
@@ -40,13 +40,13 @@ public class VariableNamingConventionsRule extends AbstractJavaRule {
     private List<String> parameterPrefixes;
     private List<String> parameterSuffixes;
 
-    private static final PropertyDescriptor<Boolean> CHECK_MEMBERS_DESCRIPTOR = booleanProperty("checkMembers").defaultValue(true).desc("Check member variables").build();
+    private static final PropertyDescriptor<Boolean> CHECK_MEMBERS_DESCRIPTOR = booleanProperty("checkMembers").defaultValue(true).setDescription("Check member variables").build();
 
-    private static final PropertyDescriptor<Boolean> CHECK_LOCALS_DESCRIPTOR = booleanProperty("checkLocals").defaultValue(true).desc("Check local variables").build();
+    private static final PropertyDescriptor<Boolean> CHECK_LOCALS_DESCRIPTOR = booleanProperty("checkLocals").defaultValue(true).setDescription("Check local variables").build();
 
-    private static final PropertyDescriptor<Boolean> CHECK_PARAMETERS_DESCRIPTOR = booleanProperty("checkParameters").defaultValue(true).desc("Check constructor and method parameter variables").build();
+    private static final PropertyDescriptor<Boolean> CHECK_PARAMETERS_DESCRIPTOR = booleanProperty("checkParameters").defaultValue(true).setDescription("Check constructor and method parameter variables").build();
 
-    private static final PropertyDescriptor<Boolean> CHECK_NATIVE_METHOD_PARAMETERS_DESCRIPTOR = booleanProperty("checkNativeMethodParameters").defaultValue(true).desc("Check method parameter of native methods").build();
+    private static final PropertyDescriptor<Boolean> CHECK_NATIVE_METHOD_PARAMETERS_DESCRIPTOR = booleanProperty("checkNativeMethodParameters").defaultValue(true).setDescription("Check method parameter of native methods").build();
 
     // the rule is deprecated and will be removed so its properties won't be converted
     private static final StringMultiProperty STATIC_PREFIXES_DESCRIPTOR = new StringMultiProperty("staticPrefix",

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AvoidDeeplyNestedIfStmtsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AvoidDeeplyNestedIfStmtsRule.java
@@ -20,7 +20,7 @@ public class AvoidDeeplyNestedIfStmtsRule extends AbstractJavaRule {
 
     private static final PropertyDescriptor<Integer> PROBLEM_DEPTH_DESCRIPTOR
             = PropertyFactory.intProperty("problemDepth")
-                             .desc("The if statement depth reporting threshold")
+                             .setDescription("The if statement depth reporting threshold")
                              .require(positive()).defaultValue(3).build();
 
     public AvoidDeeplyNestedIfStmtsRule() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CouplingBetweenObjectsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CouplingBetweenObjectsRule.java
@@ -42,7 +42,7 @@ public class CouplingBetweenObjectsRule extends AbstractJavaRule {
 
     private static final PropertyDescriptor<Integer> THRESHOLD_DESCRIPTOR
             = PropertyFactory.intProperty("threshold")
-                             .desc("Unique type reporting threshold")
+                             .setDescription("Unique type reporting threshold")
                              .require(positive()).defaultValue(20).build();
 
     public CouplingBetweenObjectsRule() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CyclomaticComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CyclomaticComplexityRule.java
@@ -41,18 +41,18 @@ public class CyclomaticComplexityRule extends AbstractJavaMetricsRule {
     @Deprecated
     private static final PropertyDescriptor<Integer> REPORT_LEVEL_DESCRIPTOR
         = PropertyFactory.intProperty("reportLevel")
-                         .desc("Deprecated! Cyclomatic Complexity reporting threshold")
+                         .setDescription("Deprecated! Cyclomatic Complexity reporting threshold")
                          .require(positive()).defaultValue(10).build();
 
 
     private static final PropertyDescriptor<Integer> CLASS_LEVEL_DESCRIPTOR
         = PropertyFactory.intProperty("classReportLevel")
-                         .desc("Total class complexity reporting threshold")
+                         .setDescription("Total class complexity reporting threshold")
                          .require(positive()).defaultValue(80).build();
 
     private static final PropertyDescriptor<Integer> METHOD_LEVEL_DESCRIPTOR
         = PropertyFactory.intProperty("methodReportLevel")
-                         .desc("Cyclomatic complexity reporting threshold")
+                         .setDescription("Cyclomatic complexity reporting threshold")
                          .require(positive()).defaultValue(10).build();
 
     private static final Map<String, CycloOption> OPTION_MAP;
@@ -65,7 +65,7 @@ public class CyclomaticComplexityRule extends AbstractJavaMetricsRule {
 
     private static final PropertyDescriptor<List<CycloOption>> CYCLO_OPTIONS_DESCRIPTOR
             = PropertyFactory.enumListProperty("cycloOptions", OPTION_MAP)
-                             .desc("Choose options for the computation of Cyclo")
+                             .setDescription("Choose options for the computation of Cyclo")
                              .emptyDefaultValue()
                              .build();
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LoosePackageCouplingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LoosePackageCouplingRule.java
@@ -39,10 +39,10 @@ import net.sourceforge.pmd.properties.PropertySource;
 public class LoosePackageCouplingRule extends AbstractJavaRule {
 
     public static final PropertyDescriptor<List<String>> PACKAGES_DESCRIPTOR =
-            stringListProperty("packages").desc("Restricted packages").emptyDefaultValue().delim(',').build();
+            stringListProperty("packages").setDescription("Restricted packages").emptyDefaultValue().delim(',').build();
 
     public static final PropertyDescriptor<List<String>> CLASSES_DESCRIPTOR =
-            stringListProperty("classes").desc("Allowed classes").emptyDefaultValue().delim(',').build();
+            stringListProperty("classes").setDescription("Allowed classes").emptyDefaultValue().delim(',').build();
 
     // The package of this source file
     private String thisPackage;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NPathComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NPathComplexityRule.java
@@ -31,12 +31,12 @@ public class NPathComplexityRule extends AbstractJavaMetricsRule {
 
     @Deprecated
     private static final PropertyDescriptor<Double> MINIMUM_DESCRIPTOR
-            = PropertyFactory.doubleProperty("minimum").desc("Deprecated! Minimum reporting threshold")
+            = PropertyFactory.doubleProperty("minimum").setDescription("Deprecated! Minimum reporting threshold")
                              .require(positive()).defaultValue(200d).build();
 
 
     private static final PropertyDescriptor<Integer> REPORT_LEVEL_DESCRIPTOR
-        = PropertyFactory.intProperty("reportLevel").desc("N-Path Complexity reporting threshold")
+        = PropertyFactory.intProperty("reportLevel").setDescription("N-Path Complexity reporting threshold")
                          .require(positive()).defaultValue(200).build();
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NcssCountRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NcssCountRule.java
@@ -36,14 +36,14 @@ public final class NcssCountRule extends AbstractJavaMetricsRule {
 
     private static final PropertyDescriptor<Integer> METHOD_REPORT_LEVEL_DESCRIPTOR =
             PropertyFactory.intProperty("methodReportLevel")
-                           .desc("NCSS reporting threshold for methods")
+                           .setDescription("NCSS reporting threshold for methods")
                            .require(positive())
                            .defaultValue(60)
                            .build();
 
     private static final PropertyDescriptor<Integer> CLASS_REPORT_LEVEL_DESCRIPTOR =
             PropertyFactory.intProperty("classReportLevel")
-                           .desc("NCSS reporting threshold for classes")
+                           .setDescription("NCSS reporting threshold for classes")
                            .require(positive())
                            .defaultValue(1500)
                            .build();
@@ -59,7 +59,7 @@ public final class NcssCountRule extends AbstractJavaMetricsRule {
 
     private static final PropertyDescriptor<List<NcssOption>> NCSS_OPTIONS_DESCRIPTOR =
             PropertyFactory.enumListProperty("ncssOptions", OPTION_MAP)
-                           .desc("Choose options for the computation of Ncss")
+                           .setDescription("Choose options for the computation of Ncss")
                            .emptyDefaultValue()
                            .build();
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SignatureDeclareThrowsExceptionRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SignatureDeclareThrowsExceptionRule.java
@@ -39,7 +39,7 @@ import net.sourceforge.pmd.properties.PropertyDescriptor;
 
 public class SignatureDeclareThrowsExceptionRule extends AbstractJavaRule {
 
-    private static final PropertyDescriptor<Boolean> IGNORE_JUNIT_COMPLETELY_DESCRIPTOR = booleanProperty("IgnoreJUnitCompletely").defaultValue(false).desc("Allow all methods in a JUnit testcase to throw Exceptions").build();
+    private static final PropertyDescriptor<Boolean> IGNORE_JUNIT_COMPLETELY_DESCRIPTOR = booleanProperty("IgnoreJUnitCompletely").defaultValue(false).setDescription("Allow all methods in a JUnit testcase to throw Exceptions").build();
 
     // Set to true when the class is determined to be a JUnit testcase
     private boolean junitImported = false;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SingularFieldRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SingularFieldRule.java
@@ -40,8 +40,8 @@ public class SingularFieldRule extends AbstractLombokAwareRule {
      * Restore old behavior by setting both properties to true, which will
      * result in many false positives
      */
-    private static final PropertyDescriptor<Boolean> CHECK_INNER_CLASSES = booleanProperty("checkInnerClasses").defaultValue(false).desc("Check inner classes").build();
-    private static final PropertyDescriptor<Boolean> DISALLOW_NOT_ASSIGNMENT = booleanProperty("disallowNotAssignment").defaultValue(false).desc("Disallow violations where the first usage is not an assignment").build();
+    private static final PropertyDescriptor<Boolean> CHECK_INNER_CLASSES = booleanProperty("checkInnerClasses").defaultValue(false).setDescription("Check inner classes").build();
+    private static final PropertyDescriptor<Boolean> DISALLOW_NOT_ASSIGNMENT = booleanProperty("disallowNotAssignment").defaultValue(false).setDescription("Disallow violations where the first usage is not an assignment").build();
 
 
     public SingularFieldRule() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/StdCyclomaticComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/StdCyclomaticComplexityRule.java
@@ -46,7 +46,7 @@ public class StdCyclomaticComplexityRule extends AbstractJavaRule {
 
     public static final PropertyDescriptor<Integer> REPORT_LEVEL_DESCRIPTOR
             = PropertyFactory.intProperty("reportLevel")
-                             .desc("Cyclomatic Complexity reporting threshold")
+                             .setDescription("Cyclomatic Complexity reporting threshold")
                              .require(positive()).defaultValue(10).build();
 
     public static final BooleanProperty SHOW_CLASSES_COMPLEXITY_DESCRIPTOR = new BooleanProperty(

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/TooManyFieldsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/TooManyFieldsRule.java
@@ -21,7 +21,7 @@ public class TooManyFieldsRule extends AbstractJavaRule {
 
     private static final PropertyDescriptor<Integer> MAX_FIELDS_DESCRIPTOR
             = PropertyFactory.intProperty("maxfields")
-                             .desc("Max allowable fields")
+                             .setDescription("Max allowable fields")
                              .defaultValue(DEFAULT_MAXFIELDS)
                              .require(positive())
                              .build();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UselessOverridingMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UselessOverridingMethodRule.java
@@ -46,7 +46,7 @@ public class UselessOverridingMethodRule extends AbstractJavaRule {
 
     // TODO extend AbstractIgnoredAnnotationsRule node
     // TODO ignore if there is javadoc
-    private static final PropertyDescriptor<Boolean> IGNORE_ANNOTATIONS_DESCRIPTOR = booleanProperty("ignoreAnnotations").defaultValue(false).desc("Ignore annotations").build();
+    private static final PropertyDescriptor<Boolean> IGNORE_ANNOTATIONS_DESCRIPTOR = booleanProperty("ignoreAnnotations").defaultValue(false).setDescription("Ignore annotations").build();
 
 
     public UselessOverridingMethodRule() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentContentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentContentRule.java
@@ -37,11 +37,11 @@ public class CommentContentRule extends AbstractCommentRule {
     private List<String> currentBadWords;
 
     // ignored when property above == True
-    public static final PropertyDescriptor<Boolean> CASE_SENSITIVE_DESCRIPTOR = booleanProperty("caseSensitive").defaultValue(false).desc("Case sensitive").build();
+    public static final PropertyDescriptor<Boolean> CASE_SENSITIVE_DESCRIPTOR = booleanProperty("caseSensitive").defaultValue(false).setDescription("Case sensitive").build();
 
     public static final PropertyDescriptor<List<String>> DISSALLOWED_TERMS_DESCRIPTOR =
             stringListProperty("disallowedTerms")
-                    .desc("Illegal terms or phrases")
+                    .setDescription("Illegal terms or phrases")
                     .defaultValues("idiot", "jerk").build(); // TODO make blank property? or add more defaults?
 
     private static final Set<PropertyDescriptor<?>> NON_REGEX_PROPERTIES;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentRequiredRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentRequiredRule.java
@@ -269,7 +269,7 @@ public class CommentRequiredRule extends AbstractCommentRule {
     private static GenericPropertyBuilder<CommentRequirement> requirementPropertyBuilder(String name, String commentType) {
         DESCRIPTOR_NAME_TO_COMMENT_TYPE.put(name, commentType);
         return PropertyFactory.enumProperty(name, CommentRequirement.mappings())
-            .desc(commentType + ". Possible values: " + CommentRequirement.labels())
+            .setDescription(commentType + ". Possible values: " + CommentRequirement.labels())
             .defaultValue(CommentRequirement.Required);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentSizeRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentSizeRule.java
@@ -26,12 +26,12 @@ public class CommentSizeRule extends AbstractCommentRule {
 
     public static final PropertyDescriptor<Integer> MAX_LINES
             = PropertyFactory.intProperty("maxLines")
-                             .desc("Maximum lines")
+                             .setDescription("Maximum lines")
                              .require(positive()).defaultValue(6).build();
     
     public static final PropertyDescriptor<Integer> MAX_LINE_LENGTH
             = PropertyFactory.intProperty("maxLineLength")
-                             .desc("Maximum line length")
+                             .setDescription("Maximum line length")
                              .require(positive()).defaultValue(80).build();
 
     private static final String CR = "\n";

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentInOperandRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentInOperandRule.java
@@ -27,22 +27,22 @@ public class AssignmentInOperandRule extends AbstractJavaRule {
 
     private static final PropertyDescriptor<Boolean> ALLOW_IF_DESCRIPTOR =
             booleanProperty("allowIf")
-                    .desc("Allow assignment within the conditional expression of an if statement")
+                    .setDescription("Allow assignment within the conditional expression of an if statement")
                     .defaultValue(false).build();
 
     private static final PropertyDescriptor<Boolean> ALLOW_FOR_DESCRIPTOR =
             booleanProperty("allowFor")
-                    .desc("Allow assignment within the conditional expression of a for statement")
+                    .setDescription("Allow assignment within the conditional expression of a for statement")
                     .defaultValue(false).build();
 
     private static final PropertyDescriptor<Boolean> ALLOW_WHILE_DESCRIPTOR =
             booleanProperty("allowWhile")
-                    .desc("Allow assignment within the conditional expression of a while statement")
+                    .setDescription("Allow assignment within the conditional expression of a while statement")
                     .defaultValue(false).build();
 
     private static final PropertyDescriptor<Boolean> ALLOW_INCREMENT_DECREMENT_DESCRIPTOR =
             booleanProperty("allowIncrementDecrement")
-                    .desc("Allow increment or decrement operators within the conditional expression of an if, for, or while statement")
+                    .setDescription("Allow increment or decrement operators within the conditional expression of an if, for, or while statement")
                     .defaultValue(false).build();
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidBranchingStatementAsLastInLoopRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidBranchingStatementAsLastInLoopRule.java
@@ -119,7 +119,7 @@ public class AvoidBranchingStatementAsLastInLoopRule extends AbstractJavaRule {
 
     private static PropertyDescriptor<List<String>> propertyFor(String stmtName) {
         return PropertyFactory.enumListProperty("check" + StringUtils.capitalize(stmtName) + "LoopTypes", LOOP_TYPES_MAPPINGS)
-                .desc("List of loop types in which " + stmtName + " statements will be checked")
+                .setDescription("List of loop types in which " + stmtName + " statements will be checked")
                 .defaultValue(DEFAULTS)
                 .build();
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDuplicateLiteralsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDuplicateLiteralsRule.java
@@ -39,14 +39,14 @@ public class AvoidDuplicateLiteralsRule extends AbstractJavaRule {
 
     public static final PropertyDescriptor<Integer> THRESHOLD_DESCRIPTOR
             = PropertyFactory.intProperty("maxDuplicateLiterals")
-                             .desc("Max duplicate literals")
+                             .setDescription("Max duplicate literals")
                              .require(positive()).defaultValue(4).build();
 
-    public static final PropertyDescriptor<Integer> MINIMUM_LENGTH_DESCRIPTOR = PropertyFactory.intProperty("minimumLength").desc("Minimum string length to check").require(positive()).defaultValue(3).build();
+    public static final PropertyDescriptor<Integer> MINIMUM_LENGTH_DESCRIPTOR = PropertyFactory.intProperty("minimumLength").setDescription("Minimum string length to check").require(positive()).defaultValue(3).build();
 
     public static final PropertyDescriptor<Boolean> SKIP_ANNOTATIONS_DESCRIPTOR =
             booleanProperty("skipAnnotations")
-                    .desc("Skip literals within annotations").defaultValue(false).build();
+                    .setDescription("Skip literals within annotations").defaultValue(false).build();
 
     // This set of properties is impossible to convert to the new framework before 7.0.0
     // It looks like it tried to implement itself delimiter escaping and such, which we

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidUsingOctalValuesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidUsingOctalValuesRule.java
@@ -20,7 +20,7 @@ public class AvoidUsingOctalValuesRule extends AbstractJavaRule {
     public static final Pattern STRICT_OCTAL_PATTERN = Pattern.compile("0[0-7]+[lL]?");
 
     private static final PropertyDescriptor<Boolean> STRICT_METHODS_DESCRIPTOR = booleanProperty("strict")
-                                                                                    .desc("Detect violations between 00 and 07")
+                                                                                    .setDescription("Detect violations between 00 and 07")
                                                                                     .defaultValue(false)
                                                                                     .build();
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/BeanMembersShouldSerializeRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/BeanMembersShouldSerializeRule.java
@@ -34,7 +34,7 @@ public class BeanMembersShouldSerializeRule extends AbstractLombokAwareRule {
 
     private String prefixProperty;
 
-    private static final PropertyDescriptor<String> PREFIX_DESCRIPTOR = stringProperty("prefix").desc("A variable prefix to skip, i.e., m_").defaultValue("").build();
+    private static final PropertyDescriptor<String> PREFIX_DESCRIPTOR = stringProperty("prefix").setDescription("A variable prefix to skip, i.e., m_").defaultValue("").build();
 
     public BeanMembersShouldSerializeRule() {
         definePropertyDescriptor(PREFIX_DESCRIPTOR);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
@@ -71,23 +71,23 @@ public class CloseResourceRule extends AbstractJavaRule {
     private Set<String> closeTargets = new HashSet<>();
     private static final PropertyDescriptor<List<String>> CLOSE_TARGETS_DESCRIPTOR =
             stringListProperty("closeTargets")
-                           .desc("Methods which may close this resource")
+                           .setDescription("Methods which may close this resource")
                            .emptyDefaultValue()
                            .delim(',').build();
 
     private static final PropertyDescriptor<List<String>> TYPES_DESCRIPTOR =
             stringListProperty("types")
-                    .desc("Affected types")
+                    .setDescription("Affected types")
                     .defaultValues("java.lang.AutoCloseable", "java.sql.Connection", "java.sql.Statement", "java.sql.ResultSet")
                     .delim(',').build();
 
     private static final PropertyDescriptor<Boolean> USE_CLOSE_AS_DEFAULT_TARGET =
             booleanProperty("closeAsDefaultTarget")
-                    .desc("Consider 'close' as a target by default").defaultValue(true).build();
+                    .setDescription("Consider 'close' as a target by default").defaultValue(true).build();
 
     private static final PropertyDescriptor<List<String>> ALLOWED_RESOURCE_TYPES =
             stringListProperty("allowedResourceTypes")
-            .desc("Exact class names that do not need to be closed")
+            .setDescription("Exact class names that do not need to be closed")
             .defaultValues("java.io.ByteArrayOutputStream", "java.io.ByteArrayInputStream", "java.io.StringWriter",
                     "java.io.CharArrayWriter")
             .build();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/DataflowAnomalyAnalysisRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/DataflowAnomalyAnalysisRule.java
@@ -35,13 +35,13 @@ import net.sourceforge.pmd.properties.PropertyFactory;
 public class DataflowAnomalyAnalysisRule extends AbstractJavaRule implements Executable {
     private static final PropertyDescriptor<Integer> MAX_PATH_DESCRIPTOR
             = PropertyFactory.intProperty("maxPaths")
-                             .desc("Maximum number of checked paths per method. A lower value will increase the performance of the rule but may decrease anomalies found.")
+                             .setDescription("Maximum number of checked paths per method. A lower value will increase the performance of the rule but may decrease anomalies found.")
                              .require(inRange(100, 8000))
                              .defaultValue(1000)
                              .build();
     private static final PropertyDescriptor<Integer> MAX_VIOLATIONS_DESCRIPTOR
             = PropertyFactory.intProperty("maxViolations")
-                             .desc("Maximum number of anomalies per class")
+                             .setDescription("Maximum number of anomalies per class")
                              .require(inRange(1, 2000))
                              .defaultValue(100)
                              .build();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/NonThreadSafeSingletonRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/NonThreadSafeSingletonRule.java
@@ -35,11 +35,11 @@ public class NonThreadSafeSingletonRule extends AbstractJavaRule {
 
     private static final PropertyDescriptor<Boolean> CHECK_NON_STATIC_METHODS_DESCRIPTOR =
             booleanProperty("checkNonStaticMethods")
-                    .desc("Check for non-static methods.  Do not set this to false and checkNonStaticFields to true.")
+                    .setDescription("Check for non-static methods.  Do not set this to false and checkNonStaticFields to true.")
                     .defaultValue(true).build();
     private static final PropertyDescriptor<Boolean> CHECK_NON_STATIC_FIELDS_DESCRIPTOR =
             booleanProperty("checkNonStaticFields")
-                    .desc("Check for non-static fields.  Do not set this to true and checkNonStaticMethods to false.")
+                    .setDescription("Check for non-static fields.  Do not set this to true and checkNonStaticMethods to false.")
                     .defaultValue(false).build();
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/UnsynchronizedStaticFormatterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/multithreading/UnsynchronizedStaticFormatterRule.java
@@ -39,7 +39,7 @@ public class UnsynchronizedStaticFormatterRule extends AbstractJavaRule {
 
     private static final PropertyDescriptor<Boolean> ALLOW_METHOD_LEVEL_SYNC =
         PropertyFactory.booleanProperty("allowMethodLevelSynchronization")
-            .desc("If true, method level synchronization is allowed as well as synchronized block. Otherwise"
+            .setDescription("If true, method level synchronization is allowed as well as synchronized block. Otherwise"
                 + " only synchronized blocks are allowed.")
             .defaultValue(false)
             .build();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveLiteralAppendsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveLiteralAppendsRule.java
@@ -82,7 +82,7 @@ public class ConsecutiveLiteralAppendsRule extends AbstractJavaRule {
 
     private static final PropertyDescriptor<Integer> THRESHOLD_DESCRIPTOR
             = PropertyFactory.intProperty("threshold")
-                             .desc("Max consecutive appends")
+                             .setDescription("Max consecutive appends")
                              .require(inRange(1, 10)).defaultValue(1).build();
 
     private int threshold = 1;

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/SuppressWarningsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/SuppressWarningsTest.java
@@ -43,10 +43,10 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST1, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
         runTestFromString(TEST2, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     @Test
@@ -54,7 +54,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST3, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     @Test
@@ -62,7 +62,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST4, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -70,7 +70,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST5, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     @Test
@@ -78,7 +78,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST6, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -86,7 +86,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST7, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -94,7 +94,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST8, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -102,7 +102,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST9, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -110,7 +110,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST9_VALUE1, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -118,7 +118,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST9_VALUE2, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -126,7 +126,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST9_VALUE3, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -134,7 +134,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST9_MULTIPLE_VALUES_1, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     @Test
@@ -142,7 +142,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST9_MULTIPLE_VALUES_2, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     @Test
@@ -150,7 +150,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST10, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(2, rpt.size());
+        assertEquals(2, rpt.getNumViolations());
     }
 
     @Test
@@ -158,7 +158,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST11, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(2, rpt.size());
+        assertEquals(2, rpt.getNumViolations());
     }
 
     @Test
@@ -166,7 +166,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST12, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     @Test
@@ -174,7 +174,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST13, new BarRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     private static final String TEST1 = "@SuppressWarnings(\"PMD\")" + PMD.EOL + "public class Foo {}";

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/AbstractMetricTestRule.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/AbstractMetricTestRule.java
@@ -34,22 +34,22 @@ public abstract class AbstractMetricTestRule extends AbstractJavaMetricsRule {
 
     private final PropertyDescriptor<List<MetricOption>> optionsDescriptor =
             PropertyFactory.enumListProperty("metricOptions", optionMappings())
-                           .desc("Choose a variant of the metric or the standard")
+                           .setDescription("Choose a variant of the metric or the standard")
                            .emptyDefaultValue().build();
 
     private final PropertyDescriptor<Boolean> reportClassesDescriptor =
             PropertyFactory.booleanProperty("reportClasses")
-                           .desc("Add class violations to the report")
+                           .setDescription("Add class violations to the report")
                            .defaultValue(isReportClasses()).build();
 
     private final PropertyDescriptor<Boolean> reportMethodsDescriptor =
             PropertyFactory.booleanProperty("reportMethods")
-                           .desc("Add method violations to the report")
+                           .setDescription("Add method violations to the report")
                            .defaultValue(isReportMethods()).build();
 
     private final PropertyDescriptor<Double> reportLevelDescriptor =
             PropertyFactory.doubleProperty("reportLevel")
-                           .desc("Minimum value required to report")
+                           .setDescription("Minimum value required to report")
                            .defaultValue(defaultReportLevel()).build();
 
     private MetricOptions metricOptions;

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/XPathJspRuleTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/XPathJspRuleTest.java
@@ -47,7 +47,7 @@ public class XPathJspRuleTest extends RuleTst {
 
         p.getSourceCodeProcessor().processSourceCode(new StringReader(MATCH), new RuleSets(rules), ctx);
 
-        assertEquals("One violation expected!", 1, report.size());
+        assertEquals("One violation expected!", 1, report.getNumViolations());
 
         RuleViolation rv = report.iterator().next();
         assertEquals(1, rv.getBeginLine());

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/AvoidTabCharacterRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/AvoidTabCharacterRule.java
@@ -16,7 +16,7 @@ import net.sourceforge.pmd.properties.PropertyFactory;
 public class AvoidTabCharacterRule extends AbstractPLSQLRule {
 
     private static final PropertyDescriptor<Boolean> EACH_LINE = PropertyFactory.booleanProperty("eachLine")
-            .desc("Whether to report each line with a tab character or only the first line")
+            .setDescription("Whether to report each line with a tab character or only the first line")
             .defaultValue(false)
             .build();
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/CodeFormatRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/CodeFormatRule.java
@@ -32,7 +32,7 @@ import net.sourceforge.pmd.properties.PropertyFactory;
 public class CodeFormatRule extends AbstractPLSQLRule {
 
     private static final PropertyDescriptor<Integer> INDENTATION_PROPERTY = PropertyFactory.intProperty("indentation")
-                                                                                           .desc("Indentation to be used for blocks").defaultValue(2).require(inRange(0, 32)).build();
+                                                                                           .setDescription("Indentation to be used for blocks").defaultValue(2).require(inRange(0, 32)).build();
 
     private int indentation = INDENTATION_PROPERTY.defaultValue();
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/LineLengthRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/LineLengthRule.java
@@ -17,12 +17,12 @@ import net.sourceforge.pmd.properties.constraints.NumericConstraints;
 public class LineLengthRule extends AbstractPLSQLRule {
 
     private static final PropertyDescriptor<Integer> MAX_LINE_LENGTH = PropertyFactory.intProperty("maxLineLength")
-            .desc("The maximum allowed line length")
+            .setDescription("The maximum allowed line length")
             .defaultValue(80)
             .require(NumericConstraints.inRange(10, 200))
             .build();
     private static final PropertyDescriptor<Boolean> EACH_LINE = PropertyFactory.booleanProperty("eachLine")
-            .desc("Whether to report each line that is longer only the first line")
+            .setDescription("Whether to report each line that is longer only the first line")
             .defaultValue(false)
             .build();
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/CyclomaticComplexityRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/CyclomaticComplexityRule.java
@@ -49,7 +49,7 @@ public class CyclomaticComplexityRule extends AbstractPLSQLRule {
 
     public static final PropertyDescriptor<Integer> REPORT_LEVEL_DESCRIPTOR
             = PropertyFactory.intProperty("reportLevel")
-                             .desc("Cyclomatic Complexity reporting threshold")
+                             .setDescription("Cyclomatic Complexity reporting threshold")
                              .require(positive()).defaultValue(10).build();
 
     public static final BooleanProperty SHOW_CLASSES_COMPLEXITY_DESCRIPTOR = new BooleanProperty(

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/TooManyFieldsRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/TooManyFieldsRule.java
@@ -30,7 +30,7 @@ public class TooManyFieldsRule extends AbstractPLSQLRule {
 
     private static final PropertyDescriptor<Integer> MAX_FIELDS_DESCRIPTOR
             = PropertyFactory.intProperty("maxfields")
-                             .desc("Max allowable fields")
+                             .setDescription("Max allowable fields")
                              .defaultValue(DEFAULT_MAXFIELDS)
                              .require(positive())
                              .build();

--- a/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
@@ -145,7 +145,7 @@ public abstract class RuleTst {
                 }
 
                 report = processUsingStringReader(test, rule);
-                res = report.size();
+                res = report.getNumViolations();
             } catch (Exception e) {
                 e.printStackTrace();
                 throw new RuntimeException('"' + test.getDescription() + "\" failed", e);
@@ -184,7 +184,7 @@ public abstract class RuleTst {
         }
 
         List<String> expectedMessages = test.getExpectedMessages();
-        if (report.size() != expectedMessages.size()) {
+        if (report.getNumViolations() != expectedMessages.size()) {
             throw new RuntimeException("Test setup error: number of expected messages doesn't match "
                     + "number of violations for test case '" + test.getDescription() + "'");
         }
@@ -210,7 +210,7 @@ public abstract class RuleTst {
         }
 
         List<Integer> expected = test.getExpectedLineNumbers();
-        if (report.size() != expected.size()) {
+        if (report.getNumViolations() != expected.size()) {
             throw new RuntimeException("Test setup error: number of execpted line numbers doesn't match "
                     + "number of violations for test case '" + test.getDescription() + "'");
         }
@@ -232,7 +232,7 @@ public abstract class RuleTst {
     private void printReport(TestDescriptor test, Report report) {
         System.out.println("--------------------------------------------------------------");
         System.out.println("Test Failure: " + test.getDescription());
-        System.out.println(" -> Expected " + test.getNumberOfProblemsExpected() + " problem(s), " + report.size()
+        System.out.println(" -> Expected " + test.getNumberOfProblemsExpected() + " problem(s), " + report.getNumViolations()
                 + " problem(s) found.");
         System.out.println(" -> Expected messages: " + test.getExpectedMessages());
         System.out.println(" -> Expected line numbers: " + test.getExpectedLineNumbers());

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/design/AvoidDeeplyNestedIfStmtsRule.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/design/AvoidDeeplyNestedIfStmtsRule.java
@@ -22,7 +22,7 @@ public class AvoidDeeplyNestedIfStmtsRule extends AbstractVmRule {
 
     private static final PropertyDescriptor<Integer> PROBLEM_DEPTH_DESCRIPTOR
             = PropertyFactory.intProperty("problemDepth")
-                             .desc("The if statement depth reporting threshold")
+                             .setDescription("The if statement depth reporting threshold")
                              .require(positive()).defaultValue(3).build();
 
     public AvoidDeeplyNestedIfStmtsRule() {


### PR DESCRIPTION
The class PropertyBuilder is used to represent PropertyBuilder.  This method named 'desc' is to specify the description of this property. Thus, the method name 'setDescription' is more intuitive than 'desc'.

The class PropertyBuilder is used to represent Report.  This method named 'size' is to get number of violations. Thus, the method name 'getNumViolations' is more intuitive than 'size'.