### PR TITLE
[java] Add more version shortcuts for older java

### DIFF
--- a/docs/pages/pmd/userdocs/cli_reference.md
+++ b/docs/pages/pmd/userdocs/cli_reference.md
@@ -88,7 +88,7 @@ The tool comes with a rather extensive help text, simply running with `-help`!
     %}
     {% include custom/cli_option_row.html options="-language,-l"
                option_arg="lang"
-               description="Specify the language PMD should use."
+               description="Specify the language PMD should use. Used together with `-version`. See also [Supported Languages](#supported-languages)."
     %}
     {% include custom/cli_option_row.html options="-minimumpriority,-min"
                option_arg="num"
@@ -138,7 +138,7 @@ The tool comes with a rather extensive help text, simply running with `-help`!
     %}
     {% include custom/cli_option_row.html options="-version,-v"
                option_arg="version"
-               description="Specify the version of a language PMD should use."
+               description="Specify the version of a language PMD should use. Used together with `-language`. See also [Supported Languages](#supported-languages)."
     %}
 </table>
 
@@ -166,12 +166,28 @@ This behavior has been introduced to ease PMD integration into scripts or hooks,
 
 ## Supported Languages
 
+The language is determined automatically by PMD from the file extensions. Some languages such as "Java"
+however support multiple versions. The default version will be used, which is usually the latest supported
+version. If you want to use an older version, so that e.g. rules, that suggest usage of language features,
+that are not available yet, won't be executed, you need to specify a specific version via the `-language`
+and `-version` parameter.
+
+These parameters are irrelevant for languages that don't support different versions.
+
+Example:
+
+``` shell
+./run.sh pmd -d src/main/java -f text -R rulesets/java/quickstart.xml -language java -version 8
+```
+
 *   [apex](pmd_rules_apex.html) (Salesforce Apex)
 *   [java](pmd_rules_java.html)
+    *   Supported Versions: 1.3, 1.4, 1.5, 5, 1.6, 6, 1.7, 7, 1.8, 8, 9, 1.9, 10, 1.10, 11, 12, 13 (default), 13-preview
 *   [ecmascript](pmd_rules_ecmascript.html) (JavaScript)
 *   [jsp](pmd_rules_jsp.html)
 *   [plsql](pmd_rules_plsql.html)
 *   [scala](pmd_rules_scala.html)
+    *   Supported Versions: 2.10, 2.11, 2.12, 2.13 (default)
 *   [vf](pmd_rules_vf.html) (Salesforce VisualForce)
 *   [vm](pmd_rules_vm.html) (Apache Velocity)
 *   [xml and xsl](pmd_rules_xml.html)

--- a/docs/pages/pmd/userdocs/tools/ant.md
+++ b/docs/pages/pmd/userdocs/tools/ant.md
@@ -209,20 +209,33 @@ nested element. Possible values are:
     <sourceLanguage name="java" version="1.3"/>
     <sourceLanguage name="java" version="1.4"/>
     <sourceLanguage name="java" version="1.5"/>
+    <sourceLanguage name="java" version="5"/> <!-- alias for 1.5 -->
     <sourceLanguage name="java" version="1.6"/>
+    <sourceLanguage name="java" version="6"/> <!-- alias for 1.6 -->
     <sourceLanguage name="java" version="1.7"/>
+    <sourceLanguage name="java" version="7"/> <!-- alias for 1.7 -->
     <sourceLanguage name="java" version="1.8"/>
+    <sourceLanguage name="java" version="8"/> <!-- alias for 1.8 -->
     <sourceLanguage name="java" version="9"/>
+    <sourceLanguage name="java" version="1.9"/> <!-- alias for 9 -->
     <sourceLanguage name="java" version="10"/>
+    <sourceLanguage name="java" version="1.10"/> <!-- alias for 10 -->
     <sourceLanguage name="java" version="11"/>
-    <sourceLanguage name="java" version="12"/> <!-- this is the default -->
+    <sourceLanguage name="java" version="12"/>
+    <sourceLanguage name="java" version="13"/> <!-- this is the default -->
+    <sourceLanguage name="java" version="13-preview"/>
     <sourceLanguage name="jsp" version=""/>
     <sourceLanguage name="pom" version=""/>
     <sourceLanguage name="plsql" version=""/>
-    <sourceLanguage name="xsl" version=""/>
-    <sourceLanguage name="xml" version=""/>
+    <sourceLanguage name="scala" version="2.10"/>
+    <sourceLanguage name="scala" version="2.11"/>
+    <sourceLanguage name="scala" version="2.12"/>
+    <sourceLanguage name="scala" version="2.13"/> <!-- this is the default -->
     <sourceLanguage name="vf" version=""/>
     <sourceLanguage name="vm" version=""/>
+    <sourceLanguage name="wsdl" version=""/>
+    <sourceLanguage name="xml" version=""/>
+    <sourceLanguage name="xsl" version=""/>
 
 ### Postprocessing the report file with XSLT
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -20,11 +20,14 @@ This is a {{ site.pmd.release_type }} release.
     *   [#2092](https://github.com/pmd/pmd/issues/2092): \[apex] ApexLexer logs visible when Apex is the selected language upon starting the designer
 *   core
     *   [#2096](https://github.com/pmd/pmd/issues/2096): \[core] Referencing category errorprone.xml produces deprecation warnings for InvalidSlf4jMessageFormat
+*   java
+    *   [#1861](https://github.com/pmd/pmd/issues/1861): \[java] Be more lenient with version numbers
 
 ### API Changes
 
 ### External Contributions
 
+*   [#2088](https://github.com/pmd/pmd/pull/2088): \[java] Add more version shortcuts for older java - [Henning Schmiedehausen](https://github.com/hgschmie)
 *   [#2089](https://github.com/pmd/pmd/pull/2089): \[core] Minor unrelated improvements to code - [Gonzalo Exequiel Ibars Ingman](https://github.com/gibarsin)
 
 {% endtocmaker %}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/BaseLanguageModule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/BaseLanguageModule.java
@@ -11,6 +11,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import net.sourceforge.pmd.annotation.Experimental;
+
 /**
  * Created by christoferdutz on 21.09.14.
  */
@@ -33,6 +35,7 @@ public abstract class BaseLanguageModule implements Language {
         this.extensions = Arrays.asList(extensions);
     }
 
+    @Experimental
     protected void addVersions(LanguageVersionHandler languageVersionHandler, boolean isDefault, String ... languageVersions) {
         if (versions == null) {
             versions = new HashMap<>();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/BaseLanguageModule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/BaseLanguageModule.java
@@ -33,6 +33,22 @@ public abstract class BaseLanguageModule implements Language {
         this.extensions = Arrays.asList(extensions);
     }
 
+    protected void addVersions(LanguageVersionHandler languageVersionHandler, boolean isDefault, String ... languageVersions) {
+        if (versions == null) {
+            versions = new HashMap<>();
+        }
+
+        LanguageVersion languageVersion = new LanguageVersion(this, languageVersions[0], languageVersionHandler);
+
+        for (String version : languageVersions) {
+            versions.put(version, languageVersion);
+        }
+
+        if (isDefault) {
+            defaultVersion = languageVersion;
+        }
+    }
+
     protected void addVersion(String version, LanguageVersionHandler languageVersionHandler, boolean isDefault) {
         if (versions == null) {
             versions = new HashMap<>();

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageModule.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageModule.java
@@ -41,10 +41,10 @@ public class DummyLanguageModule extends BaseLanguageModule {
         addVersion("1.2", new Handler(), false);
         addVersion("1.3", new Handler(), false);
         addVersion("1.4", new Handler(), false);
-        addVersion("1.5", new Handler(), false);
-        addVersion("1.6", new Handler(), false);
-        addVersion("1.7", new Handler(), true);
-        addVersion("1.8", new Handler(), false);
+        addVersions(new Handler(), false, "1.5", "5");
+        addVersions(new Handler(), false, "1.6", "6");
+        addVersions(new Handler(), true, "1.7", "7");
+        addVersions(new Handler(), false, "1.8", "8");
     }
 
     public static class DummyRuleChainVisitor extends AbstractRuleChainVisitor {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/LanguageRegistryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/LanguageRegistryTest.java
@@ -30,4 +30,30 @@ public class LanguageRegistryTest {
         Assert.assertNotNull(dummyDefault2);
         Assert.assertSame(dummyDefault, dummyDefault2);
     }
+
+    @Test
+    public void getLanguageVersionByNameAliasTest() {
+        LanguageVersion dummy17 = LanguageRegistry.findLanguageVersionByTerseName("dummy 1.7");
+        Assert.assertNotNull(dummy17);
+        Assert.assertEquals("1.7", dummy17.getVersion());
+
+        LanguageVersion dummy7 = LanguageRegistry.findLanguageVersionByTerseName("dummy 7");
+        Assert.assertNotNull(dummy7);
+        Assert.assertEquals("1.7", dummy17.getVersion());
+        Assert.assertSame(dummy17, dummy7);
+    }
+
+    @Test
+    public void getLanguageVersionByAliasTest() {
+        Language dummy = LanguageRegistry.findLanguageByTerseName("dummy");
+
+        LanguageVersion dummy17 = dummy.getVersion("1.7");
+        Assert.assertNotNull(dummy17);
+        Assert.assertEquals("1.7", dummy17.getVersion());
+
+        LanguageVersion dummy7 = dummy.getVersion("7");
+        Assert.assertNotNull(dummy7);
+        Assert.assertEquals("1.7", dummy17.getVersion());
+        Assert.assertSame(dummy17, dummy7);
+    }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/JavaLanguageModule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/JavaLanguageModule.java
@@ -20,9 +20,9 @@ public class JavaLanguageModule extends BaseLanguageModule {
         addVersion("1.3", new JavaLanguageHandler(3), false);
         addVersion("1.4", new JavaLanguageHandler(4), false);
         addVersion("1.5", new JavaLanguageHandler(5), false);
-        addVersion("1.6", new JavaLanguageHandler(6), false);
-        addVersion("1.7", new JavaLanguageHandler(7), false);
-        addVersion("1.8", new JavaLanguageHandler(8), false);
+        addVersions(new JavaLanguageHandler(6), false, "1.6", "6");
+        addVersions(new JavaLanguageHandler(7), false, "1.7", "7");
+        addVersions(new JavaLanguageHandler(8), false, "1.8", "8");
         addVersion("9", new JavaLanguageHandler(9), false);
         addVersion("10", new JavaLanguageHandler(10), false);
         addVersion("11", new JavaLanguageHandler(11), false);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/JavaLanguageModule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/JavaLanguageModule.java
@@ -19,12 +19,12 @@ public class JavaLanguageModule extends BaseLanguageModule {
         super(NAME, null, TERSE_NAME, JavaRuleChainVisitor.class, "java");
         addVersion("1.3", new JavaLanguageHandler(3), false);
         addVersion("1.4", new JavaLanguageHandler(4), false);
-        addVersion("1.5", new JavaLanguageHandler(5), false);
+        addVersions(new JavaLanguageHandler(5), false, "1.5", "5");
         addVersions(new JavaLanguageHandler(6), false, "1.6", "6");
         addVersions(new JavaLanguageHandler(7), false, "1.7", "7");
         addVersions(new JavaLanguageHandler(8), false, "1.8", "8");
-        addVersion("9", new JavaLanguageHandler(9), false);
-        addVersion("10", new JavaLanguageHandler(10), false);
+        addVersions(new JavaLanguageHandler(9), false, "9", "1.9");
+        addVersions(new JavaLanguageHandler(10), false, "10", "1.10");
         addVersion("11", new JavaLanguageHandler(11), false);
         addVersion("12", new JavaLanguageHandler(12), false);
         addVersion("12-preview", new JavaLanguageHandler(12, true), false);


### PR DESCRIPTION
This fixes #1861 

Newer java compiler (java 9+) support the `--release` option to choose
for which version of the JRE to compile. This parameter only takes
simple values as documented by `javac --help`:

```
--release <release>
        Compile for a specific VM version. Supported targets: 6, 7, 8, 9, 10, 11
```

adding these versions to pmd allows the use of the same versions (6, 7
and 8) with PMD as with the compiler, thus removing the need to juggle
between single digit versions for the compiler and 1.<x> for PMD.

<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

