### PR TITLE
[java] Deprecate JavaQualifiedName and a few other things

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -42,6 +42,17 @@ This is a {{ site.pmd.release_type }} release.
 
 * {% jdoc java::lang.java.AbstractJavaParser %}
 * {% jdoc java::lang.java.AbstractJavaHandler %}
+* {% jdoc java::lang.java.ast.ASTAnyTypeDeclaration.TypeKind %}
+* {% jdoc java::lang.java.ast.ASTAnyTypeDeclaration#getKind() %}
+* {% jdoc java::lang.java.ast.JavaQualifiedName %}
+* {% jdoc java::lang.java.ast.ASTCompilationUnit#declarationsAreInDefaultPackage() %}
+* {% jdoc java::lang.java.ast.JavaQualifiableNode %}
+  * {% jdoc java::lang.java.ast.ASTAnyTypeDeclaration#getQualifiedName() %}
+  * {% jdoc java::lang.java.ast.ASTMethodOrConstructorDeclaration#getQualifiedName() %}
+  * {% jdoc java::lang.java.ast.ASTLambdaExpression#getQualifiedName() %}
+* {% jdoc_package java::lang.java.qname %} and its contents
+* {% jdoc java::lang.java.ast.ASTMethodLikeNode %}
+  * Its methods will also be removed from its implementations, {% jdoc java::lang.java.ast.ASTMethodOrConstructorDeclaration %}, {% jdoc java::lang.java.ast.ASTLambdaExpression %}.
 
 
 ### External Contributions

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnyTypeBodyDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnyTypeBodyDeclaration.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration.TypeKind;
+
 /**
  * Marker interface for type body declarations, such as annotation members, field or method declarations.
  *
@@ -22,6 +24,7 @@ public interface ASTAnyTypeBodyDeclaration extends JavaNode {
      */
     JavaNode getDeclarationNode();
 
+
     /**
      * Gets the kind of declaration this node contains.
      * This is a cue for the node type the child of this
@@ -29,7 +32,12 @@ public interface ASTAnyTypeBodyDeclaration extends JavaNode {
      */
     DeclarationKind getKind();
 
-    /** Kind of declaration. */
+
+    /**
+     * Kind of declaration. This is not deprecated because the node will
+     * go away entirely in 7.0.0 and one cannot avoid using it on master.
+     * See {@link TypeKind} for the reasons for deprecation.
+     */
     enum DeclarationKind {
         /** See {@link ASTInitializer}. */
         INITIALIZER,

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnyTypeDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnyTypeDeclaration.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.java.ast;
 import java.util.List;
 import java.util.Locale;
 
+import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.lang.java.qname.JavaTypeQualifiedName;
 
 
@@ -18,10 +19,39 @@ import net.sourceforge.pmd.lang.java.qname.JavaTypeQualifiedName;
 public interface ASTAnyTypeDeclaration extends TypeNode, JavaQualifiableNode, AccessNode, JavaNode {
 
     /**
+     * Returns the simple name of this type declaration. Returns null
+     * if this is an anonymous class declaration.
+     */
+    // note that anonymous class declarations won't extend ASTAnyTypeDeclaration
+    // until PMD 7.0.0 so this is @NonNull until then
+    // @Nullable
+    String getSimpleName();
+
+
+    /**
+     * @deprecated Use {@link #getSimpleName()}
+     */
+    @Deprecated
+    @Override
+    String getImage();
+
+
+    /**
+     * Returns the binary name of this type declaration. This
+     * is like {@link Class#getName()}.
+     */
+    // @NotNull
+    String getBinaryName();
+
+
+    /**
      * Finds the type kind of this declaration.
      *
      * @return The type kind of this declaration.
+     *
+     * @deprecated See {@link TypeKind}
      */
+    @Deprecated
     TypeKind getTypeKind();
 
 
@@ -33,8 +63,11 @@ public interface ASTAnyTypeDeclaration extends TypeNode, JavaQualifiableNode, Ac
     List<ASTAnyTypeBodyDeclaration> getDeclarations();
 
 
-
+    /**
+     * @deprecated Use {@link #getBinaryName()}
+     */
     @Override
+    @Deprecated
     JavaTypeQualifiedName getQualifiedName();
 
 
@@ -43,9 +76,30 @@ public interface ASTAnyTypeDeclaration extends TypeNode, JavaQualifiableNode, Ac
      */
     boolean isNested();
 
+
     /**
      * The kind of type this node declares.
+     *
+     * @deprecated This is not useful, not adapted to the problem, and
+     *     does not scale to changes in the Java language. The only use
+     *     of this is to get a name, this can be replaced with {@link PrettyPrintingUtil}.
+     *
+     *     <p>Besides, the real problem is that
+     *     <ul>
+     *         <li>enums are also classes
+     *         <li>annotations are also interfaces
+     *         <li>there are also anonymous classes in PMD 7.0, so this
+     *         cannot even be used to downcast safely
+     *     </ul>
+     *     We can also expect new kinds of type declarations (eg records)
+     *     in the future, which will force us to add new constants and aggravates
+     *     the problem.
+     *
+     *     Ultimately, dividing "kinds" with an enum is not adapted.
+     *
+     *     Same problem with {@link ASTAnyTypeBodyDeclaration.DeclarationKind}
      */
+    @Deprecated
     enum TypeKind {
         CLASS, INTERFACE, ENUM, ANNOTATION;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCompilationUnit.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCompilationUnit.java
@@ -44,6 +44,10 @@ public class ASTCompilationUnit extends AbstractJavaTypeNode implements RootNode
         return visitor.visit(this, data);
     }
 
+    /**
+     * @deprecated Use {@code getPackageName().isEmpty()}
+     */
+    @Deprecated
     public boolean declarationsAreInDefaultPackage() {
         return getPackageDeclaration() == null;
     }
@@ -54,6 +58,16 @@ public class ASTCompilationUnit extends AbstractJavaTypeNode implements RootNode
             return n instanceof ASTPackageDeclaration ? (ASTPackageDeclaration) n : null;
         }
         return null;
+    }
+
+    /**
+     * Returns the package name of this compilation unit. If this is in
+     * the default package, returns the empty string.
+     */
+    // @NonNull
+    public String getPackageName() {
+        ASTPackageDeclaration pdecl = getPackageDeclaration();
+        return pdecl == null ? "" : pdecl.getPackageNameImage();
     }
 
     @InternalApi

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractAnyTypeDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractAnyTypeDeclaration.java
@@ -36,6 +36,21 @@ public abstract class AbstractAnyTypeDeclaration extends AbstractJavaAccessTypeN
             || jjtGetParent() instanceof ASTAnnotationTypeMemberDeclaration;
     }
 
+    @Override
+    @Deprecated
+    public String getImage() {
+        return super.getImage();
+    }
+
+    @Override
+    public String getBinaryName() {
+        return getQualifiedName().getBinaryName();
+    }
+
+    @Override
+    public String getSimpleName() {
+        return getImage();
+    }
 
     /**
      * Returns true if the enclosing type of this type declaration

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractMethodLikeNode.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractMethodLikeNode.java
@@ -32,6 +32,7 @@ public abstract class AbstractMethodLikeNode extends AbstractJavaAccessNode impl
 
 
     @Override
+    @Deprecated
     public JavaOperationQualifiedName getQualifiedName() {
         return qualifiedName;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaQualifiableNode.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaQualifiableNode.java
@@ -11,7 +11,10 @@ import net.sourceforge.pmd.lang.ast.QualifiableNode;
  * Java nodes that can be described with a qualified name.
  *
  * @author Clément Fournier
+ *
+ * @deprecated See {@link JavaQualifiedName}
  */
+@Deprecated
 public interface JavaQualifiableNode extends QualifiableNode {
 
     /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaQualifiedName.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaQualifiedName.java
@@ -31,7 +31,21 @@ import net.sourceforge.pmd.lang.java.qname.QualifiedNameFactory;
  *
  * @since 5.8.1
  * @author Clément Fournier
+ *
+ * @deprecated This class and subclasses will be removed in PMD 7.0 for
+ *             lack of usefulness. JavaQualifiedName cannot be used to
+ *             represent unknown entities, because in Java source, the
+ *             only thing we can observe are *canonical* names, which
+ *             eg don't exist for local classes, and can be ambiguous
+ *             between a member class and a package name.
+ *
+ *             <p>So you can't build a conformant JavaQualifiedName without
+ *             having parsed the source file where the entity is. But since
+ *             you have parsed the file, you have much better data structures
+ *             than JavaQualifiedName to reflect the content of the program:
+ *             you have nodes. So we can do away with this class.
  */
+@Deprecated
 public abstract class JavaQualifiedName implements QualifiedName {
 
     // toString cache

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/MethodLikeNode.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/MethodLikeNode.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.java.ast;
 
 import java.util.Locale;
 
+import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration.TypeKind;
 import net.sourceforge.pmd.lang.java.qname.JavaOperationQualifiedName;
 
 
@@ -14,7 +15,12 @@ import net.sourceforge.pmd.lang.java.qname.JavaOperationQualifiedName;
  *
  * @author Clément Fournier
  * @since 6.1.0
+ * @deprecated Lambda expressions should not be grouped with other kinds
+ *     of method declarations, they have nothing in common. Giving them a
+ *     qualified name is hacky and compiler-implementation-dependent.
+ *     Ultimately this supertype is not useful and can go away.
  */
+@Deprecated
 public interface MethodLikeNode extends AccessNode, JavaQualifiableNode, JavaNode {
 
     /**
@@ -24,15 +30,27 @@ public interface MethodLikeNode extends AccessNode, JavaQualifiableNode, JavaNod
      * implementing class.
      *
      * @return The kind of method-like
+     * @deprecated Same reason as for {@link TypeKind}
      */
+    @Deprecated
     MethodLikeKind getKind();
 
 
+    /**
+     * @deprecated Qualified names are not very useful objects. Use them
+     *     to get a nice string for a method, but this is not going
+     */
     @Override
+    @Deprecated
     JavaOperationQualifiedName getQualifiedName();
 
 
-    /** Kind of method-like. */
+    /**
+     * Kind of method-like.
+     *
+     * @deprecated Same reason as for {@link TypeKind}
+     */
+    @Deprecated
     enum MethodLikeKind {
         METHOD,
         CONSTRUCTOR,

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/PrettyPrintingUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/PrettyPrintingUtil.java
@@ -1,0 +1,77 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.ast.internal;
+
+import net.sourceforge.pmd.lang.java.ast.ASTAnnotationTypeDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTEnumDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
+import net.sourceforge.pmd.lang.java.ast.ASTFormalParameters;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodOrConstructorDeclaration;
+
+/**
+ * @author Clément Fournier
+ */
+public final class PrettyPrintingUtil {
+
+    private PrettyPrintingUtil() {
+        // util class
+    }
+
+    /**
+     * Returns a normalized method name. This just looks at the image of the types of the parameters.
+     */
+    public static String displaySignature(String methodName, ASTFormalParameters params) {
+
+        StringBuilder sb = new StringBuilder();
+        sb.append(methodName);
+        sb.append('(');
+
+        boolean first = true;
+        for (ASTFormalParameter param : params) {
+            if (!first) {
+                sb.append(", ");
+            }
+            first = false;
+
+            sb.append(param.getTypeNode().getTypeImage());
+            if (param.isVarargs()) {
+                sb.append("...");
+            }
+        }
+
+        sb.append(')');
+
+        return sb.toString();
+    }
+
+    /**
+     * Returns a normalized method name. This just looks at the image of the types of the parameters.
+     */
+    public static String displaySignature(ASTMethodOrConstructorDeclaration node) {
+        ASTFormalParameters params = node.getFirstDescendantOfType(ASTFormalParameters.class);
+        String name = node instanceof ASTMethodDeclaration ? ((ASTMethodDeclaration) node).getName() : node.getImage();
+
+        return displaySignature(name, params);
+    }
+
+    /**
+     * Returns the generic kind of declaration this is, eg "enum" or "class".
+     */
+    public static String kindName(ASTAnyTypeDeclaration decl) {
+        if (decl instanceof ASTClassOrInterfaceDeclaration
+            && ((ASTClassOrInterfaceDeclaration) decl).isInterface()) {
+            return "interface";
+        } else if (decl instanceof ASTAnnotationTypeDeclaration) {
+            return "annotation";
+        } else if (decl instanceof ASTEnumDeclaration) {
+            return "enum";
+        }
+        return "class";
+    }
+
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/qname/JavaOperationQualifiedName.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/qname/JavaOperationQualifiedName.java
@@ -14,7 +14,10 @@ import net.sourceforge.pmd.lang.java.ast.JavaQualifiedName;
  *
  * @author Clément Fournier
  * @since 6.1.0
+ *
+ * @deprecated See {@link JavaQualifiedName}
  */
+@Deprecated
 public final class JavaOperationQualifiedName extends JavaQualifiedName {
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/qname/JavaTypeQualifiedName.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/qname/JavaTypeQualifiedName.java
@@ -18,7 +18,10 @@ import net.sourceforge.pmd.lang.java.ast.JavaQualifiedName;
  *
  * @author Clément Fournier
  * @since 6.1.0
+ *
+ * @deprecated See {@link JavaQualifiedName}
  */
+@Deprecated
 public final class JavaTypeQualifiedName extends JavaQualifiedName {
 
     /** Local index value for when the class is not local. */

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/qname/QualifiedNameFactory.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/qname/QualifiedNameFactory.java
@@ -20,7 +20,10 @@ import net.sourceforge.pmd.lang.java.qname.ImmutableList.ListFactory;
  *
  * @author Clément Fournier
  * @since 6.1.0
+ *
+ * @deprecated Was internal API, will be removed. See {@link JavaQualifiedName}.
  */
+@Deprecated
 public final class QualifiedNameFactory {
 
     /** Operation part of a lambda. */

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/qname/QualifiedNameResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/qname/QualifiedNameResolver.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.lang3.mutable.MutableInt;
 
+import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTAllocationExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
@@ -21,7 +22,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTEnumConstant;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTFormalParameters;
 import net.sourceforge.pmd.lang.java.ast.ASTInitializer;
 import net.sourceforge.pmd.lang.java.ast.ASTLambdaExpression;
@@ -31,6 +31,7 @@ import net.sourceforge.pmd.lang.java.ast.AbstractAnyTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.JavaParserVisitorReducedAdapter;
 import net.sourceforge.pmd.lang.java.ast.JavaQualifiableNode;
 import net.sourceforge.pmd.lang.java.ast.MethodLikeNode;
+import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.lang.java.qname.ImmutableList.ListFactory;
 import net.sourceforge.pmd.lang.java.typeresolution.PMDASMClassLoader;
 
@@ -40,7 +41,10 @@ import net.sourceforge.pmd.lang.java.typeresolution.PMDASMClassLoader;
  *
  * @author Clément Fournier
  * @since 6.1.0
+ * @deprecated Is internal API
  */
+@Deprecated
+@InternalApi
 public class QualifiedNameResolver extends JavaParserVisitorReducedAdapter {
 
     // Package names to package representation.
@@ -109,9 +113,10 @@ public class QualifiedNameResolver extends JavaParserVisitorReducedAdapter {
 
     /**
      * Initialises the visitor and starts it.
+     *
      * @param classLoader The classloader that will be used by type qualified names
      *                    to load their type.
-     * @param rootNode The root hierarchy
+     * @param rootNode    The root hierarchy
      */
     public void initializeWith(ClassLoader classLoader, ASTCompilationUnit rootNode) {
         this.classLoader = PMDASMClassLoader.getInstance(classLoader);
@@ -204,10 +209,10 @@ public class QualifiedNameResolver extends JavaParserVisitorReducedAdapter {
         if (node instanceof ASTClassOrInterfaceDeclaration
                 && ((ASTClassOrInterfaceDeclaration) node).isLocal()) {
 
-            localIndex = getNextIndexFromHistogram(currentLocalIndices.peek(), node.getImage(), 1);
+            localIndex = getNextIndexFromHistogram(currentLocalIndices.peek(), node.getSimpleName(), 1);
         }
 
-        updateClassContext(node.getImage(), localIndex);
+        updateClassContext(node.getSimpleName(), localIndex);
 
         ((AbstractAnyTypeDeclaration) node).setQualifiedName(contextClassQName());
 
@@ -409,27 +414,7 @@ public class QualifiedNameResolver extends JavaParserVisitorReducedAdapter {
 
     /** Returns a normalized method name (not Java-canonical!). */
     private static String getOperationName(String methodName, ASTFormalParameters params) {
-
-        StringBuilder sb = new StringBuilder();
-        sb.append(methodName);
-        sb.append('(');
-
-        boolean first = true;
-        for (ASTFormalParameter param : params) {
-            if (!first) {
-                sb.append(", ");
-            }
-            first = false;
-
-            sb.append(param.getTypeNode().getTypeImage());
-            if (param.isVarargs()) {
-                sb.append("...");
-            }
-        }
-
-        sb.append(')');
-
-        return sb.toString();
+        return PrettyPrintingUtil.displaySignature(methodName, params);
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
@@ -26,6 +26,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTEnumDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTFormalParameters;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
+import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
 
@@ -222,7 +223,7 @@ public class MissingOverrideRule extends AbstractJavaRule {
         try {
             boolean overridden = currentLookup.peek().isOverridden(node.getName(), node.getFormalParameters());
             if (overridden) {
-                addViolation(data, node, new Object[]{node.getQualifiedName().getOperation()});
+                addViolation(data, node, new Object[]{PrettyPrintingUtil.displaySignature(node)});
             }
         } catch (NoSuchMethodException e) {
             // may happen in the body of an enum constant,

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ClassNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ClassNamingConventionsRule.java
@@ -16,6 +16,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTEnumDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTInitializer;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.AccessNode;
+import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 
 
@@ -147,6 +148,6 @@ public class ClassNamingConventionsRule extends AbstractNamingConventionRule<AST
 
     @Override
     String kindDisplayName(ASTAnyTypeDeclaration node, PropertyDescriptor<Pattern> descriptor) {
-        return isUtilityClass(node) ? "utility class" : node.getTypeKind().getPrintableName();
+        return isUtilityClass(node) ? "utility class" : PrettyPrintingUtil.kindName(node);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryModifierRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryModifierRule.java
@@ -26,7 +26,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodOrConstructorDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTResource;
 import net.sourceforge.pmd.lang.java.ast.AccessNode;
-import net.sourceforge.pmd.lang.java.ast.MethodLikeNode;
+import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
 
@@ -72,7 +72,7 @@ public class UnnecessaryModifierRule extends AbstractJavaRule {
             return ((ASTMethodDeclaration) node).getName();
         } else if (node instanceof ASTMethodOrConstructorDeclaration) {
             // constructors are differentiated by their parameters, while we only use method name for methods
-            return ((ASTConstructorDeclaration) node).getQualifiedName().getOperation();
+            return PrettyPrintingUtil.displaySignature((ASTConstructorDeclaration) node);
         } else if (node instanceof ASTFieldDeclaration) {
             return ((ASTFieldDeclaration) node).getVariableName();
         } else if (node instanceof ASTResource) {
@@ -86,9 +86,11 @@ public class UnnecessaryModifierRule extends AbstractJavaRule {
     // TODO same here
     private String getPrintableNodeKind(Node node) {
         if (node instanceof ASTAnyTypeDeclaration) {
-            return ((ASTAnyTypeDeclaration) node).getTypeKind().getPrintableName();
-        } else if (node instanceof MethodLikeNode) {
-            return ((MethodLikeNode) node).getKind().getPrintableName();
+            return PrettyPrintingUtil.kindName((ASTAnyTypeDeclaration) node);
+        } else if (node instanceof ASTMethodDeclaration || node instanceof ASTAnnotationMethodDeclaration) {
+            return "method";
+        } else if (node instanceof ASTConstructorDeclaration) {
+            return "constructor";
         } else if (node instanceof ASTFieldDeclaration) {
             return "field";
         } else if (node instanceof ASTResource) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CyclomaticComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CyclomaticComplexityRule.java
@@ -14,6 +14,7 @@ import java.util.logging.Logger;
 import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.MethodLikeNode;
+import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.lang.java.metrics.JavaMetrics;
 import net.sourceforge.pmd.lang.java.metrics.api.JavaClassMetricKey;
 import net.sourceforge.pmd.lang.java.metrics.api.JavaOperationMetricKey;
@@ -34,7 +35,7 @@ import net.sourceforge.pmd.properties.PropertyFactory;
  * @version 6.0.0
  */
 public class CyclomaticComplexityRule extends AbstractJavaMetricsRule {
-    
+
     private static final Logger LOG = Logger.getLogger(CyclomaticComplexityRule.class.getName());
 
     // Deprecated, kept for backwards compatibility (6.0.0)
@@ -56,7 +57,7 @@ public class CyclomaticComplexityRule extends AbstractJavaMetricsRule {
                          .require(positive()).defaultValue(10).build();
 
     private static final Map<String, CycloOption> OPTION_MAP;
-    
+
     static {
         OPTION_MAP = new HashMap<>();
         OPTION_MAP.put(CycloOption.IGNORE_BOOLEAN_PATHS.valueName(), CycloOption.IGNORE_BOOLEAN_PATHS);
@@ -86,17 +87,17 @@ public class CyclomaticComplexityRule extends AbstractJavaMetricsRule {
         int methodLevel = getProperty(METHOD_LEVEL_DESCRIPTOR);
         int classLevel = getProperty(CLASS_LEVEL_DESCRIPTOR);
         int commonLevel = getProperty(REPORT_LEVEL_DESCRIPTOR);
-        
+
         if (methodLevel == METHOD_LEVEL_DESCRIPTOR.defaultValue()
             && classLevel == CLASS_LEVEL_DESCRIPTOR.defaultValue()
             && commonLevel != REPORT_LEVEL_DESCRIPTOR.defaultValue()) {
-            LOG.warning("Rule CyclomaticComplexity uses deprecated property 'reportLevel'. " 
-                        + "Future versions of PMD will remove support for this property. " 
+            LOG.warning("Rule CyclomaticComplexity uses deprecated property 'reportLevel'. "
+                        + "Future versions of PMD will remove support for this property. "
                         + "Please use 'methodReportLevel' and 'classReportLevel' instead!");
             methodLevel = commonLevel;
             classLevel = commonLevel * 8;
         }
-        
+
         methodReportLevel = methodLevel;
         classReportLevel = classLevel;
     }
@@ -106,7 +107,7 @@ public class CyclomaticComplexityRule extends AbstractJavaMetricsRule {
         // methodReportLevel = getProperty(METHOD_LEVEL_DESCRIPTOR);
         // classReportLevel = getProperty(CLASS_LEVEL_DESCRIPTOR);
         assignReportLevelsCompat();
-        
+
         cycloOptions = MetricOptions.ofOptions(getProperty(CYCLO_OPTIONS_DESCRIPTOR));
 
 
@@ -126,10 +127,10 @@ public class CyclomaticComplexityRule extends AbstractJavaMetricsRule {
             if (classWmc >= classReportLevel) {
                 int classHighest = (int) JavaMetrics.get(JavaOperationMetricKey.CYCLO, node, cycloOptions, ResultOption.HIGHEST);
 
-                String[] messageParams = {node.getTypeKind().getPrintableName(),
-                                          node.getImage(),
+                String[] messageParams = {PrettyPrintingUtil.kindName(node),
+                                          node.getSimpleName(),
                                           " total",
-                                          classWmc + " (highest " + classHighest + ")", };
+                                          classWmc + " (highest " + classHighest + ")",};
 
                 addViolation(data, node, messageParams);
             }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CyclomaticComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CyclomaticComplexityRule.java
@@ -13,6 +13,8 @@ import java.util.logging.Logger;
 
 import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodOrConstructorDeclaration;
 import net.sourceforge.pmd.lang.java.ast.MethodLikeNode;
 import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.lang.java.metrics.JavaMetrics;
@@ -130,7 +132,7 @@ public class CyclomaticComplexityRule extends AbstractJavaMetricsRule {
                 String[] messageParams = {PrettyPrintingUtil.kindName(node),
                                           node.getSimpleName(),
                                           " total",
-                                          classWmc + " (highest " + classHighest + ")",};
+                                          classWmc + " (highest " + classHighest + ")", };
 
                 addViolation(data, node, messageParams);
             }
@@ -145,10 +147,20 @@ public class CyclomaticComplexityRule extends AbstractJavaMetricsRule {
         int cyclo = (int) JavaMetrics.get(JavaOperationMetricKey.CYCLO, node, cycloOptions);
         if (cyclo >= methodReportLevel) {
 
-            addViolation(data, node, new String[]{node.getKind().getPrintableName(),
-                                                  node.getQualifiedName().getOperation(),
-                                                  "",
-                                                  "" + cyclo, });
+
+            String opname = node instanceof ASTMethodOrConstructorDeclaration
+                            ? PrettyPrintingUtil.displaySignature((ASTMethodOrConstructorDeclaration) node)
+                            : "lambda";
+
+            String kindname = node instanceof ASTMethodOrConstructorDeclaration
+                              ? node instanceof ASTConstructorDeclaration ? "constructor" : "method"
+                              : "lambda";
+
+
+            addViolation(data, node, new String[] {kindname,
+                                                   opname,
+                                                   "",
+                                                   "" + cyclo, });
         }
 
         return data;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/DataClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/DataClassRule.java
@@ -35,7 +35,7 @@ public class DataClassRule extends AbstractJavaMetricsRule {
             int noam = (int) JavaMetrics.get(JavaClassMetricKey.NOAM, node);
             int wmc = (int) JavaMetrics.get(JavaClassMetricKey.WMC, node);
 
-            addViolation(data, node, new Object[] {node.getImage(),
+            addViolation(data, node, new Object[] {node.getSimpleName(),
                                                    StringUtil.percentageString(woc, 3),
                                                    nopa, noam, wmc, });
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NPathComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NPathComplexityRule.java
@@ -12,6 +12,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodOrConstructorDeclaration;
 import net.sourceforge.pmd.lang.java.ast.MethodLikeNode;
+import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.lang.java.metrics.JavaMetrics;
 import net.sourceforge.pmd.lang.java.metrics.api.JavaOperationMetricKey;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaMetricsRule;
@@ -74,7 +75,7 @@ public class NPathComplexityRule extends AbstractJavaMetricsRule {
         int npath = (int) JavaMetrics.get(JavaOperationMetricKey.NPATH, (MethodLikeNode) node);
         if (npath >= reportLevel) {
             addViolation(data, node, new String[]{node instanceof ASTMethodDeclaration ? "method" : "constructor",
-                                                  node.getQualifiedName().getOperation(), "" + npath, });
+                                                  PrettyPrintingUtil.displaySignature(node), "" + npath,});
         }
 
         return data;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NPathComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NPathComplexityRule.java
@@ -75,7 +75,7 @@ public class NPathComplexityRule extends AbstractJavaMetricsRule {
         int npath = (int) JavaMetrics.get(JavaOperationMetricKey.NPATH, (MethodLikeNode) node);
         if (npath >= reportLevel) {
             addViolation(data, node, new String[]{node instanceof ASTMethodDeclaration ? "method" : "constructor",
-                                                  PrettyPrintingUtil.displaySignature(node), "" + npath,});
+                                                  PrettyPrintingUtil.displaySignature(node), "" + npath, });
         }
 
         return data;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NcssCountRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NcssCountRule.java
@@ -15,6 +15,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodOrConstructorDeclaration;
+import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.lang.java.metrics.JavaMetrics;
 import net.sourceforge.pmd.lang.java.metrics.api.JavaClassMetricKey;
 import net.sourceforge.pmd.lang.java.metrics.api.JavaOperationMetricKey;
@@ -114,7 +115,7 @@ public final class NcssCountRule extends AbstractJavaMetricsRule {
         int methodSize = (int) JavaMetrics.get(JavaOperationMetricKey.NCSS, node, ncssOptions);
         if (methodSize >= methodReportLevel) {
             addViolation(data, node, new String[] {node instanceof ASTMethodDeclaration ? "method" : "constructor",
-                                                   node.getQualifiedName().getOperation(), "" + methodSize, });
+                                                   PrettyPrintingUtil.displaySignature(node), "" + methodSize, });
         }
 
         return data;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
@@ -43,7 +43,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTTryStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableInitializer;
-import net.sourceforge.pmd.lang.java.ast.MethodLikeNode.MethodLikeKind;
 import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
@@ -209,9 +208,9 @@ public class CloseResourceRule extends AbstractJavaRule {
         ASTName name = initializer.getFirstDescendantOfType(ASTName.class);
         if (name != null) {
             ASTFormalParameters formalParameters = null;
-            if (methodOrCstor.getKind() == MethodLikeKind.METHOD) {
+            if (methodOrCstor instanceof ASTMethodDeclaration) {
                 formalParameters = ((ASTMethodDeclaration) methodOrCstor).getFormalParameters();
-            } else if (methodOrCstor.getKind() == MethodLikeKind.CONSTRUCTOR) {
+            } else if (methodOrCstor instanceof ASTConstructorDeclaration) {
                 formalParameters = ((ASTConstructorDeclaration) methodOrCstor).getFormalParameters();
             }
             if (formalParameters != null) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -1556,11 +1556,11 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
         }
 
 
-        if (node.declarationsAreInDefaultPackage()) {
-            return classDecl.getImage();
+        if (node.getPackageName().isEmpty()) {
+            return classDecl.getSimpleName();
         }
-        importedOnDemand.add(node.getPackageDeclaration().getPackageNameImage());
-        return classDecl.getQualifiedName().toString();
+        importedOnDemand.add(node.getPackageName());
+        return classDecl.getBinaryName();
     }
 
     /**

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -720,7 +720,7 @@ In JUnit 5, one of the following annotations should be used for tests: @Test, @R
                 <value>
 <![CDATA[
 //ClassOrInterfaceDeclaration[
-       matches(@Image, $testClassPattern)
+       matches(@SimpleName, $testClassPattern)
         or ExtendsList/ClassOrInterfaceType[pmd-java:typeIs('junit.framework.TestCase')]]
 
     /ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration[MethodDeclaration[@Public=true() and starts-with(@Name, 'test')]]

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -29,12 +29,12 @@ by {% rule java/codestyle/ClassNamingConventions %}.
 <![CDATA[
 //ClassOrInterfaceDeclaration
  [@Abstract='true' and @Interface='false']
- [not (starts-with(@Image,'Abstract'))]
+ [not (starts-with(@SimpleName,'Abstract'))]
 |
 //ClassOrInterfaceDeclaration
  [@Abstract='false']
  [$strict='true']
- [starts-with(@Image, 'Abstract')]
+ [starts-with(@SimpleName, 'Abstract')]
 ]]>
                 </value>
             </property>
@@ -161,7 +161,7 @@ by the more general rule {% rule java/codestyle/FormalParameterNamingConventions
                 <value>
 <![CDATA[
 //MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter/VariableDeclaratorId[
-        pmd:matches(@Image,'^in[A-Z].*','^out[A-Z].*','^in$','^out$')
+        pmd:matches(@VariableName,'^in[A-Z].*','^out[A-Z].*','^in$','^out$')
 ]
 ]]>
                 </value>
@@ -1092,7 +1092,7 @@ The Local Home interface of a Session EJB should be suffixed by 'LocalHome'.
     and
     not
     (
-        ends-with(@Image,'LocalHome')
+        ends-with(@SimpleName,'LocalHome')
     )
 ]
 ]]>
@@ -1130,7 +1130,7 @@ The Local Interface of a Session EJB should be suffixed by 'Local'.
     and
     not
     (
-        ends-with(@Image,'Local')
+        ends-with(@SimpleName,'Local')
     )
 ]
 ]]>
@@ -1261,7 +1261,7 @@ The EJB Specification states that any MessageDrivenBean or SessionBean should be
     and
     not
     (
-        ends-with(@Image,'Bean')
+        ends-with(@SimpleName,'Bean')
     )
 ]
 ]]>
@@ -1541,11 +1541,11 @@ Remote Interface of a Session EJB should not have a suffix.
     )
     and
     (
-        ends-with(@Image,'Session')
+        ends-with(@SimpleName,'Session')
         or
-        ends-with(@Image,'EJB')
+        ends-with(@SimpleName,'EJB')
         or
-        ends-with(@Image,'Bean')
+        ends-with(@SimpleName,'Bean')
     )
 ]
 ]]>
@@ -1588,7 +1588,7 @@ A Remote Home interface type of a Session EJB should be suffixed by 'Home'.
     and
     not
     (
-        ends-with(@Image,'Home')
+        ends-with(@SimpleName,'Home')
     )
 ]
 ]]>
@@ -1619,7 +1619,7 @@ Short Classnames with fewer than e.g. five characters are not recommended.
             <property name="xpath">
                 <value>
 <![CDATA[
-//ClassOrInterfaceDeclaration[string-length(@Image) < $minimum]
+//ClassOrInterfaceDeclaration[string-length(@SimpleName) < $minimum]
 ]]>
                 </value>
             </property>
@@ -2096,7 +2096,7 @@ public class Foo {
 [PrimarySuffix[@Arguments='false' and @ArrayDereference = 'false']]
 [not(PrimarySuffix/MemberSelector)]
 [ancestor::ClassOrInterfaceBodyDeclaration[1][@AnonymousInnerClass='false']]
-/PrimaryPrefix/Name[@Image = ancestor::ClassOrInterfaceDeclaration[1]/@Image]
+/PrimaryPrefix/Name[@Image = ancestor::ClassOrInterfaceDeclaration[1]/@SimpleName]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -705,7 +705,7 @@ public String bar(String string) {
   @Name='onStart'
   ]
     /Block[not(
-      (BlockStatement[1]/Statement/StatementExpression/PrimaryExpression[./PrimaryPrefix[@SuperModifier='true']]/PrimarySuffix[@Image= ancestor::MethodDeclaration/MethodDeclarator/@Image]))]
+      (BlockStatement[1]/Statement/StatementExpression/PrimaryExpression[./PrimaryPrefix[@SuperModifier='true']]/PrimarySuffix[@Image= ancestor::MethodDeclaration/@Name]))]
 [ancestor::ClassOrInterfaceDeclaration[ExtendsList/ClassOrInterfaceType[
   pmd-java:typeIs('android.app.Activity') or
   pmd-java:typeIs('android.app.Application') or
@@ -750,7 +750,7 @@ Super should be called at the end of the method
   @Name='onTerminate'
   ]
    /Block/BlockStatement[last()]
-    [not(Statement/StatementExpression/PrimaryExpression[./PrimaryPrefix[@SuperModifier='true']]/PrimarySuffix[@Image= ancestor::MethodDeclaration/MethodDeclarator/@Image])]
+    [not(Statement/StatementExpression/PrimaryExpression[./PrimaryPrefix[@SuperModifier='true']]/PrimarySuffix[@Image= ancestor::MethodDeclaration/@Name])]
 [ancestor::ClassOrInterfaceDeclaration[ExtendsList/ClassOrInterfaceType[
   pmd-java:typeIs('android.app.Activity') or
   pmd-java:typeIs('android.app.Application') or
@@ -939,7 +939,7 @@ Note: This is only possible with Java 1.5 or higher.
 [
 @Name = 'clone'
 and @Arity = 0
-and not (ResultType//ClassOrInterfaceType/@Image = ancestor::ClassOrInterfaceDeclaration[1]/@Image)
+and not (ResultType//ClassOrInterfaceType/@Image = ancestor::ClassOrInterfaceDeclaration[1]/@SimpleName)
 ]
 ]]>
                 </value>
@@ -2452,10 +2452,10 @@ See the property `annotations`.
            [(./ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/MethodDeclaration
                 [@Public=true()]
                 [./ResultType/Type/ReferenceType/ClassOrInterfaceType
-                    [@Image = //ClassOrInterfaceDeclaration[@Nested=false()]/@Image]
+                    [@Image = //ClassOrInterfaceDeclaration[@Nested=false()]/@SimpleName]
                 ]
             ) or (
-                ./ExtendsList/ClassOrInterfaceType[@Image = //ClassOrInterfaceDeclaration[@Nested=false()]/@Image]
+                ./ExtendsList/ClassOrInterfaceType[@Image = //ClassOrInterfaceDeclaration[@Nested=false()]/@SimpleName]
             )]
         )
 ]
@@ -2650,7 +2650,7 @@ Object clone() should be implemented with super.clone().
 [count(./Block//*[
     (self::AllocationExpression) and
     (./ClassOrInterfaceType/@Image = ancestor::
-ClassOrInterfaceDeclaration[1]/@Image)
+ClassOrInterfaceDeclaration[1]/@SimpleName)
   ])> 0
 ]
 ]]>
@@ -2696,8 +2696,8 @@ with the restriction that the logger needs to be passed into the constructor.
     or (@Static = false() and .//VariableDeclaratorId[@Image != $loggerName])
 
     (: check logger argument type matches class or enum name :)
-    or .//ArgumentList//ClassOrInterfaceType[@Image != ancestor::ClassOrInterfaceDeclaration/@Image]
-    or .//ArgumentList//ClassOrInterfaceType[@Image != ancestor::EnumDeclaration/@Image]
+    or .//ArgumentList//ClassOrInterfaceType[@Image != ancestor::ClassOrInterfaceDeclaration/@SimpleName]
+    or .//ArgumentList//ClassOrInterfaceType[@Image != ancestor::EnumDeclaration/@SimpleName]
 ]
 [not(
      (: special case - final logger initialized inside constructor :)

--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -808,7 +808,7 @@ ArrayList is a much better Collection implementation than Vector if thread-safe 
             <property name="xpath">
                 <value>
 <![CDATA[
-//CompilationUnit[count(ImportDeclaration) = 0 or count(ImportDeclaration/Name[@Image='java.util.Vector']) > 0]
+//CompilationUnit[count(ImportDeclaration) = 0 or count(ImportDeclaration[@ImportedName='java.util.Vector']) > 0]
   //AllocationExpression/ClassOrInterfaceType
     [@Image='Vector' or @Image='java.util.Vector']
 ]]>


### PR DESCRIPTION
Deprecations are explained in javadoc. Removing JavaQualifiedName is possible through simplifying the metrics framework for 7.0. It's also becoming less relevant because of symbols. Deprecations for the metrics framework can come in another PR (maybe we can even work on the new implementation on master).