### PR TITLE
[java] Wrong name for inner classes

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolation.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolation.java
@@ -101,6 +101,11 @@ public class JavaRuleViolation extends ParametricRuleViolation<JavaNode> {
 
     private void setClassNameFrom(JavaNode node) {
         String qualifiedName = null;
+
+        if (node.getScope() instanceof ClassScope) {
+            qualifiedName = ((ClassScope) node.getScope()).getClassName();
+        }
+
         for (AbstractAnyTypeDeclaration parent : node.getParentsOfType(AbstractAnyTypeDeclaration.class)) {
             String clsName = parent.getScope().getEnclosingScope(ClassScope.class).getClassName();
             if (qualifiedName == null) {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolationTest.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.java.rule;
 import static org.junit.Assert.assertEquals;
 
 import java.io.StringReader;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -15,6 +16,7 @@ import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersionHandler;
 import net.sourceforge.pmd.lang.ParserOptions;
 import net.sourceforge.pmd.lang.java.JavaLanguageModule;
+import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
@@ -129,5 +131,21 @@ public class JavaRuleViolationTest {
         JavaRuleViolation violation = new JavaRuleViolation(null, new RuleContext(), importNode, null);
         assertEquals("pkg", violation.getPackageName());
         assertEquals("Foo", violation.getClassName());
+    }
+
+    /**
+     * Test that the name of the inner class is taken correctly.
+     */
+    @Test
+    public void testInnerClass() {
+        ASTCompilationUnit ast = parse("class Foo { class Bar { } }");
+        List<ASTClassOrInterfaceDeclaration> classes = ast.findDescendantsOfType(ASTClassOrInterfaceDeclaration.class);
+        assertEquals(2, classes.size());
+
+        JavaRuleViolation fooViolation = new JavaRuleViolation(null, new RuleContext(), classes.get(0), null);
+        assertEquals("Foo", fooViolation.getClassName());
+        
+        JavaRuleViolation barViolation = new JavaRuleViolation(null, new RuleContext(), classes.get(1), null);
+        assertEquals("Foo$Bar", barViolation.getClassName());
     }
 }


### PR DESCRIPTION
Fix #2105.

When a Java class has inner classes, their classname is not correctly reported when looking at the class itself. This is not an issue for code inside a class, but the inner class declaration itself.

This is fixed by also looking at the scope of the current node instead of just its parents.