### PR TITLE
[plsql] Fix for mistaking / for MultiplicativeExpression

### DIFF
--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -3136,7 +3136,7 @@ ASTMultiplicativeExpression MultiplicativeExpression() #MultiplicativeExpression
   //UnaryExpression() ( ( "*" | "/" | <MOD> ) UnaryExpression() )*
  (
   (simpleNode = UnaryExpression(true) ) { sb.append(simpleNode.getImage()); }
-  (
+  ( LOOKAHEAD(2)
     ( ("**"  ) { sb.append(" ** "); } //Exponentiation
     | ("*"  ) { sb.append(" * "); }
     | ("/"  ) { sb.append(" / "); }

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ViewTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ViewTest.java
@@ -29,4 +29,12 @@ public class ViewTest extends AbstractPLSQLParserTst {
         ASTInput input = parsePLSQL(code);
         Assert.assertNotNull(input);
     }
+
+    @Test
+    public void parseCreateViewWithoutSemicolon() throws Exception {
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("QueryWithoutSemicolon.sql"),
+                StandardCharsets.UTF_8);
+        ASTInput input = parsePLSQL(code);
+        Assert.assertNotNull(input);
+    }
 }

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/QueryWithoutSemicolon.sql
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/QueryWithoutSemicolon.sql
@@ -1,0 +1,6 @@
+create or replace view beneficiary as
+       select os.obj_seq_no,
+              nvl(os.n01, 0) procentage
+              from   object_slave os
+              where  obj_slave_type_id = 'BENEFICIARY'
+/


### PR DESCRIPTION
<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [ ] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [ ] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
Scripts shown below is bad coding exmaple (it should end with semicolon), but it is accepted by sqlplus so it should also be parsed.
It results in ParseException because / is consumed in MultiplicativeExpression.

```
create or replace view beneficiary as
       select os.obj_seq_no,
              nvl(os.n01, 0) procentage
              from   object_slave os
              where  obj_slave_type_id = 'BENEFICIARY'
/
```
