### PR TITLE
[java,apex] Deprecate CanSuppressWarnings

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -29,6 +29,10 @@ This is a {{ site.pmd.release_type }} release.
 * pmd-java
   * {% jdoc java::lang.java.ast.CanSuppressWarnings %} and its implementations
   * {% jdoc java::lang.java.rule.AbstractJavaRule#isSuppressed(Node) %}
+  * {% jdoc java::lang.java.rule.JavaRuleViolation#isSupressed(Node,Rule) %}
+* pmd-apex
+  * {% jdoc java::lang.apex.ast.CanSuppressWarnings %} and its implementations
+  * {% jdoc java::lang.apex.rule.ApexRuleViolation#isSupressed(Node,Rule) %}
 
 
 ### External Contributions

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -21,6 +21,16 @@ This is a {{ site.pmd.release_type }} release.
 
 ### API Changes
 
+
+#### Deprecated APIs
+
+##### For removal
+
+* pmd-java
+  * {% jdoc java::lang.java.ast.CanSuppressWarnings %} and its implementations
+  * {% jdoc java::lang.java.rule.AbstractJavaRule#isSuppressed(Node) %}
+
+
 ### External Contributions
 
 {% endtocmaker %}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/CanSuppressWarnings.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/CanSuppressWarnings.java
@@ -6,6 +6,11 @@ package net.sourceforge.pmd.lang.apex.ast;
 
 import net.sourceforge.pmd.Rule;
 
+/**
+ * @deprecated This interface will be removed, the AST should not know about rules.
+ */
+@Deprecated
 public interface CanSuppressWarnings {
+    @Deprecated
     boolean hasSuppressWarningsAnnotationFor(Rule rule);
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/ApexRuleViolation.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/ApexRuleViolation.java
@@ -44,9 +44,10 @@ public class ApexRuleViolation<T> extends ParametricRuleViolation<Node> {
     /**
      * Check for suppression on this node, on parents, and on contained types
      * for ASTCompilationUnit
-     * 
-     * @param node
+     *
+     * @deprecated Is internal API, not useful, there's a typo. See <a href="https://github.com/pmd/pmd/pull/1927">#1927</a>
      */
+    @Deprecated
     public static boolean isSupressed(Node node, Rule rule) {
         boolean result = suppresses(node, rule);
 
@@ -57,7 +58,7 @@ public class ApexRuleViolation<T> extends ParametricRuleViolation<Node> {
                 parent = parent.jjtGetParent();
             }
         }
-        
+
         return result;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/CanSuppressWarnings.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/CanSuppressWarnings.java
@@ -6,6 +6,12 @@ package net.sourceforge.pmd.lang.java.ast;
 
 import net.sourceforge.pmd.Rule;
 
+/**
+ * @deprecated This interface will be removed, the AST should not know about rules.
+ */
+@Deprecated
 public interface CanSuppressWarnings {
+
+    @Deprecated
     boolean hasSuppressWarningsAnnotationFor(Rule rule);
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJavaRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJavaRule.java
@@ -70,6 +70,11 @@ public abstract class AbstractJavaRule extends AbstractRule implements JavaParse
         return false;
     }
 
+    /**
+     * @deprecated Not useful, and suppression should happen transparently to rule implementations.
+     *             This will be removed with 7.0.0
+     */
+    @Deprecated
     protected boolean isSuppressed(Node node) {
         return JavaRuleViolation.isSupressed(node, this);
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolation.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolation.java
@@ -77,7 +77,10 @@ public class JavaRuleViolation extends ParametricRuleViolation<JavaNode> {
      * for ASTCompilationUnit
      *
      * @param node
+     *
+     * @deprecated Is internal API, not useful, there's a typo in there. See <a href="https://github.com/pmd/pmd/pull/1927">#1927</a>
      */
+    @Deprecated
     public static boolean isSupressed(Node node, Rule rule) {
         boolean result = suppresses(node, rule);
 
@@ -119,7 +122,7 @@ public class JavaRuleViolation extends ParametricRuleViolation<JavaNode> {
                     }
                 }
             }
-            
+
             // Still not found?
             if (qualifiedName == null) {
                 for (ClassNameDeclaration c : classes) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolation.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolation.java
@@ -78,7 +78,7 @@ public class JavaRuleViolation extends ParametricRuleViolation<JavaNode> {
      *
      * @param node
      *
-     * @deprecated Is internal API, not useful, there's a typo in there. See <a href="https://github.com/pmd/pmd/pull/1927">#1927</a>
+     * @deprecated Is internal API, not useful, there's a typo. See <a href="https://github.com/pmd/pmd/pull/1927">#1927</a>
      */
     @Deprecated
     public static boolean isSupressed(Node node, Rule rule) {


### PR DESCRIPTION
This follows up on #1927 to implement the required deprecations. I chose to keep the release notes just a simple listing, because they already link to javadoc