### PR TITLE
[java] Stop checking UR anomalies

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/DataflowAnomalyAnalysisRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/DataflowAnomalyAnalysisRule.java
@@ -131,8 +131,6 @@ public class DataflowAnomalyAnalysisRule extends AbstractJavaRule implements Exe
 
         if (va.accessTypeMatches(u.accessType) && va.isDefinition()) { // DD
             addDaaViolation(rc, lastNode, "DD", va.getVariableName(), startLine, endLine);
-        } else if (u.accessType == VariableAccess.UNDEFINITION && va.isReference()) { // UR
-            addDaaViolation(rc, lastNode, "UR", va.getVariableName(), startLine, endLine);
         } else if (u.accessType == VariableAccess.DEFINITION && va.isUndefinition()) { // DU
             addDaaViolation(rc, firstNode, "DU", va.getVariableName(), startLine, endLine);
         }

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -1120,9 +1120,8 @@ public class JuniorClass extends SeniorClass {
         <description>The dataflow analysis tracks local definitions, undefinitions and references to variables on different paths on the data flow.
 From those informations there can be found various problems.
 
-1. UR - Anomaly: There is a reference to a variable that was not defined before. This is a bug and leads to an error.
-2. DU - Anomaly: A recently defined variable is undefined. These anomalies may appear in normal source text.
-3. DD - Anomaly: A recently defined variable is redefined. This is ominous but don't have to be a bug.
+1. DU - Anomaly: A recently defined variable is undefined. These anomalies may appear in normal source text.
+2. DD - Anomaly: A recently defined variable is redefined. This is ominous but don't have to be a bug.
         </description>
         <priority>5</priority>
         <example>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/DataflowAnomalyAnalysis.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/DataflowAnomalyAnalysis.xml
@@ -50,7 +50,7 @@ public class Foo {
         <description><![CDATA[
 UR anomaly
      ]]></description>
-        <expected-problems>1</expected-problems>
+        <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
  void bar() {
@@ -81,7 +81,7 @@ public class Foo {
     <test-code>
         <description>#1393 PMD hanging during DataflowAnomalyAnalysis</description>
         <!-- Note: due to https://sourceforge.net/p/pmd/bugs/1383/ the 6 problems are false positives!  -->
-        <expected-problems>6</expected-problems>
+        <expected-problems>3</expected-problems>
         <code><![CDATA[
 public class LoopTest {
     public static void main(String[] args) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/DataflowAnomalyAnalysis.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/DataflowAnomalyAnalysis.xml
@@ -80,7 +80,7 @@ public class Foo {
 
     <test-code>
         <description>#1393 PMD hanging during DataflowAnomalyAnalysis</description>
-        <!-- Note: due to https://sourceforge.net/p/pmd/bugs/1383/ the 6 problems are false positives!  -->
+        <!-- Note: due to https://sourceforge.net/p/pmd/bugs/1383/ the 3 problems are false positives!  -->
         <expected-problems>3</expected-problems>
         <code><![CDATA[
 public class LoopTest {


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

This PR stops checking for UR anomalies in the DataflowAnomalyAnalysis rule in Java. Note, I retained the UR anomaly test, but changed the expected number of errors to zero. I also updated the documentation to remove the reference to UR anomalies.

Fixes: #1636