### PR TITLE
[plsql] Fixes for referencing record type variables

### DIFF
--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -1885,6 +1885,7 @@ ASTVariableName VariableName() :
 {
     id = ID() { name.append(id.getImage()); }
     [ "." id = ID() { name.append('.').append(id.getImage()); } ]
+    [ "." id = ID() { name.append('.').append(id.getImage()); } ]
     {
         jjtThis.setImage(name.toString());
         return jjtThis;
@@ -2325,7 +2326,7 @@ ASTValuesClause ValuesClause() :
     (
         "(" ( Expression() | <_DEFAULT> ) ( "," ( Expression() | <_DEFAULT> ) )* ")"
     |
-        ID() // that's a record variable name
+        Name() // that's a record variable name
     )
     { return jjtThis; }
 }
@@ -2409,7 +2410,7 @@ ASTUpdateSetClause UpdateSetClause() :
 {
     <SET>
     (
-        LOOKAHEAD(1) <ROW> "=" ID()
+        LOOKAHEAD(1) <ROW> "=" Name()
     |
         "VALUE" "(" TableAlias() ")" "=" ( LOOKAHEAD(1) "(" Subquery() ")" | Expression() )
     |
@@ -2431,7 +2432,7 @@ ASTUpdateSetClause UpdateSetClause() :
 ASTReturningClause ReturningClause() :
 {}
 {
-    ( <RETURN> | <RETURNING> ) ( Expression() (",")? )+ <INTO> ( ID() (",")? )+
+    ( <RETURN> | <RETURNING> ) ( Expression() (",")? )+ <INTO> ( Name() (",")? )+
     { return jjtThis; }
 }
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/RecordTypeTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/RecordTypeTest.java
@@ -1,0 +1,24 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.plsql.ast;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.sourceforge.pmd.lang.plsql.AbstractPLSQLParserTst;
+
+public class RecordTypeTest extends AbstractPLSQLParserTst {
+
+    @Test
+    public void parseRecordType() throws Exception {
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("RecordType.pls"),
+                StandardCharsets.UTF_8);
+        ASTInput input = parsePLSQL(code);
+        Assert.assertNotNull(input);
+    }
+}

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/RecordType.pls
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/RecordType.pls
@@ -1,0 +1,47 @@
+create or replace package body solt9001 is
+
+  procedure upd is
+
+  begin
+
+      update solt90_web_service_log
+      set    row = solt9001.rec
+      returning record_version into solt9001.rec.record_version;
+
+  end upd;
+
+end;
+/
+
+create or replace package body solt9001 is
+
+  procedure upd is
+
+  begin
+
+      update solt90_web_service_log
+      set    row = solt9001.rec
+      returning record_version into solt9001.rec.record_version;
+
+  end upd;
+
+end;
+/
+
+create or replace function test return varchar2 is
+  begin
+
+    insert into sol_individual_commission_rate
+    values solt4601.rec
+    returning record_version, rowid into solt4601.rec.record_version, solt4601.current_rowid;
+
+    return null;
+  end test;
+/
+
+begin
+
+select id_no into t4666.rec.agent_no from name where company_reg_no = '66666111';
+
+end;
+/


### PR DESCRIPTION
<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [ ] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [ ] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
Used Name() instead of ID() and modified VariableName() so package.record_variable.field can be parsed correctly.

Fixes #1950
Fixes #1948
Fixes #1935
