### PR TITLE
[core] print a warning message on encountering a duplicate rule

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
@@ -169,6 +169,7 @@ public class RuleSet implements ChecksumAware {
             for (final Iterator<Rule> it = rules.iterator(); it.hasNext();) {
                 final Rule r = it.next();
                 if (r.getName().equals(rule.getName()) && r.getLanguage() == rule.getLanguage()) {
+                    LOG.warning("The rule with name " + rule.getName() + " was duplicated and has been overwritten.");
                     it.remove();
                 }
             }


### PR DESCRIPTION
Fixes #2006 by printing a warning instead of just silently overwriting duplicate rules.

This is a hacktoberfest contribution!