### PR TITLE
[java] Start deprecating some image attributes

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/annotation/internal/DeprecationInfo.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/annotation/internal/DeprecationInfo.java
@@ -1,0 +1,30 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.annotation.internal;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+
+/**
+ * Complements a {@link Deprecated} annotation with information about
+ * migration. These features were only added to {@link Deprecated} in
+ * JDK 9.
+ *
+ * <p>This annotation does not replace a {@code @deprecated} Javadoc
+ * tag and is used to display information to XPath users (while Javadoc
+ * caters to the Java API). It's not published API, also not {@link Documented}.
+ *
+ * @since 6.18.0
+ */
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DeprecationInfo {
+
+
+    String xpathReplacement();
+
+
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/annotation/internal/XPathMigration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/annotation/internal/XPathMigration.java
@@ -21,10 +21,13 @@ import java.lang.annotation.RetentionPolicy;
  * @since 6.18.0
  */
 @Retention(RetentionPolicy.RUNTIME)
-public @interface DeprecationInfo {
+public @interface XPathMigration {
 
 
-    String xpathReplacement();
+    /**
+     * An English sentence like "Use @SuchAttribute instead".
+     */
+    String replacement();
 
 
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/Node.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/Node.java
@@ -100,6 +100,11 @@ public interface Node {
      */
     String getImage();
 
+
+    /**
+     * @deprecated Setting the image should not be done in user code.
+     */
+    @Deprecated
     void setImage(String image);
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/Attribute.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/Attribute.java
@@ -9,13 +9,10 @@ import java.lang.reflect.Method;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.lang3.StringUtils;
-
-import net.sourceforge.pmd.annotation.internal.DeprecationInfo;
 import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.ast.xpath.internal.XPathReportingUtils;
 
 /**
  * Represents an XPath attribute of a specific node.
@@ -71,11 +68,7 @@ public class Attribute {
             return value;
         }
 
-        if (method.isAnnotationPresent(Deprecated.class) && LOG.isLoggable(Level.WARNING)
-            && DETECTED_DEPRECATED_ATTRIBUTES.putIfAbsent(getLoggableAttributeName(), Boolean.TRUE) == null) {
-
-            LOG.warning(deprecationMsg(method.getAnnotation(DeprecationInfo.class)));
-        }
+        XPathReportingUtils.logIfDeprecated(this, method);
 
         // this lazy loading reduces calls to Method.invoke() by about 90%
         try {
@@ -87,14 +80,6 @@ public class Attribute {
         return null;
     }
 
-    private String deprecationMsg(DeprecationInfo info) {
-        // this message needs to be kept in sync with PMDCoverageTest
-        String msg = "Use of deprecated attribute '" + getLoggableAttributeName() + "' in XPath query";
-        if (info != null) {
-            msg += ", " + StringUtils.uncapitalize(info.xpathReplacement());
-        }
-        return msg;
-    }
 
     public String getStringValue() {
         if (stringValue != null) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/Attribute.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/Attribute.java
@@ -12,6 +12,9 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.apache.commons.lang3.StringUtils;
+
+import net.sourceforge.pmd.annotation.internal.DeprecationInfo;
 import net.sourceforge.pmd.lang.ast.Node;
 
 /**
@@ -69,9 +72,9 @@ public class Attribute {
         }
 
         if (method.isAnnotationPresent(Deprecated.class) && LOG.isLoggable(Level.WARNING)
-                && DETECTED_DEPRECATED_ATTRIBUTES.putIfAbsent(getLoggableAttributeName(), Boolean.TRUE) == null) {
-            // this message needs to be kept in sync with PMDCoverageTest
-            LOG.warning("Use of deprecated attribute '" + getLoggableAttributeName() + "' in XPath query");
+            && DETECTED_DEPRECATED_ATTRIBUTES.putIfAbsent(getLoggableAttributeName(), Boolean.TRUE) == null) {
+
+            LOG.warning(deprecationMsg(method.getAnnotation(DeprecationInfo.class)));
         }
 
         // this lazy loading reduces calls to Method.invoke() by about 90%
@@ -82,6 +85,15 @@ public class Attribute {
             iae.printStackTrace();
         }
         return null;
+    }
+
+    private String deprecationMsg(DeprecationInfo info) {
+        // this message needs to be kept in sync with PMDCoverageTest
+        String msg = "Use of deprecated attribute '" + getLoggableAttributeName() + "' in XPath query";
+        if (info != null) {
+            msg += ", " + StringUtils.uncapitalize(info.xpathReplacement());
+        }
+        return msg;
     }
 
     public String getStringValue() {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/internal/XPathReportingUtils.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/internal/XPathReportingUtils.java
@@ -1,0 +1,63 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.ast.xpath.internal;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+
+import net.sourceforge.pmd.annotation.internal.DeprecationInfo;
+import net.sourceforge.pmd.lang.ast.xpath.Attribute;
+
+public class XPathReportingUtils {
+
+    private static final Logger LOG = Logger.getLogger(Attribute.class.getName());
+    private static final ConcurrentMap<String, Boolean> DETECTED_DEPRECATED_ATTRIBUTES = new ConcurrentHashMap<>();
+
+    private static final String MESSAGE_PREFIX = "Use of deprecated attribute";
+
+    private static final Pattern DEPRECATED_ATTR_PATTERN =
+        Pattern.compile(Pattern.quote(MESSAGE_PREFIX) + " '(\\w+/@\\w+)'");
+
+    private static String getLoggableAttributeName(Attribute attr) {
+        return attr.getParent().getXPathNodeName() + "/@" + attr.getName();
+    }
+
+    public static List<String> deprecatedAttrNames(String log) {
+        Matcher m = DEPRECATED_ATTR_PATTERN.matcher(log);
+        List<String> result = new ArrayList<>();
+        while (m.find()) {
+            result.add(m.group(1));
+        }
+
+        return result;
+    }
+
+    public static void logIfDeprecated(Attribute attr, Method method) {
+        if (method.isAnnotationPresent(Deprecated.class) && LOG.isLoggable(Level.WARNING)
+            && DETECTED_DEPRECATED_ATTRIBUTES.putIfAbsent(getLoggableAttributeName(attr), Boolean.TRUE) == null) {
+
+            LOG.warning(deprecationMsg(attr, method.getAnnotation(DeprecationInfo.class)));
+        }
+    }
+
+    private static String deprecationMsg(Attribute attr, DeprecationInfo info) {
+        // this message needs to be kept in sync with PMDCoverageTest
+        String msg = MESSAGE_PREFIX + " '" + getLoggableAttributeName(attr) + "' in XPath query";
+        if (info != null) {
+            msg += ", " + StringUtils.uncapitalize(info.xpathReplacement());
+        }
+        return msg;
+    }
+
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/internal/XPathReportingUtils.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/internal/XPathReportingUtils.java
@@ -16,7 +16,7 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 
-import net.sourceforge.pmd.annotation.internal.DeprecationInfo;
+import net.sourceforge.pmd.annotation.internal.XPathMigration;
 import net.sourceforge.pmd.lang.ast.xpath.Attribute;
 
 public class XPathReportingUtils {
@@ -47,15 +47,15 @@ public class XPathReportingUtils {
         if (method.isAnnotationPresent(Deprecated.class) && LOG.isLoggable(Level.WARNING)
             && DETECTED_DEPRECATED_ATTRIBUTES.putIfAbsent(getLoggableAttributeName(attr), Boolean.TRUE) == null) {
 
-            LOG.warning(deprecationMsg(attr, method.getAnnotation(DeprecationInfo.class)));
+            LOG.warning(deprecationMsg(attr, method.getAnnotation(XPathMigration.class)));
         }
     }
 
-    private static String deprecationMsg(Attribute attr, DeprecationInfo info) {
+    private static String deprecationMsg(Attribute attr, XPathMigration info) {
         // this message needs to be kept in sync with PMDCoverageTest
         String msg = MESSAGE_PREFIX + " '" + getLoggableAttributeName(attr) + "' in XPath query";
         if (info != null) {
-            msg += ", " + StringUtils.uncapitalize(info.xpathReplacement());
+            msg += ", " + StringUtils.uncapitalize(info.replacement());
         }
         return msg;
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/xpath/internal/XPathReportingUtilsTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/xpath/internal/XPathReportingUtilsTest.java
@@ -1,0 +1,38 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.ast.xpath.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+
+/**
+ * @author Clément Fournier
+ */
+public class XPathReportingUtilsTest {
+
+    @Test
+    public void testDeprecatedAttrNames() {
+
+        String testOutput = "août 08, 2019 10:30:29 PM net.sourceforge.pmd.PMD processFiles\n"
+            + "AVERTISSEMENT: This analysis could be faster, please consider using Incremental Analysis: https://pmd.github.io/latest/pmd_userdocs_incremental_analysis.html\n"
+            + "août 08, 2019 10:30:29 PM net.sourceforge.pmd.processor.AbstractPMDProcessor removeBrokenRules\n"
+            + "AVERTISSEMENT: Removed misconfigured rule: LoosePackageCoupling  cause: No packages or classes specified\n"
+            + "août 08, 2019 10:30:29 PM net.sourceforge.pmd.lang.ast.xpath.internal.XPathReportingUtils logIfDeprecated\n"
+            + "AVERTISSEMENT: Use of deprecated attribute 'ClassOrInterfaceDeclaration/@Image' in XPath query, use @SimpleName instead\n"
+            + "août 08, 2019 10:30:29 PM net.sourceforge.pmd.lang.ast.xpath.internal.XPathReportingUtils logIfDeprecated\n"
+            + "AVERTISSEMENT: Use of deprecated attribute 'VariableDeclaratorId/@Image' in XPath query, use @VariableName instead\n";
+
+        List<String> detected = XPathReportingUtils.deprecatedAttrNames(testOutput);
+
+        assertTrue("Should detect VariableDeclaratorId", detected.contains("VariableDeclaratorId/@Image"));
+        assertTrue("Should detect ClassOrInterfaceDeclaration", detected.contains("ClassOrInterfaceDeclaration/@Image"));
+        assertEquals("Should not contain more", 2, detected.size());
+
+    }
+}

--- a/pmd-java/pom.xml
+++ b/pmd-java/pom.xml
@@ -155,11 +155,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.stefanbirkner</groupId>
-            <artifactId>system-rules</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.apache.ant</groupId>
             <artifactId>ant-testutil</artifactId>
             <scope>test</scope>

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassOrInterfaceDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassOrInterfaceDeclaration.java
@@ -8,7 +8,7 @@ import java.util.Collections;
 import java.util.List;
 
 import net.sourceforge.pmd.annotation.InternalApi;
-import net.sourceforge.pmd.annotation.internal.DeprecationInfo;
+import net.sourceforge.pmd.annotation.internal.XPathMigration;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.util.CollectionUtil;
 
@@ -113,7 +113,7 @@ public class ASTClassOrInterfaceDeclaration extends AbstractAnyTypeDeclaration {
      * @deprecated Use {@link #getSimpleName()}
      */
     @Deprecated
-    @DeprecationInfo(xpathReplacement = "Use @SimpleName instead")
+    @XPathMigration(replacement = "Use @SimpleName instead")
     @Override
     public String getImage() {
         return super.getImage();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassOrInterfaceDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassOrInterfaceDeclaration.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.List;
 
 import net.sourceforge.pmd.annotation.InternalApi;
+import net.sourceforge.pmd.annotation.internal.DeprecationInfo;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.util.CollectionUtil;
 
@@ -101,6 +102,22 @@ public class ASTClassOrInterfaceDeclaration extends AbstractAnyTypeDeclaration {
         return isInterface() ? TypeKind.INTERFACE : TypeKind.CLASS;
     }
 
+    /**
+     * Returns the simple name of this type declaration.
+     */
+    public String getSimpleName() {
+        return getImage();
+    }
+
+    /**
+     * @deprecated Use {@link #getSimpleName()}
+     */
+    @Deprecated
+    @DeprecationInfo(xpathReplacement = "Use @SimpleName instead")
+    @Override
+    public String getImage() {
+        return super.getImage();
+    }
 
     @Override
     public List<ASTAnyTypeBodyDeclaration> getDeclarations() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclaratorId.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclaratorId.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.java.ast;
 import java.util.List;
 
 import net.sourceforge.pmd.annotation.InternalApi;
-import net.sourceforge.pmd.annotation.internal.DeprecationInfo;
+import net.sourceforge.pmd.annotation.internal.XPathMigration;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
 import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
@@ -168,7 +168,7 @@ public class ASTVariableDeclaratorId extends AbstractJavaTypeNode implements Dim
      */
     @Override
     @Deprecated
-    @DeprecationInfo(xpathReplacement = "Use @VariableName instead")
+    @XPathMigration(replacement = "Use @VariableName instead")
     public String getImage() {
         return super.getImage();
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclaratorId.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclaratorId.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.java.ast;
 import java.util.List;
 
 import net.sourceforge.pmd.annotation.InternalApi;
+import net.sourceforge.pmd.annotation.internal.DeprecationInfo;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
 import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
@@ -162,6 +163,15 @@ public class ASTVariableDeclaratorId extends AbstractJavaTypeNode implements Dim
         return getImage();
     }
 
+    /**
+     * @deprecated Use {@link #getVariableName()}.
+     */
+    @Override
+    @Deprecated
+    @DeprecationInfo(xpathReplacement = "Use @VariableName instead")
+    public String getImage() {
+        return super.getImage();
+    }
 
     /**
      * Returns true if the variable declared by this node is declared final.

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -662,7 +662,7 @@ In JUnit 5, one of the following annotations should be used for tests: @Test, @R
                 <value>
 <![CDATA[
 //ClassOrInterfaceDeclaration[
-       matches(@Image, $testClassPattern)
+       matches(@SimpleName, $testClassPattern)
         or ExtendsList/ClassOrInterfaceType[pmd-java:typeIs('junit.framework.TestCase')]]
 
     /ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration[MethodDeclaration[@Public=true()]/MethodDeclarator[starts-with(@Image, 'test')]]

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -161,7 +161,7 @@ by the more general rule {% rule java/codestyle/FormalParameterNamingConventions
                 <value>
 <![CDATA[
 //MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/VariableDeclaratorId[
-        pmd:matches(@Image,'^in[A-Z].*','^out[A-Z].*','^in$','^out$')
+        pmd:matches(@VariableName,'^in[A-Z].*','^out[A-Z].*','^in$','^out$')
 ]
 ]]>
                 </value>
@@ -1217,7 +1217,7 @@ Fields, formal arguments, or local variable names that are too long can make the
             <property name="xpath">
                 <value>
 <![CDATA[
-//VariableDeclaratorId[string-length(@Image) > $minimum]
+//VariableDeclaratorId[string-length(@VariableName) > $minimum]
 ]]>
                 </value>
             </property>
@@ -1343,7 +1343,7 @@ by the more general rule
                 <value>
 <![CDATA[
 //VariableDeclaratorId
-[starts-with(@Image, 'm_')]
+[starts-with(@VariableName, 'm_')]
 [not (../../../FieldDeclaration)]
 ]]>
                 </value>
@@ -1678,7 +1678,7 @@ Fields, local variables, or parameter names that are very short are not helpful 
             <property name="xpath">
                 <value>
 <![CDATA[
-//VariableDeclaratorId[string-length(@Image) < $minimum]
+//VariableDeclaratorId[string-length(@VariableName) < $minimum]
  (: ForStatement :)
  [not(../../..[self::ForInit])]
  (: Foreach statement :)
@@ -1731,7 +1731,7 @@ by the more general rule {% rule java/codestyle/FieldNamingConventions %}.
 //ClassOrInterfaceDeclaration[@Interface='false']
  /ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/FieldDeclaration
   [@Final='false']
-  [VariableDeclarator/VariableDeclaratorId[upper-case(@Image)=@Image]]
+  [VariableDeclarator/VariableDeclaratorId[upper-case(@VariableName)=@VariableName]]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -29,7 +29,7 @@ by {% rule java/codestyle/ClassNamingConventions %}.
 <![CDATA[
 //ClassOrInterfaceDeclaration
  [@Abstract='true' and @Interface='false']
- [not (starts-with(@Image,'Abstract'))]
+ [not (starts-with(@SimpleName,'Abstract'))]
 |
 //ClassOrInterfaceDeclaration
  [@Abstract='false']
@@ -1619,7 +1619,7 @@ Short Classnames with fewer than e.g. five characters are not recommended.
             <property name="xpath">
                 <value>
 <![CDATA[
-//ClassOrInterfaceDeclaration[string-length(@Image) < $minimum]
+//ClassOrInterfaceDeclaration[string-length(@SimpleName) < $minimum]
 ]]>
                 </value>
             </property>
@@ -2096,7 +2096,7 @@ public class Foo {
 [PrimarySuffix[@Arguments='false' and @ArrayDereference = 'false']]
 [not(PrimarySuffix/MemberSelector)]
 [ancestor::ClassOrInterfaceBodyDeclaration[1][@AnonymousInnerClass='false']]
-/PrimaryPrefix/Name[@Image = ancestor::ClassOrInterfaceDeclaration[1]/@Image]
+/PrimaryPrefix/Name[@Image = ancestor::ClassOrInterfaceDeclaration[1]/@SimpleName]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -129,7 +129,7 @@ Catch blocks that merely rethrow a caught exception only add to code size and ru
                 <value>
 <![CDATA[
 //CatchStatement[FormalParameter
- /VariableDeclaratorId/@Image = Block/BlockStatement/Statement
+ /VariableDeclaratorId/@VariableName = Block/BlockStatement/Statement
  /ThrowStatement/Expression/PrimaryExpression[count(PrimarySuffix)=0]/PrimaryPrefix/Name/@Image
  and count(Block/BlockStatement/Statement) =1]
 ]]>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -138,7 +138,7 @@ Use of the term 'assert' will conflict with newer versions of Java since it is a
         <priority>2</priority>
         <properties>
             <property name="xpath">
-                <value>//VariableDeclaratorId[@Image='assert']</value>
+                <value>//VariableDeclaratorId[@VariableName='assert']</value>
             </property>
         </properties>
         <example>
@@ -293,13 +293,13 @@ exactly equal to 0.1, as one would expect.  Therefore, it is generally recommend
         Name[ancestor::Block/BlockStatement/LocalVariableDeclaration
                 [Type[PrimitiveType[@Image='double' or @Image='float']
                       or ReferenceType/ClassOrInterfaceType[@Image='Double' or @Image='Float']]]
-                /VariableDeclarator/VariableDeclaratorId/@Image = @Image
+                /VariableDeclarator/VariableDeclaratorId/@VariableName = @Image
             ]
         or
         Name[ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter
                 [Type[PrimitiveType[@Image='double' or @Image='float']
                       or ReferenceType/ClassOrInterfaceType[@Image='Double' or @Image='Float']]]
-                /VariableDeclaratorId/@Image = @Image
+                /VariableDeclaratorId/@VariableName = @Image
             ]
     ]
 ]
@@ -352,7 +352,7 @@ Use of the term 'enum' will conflict with newer versions of Java since it is a r
         <priority>2</priority>
         <properties>
             <property name="xpath">
-                <value>//VariableDeclaratorId[@Image='enum']</value>
+                <value>//VariableDeclaratorId[@VariableName='enum']</value>
             </property>
         </properties>
         <example>
@@ -426,7 +426,7 @@ Each caught exception type should be handled in its own catch clause.
  /following-sibling::Block//InstanceOfExpression/PrimaryExpression/PrimaryPrefix
   /Name[
    @Image = ./ancestor::Block/preceding-sibling::FormalParameter
-    /VariableDeclaratorId/@Image
+    /VariableDeclaratorId/@VariableName
   ]
 ]]>
                 </value>
@@ -520,15 +520,15 @@ only add to code size.  Either remove the invocation, or use the return result.
 <![CDATA[
 //CatchStatement/Block/BlockStatement/Statement/StatementExpression/PrimaryExpression/PrimaryPrefix/Name
 [
-   @Image = concat(../../../../../../../FormalParameter/VariableDeclaratorId/@Image, '.getMessage')
+   @Image = concat(../../../../../../../FormalParameter/VariableDeclaratorId/@VariableName, '.getMessage')
    or
-   @Image = concat(../../../../../../../FormalParameter/VariableDeclaratorId/@Image, '.getLocalizedMessage')
+   @Image = concat(../../../../../../../FormalParameter/VariableDeclaratorId/@VariableName, '.getLocalizedMessage')
    or
-   @Image = concat(../../../../../../../FormalParameter/VariableDeclaratorId/@Image, '.getCause')
+   @Image = concat(../../../../../../../FormalParameter/VariableDeclaratorId/@VariableName, '.getCause')
    or
-   @Image = concat(../../../../../../../FormalParameter/VariableDeclaratorId/@Image, '.getStackTrace')
+   @Image = concat(../../../../../../../FormalParameter/VariableDeclaratorId/@VariableName, '.getStackTrace')
    or
-   @Image = concat(../../../../../../../FormalParameter/VariableDeclaratorId/@Image, '.toString')
+   @Image = concat(../../../../../../../FormalParameter/VariableDeclaratorId/@VariableName, '.toString')
 ]
 ]]>
                 </value>
@@ -1450,7 +1450,7 @@ or reported.
  [FormalParameter/Type/ReferenceType
    /ClassOrInterfaceType[@Image != 'InterruptedException' and @Image != 'CloneNotSupportedException']
  ]
- [FormalParameter/VariableDeclaratorId[not(matches(@Image, $allowExceptionNameRegex))]]
+ [FormalParameter/VariableDeclaratorId[not(matches(@VariableName, $allowExceptionNameRegex))]]
 ]]>
                 </value>
             </property>
@@ -2092,7 +2092,7 @@ Avoid jumbled loop incrementers - its usually a mistake, and is confusing even i
   [
     ForUpdate/StatementExpressionList/StatementExpression/PostfixExpression/PrimaryExpression/PrimaryPrefix/Name/@Image
     =
-    ancestor::ForStatement/ForInit//VariableDeclaratorId/@Image
+    ancestor::ForStatement/ForInit//VariableDeclaratorId/@VariableName
   ]
 ]]>
                 </value>
@@ -2383,7 +2383,7 @@ chain needs an own serialVersionUID field. See also [Should an abstract class ha
 //ClassOrInterfaceDeclaration
     [@Interface = 'false']
     [count(ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration
-        /FieldDeclaration/VariableDeclarator/VariableDeclaratorId[@Image='serialVersionUID']) = 0]
+        /FieldDeclaration/VariableDeclarator/VariableDeclaratorId[@VariableName='serialVersionUID']) = 0]
     [(ImplementsList | ExtendsList)/ClassOrInterfaceType[pmd-java:typeIs('java.io.Serializable')]]
 ]]>
                 </value>
@@ -2683,8 +2683,8 @@ with the restriction that the logger needs to be passed into the constructor.
     (: check modifiers :)
     (@Private = false() or @Final = false())
     (: check logger name :)
-    or (@Static and .//VariableDeclaratorId[@Image != $staticLoggerName])
-    or (@Static = false() and .//VariableDeclaratorId[@Image != $loggerName])
+    or (@Static and .//VariableDeclaratorId[@VariableName != $staticLoggerName])
+    or (@Static = false() and .//VariableDeclaratorId[@VariableName != $loggerName])
 
     (: check logger argument type matches class or enum name :)
     or .//ArgumentList//ClassOrInterfaceType[@Image != ancestor::ClassOrInterfaceDeclaration/@Image]
@@ -2698,7 +2698,7 @@ with the restriction that the logger needs to be passed into the constructor.
      ancestor::ClassOrInterfaceBody//ConstructorDeclaration//StatementExpression
         [PrimaryExpression[PrimaryPrefix[@ThisModifier]]/PrimarySuffix[@Image=$loggerName]]
         [AssignmentOperator[@Image = '=']]
-        [Expression/PrimaryExpression/PrimaryPrefix/Name[@Image = ancestor::ConstructorDeclaration//FormalParameter/VariableDeclaratorId/@Image]]
+        [Expression/PrimaryExpression/PrimaryPrefix/Name[@Image = ancestor::ConstructorDeclaration//FormalParameter/VariableDeclaratorId/@VariableName]]
         [count(.//AllocationExpression)=0]
   )
 ]
@@ -3327,9 +3327,9 @@ To make sure the full stacktrace is printed out, use the logging statement with 
 /PrimaryExpression[PrimaryPrefix/Name[starts-with(@Image,
 concat(ancestor::ClassOrInterfaceDeclaration/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/FieldDeclaration
 [Type//ClassOrInterfaceType[@Image='Log']]
-/VariableDeclarator/VariableDeclaratorId/@Image, '.'))]]
+/VariableDeclarator/VariableDeclaratorId/@VariableName, '.'))]]
 [PrimarySuffix/Arguments[@ArgumentCount='1']]
-[PrimarySuffix/Arguments//Name/@Image = ancestor::CatchStatement/FormalParameter/VariableDeclaratorId/@Image]
+[PrimarySuffix/Arguments//Name/@Image = ancestor::CatchStatement/FormalParameter/VariableDeclaratorId/@VariableName]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -939,7 +939,7 @@ Note: This is only possible with Java 1.5 or higher.
 [
 MethodDeclarator/@Image = 'clone'
 and MethodDeclarator/FormalParameters/@ParameterCount = 0
-and not (ResultType//ClassOrInterfaceType/@Image = ancestor::ClassOrInterfaceDeclaration[1]/@Image)
+and not (ResultType//ClassOrInterfaceType/@Image = ancestor::ClassOrInterfaceDeclaration[1]/@SimpleName)
 ]
 ]]>
                 </value>
@@ -2446,7 +2446,7 @@ See the property `annotations`.
            [./ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/MethodDeclaration
                 [@Public=true()]
                 [./ResultType/Type/ReferenceType/ClassOrInterfaceType
-                    [@Image = //ClassOrInterfaceDeclaration[@Nested=false()]/@Image]
+                    [@Image = //ClassOrInterfaceDeclaration[@Nested=false()]/@SimpleName]
                 ]
             ]
         )
@@ -2641,7 +2641,7 @@ Object clone() should be implemented with super.clone().
 [count(../Block//*[
     (self::AllocationExpression) and
     (./ClassOrInterfaceType/@Image = ancestor::
-ClassOrInterfaceDeclaration[1]/@Image)
+ClassOrInterfaceDeclaration[1]/@SimpleName)
   ])> 0
 ]
 ]]>
@@ -2687,7 +2687,7 @@ with the restriction that the logger needs to be passed into the constructor.
     or (@Static = false() and .//VariableDeclaratorId[@VariableName != $loggerName])
 
     (: check logger argument type matches class or enum name :)
-    or .//ArgumentList//ClassOrInterfaceType[@Image != ancestor::ClassOrInterfaceDeclaration/@Image]
+    or .//ArgumentList//ClassOrInterfaceType[@Image != ancestor::ClassOrInterfaceDeclaration/@SimpleName]
     or .//ArgumentList//ClassOrInterfaceType[@Image != ancestor::EnumDeclaration/@Image]
 ]
 [not(

--- a/pmd-java/src/main/resources/category/java/multithreading.xml
+++ b/pmd-java/src/main/resources/category/java/multithreading.xml
@@ -168,7 +168,7 @@ Explicitly calling Thread.run() method will execute in the caller's thread of co
     PrimaryPrefix
     [
         ./Name[ends-with(@Image, '.run') or @Image = 'run']
-        and substring-before(Name/@Image, '.') =//VariableDeclarator/VariableDeclaratorId/@Image
+        and substring-before(Name/@Image, '.') =//VariableDeclarator/VariableDeclaratorId/@VariableName
             [../../../Type/ReferenceType/ClassOrInterfaceType[pmd-java:typeIs('java.lang.Thread')]]
         or (./AllocationExpression/ClassOrInterfaceType[pmd-java:typeIs('java.lang.Thread')]
         and ../PrimarySuffix[@Image = 'run'])

--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -862,7 +862,7 @@ You must use new ArrayList<>(Arrays.asList(...)) if that is inconvenient for you
      ]
      /VariableDeclarator/VariableDeclaratorId[
       count(..//AllocationExpression/ClassOrInterfaceType[
-       @Image="ArrayList"
+       @VariableName="ArrayList"
       ]
       )=1
      ]/@Image
@@ -870,9 +870,9 @@ You must use new ArrayList<>(Arrays.asList(...)) if that is inconvenient for you
    and
    PrimaryExpression/PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Name
    [
-     @Image = ancestor::MethodDeclaration[1]//LocalVariableDeclaration/VariableDeclarator/VariableDeclaratorId[@ArrayType="true"]/@Image
+     @Image = ancestor::MethodDeclaration[1]//LocalVariableDeclaration/VariableDeclarator/VariableDeclaratorId[@ArrayType="true"]/@VariableName
      or
-     @Image = ancestor::MethodDeclaration[1]//FormalParameter/VariableDeclaratorId/@Image
+     @Image = ancestor::MethodDeclaration[1]//FormalParameter/VariableDeclaratorId/@VariableName
    ]
    /../..[count(.//PrimarySuffix)
    =1]/PrimarySuffix/Expression/PrimaryExpression/PrimaryPrefix

--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -862,10 +862,10 @@ You must use new ArrayList<>(Arrays.asList(...)) if that is inconvenient for you
      ]
      /VariableDeclarator/VariableDeclaratorId[
       count(..//AllocationExpression/ClassOrInterfaceType[
-       @VariableName="ArrayList"
+       @Image="ArrayList"
       ]
       )=1
-     ]/@Image
+     ]/@VariableName
     ]
    and
    PrimaryExpression/PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Name

--- a/pmd-java/src/test/java/net/sourceforge/pmd/coverage/PMDCoverageTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/coverage/PMDCoverageTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.coverage;
 
+import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
@@ -17,20 +18,20 @@ import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.contrib.java.lang.system.StandardErrorStreamLog;
-import org.junit.contrib.java.lang.system.StandardOutputStreamLog;
+import org.junit.contrib.java.lang.system.SystemErrRule;
+import org.junit.contrib.java.lang.system.SystemOutRule;
 
 import net.sourceforge.pmd.PMD;
+import net.sourceforge.pmd.lang.ast.xpath.internal.XPathReportingUtils;
 
 public class PMDCoverageTest {
 
-    @Rule
-    public StandardOutputStreamLog output = new StandardOutputStreamLog();
+    @org.junit.Rule
+    public final SystemErrRule errorStream = new SystemErrRule().enableLog();
 
-    @Rule
-    public StandardErrorStreamLog errorStream = new StandardErrorStreamLog();
+    @org.junit.Rule
+    public final SystemOutRule output = new SystemOutRule().enableLog();
 
     /**
      * Test some of the PMD command line options
@@ -68,7 +69,7 @@ public class PMDCoverageTest {
 
             assertEquals("No exceptions expected", 0, StringUtils.countMatches(errorStream.getLog(), "Exception applying rule"));
             assertFalse("Wrong configuration? Ruleset not found", errorStream.getLog().contains("Ruleset not found"));
-            assertEquals("No usage of deprecated XPath attributes expected", 0, StringUtils.countMatches(errorStream.getLog(), "Use of deprecated attribute"));
+            assertEquals("No usage of deprecated XPath attributes expected", emptyList(), XPathReportingUtils.deprecatedAttrNames(errorStream.getLog()));
 
             String report = FileUtils.readFileToString(f, StandardCharsets.UTF_8);
             assertEquals("No processing errors expected", 0, StringUtils.countMatches(report, "Error while processing"));

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/ant/classpathtest/ruleset.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/ant/classpathtest/ruleset.xml
@@ -26,7 +26,7 @@ Avoid jumbled loop incrementers - its usually a mistake, and is confusing even i
  [
   ForUpdate/StatementExpressionList/StatementExpression/PostfixExpression/PrimaryExpression/PrimaryPrefix/Name/@Image
   =
-  ancestor::ForStatement/ForInit//VariableDeclaratorId/@Image
+  ancestor::ForStatement/ForInit//VariableDeclaratorId/@VariableName
  ]
  ]]>
              </value>

--- a/pmd-test/pom.xml
+++ b/pmd-test/pom.xml
@@ -19,6 +19,11 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-core</artifactId>
         </dependency>

--- a/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
@@ -4,7 +4,9 @@
 
 package net.sourceforge.pmd.testframework;
 
+import static java.util.Collections.emptyList;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 import java.io.IOException;
@@ -25,6 +27,7 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 
+import org.junit.contrib.java.lang.system.SystemErrRule;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -45,6 +48,7 @@ import net.sourceforge.pmd.RuleSets;
 import net.sourceforge.pmd.RuleViolation;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersion;
+import net.sourceforge.pmd.lang.ast.xpath.internal.XPathReportingUtils;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.renderers.TextRenderer;
 
@@ -53,6 +57,8 @@ import net.sourceforge.pmd.renderers.TextRenderer;
  */
 public abstract class RuleTst {
     private final DocumentBuilder documentBuilder;
+    @org.junit.Rule
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog();
 
     public RuleTst() {
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
@@ -90,7 +96,7 @@ public abstract class RuleTst {
     }
 
     protected List<Rule> getRules() {
-        return Collections.emptyList();
+        return emptyList();
     }
 
     /**
@@ -157,6 +163,7 @@ public abstract class RuleTst {
                     test.getNumberOfProblemsExpected(), res);
             assertMessages(report, test);
             assertLineNumbers(report, test);
+            assertEquals("Rule " + rule.getName() + " uses deprecated attributes", emptyList(), XPathReportingUtils.deprecatedAttrNames(systemErrRule.getLog()));
         } finally {
             // Restore old properties
             for (Map.Entry<PropertyDescriptor<?>, Object> entry : oldProperties.entrySet()) {


### PR DESCRIPTION
* Deprecate `@Image` for VariableDeclaratorId and ClassOrInterfaceDeclaration, replace with some getters with a better name
  * Replace their usages in XPath rules
* Move logging logic to internal util class, which removes a duplicated hardcoded string
* Improve the coverage test to mention which deprecated attributes are being used
* Add a way to access the replacement info for XPath users, with an annotation on the deprecated getter. Users will see something like:
```
WARNING: Use of deprecated attribute 'VariableDeclaratorId/@Image' in XPath query, use @VariableName instead
```
Info about *which* rule is using the attribute is unfortunately missing and hard to recover. 

TODO:
* I tried to get `RuleTst` to mention which rules are using the deprecated attributes, but this is bugged when executing tests of several rules since the logger is static and the warning is printed at most once. Maybe this isn't really needed though, we can do better with better logging facilities later on.
* Document in release notes
