### PR TITLE
fix:[ci] Danger is failing builds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@ source 'https://rubygems.org/'
 
 gem 'pmdtester', :git => 'https://github.com/pmd/pmd-regression-tester.git'
 gem 'danger', '~> 5.6', '>= 5.6'
-gem 'faraday', '<0.16.0' # see pmd/pmd#2040
 
 # This group is only needed for rendering release notes
 # this happens during release (.travis/release.sh and do-release.sh)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,86 @@
+GIT
+  remote: https://github.com/pmd/pmd-regression-tester.git
+  revision: 8e652477b3547d6c843864a2641389a4c61c383e
+  specs:
+    pmdtester (1.0.0.pre.SNAPSHOT)
+      differ
+      nokogiri (~> 1.8.2)
+      rufus-scheduler (~> 3.5, >= 3.5)
+      slop (~> 4.6.2)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    claide (1.0.3)
+    claide-plugins (0.9.2)
+      cork
+      nap
+      open4 (~> 1.3)
+    colored2 (3.1.2)
+    concurrent-ruby (1.1.5)
+    cork (0.3.0)
+      colored2 (~> 3.1)
+    danger (5.16.1)
+      claide (~> 1.0)
+      claide-plugins (>= 0.9.2)
+      colored2 (~> 3.1)
+      cork (~> 0.1)
+      faraday (~> 0.9)
+      faraday-http-cache (~> 1.0)
+      git (~> 1.5)
+      kramdown (~> 1.5)
+      no_proxy_fix
+      octokit (~> 4.7)
+      terminal-table (~> 1)
+    differ (0.1.2)
+    et-orbi (1.2.2)
+      tzinfo
+    faraday (0.16.2)
+      multipart-post (>= 1.2, < 3)
+    faraday-http-cache (1.3.1)
+      faraday (~> 0.8)
+    fugit (1.3.3)
+      et-orbi (~> 1.1, >= 1.1.8)
+      raabro (~> 1.1)
+    git (1.5.0)
+    kramdown (1.17.0)
+    liquid (4.0.3)
+    mini_portile2 (2.3.0)
+    multipart-post (2.1.1)
+    nap (1.1.0)
+    no_proxy_fix (0.1.2)
+    nokogiri (1.8.5)
+      mini_portile2 (~> 2.3.0)
+    octokit (4.14.0)
+      sawyer (~> 0.8.0, >= 0.5.3)
+    open4 (1.3.4)
+    public_suffix (4.0.1)
+    raabro (1.1.6)
+    rouge (3.11.0)
+    rufus-scheduler (3.6.0)
+      fugit (~> 1.1, >= 1.1.6)
+    safe_yaml (1.0.5)
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
+    slop (4.6.2)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
+    tzinfo (2.0.0)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (1.6.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  danger (~> 5.6, >= 5.6)
+  liquid (>= 4.0.0)
+  pmdtester!
+  rouge (>= 1.7, < 4)
+  safe_yaml (>= 1.0)
+
+BUNDLED WITH
+   2.0.1


### PR DESCRIPTION
faraday 0.16.2 has been released today, so this PR

* reverts the temporary workaround
* add Gemfile.lock to pin down the current versions

This means, that we'll need to run "bundle update" manually from time to time. But we shouldn't be surprised by any updated dependency in the future.

Fixes #2040 
