### PR TITLE
[core] RuleContext as threadlocal

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleContext.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleContext.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Logger;
 
+import net.sourceforge.pmd.annotation.Experimental;
 import net.sourceforge.pmd.lang.LanguageVersion;
 
 /**
@@ -36,6 +37,7 @@ public class RuleContext {
     private LanguageVersion languageVersion;
     private final ConcurrentMap<String, Object> attributes;
     private boolean ignoreExceptions = true;
+    private Rule currentRule;
 
     /**
      * Default constructor.
@@ -246,5 +248,15 @@ public class RuleContext {
      */
     public boolean isIgnoreExceptions() {
         return ignoreExceptions;
+    }
+
+    @Experimental
+    public void setCurrentRule(Rule currentRule) {
+        this.currentRule = currentRule;
+    }
+
+    @Experimental
+    public Rule getCurrentRule() {
+        return currentRule;
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleContextHolder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleContextHolder.java
@@ -1,0 +1,28 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd;
+
+import net.sourceforge.pmd.annotation.Experimental;
+
+@Experimental
+public final class RuleContextHolder {
+
+    private RuleContextHolder() {
+    }
+
+    private static final ThreadLocal<RuleContext> THREAD_LOCAL = new ThreadLocal<>();
+
+    public static RuleContext get() {
+        return THREAD_LOCAL.get();
+    }
+
+    public static void set(RuleContext ruleContext) {
+        THREAD_LOCAL.set(ruleContext);
+    }
+
+    public static void reset() {
+        THREAD_LOCAL.remove();
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
@@ -552,6 +552,7 @@ public class RuleSet implements ChecksumAware {
                 if (!rule.isRuleChain() && applies(rule, ctx.getLanguageVersion())) {
 
                     try (TimedOperation rto = TimeTracker.startOperation(TimedOperationCategory.RULE, rule.getName())) {
+                        ctx.setCurrentRule(rule);
                         rule.apply(acuList, ctx);
                     } catch (RuntimeException e) {
                         if (ctx.isIgnoreExceptions()) {
@@ -564,6 +565,8 @@ public class RuleSet implements ChecksumAware {
                         } else {
                             throw e;
                         }
+                    } finally {
+                        ctx.setCurrentRule(null);
                     }
                 }
             }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/SourceCodeProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/SourceCodeProcessor.java
@@ -92,6 +92,7 @@ public class SourceCodeProcessor {
             }
 
             try {
+                RuleContextHolder.set(ctx);
                 ruleSets.start(ctx);
                 processSource(sourceCode, ruleSets, ctx);
             } catch (ParseException pe) {
@@ -102,6 +103,7 @@ public class SourceCodeProcessor {
                 throw new PMDException("Error while processing " + ctx.getSourceCodeFile(), e);
             } finally {
                 ruleSets.end(ctx);
+                RuleContextHolder.reset();
             }
         }
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/Attribute.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/Attribute.java
@@ -12,6 +12,9 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.RuleContext;
+import net.sourceforge.pmd.RuleContextHolder;
 import net.sourceforge.pmd.annotation.Experimental;
 import net.sourceforge.pmd.lang.ast.Node;
 
@@ -76,9 +79,9 @@ public class Attribute {
         }
 
         if (method.isAnnotationPresent(Deprecated.class) && LOG.isLoggable(Level.WARNING)
-                && DETECTED_DEPRECATED_ATTRIBUTES.putIfAbsent(getLoggableAttributeName(), Boolean.TRUE) == null) {
+                && DETECTED_DEPRECATED_ATTRIBUTES.putIfAbsent(getRuleName() + ":" + getLoggableAttributeName(), Boolean.TRUE) == null) {
             // this message needs to be kept in sync with PMDCoverageTest
-            LOG.warning("Use of deprecated attribute '" + getLoggableAttributeName() + "' in XPath query");
+            LOG.warning("Use of deprecated attribute '" + getLoggableAttributeName() + "' in XPath query in rule '" + getRuleName() + "'.");
         }
 
         // this lazy loading reduces calls to Method.invoke() by about 90%
@@ -126,6 +129,15 @@ public class Attribute {
 
     private String getLoggableAttributeName() {
         return parent.getXPathNodeName() + "/@" + name;
+    }
+
+    private String getRuleName() {
+        RuleContext ctx = RuleContextHolder.get();
+        if (ctx != null && ctx.getCurrentRule() != null) {
+            Rule rule = ctx.getCurrentRule();
+            return rule.getRuleSetName() + "/" + rule.getName();
+        }
+        return "unknown rule";
     }
 
     @Override

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRuleChainVisitor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRuleChainVisitor.java
@@ -84,6 +84,7 @@ public abstract class AbstractRuleChainVisitor implements RuleChainVisitor {
                         continue;
                     }
                     try (TimedOperation rcto = TimeTracker.startOperation(TimedOperationCategory.RULECHAIN_RULE, rule.getName())) {
+                        ctx.setCurrentRule(rule);
                         final List<String> nodeNames = rule.getRuleChainVisits();
                         for (int j = 0; j < nodeNames.size(); j++) {
                             List<Node> ns = nodeNameToNodes.get(nodeNames.get(j));
@@ -109,6 +110,8 @@ public abstract class AbstractRuleChainVisitor implements RuleChainVisitor {
                         } else {
                             throw e;
                         }
+                    } finally {
+                        ctx.setCurrentRule(null);
                     }
                 }
             }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/AbstractNodeTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/AbstractNodeTest.java
@@ -15,8 +15,11 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import net.sourceforge.pmd.RuleContext;
+import net.sourceforge.pmd.RuleContextHolder;
 import net.sourceforge.pmd.junit.JavaUtilLoggingRule;
 import net.sourceforge.pmd.lang.ast.xpath.Attribute;
+import net.sourceforge.pmd.lang.rule.XPathRule;
 
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
@@ -238,14 +241,23 @@ public class AbstractNodeTest {
             }
         }
 
-        addChild(new MyRootNode(nextId()), new DummyNodeWithDeprecatedAttribute(2)).findChildNodesWithXPath("//dummyNode[@Size=1]");
+        try {
+            RuleContext ruleContext = new RuleContext();
+            net.sourceforge.pmd.Rule rule = new XPathRule();
+            rule.setName("RuleName");
+            ruleContext.setCurrentRule(rule);
+            RuleContextHolder.set(ruleContext);
 
-        String log = loggingRule.getLog();
+            addChild(new MyRootNode(nextId()), new DummyNodeWithDeprecatedAttribute(2)).findChildNodesWithXPath("//dummyNode[@Size=1]");
 
-        assertTrue(log.contains("deprecated"));
-        assertTrue(log.contains("attribute"));
-        assertTrue(log.contains("dummyNode/@Size"));
+            String log = loggingRule.getLog();
+
+            assertTrue(log.contains("RuleName"));
+            assertTrue(log.contains("deprecated"));
+            assertTrue(log.contains("attribute"));
+            assertTrue(log.contains("dummyNode/@Size"));
+        } finally {
+            RuleContextHolder.reset();
+        }
     }
-
-
 }

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -316,13 +316,13 @@ prefix for these methods.
             <property name="xpath">
                 <value>
 <![CDATA[
-//MethodDeclaration[
-MethodDeclarator[count(FormalParameters/FormalParameter) = 0 or $checkParameterizedMethods = 'true']
-                [starts-with(@Image, 'get')]
-and
-ResultType/Type/PrimitiveType[@Image = 'boolean']
-and not(../Annotation//Name[@Image = 'Override'])
-]
+//MethodDeclaration
+    [starts-with(@Name, 'get')]
+    [@Arity = 0 or $checkParameterizedMethods = 'true']
+    [
+        ResultType/Type/PrimitiveType[@Image = 'boolean']
+        and not(../Annotation//Name[@Image = 'Override'])
+    ]
 ]]>
                 </value>
             </property>
@@ -1647,7 +1647,7 @@ Method names that are very short are not helpful to the reader.
             <property name="xpath">
                 <value>
 <![CDATA[
-//MethodDeclarator[string-length(@Image) < $minimum]
+//MethodDeclaration[string-length(@Name) < $minimum]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -1557,11 +1557,11 @@ complexity and find a way to have more fine grained objects.
                                 something like this:
                                     not (
                                             (
-                                                starts-with(@Image,'get')
+                                                starts-with(@Name,'get')
                                                 or
-                                                starts-with(@Image,'set')
+                                                starts-with(@Name,'set')
                                                 or
-                                                starts-with(@Image,'is')
+                                                starts-with(@Name,'is')
                                             )
                                             and (
                                                     (
@@ -1571,18 +1571,18 @@ complexity and find a way to have more fine grained objects.
                                                     ) <= 3
                                             )
                                         )
-                                This will avoid discarding 'real' method...
+                                This will avoid discarding 'real' methods...
                      -->
 <![CDATA[
  //ClassOrInterfaceDeclaration/ClassOrInterfaceBody
      [
-      count(./ClassOrInterfaceBodyDeclaration/MethodDeclaration/MethodDeclarator[
+      count(./ClassOrInterfaceBodyDeclaration/MethodDeclaration[
          not (
-                starts-with(@Image,'get')
+                starts-with(@Name,'get')
                 or
-                starts-with(@Image,'set')
+                starts-with(@Name,'set')
                 or
-                starts-with(@Image,'is')
+                starts-with(@Name,'is')
             )
       ]) > $maxmethods
    ]

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -694,16 +694,16 @@ public String bar(String string) {
             <property name="xpath">
                 <value>
 <![CDATA[
-//MethodDeclaration[MethodDeclarator[
-  @Image='onCreate' or
-  @Image='onConfigurationChanged' or
-  @Image='onPostCreate' or
-  @Image='onPostResume' or
-  @Image='onRestart' or
-  @Image='onRestoreInstanceState' or
-  @Image='onResume' or
-  @Image='onStart'
-  ]]
+//MethodDeclaration[
+  @Name='onCreate' or
+  @Name='onConfigurationChanged' or
+  @Name='onPostCreate' or
+  @Name='onPostResume' or
+  @Name='onRestart' or
+  @Name='onRestoreInstanceState' or
+  @Name='onResume' or
+  @Name='onStart'
+  ]
     /Block[not(
       (BlockStatement[1]/Statement/StatementExpression/PrimaryExpression[./PrimaryPrefix[@SuperModifier='true']]/PrimarySuffix[@Image= ancestor::MethodDeclaration/MethodDeclarator/@Image]))]
 [ancestor::ClassOrInterfaceDeclaration[ExtendsList/ClassOrInterfaceType[
@@ -741,14 +741,14 @@ Super should be called at the end of the method
             <property name="xpath">
                 <value>
 <![CDATA[
-//MethodDeclaration[MethodDeclarator[
-  @Image='finish' or
-  @Image='onDestroy' or
-  @Image='onPause' or
-  @Image='onSaveInstanceState' or
-  @Image='onStop' or
-  @Image='onTerminate'
-  ]]
+//MethodDeclaration[
+  @Name='finish' or
+  @Name='onDestroy' or
+  @Name='onPause' or
+  @Name='onSaveInstanceState' or
+  @Name='onStop' or
+  @Name='onTerminate'
+  ]
    /Block/BlockStatement[last()]
     [not(Statement/StatementExpression/PrimaryExpression[./PrimaryPrefix[@SuperModifier='true']]/PrimarySuffix[@Image= ancestor::MethodDeclaration/MethodDeclarator/@Image])]
 [ancestor::ClassOrInterfaceDeclaration[ExtendsList/ClassOrInterfaceType[
@@ -864,8 +864,8 @@ Object.clone (which is protected) with a public method."
                 <value>
 <![CDATA[
 //MethodDeclaration[@Public='false']
-  [MethodDeclarator/@Image = 'clone']
-  [MethodDeclarator/FormalParameters/@ParameterCount = 0]
+  [@Name = 'clone']
+  [@Arity = 0]
 ]]>
                 </value>
             </property>
@@ -937,8 +937,8 @@ Note: This is only possible with Java 1.5 or higher.
 <![CDATA[
 //MethodDeclaration
 [
-MethodDeclarator/@Image = 'clone'
-and MethodDeclarator/FormalParameters/@ParameterCount = 0
+@Name = 'clone'
+and @Arity = 0
 and not (ResultType//ClassOrInterfaceType/@Image = ancestor::ClassOrInterfaceDeclaration[1]/@Image)
 ]
 ]]>
@@ -978,8 +978,8 @@ The method clone() should throw a CloneNotSupportedException.
 <![CDATA[
 //MethodDeclaration
 [
-MethodDeclarator/@Image = 'clone'
-and count(MethodDeclarator/FormalParameters/*) = 0
+@Name = 'clone'
+and @Arity = 0
 and count(NameList/Name[contains
 (@Image,'CloneNotSupportedException')]) = 0
 ]
@@ -1484,7 +1484,7 @@ Empty finalize methods serve no purpose and should be removed. Note that Oracle 
             <property name="xpath">
                 <value>
 <![CDATA[
-//MethodDeclaration[MethodDeclarator[@Image='finalize'][not(FormalParameters/*)]]
+//MethodDeclaration[@Name='finalize'][@Arity = 0]
   /Block[count(*)=0]
 ]]>
                 </value>
@@ -1850,7 +1850,7 @@ If the finalize() is implemented, its last action should be to call super.finali
 <!-- in English: a method declaration of finalize(), with no arguments, containing
 a block whose last statement is NOT a call to super.finalize -->
 <![CDATA[
-//MethodDeclaration[MethodDeclarator[@Image='finalize'][not(FormalParameters/*)]]
+//MethodDeclaration[@Name='finalize'][@Arity = 0]
    /Block
       /BlockStatement[last()]
       [not(Statement/StatementExpression/PrimaryExpression
@@ -1892,7 +1892,7 @@ If the finalize() is implemented, it should do something besides just calling su
             <property name="xpath">
                 <value>
 <![CDATA[
-//MethodDeclaration[MethodDeclarator[@Image="finalize"][not(FormalParameters/*)]]
+//MethodDeclaration[@Name='finalize'][@Arity = 0]
    /Block[count(BlockStatement)=1]
      /BlockStatement[
        Statement/StatementExpression/PrimaryExpression
@@ -1929,8 +1929,7 @@ Note that Oracle has declared Object.finalize() as deprecated since JDK 9.
             <property name="xpath">
                 <value>
 <![CDATA[
-//MethodDeclaration
- /MethodDeclarator[@Image='finalize'][FormalParameters[count(*)>0]]
+//MethodDeclaration[@Name='finalize'][@Arity > 0]
 ]]>
                 </value>
             </property>
@@ -1963,9 +1962,7 @@ Note that Oracle has declared Object.finalize() as deprecated since JDK 9.
             <property name="xpath">
                 <value>
 <![CDATA[
-//MethodDeclaration[@Protected="false"]
-  /MethodDeclarator[@Image="finalize"]
-  [not(FormalParameters/*)]
+//MethodDeclaration[@Protected="false"][@Name='finalize'][@Arity = 0]
 ]]>
                 </value>
             </property>
@@ -2127,11 +2124,11 @@ Some JUnit framework methods are easy to misspell.
             <property name="xpath">
                 <value>
 <![CDATA[
-//MethodDeclarator[(not(@Image = 'setUp')
- and translate(@Image, 'SETuP', 'setUp') = 'setUp')
- or (not(@Image = 'tearDown')
- and translate(@Image, 'TEARdOWN', 'tearDown') = 'tearDown')]
- [FormalParameters[count(*) = 0]]
+//MethodDeclaration[(not(@Name = 'setUp')
+ and translate(@Name, 'SETuP', 'setUp') = 'setUp')
+ or (not(@Name = 'tearDown')
+ and translate(@Name, 'TEARdOWN', 'tearDown') = 'tearDown')]
+ [@Arity = 0]
 [ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeIs('junit.framework.TestCase')]
     or //MarkerAnnotation/Name[
         pmd-java:typeIs('org.junit.Test')
@@ -2171,8 +2168,8 @@ The suite() method in a JUnit test needs to be both public and static.
                 <value>
 <![CDATA[
 //MethodDeclaration[not(@Static='true') or not(@Public='true')]
-[MethodDeclarator/@Image='suite']
-[MethodDeclarator/FormalParameters/@ParameterCount=0]
+[@Name='suite']
+[@Arity = 0]
 [ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeIs('junit.framework.TestCase')]
     or //MarkerAnnotation/Name[
         pmd-java:typeIs('org.junit.Test')
@@ -2636,10 +2633,10 @@ Object clone() should be implemented with super.clone().
             <property name="xpath">
                 <value>
 <![CDATA[
-//MethodDeclarator
-[@Image = 'clone']
-[count(FormalParameters/*) = 0]
-[count(../Block//*[
+//MethodDeclaration
+[@Name = 'clone']
+[@Arity = 0]
+[count(./Block//*[
     (self::AllocationExpression) and
     (./ClassOrInterfaceType/@Image = ancestor::
 ClassOrInterfaceDeclaration[1]/@Image)
@@ -3009,23 +3006,23 @@ intention to override the equals(Object) method.
             <property name="xpath">
                 <value>
 <![CDATA[
-//MethodDeclarator[@Image = 'equals']
+//MethodDeclaration[@Name = 'equals']
 [   
-    (count(FormalParameters/*) = 1
-    and not (FormalParameters/FormalParameter/Type/ReferenceType/ClassOrInterfaceType
+    (@Arity = 1
+    and not (MethodDeclarator/FormalParameters/FormalParameter/Type/ReferenceType/ClassOrInterfaceType
         [@Image = 'Object' or @Image = 'java.lang.Object'])
-    or not (../ResultType/Type/PrimitiveType[@Image = 'boolean'])
+    or not (ResultType/Type/PrimitiveType[@Image = 'boolean'])
     )  or  (
-    count(FormalParameters/*) = 2
-    and ../ResultType/Type/PrimitiveType[@Image = 'boolean']
-    and FormalParameters//ClassOrInterfaceType[@Image = 'Object' or @Image = 'java.lang.Object']
-    and not(../../Annotation/MarkerAnnotation/Name[@Image='Override'])
+    @Arity = 2
+    and ResultType/Type/PrimitiveType[@Image = 'boolean']
+    and MethodDeclarator/FormalParameters//ClassOrInterfaceType[@Image = 'Object' or @Image = 'java.lang.Object']
+    and not(../Annotation/MarkerAnnotation/Name[@Image='Override'])
     )
 ]
-| //MethodDeclarator[@Image = 'equal']
+| //MethodDeclaration[@Name = 'equal']
 [
-    count(FormalParameters/*) = 1
-    and FormalParameters/FormalParameter/Type/ReferenceType/ClassOrInterfaceType
+    @Arity = 1
+    and MethodDeclarator/FormalParameters/FormalParameter/Type/ReferenceType/ClassOrInterfaceType
         [@Image = 'Object' or @Image = 'java.lang.Object']
 ]
 ]]>


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

Introduce a rule context holder, to have access to the
current rule. This is used to log deprecated xpath attributes.

The deprecated attributes are now logged once per rule and not
once at all.

RuleContext can be considered the "analysis context". Each thread
uses its own rule context, established by PmdRunnable.

Fixes #2019

Note: #2044 is still required, because the deprecation messages are only logged once per JVM due to static caching.

The log messages might look like this:

```
Okt. 05, 2019 8:13:57 NACHM. net.sourceforge.pmd.lang.ast.xpath.Attribute getValue
WARNING: Use of deprecated attribute 'MethodDeclarator/@Image' in XPath query in rule 'Code Style/BooleanGetMethodName'.
Okt. 05, 2019 8:13:57 NACHM. net.sourceforge.pmd.lang.ast.xpath.Attribute getValue
WARNING: Use of deprecated attribute 'MethodDeclarator/@Image' in XPath query in rule 'Code Style/ShortMethodName'.
Okt. 05, 2019 8:13:57 NACHM. net.sourceforge.pmd.lang.ast.xpath.Attribute getValue
WARNING: Use of deprecated attribute 'MethodDeclarator/@Image' in XPath query in rule 'Design/TooManyMethods'.
Okt. 05, 2019 8:13:57 NACHM. net.sourceforge.pmd.lang.ast.xpath.Attribute getValue
WARNING: Use of deprecated attribute 'MethodDeclarator/@Image' in XPath query in rule 'Error Prone/CallSuperFirst'.
Okt. 05, 2019 8:13:57 NACHM. net.sourceforge.pmd.lang.ast.xpath.Attribute getValue
WARNING: Use of deprecated attribute 'MethodDeclarator/@Image' in XPath query in rule 'Error Prone/CallSuperLast'.
Okt. 05, 2019 8:13:57 NACHM. net.sourceforge.pmd.lang.ast.xpath.Attribute getValue
WARNING: Use of deprecated attribute 'MethodDeclarator/@Image' in XPath query in rule 'Error Prone/CloneMethodReturnTypeMustMatchClassName'.
Okt. 05, 2019 8:13:57 NACHM. net.sourceforge.pmd.lang.ast.xpath.Attribute getValue
WARNING: Use of deprecated attribute 'MethodDeclarator/@Image' in XPath query in rule 'Error Prone/CloneThrowsCloneNotSupportedException'.
Okt. 05, 2019 8:13:57 NACHM. net.sourceforge.pmd.lang.ast.xpath.Attribute getValue
WARNING: Use of deprecated attribute 'MethodDeclarator/@Image' in XPath query in rule 'Error Prone/EmptyFinalizer'.
Okt. 05, 2019 8:13:57 NACHM. net.sourceforge.pmd.lang.ast.xpath.Attribute getValue
WARNING: Use of deprecated attribute 'MethodDeclarator/@Image' in XPath query in rule 'Error Prone/CloneMethodMustBePublic'.
Okt. 05, 2019 8:13:57 NACHM. net.sourceforge.pmd.lang.ast.xpath.Attribute getValue
WARNING: Use of deprecated attribute 'MethodDeclarator/@Image' in XPath query in rule 'Error Prone/FinalizeDoesNotCallSuperFinalize'.
Okt. 05, 2019 8:13:57 NACHM. net.sourceforge.pmd.lang.ast.xpath.Attribute getValue
WARNING: Use of deprecated attribute 'MethodDeclarator/@Image' in XPath query in rule 'Error Prone/FinalizeOnlyCallsSuperFinalize'.
Okt. 05, 2019 8:13:57 NACHM. net.sourceforge.pmd.lang.ast.xpath.Attribute getValue
WARNING: Use of deprecated attribute 'MethodDeclarator/@Image' in XPath query in rule 'Error Prone/FinalizeOverloaded'.
Okt. 05, 2019 8:13:57 NACHM. net.sourceforge.pmd.lang.ast.xpath.Attribute getValue
WARNING: Use of deprecated attribute 'MethodDeclarator/@Image' in XPath query in rule 'Error Prone/FinalizeShouldBeProtected'.
Okt. 05, 2019 8:13:57 NACHM. net.sourceforge.pmd.lang.ast.xpath.Attribute getValue
WARNING: Use of deprecated attribute 'MethodDeclarator/@Image' in XPath query in rule 'Error Prone/JUnitSpelling'.
Okt. 05, 2019 8:13:57 NACHM. net.sourceforge.pmd.lang.ast.xpath.Attribute getValue
WARNING: Use of deprecated attribute 'MethodDeclarator/@Image' in XPath query in rule 'Error Prone/JUnitStaticSuite'.
Okt. 05, 2019 8:13:57 NACHM. net.sourceforge.pmd.lang.ast.xpath.Attribute getValue
WARNING: Use of deprecated attribute 'MethodDeclarator/@Image' in XPath query in rule 'Error Prone/ProperCloneImplementation'.
Okt. 05, 2019 8:13:57 NACHM. net.sourceforge.pmd.lang.ast.xpath.Attribute getValue
WARNING: Use of deprecated attribute 'MethodDeclarator/@Image' in XPath query in rule 'Error Prone/SuspiciousEqualsMethodName'.
```
