### PR TITLE
[core] RuleSetFactory - recognize rule reference for same ruleset

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -18,6 +18,8 @@ This is a {{ site.pmd.release_type }} release.
 
 *   apex
     *   [#2092](https://github.com/pmd/pmd/issues/2092): \[apex] ApexLexer logs visible when Apex is the selected language upon starting the designer
+*   core
+    *   [#2096](https://github.com/pmd/pmd/issues/2096): \[core] Referencing category errorprone.xml produces deprecation warnings for InvalidSlf4jMessageFormat
 
 ### API Changes
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
@@ -639,6 +639,10 @@ public class RuleSetFactory {
                 && containsRule(ruleSetReferenceId, otherRuleSetReferenceId.getRuleName())) {
             otherRuleSetReferenceId = new RuleSetReferenceId(ref, ruleSetReferenceId);
             isSameRuleSet = true;
+        } else if (otherRuleSetReferenceId.isExternal()
+                && otherRuleSetReferenceId.getRuleSetFileName().equals(ruleSetReferenceId.getRuleSetFileName())) {
+            otherRuleSetReferenceId = new RuleSetReferenceId(otherRuleSetReferenceId.getRuleName(), ruleSetReferenceId);
+            isSameRuleSet = true;
         }
         // do not ignore deprecated rule references
         Rule referencedRule = ruleSetFactory.createRule(otherRuleSetReferenceId, true);

--- a/pmd-core/src/test/resources/rulesets/dummy/basic.xml
+++ b/pmd-core/src/test/resources/rulesets/dummy/basic.xml
@@ -18,7 +18,11 @@ Just for test
      </example>
     </rule>
 
+    <!-- variant 1 of a renamed rule. This is definitively within the same ruleset. -->
     <rule deprecated="true" name="OldNameOfDummyBasicMockRule" ref="DummyBasicMockRule"/>
+    <!-- variant 2 of a renamed and/or moved rule. This could also keep the rule name but
+         move the rule into a different rule or do any combination of both -->
+    <rule deprecated="true" name="OldNameOfDummyBasicMockRule2" ref="rulesets/dummy/basic.xml/DummyBasicMockRule"/>
 
     <rule name="SampleXPathRule" language="dummy" since="1.1" message="Test Rule 2" class="net.sourceforge.pmd.lang.rule.XPathRule"
         externalInfoUrl="${pmd.website.baseurl}/rules/dummy/basic.xml#SampleXPathRule">

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/AllRulesIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/AllRulesIT.java
@@ -40,6 +40,7 @@ public class AllRulesIT extends AbstractBinaryDistributionTest {
         result.assertNoError("Exception applying rule");
         result.assertNoError("Ruleset not found");
         result.assertNoError("Use of deprecated attribute");
+        result.assertNoError("instead of the deprecated"); // rule deprecations
         result.assertNoErrorInReport("Error while processing");
         result.assertNoErrorInReport("Error while parsing");
 


### PR DESCRIPTION
There are two variants, how a renamed rule can be expressed in the
ruleset via a deprecated rule reference: referencing just the
new rule name or referencing the ruleset+new rule name. The latter
case was not covered yet, it was not detected, that the rule ref
references are rule in the same ruleset.

Fixes #2096

<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

