### PR TITLE
[java] Fix computation of metrics with annotations

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/impl/AbstractJavaClassMetric.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/impl/AbstractJavaClassMetric.java
@@ -115,9 +115,7 @@ public abstract class AbstractJavaClassMetric extends AbstractJavaMetric<ASTAnyT
         List<ASTAnyTypeBodyDeclaration> decls = node.getDeclarations();
 
         for (ASTAnyTypeBodyDeclaration decl : decls) {
-            if (decl.jjtGetNumChildren() > 0 && tClass.isInstance(decl.jjtGetChild(0))) {
-                result.add(tClass.cast(decl.jjtGetChild(0)));
-            }
+            result.addAll(decl.findChildrenOfType(tClass));
         }
 
         return result;

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/metrics/impl/xml/NoamTest.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/metrics/impl/xml/NoamTest.xml
@@ -10,6 +10,7 @@ public class Foo {
   private double speed;
   private MutableInt mutX;
   private boolean bool;
+  private String words;
 
   public int getValue() {
         return value;
@@ -34,6 +35,12 @@ public class Foo {
   private int value() {
     return value;
   }
+
+  @Override
+  @TestAnnotation
+  public String getWords() {
+    return words;
+  }
 }
      ]]></code-fragment>
 
@@ -42,7 +49,7 @@ public class Foo {
         <description>Full example</description>
         <expected-problems>1</expected-problems>
         <expected-messages>
-            <message>'Foo' has value 3.</message>
+            <message>'Foo' has value 4.</message>
         </expected-messages>
         <code-ref id="full-example"/>
     </test-code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/metrics/impl/xml/NopaTest.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/metrics/impl/xml/NopaTest.xml
@@ -17,6 +17,8 @@ public class Foo {
   public int i;
   public int j;
 
+  @Inject public int k;
+
   public static void bar() {
 
   }
@@ -28,7 +30,7 @@ public class Foo {
         <description>Full example</description>
         <expected-problems>1</expected-problems>
         <expected-messages>
-            <message>'Foo' has value 7.</message>
+            <message>'Foo' has value 8.</message>
         </expected-messages>
         <code-ref id="full-example"/>
     </test-code>


### PR DESCRIPTION
Fixes #1912 by using all children of a body declaration instead of just the first child to find a specific type of node.

