### PR TITLE
[on hold] [core] Change method name 'size' to 'getNumViolations', save the old method as deprecated and update documentation

### DIFF
--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/SuppressWarningsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/SuppressWarningsTest.java
@@ -37,10 +37,10 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST1, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
         runTestFromString(TEST2, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     @Test
@@ -48,7 +48,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST3, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     @Test
@@ -56,7 +56,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST4, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -64,7 +64,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST5, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     @Test
@@ -72,7 +72,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST6, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -80,7 +80,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST7, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -88,7 +88,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST8, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -96,7 +96,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST9, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -104,7 +104,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST9_MULTIPLE_VALUES, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     @Test
@@ -112,7 +112,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST10, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(2, rpt.size());
+        assertEquals(2, rpt.getNumViolations());
     }
 
     @Test
@@ -120,7 +120,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST11, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(2, rpt.size());
+        assertEquals(2, rpt.getNumViolations());
     }
 
     @Test
@@ -128,7 +128,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST12, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     @Test
@@ -136,7 +136,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST13, new BarRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     private static final String TEST1 = "@SuppressWarnings('PMD')" + PMD.EOL + "public class Foo {}";

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/SuppressWarningsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/SuppressWarningsTest.java
@@ -37,10 +37,10 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST1, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(0, rpt.getNumViolations());
+        assertEquals(0, rpt.getNumberOfViolations());
         runTestFromString(TEST2, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(0, rpt.getNumViolations());
+        assertEquals(0, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -48,7 +48,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST3, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(0, rpt.getNumViolations());
+        assertEquals(0, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -56,7 +56,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST4, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(1, rpt.getNumViolations());
+        assertEquals(1, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -64,7 +64,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST5, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(0, rpt.getNumViolations());
+        assertEquals(0, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -72,7 +72,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST6, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(1, rpt.getNumViolations());
+        assertEquals(1, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -80,7 +80,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST7, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(1, rpt.getNumViolations());
+        assertEquals(1, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -88,7 +88,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST8, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(1, rpt.getNumViolations());
+        assertEquals(1, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -96,7 +96,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST9, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(1, rpt.getNumViolations());
+        assertEquals(1, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -104,7 +104,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST9_MULTIPLE_VALUES, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(0, rpt.getNumViolations());
+        assertEquals(0, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -112,7 +112,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST10, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(2, rpt.getNumViolations());
+        assertEquals(2, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -120,7 +120,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST11, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(2, rpt.getNumViolations());
+        assertEquals(2, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -128,7 +128,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST12, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(0, rpt.getNumViolations());
+        assertEquals(0, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -136,7 +136,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST13, new BarRule(), rpt,
                 LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
-        assertEquals(0, rpt.getNumViolations());
+        assertEquals(0, rpt.getNumberOfViolations());
     }
 
     private static final String TEST1 = "@SuppressWarnings('PMD')" + PMD.EOL + "public class Foo {}";

--- a/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
@@ -518,11 +518,7 @@ public class Report implements Iterable<RuleViolation> {
         return getNumberOfViolations();
     }
 
-    /**
-     * The number of violations.
-     *
-     * @return number of violations.
-     */
+   
     public int getNumberOfViolations() {
         return violations.size();
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
@@ -508,12 +508,12 @@ public class Report implements Iterable<RuleViolation> {
     }
 
 
+    @Deprecated
     /**
      * The number of violations.
      *
      * @return number of violations.
      */
-    @Deprecated
     public int size() {
         return getNumViolations();
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
@@ -515,7 +515,7 @@ public class Report implements Iterable<RuleViolation> {
      * @return number of violations.
      */
     public int size() {
-        return getNumViolations();
+        return getNumberOfViolations();
     }
 
     /**
@@ -523,7 +523,7 @@ public class Report implements Iterable<RuleViolation> {
      *
      * @return number of violations.
      */
-    public int getNumViolations() {
+    public int getNumberOfViolations() {
         return violations.size();
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
@@ -512,7 +512,7 @@ public class Report implements Iterable<RuleViolation> {
      *
      * @return number of violations.
      *
-     * @deprecated replaced by getNumberOfViolations()
+     * @deprecated see {@link #getNumberOfViolations()}
      */
     @Deprecated
     public int size() {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
@@ -507,18 +507,19 @@ public class Report implements Iterable<RuleViolation> {
         return violationTree.size();
     }
 
-
-    @Deprecated
     /**
      * The number of violations.
      *
      * @return number of violations.
+     *
+     * @deprecated replaced by getNumberOfViolations()
      */
+    @Deprecated
     public int size() {
         return getNumberOfViolations();
     }
 
-   
+
     public int getNumberOfViolations() {
         return violations.size();
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
@@ -520,6 +520,10 @@ public class Report implements Iterable<RuleViolation> {
     }
 
 
+    /**
+     * Get number of violations.
+     *
+     */
     public int getNumberOfViolations() {
         return violations.size();
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
@@ -507,12 +507,23 @@ public class Report implements Iterable<RuleViolation> {
         return violationTree.size();
     }
 
+
     /**
      * The number of violations.
      *
      * @return number of violations.
      */
+    @Deprecated
     public int size() {
+        return getNumViolations();
+    }
+
+    /**
+     * The number of violations.
+     *
+     * @return number of violations.
+     */
+    public int getNumViolations() {
         return violations.size();
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
@@ -165,7 +165,7 @@ public class PMDTaskImpl {
 
                 @Override
                 public void renderFileReport(Report r) {
-                    int size = r.size();
+                    int size = r.getNumViolations();
                     if (size > 0) {
                         reportSize.addAndGet(size);
                     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
@@ -165,7 +165,7 @@ public class PMDTaskImpl {
 
                 @Override
                 public void renderFileReport(Report r) {
-                    int size = r.getNumViolations();
+                    int size = r.getNumberOfViolations();
                     if (size > 0) {
                         reportSize.addAndGet(size);
                     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleContextTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleContextTest.java
@@ -22,7 +22,7 @@ public class RuleContextTest {
     @Test
     public void testReport() {
         RuleContext ctx = new RuleContext();
-        assertEquals(0, ctx.getReport().getNumViolations());
+        assertEquals(0, ctx.getReport().getNumberOfViolations());
         Report r = new Report();
         ctx.setReport(r);
         Report r2 = ctx.getReport();

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleContextTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleContextTest.java
@@ -22,7 +22,7 @@ public class RuleContextTest {
     @Test
     public void testReport() {
         RuleContext ctx = new RuleContext();
-        assertEquals(0, ctx.getReport().size());
+        assertEquals(0, ctx.getReport().getNumViolations());
         Report r = new Report();
         ctx.setReport(r);
         Report r2 = ctx.getReport();

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetTest.java
@@ -440,7 +440,7 @@ public class RuleSetTest {
         ctx.setSourceCodeFile(file);
         ctx.setLanguageVersion(LanguageRegistry.getLanguage(DummyLanguageModule.NAME).getDefaultVersion());
         ruleSets.apply(makeCompilationUnits(), ctx, LanguageRegistry.getLanguage(DummyLanguageModule.NAME));
-        assertEquals("Violations", 2, r.size());
+        assertEquals("Violations", 2, r.getNumViolations());
 
         // One violation
         ruleSet1 = createRuleSetBuilder("RuleSet1")
@@ -455,7 +455,7 @@ public class RuleSetTest {
         r = new Report();
         ctx.setReport(r);
         ruleSets.apply(makeCompilationUnits(), ctx, LanguageRegistry.getLanguage(DummyLanguageModule.NAME));
-        assertEquals("Violations", 1, r.size());
+        assertEquals("Violations", 1, r.getNumViolations());
     }
     
     @Test
@@ -483,7 +483,7 @@ public class RuleSetTest {
         context.setReport(new Report());
         ruleset.apply(makeCompilationUnits(), context);
 
-        assertEquals("Invalid number of Violations Reported", size, context.getReport().size());
+        assertEquals("Invalid number of Violations Reported", size, context.getReport().getNumViolations());
 
         Iterator<RuleViolation> violations = context.getReport().iterator();
         while (violations.hasNext()) {
@@ -580,7 +580,7 @@ public class RuleSetTest {
         assertEquals("Wrong error message", "RuntimeException: Test exception while applying rule", errors.get(0).getMsg());
         assertTrue("Should be a RuntimeException", errors.get(0).getError() instanceof RuntimeException);
 
-        assertEquals("There should be a violation", 1, context.getReport().size());
+        assertEquals("There should be a violation", 1, context.getReport().getNumViolations());
     }
 
     @Test
@@ -620,7 +620,7 @@ public class RuleSetTest {
         assertEquals("Wrong error message", "RuntimeException: Test exception while applying rule", errors.get(0).getMsg());
         assertTrue("Should be a RuntimeException", errors.get(0).getError() instanceof RuntimeException);
 
-        assertEquals("There should be a violation", 1, context.getReport().size());
+        assertEquals("There should be a violation", 1, context.getReport().getNumViolations());
     }
 
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetTest.java
@@ -440,7 +440,7 @@ public class RuleSetTest {
         ctx.setSourceCodeFile(file);
         ctx.setLanguageVersion(LanguageRegistry.getLanguage(DummyLanguageModule.NAME).getDefaultVersion());
         ruleSets.apply(makeCompilationUnits(), ctx, LanguageRegistry.getLanguage(DummyLanguageModule.NAME));
-        assertEquals("Violations", 2, r.getNumViolations());
+        assertEquals("Violations", 2, r.getNumberOfViolations());
 
         // One violation
         ruleSet1 = createRuleSetBuilder("RuleSet1")
@@ -455,7 +455,7 @@ public class RuleSetTest {
         r = new Report();
         ctx.setReport(r);
         ruleSets.apply(makeCompilationUnits(), ctx, LanguageRegistry.getLanguage(DummyLanguageModule.NAME));
-        assertEquals("Violations", 1, r.getNumViolations());
+        assertEquals("Violations", 1, r.getNumberOfViolations());
     }
     
     @Test
@@ -483,7 +483,7 @@ public class RuleSetTest {
         context.setReport(new Report());
         ruleset.apply(makeCompilationUnits(), context);
 
-        assertEquals("Invalid number of Violations Reported", size, context.getReport().getNumViolations());
+        assertEquals("Invalid number of Violations Reported", size, context.getReport().getNumberOfViolations());
 
         Iterator<RuleViolation> violations = context.getReport().iterator();
         while (violations.hasNext()) {
@@ -580,7 +580,7 @@ public class RuleSetTest {
         assertEquals("Wrong error message", "RuntimeException: Test exception while applying rule", errors.get(0).getMsg());
         assertTrue("Should be a RuntimeException", errors.get(0).getError() instanceof RuntimeException);
 
-        assertEquals("There should be a violation", 1, context.getReport().getNumViolations());
+        assertEquals("There should be a violation", 1, context.getReport().getNumberOfViolations());
     }
 
     @Test
@@ -620,7 +620,7 @@ public class RuleSetTest {
         assertEquals("Wrong error message", "RuntimeException: Test exception while applying rule", errors.get(0).getMsg());
         assertTrue("Should be a RuntimeException", errors.get(0).getError() instanceof RuntimeException);
 
-        assertEquals("There should be a violation", 1, context.getReport().getNumViolations());
+        assertEquals("There should be a violation", 1, context.getReport().getNumberOfViolations());
     }
 
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/stat/StatisticalRuleTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/stat/StatisticalRuleTest.java
@@ -288,7 +288,7 @@ public class StatisticalRuleTest {
 
         Report report = makeReport(rule);
 
-        assertEquals("Expecting only one result", 1, report.size());
+        assertEquals("Expecting only one result", 1, report.getNumViolations());
     }
 
     // Okay, we have three properties we need to
@@ -819,15 +819,15 @@ public class StatisticalRuleTest {
                 assertEquals(
                         "Unexpected number of results: sigma= " + Double.toString(sigma) + " min= "
                                 + Double.toString(minimum) + " topscore= " + Integer.toString(topScore),
-                        expected, report.size());
+                        expected, report.getNumViolations());
             } else {
                 String assertStr = "Unexpected number of results: sigma= " + Double.toString(sigma) + " min= "
                         + Double.toString(minimum) + " topscore= " + Integer.toString(topScore) + " expected= "
                         + Integer.toString(expected) + " +/- " + Integer.toString(delta) + " actual-result= "
-                        + report.size();
+                        + report.getNumViolations();
 
-                assertTrue(assertStr, report.size() >= (expected - delta));
-                assertTrue(assertStr, report.size() <= (expected + delta));
+                assertTrue(assertStr, report.getNumViolations() >= (expected - delta));
+                assertTrue(assertStr, report.getNumViolations() <= (expected + delta));
             }
         } catch (AssertionFailedError afe) {
             System.err.println("******** " + testName + " ***********");

--- a/pmd-core/src/test/java/net/sourceforge/pmd/stat/StatisticalRuleTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/stat/StatisticalRuleTest.java
@@ -288,7 +288,7 @@ public class StatisticalRuleTest {
 
         Report report = makeReport(rule);
 
-        assertEquals("Expecting only one result", 1, report.getNumViolations());
+        assertEquals("Expecting only one result", 1, report.getNumberOfViolations());
     }
 
     // Okay, we have three properties we need to
@@ -819,15 +819,15 @@ public class StatisticalRuleTest {
                 assertEquals(
                         "Unexpected number of results: sigma= " + Double.toString(sigma) + " min= "
                                 + Double.toString(minimum) + " topscore= " + Integer.toString(topScore),
-                        expected, report.getNumViolations());
+                        expected, report.getNumberOfViolations());
             } else {
                 String assertStr = "Unexpected number of results: sigma= " + Double.toString(sigma) + " min= "
                         + Double.toString(minimum) + " topscore= " + Integer.toString(topScore) + " expected= "
                         + Integer.toString(expected) + " +/- " + Integer.toString(delta) + " actual-result= "
-                        + report.getNumViolations();
+                        + report.getNumberOfViolations();
 
-                assertTrue(assertStr, report.getNumViolations() >= (expected - delta));
-                assertTrue(assertStr, report.getNumViolations() <= (expected + delta));
+                assertTrue(assertStr, report.getNumberOfViolations() >= (expected - delta));
+                assertTrue(assertStr, report.getNumberOfViolations() <= (expected + delta));
             }
         } catch (AssertionFailedError afe) {
             System.err.println("******** " + testName + " ***********");

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/SuppressWarningsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/SuppressWarningsTest.java
@@ -43,10 +43,10 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST1, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
         runTestFromString(TEST2, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     @Test
@@ -54,7 +54,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST3, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     @Test
@@ -62,7 +62,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST4, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -70,7 +70,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST5, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     @Test
@@ -78,7 +78,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST6, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -86,7 +86,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST7, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -94,7 +94,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST8, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -102,7 +102,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST9, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -110,7 +110,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST9_VALUE1, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -118,7 +118,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST9_VALUE2, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -126,7 +126,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST9_VALUE3, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(1, rpt.size());
+        assertEquals(1, rpt.getNumViolations());
     }
 
     @Test
@@ -134,7 +134,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST9_MULTIPLE_VALUES_1, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     @Test
@@ -142,7 +142,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST9_MULTIPLE_VALUES_2, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     @Test
@@ -150,7 +150,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST10, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(2, rpt.size());
+        assertEquals(2, rpt.getNumViolations());
     }
 
     @Test
@@ -158,7 +158,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST11, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(2, rpt.size());
+        assertEquals(2, rpt.getNumViolations());
     }
 
     @Test
@@ -166,7 +166,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST12, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     @Test
@@ -174,7 +174,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST13, new BarRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(0, rpt.size());
+        assertEquals(0, rpt.getNumViolations());
     }
 
     private static final String TEST1 = "@SuppressWarnings(\"PMD\")" + PMD.EOL + "public class Foo {}";

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/SuppressWarningsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/SuppressWarningsTest.java
@@ -43,10 +43,10 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST1, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(0, rpt.getNumViolations());
+        assertEquals(0, rpt.getNumberOfViolations());
         runTestFromString(TEST2, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(0, rpt.getNumViolations());
+        assertEquals(0, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -54,7 +54,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST3, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(0, rpt.getNumViolations());
+        assertEquals(0, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -62,7 +62,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST4, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(1, rpt.getNumViolations());
+        assertEquals(1, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -70,7 +70,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST5, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(0, rpt.getNumViolations());
+        assertEquals(0, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -78,7 +78,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST6, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(1, rpt.getNumViolations());
+        assertEquals(1, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -86,7 +86,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST7, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(1, rpt.getNumViolations());
+        assertEquals(1, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -94,7 +94,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST8, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(1, rpt.getNumViolations());
+        assertEquals(1, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -102,7 +102,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST9, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(1, rpt.getNumViolations());
+        assertEquals(1, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -110,7 +110,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST9_VALUE1, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(1, rpt.getNumViolations());
+        assertEquals(1, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -118,7 +118,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST9_VALUE2, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(1, rpt.getNumViolations());
+        assertEquals(1, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -126,7 +126,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST9_VALUE3, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(1, rpt.getNumViolations());
+        assertEquals(1, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -134,7 +134,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST9_MULTIPLE_VALUES_1, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(0, rpt.getNumViolations());
+        assertEquals(0, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -142,7 +142,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST9_MULTIPLE_VALUES_2, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(0, rpt.getNumViolations());
+        assertEquals(0, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -150,7 +150,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST10, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(2, rpt.getNumViolations());
+        assertEquals(2, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -158,7 +158,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST11, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(2, rpt.getNumViolations());
+        assertEquals(2, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -166,7 +166,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST12, new FooRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(0, rpt.getNumViolations());
+        assertEquals(0, rpt.getNumberOfViolations());
     }
 
     @Test
@@ -174,7 +174,7 @@ public class SuppressWarningsTest extends RuleTst {
         Report rpt = new Report();
         runTestFromString(TEST13, new BarRule(), rpt,
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5"));
-        assertEquals(0, rpt.getNumViolations());
+        assertEquals(0, rpt.getNumberOfViolations());
     }
 
     private static final String TEST1 = "@SuppressWarnings(\"PMD\")" + PMD.EOL + "public class Foo {}";

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/XPathJspRuleTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/XPathJspRuleTest.java
@@ -47,7 +47,7 @@ public class XPathJspRuleTest extends RuleTst {
 
         p.getSourceCodeProcessor().processSourceCode(new StringReader(MATCH), new RuleSets(rules), ctx);
 
-        assertEquals("One violation expected!", 1, report.size());
+        assertEquals("One violation expected!", 1, report.getNumViolations());
 
         RuleViolation rv = report.iterator().next();
         assertEquals(1, rv.getBeginLine());

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/XPathJspRuleTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/XPathJspRuleTest.java
@@ -47,7 +47,7 @@ public class XPathJspRuleTest extends RuleTst {
 
         p.getSourceCodeProcessor().processSourceCode(new StringReader(MATCH), new RuleSets(rules), ctx);
 
-        assertEquals("One violation expected!", 1, report.getNumViolations());
+        assertEquals("One violation expected!", 1, report.getNumberOfViolations());
 
         RuleViolation rv = report.iterator().next();
         assertEquals(1, rv.getBeginLine());

--- a/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
@@ -145,7 +145,7 @@ public abstract class RuleTst {
                 }
 
                 report = processUsingStringReader(test, rule);
-                res = report.getNumViolations();
+                res = report.getNumberOfViolations();
             } catch (Exception e) {
                 e.printStackTrace();
                 throw new RuntimeException('"' + test.getDescription() + "\" failed", e);
@@ -184,7 +184,7 @@ public abstract class RuleTst {
         }
 
         List<String> expectedMessages = test.getExpectedMessages();
-        if (report.getNumViolations() != expectedMessages.size()) {
+        if (report.getNumberOfViolations() != expectedMessages.size()) {
             throw new RuntimeException("Test setup error: number of expected messages doesn't match "
                     + "number of violations for test case '" + test.getDescription() + "'");
         }
@@ -210,7 +210,7 @@ public abstract class RuleTst {
         }
 
         List<Integer> expected = test.getExpectedLineNumbers();
-        if (report.getNumViolations() != expected.size()) {
+        if (report.getNumberOfViolations() != expected.size()) {
             throw new RuntimeException("Test setup error: number of execpted line numbers doesn't match "
                     + "number of violations for test case '" + test.getDescription() + "'");
         }
@@ -232,7 +232,7 @@ public abstract class RuleTst {
     private void printReport(TestDescriptor test, Report report) {
         System.out.println("--------------------------------------------------------------");
         System.out.println("Test Failure: " + test.getDescription());
-        System.out.println(" -> Expected " + test.getNumberOfProblemsExpected() + " problem(s), " + report.getNumViolations()
+        System.out.println(" -> Expected " + test.getNumberOfProblemsExpected() + " problem(s), " + report.getNumberOfViolations()
                 + " problem(s) found.");
         System.out.println(" -> Expected messages: " + test.getExpectedMessages());
         System.out.println(" -> Expected line numbers: " + test.getExpectedLineNumbers());

--- a/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
@@ -145,7 +145,7 @@ public abstract class RuleTst {
                 }
 
                 report = processUsingStringReader(test, rule);
-                res = report.size();
+                res = report.getNumViolations();
             } catch (Exception e) {
                 e.printStackTrace();
                 throw new RuntimeException('"' + test.getDescription() + "\" failed", e);
@@ -184,7 +184,7 @@ public abstract class RuleTst {
         }
 
         List<String> expectedMessages = test.getExpectedMessages();
-        if (report.size() != expectedMessages.size()) {
+        if (report.getNumViolations() != expectedMessages.size()) {
             throw new RuntimeException("Test setup error: number of expected messages doesn't match "
                     + "number of violations for test case '" + test.getDescription() + "'");
         }
@@ -210,7 +210,7 @@ public abstract class RuleTst {
         }
 
         List<Integer> expected = test.getExpectedLineNumbers();
-        if (report.size() != expected.size()) {
+        if (report.getNumViolations() != expected.size()) {
             throw new RuntimeException("Test setup error: number of execpted line numbers doesn't match "
                     + "number of violations for test case '" + test.getDescription() + "'");
         }
@@ -232,7 +232,7 @@ public abstract class RuleTst {
     private void printReport(TestDescriptor test, Report report) {
         System.out.println("--------------------------------------------------------------");
         System.out.println("Test Failure: " + test.getDescription());
-        System.out.println(" -> Expected " + test.getNumberOfProblemsExpected() + " problem(s), " + report.size()
+        System.out.println(" -> Expected " + test.getNumberOfProblemsExpected() + " problem(s), " + report.getNumViolations()
                 + " problem(s) found.");
         System.out.println(" -> Expected messages: " + test.getExpectedMessages());
         System.out.println(" -> Expected line numbers: " + test.getExpectedLineNumbers());


### PR DESCRIPTION
This is the updated pull request from the suggestion of author from discussion #1957 