### PR TITLE
[java] Deprecate abstract java parser, internalize some other APIs

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -18,6 +18,22 @@ This is a {{ site.pmd.release_type }} release.
 
 ### API Changes
 
+
+#### Deprecated APIs
+
+##### Internal API
+
+* {% jdoc java::lang.java.JavaLanguageHandler %}
+* {% jdoc java::lang.java.JavaLanguageParser %}
+* {% jdoc java::lang.java.JavaDataFlowHandler %}
+
+
+##### For removal
+
+* {% jdoc java::lang.java.AbstractJavaParser %}
+* {% jdoc java::lang.java.AbstractJavaHandler %}
+
+
 ### External Contributions
 
 {% endtocmaker %}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/AbstractJavaHandler.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/AbstractJavaHandler.java
@@ -49,7 +49,10 @@ import net.sf.saxon.sxpath.IndependentContext;
  * classes as adapters of the visitors to the VisitorStarter interface.
  *
  * @author pieter_van_raemdonck - Application Engineers NV/SA - www.ae.be
+ *
+ * @deprecated For removal, the abstraction is not useful.
  */
+@Deprecated
 public abstract class AbstractJavaHandler extends AbstractLanguageVersionHandler {
 
     private final LanguageMetricsProvider<ASTAnyTypeDeclaration, MethodLikeNode> myMetricsProvider = new JavaMetricsProvider();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/AbstractJavaParser.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/AbstractJavaParser.java
@@ -23,7 +23,10 @@ import net.sourceforge.pmd.lang.java.ast.ParseException;
  *
  * @see AbstractParser
  * @see JavaParser
+ *
+ * @deprecated For removal, the abstraction is not useful.
  */
+@Deprecated
 public abstract class AbstractJavaParser extends AbstractParser {
     private JavaParser parser;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/JavaDataFlowHandler.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/JavaDataFlowHandler.java
@@ -6,12 +6,18 @@ package net.sourceforge.pmd.lang.java;
 
 import java.util.List;
 
+import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.DataFlowHandler;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.dfa.DataFlowNode;
 import net.sourceforge.pmd.lang.java.ast.ASTLabeledStatement;
 import net.sourceforge.pmd.lang.java.dfa.JavaDataFlowNode;
 
+/**
+ * @deprecated Is internal API.
+ */
+@InternalApi
+@Deprecated
 public class JavaDataFlowHandler implements DataFlowHandler {
     @Override
     public DataFlowNode createDataFlowNode(List<DataFlowNode> dataFlow, Node node) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/JavaLanguageHandler.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/JavaLanguageHandler.java
@@ -4,9 +4,16 @@
 
 package net.sourceforge.pmd.lang.java;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.lang.Parser;
 import net.sourceforge.pmd.lang.ParserOptions;
 
+/**
+ * @deprecated This is internal API, use {@link LanguageVersion#getLanguageVersionHandler()}.
+ */
+@Deprecated
+@InternalApi
 public class JavaLanguageHandler extends AbstractJavaHandler {
     private final int jdkVersion;
     private final boolean preview;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/JavaLanguageParser.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/JavaLanguageParser.java
@@ -6,6 +6,8 @@ package net.sourceforge.pmd.lang.java;
 
 import java.io.Reader;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+import net.sourceforge.pmd.lang.LanguageVersionHandler;
 import net.sourceforge.pmd.lang.ParserOptions;
 import net.sourceforge.pmd.lang.java.ast.JavaParser;
 import net.sourceforge.pmd.lang.java.ast.ParseException;
@@ -15,7 +17,11 @@ import net.sourceforge.pmd.lang.java.ast.ParseException;
  *
  * @author Pieter_Van_Raemdonck - Application Engineers NV/SA - www.ae.be
  * @author Andreas Dangel
+ *
+ * @deprecated This is internal API, use {@link LanguageVersionHandler#getParser(ParserOptions)}.
  */
+@InternalApi
+@Deprecated
 public class JavaLanguageParser extends AbstractJavaParser {
     private final int jdkVersion;
     private final boolean preview;


### PR DESCRIPTION
The deprecations listed on #2120. 

In the end I think this should be done for all language modules, though this PR only implements it for Java