### PR TITLE
[plsql] Fix for cursors in anonymous blocks

### DIFF
--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -251,7 +251,7 @@ ASTInput Input(String sourcecode) : {}
 	 | LOOKAHEAD(6) Directory()
 	 | LOOKAHEAD(6) DatabaseLink()
 	 | LOOKAHEAD(6) Global()
-         | LOOKAHEAD(6) DDLCommand() //Ignore any other DDL Event
+     | LOOKAHEAD(6) DDLCommand() //Ignore any other DDL Event
 	 | LOOKAHEAD(2) SqlPlusCommand()
 	 | UpdateStatement()
 	 | DeleteStatement()
@@ -351,20 +351,18 @@ ASTGlobal Global()  :
 {
 }
 {
-
 	/*
 	  Remove triggers from global processing because their schema may be defined in the trigger code itself
 	  Still wrap the trigger in a fake package but make the package name dependent on the actual schema
 	  defaulting to the globalPackageName if it cannot be found
 	*/
-	(LOOKAHEAD ( ( Label() )* [<DECLARE> DeclarativeSection()] <BEGIN>) ( Label() )* Block() ";" | LOOKAHEAD (4) ProgramUnit()
+	(
+	LOOKAHEAD ( ( Label() )* ( <DECLARE> | <BEGIN> ) ) ( Label() )* Block() ";"
+	|
+	LOOKAHEAD (4) ProgramUnit()
 	)
-
-
       { return jjtThis ; }
 }
-
-
 
 ASTBlock Block()  :
 {

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/AnonymousBlockTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/AnonymousBlockTest.java
@@ -1,0 +1,32 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.plsql.ast;
+
+import java.nio.charset.StandardCharsets;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.sourceforge.pmd.lang.plsql.AbstractPLSQLParserTst;
+
+public class AnonymousBlockTest extends AbstractPLSQLParserTst {
+
+    @Test
+    public void parseCursorInsideProcAnonymousBlock() throws Exception {
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("AnonymousBlock1.sql"),
+                StandardCharsets.UTF_8);
+        ASTInput input = parsePLSQL(code);
+        Assert.assertNotNull(input);
+    }
+
+    @Test
+    public void parseCursorInsideAnonymousBlock() throws Exception {
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("AnonymousBlock2.sql"),
+                StandardCharsets.UTF_8);
+        ASTInput input = parsePLSQL(code);
+        Assert.assertNotNull(input);
+    }
+}

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/AnonymousBlock1.sql
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/AnonymousBlock1.sql
@@ -1,0 +1,21 @@
+declare
+  gw_acl_name   varchar2(100);
+
+  procedure create_acl(p_acl_name in varchar2) is
+    cursor c_acl is
+      select dna.acl
+      from   dba_network_acls dna
+      where  acl like '%' || p_acl_name;
+    w_acl_name varchar2(100);
+  begin
+    open c_acl;
+    fetch c_acl
+      into w_acl_name;
+    close c_acl;
+
+  end;
+
+begin
+  null;
+end;
+/

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/AnonymousBlock2.sql
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/AnonymousBlock2.sql
@@ -1,0 +1,12 @@
+declare
+
+  cursor c_queue_exists(cp_queue_name xla_reference_code.code%type) is
+    select 1
+    from   dba_queues dq
+    where  dq.name = cp_queue_name;
+
+  r_queue_exists c_queue_exists%rowtype;
+begin
+  null;
+end;
+/


### PR DESCRIPTION
<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [ ] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [ ] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:** Functions for skipping tokens (like Skip2NextTokenOccurrence or Read2NextOccurrence) do not work when used in LOOKAHEAD. It often causes parsing exceptions,
I simplified LOOKAHEAD expressions in Global function.
Fixes #1936
Fixes #1933

