### PR TITLE
[java] UnusedPrivateMethod false-positive with method result

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -38,6 +38,7 @@ This is a {{ site.pmd.release_type }} release.
 *   java
     *   [#2042](https://github.com/pmd/pmd/issues/2042): \[java] PMD crashes with ClassFormatError: Absent Code attribute...
 *   java-bestpractices
+    *   [#1531](https://github.com/pmd/pmd/issues/1531): \[java] UnusedPrivateMethod false-positive with method result
     *   [#2025](https://github.com/pmd/pmd/issues/2025): \[java] UnusedImports when @see / @link pattern includes a FQCN
 *   java-codestyle
     *   [#2017](https://github.com/pmd/pmd/issues/2017): \[java] UnnecessaryFullyQualifiedName triggered for inner class

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/ClassScope.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/ClassScope.java
@@ -480,55 +480,57 @@ public class ClassScope extends AbstractJavaScope {
                 isMethodCall = argument.jjtGetChild(0).jjtGetNumChildren() > 1;
             }
             TypedNameDeclaration type = null;
-            if (child instanceof ASTName && !isMethodCall) {
-                ASTName name = (ASTName) child;
-                Scope s = name.getScope();
-                final JavaNameOccurrence nameOccurrence = new JavaNameOccurrence(name, name.getImage());
-                while (s != null) {
-                    if (s.contains(nameOccurrence)) {
-                        break;
-                    }
-                    s = s.getParent();
-                }
-                if (s != null) {
-                    Map<VariableNameDeclaration, List<NameOccurrence>> vars = s
-                            .getDeclarations(VariableNameDeclaration.class);
-                    for (VariableNameDeclaration d : vars.keySet()) {
-                        // in case of simple lambda expression, the type
-                        // might be unknown
-                        if (d.getImage().equals(name.getImage()) && d.getTypeImage() != null) {
-                            String typeName = d.getTypeImage();
-                            typeName = qualifyTypeName(typeName);
-                            Node declaringNode = qualifiedTypeNames.get(typeName);
-                            type = new SimpleTypedNameDeclaration(typeName,
-                                    this.getEnclosingScope(SourceFileScope.class).resolveType(typeName),
-                                    determineSuper(declaringNode));
+            if (!isMethodCall) {
+                if (child instanceof ASTName) {
+                    ASTName name = (ASTName) child;
+                    Scope s = name.getScope();
+                    final JavaNameOccurrence nameOccurrence = new JavaNameOccurrence(name, name.getImage());
+                    while (s != null) {
+                        if (s.contains(nameOccurrence)) {
                             break;
                         }
+                        s = s.getParent();
                     }
+                    if (s != null) {
+                        Map<VariableNameDeclaration, List<NameOccurrence>> vars = s
+                                .getDeclarations(VariableNameDeclaration.class);
+                        for (VariableNameDeclaration d : vars.keySet()) {
+                            // in case of simple lambda expression, the type
+                            // might be unknown
+                            if (d.getImage().equals(name.getImage()) && d.getTypeImage() != null) {
+                                String typeName = d.getTypeImage();
+                                typeName = qualifyTypeName(typeName);
+                                Node declaringNode = qualifiedTypeNames.get(typeName);
+                                type = new SimpleTypedNameDeclaration(typeName,
+                                        this.getEnclosingScope(SourceFileScope.class).resolveType(typeName),
+                                        determineSuper(declaringNode));
+                                break;
+                            }
+                        }
+                    }
+                } else if (child instanceof ASTLiteral) {
+                    ASTLiteral literal = (ASTLiteral) child;
+                    if (literal.isCharLiteral()) {
+                        type = new SimpleTypedNameDeclaration("char", literal.getType());
+                    } else if (literal.isStringLiteral()) {
+                        type = new SimpleTypedNameDeclaration("String", literal.getType());
+                    } else if (literal.isFloatLiteral()) {
+                        type = new SimpleTypedNameDeclaration("float", literal.getType());
+                    } else if (literal.isDoubleLiteral()) {
+                        type = new SimpleTypedNameDeclaration("double", literal.getType());
+                    } else if (literal.isIntLiteral()) {
+                        type = new SimpleTypedNameDeclaration("int", literal.getType());
+                    } else if (literal.isLongLiteral()) {
+                        type = new SimpleTypedNameDeclaration("long", literal.getType());
+                    } else if (literal.jjtGetNumChildren() == 1
+                            && literal.jjtGetChild(0) instanceof ASTBooleanLiteral) {
+                        type = new SimpleTypedNameDeclaration("boolean", Boolean.TYPE);
+                    }
+                } else if (child instanceof ASTAllocationExpression
+                        && child.jjtGetChild(0) instanceof ASTClassOrInterfaceType) {
+                    ASTClassOrInterfaceType classInterface = (ASTClassOrInterfaceType) child.jjtGetChild(0);
+                    type = convertToSimpleType(classInterface);
                 }
-            } else if (child instanceof ASTLiteral) {
-                ASTLiteral literal = (ASTLiteral) child;
-                if (literal.isCharLiteral()) {
-                    type = new SimpleTypedNameDeclaration("char", literal.getType());
-                } else if (literal.isStringLiteral()) {
-                    type = new SimpleTypedNameDeclaration("String", literal.getType());
-                } else if (literal.isFloatLiteral()) {
-                    type = new SimpleTypedNameDeclaration("float", literal.getType());
-                } else if (literal.isDoubleLiteral()) {
-                    type = new SimpleTypedNameDeclaration("double", literal.getType());
-                } else if (literal.isIntLiteral()) {
-                    type = new SimpleTypedNameDeclaration("int", literal.getType());
-                } else if (literal.isLongLiteral()) {
-                    type = new SimpleTypedNameDeclaration("long", literal.getType());
-                } else if (literal.jjtGetNumChildren() == 1
-                        && literal.jjtGetChild(0) instanceof ASTBooleanLiteral) {
-                    type = new SimpleTypedNameDeclaration("boolean", Boolean.TYPE);
-                }
-            } else if (child instanceof ASTAllocationExpression
-                    && child.jjtGetChild(0) instanceof ASTClassOrInterfaceType) {
-                ASTClassOrInterfaceType classInterface = (ASTClassOrInterfaceType) child.jjtGetChild(0);
-                type = convertToSimpleType(classInterface);
             }
             if (type == null && !parameterTypes.isEmpty()) {
                 // replace the unknown type with the correct parameter type

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
@@ -1603,4 +1603,45 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#1531 [java] UnusedPrivateMethod false-positive with method result</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class UnusedPrivateMethodFP {
+    private void print(String s) { // <- unused private method?
+        System.out.println(s);
+    }
+
+    public void run() {
+        print(new Integer(1).toString()); // it is used here
+    }
+
+    private void print2(String s) {
+        System.out.println(s);
+    }
+
+    public void run2() {
+        String temp = new Integer(1).toString();
+        print2(temp); // workaround with extra temporary variable
+    }
+
+    private void print3(String s) {
+        System.out.println(s);
+    }
+
+    public void run3() {
+        print3((String)new Integer(1).toString()); // workaround with extra cast
+    }
+
+    public void runBoolean(String s) {
+        privateBooleanMethod(s, "true".equals(s));
+    }
+
+    private void privateBooleanMethod(String s, boolean isTrue) {
+        System.out.println(s);
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Fixes #1531

In case we determined, that the method argument is a method call,
then we skip now completly trying to determine the correct argument
type. It was half-way fixed before for the first if condition, but
we still evaluated e.g. the allocation expression in

    print(new Integer(1).toString());

and wrongly assumed, the argument type would be an integer,
without taking into account the `toString()` method call.

The same happened with

    privateBooleanMethod(s, "true".equals(s));

where we took the 2nd argument as a literal and assumed
it is a "String", while the method call result actually
is a boolean.

With this change now, the false positive is fixed.

However, since we don't determine the argument type at all, the
method is matched solely on argument count. This will obviously
lead to wrong matches if method overloading is used.

<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

