### PR TITLE
[core] Enable type resolution by default for XPath rules

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -44,6 +44,7 @@ This is a {{ site.pmd.release_type }} release.
 *   core
     *   [#2014](https://github.com/pmd/pmd/issues/2014): \[core] Making add(SourceCode sourceCode) public for alternative file systems
     *   [#2036](https://github.com/pmd/pmd/issues/2036): \[core] Wrong include/exclude patterns are silently ignored
+    *   [#2048](https://github.com/pmd/pmd/issues/2048): \[core] Enable type resolution by default for XPath rules
     *   [#2067](https://github.com/pmd/pmd/issues/2067): \[core] Build issue on Windows
     *   [#2068](https://github.com/pmd/pmd/pull/2068): \[core] Rule loader should use the same resources loader for the ruleset
     *   [#2071](https://github.com/pmd/pmd/issues/2071): \[ci] Add travis build on windows

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/XPathRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/XPathRule.java
@@ -67,6 +67,8 @@ public class XPathRule extends AbstractRule {
     public XPathRule() {
         definePropertyDescriptor(XPATH_DESCRIPTOR);
         definePropertyDescriptor(VERSION_DESCRIPTOR);
+        // Enable Type Resolution on XPath Rules by default - see issue #2048
+        super.setTypeResolution(true);
     }
 
     /**

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/XPathRuleTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/XPathRuleTest.java
@@ -1,0 +1,29 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.rule;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class XPathRuleTest {
+
+    /**
+     * It's easy to forget the attribute "typeResolution=true" when
+     * defining XPath rules in xml. Therefore we by default enable
+     * typeresolution. For Java rules, type resolution was enabled by
+     * default long time ago.
+     * 
+     * @see <a href="https://github.com/pmd/pmd/issues/2048">#2048 [core] Enable type resolution by default for XPath rules</a>
+     */
+    @Test
+    public void typeResolutionShouldBeEnabledByDefault() {
+        XPathRule rule = new XPathRule();
+        Assert.assertTrue(rule.isTypeResolution());
+
+        XPathRule rule2 = new XPathRule(".");
+        Assert.assertTrue(rule2.isTypeResolution());
+    }
+
+}


### PR DESCRIPTION
**PR Description:**

Fixes #2048

All XPath rules will have now type resolution enabled by default.
While this change is in core, it actually only affects Java, since
this is the only language which has a type resolution facade
registered in its language handler.

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)


