### PR TITLE
[java] Deprecate AbstractJavaRule#getDeclaringType(Node)

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -64,6 +64,7 @@ This is a {{ site.pmd.release_type }} release.
 * pmd-java
   * {% jdoc java::lang.java.ast.CanSuppressWarnings %} and its implementations
   * {% jdoc java::lang.java.rule.AbstractJavaRule#isSuppressed(Node) %}
+  * {% jdoc java::lang.java.rule.AbstractJavaRule#getDeclaringType(Node) %}.
   * {% jdoc java::lang.java.rule.JavaRuleViolation#isSupressed(Node,Rule) %}
   * {% jdoc java::lang.java.ast.ASTMethodDeclarator %}
   * {% jdoc java::lang.java.ast.ASTMethodDeclaration#getMethodName() %}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJavaRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJavaRule.java
@@ -47,7 +47,13 @@ public abstract class AbstractJavaRule extends AbstractRule implements JavaParse
      *
      * @param node
      *            the node which will be searched
+     *
+     * @deprecated This method just returns the type name as a string
+     *     which doesn't leverage any type resolution. Use {@link Node#getFirstParentOfType(Class)}
+     *     directly to find the node of type {@link ASTClassOrInterfaceBodyDeclaration} via the
+     *     {@code getType} method.
      */
+    @Deprecated
     protected final String getDeclaringType(Node node) {
         ASTClassOrInterfaceDeclaration c = node.getFirstParentOfType(ASTClassOrInterfaceDeclaration.class);
         if (c != null) {


### PR DESCRIPTION
~add replacement JavaNode#getEnclosingType()~

Follow-up on #2034

btw. I've also updated https://github.com/pmd/pmd/wiki/PMD-7.0.0-Java and https://github.com/pmd/pmd/wiki/Java_clean_changes
