### PR TITLE
[java] CommentRequired: make property names consistent

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -25,6 +25,11 @@ While the language implementation is quite complete, Modelica support is conside
 for now. This is to allow us to change the rule API (e.g. the AST classes) slightly and improve
 the implementation based on your feedback.
 
+#### Modified Rules
+
+*   The Java rule {% rule "java/documentation/CommentRequired" %} (`java-documentation`) has a new property
+    `classCommentRequirement`. This replaces the now deprecated property `headerCommentRequirement`, since
+    the name was misleading. (File) header comments are not checked, but class comments are.
 
 ### Fixed Issues
 
@@ -32,6 +37,8 @@ the implementation based on your feedback.
     *   [#2167](https://github.com/pmd/pmd/issues/2167): \[java] UnnecessaryLocalBeforeReturn false positive with variable captured by method reference
 *   java-bestpractices
     *   [#2149](https://github.com/pmd/pmd/issues/2149): \[java] JUnitAssertionsShouldIncludeMessage - False positive with assertEquals and JUnit5
+*   java-documentation
+    *   [#1683](https://github.com/pmd/pmd/issues/1683): \[java] CommentRequired property names are inconsistent
 *   java-performance
     *   [#2141](https://github.com/pmd/pmd/issues/2141): \[java] StringInstatiation: False negative with String-array access
 
@@ -81,6 +88,7 @@ You can identify them with the `@InternalApi` annotation. You'll also get a depr
 ### External Contributions
 
 *   [#2041](https://github.com/pmd/pmd/pull/2041): \[modelica] Initial implementation for PMD - [Anatoly Trosinenko](https://github.com/atrosinenko)
+*   [#2069](https://github.com/pmd/pmd/pull/2069): \[java] CommentRequired: make property names consistent - [snuyanzin](https://github.com/snuyanzin)
 
 {% endtocmaker %}
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/AbstractCommentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/AbstractCommentRule.java
@@ -19,8 +19,10 @@ import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTEnumDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTPackageDeclaration;
 import net.sourceforge.pmd.lang.java.ast.AbstractJavaAccessNode;
 import net.sourceforge.pmd.lang.java.ast.AbstractJavaAccessTypeNode;
+import net.sourceforge.pmd.lang.java.ast.AbstractJavaNode;
 import net.sourceforge.pmd.lang.java.ast.Comment;
 import net.sourceforge.pmd.lang.java.ast.CommentUtil;
 import net.sourceforge.pmd.lang.java.ast.FormalComment;
@@ -64,17 +66,15 @@ public abstract class AbstractCommentRule extends AbstractJavaRule {
 
         SortedMap<Integer, Node> itemsByLineNumber = orderedCommentsAndDeclarations(cUnit);
         FormalComment lastComment = null;
-        AbstractJavaAccessNode lastNode = null;
+        AbstractJavaNode lastNode = null;
 
         for (Entry<Integer, Node> entry : itemsByLineNumber.entrySet()) {
             Node value = entry.getValue();
-
-            if (value instanceof AbstractJavaAccessNode) {
-                AbstractJavaAccessNode node = (AbstractJavaAccessNode) value;
-
+            if (value instanceof AbstractJavaAccessNode || value instanceof ASTPackageDeclaration) {
+                AbstractJavaNode node = (AbstractJavaNode) value;
                 // maybe the last comment is within the last node
-                if (lastComment != null && isCommentNotWithin(lastComment, lastNode, node)
-                        && isCommentBefore(lastComment, node)) {
+                if (lastComment != null && isCommentNotWithin(lastComment, lastNode, value)
+                        && isCommentBefore(lastComment, value)) {
                     node.comment(lastComment);
                     lastComment = null;
                 }
@@ -107,6 +107,8 @@ public abstract class AbstractCommentRule extends AbstractJavaRule {
 
     protected SortedMap<Integer, Node> orderedCommentsAndDeclarations(ASTCompilationUnit cUnit) {
         SortedMap<Integer, Node> itemsByLineNumber = new TreeMap<>();
+
+        addDeclarations(itemsByLineNumber, cUnit.findDescendantsOfType(ASTPackageDeclaration.class, true));
 
         addDeclarations(itemsByLineNumber, cUnit.findDescendantsOfType(ASTClassOrInterfaceDeclaration.class, true));
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentRequiredRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentRequiredRule.java
@@ -45,7 +45,8 @@ public class CommentRequiredRule extends AbstractCommentRule {
         = requirementPropertyBuilder("methodWithOverrideCommentRequirement", "Comments on @Override methods")
         .defaultValue(CommentRequirement.Ignored).build();
     private static final PropertyDescriptor<CommentRequirement> HEADER_CMT_REQUIREMENT_DESCRIPTOR
-        = requirementPropertyBuilder("headerCommentRequirement", "Header comments").build();
+        = requirementPropertyBuilder("headerCommentRequirement", "Header comments")
+        .defaultValue(CommentRequirement.Ignored).build();
     private static final PropertyDescriptor<CommentRequirement> CLASS_CMT_REQUIREMENT_DESCRIPTOR
         = requirementPropertyBuilder("classCommentRequirement", "Class comments").build();
     private static final PropertyDescriptor<CommentRequirement> FIELD_CMT_REQUIREMENT_DESCRIPTOR

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentRequiredRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentRequiredRule.java
@@ -20,6 +20,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMarkerAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
+import net.sourceforge.pmd.lang.java.ast.ASTPackageDeclaration;
 import net.sourceforge.pmd.lang.java.ast.AbstractJavaAccessNode;
 import net.sourceforge.pmd.lang.java.ast.AbstractJavaNode;
 import net.sourceforge.pmd.lang.java.multifile.signature.JavaOperationSignature;
@@ -45,6 +46,8 @@ public class CommentRequiredRule extends AbstractCommentRule {
         .defaultValue(CommentRequirement.Ignored).build();
     private static final PropertyDescriptor<CommentRequirement> HEADER_CMT_REQUIREMENT_DESCRIPTOR
         = requirementPropertyBuilder("headerCommentRequirement", "Header comments").build();
+    private static final PropertyDescriptor<CommentRequirement> CLASS_CMT_REQUIREMENT_DESCRIPTOR
+        = requirementPropertyBuilder("classCommentRequirement", "Class comments").build();
     private static final PropertyDescriptor<CommentRequirement> FIELD_CMT_REQUIREMENT_DESCRIPTOR
         = requirementPropertyBuilder("fieldCommentRequirement", "Field comments").build();
     private static final PropertyDescriptor<CommentRequirement> PUB_METHOD_CMT_REQUIREMENT_DESCRIPTOR
@@ -64,6 +67,7 @@ public class CommentRequiredRule extends AbstractCommentRule {
     public CommentRequiredRule() {
         definePropertyDescriptor(OVERRIDE_CMT_DESCRIPTOR);
         definePropertyDescriptor(ACCESSOR_CMT_DESCRIPTOR);
+        definePropertyDescriptor(CLASS_CMT_REQUIREMENT_DESCRIPTOR);
         definePropertyDescriptor(HEADER_CMT_REQUIREMENT_DESCRIPTOR);
         definePropertyDescriptor(FIELD_CMT_REQUIREMENT_DESCRIPTOR);
         definePropertyDescriptor(PUB_METHOD_CMT_REQUIREMENT_DESCRIPTOR);
@@ -109,6 +113,13 @@ public class CommentRequiredRule extends AbstractCommentRule {
 
     @Override
     public Object visit(ASTClassOrInterfaceDeclaration decl, Object data) {
+        checkCommentMeetsRequirement(data, decl, CLASS_CMT_REQUIREMENT_DESCRIPTOR);
+        return super.visit(decl, data);
+    }
+
+
+    @Override
+    public Object visit(ASTPackageDeclaration decl, Object data) {
         checkCommentMeetsRequirement(data, decl, HEADER_CMT_REQUIREMENT_DESCRIPTOR);
         return super.visit(decl, data);
     }
@@ -212,6 +223,7 @@ public class CommentRequiredRule extends AbstractCommentRule {
         return getProperty(OVERRIDE_CMT_DESCRIPTOR) == CommentRequirement.Ignored
                 && getProperty(ACCESSOR_CMT_DESCRIPTOR) == CommentRequirement.Ignored
                 && getProperty(HEADER_CMT_REQUIREMENT_DESCRIPTOR) == CommentRequirement.Ignored
+                && getProperty(CLASS_CMT_REQUIREMENT_DESCRIPTOR) == CommentRequirement.Ignored
                 && getProperty(FIELD_CMT_REQUIREMENT_DESCRIPTOR) == CommentRequirement.Ignored
                 && getProperty(PUB_METHOD_CMT_REQUIREMENT_DESCRIPTOR) == CommentRequirement.Ignored
                 && getProperty(PROT_METHOD_CMT_REQUIREMENT_DESCRIPTOR) == CommentRequirement.Ignored

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentRequiredRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentRequiredRule.java
@@ -11,7 +11,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.logging.Logger;
 
+import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
@@ -20,7 +22,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMarkerAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
-import net.sourceforge.pmd.lang.java.ast.ASTPackageDeclaration;
 import net.sourceforge.pmd.lang.java.ast.AbstractJavaAccessNode;
 import net.sourceforge.pmd.lang.java.ast.AbstractJavaNode;
 import net.sourceforge.pmd.lang.java.multifile.signature.JavaOperationSignature;
@@ -33,10 +34,10 @@ import net.sourceforge.pmd.properties.PropertyFactory;
  * @author Brian Remedios
  */
 public class CommentRequiredRule extends AbstractCommentRule {
+    private static final Logger LOG = Logger.getLogger(CommentRequiredRule.class.getName());
 
     // Used to pretty print a message
     private static final Map<String, String> DESCRIPTOR_NAME_TO_COMMENT_TYPE = new HashMap<>();
-
 
     private static final PropertyDescriptor<CommentRequirement> ACCESSOR_CMT_DESCRIPTOR
         = requirementPropertyBuilder("accessorCommentRequirement", "Comments on getters and setters\"")
@@ -45,8 +46,7 @@ public class CommentRequiredRule extends AbstractCommentRule {
         = requirementPropertyBuilder("methodWithOverrideCommentRequirement", "Comments on @Override methods")
         .defaultValue(CommentRequirement.Ignored).build();
     private static final PropertyDescriptor<CommentRequirement> HEADER_CMT_REQUIREMENT_DESCRIPTOR
-        = requirementPropertyBuilder("headerCommentRequirement", "Header comments")
-        .defaultValue(CommentRequirement.Ignored).build();
+        = requirementPropertyBuilder("headerCommentRequirement", "Deprecated! Header comments. Please use the property \"classCommentRequired\" instead.").build();
     private static final PropertyDescriptor<CommentRequirement> CLASS_CMT_REQUIREMENT_DESCRIPTOR
         = requirementPropertyBuilder("classCommentRequirement", "Class comments").build();
     private static final PropertyDescriptor<CommentRequirement> FIELD_CMT_REQUIREMENT_DESCRIPTOR
@@ -64,6 +64,8 @@ public class CommentRequiredRule extends AbstractCommentRule {
         = requirementPropertyBuilder("serialPersistentFieldsCommentRequired", "Serial persistent fields comments")
         .defaultValue(CommentRequirement.Ignored).build();
 
+    /** stores the resolved property values. This is necessary in order to transparently use deprecated properties. */
+    private final Map<PropertyDescriptor<CommentRequirement>, CommentRequirement> propertyValues = new HashMap<>();
 
     public CommentRequiredRule() {
         definePropertyDescriptor(OVERRIDE_CMT_DESCRIPTOR);
@@ -78,10 +80,37 @@ public class CommentRequiredRule extends AbstractCommentRule {
         definePropertyDescriptor(SERIAL_PERSISTENT_FIELDS_CMT_REQUIREMENT_DESCRIPTOR);
     }
 
+    @Override
+    public void start(RuleContext ctx) {
+        propertyValues.put(ACCESSOR_CMT_DESCRIPTOR, getProperty(ACCESSOR_CMT_DESCRIPTOR));
+        propertyValues.put(OVERRIDE_CMT_DESCRIPTOR, getProperty(OVERRIDE_CMT_DESCRIPTOR));
+        propertyValues.put(FIELD_CMT_REQUIREMENT_DESCRIPTOR, getProperty(FIELD_CMT_REQUIREMENT_DESCRIPTOR));
+        propertyValues.put(PUB_METHOD_CMT_REQUIREMENT_DESCRIPTOR, getProperty(PUB_METHOD_CMT_REQUIREMENT_DESCRIPTOR));
+        propertyValues.put(PROT_METHOD_CMT_REQUIREMENT_DESCRIPTOR, getProperty(PROT_METHOD_CMT_REQUIREMENT_DESCRIPTOR));
+        propertyValues.put(ENUM_CMT_REQUIREMENT_DESCRIPTOR, getProperty(ENUM_CMT_REQUIREMENT_DESCRIPTOR));
+        propertyValues.put(SERIAL_VERSION_UID_CMT_REQUIREMENT_DESCRIPTOR,
+                getProperty(SERIAL_VERSION_UID_CMT_REQUIREMENT_DESCRIPTOR));
+        propertyValues.put(SERIAL_PERSISTENT_FIELDS_CMT_REQUIREMENT_DESCRIPTOR,
+                getProperty(SERIAL_PERSISTENT_FIELDS_CMT_REQUIREMENT_DESCRIPTOR));
+
+        CommentRequirement headerCommentRequirementValue = getProperty(HEADER_CMT_REQUIREMENT_DESCRIPTOR);
+        boolean headerCommentRequirementValueOverridden = headerCommentRequirementValue != CommentRequirement.Required;
+        CommentRequirement classCommentRequirementValue = getProperty(CLASS_CMT_REQUIREMENT_DESCRIPTOR);
+        boolean classCommentRequirementValueOverridden = classCommentRequirementValue != CommentRequirement.Required;
+
+        if (headerCommentRequirementValueOverridden && !classCommentRequirementValueOverridden) {
+            LOG.warning("Rule CommentRequired uses deprecated property 'headerCommentRequirement'. "
+                    + "Future versions of PMD will remove support for this property. "
+                    + "Please use 'classCommentRequirement' instead!");
+            propertyValues.put(CLASS_CMT_REQUIREMENT_DESCRIPTOR, headerCommentRequirementValue);
+        } else {
+            propertyValues.put(CLASS_CMT_REQUIREMENT_DESCRIPTOR, classCommentRequirementValue);
+        }
+    }
 
     private void checkCommentMeetsRequirement(Object data, AbstractJavaNode node,
                                               PropertyDescriptor<CommentRequirement> descriptor) {
-        switch (getProperty(descriptor)) {
+        switch (propertyValues.get(descriptor)) {
         case Ignored:
             break;
         case Required:
@@ -115,13 +144,6 @@ public class CommentRequiredRule extends AbstractCommentRule {
     @Override
     public Object visit(ASTClassOrInterfaceDeclaration decl, Object data) {
         checkCommentMeetsRequirement(data, decl, CLASS_CMT_REQUIREMENT_DESCRIPTOR);
-        return super.visit(decl, data);
-    }
-
-
-    @Override
-    public Object visit(ASTPackageDeclaration decl, Object data) {
-        checkCommentMeetsRequirement(data, decl, HEADER_CMT_REQUIREMENT_DESCRIPTOR);
         return super.visit(decl, data);
     }
 
@@ -193,9 +215,9 @@ public class CommentRequiredRule extends AbstractCommentRule {
      * This field must be initialized with an array of ObjectStreamField objects.
      * The modifiers for the field are required to be private, static, and final.
      *
-     * @see <a href="https://docs.oracle.com/javase/7/docs/platform/serialization/spec/serial-arch.html#6250">Oracle docs</a>
      * @param field the field, must not be null
-     * @return true if the field ia a serialPersistentFields variable, otherwise false
+     * @return true if the field is a serialPersistentFields variable, otherwise false
+     * @see <a href="https://docs.oracle.com/javase/7/docs/platform/serialization/spec/serial-arch.html#6250">Oracle docs</a>
      */
     private boolean isSerialPersistentFields(final ASTFieldDeclaration field) {
         return "serialPersistentFields".equals(field.getVariableName())
@@ -212,7 +234,6 @@ public class CommentRequiredRule extends AbstractCommentRule {
         return super.visit(decl, data);
     }
 
-
     @Override
     public Object visit(ASTCompilationUnit cUnit, Object data) {
         assignCommentsToDeclarations(cUnit);
@@ -223,8 +244,8 @@ public class CommentRequiredRule extends AbstractCommentRule {
 
         return getProperty(OVERRIDE_CMT_DESCRIPTOR) == CommentRequirement.Ignored
                 && getProperty(ACCESSOR_CMT_DESCRIPTOR) == CommentRequirement.Ignored
-                && getProperty(HEADER_CMT_REQUIREMENT_DESCRIPTOR) == CommentRequirement.Ignored
-                && getProperty(CLASS_CMT_REQUIREMENT_DESCRIPTOR) == CommentRequirement.Ignored
+                && (getProperty(CLASS_CMT_REQUIREMENT_DESCRIPTOR) == CommentRequirement.Ignored
+                        || getProperty(HEADER_CMT_REQUIREMENT_DESCRIPTOR) == CommentRequirement.Ignored)
                 && getProperty(FIELD_CMT_REQUIREMENT_DESCRIPTOR) == CommentRequirement.Ignored
                 && getProperty(PUB_METHOD_CMT_REQUIREMENT_DESCRIPTOR) == CommentRequirement.Ignored
                 && getProperty(PROT_METHOD_CMT_REQUIREMENT_DESCRIPTOR) == CommentRequirement.Ignored

--- a/pmd-java/src/main/resources/category/java/documentation.xml
+++ b/pmd-java/src/main/resources/category/java/documentation.xml
@@ -31,7 +31,7 @@ A rule for the politically correct... we don't want to offend anyone.
           class="net.sourceforge.pmd.lang.java.rule.documentation.CommentRequiredRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_documentation.html#commentrequired">
         <description>
-Denotes whether comments are required (or unwanted) for specific language elements.
+Denotes whether javadoc (formal) comments are required (or unwanted) for specific language elements.
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentRequiredTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentRequiredTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 import org.junit.Test;
@@ -23,6 +24,14 @@ public class CommentRequiredTest extends PmdRuleTst {
         assertNull("By default, the rule should be functional", rule.dysfunctionReason());
 
         List<PropertyDescriptor<?>> propertyDescriptors = getProperties(rule);
+        // remove  deprecated properties
+        for (Iterator<PropertyDescriptor<?>> it = propertyDescriptors.iterator(); it.hasNext();) {
+            PropertyDescriptor<?> property = it.next();
+            if (property.description().startsWith("Deprecated!")) {
+                it.remove();
+            }
+        }
+
         for (PropertyDescriptor<?> property : propertyDescriptors) {
             setPropertyValue(rule, property, "Ignored");
         }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/documentation/xml/CommentRequired.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/documentation/xml/CommentRequired.xml
@@ -512,33 +512,31 @@ public class CommentRequired {
 
     <test-code>
         <description>#1683 [java] CommentRequired property names are inconsistent</description>
+        <rule-property name="headerCommentRequirement">Required</rule-property>
         <expected-problems>1</expected-problems>
-        <expected-linenumbers>7</expected-linenumbers>
         <code><![CDATA[
-/** license */
 package test.my_package;
 /** The class comment */
-public class CommentRequired implements Serializable {
-    /** My list */
-    List next;
-    private final ObjectStreamField[] serialPersistentFields = {new ObjectStreamField("next", List.class)};
+public class CommentRequired {
 }
         ]]></code>
     </test-code>
 
     <test-code>
         <description>#1683 [java] CommentRequired property names are inconsistent - package with comment without new lines</description>
-        <expected-problems>2</expected-problems>
+        <rule-property name="headerCommentRequirement">Required</rule-property>
+        <expected-problems>1</expected-problems>
         <code><![CDATA[
-/** licence comment */ package test.my_package; /** Test class */ public class Test { public void method1() { /** comment here */ } public void method2() { } }
+/** licence comment */ package test.my_package; public class Test { /** public method */ public void method() { } }
         ]]></code>
     </test-code>
 
     <test-code>
         <description>#1683 [java] CommentRequired property names are inconsistent - package without comment and without new lines</description>
-        <expected-problems>3</expected-problems>
+        <rule-property name="headerCommentRequirement">Required</rule-property>
+        <expected-problems>2</expected-problems>
         <code><![CDATA[
-package test.my_package; /** Test class */ public class Test { public void method1() { /** comment here */ } public void method2() { } }
+package test.my_package; public class Test { /** public method */ public void method() { } }
         ]]></code>
     </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/documentation/xml/CommentRequired.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/documentation/xml/CommentRequired.xml
@@ -51,6 +51,7 @@ public class Foo {
     <test-code>
         <description>Missing comments - only class level required.</description>
         <rule-property name="headerCommentRequirement">Required</rule-property>
+        <rule-property name="classCommentRequirement">Required</rule-property>
         <rule-property name="fieldCommentRequirement">Ignored</rule-property>
         <rule-property name="publicMethodCommentRequirement">Ignored</rule-property>
         <rule-property name="protectedMethodCommentRequirement">Ignored</rule-property>
@@ -62,6 +63,7 @@ public class Foo {
     <test-code>
         <description>Too many comments - all comments are unwanted.</description>
         <rule-property name="headerCommentRequirement">Unwanted</rule-property>
+        <rule-property name="classCommentRequirement">Unwanted</rule-property>
         <rule-property name="fieldCommentRequirement">Unwanted</rule-property>
         <rule-property name="publicMethodCommentRequirement">Unwanted</rule-property>
         <rule-property name="protectedMethodCommentRequirement">Unwanted</rule-property>
@@ -240,6 +242,9 @@ public class CommentRequired implements Serializable {
         <description>#1522 [java] CommentRequired: false positive</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+        /**
+          * Kommentar zu de.konsens.biene.ka.client
+          */
 package de.konsens.biene.ka.client;
 
 /**
@@ -505,5 +510,35 @@ public class CommentRequired {
         ]]></code>
     </test-code>
 
+    <test-code>
+        <description>#1683 [java] CommentRequired property names are inconsistent</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+/** license */
+package test.my_package;
+/** The class comment */
+public class CommentRequired implements Serializable {
+    /** My list */
+    List next;
+    private final ObjectStreamField[] serialPersistentFields = {new ObjectStreamField("next", List.class)};
+}
+        ]]></code>
+    </test-code>
 
+    <test-code>
+        <description>#1683 [java] CommentRequired property names are inconsistent - package with comment without new lines</description>
+        <expected-problems>2</expected-problems>
+        <code><![CDATA[
+/** licence comment */ package test.my_package; /** Test class */ public class Test { public void method1() { /** comment here */ } public void method2() { } }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#1683 [java] CommentRequired property names are inconsistent - package without comment and without new lines</description>
+        <expected-problems>3</expected-problems>
+        <code><![CDATA[
+package test.my_package; /** Test class */ public class Test { public void method1() { /** comment here */ } public void method2() { } }
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/documentation/xml/CommentRequired.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/documentation/xml/CommentRequired.xml
@@ -50,7 +50,6 @@ public class Foo {
 
     <test-code>
         <description>Missing comments - only class level required.</description>
-        <rule-property name="headerCommentRequirement">Required</rule-property>
         <rule-property name="classCommentRequirement">Required</rule-property>
         <rule-property name="fieldCommentRequirement">Ignored</rule-property>
         <rule-property name="publicMethodCommentRequirement">Ignored</rule-property>
@@ -62,7 +61,6 @@ public class Foo {
 
     <test-code>
         <description>Too many comments - all comments are unwanted.</description>
-        <rule-property name="headerCommentRequirement">Unwanted</rule-property>
         <rule-property name="classCommentRequirement">Unwanted</rule-property>
         <rule-property name="fieldCommentRequirement">Unwanted</rule-property>
         <rule-property name="publicMethodCommentRequirement">Unwanted</rule-property>
@@ -242,9 +240,6 @@ public class CommentRequired implements Serializable {
         <description>#1522 [java] CommentRequired: false positive</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-        /**
-          * Kommentar zu de.konsens.biene.ka.client
-          */
 package de.konsens.biene.ka.client;
 
 /**
@@ -511,32 +506,22 @@ public class CommentRequired {
     </test-code>
 
     <test-code>
-        <description>#1683 [java] CommentRequired property names are inconsistent</description>
-        <rule-property name="headerCommentRequirement">Required</rule-property>
+        <description>#1683 [java] CommentRequired property names are inconsistent - use deprecated property</description>
+        <rule-property name="headerCommentRequirement">Unwanted</rule-property>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
-package test.my_package;
-/** The class comment */
-public class CommentRequired {
-}
+/** Unwanted class comment */
+public class CommentRequirement {}
         ]]></code>
     </test-code>
 
     <test-code>
-        <description>#1683 [java] CommentRequired property names are inconsistent - package with comment without new lines</description>
-        <rule-property name="headerCommentRequirement">Required</rule-property>
+        <description>#1683 [java] CommentRequired property names are inconsistent - use new property</description>
+        <rule-property name="classCommentRequirement">Unwanted</rule-property>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
-/** licence comment */ package test.my_package; public class Test { /** public method */ public void method() { } }
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>#1683 [java] CommentRequired property names are inconsistent - package without comment and without new lines</description>
-        <rule-property name="headerCommentRequirement">Required</rule-property>
-        <expected-problems>2</expected-problems>
-        <code><![CDATA[
-package test.my_package; public class Test { /** public method */ public void method() { } }
+/** Unwanted class comment */
+public class CommentRequirement {}
         ]]></code>
     </test-code>
 </test-data>


### PR DESCRIPTION
The PR fixes #1683 by introducing a separate property for class comment and making header property checking only header top-level comments