### PR TITLE
[core] Rule loader should use the same resources loader for the ruleset

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
@@ -587,7 +587,7 @@ public class RuleSetFactory {
                 && !isRuleName(ruleElement, ruleSetReferenceId.getRuleName())) {
             return;
         }
-        Rule rule = new RuleFactory().buildRule(ruleElement);
+        Rule rule = new RuleFactory().buildRule(ruleElement, resourceLoader);
         rule.setRuleSetName(ruleSetBuilder.getName());
 
         ruleSetBuilder.addRule(rule);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
@@ -587,7 +587,7 @@ public class RuleSetFactory {
                 && !isRuleName(ruleElement, ruleSetReferenceId.getRuleName())) {
             return;
         }
-        Rule rule = new RuleFactory().buildRule(ruleElement, resourceLoader);
+        Rule rule = new RuleFactory(resourceLoader).buildRule(ruleElement);
         rule.setRuleSetName(ruleSetBuilder.getName());
 
         ruleSetBuilder.addRule(rule);
@@ -670,7 +670,7 @@ public class RuleSetFactory {
 
         RuleSetReference ruleSetReference = new RuleSetReference(otherRuleSetReferenceId.getRuleSetFileName(), false);
 
-        RuleReference ruleReference = new RuleFactory().decorateRule(referencedRule, ruleSetReference, ruleElement);
+        RuleReference ruleReference = new RuleFactory(resourceLoader).decorateRule(referencedRule, ruleSetReference, ruleElement);
 
         if (warnDeprecated && ruleReference.isDeprecated()) {
             if (LOG.isLoggable(Level.WARNING)) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/rules/RuleBuilder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/rules/RuleBuilder.java
@@ -49,7 +49,7 @@ public class RuleBuilder {
 
     @Deprecated
     public RuleBuilder(String name, String clazz, String language) {
-        this(name, new ResourceLoader(), clazz, language)
+        this(name, new ResourceLoader(), clazz, language);
     }
 
     public RuleBuilder(String name, ResourceLoader resourceLoader, String clazz, String language) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/rules/RuleBuilder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/rules/RuleBuilder.java
@@ -49,10 +49,7 @@ public class RuleBuilder {
 
     @Deprecated
     public RuleBuilder(String name, String clazz, String language) {
-        this.name = name;
-        this.resourceLoader = new ResourceLoader();
-        language(language);
-        className(clazz);
+        this(name, new ResourceLoader(), clazz, language)
     }
 
     public RuleBuilder(String name, ResourceLoader resourceLoader, String clazz, String language) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/rules/RuleBuilder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/rules/RuleBuilder.java
@@ -17,6 +17,7 @@ import net.sourceforge.pmd.lang.Language;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.util.ResourceLoader;
 
 
 /**
@@ -30,6 +31,7 @@ public class RuleBuilder {
 
     private List<PropertyDescriptor<?>> definedProperties = new ArrayList<>();
     private String name;
+    private ResourceLoader resourceLoader;
     private String clazz;
     private Language language;
     private String minimumVersion;
@@ -45,8 +47,9 @@ public class RuleBuilder {
     private boolean isUsesMultifile;
     private boolean isUsesTyperesolution;
 
-    public RuleBuilder(String name, String clazz, String language) {
+    public RuleBuilder(String name, ResourceLoader resourceLoader, String clazz, String language) {
         this.name = name;
+        this.resourceLoader = resourceLoader;
         language(language);
         className(clazz);
     }
@@ -177,7 +180,7 @@ public class RuleBuilder {
     }
 
     public Rule build() throws ClassNotFoundException, IllegalAccessException, InstantiationException {
-        Rule rule = (Rule) RuleBuilder.class.getClassLoader().loadClass(clazz).newInstance();
+        Rule rule = resourceLoader.loadRuleFromClassPath(clazz);
 
         rule.setName(name);
         rule.setRuleClass(clazz);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/rules/RuleBuilder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/rules/RuleBuilder.java
@@ -47,6 +47,14 @@ public class RuleBuilder {
     private boolean isUsesMultifile;
     private boolean isUsesTyperesolution;
 
+    @Deprecated
+    public RuleBuilder(String name, String clazz, String language) {
+        this.name = name;
+        this.resourceLoader = new ResourceLoader();
+        language(language);
+        className(clazz);
+    }
+
     public RuleBuilder(String name, ResourceLoader resourceLoader, String clazz, String language) {
         this.name = name;
         this.resourceLoader = resourceLoader;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/rules/RuleFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/rules/RuleFactory.java
@@ -31,6 +31,7 @@ import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyDescriptorField;
 import net.sourceforge.pmd.properties.PropertyTypeId;
 import net.sourceforge.pmd.properties.builders.PropertyDescriptorExternalBuilder;
+import net.sourceforge.pmd.util.ResourceLoader;
 
 
 /**
@@ -121,16 +122,18 @@ public class RuleFactory {
      * with regards to the expected schema, while RuleBuilder validates the semantics.
      *
      * @param ruleElement The rule element to parse
+     * @param resourceLoader The resource loader to load the rule from jar
      *
      * @return A new instance of the rule described by this element
      * @throws IllegalArgumentException if the element doesn't describe a valid rule.
      */
-    public Rule buildRule(Element ruleElement) {
+    public Rule buildRule(Element ruleElement, final ResourceLoader resourceLoader) {
         checkRequiredAttributesArePresent(ruleElement);
 
         String name = ruleElement.getAttribute(NAME);
 
         RuleBuilder builder = new RuleBuilder(name,
+                resourceLoader,
                 ruleElement.getAttribute(CLASS),
                 ruleElement.getAttribute("language"));
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/rules/RuleFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/rules/RuleFactory.java
@@ -60,6 +60,20 @@ public class RuleFactory {
     
     private static final List<String> REQUIRED_ATTRIBUTES = Collections.unmodifiableList(Arrays.asList(NAME, CLASS));
 
+    private final ResourceLoader resourceLoader;
+
+    @Deprecated
+    public RuleFactory() {
+        this(new ResourceLoader());
+    }
+
+    /**
+     * @param resourceLoader The resource loader to load the rule from jar
+     */
+    public RuleFactory(final ResourceLoader resourceLoader) {
+        this.resourceLoader = resourceLoader;
+    }
+
     /**
      * Decorates a referenced rule with the metadata that are overridden in the given rule element.
      *
@@ -122,12 +136,11 @@ public class RuleFactory {
      * with regards to the expected schema, while RuleBuilder validates the semantics.
      *
      * @param ruleElement The rule element to parse
-     * @param resourceLoader The resource loader to load the rule from jar
      *
      * @return A new instance of the rule described by this element
      * @throws IllegalArgumentException if the element doesn't describe a valid rule.
      */
-    public Rule buildRule(Element ruleElement, final ResourceLoader resourceLoader) {
+    public Rule buildRule(Element ruleElement) {
         checkRequiredAttributesArePresent(ruleElement);
 
         String name = ruleElement.getAttribute(NAME);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/ResourceLoader.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/ResourceLoader.java
@@ -13,6 +13,7 @@ import java.net.URLConnection;
 import java.nio.file.Files;
 import java.util.Objects;
 
+import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleSetNotFoundException;
 
 public class ResourceLoader {
@@ -117,5 +118,18 @@ public class ResourceLoader {
         }
         
         return is;
+    }
+
+    /**
+     * Load the rule from the classloader from resource loader, consistent with the ruleset
+     *
+     * @param clazz
+     * @return
+     * @throws ClassNotFoundException
+     * @throws IllegalAccessException
+     * @throws InstantiationException
+     */
+    public Rule loadRuleFromClassPath(final String clazz) throws ClassNotFoundException, IllegalAccessException, InstantiationException {
+        return (Rule) classLoader.loadClass(clazz).newInstance();
     }
 }


### PR DESCRIPTION
**PR Description:**
In PMDTaskImpl

RuleSet is loaded via the resourceLoader, however, Rule is loaded via a default classloader.

If a customized rule jar is supplied via another path, a ClassNotFoundException would be thrown. 
