### PR TITLE
[apex] Really fix ApexLexer logging

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -16,6 +16,9 @@ This is a {{ site.pmd.release_type }} release.
 
 ### Fixed Issues
 
+*   apex
+    *   [#2092](https://github.com/pmd/pmd/issues/2092): \[apex] ApexLexer logs visible when Apex is the selected language upon starting the designer
+
 ### API Changes
 
 ### External Contributions

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ApexJorjeLogging.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ApexJorjeLogging.java
@@ -10,6 +10,9 @@ import java.util.logging.Logger;
 import apex.jorje.parser.impl.BaseApexLexer;
 
 public final class ApexJorjeLogging {
+    // note: that's a static/strong reference in order to avoid that the logger is garbage collected
+    private static final Logger APEX_LOGGER = Logger.getLogger(BaseApexLexer.class.getName());
+
     private ApexJorjeLogging() {
         // this is a utility class
     }
@@ -19,7 +22,6 @@ public final class ApexJorjeLogging {
         // Jul 16, 2017 8:49:56 PM apex.jorje.parser.impl.BaseApexLexer dedupe
         // INFORMATION: Deduped array ApexLexer.DFA23_transition. Found 7927114 shorts which is 15MB not
         // including array overhead. Removed 7204963 shorts which is 13MB not counting array overhead. Took 18ms.
-        Logger log = Logger.getLogger(BaseApexLexer.class.getSimpleName());
-        log.setLevel(Level.WARNING);
+        APEX_LOGGER.setLevel(Level.WARNING);
     }
 }

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/AllRulesIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/AllRulesIT.java
@@ -42,5 +42,8 @@ public class AllRulesIT extends AbstractBinaryDistributionTest {
         result.assertNoError("Use of deprecated attribute");
         result.assertNoErrorInReport("Error while processing");
         result.assertNoErrorInReport("Error while parsing");
+
+        // See bug #2092: [apex] ApexLexer logs visible when Apex is the selected language upon starting the designer 
+        result.assertNoError("Deduped array ApexLexer");
     }
 }


### PR DESCRIPTION
The fix introduced with #503 (fba00843bb523cbeb06157c4793ffc29bd9a6ee7)
was incomplete and didn't work:
* The logger uses the full class name insteand of simple name
* After we changed the log level of the logger, the logger
  could be garbage collected before ApexLexer retrieves it and
  thus the configuration could be lost

Fixes #2092 

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

