### PR TITLE
[core] Fix renderer tests for windows builds

### DIFF
--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/AbstractRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/AbstractRendererTest.java
@@ -22,7 +22,7 @@ import net.sourceforge.pmd.lang.ast.DummyNode;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.rule.ParametricRuleViolation;
 
-public abstract class AbstractRendererTst {
+public abstract class AbstractRendererTest {
 
     public abstract Renderer getRenderer();
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/AbstractRendererTst.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/AbstractRendererTst.java
@@ -53,7 +53,7 @@ public abstract class AbstractRendererTst {
     }
 
     protected String getSourceCodeFilename() {
-        return "n/a";
+        return "notAvailable.ext";
     }
 
     @Test(expected = NullPointerException.class)

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/CSVRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/CSVRendererTest.java
@@ -8,7 +8,7 @@ import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.Report.ConfigurationError;
 import net.sourceforge.pmd.Report.ProcessingError;
 
-public class CSVRendererTest extends AbstractRendererTst {
+public class CSVRendererTest extends AbstractRendererTest {
 
     @Override
     public Renderer getRenderer() {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/CSVRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/CSVRendererTest.java
@@ -18,7 +18,7 @@ public class CSVRendererTest extends AbstractRendererTst {
     @Override
     public String getExpected() {
         return getHeader()
-                + "\"1\",\"\",\"n/a\",\"5\",\"1\",\"blah\",\"RuleSet\",\"Foo\"" + PMD.EOL;
+                + "\"1\",\"\",\"" + getSourceCodeFilename() + "\",\"5\",\"1\",\"blah\",\"RuleSet\",\"Foo\"" + PMD.EOL;
     }
 
     @Override
@@ -29,8 +29,8 @@ public class CSVRendererTest extends AbstractRendererTst {
     @Override
     public String getExpectedMultiple() {
         return getHeader()
-                + "\"1\",\"\",\"n/a\",\"5\",\"1\",\"blah\",\"RuleSet\",\"Foo\"" + PMD.EOL
-                + "\"2\",\"\",\"n/a\",\"5\",\"1\",\"blah\",\"RuleSet\",\"Foo\"" + PMD.EOL;
+                + "\"1\",\"\",\"" + getSourceCodeFilename() + "\",\"5\",\"1\",\"blah\",\"RuleSet\",\"Foo\"" + PMD.EOL
+                + "\"2\",\"\",\"" + getSourceCodeFilename() + "\",\"5\",\"1\",\"blah\",\"RuleSet\",\"Foo\"" + PMD.EOL;
     }
 
     @Override

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/CodeClimateRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/CodeClimateRendererTest.java
@@ -37,7 +37,7 @@ public class CodeClimateRendererTest extends AbstractRendererTst {
                 + "Name | Value | Description\\n" + "--- | --- | ---\\n"
                 + "violationSuppressRegex | | Suppress violations with messages matching a regular expression\\n"
                 + "violationSuppressXPath | | Suppress violations on nodes which match a given relative XPath expression.\\n"
-                + "\"},\"categories\":[\"Style\"],\"location\":{\"path\":\"n/a\",\"lines\":{\"begin\":1,\"end\":1}},\"severity\":\"info\",\"remediation_points\":50000}"
+                + "\"},\"categories\":[\"Style\"],\"location\":{\"path\":\"" + getSourceCodeFilename() + "\",\"lines\":{\"begin\":1,\"end\":1}},\"severity\":\"info\",\"remediation_points\":50000}"
                 + "\u0000" + PMD.EOL;
     }
 
@@ -54,7 +54,7 @@ public class CodeClimateRendererTest extends AbstractRendererTst {
                 + "violationSuppressXPath | | Suppress violations on nodes which match a given relative XPath expression.\\n"
                 + "multiString | default1,default2 | multi string property\\n"
                 + "stringProperty | the string value\\nsecond line with 'quotes' | simple string property\\n"
-                + "\"},\"categories\":[\"Style\"],\"location\":{\"path\":\"n/a\",\"lines\":{\"begin\":1,\"end\":1}},\"severity\":\"info\",\"remediation_points\":50000}"
+                + "\"},\"categories\":[\"Style\"],\"location\":{\"path\":\"" + getSourceCodeFilename() + "\",\"lines\":{\"begin\":1,\"end\":1}},\"severity\":\"info\",\"remediation_points\":50000}"
                 + "\u0000" + PMD.EOL;
     }
 
@@ -74,7 +74,7 @@ public class CodeClimateRendererTest extends AbstractRendererTst {
                 + "Name | Value | Description\\n" + "--- | --- | ---\\n"
                 + "violationSuppressRegex | | Suppress violations with messages matching a regular expression\\n"
                 + "violationSuppressXPath | | Suppress violations on nodes which match a given relative XPath expression.\\n"
-                + "\"},\"categories\":[\"Style\"],\"location\":{\"path\":\"n/a\",\"lines\":{\"begin\":1,\"end\":1}},\"severity\":\"info\",\"remediation_points\":50000}"
+                + "\"},\"categories\":[\"Style\"],\"location\":{\"path\":\"" + getSourceCodeFilename() + "\",\"lines\":{\"begin\":1,\"end\":1}},\"severity\":\"info\",\"remediation_points\":50000}"
                 + "\u0000" + PMD.EOL + "{\"type\":\"issue\",\"check_name\":\"Foo\",\"description\":\"blah\","
                 + "\"content\":{\"body\":\"## Foo\\n\\nSince: PMD null\\n\\nPriority: Low\\n\\n"
                 + "[Categories](https://github.com/codeclimate/spec/blob/master/SPEC.md#categories): Style\\n\\n"
@@ -84,7 +84,7 @@ public class CodeClimateRendererTest extends AbstractRendererTst {
                 + "Name | Value | Description\\n" + "--- | --- | ---\\n"
                 + "violationSuppressRegex | | Suppress violations with messages matching a regular expression\\n"
                 + "violationSuppressXPath | | Suppress violations on nodes which match a given relative XPath expression.\\n"
-                + "\"},\"categories\":[\"Style\"],\"location\":{\"path\":\"n/a\",\"lines\":{\"begin\":1,\"end\":1}},\"severity\":\"info\",\"remediation_points\":50000}"
+                + "\"},\"categories\":[\"Style\"],\"location\":{\"path\":\"" + getSourceCodeFilename() + "\",\"lines\":{\"begin\":1,\"end\":1}},\"severity\":\"info\",\"remediation_points\":50000}"
                 + "\u0000" + PMD.EOL;
     }
     

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/CodeClimateRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/CodeClimateRendererTest.java
@@ -19,7 +19,7 @@ import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.rule.ParametricRuleViolation;
 import net.sourceforge.pmd.lang.rule.XPathRule;
 
-public class CodeClimateRendererTest extends AbstractRendererTst {
+public class CodeClimateRendererTest extends AbstractRendererTest {
 
     @Override
     public Renderer getRenderer() {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/EmacsRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/EmacsRendererTest.java
@@ -6,7 +6,7 @@ package net.sourceforge.pmd.renderers;
 
 import net.sourceforge.pmd.PMD;
 
-public class EmacsRendererTest extends AbstractRendererTst {
+public class EmacsRendererTest extends AbstractRendererTest {
 
     @Override
     public Renderer getRenderer() {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/EmacsRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/EmacsRendererTest.java
@@ -15,7 +15,7 @@ public class EmacsRendererTest extends AbstractRendererTst {
 
     @Override
     public String getExpected() {
-        return "n/a:1: blah" + PMD.EOL;
+        return getSourceCodeFilename() + ":1: blah" + PMD.EOL;
     }
 
     @Override
@@ -25,6 +25,6 @@ public class EmacsRendererTest extends AbstractRendererTst {
 
     @Override
     public String getExpectedMultiple() {
-        return "n/a:1: blah" + PMD.EOL + "n/a:1: blah" + PMD.EOL;
+        return getSourceCodeFilename() + ":1: blah" + PMD.EOL + getSourceCodeFilename() + ":1: blah" + PMD.EOL;
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/EmptyRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/EmptyRendererTest.java
@@ -6,7 +6,7 @@ package net.sourceforge.pmd.renderers;
 
 import org.junit.Test;
 
-public class EmptyRendererTest extends AbstractRendererTst {
+public class EmptyRendererTest extends AbstractRendererTest {
 
     @Override
     public Renderer getRenderer() {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/HTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/HTMLRendererTest.java
@@ -8,7 +8,7 @@ import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.Report.ConfigurationError;
 import net.sourceforge.pmd.Report.ProcessingError;
 
-public class HTMLRendererTest extends AbstractRendererTst {
+public class HTMLRendererTest extends AbstractRendererTest {
 
     @Override
     protected String getSourceCodeFilename() {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/HTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/HTMLRendererTest.java
@@ -11,20 +11,24 @@ import net.sourceforge.pmd.Report.ProcessingError;
 public class HTMLRendererTest extends AbstractRendererTst {
 
     @Override
-    public Renderer getRenderer() {
-        return new HTMLRenderer();
+    protected String getSourceCodeFilename() {
+        return "someFilename<br>thatNeedsEscaping.ext";
+    }
+
+    private String getEscapedFilename() {
+        return "someFilename&lt;br&gt;thatNeedsEscaping.ext";
     }
 
     @Override
-    protected String getSourceCodeFilename() {
-        return "filename/that/needs <script>alert(1)</script> escaping.ext";
+    public Renderer getRenderer() {
+        return new HTMLRenderer();
     }
 
     @Override
     public String getExpected() {
         return getHeader()
                 + "<tr bgcolor=\"lightgrey\"> " + PMD.EOL + "<td align=\"center\">1</td>" + PMD.EOL
-                + "<td width=\"*%\">filename/that/needs &lt;script&gt;alert(1)&lt;/script&gt; escaping.ext</td>" + PMD.EOL + "<td align=\"center\" width=\"5%\">1</td>" + PMD.EOL
+                + "<td width=\"*%\">" + getEscapedFilename() + "</td>" + PMD.EOL + "<td align=\"center\" width=\"5%\">1</td>" + PMD.EOL
                 + "<td width=\"*\">blah</td>" + PMD.EOL + "</tr>" + PMD.EOL + "</table></body></html>" + PMD.EOL;
     }
 
@@ -38,9 +42,9 @@ public class HTMLRendererTest extends AbstractRendererTst {
     public String getExpectedMultiple() {
         return getHeader()
                 + "<tr bgcolor=\"lightgrey\"> " + PMD.EOL + "<td align=\"center\">1</td>" + PMD.EOL
-                + "<td width=\"*%\">filename/that/needs &lt;script&gt;alert(1)&lt;/script&gt; escaping.ext</td>" + PMD.EOL + "<td align=\"center\" width=\"5%\">1</td>" + PMD.EOL
+                + "<td width=\"*%\">" + getEscapedFilename() + "</td>" + PMD.EOL + "<td align=\"center\" width=\"5%\">1</td>" + PMD.EOL
                 + "<td width=\"*\">blah</td>" + PMD.EOL + "</tr>" + PMD.EOL + "<tr> " + PMD.EOL
-                + "<td align=\"center\">2</td>" + PMD.EOL + "<td width=\"*%\">filename/that/needs &lt;script&gt;alert(1)&lt;/script&gt; escaping.ext</td>" + PMD.EOL
+                + "<td align=\"center\">2</td>" + PMD.EOL + "<td width=\"*%\">" + getEscapedFilename() + "</td>" + PMD.EOL
                 + "<td align=\"center\" width=\"5%\">1</td>" + PMD.EOL + "<td width=\"*\">blah</td>" + PMD.EOL + "</tr>"
                 + PMD.EOL + "</table></body></html>" + PMD.EOL;
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/IDEAJRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/IDEAJRendererTest.java
@@ -6,7 +6,7 @@ package net.sourceforge.pmd.renderers;
 
 import net.sourceforge.pmd.PMD;
 
-public class IDEAJRendererTest extends AbstractRendererTst {
+public class IDEAJRendererTest extends AbstractRendererTest {
 
     @Override
     public Renderer getRenderer() {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/PapariTextRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/PapariTextRendererTest.java
@@ -4,7 +4,6 @@
 
 package net.sourceforge.pmd.renderers;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.Reader;
 import java.io.StringReader;
@@ -14,12 +13,6 @@ import net.sourceforge.pmd.Report.ConfigurationError;
 import net.sourceforge.pmd.Report.ProcessingError;
 
 public class PapariTextRendererTest extends AbstractRendererTst {
-
-    private static String naString = "n/a";
-
-    static {
-        naString = naString.substring(naString.lastIndexOf(File.separator) + 1);
-    }
 
     @Override
     public Renderer getRenderer() {
@@ -35,7 +28,7 @@ public class PapariTextRendererTest extends AbstractRendererTst {
 
     @Override
     public String getExpected() {
-        return "* file: n/a" + PMD.EOL + "    src:  " + naString + ":1:1" + PMD.EOL + "    rule: Foo" + PMD.EOL
+        return "* file: " + getSourceCodeFilename() + PMD.EOL + "    src:  " + getSourceCodeFilename() + ":1:1" + PMD.EOL + "    rule: Foo" + PMD.EOL
                 + "    msg:  blah" + PMD.EOL + "    code: public class Foo {}" + PMD.EOL + PMD.EOL + PMD.EOL + PMD.EOL
                 + "Summary:" + PMD.EOL + PMD.EOL + " : 1" + PMD.EOL + "* warnings: 1" + PMD.EOL;
     }
@@ -47,9 +40,9 @@ public class PapariTextRendererTest extends AbstractRendererTst {
 
     @Override
     public String getExpectedMultiple() {
-        return "* file: n/a" + PMD.EOL + "    src:  " + naString + ":1:1" + PMD.EOL + "    rule: Foo" + PMD.EOL
+        return "* file: " + getSourceCodeFilename() + PMD.EOL + "    src:  " + getSourceCodeFilename() + ":1:1" + PMD.EOL + "    rule: Foo" + PMD.EOL
                 + "    msg:  blah" + PMD.EOL + "    code: public class Foo {}" + PMD.EOL + PMD.EOL + "    src:  "
-                + naString + ":1:1" + PMD.EOL + "    rule: Foo" + PMD.EOL + "    msg:  blah" + PMD.EOL
+                + getSourceCodeFilename() + ":1:1" + PMD.EOL + "    rule: Foo" + PMD.EOL + "    msg:  blah" + PMD.EOL
                 + "    code: public class Foo {}" + PMD.EOL + PMD.EOL + PMD.EOL + PMD.EOL + "Summary:" + PMD.EOL
                 + PMD.EOL + " : 2" + PMD.EOL + "* warnings: 2" + PMD.EOL;
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/PapariTextRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/PapariTextRendererTest.java
@@ -12,7 +12,7 @@ import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.Report.ConfigurationError;
 import net.sourceforge.pmd.Report.ProcessingError;
 
-public class PapariTextRendererTest extends AbstractRendererTst {
+public class PapariTextRendererTest extends AbstractRendererTest {
 
     @Override
     public Renderer getRenderer() {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/RenderersTests.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/RenderersTests.java
@@ -14,6 +14,19 @@ import org.junit.runners.Suite.SuiteClasses;
  * @author Boris Gruschko ( boris at gruschko.org )
  */
 @RunWith(Suite.class)
-@SuiteClasses({ CSVRendererTest.class, EmacsRendererTest.class, XMLRendererTest.class, TextPadRendererTest.class })
+@SuiteClasses({
+        CodeClimateRendererTest.class,
+        CSVRendererTest.class,
+        EmacsRendererTest.class,
+        HTMLRendererTest.class,
+        IDEAJRendererTest.class,
+        PapariTextRendererTest.class,
+        SummaryHTMLRendererTest.class,
+        TextPadRendererTest.class,
+        VBHTMLRendererTest.class,
+        XMLRendererTest.class,
+        XSLTRendererTest.class,
+        YAHTMLRendererTest.class
+})
 public class RenderersTests {
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/SummaryHTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/SummaryHTMLRendererTest.java
@@ -32,6 +32,11 @@ public class SummaryHTMLRendererTest extends AbstractRendererTst {
     }
 
     @Override
+    protected String getSourceCodeFilename() {
+        return "notAvailable";
+    }
+
+    @Override
     public String getExpected() {
         return "<html><head><title>PMD</title></head><body>" + PMD.EOL + "<center><h2>Summary</h2></center>" + PMD.EOL
                 + "<table align=\"center\" cellspacing=\"0\" cellpadding=\"3\">" + PMD.EOL
@@ -42,7 +47,7 @@ public class SummaryHTMLRendererTest extends AbstractRendererTst {
                 + "<center><h3>PMD report</h3></center><center><h3>Problems found</h3></center><table align=\"center\" cellspacing=\"0\" cellpadding=\"3\"><tr>"
                 + PMD.EOL + "<th>#</th><th>File</th><th>Line</th><th>Problem</th></tr>" + PMD.EOL
                 + "<tr bgcolor=\"lightgrey\"> " + PMD.EOL + "<td align=\"center\">1</td>" + PMD.EOL
-                + "<td width=\"*%\"><a href=\"link_prefixn/a.html#line_prefix1\">n/a</a></td>" + PMD.EOL
+                + "<td width=\"*%\"><a href=\"link_prefix" + getSourceCodeFilename() + ".html#line_prefix1\">" + getSourceCodeFilename() + "</a></td>" + PMD.EOL
                 + "<td align=\"center\" width=\"5%\">1</td>" + PMD.EOL + "<td width=\"*\">blah</td>" + PMD.EOL + "</tr>"
                 + PMD.EOL + "</table></tr></table></body></html>" + PMD.EOL;
 
@@ -71,10 +76,10 @@ public class SummaryHTMLRendererTest extends AbstractRendererTst {
                 + "<center><h3>PMD report</h3></center><center><h3>Problems found</h3></center><table align=\"center\" cellspacing=\"0\" cellpadding=\"3\"><tr>"
                 + PMD.EOL + "<th>#</th><th>File</th><th>Line</th><th>Problem</th></tr>" + PMD.EOL
                 + "<tr bgcolor=\"lightgrey\"> " + PMD.EOL + "<td align=\"center\">1</td>" + PMD.EOL
-                + "<td width=\"*%\"><a href=\"link_prefixn/a.html#line_prefix1\">n/a</a></td>" + PMD.EOL
+                + "<td width=\"*%\"><a href=\"link_prefix" + getSourceCodeFilename() + ".html#line_prefix1\">" + getSourceCodeFilename() + "</a></td>" + PMD.EOL
                 + "<td align=\"center\" width=\"5%\">1</td>" + PMD.EOL + "<td width=\"*\">blah</td>" + PMD.EOL + "</tr>"
                 + PMD.EOL + "<tr> " + PMD.EOL + "<td align=\"center\">2</td>" + PMD.EOL
-                + "<td width=\"*%\"><a href=\"link_prefixn/a.html#line_prefix1\">n/a</a></td>" + PMD.EOL
+                + "<td width=\"*%\"><a href=\"link_prefix" + getSourceCodeFilename() + ".html#line_prefix1\">" + getSourceCodeFilename() + "</a></td>" + PMD.EOL
                 + "<td align=\"center\" width=\"5%\">1</td>" + PMD.EOL + "<td width=\"*\">blah</td>" + PMD.EOL + "</tr>"
                 + PMD.EOL + "</table></tr></table></body></html>" + PMD.EOL;
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/SummaryHTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/SummaryHTMLRendererTest.java
@@ -21,7 +21,7 @@ import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.rule.ParametricRuleViolation;
 
-public class SummaryHTMLRendererTest extends AbstractRendererTst {
+public class SummaryHTMLRendererTest extends AbstractRendererTest {
 
     @Override
     public Renderer getRenderer() {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/TextPadRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/TextPadRendererTest.java
@@ -6,7 +6,7 @@ package net.sourceforge.pmd.renderers;
 
 import net.sourceforge.pmd.PMD;
 
-public class TextPadRendererTest extends AbstractRendererTst {
+public class TextPadRendererTest extends AbstractRendererTest {
 
     @Override
     public Renderer getRenderer() {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/TextPadRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/TextPadRendererTest.java
@@ -15,7 +15,7 @@ public class TextPadRendererTest extends AbstractRendererTst {
 
     @Override
     public String getExpected() {
-        return "n/a(1,  Foo):  blah" + PMD.EOL;
+        return getSourceCodeFilename() + "(1,  Foo):  blah" + PMD.EOL;
     }
 
     @Override
@@ -25,7 +25,7 @@ public class TextPadRendererTest extends AbstractRendererTst {
 
     @Override
     public String getExpectedMultiple() {
-        return "n/a(1,  Foo):  blah" + PMD.EOL + "n/a(1,  Foo):  blah" + PMD.EOL;
+        return getSourceCodeFilename() + "(1,  Foo):  blah" + PMD.EOL + getSourceCodeFilename() + "(1,  Foo):  blah" + PMD.EOL;
     }
 
     public static junit.framework.Test suite() {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/TextRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/TextRendererTest.java
@@ -17,7 +17,7 @@ public class TextRendererTest extends AbstractRendererTst {
 
     @Override
     public String getExpected() {
-        return "n/a:1:\tblah" + PMD.EOL;
+        return getSourceCodeFilename() + ":1:\tblah" + PMD.EOL;
     }
 
     @Override
@@ -27,7 +27,8 @@ public class TextRendererTest extends AbstractRendererTst {
 
     @Override
     public String getExpectedMultiple() {
-        return "n/a:1:\tblah" + PMD.EOL + "n/a:1:\tblah" + PMD.EOL;
+        return getSourceCodeFilename() + ":1:\tblah" + PMD.EOL
+                + getSourceCodeFilename() + ":1:\tblah" + PMD.EOL;
     }
 
     @Override

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/TextRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/TextRendererTest.java
@@ -8,7 +8,7 @@ import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.Report.ConfigurationError;
 import net.sourceforge.pmd.Report.ProcessingError;
 
-public class TextRendererTest extends AbstractRendererTst {
+public class TextRendererTest extends AbstractRendererTest {
 
     @Override
     public Renderer getRenderer() {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/VBHTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/VBHTMLRendererTest.java
@@ -26,7 +26,7 @@ public class VBHTMLRendererTest extends AbstractRendererTst {
                 + PMD.EOL + "#TableHeader { background-color: #003366; }" + PMD.EOL
                 + "#RowColor1 { background-color: #eeeeee; }" + PMD.EOL + "#RowColor2 { background-color: white; }"
                 + PMD.EOL
-                + "--></style><body><center><table border=\"0\" width=\"80%\"><tr id=TableHeader><td colspan=\"2\"><font class=title>&nbsp;n/a</font></tr>"
+                + "--></style><body><center><table border=\"0\" width=\"80%\"><tr id=TableHeader><td colspan=\"2\"><font class=title>&nbsp;" + getSourceCodeFilename() + "</font></tr>"
                 + PMD.EOL
                 + "<tr id=RowColor2><td width=\"50\" align=\"right\"><font class=body>1&nbsp;&nbsp;&nbsp;</font></td><td><font class=body>blah</font></td></tr>"
                 + PMD.EOL + "</table><br></center></body></html>" + PMD.EOL;
@@ -56,7 +56,7 @@ public class VBHTMLRendererTest extends AbstractRendererTst {
                 + PMD.EOL + "#TableHeader { background-color: #003366; }" + PMD.EOL
                 + "#RowColor1 { background-color: #eeeeee; }" + PMD.EOL + "#RowColor2 { background-color: white; }"
                 + PMD.EOL
-                + "--></style><body><center><table border=\"0\" width=\"80%\"><tr id=TableHeader><td colspan=\"2\"><font class=title>&nbsp;n/a</font></tr>"
+                + "--></style><body><center><table border=\"0\" width=\"80%\"><tr id=TableHeader><td colspan=\"2\"><font class=title>&nbsp;" + getSourceCodeFilename() + "</font></tr>"
                 + PMD.EOL
                 + "<tr id=RowColor2><td width=\"50\" align=\"right\"><font class=body>1&nbsp;&nbsp;&nbsp;</font></td><td><font class=body>blah</font></td></tr>"
                 + PMD.EOL

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/VBHTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/VBHTMLRendererTest.java
@@ -8,7 +8,7 @@ import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.Report.ConfigurationError;
 import net.sourceforge.pmd.Report.ProcessingError;
 
-public class VBHTMLRendererTest extends AbstractRendererTst {
+public class VBHTMLRendererTest extends AbstractRendererTest {
 
     @Override
     public Renderer getRenderer() {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
@@ -36,7 +36,7 @@ public class XMLRendererTest extends AbstractRendererTst {
 
     @Override
     public String getExpected() {
-        return getHeader() + "<file name=\"n/a\">" + PMD.EOL
+        return getHeader() + "<file name=\"" + getSourceCodeFilename() + "\">" + PMD.EOL
                 + "<violation beginline=\"1\" endline=\"1\" begincolumn=\"1\" endcolumn=\"1\" rule=\"Foo\" ruleset=\"RuleSet\" priority=\"5\">"
                 + PMD.EOL + "blah" + PMD.EOL + "</violation>" + PMD.EOL + "</file>" + PMD.EOL + "</pmd>" + PMD.EOL;
     }
@@ -48,7 +48,7 @@ public class XMLRendererTest extends AbstractRendererTst {
 
     @Override
     public String getExpectedMultiple() {
-        return getHeader() + "<file name=\"n/a\">" + PMD.EOL
+        return getHeader() + "<file name=\"" + getSourceCodeFilename() + "\">" + PMD.EOL
                 + "<violation beginline=\"1\" endline=\"1\" begincolumn=\"1\" endcolumn=\"1\" rule=\"Foo\" ruleset=\"RuleSet\" priority=\"5\">"
                 + PMD.EOL + "blah" + PMD.EOL + "</violation>" + PMD.EOL
                 + "<violation beginline=\"1\" endline=\"1\" begincolumn=\"1\" endcolumn=\"2\" rule=\"Foo\" ruleset=\"RuleSet\" priority=\"5\">"
@@ -79,14 +79,14 @@ public class XMLRendererTest extends AbstractRendererTst {
         return result;
     }
 
-    private static RuleViolation createRuleViolation(String description) {
+    private RuleViolation createRuleViolation(String description) {
         DummyNode node = new DummyNode(1);
         node.testingOnlySetBeginLine(1);
         node.testingOnlySetBeginColumn(1);
         node.testingOnlySetEndLine(1);
         node.testingOnlySetEndColumn(1);
         RuleContext ctx = new RuleContext();
-        ctx.setSourceCodeFile(new File("n/a"));
+        ctx.setSourceCodeFile(new File(getSourceCodeFilename()));
         return new ParametricRuleViolation<Node>(new FooRule(), ctx, node, description);
     }
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
@@ -27,7 +27,7 @@ import net.sourceforge.pmd.lang.ast.DummyNode;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.rule.ParametricRuleViolation;
 
-public class XMLRendererTest extends AbstractRendererTst {
+public class XMLRendererTest extends AbstractRendererTest {
 
     @Override
     public Renderer getRenderer() {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/YAHTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/YAHTMLRendererTest.java
@@ -31,7 +31,7 @@ import net.sourceforge.pmd.lang.ast.DummyNode;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.rule.ParametricRuleViolation;
 
-public class YAHTMLRendererTest extends AbstractRendererTst {
+public class YAHTMLRendererTest extends AbstractRendererTest {
 
     private String outputDir;
 


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [X] The PR is submitted against `master`. 
 - [X] `./mvnw clean verify` passes.

**PR Description:**

Remove the platform-specific file separators from the test cases and does some cleaning work.

Before, there were many instances of the `sourcecodeFilename` being hard-coded into the dest data. This PR also cleans up the tests so that they will always rely on the values returned by a utility method (most commonly `AbstractRendererTest#getSourceCodeFilename`.

Fixes #2067 