### PR TITLE
[java] LawOfDemeter to support inner builder pattern

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LawOfDemeterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LawOfDemeterRule.java
@@ -168,7 +168,8 @@ public class LawOfDemeterRule extends AbstractJavaRule {
 
         private boolean isNotBuilder() {
             return baseType != StringBuffer.class && baseType != StringBuilder.class
-                    && !"StringBuilder".equals(baseTypeName) && !"StringBuffer".equals(baseTypeName);
+                    && !"StringBuilder".equals(baseTypeName) && !"StringBuffer".equals(baseTypeName)
+                    && !methodName.endsWith("Builder");
         }
 
         private static List<ASTPrimarySuffix> findSuffixesWithoutArguments(ASTPrimaryExpression expr) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/LawOfDemeter.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/LawOfDemeter.xml
@@ -272,4 +272,18 @@ public class Test {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>#1429 False Positive for Law of Demeter</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Test {
+    public void bar() {
+        // Inner Builder pattern chained
+        final Bar bar = Bar.newBuilder()
+            .withFoo("foo")
+            .build();
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Adds another conditional to the [LawOfDemeter](https://pmd.github.io/latest/pmd_rules_java_design.html#lawofdemeter) rule to allow for the use of the Inner Builder pattern, like so:
```java
public class Test {
    public void bar() {
        // Inner Builder pattern chained
        final Bar bar = Bar.newBuilder()
            .withFoo("foo")
            .build();
    }
}
```

**Care**: Does not use the _PREFIX_EXCLUSION_PATTERN_ as this would only check against the _baseName_ when it had to check for the _methodName_ in this case.