### PR TITLE
[core] Add designer bindings interface

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/AbstractLanguageVersionHandler.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/AbstractLanguageVersionHandler.java
@@ -8,6 +8,7 @@ import java.io.Writer;
 
 import net.sourceforge.pmd.lang.dfa.DFAGraphRule;
 import net.sourceforge.pmd.lang.metrics.LanguageMetricsProvider;
+import net.sourceforge.pmd.util.designerbindings.DesignerBindings;
 
 
 /**
@@ -79,5 +80,10 @@ public abstract class AbstractLanguageVersionHandler implements LanguageVersionH
     @Override
     public LanguageMetricsProvider<?, ?> getLanguageMetricsProvider() {
         return null;
+    }
+
+    @Override
+    public DesignerBindings getDesignerBindings() {
+        return DesignerBindings.DefaultDesignerBindings.getInstance();
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageVersionHandler.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageVersionHandler.java
@@ -11,6 +11,8 @@ import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.dfa.DFAGraphRule;
 import net.sourceforge.pmd.lang.metrics.LanguageMetricsProvider;
 import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
+import net.sourceforge.pmd.util.designerbindings.DesignerBindings;
+import net.sourceforge.pmd.util.designerbindings.DesignerBindings.DefaultDesignerBindings;
 
 /**
  * Interface for obtaining the classes necessary for checking source files of a
@@ -149,5 +151,16 @@ public interface LanguageVersionHandler {
      */
     @Experimental
     LanguageMetricsProvider<?, ?> getLanguageMetricsProvider();
+
+
+    /**
+     * Returns the designer bindings for this language version.
+     * Null is not an acceptable result, use {@link DefaultDesignerBindings#getInstance()}
+     * instead.
+     *
+     * @since 6.20.0
+     */
+    @Experimental
+    DesignerBindings getDesignerBindings();
 
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/designerbindings/DesignerBindings.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/designerbindings/DesignerBindings.java
@@ -1,0 +1,46 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.designerbindings;
+
+import net.sourceforge.pmd.annotation.Experimental;
+import net.sourceforge.pmd.lang.symboltable.ScopedNode;
+
+/**
+ * Gathers some services to customise how language implementations bind
+ * to the designer.
+ *
+ * @author Clément Fournier
+ * @since 6.20.0
+ */
+@Experimental
+public interface DesignerBindings {
+
+    /**
+     * Returns an instance of {@link RelatedNodesSelector}, or
+     * null if it should be defaulted to using the old symbol table ({@link ScopedNode}).
+     * That default behaviour is implemented in the designer directly.
+     */
+    RelatedNodesSelector getRelatedNodesSelector();
+
+
+    /**
+     * A base implementation for {@link DesignerBindings}.
+     */
+    class DefaultDesignerBindings implements DesignerBindings {
+
+        private static final DefaultDesignerBindings INSTANCE = new DefaultDesignerBindings();
+
+        @Override
+        public RelatedNodesSelector getRelatedNodesSelector() {
+            return null;
+        }
+
+        /** Returns the default instance. */
+        public static DefaultDesignerBindings getInstance() {
+            return INSTANCE;
+        }
+    }
+
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/designerbindings/RelatedNodesSelector.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/designerbindings/RelatedNodesSelector.java
@@ -1,0 +1,45 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.designerbindings;
+
+import java.util.List;
+
+import net.sourceforge.pmd.annotation.Experimental;
+import net.sourceforge.pmd.lang.ast.Node;
+
+/**
+ * Provides a way for the designer to highlight related nodes upon selection,
+ * eg those nodes referring to the same variable or method.
+ *
+ * <p>This API only published to bind to the designer for now, it should
+ * not be used by rule code. The criterion for selecting nodes to highlight
+ * is subject to change at the implementation's discretion. In particular it's
+ * not necessarily the usages of a variable.
+ *
+ * <p>The binary API is <b>unstable</b> until at least 7.0, meaning the only
+ * place this can be implemented safely is within PMD's own codebase.
+ *
+ * @author Clément Fournier
+ * @since 6.20.0
+ */
+@Experimental
+public interface RelatedNodesSelector {
+
+
+    /**
+     * Returns a list of nodes that should be highlighted when selecting
+     * the given node. This is eg the nodes that correspond to usages of
+     * a variable declared by the given node. If the node cannot be handled
+     * by this resolver or is otherwise uninteresting, then returns an empty list.
+     *
+     * @param node A node, with no guarantee about type. Implementations
+     *             should check their casts.
+     *
+     * @return A list of nodes to highlight
+     */
+    List<Node> getHighlightedNodesWhenSelecting(Node node);
+
+
+}


### PR DESCRIPTION
Add an interface that language implementations may implement to bind to the designer and display node highlight. This is a first step towards removing the designer dependency on the old symbol table that's in pmd-core. Once this is merged we can bump the pmd-core version of the designer and reimplement usage highlight in terms of this interface. It would be defaulted to the current behaviour, of using ScopedNode. 

This will allow the Modelica module to support usage highlight in the designer without relying on the old symbol table interfaces (ref #2041). Same can be said for the java module and its 7.0 symbol table reimplementation.

Eventually other interfaces may be provided by DesignerBindings, each being an extension point of the designer. For example, one of those can replace `getImage` for the designer treeview.