### PR TITLE
[java] Preserve possible type of the target reference for method invocations

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -25,6 +25,8 @@ This is a {{ site.pmd.release_type }} release.
 *   java
     *   [#1861](https://github.com/pmd/pmd/issues/1861): \[java] Be more lenient with version numbers
     *   [#2105](https://github.com/pmd/pmd/issues/2105): \[java] Wrong name for inner classes in violations
+*   java-bestpractices
+    *   [#2016](https://github.com/pmd/pmd/issues/2016): \[java] UnusedImports: False positive if wildcard is used and only static methods
 *   java-codestyle
     *   [#1362](https://github.com/pmd/pmd/issues/1362): \[java] LinguisticNaming flags Predicates with boolean-style names
     *   [#2029](https://github.com/pmd/pmd/issues/2029): \[java] UnnecessaryFullyQualifiedName false-positive for non-static nested classes

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
@@ -24,7 +24,6 @@ import net.sourceforge.pmd.lang.java.ast.DummyJavaNode;
 import net.sourceforge.pmd.lang.java.ast.FormalComment;
 import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
-import net.sourceforge.pmd.lang.java.typeresolution.ClassTypeResolver;
 import net.sourceforge.pmd.lang.rule.ImportWrapper;
 
 public class UnusedImportsRule extends AbstractJavaRule {
@@ -144,23 +143,6 @@ public class UnusedImportsRule extends AbstractJavaRule {
 
     @Override
     public Object visit(ASTName node, Object data) {
-        if (isMethodCall(node) && isQualifiedName(node)) {
-            String name = node.getImage().substring(0, node.getImage().lastIndexOf('.'));
-            // try to resolve with on demand imports...
-            ClassTypeResolver classTypeResolver = node.getFirstParentOfType(ASTCompilationUnit.class).getClassTypeResolver();
-            Iterator<ImportWrapper> it = imports.iterator();
-            while (it.hasNext()) {
-                ImportWrapper i = it.next();
-                if (i.getName() == null) {
-                    String fullName = i.getFullName() + "." + name;
-                    if (classTypeResolver.loadClass(fullName) != null) {
-                        // found a match
-                        it.remove();
-                        return data;
-                    }
-                }
-            }
-        }
         check(node);
         return data;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
@@ -143,6 +143,23 @@ public class UnusedImportsRule extends AbstractJavaRule {
 
     @Override
     public Object visit(ASTName node, Object data) {
+        if (isMethodCall(node) && isQualifiedName(node)) {
+            String name = node.getImage().substring(0, node.getImage().lastIndexOf('.'));
+            // try to resolve with on demand imports...
+            ClassTypeResolver classTypeResolver = node.getFirstParentOfType(ASTCompilationUnit.class).getClassTypeResolver();
+            Iterator<ImportWrapper> it = imports.iterator();
+            while (it.hasNext()) {
+                ImportWrapper i = it.next();
+                if (i.getName() == null) {
+                    String fullName = i.getFullName() + "." + name;
+                    if (classTypeResolver.loadClass(fullName) != null) {
+                        // found a match
+                        it.remove();
+                        return data;
+                    }
+                }
+            }
+        }
         check(node);
         return data;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
@@ -24,6 +24,7 @@ import net.sourceforge.pmd.lang.java.ast.DummyJavaNode;
 import net.sourceforge.pmd.lang.java.ast.FormalComment;
 import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
+import net.sourceforge.pmd.lang.java.typeresolution.ClassTypeResolver;
 import net.sourceforge.pmd.lang.rule.ImportWrapper;
 
 public class UnusedImportsRule extends AbstractJavaRule {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedimports/Issue2016.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedimports/Issue2016.java
@@ -4,7 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.bestpractices.unusedimports;
 
-import java.util.*;
+import java.util.Objects;
 
 /**
  * Note: In order for this test case to work, the class "Issue2016" must also be compiled and available

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedimports/Issue2016.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedimports/Issue2016.java
@@ -1,0 +1,17 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices.unusedimports;
+
+import java.util.*;
+
+/**
+ * Note: In order for this test case to work, the class "Issue2016" must also be compiled and available
+ * on the auxclasspath.
+ */
+public class Issue2016 {
+    public void testFunction() {
+        Objects.toString(null);
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
@@ -24,6 +24,7 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.StringTokenizer;
 
@@ -100,6 +101,7 @@ import net.sourceforge.pmd.typeresolution.testdata.JavaTypeDefinitionToStringNPE
 import net.sourceforge.pmd.typeresolution.testdata.Literals;
 import net.sourceforge.pmd.typeresolution.testdata.LocalGenericClass;
 import net.sourceforge.pmd.typeresolution.testdata.MethodAccessibility;
+import net.sourceforge.pmd.typeresolution.testdata.MethodCallExpressionTypes;
 import net.sourceforge.pmd.typeresolution.testdata.MethodFirstPhase;
 import net.sourceforge.pmd.typeresolution.testdata.MethodGenericExplicit;
 import net.sourceforge.pmd.typeresolution.testdata.MethodGenericParam;
@@ -1552,13 +1554,13 @@ public class ClassTypeResolverTest {
 
         // int c = StaticMembers.primitiveStaticMethod();
         assertEquals(int.class, expressions.get(index).getType());
-        assertEquals(int.class, getChildType(expressions.get(index), 0));
-        assertEquals(int.class, getChildType(expressions.get(index++), 1));
+        assertEquals(StaticMembers.class, getChildType(expressions.get(index), 0)); // PrimaryPrefix
+        assertEquals(int.class, getChildType(expressions.get(index++), 1)); // PrimarySuffix
 
         // String c = MethodStaticAccess.Nested.primitiveStaticMethod();
         assertEquals(String.class, expressions.get(index).getType());
-        assertEquals(String.class, getChildType(expressions.get(index), 0));
-        assertEquals(String.class, getChildType(expressions.get(index++), 1));
+        assertEquals(MethodStaticAccess.Nested.class, getChildType(expressions.get(index), 0)); // PrimaryPrefix
+        assertEquals(String.class, getChildType(expressions.get(index++), 1)); // PrimarySuffix
 
         // Make sure we got them all
         assertEquals("All expressions not tested", index, expressions.size());
@@ -1837,6 +1839,14 @@ public class ClassTypeResolverTest {
     @Test
     public void testLocalGenericClass() throws Exception {
         parseAndTypeResolveForClass(LocalGenericClass.class, "9");
+    }
+
+    @Test
+    public void testMethodCallExpressionTypes() throws Exception {
+        ASTCompilationUnit cu = parseAndTypeResolveForClass(MethodCallExpressionTypes.class, "11");
+        ASTPrimaryExpression expr = cu.getFirstDescendantOfType(ASTPrimaryExpression.class);
+        assertEquals(forClass(String.class), expr.getTypeDefinition());
+        assertEquals(forClass(Objects.class), expr.getFirstChildOfType(ASTPrimaryPrefix.class).getTypeDefinition());
     }
 
     private JavaTypeDefinition getChildTypeDef(Node node, int childIndex) {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/MethodCallExpressionTypes.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/MethodCallExpressionTypes.java
@@ -1,0 +1,13 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.typeresolution.testdata;
+
+import java.util.Objects;
+
+public class MethodCallExpressionTypes {
+    public void bar() {
+        Objects.toString(null);
+    }
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedImports.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedImports.xml
@@ -538,6 +538,7 @@ public class VendingV2PaymentRequest {
         <code><![CDATA[
 package net.sourceforge.pmd.lang.java.rule.bestpractices.unusedimports;
 
+// star import is important here for the test case!!
 import java.util.*;
 
 /**

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedImports.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedImports.xml
@@ -531,4 +531,24 @@ public class VendingV2PaymentRequest {
 }	
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#2016 [java] UnusedImports: False positive if wildcard is used and only static methods</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+package net.sourceforge.pmd.lang.java.rule.bestpractices.unusedimports;
+
+import java.util.*;
+
+/**
+ * Note: In order for this test case to work, the class "Issue2016" must also be compiled and available
+ * on the auxclasspath.
+ */
+public class Issue2016 {
+    public void testFunction() {
+        Objects.toString(null);
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
This fixes #2016, where we already resolved the method invocation to the result type. That's ok for the whole expression, but we loose the information, on which type the method is invoked.
I've put that now back down the AST like that:

```
Code:
Objects.toString(null);

PrimaryExpression  -> Type = java.lang.String
  |- PrimaryPrefix  -> Type = java.util.Objects
     |- Name "Objects.toString" -> Type = java.util.Objects
  |- PrimarySuffix
     |- Arguments
        |- ArgumentList
```

The solution is not elegant, since we resolve the type of ASTName multiple times, but it works for this case at least and doesn't seem to break other parts - except for the one test case I adjusted.

The reason, why the class "Issue2016" needs to be compiled on the auxclass path is: We use ASM to visit the bytecode and collect all referenced types. That allows us to resolve type of "Objects" to "java.util.Objects". In theory, for that, we don't need ASM, because we should be able to resolve Objects using the wildcard import ourselves, but that doesn't seem to work (and is another problem, not part of this PR).
