### PR TITLE
[java] Fix false negative in AvoidLiteralsInIfCondition

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -18,6 +18,8 @@ This is a {{ site.pmd.release_type }} release.
 
 *   java-bestpractices
     *   [#2149](https://github.com/pmd/pmd/issues/2149): \[java] JUnitAssertionsShouldIncludeMessage - False positive with assertEquals and JUnit5
+*   java-errorprone
+    *   [#2140](https://github.com/pmd/pmd/issues/2140): \[java] AvoidLiteralsInIfCondition: false negative for expressions
 *   java-performance
     *   [#2141](https://github.com/pmd/pmd/issues/2141): \[java] StringInstatiation: False negative with String-array access
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -14,6 +14,12 @@ This is a {{ site.pmd.release_type }} release.
 
 ### New and noteworthy
 
+#### Modified Rules
+
+*   The Java rule {% rule "java/errorprone/AvoidLiteralsInIfCondition" %} (`java-errorprone`) has a new property
+    `ignoreExpressions`. This property is set by default to `true` in order to maintain compatibility. If this
+    property is set to false, then literals in more complex expressions are considered as well.
+
 ### Fixed Issues
 
 *   java-bestpractices

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/saxon/ElementNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/saxon/ElementNode.java
@@ -101,7 +101,25 @@ public class ElementNode extends AbstractNodeInfo {
 
     @Override
     public int compareOrder(NodeInfo other) {
-        return Integer.signum(this.node.jjtGetId() - ((ElementNode) other).node.jjtGetId());
+        int result;
+        if (this.isSameNodeInfo(other)) {
+            result = 0;
+        } else {
+            result = Integer.signum(this.getLineNumber() - other.getLineNumber());
+            if (result == 0) {
+                result = Integer.signum(this.getColumnNumber() - other.getColumnNumber());
+            }
+            if (result == 0) {
+                if (this.getParent().equals(other.getParent())) {
+                    result = Integer.signum(this.getSiblingPosition() - ((ElementNode) other).getSiblingPosition());
+                } else {
+                    // we must not return 0 here, otherwise the node might be removed as duplicate when creating
+                    // a union set. The the nodes are definitively different nodes (isSameNodeInfo == false).
+                    result = 1;
+                }
+            }
+        }
+        return result;
     }
 
     @SuppressWarnings("PMD.MissingBreakInSwitch")

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNode.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNode.java
@@ -6,24 +6,30 @@ package net.sourceforge.pmd.lang.ast;
 
 public class DummyNode extends AbstractNode {
     private final boolean findBoundary;
-    
+    private final String xpathName;
+
     public DummyNode(int id) {
         this(id, false);
     }
-    
+
     public DummyNode(int id, boolean findBoundary) {
+        this(id, findBoundary, "dummyNode");
+    }
+
+    public DummyNode(int id, boolean findBoundary, String xpathName) {
         super(id);
         this.findBoundary = findBoundary;
+        this.xpathName = xpathName;
     }
 
     @Override
     public String toString() {
-        return "dummyNode";
+        return xpathName;
     }
 
     @Override
     public String getXPathNodeName() {
-        return "dummyNode";
+        return xpathName;
     }
     
     @Override

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/saxon/ElementNodeTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/saxon/ElementNodeTest.java
@@ -1,0 +1,59 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.rule.xpath.saxon;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.sourceforge.pmd.lang.ast.DummyNode;
+import net.sourceforge.pmd.lang.ast.xpath.saxon.DocumentNode;
+import net.sourceforge.pmd.lang.ast.xpath.saxon.ElementNode;
+
+public class ElementNodeTest {
+
+    @Test
+    public void testCompareOrder() {
+        DummyNode node = new DummyNode(1, false, "dummy");
+        DummyNode foo1 = new DummyNode(2, false, "foo");
+        foo1.testingOnlySetBeginLine(1);
+        DummyNode foo2 = new DummyNode(2, false, "foo");
+        foo2.testingOnlySetBeginLine(2);
+        node.jjtAddChild(foo1, 0);
+        node.jjtAddChild(foo2, 1);
+
+        DocumentNode document = new DocumentNode(node);
+        ElementNode elementFoo1 = document.nodeToElementNode.get(foo1);
+        ElementNode elementFoo2 = document.nodeToElementNode.get(foo2);
+
+        Assert.assertFalse(elementFoo1.isSameNodeInfo(elementFoo2));
+        Assert.assertFalse(elementFoo2.isSameNodeInfo(elementFoo1));
+        Assert.assertTrue(elementFoo1.compareOrder(elementFoo2) < 0);
+        Assert.assertTrue(elementFoo2.compareOrder(elementFoo1) > 0);
+
+        Assert.assertEquals(0, elementFoo1.compareOrder(elementFoo1));
+    }
+
+    @Test
+    public void testCompareOrderSamePosition() {
+        DummyNode node = new DummyNode(1, false, "dummy");
+        DummyNode foo1 = new DummyNode(2, false, "foo");
+        foo1.testingOnlySetBeginLine(1);
+        foo1.testingOnlySetBeginColumn(1);
+        DummyNode foo2 = new DummyNode(2, false, "foo");
+        foo2.testingOnlySetBeginLine(1);
+        foo2.testingOnlySetBeginColumn(1);
+        node.jjtAddChild(foo1, 0);
+        node.jjtAddChild(foo2, 1);
+
+        DocumentNode document = new DocumentNode(node);
+        ElementNode elementFoo1 = document.nodeToElementNode.get(foo1);
+        ElementNode elementFoo2 = document.nodeToElementNode.get(foo2);
+
+        Assert.assertFalse(elementFoo1.isSameNodeInfo(elementFoo2));
+        Assert.assertFalse(elementFoo2.isSameNodeInfo(elementFoo1));
+        Assert.assertTrue(elementFoo1.compareOrder(elementFoo2) < 0);
+        Assert.assertTrue(elementFoo2.compareOrder(elementFoo1) > 0);
+    }
+}

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -461,28 +461,42 @@ try {  // Prefer this:
 Avoid using hard-coded literals in conditional statements. By declaring them as static variables
 or private members with descriptive names maintainability is enhanced. By default, the literals "-1" and "0" are ignored.
 More exceptions can be defined with the property "ignoreMagicNumbers".
+
+The rule doesn't consider deeper expressions by default, but this can be enabled via the property `ignoreExpressions`.
+With this property set to false, if-conditions like `i == 1 + 5` are reported as well. Note that in that case,
+the property ignoreMagicNumbers is not taken into account, if there are multiple literals involved in such an expression.
         </description>
         <priority>3</priority>
         <properties>
             <property name="ignoreMagicNumbers"
                       description="Comma-separated list of magic numbers, that should be ignored"
                       type="String" value="-1,0"/>
+            <property name="ignoreExpressions"
+                      description="If true, only literals in simple if conditions are considered. Otherwise literals in expressions are checked, too."
+                      type="Boolean" value="true"/>
             <property name="xpath">
                 <value>
 <![CDATA[
-//IfStatement/Expression//*[local-name() != 'UnaryExpression' or @Operator != '-']/PrimaryExpression/PrimaryPrefix/Literal
+(: simple case - no deep expressions :)
+//IfStatement[$ignoreExpressions = true()]/Expression/*/PrimaryExpression/PrimaryPrefix/Literal
+    [not(NullLiteral)]
+    [not(BooleanLiteral)]
+    [empty(index-of(tokenize($ignoreMagicNumbers, '\s*,\s*'), @Image))]
+|
+(: consider also deeper expressions :)
+//IfStatement[$ignoreExpressions = false()]/Expression//*[local-name() != 'UnaryExpression' or @Operator != '-']/PrimaryExpression/PrimaryPrefix/Literal
     [not(NullLiteral)]
     [not(BooleanLiteral)]
     [empty(index-of(tokenize($ignoreMagicNumbers, '\s*,\s*'), @Image))]
 |
 (: consider negative literals :)
-//IfStatement/Expression//UnaryExpression[@Operator = '-']/PrimaryExpression/PrimaryPrefix/Literal
+//IfStatement[$ignoreExpressions = false()]/Expression//UnaryExpression[@Operator = '-']/PrimaryExpression/PrimaryPrefix/Literal
     [not(NullLiteral)]
     [not(BooleanLiteral)]
     [empty(index-of(tokenize($ignoreMagicNumbers, '\s*,\s*'), concat('-', @Image)))]
 |
 (: consider multiple literals in expressions :)
-//IfStatement/Expression[count(*/PrimaryExpression/PrimaryPrefix/Literal
+//IfStatement[$ignoreExpressions = false()]/Expression[count(*/PrimaryExpression/PrimaryPrefix/Literal
     [not(NullLiteral)]
     [not(BooleanLiteral)]) > 1]
 ]]>
@@ -509,6 +523,10 @@ public void checkRequests() {
 
     if (aDouble > 0.0) {}                  // magic number 0.0
     if (aDouble >= Double.MIN_VALUE) {}    // preferred approach
+
+    // with rule property "ignoreExpressions" set to "false"
+    if (i == pos + 5) {}  // violation: magic number 5 within an (additive) expression
+    if (i == pos + SUFFIX_LENGTH) {} // preferred approach
 }
 ]]>
         </example>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -470,18 +470,16 @@ More exceptions can be defined with the property "ignoreMagicNumbers".
             <property name="xpath">
                 <value>
 <![CDATA[
-//IfStatement[Expression//*[local-name() != 'UnaryExpression' or @Operator != '-']/PrimaryExpression/PrimaryPrefix/Literal
+//IfStatement/Expression//*[local-name() != 'UnaryExpression' or @Operator != '-']/PrimaryExpression/PrimaryPrefix/Literal
     [not(NullLiteral)]
     [not(BooleanLiteral)]
     [empty(index-of(tokenize($ignoreMagicNumbers, '\s*,\s*'), @Image))]
-]
 |
 (: consider negative literals :)
-//IfStatement[Expression//UnaryExpression[@Operator = '-']/PrimaryExpression/PrimaryPrefix/Literal
+//IfStatement/Expression//UnaryExpression[@Operator = '-']/PrimaryExpression/PrimaryPrefix/Literal
     [not(NullLiteral)]
     [not(BooleanLiteral)]
     [empty(index-of(tokenize($ignoreMagicNumbers, '\s*,\s*'), concat('-', @Image)))]
-]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -480,6 +480,11 @@ More exceptions can be defined with the property "ignoreMagicNumbers".
     [not(NullLiteral)]
     [not(BooleanLiteral)]
     [empty(index-of(tokenize($ignoreMagicNumbers, '\s*,\s*'), concat('-', @Image)))]
+|
+(: consider multiple literals in expressions :)
+//IfStatement/Expression[count(*/PrimaryExpression/PrimaryPrefix/Literal
+    [not(NullLiteral)]
+    [not(BooleanLiteral)]) > 1]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -470,10 +470,18 @@ More exceptions can be defined with the property "ignoreMagicNumbers".
             <property name="xpath">
                 <value>
 <![CDATA[
-//IfStatement/Expression/*/PrimaryExpression/PrimaryPrefix/Literal
-[not(NullLiteral)]
-[not(BooleanLiteral)]
-[empty(index-of(tokenize($ignoreMagicNumbers, '\s*,\s*'), @Image))]
+//IfStatement[Expression//*[local-name() != 'UnaryExpression' or @Operator != '-']/PrimaryExpression/PrimaryPrefix/Literal
+    [not(NullLiteral)]
+    [not(BooleanLiteral)]
+    [empty(index-of(tokenize($ignoreMagicNumbers, '\s*,\s*'), @Image))]
+]
+|
+(: consider negative literals :)
+//IfStatement[Expression//UnaryExpression[@Operator = '-']/PrimaryExpression/PrimaryPrefix/Literal
+    [not(NullLiteral)]
+    [not(BooleanLiteral)]
+    [empty(index-of(tokenize($ignoreMagicNumbers, '\s*,\s*'), concat('-', @Image)))]
+]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidLiteralsInIfCondition.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidLiteralsInIfCondition.xml
@@ -93,8 +93,8 @@ public class Foo {
 
   <test-code>
     <description>#2140 [java] AvoidLiteralsInIfCondition: false negative for expressions</description>
-    <expected-problems>3</expected-problems>
-    <expected-linenumbers>3,4,5</expected-linenumbers>
+    <expected-problems>4</expected-problems>
+    <expected-linenumbers>3,3,4,5</expected-linenumbers>
     <code><![CDATA[
 public class Foo {
     public void bar(int a) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidLiteralsInIfCondition.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidLiteralsInIfCondition.xml
@@ -25,8 +25,7 @@ public class PrimitiveType {
     if(i==PRIMITIVE_TYPE) {
     }
   }
-}
-    ]]></code>
+}    ]]></code>
   </test-code>
   <test-code>
     <description>allow null literal</description>
@@ -47,7 +46,7 @@ public class MyClass {
 public class Foo {
     public void bar() {
         if( ( flags & Flag.IMPORTANT ) != 0 ) {}
-        if (aString.indexOf('.') != -1) {}     // magic number -1, by default ignored
+        if (aString.indexOf(DOT) != -1) {}     // magic number -1, by default ignored
     }
 }
     ]]></code>
@@ -71,7 +70,7 @@ public class Foo {
     <code><![CDATA[
 public class Foo {
     public void bar() {
-        if (true && aDouble > 0.0) {
+        if (true && aDouble > 0) {
         }
     }
 }
@@ -92,4 +91,19 @@ public class Foo {
     ]]></code>
   </test-code>
 
+  <test-code>
+    <description>#2140 [java] AvoidLiteralsInIfCondition: false negative for expressions</description>
+    <expected-problems>3</expected-problems>
+    <expected-linenumbers>3,4,5</expected-linenumbers>
+    <code><![CDATA[
+public class Foo {
+    public void bar(int a) {
+        if (a > 3 + 5) {}
+        if (b == -5) {}
+        if (true && b == -5) {}
+        if (c == -1) {}
+    }
+}
+    ]]></code>
+  </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidLiteralsInIfCondition.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidLiteralsInIfCondition.xml
@@ -106,4 +106,23 @@ public class Foo {
 }
     ]]></code>
   </test-code>
+
+  <test-code>
+    <description>More tests with expressions (see #2150)</description>
+    <rule-property name="ignoreMagicNumbers">-1,0,1</rule-property>
+    <expected-problems>4</expected-problems>
+    <expected-linenumbers>4,7,7,8</expected-linenumbers>
+    <code><![CDATA[
+public class AvoidLiteralsInIfConditionWithExpressions {
+    public void test() {
+        if (1) {}    // ok, "1" is in ignoreMagicNumbers
+        if (1+1) {}  // not ok! multiple literals in expression
+        if (a+1) {}  // ok, single literal, whitelisted
+        if (bodyStart >= 0 && bodyStart != (currentToken.length() - 1)) {} // ok, single literal per expression, both whitelisted
+        if (1 * 5) {} // not ok - literal 5 and also a expression with two literals
+        if (a + 5) {} // not ok
+    }
+}
+    ]]></code>
+  </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidLiteralsInIfCondition.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidLiteralsInIfCondition.xml
@@ -93,6 +93,7 @@ public class Foo {
 
   <test-code>
     <description>#2140 [java] AvoidLiteralsInIfCondition: false negative for expressions</description>
+    <rule-property name="ignoreExpressions">false</rule-property>
     <expected-problems>4</expected-problems>
     <expected-linenumbers>3,3,4,5</expected-linenumbers>
     <code><![CDATA[
@@ -109,9 +110,10 @@ public class Foo {
 
   <test-code>
     <description>More tests with expressions (see #2150)</description>
+    <rule-property name="ignoreExpressions">false</rule-property>
     <rule-property name="ignoreMagicNumbers">-1,0,1</rule-property>
-    <expected-problems>4</expected-problems>
-    <expected-linenumbers>4,7,7,8</expected-linenumbers>
+    <expected-problems>8</expected-problems>
+    <expected-linenumbers>4,7,7,8,9,10,11,11</expected-linenumbers>
     <code><![CDATA[
 public class AvoidLiteralsInIfConditionWithExpressions {
     public void test() {
@@ -121,6 +123,9 @@ public class AvoidLiteralsInIfConditionWithExpressions {
         if (bodyStart >= 0 && bodyStart != (currentToken.length() - 1)) {} // ok, single literal per expression, both whitelisted
         if (1 * 5) {} // not ok - literal 5 and also a expression with two literals
         if (a + 5) {} // not ok
+        if (i == a + 5) {} // not ok - literal 5
+        if (i == 1 + 5) {} // not ok - expression with two literals
+        if (s.equals("Prefix" + "Suffix")) {}
     }
 }
     ]]></code>


### PR DESCRIPTION
Fixes #2140 

This also contains a fix in the Saxon XPath integration in PMD: When using the union operator, we sometimes threw some nodes of the result away...

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)
