### PR TITLE
[java] Fixes 336, slf4j log4j2 support

### DIFF
--- a/docs/pages/pmd/rules/java.md
+++ b/docs/pages/pmd/rules/java.md
@@ -254,7 +254,7 @@ folder: pmd/rules
 *   [IdempotentOperations](pmd_rules_java_errorprone.html#idempotentoperations): Avoid idempotent operations - they have no effect.
 *   [ImportFromSamePackage](pmd_rules_java_errorprone.html#importfromsamepackage): There is no need to import a type that lives in the same package.
 *   [InstantiationToGetClass](pmd_rules_java_errorprone.html#instantiationtogetclass): Avoid instantiating an object just to call getClass() on it; use the .class public member instead.
-*   [InvalidSlf4jMessageFormat](pmd_rules_java_errorprone.html#invalidslf4jmessageformat): Check for messages in slf4j and log4j2 loggers with non matching number of arguments and placehol...
+*   [InvalidSlf4jMessageFormat](pmd_rules_java_errorprone.html#invalidslf4jmessageformat): Check for messages in slf4j and log4j2 loggers with non matching number of arguments and placeholders.
 *   [JumbledIncrementer](pmd_rules_java_errorprone.html#jumbledincrementer): Avoid jumbled loop incrementers - its usually a mistake, and is confusing even if intentional.
 *   [JUnitSpelling](pmd_rules_java_errorprone.html#junitspelling): Some JUnit framework methods are easy to misspell.
 *   [JUnitStaticSuite](pmd_rules_java_errorprone.html#junitstaticsuite): The suite() method in a JUnit test needs to be both public and static.

--- a/docs/pages/pmd/rules/java.md
+++ b/docs/pages/pmd/rules/java.md
@@ -254,7 +254,7 @@ folder: pmd/rules
 *   [IdempotentOperations](pmd_rules_java_errorprone.html#idempotentoperations): Avoid idempotent operations - they have no effect.
 *   [ImportFromSamePackage](pmd_rules_java_errorprone.html#importfromsamepackage): There is no need to import a type that lives in the same package.
 *   [InstantiationToGetClass](pmd_rules_java_errorprone.html#instantiationtogetclass): Avoid instantiating an object just to call getClass() on it; use the .class public member instead.
-*   [InvalidSlf4jMessageFormat](pmd_rules_java_errorprone.html#invalidslf4jmessageformat): Check for messages in slf4j loggers with non matching number of arguments and placeholders.
+*   [InvalidSlf4jMessageFormat](pmd_rules_java_errorprone.html#invalidslf4jmessageformat): Check for messages in slf4j and log4j2 loggers with non matching number of arguments and placehol...
 *   [JumbledIncrementer](pmd_rules_java_errorprone.html#jumbledincrementer): Avoid jumbled loop incrementers - its usually a mistake, and is confusing even if intentional.
 *   [JUnitSpelling](pmd_rules_java_errorprone.html#junitspelling): Some JUnit framework methods are easy to misspell.
 *   [JUnitStaticSuite](pmd_rules_java_errorprone.html#junitstaticsuite): The suite() method in a JUnit test needs to be both public and static.

--- a/docs/pages/pmd/rules/java/errorprone.md
+++ b/docs/pages/pmd/rules/java/errorprone.md
@@ -2278,7 +2278,7 @@ Class c = String.class;{%endraw%}
 
 **Priority:** Low (5)
 
-Check for messages in slf4j loggers with non matching number of arguments and placeholders.
+Check for messages in slf4j and log4j2 loggers with non matching number of arguments and placeholders.
 
 **This rule is defined by the following Java class:** [net.sourceforge.pmd.lang.java.rule.errorprone.InvalidSlf4jMessageFormatRule](https://github.com/pmd/pmd/blob/master/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidSlf4jMessageFormatRule.java)
 

--- a/pmd-java/pom.xml
+++ b/pmd-java/pom.xml
@@ -4,6 +4,10 @@
     <artifactId>pmd-java</artifactId>
     <name>PMD Java</name>
 
+    <properties>
+        <kotlin.version>1.3.50</kotlin.version>
+    </properties>
+
     <parent>
         <groupId>net.sourceforge.pmd</groupId>
         <artifactId>pmd</artifactId>
@@ -41,6 +45,32 @@
 
             <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>test-compile</id>
+                        <phase>test-compile</phase>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                        <configuration>
+                            <sourceDirs>
+                                <source>src/test/java</source>
+                                <source>src/test/kotlin</source>
+                            </sourceDirs>
+                        </configuration>
+                    </execution>
+                </executions>
+                <configuration>
+                    <jvmTarget>1.8</jvmTarget>
+                </configuration>
                 <groupId>org.jetbrains.kotlin</groupId>
             </plugin>
 
@@ -91,6 +121,20 @@
                 <configuration>
                     <suppressionsLocation>pmd-java-checkstyle-suppressions.xml</suppressionsLocation>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>default-testCompile</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>
@@ -143,6 +187,18 @@
             <artifactId>slf4j-api</artifactId>
             <scope>test</scope>
         </dependency>
+	   <dependency>
+		<groupId>org.apache.logging.log4j</groupId>
+		<artifactId>log4j-api</artifactId>
+		<version>2.12.1</version>
+		<scope>test</scope>
+	  </dependency>
+	  <dependency>
+		<groupId>org.apache.logging.log4j</groupId>
+		<artifactId>log4j-core</artifactId>
+		<version>2.12.1</version>
+		<scope>test</scope>
+	  </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
@@ -167,6 +223,17 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-test</artifactId>
+            <version>${kotlin.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pmd-java/pom.xml
+++ b/pmd-java/pom.xml
@@ -4,7 +4,6 @@
     <artifactId>pmd-java</artifactId>
     <name>PMD Java</name>
 
-
     <parent>
         <groupId>net.sourceforge.pmd</groupId>
         <artifactId>pmd</artifactId>
@@ -182,5 +181,5 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
-     </dependencies>
+    </dependencies>
 </project>

--- a/pmd-java/pom.xml
+++ b/pmd-java/pom.xml
@@ -4,9 +4,6 @@
     <artifactId>pmd-java</artifactId>
     <name>PMD Java</name>
 
-    <properties>
-        <kotlin.version>1.3.50</kotlin.version>
-    </properties>
 
     <parent>
         <groupId>net.sourceforge.pmd</groupId>
@@ -45,32 +42,6 @@
 
             <plugin>
                 <artifactId>kotlin-maven-plugin</artifactId>
-                <version>${kotlin.version}</version>
-                <executions>
-                    <execution>
-                        <id>compile</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>test-compile</id>
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>test-compile</goal>
-                        </goals>
-                        <configuration>
-                            <sourceDirs>
-                                <source>src/test/java</source>
-                                <source>src/test/kotlin</source>
-                            </sourceDirs>
-                        </configuration>
-                    </execution>
-                </executions>
-                <configuration>
-                    <jvmTarget>1.8</jvmTarget>
-                </configuration>
                 <groupId>org.jetbrains.kotlin</groupId>
             </plugin>
 
@@ -121,20 +92,6 @@
                 <configuration>
                     <suppressionsLocation>pmd-java-checkstyle-suppressions.xml</suppressionsLocation>
                 </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>default-compile</id>
-                        <phase>none</phase>
-                    </execution>
-                    <execution>
-                        <id>default-testCompile</id>
-                        <phase>none</phase>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>
@@ -225,16 +182,5 @@
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
-            <version>${kotlin.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test</artifactId>
-            <version>${kotlin.version}</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+     </dependencies>
 </project>

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidSlf4jMessageFormatRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidSlf4jMessageFormatRule.java
@@ -55,8 +55,7 @@ public class InvalidSlf4jMessageFormatRule extends AbstractJavaRule {
         loggersMap.put("org.apache.logging.log4j.Logger", Collections
                 .unmodifiableSet(new HashSet<String>(Arrays.asList("trace", "debug", "info", "warn", "error", "fatal", "all"))));
 
-        LOGGERS = Collections
-                .unmodifiableMap(new HashMap<String, Set<String>>(loggersMap));
+        LOGGERS = loggersMap;
     }
 
     public InvalidSlf4jMessageFormatRule() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidSlf4jMessageFormatRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidSlf4jMessageFormatRule.java
@@ -7,8 +7,10 @@ package net.sourceforge.pmd.lang.java.rule.errorprone;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -43,12 +45,18 @@ import net.sourceforge.pmd.lang.symboltable.NameDeclaration;
 public class InvalidSlf4jMessageFormatRule extends AbstractJavaRule {
     private static final Logger LOG = Logger.getLogger(InvalidSlf4jMessageFormatRule.class.getName());
 
-    private static final Set<String> LOGGER_LEVELS;
-    private static final String LOGGER_CLASS = "org.slf4j.Logger";
+    private static final Map<String, Set<String>> LOGGERS;
 
     static {
-        LOGGER_LEVELS = Collections
-                .unmodifiableSet(new HashSet<String>(Arrays.asList("trace", "debug", "info", "warn", "error")));
+        Map<String, Set<String>> loggersMap = new HashMap<>();
+
+        loggersMap.put("org.slf4j.Logger", Collections
+                .unmodifiableSet(new HashSet<String>(Arrays.asList("trace", "debug", "info", "warn", "error"))));
+        loggersMap.put("org.apache.logging.log4j.Logger", Collections
+                .unmodifiableSet(new HashSet<String>(Arrays.asList("trace", "debug", "info", "warn", "error", "fatal", "all"))));
+
+        LOGGERS = Collections
+                .unmodifiableMap(new HashMap<String, Set<String>>(loggersMap));
     }
 
     public InvalidSlf4jMessageFormatRule() {
@@ -62,11 +70,13 @@ public class InvalidSlf4jMessageFormatRule extends AbstractJavaRule {
         if (!(nameDeclaration instanceof VariableNameDeclaration)) {
             return data;
         }
-
-        // ignore non slf4j logger
+        final String loggingClass;
+        // ignore unsupported logger
         Class<?> type = ((VariableNameDeclaration) nameDeclaration).getType();
-        if (type == null || !type.getName().equals(LOGGER_CLASS)) {
+        if (type == null || !LOGGERS.containsKey(type.getName())) {
             return data;
+        } else {
+            loggingClass = type.getName();
         }
 
         // get the node that contains the logger
@@ -77,7 +87,7 @@ public class InvalidSlf4jMessageFormatRule extends AbstractJavaRule {
                 .getImage().replace(nameDeclaration.getImage() + ".", "");
 
         // ignore if not a log level
-        if (!LOGGER_LEVELS.contains(method)) {
+        if (!LOGGERS.get(loggingClass).contains(method)) {
             return data;
         }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/MoreThanOneLoggerRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/MoreThanOneLoggerRule.java
@@ -22,6 +22,7 @@ import net.sourceforge.pmd.util.NumericConstants;
 public class MoreThanOneLoggerRule extends AbstractJavaRule {
 
     private static final String LOG4J_LOGGER_NAME = "org.apache.log4j.Logger";
+    private static final String LOG4J2_LOGGER_NAME = "org.apache.logging.log4j.Logger";
     private static final String JAVA_LOGGER_NAME = "java.util.logging.Logger";
     private static final String SLF4J_LOGGER_NAME = "org.slf4j.Logger";
 
@@ -72,7 +73,8 @@ public class MoreThanOneLoggerRule extends AbstractJavaRule {
                     Class<?> clazzType = ((ASTClassOrInterfaceType) classOrIntType).getType();
                     if (clazzType != null
                             && (TypeHelper.isA((ASTClassOrInterfaceType) classOrIntType, LOG4J_LOGGER_NAME)
-                                || TypeHelper.isA((ASTClassOrInterfaceType) classOrIntType, JAVA_LOGGER_NAME)
+                            || TypeHelper.isA((ASTClassOrInterfaceType) classOrIntType, LOG4J2_LOGGER_NAME)
+                            || TypeHelper.isA((ASTClassOrInterfaceType) classOrIntType, JAVA_LOGGER_NAME)
                                 || TypeHelper.isA((ASTClassOrInterfaceType) classOrIntType, SLF4J_LOGGER_NAME))
                             || clazzType == null && "Logger".equals(classOrIntType.getImage())) {
                         ++count;

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2063,7 +2063,7 @@ Class c = String.class;
           class="net.sourceforge.pmd.lang.java.rule.errorprone.InvalidSlf4jMessageFormatRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#invalidslf4jmessageformat">
         <description>
-Check for messages in slf4j loggers with non matching number of arguments and placeholders.
+Check for messages in slf4j and log4j2 loggers with non matching number of arguments and placeholders.
         </description>
         <priority>5</priority>
         <example>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidSlf4jMessageFormat.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidSlf4jMessageFormat.xml
@@ -380,4 +380,381 @@ public final class Main {
             }
         ]]></code>
     </test-code>
+    <test-code>
+        <description><![CDATA[
+missing argument
+        ]]></description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>9</expected-linenumbers>
+        <code><![CDATA[
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
+public class Foo {
+	private static final Logger LOGGER = LogManager.getLogger(Foo.class);
+
+	public void call() {
+		final String oneArg = "one argument";
+		LOGGER.error("forget the arg {} and {}", oneArg);
+	}
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+too many arguments
+         ]]></description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>9</expected-linenumbers>
+        <code><![CDATA[
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
+public class Foo {
+	private static final Logger LOGGER = LogManager.getLogger(Foo.class);
+	private final String MESSAGE = "too many args {}";
+
+	public void call() {
+		LOGGER.error(MESSAGE, "arg1", "arg2");
+	}
+}
+         ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+Logger without problems
+        ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
+public class Foo {
+	private static final Logger LOGGER = LogManager.getLogger(Foo.class);
+
+	public void call() {
+		final String message = "expected {} argument";
+		LOGGER.error(message, 1);
+	}
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+         <description><![CDATA[
+ignore the exception param
+        ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
+public class Foo {
+	private static final Logger LOGGER = LogManager.getLogger(Foo.class);
+
+	public void call() {
+		LOGGER.error("params {} and {}", "arg1", "arg2", new IllegalStateException("Extra arg"));
+	}
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Class cast exception with Method calls</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class MethodCallClassCastExceptionProblem {
+    public void foo() {
+        // a method call
+        otherMethod();
+    }
+
+    private void otherMethod() {
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Null pointer with VariableNameDeclaration / VariableDeclaratorId</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class NullPointerTypeProblem {
+    public void foo() {
+        java.util.StringTokenizer st = new java.util.StringTokenizer("a.b.c.d", ".");
+        while (st.hasMoreTokens()) {
+            System.out.println(st.nextToken());
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Log4j2 NPE</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+package my.test;
+
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
+public class Test {
+
+    private static final Logger log = LogManager.getLogger(Test.class);
+
+    public static void main(String[] args) {
+        log.info("1" + "2");
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Log4j2: doesn't ignore exception param</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
+public class InvalidLog4j2ExceptionTest {
+
+    private static final Logger LOGGER = LogManager.getLogger(InvalidLog4j2ExceptionTest.class);
+
+    public void foo() {
+        try {
+            throw new RuntimeException();
+        } catch (RuntimeException e) {
+            try {
+                LOGGER.error("Exception was thrown during conversion from tc model: {}.", jsonMarshaller.marshall(tcmport));
+            } catch (IOException e1) {
+                LOGGER.error("Problem to marshall to json tcImport: {}", tcsTripImport, e1);
+            }
+            throw e;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Log4j2: False positive with placeholder and exception</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
+public class InvalidSl4jExceptionBug1541 {
+    private static final Logger log = LogManager.getLogger(InvalidSl4jExceptionBug1541.class);
+
+    public static void main(String[] args) {
+        try {
+            // ...
+        } catch (Exception e) {
+            log.error("Arg1 = {}. Exception: {}", "arg1Value", e);
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Log4j2: fails with NPE</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
+public class TestBug1551
+{
+    private static final Logger LOGGER = LogManager.getLogger(TestBug1551.class);
+
+    public void test()
+    {
+        String message = generateMessage();
+        LOGGER.info(message);
+    }
+
+    private String generateMessage()
+    {
+        return "message";
+    }
+}
+        ]]></code>
+    </test-code>
+    
+    <test-code>
+        <description>Log4j2: false positive with pre-incremented variable</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
+public class Foo
+{
+    private static final Logger LOGGER = LogManager.getLogger(Foo.class);
+
+    public void test()
+    {
+        int attempt = 0;
+        LOGGER.info("test (attempt #{})", ++attempt);
+    }
+}
+        ]]></code>
+    </test-code>
+    
+    <test-code>
+        <description>NPE in PMD 5.8.1 Log4j2</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            import org.apache.logging.log4j.Logger;
+        
+            public class LoggerHelper {
+                public LoggerHelper(String loggerName) {
+                    Logger logger = LogManager.getLogger(loggerName);
+                    logger.info(message);
+                }
+            }
+        ]]></code>
+    </test-code>
+    
+    <test-code>
+        <description>Log4j2 false positive: too many arguments with string concatenation operator</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
+public final class Main {
+    private static final Logger LOGGER = LogManager.getLogger(Main.class);
+
+    private Main() {
+    }
+
+    public static void main(String[] args) {
+        String string0 = "a";
+        String string1 = "b";
+        LOGGER.trace("first line {}"
+                + "second line {}",
+                string0,
+                string1);
+        String string2 = "c";
+        LOGGER.debug("first line {} "
+                + "second line {} and "
+                + "the third line {}.",
+                string0, string1, string2);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>NPE in static block (see #1512)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            import org.apache.logging.log4j.Logger;
+
+            public class LoggerHelper {
+                static {
+                    Logger logger = LogManager.getLogger(loggerName);
+                    logger.info(message);
+                }
+            }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>missing argument in static block</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>8</expected-linenumbers>
+        <code><![CDATA[
+            import org.apache.logging.log4j.Logger;
+
+            public class LoggerHelper {
+                static {
+                    final String pattern = "log: {}";
+
+                    Logger logger = LogManager.getLogger(loggerName);
+                    logger.info(pattern, 1, 2);
+                }
+            }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>NPE in lambda call (see #1512)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            import org.apache.logging.log4j.Logger;
+
+            public class LoggerHelper {
+                final Logger logger = LogManager.getLogger(loggerName);
+
+                final List<String> list = someMethod(message -> logger.info(message));
+            }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>missing argument in lambda call</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>9</expected-linenumbers>
+        <code><![CDATA[
+            import org.apache.logging.log4j.Logger;
+
+            public class LoggerHelper {
+                final Logger logger = LogManager.getLogger(loggerName);
+
+                final List<String> list = someMethod(message -> {
+                    final String pattern = "log: {}";
+
+                    logger.info(pattern, 1, 2);
+                });
+            }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>NPE in enums (see #1549)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            import org.apache.logging.log4j.Logger;
+            import org.apache.logging.log4j.LogManager;
+
+            public enum LoggerHelper {
+                INSTANCE;
+
+                private final Logger log = LogManager.getLogger(LoggerHelper.class);
+
+                public void sendMessage(String message) {
+                    log.info(message);
+                }
+
+                public static void main(String[] args) {
+                    LoggerHelper.INSTANCE.sendMessage("A message");
+                }
+            }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>missing argument in enum</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>12</expected-linenumbers>
+        <code><![CDATA[
+            import org.apache.logging.log4j.Logger;
+            import org.apache.logging.log4j.LogManager;
+
+            public enum LoggerHelper {
+                INSTANCE;
+
+                private static final String pattern = "log: {}";
+
+                public static void main(String[] args) {
+                    final Logger logger = LogManager.getLogger(LoggerHelper.class);
+
+                    logger.info(pattern, 1, 2);
+                }
+            }
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidSlf4jMessageFormat.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidSlf4jMessageFormat.xml
@@ -382,7 +382,7 @@ public final class Main {
     </test-code>
     <test-code>
         <description><![CDATA[
-missing argument
+log4j2: missing argument
         ]]></description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>9</expected-linenumbers>
@@ -402,7 +402,7 @@ public class Foo {
     </test-code>
     <test-code>
         <description><![CDATA[
-too many arguments
+log4j2: too many arguments
          ]]></description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>9</expected-linenumbers>
@@ -422,7 +422,7 @@ public class Foo {
     </test-code>
     <test-code>
         <description><![CDATA[
-Logger without problems
+log4j2: Logger without problems
         ]]></description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
@@ -441,7 +441,7 @@ public class Foo {
     </test-code>
     <test-code>
          <description><![CDATA[
-ignore the exception param
+log4j2: ignore the exception param
         ]]></description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
@@ -459,7 +459,7 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>Class cast exception with Method calls</description>
+        <description>log4j2: Class cast exception with Method calls</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class MethodCallClassCastExceptionProblem {
@@ -475,7 +475,7 @@ public class MethodCallClassCastExceptionProblem {
     </test-code>
 
     <test-code>
-        <description>Null pointer with VariableNameDeclaration / VariableDeclaratorId</description>
+        <description>log4j2: Null pointer with VariableNameDeclaration / VariableDeclaratorId</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class NullPointerTypeProblem {
@@ -648,7 +648,7 @@ public final class Main {
     </test-code>
 
     <test-code>
-        <description>NPE in static block (see #1512)</description>
+        <description>log4j2: NPE in static block (see #1512)</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
             import org.apache.logging.log4j.Logger;
@@ -663,7 +663,7 @@ public final class Main {
     </test-code>
 
     <test-code>
-        <description>missing argument in static block</description>
+        <description>log4j2: missing argument in static block</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>8</expected-linenumbers>
         <code><![CDATA[
@@ -681,7 +681,7 @@ public final class Main {
     </test-code>
 
     <test-code>
-        <description>NPE in lambda call (see #1512)</description>
+        <description>log4j2: NPE in lambda call (see #1512)</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
             import org.apache.logging.log4j.Logger;
@@ -695,7 +695,7 @@ public final class Main {
     </test-code>
 
     <test-code>
-        <description>missing argument in lambda call</description>
+        <description>log4j2: missing argument in lambda call</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>9</expected-linenumbers>
         <code><![CDATA[
@@ -714,7 +714,7 @@ public final class Main {
     </test-code>
 
     <test-code>
-        <description>NPE in enums (see #1549)</description>
+        <description>log4j2: NPE in enums (see #1549)</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
             import org.apache.logging.log4j.Logger;
@@ -737,7 +737,7 @@ public final class Main {
     </test-code>
 
     <test-code>
-        <description>missing argument in enum</description>
+        <description>log4j2: missing argument in enum</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>12</expected-linenumbers>
         <code><![CDATA[

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/MoreThanOneLogger.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/MoreThanOneLogger.xml
@@ -75,4 +75,25 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>Add log4j2 Logger type</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.apache.logging.log4j.Logger;
+public class Foo {
+    Logger log;
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Logger type log4j2: Two Loggers</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import org.apache.logging.log4j.Logger;
+public class Foo {
+    Logger log;
+    Logger log2;
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [ ] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [ ] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

Fixes #336.

The InvalidSlf4jMessageFormat rule can apply to log4j2 as well. The scope of the changes is limited to adding log4j2 support to the rule.
Changing the name of the rule should be considered at some point but this would also require a documentation change.

Modified rules:
* [InvalidSlf4jMessageFormat](https://pmd.github.io/latest/pmd_rules_java_errorprone.html#invalidslf4jmessageformat)
* [MoreThanOneLogger](https://pmd.github.io/latest/pmd_rules_java_errorprone.html#morethanonelogger)
