### PR TITLE
[core] Avoid crashes with analysis cache when classpath references non-existing directories

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/AbstractAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/AbstractAnalysisCache.java
@@ -193,7 +193,7 @@ public abstract class AbstractAnalysisCache implements AnalysisCache {
                             EnumSet.of(FileVisitOption.FOLLOW_LINKS), 1, jarFileVisitor);
                 } else if (f.isFile()) {
                     entries.add(f.toURI().toURL());
-                } else {
+                } else if (f.exists()) { // ignore non-existing directories
                     Files.walkFileTree(f.toPath(), EnumSet.of(FileVisitOption.FOLLOW_LINKS), Integer.MAX_VALUE,
                             fileVisitor);
                 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cache/FileAnalysisCacheTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cache/FileAnalysisCacheTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -224,9 +225,11 @@ public class FileAnalysisCacheTest {
                 + tempFolder.getRoot().getAbsolutePath() + File.separator + "non-existing-dir");
         
         final FileAnalysisCache reloadedCache = new FileAnalysisCache(newCacheFile);
-        reloadedCache.checkValidity(rs, cl);
-        assertFalse("Cache believes cache is up to date when the classpath changed",
-                reloadedCache.isUpToDate(sourceFile));
+        try {
+            reloadedCache.checkValidity(rs, cl);
+        } catch (final Exception e) {
+            fail("Validity check failed when classpath includes non-existing directories");
+        }
     }
     
     @Test

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cache/FileAnalysisCacheTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cache/FileAnalysisCacheTest.java
@@ -216,6 +216,20 @@ public class FileAnalysisCacheTest {
     }
 
     @Test
+    public void testClasspathNonExistingEntryIsIgnored() throws MalformedURLException, IOException {
+        final RuleSets rs = mock(RuleSets.class);
+        final ClassLoader cl = mock(ClassLoader.class);
+        
+        System.setProperty("java.class.path", System.getProperty("java.class.path") + File.pathSeparator
+                + tempFolder.getRoot().getAbsolutePath() + File.separator + "non-existing-dir");
+        
+        final FileAnalysisCache reloadedCache = new FileAnalysisCache(newCacheFile);
+        reloadedCache.checkValidity(rs, cl);
+        assertFalse("Cache believes cache is up to date when the classpath changed",
+                reloadedCache.isUpToDate(sourceFile));
+    }
+    
+    @Test
     public void testClasspathChangeInvalidatesCache() throws MalformedURLException, IOException {
         final RuleSets rs = mock(RuleSets.class);
         final ClassLoader cl = mock(ClassLoader.class);


### PR DESCRIPTION
As I was working on #1923 I came across this bug due to how ant is setup on my machine.

This issue is not included in the original #1923 report, so it seems to be unrelated to those problems.