### PR TITLE
[core] analysis cache: Use always different checksum

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/AnalysisResult.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/AnalysisResult.java
@@ -53,7 +53,10 @@ public class AnalysisResult {
             // the analysis will fail and report the error on it's own since the checksum won't match
         }
 
-        return 0;
+        // we couldn't read the file, maybe the file doesn't exist
+        // in any case, we can't use the cache. Returning here the timestamp should make
+        // sure, we see that the file changed every time we analyze it.
+        return System.currentTimeMillis();
     }
 
     public long getFileChecksum() {


### PR DESCRIPTION
If the checksum couldn't be determined, then we use now
System.currentTimeMillis. This should result in a different
checksum everytime the same file is analyzed, so that it
appears dirty. In that case, the cached results won't be used.

<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [ ] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

