### PR TITLE
[java] Predicates treated like booleans

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LinguisticNamingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LinguisticNamingRule.java
@@ -103,7 +103,6 @@ public class LinguisticNamingRule extends AbstractIgnoredAnnotationRule {
                 checkTransformMethods(node, data, nameOfMethod);
             }
         }
-
         return data;
     }
 
@@ -150,7 +149,9 @@ public class LinguisticNamingRule extends AbstractIgnoredAnnotationRule {
     }
 
     private boolean isBooleanType(ASTType node) {
-        return "boolean".equalsIgnoreCase(node.getTypeImage()) || TypeHelper.isA(node, "java.util.concurrent.atomic.AtomicBoolean");
+        return "boolean".equalsIgnoreCase(node.getTypeImage())
+                || TypeHelper.isA(node, "java.util.concurrent.atomic.AtomicBoolean")
+                || TypeHelper.isA(node, "java.util.function.Predicate");
     }
 
     private void checkBooleanMethods(ASTMethodDeclaration node, Object data, String nameOfMethod) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LinguisticNaming.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LinguisticNaming.xml
@@ -577,7 +577,7 @@ public class Bar extends Foo {
         ]]></code>
     </test-code>
     <test-code>
-        <description>Predicate properties are treated like booleans</description>
+        <description>Predicate fields are treated like booleans</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 import java.util.function.Predicate;

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LinguisticNaming.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LinguisticNaming.xml
@@ -576,13 +576,29 @@ public class Bar extends Foo {
 }
         ]]></code>
     </test-code>
-    <!--test-code>
-        <description>Predicates are treated like booleans</description>
-        <expected-problems>1</expected-problems>
+    <test-code>
+        <description>Predicate properties are treated like booleans</description>
+        <expected-problems>0</expected-problems>
         <code><![CDATA[
+import java.util.function.Predicate;
+
 public class ClassWithPredicates {
     public Predicate<String> isNotEmpty = string -> !string.isEmpty();
 }
         ]]></code>
-    </test-code-->
+    </test-code>
+    <test-code>
+        <description>Predicate variables are treated like booleans</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.function.Predicate;
+
+public class SomeClass {
+    public static void main(String[] args) {
+        Predicate<String> isEmpty = string -> string.isEmpty();
+    }
+}
+        ]]></code>
+    </test-code>
+
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LinguisticNaming.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LinguisticNaming.xml
@@ -576,4 +576,13 @@ public class Bar extends Foo {
 }
         ]]></code>
     </test-code>
+    <!--test-code>
+        <description>Predicates are treated like booleans</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class ClassWithPredicates {
+    public Predicate<String> isNotEmpty = string -> !string.isEmpty();
+}
+        ]]></code>
+    </test-code-->
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LinguisticNaming.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LinguisticNaming.xml
@@ -583,7 +583,7 @@ public class Bar extends Foo {
 import java.util.function.Predicate;
 
 public class ClassWithPredicates {
-    public Predicate<String> isNotEmpty = string -> !string.isEmpty();
+    private final Predicate<String> isNotEmpty = string -> !string.isEmpty();
 }
         ]]></code>
     </test-code>
@@ -595,7 +595,7 @@ import java.util.function.Predicate;
 
 public class SomeClass {
     public static void main(String[] args) {
-        Predicate<String> isEmpty = string -> string.isEmpty();
+        Predicate<String> isEmpty = String::isEmpty;
     }
 }
         ]]></code>


### PR DESCRIPTION
Fixes #1362 

<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [X] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [X] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
Related to #1362. The rule java/codestyle/LinguisticNaming doesn't treat Predicates as booleans, even though they are boolean-valued functions. This PR changes the behaviour of the respected class so that predicates are treated as booleans for this rule.
