### PR TITLE
[core] Preserve newlines in DocumentFile

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -28,6 +28,8 @@ the implementation based on your feedback.
 
 ### Fixed Issues
 
+*   core
+    *   [#2170](https://github.com/pmd/pmd/issues/2170): \[core] DocumentFile doesn't preserve newlines
 *   java-codestyle
     *   [#2167](https://github.com/pmd/pmd/issues/2167): \[java] UnnecessaryLocalBeforeReturn false positive with variable captured by method reference
 *   java-bestpractices

--- a/pmd-core/src/main/java/net/sourceforge/pmd/document/DocumentFile.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/document/DocumentFile.java
@@ -21,6 +21,8 @@ import java.util.Scanner;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.apache.commons.io.IOUtils;
+
 /**
  * Implementation that handles a Document as a file in the filesystem and receives operations in a sorted manner
  * (i.e. the regions are sorted). This improves the efficiency of reading the file by only scanning it once while
@@ -157,11 +159,7 @@ public class DocumentFile implements Document, Closeable {
     }
 
     private void writeUntilEOF() throws IOException {
-        String line;
-
-        while ((line = reader.readLine()) != null) {
-            writer.write(line);
-        }
+        IOUtils.copy(reader, writer);
     }
 
     /* package-private */ List<Integer> getLineToOffset() {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/document/DocumentFileTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/document/DocumentFileTest.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -45,6 +46,22 @@ public class DocumentFileTest {
         try (FileInputStream stream = new FileInputStream(temporaryFile)) {
             final String actualContent = new String(readAllBytes(stream));
             assertEquals("public static void main(String[] args) {}", actualContent);
+        }
+    }
+
+    @Test
+    public void shouldPreserveNewlines() throws IOException {
+        final String testFileContent = IOUtils.toString(
+                DocumentFileTest.class.getResource("ShouldPreserveNewlines.java"), StandardCharsets.UTF_8);
+        writeContentToTemporaryFile(testFileContent);
+
+        try (DocumentFile documentFile = new DocumentFile(temporaryFile, StandardCharsets.UTF_8)) {
+            documentFile.insert(0, 0, "public ");
+        }
+
+        try (FileInputStream stream = new FileInputStream(temporaryFile)) {
+            final String actualContent = new String(readAllBytes(stream));
+            assertEquals("public " + testFileContent, actualContent);
         }
     }
 

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/document/ShouldPreserveNewlines.java
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/document/ShouldPreserveNewlines.java
@@ -1,0 +1,8 @@
+class ShouldPreserveNewlines {
+    public static void main(String[] args) {
+        System.out.println("Test");
+    }
+}
+// note: multiple empty lines at the end
+
+


### PR DESCRIPTION
Fixes #2170 [core] DocumentFile doesn't preserve newlines

<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

