### PR TITLE
[java] Update doc for unused formal parameter

### DIFF
--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -1300,7 +1300,9 @@ class Foo{
           class="net.sourceforge.pmd.lang.java.rule.bestpractices.UnusedFormalParameterRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_bestpractices.html#unusedformalparameter">
         <description>
-Avoid passing parameters to methods or constructors without actually referencing them in the method body.
+Avoid passing parameters to methods or constructors without actually referencing them in the method body. 
+Removing unused formal parameters from public methods could cause a ripple effect through the code base. 
+Hence, by default, this rule only considers private methods. To include non-private methods, set the 'checkAll' property to true.
         </description>
         <priority>3</priority>
         <example>


### PR DESCRIPTION
Added justification as to why we are not checking unused parameters for public methods.

Fixes #1227 