### PR TITLE
[plsql] Fix StringLiteral token

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -55,6 +55,8 @@ the implementation based on your feedback.
     *   [#2140](https://github.com/pmd/pmd/issues/2140): \[java] AvoidLiteralsInIfCondition: false negative for expressions
 *   java-performance
     *   [#2141](https://github.com/pmd/pmd/issues/2141): \[java] StringInstatiation: False negative with String-array access
+*   plsql
+    *   [#2008](https://github.com/pmd/pmd/issues/2008): \[plsql] In StringLiteral using alternative quoting mechanism single quotes cause parsing errors
 
 ### API Changes
 

--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -3425,54 +3425,10 @@ ASTLiteral Literal() :
 }
 
 ASTStringLiteral  StringLiteral() :
+{}
 {
-	Token thisToken = null;
-	StringBuilder literal = new StringBuilder() ;
-	char startDelimiter ;
-	char endDelimiter ;
-	String terminator = null;
-}
-{
-  //Essentially unchanged
- (
-  thisToken = <STRING_LITERAL>
-  {
-   literal.append(thisToken.image);
-   /*
-   This might be Q-Quoted string and this might be only a partial string
-   The token will only match up to the first single quote.
-   The code below appends any remaining part, theh returns the complete string
-   */
-   if (thisToken.image.toUpperCase().startsWith("Q'")
-       && thisToken.image.length() > 2
-      )
-   {
-   // Get the first token of the string so that the delimiter can be identified
-
-     startDelimiter= thisToken.image.charAt(2) ;
-     /*
-     if the start delimiter is one of [, {, <, or (, the end delimiter
-     is the corresponding closing character
-     */
-     switch (startDelimiter)
-     {
-      case '<' : endDelimiter = '>' ; break ;
-      case '{' : endDelimiter = '}' ;  break ;
-      case '(' : endDelimiter = ')' ;  break ;
-      case '[' : endDelimiter = ']' ;  break ;
-      default: endDelimiter = startDelimiter ;
-     }
-
-     terminator = new String(endDelimiter + "'");
-     if (!thisToken.image.endsWith(terminator))
-     {
-       //Loop until we find atoken that ends with a single-quote precede by the terminator
-       literal.append(ReadPastNextOccurrence(terminator));
-     }
-   }
-  }
- )
- { jjtThis.setImage(literal.toString()) ;  jjtThis.value = literal.toString() ; return jjtThis ; }
+  <STRING_LITERAL>
+ { jjtThis.setImage(token.image); return jjtThis ; }
 }
 
 
@@ -5109,26 +5065,9 @@ TOKEN :
 |
 < #INTEGER_LITERAL: ( <DIGIT> )+ >
 |
-
-< #_WHATEVER_CHARACTER_WO_ASTERISK: (~["'"]) >
+< #_WHATEVER_CHARACTER_WO_APOSTROPHE: (~["'"]) >
 |
-< CHARACTER_LITERAL: "'" (<_WHATEVER_CHARACTER_WO_ASTERISK> | <SPECIAL_CHARACTERS>)? "'" >
-//|< STRING_LITERAL:
-//  (["q","Q"])* "'" (<_WHATEVER_CHARACTER_WO_ASTERISK> | <SPECIAL_CHARACTERS> | "''")* "'"
-//> //Cope with Q-quoted stringswithout single quotes in them
-|< STRING_LITERAL:
-// Hard-code the most likely q-quote strings
-             "'" (<_WHATEVER_CHARACTER_WO_ASTERISK> | <SPECIAL_CHARACTERS> | "''")* "'"
-|(["n","N"]) "'" (<_WHATEVER_CHARACTER_WO_ASTERISK> | <SPECIAL_CHARACTERS> | "''")* "'" //National Character Set String
-|(["q","Q"]) "'" (<_WHATEVER_CHARACTER_WO_ASTERISK> | <SPECIAL_CHARACTERS> | "''")* "'" // Bug 160632
-|(["q","Q"]) "'[" (~["[","]"])* "]'"
-|(["q","Q"]) "'{" (~["{","}"])* "}'"
-|(["q","Q"]) "'<" (~["<",">"])* ">'"
-|(["q","Q"]) "'(" (~["(",")"])* ")'"
-|(["q","Q"]) "'/" (~["/"])* "/'"
-|(["q","Q"]) "'!" (~["!"])* "!'"
-|(["q","Q"]) "'#" (~["#"])* "#'"
-> //Cope with Q-quoted stringswithout single quotes in them
+< CHARACTER_LITERAL: "'" (<_WHATEVER_CHARACTER_WO_APOSTROPHE> | <SPECIAL_CHARACTERS>)? "'" >
 |
 < #_WHATEVER_CHARACTER_WO_QUOTE: (~["\""]) >
 |
@@ -5146,6 +5085,41 @@ TOKEN :
 |
 <SQLPLUS_TERMINATOR: ( ";" | "/" ) >
 }
+
+/**
+ * https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/Literals.html#GUID-1824CBAA-6E16-4921-B2A6-112FB02248DA
+ */
+<DEFAULT> MORE :
+{
+   < #_ALTERNATIVE_QUOTING_STRING_LITERAL:
+       (["q","Q"]) "'[" (~["]"] | "]" ~["'"] )* "]"
+     | (["q","Q"]) "'{" (~["}"] | "}" ~["'"] )* "}"
+     | (["q","Q"]) "'<" (~[">"] | ">" ~["'"] )* ">"
+     | (["q","Q"]) "'(" (~[")"] | ")" ~["'"] )* ")"
+   >
+ | <(["n","N"])? "'" (<_WHATEVER_CHARACTER_WO_APOSTROPHE> | <SPECIAL_CHARACTERS> | "''")*> : IN_STRING_LITERAL_TOKENIZE
+ | <(["n","N"])? <_ALTERNATIVE_QUOTING_STRING_LITERAL>> : IN_STRING_LITERAL_TOKENIZE
+
+ // special handling for custom quote delimiters
+ | <(["n","N"])? (["q","Q"]) "'" (~[" ", "\t", "\r", "\n", "[", "{", "<", "("])> : IN_STRING_LITERAL
+}
+<IN_STRING_LITERAL> MORE : {
+    <~["'"]>
+  | <"'"> {
+     int quoteDelimiter = image.charAt(2);
+     if (image.charAt(0) == 'n' || image.charAt(0) == 'N') {
+         quoteDelimiter = image.charAt(3);
+     }
+     int beforeQuote = image.charAt(image.length() - 2);
+     if (quoteDelimiter == beforeQuote) {
+         input_stream.backup(1);
+         image.setLength(image.length() - 1);
+         SwitchTo(IN_STRING_LITERAL_TOKENIZE);
+     }
+  }
+}
+<IN_STRING_LITERAL_TOKENIZE> TOKEN : { <STRING_LITERAL: "'"> : DEFAULT }
+
 
 /**
  * PL/SQL Reserved words

--- a/pmd-plsql/src/main/ant/alljavacc.xml
+++ b/pmd-plsql/src/main/ant/alljavacc.xml
@@ -67,6 +67,7 @@
         <delete file="${target}/net/sourceforge/pmd/lang/plsql/ast/ASTRegexpLikeCondition.java" />
         <delete file="${target}/net/sourceforge/pmd/lang/plsql/ast/ASTSelectIntoStatement.java" />
         <delete file="${target}/net/sourceforge/pmd/lang/plsql/ast/ASTSelectStatement.java" />
+        <delete file="${target}/net/sourceforge/pmd/lang/plsql/ast/ASTStringLiteral.java" />
         <delete file="${target}/net/sourceforge/pmd/lang/plsql/ast/ASTSubqueryOperation.java" />
         <delete file="${target}/net/sourceforge/pmd/lang/plsql/ast/ASTTriggerTimingPointSection.java" />
         <delete file="${target}/net/sourceforge/pmd/lang/plsql/ast/ASTTriggerUnit.java" />

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTStringLiteral.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTStringLiteral.java
@@ -1,0 +1,43 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+
+package net.sourceforge.pmd.lang.plsql.ast;
+
+public final class ASTStringLiteral extends net.sourceforge.pmd.lang.plsql.ast.AbstractPLSQLNode {
+
+
+    ASTStringLiteral(int id) {
+        super(id);
+    }
+
+
+    ASTStringLiteral(PLSQLParser p, int id) {
+        super(p, id);
+    }
+
+
+    @Override
+    public Object jjtAccept(PLSQLParserVisitor visitor, Object data) {
+        return visitor.visit(this, data);
+    }
+
+    /**
+     * Gets the plain string from the string literal.
+     * @return the plain string value from the string literal.
+     */
+    public String getString() {
+        String image = getImage();
+        if (image.charAt(0) == 'N' || image.charAt(0) == 'n') {
+            image = image.substring(1);
+        }
+
+        if (image.charAt(0) == '\'') {
+            image = image.substring(1, image.length() - 1);
+        } else if (image.charAt(0) == 'Q' || image.charAt(0) == 'q') {
+            image = image.substring("q'x".length(), image.length() - 2);
+        }
+        return image;
+    }
+}

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/StringLiteralsTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/StringLiteralsTest.java
@@ -49,6 +49,6 @@ public class StringLiteralsTest extends AbstractPLSQLParserTst {
     }
 
     private static String normalizeEol(String s) {
-        return s.replaceAll("\n|\r|\r\n|\n\r", "\n");
+        return s.replaceAll("\r\n|\n\r|\n|\r", "\n");
     }
 }

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/StringLiteralsTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/StringLiteralsTest.java
@@ -40,11 +40,15 @@ public class StringLiteralsTest extends AbstractPLSQLParserTst {
         ASTInput input = parsePLSQL(code);
         List<ASTStringLiteral> strings = input.findDescendantsOfType(ASTStringLiteral.class);
         Assert.assertEquals(1, strings.size());
-        Assert.assertTrue(strings.get(0).getString().startsWith("\ncreate or replace and"));
+        Assert.assertTrue(normalizeEol(strings.get(0).getString()).startsWith("\ncreate or replace and"));
     }
 
     private static void assertString(String quoted, String plain, int index, List<ASTStringLiteral> strings) {
-        Assert.assertEquals(quoted, strings.get(index).getImage());
-        Assert.assertEquals(plain, strings.get(index).getString());
+        Assert.assertEquals(quoted, normalizeEol(strings.get(index).getImage()));
+        Assert.assertEquals(plain, normalizeEol(strings.get(index).getString()));
+    }
+
+    private static String normalizeEol(String s) {
+        return s.replaceAll("\n|\r|\r\n|\n\r", "\n");
     }
 }

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/StringLiteralsTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/StringLiteralsTest.java
@@ -33,6 +33,15 @@ public class StringLiteralsTest extends AbstractPLSQLParserTst {
                 "\n" + "    also multiple\n" + "    lines\n" + "  ", 15, strings);
     }
 
+    @Test
+    public void parseMultilineVarchar() throws Exception {
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("MultilineVarchar.pls"),
+                StandardCharsets.UTF_8);
+        ASTInput input = parsePLSQL(code);
+        List<ASTStringLiteral> strings = input.findDescendantsOfType(ASTStringLiteral.class);
+        Assert.assertEquals(1, strings.size());
+        Assert.assertTrue(strings.get(0).getString().startsWith("\ncreate or replace and"));
+    }
 
     private static void assertString(String quoted, String plain, int index, List<ASTStringLiteral> strings) {
         Assert.assertEquals(quoted, strings.get(index).getImage());

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/StringLiteralsTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/StringLiteralsTest.java
@@ -1,0 +1,41 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.plsql.ast;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.sourceforge.pmd.lang.plsql.AbstractPLSQLParserTst;
+
+public class StringLiteralsTest extends AbstractPLSQLParserTst {
+
+
+    @Test
+    public void parseStringLiterals() throws Exception {
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("StringLiterals.pls"),
+                StandardCharsets.UTF_8);
+        ASTInput input = parsePLSQL(code);
+        List<ASTStringLiteral> strings = input.findDescendantsOfType(ASTStringLiteral.class);
+        Assert.assertEquals(20, strings.size());
+
+        assertString("'Hello'", "Hello", 0, strings);
+        assertString("N'nchar literal'", "nchar literal", 4, strings);
+        assertString("nQ'[ab']cd]'", "ab']cd", 11, strings);
+        assertString("Q'{SELECT * FROM employees WHERE last_name = 'Smith';}'",
+                "SELECT * FROM employees WHERE last_name = 'Smith';", 13, strings);
+        assertString("q'{\n" + "    also multiple\n" + "    lines\n" + "  }'",
+                "\n" + "    also multiple\n" + "    lines\n" + "  ", 15, strings);
+    }
+
+
+    private static void assertString(String quoted, String plain, int index, List<ASTStringLiteral> strings) {
+        Assert.assertEquals(quoted, strings.get(index).getImage());
+        Assert.assertEquals(plain, strings.get(index).getString());
+    }
+}

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/MultilineVarchar.pls
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/MultilineVarchar.pls
@@ -1,0 +1,37 @@
+--
+-- From https://github.com/pmd/pmd/pull/1988
+--
+declare
+
+  w_java_source clob := q'%
+create or replace and compile java source named PdfUtils as
+  /** BLOB encryption class using AES 128bit
+  * Load class to oracle db. Class file is on the oracle serever:
+  *      sql script:
+  *               exec sys.dbms_java.loadjava('-v -r /tsfa/tia7400/PdfPassword.class');
+  *      command line:
+  *              loadjava -user tia -resolve -verbose -r /tsfa/tia7400/PdfPassword.java
+  *              dropjava -user tia -resolve -verbose -r /tsfa/tia7400/PdfPassword.java
+  */
+    /**
+     * Function reads input blob, encrypts and returns it to the caller
+     * @author Karol Wozniak
+     * @param secret password key
+     * @param fortuneBLOB blob var
+     * @return oracle.sql.BLOB
+     */
+    public static BLOB encryptPdf(String secret, Blob blobVar) throws Exception {
+        System.out.println("Start readBlob");
+        blobfile = writeToBlob(boas.toByteArray());
+        is.close();
+        reader.close();
+        System.out.println("encrypted using password " + secret);
+        System.out.println("End readBlob");
+        return blobfile;
+    }
+};
+%';
+
+begin
+  null;
+end;

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/StringLiterals.pls
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/StringLiterals.pls
@@ -1,0 +1,45 @@
+--
+-- See https://github.com/pmd/pmd/issues/2008
+-- [plsql] In StringLiteral using alternative quoting mechanism single quotes cause parsing errors
+--
+-- https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/Literals.html#GUID-1824CBAA-6E16-4921-B2A6-112FB02248DA
+--
+
+declare
+
+  literal1 clob := 'Hello';
+  literal2 clob := 'ORACLE.dbs';
+  literal3 clob := 'Jackie''s raincoat';
+  literal4 clob := '09-MAR-98';
+  literal5 clob := N'nchar literal';
+
+  -- alternative quoting mechanism
+  qliteral1a clob := q'[abc]';
+  qliteral1b clob := q'[ab']cd]';
+  qliteral1c clob := q'[ab[cd]';
+  qliteral1d clob := q'[ab]cd]';
+  qliteral1e clob := q'[ab
+  cd]';
+  qliteral1f clob := Nq'[a"b"c]';
+  qliteral1g clob := nQ'[ab']cd]';
+
+  qliteral1 clob := q'!name LIKE '%DBMS_%%'!';
+  qliteral2 clob := Q'{SELECT * FROM employees WHERE last_name = 'Smith';}';
+  qliteral1a clob := q'! test !';
+  qliteral2a clob := q'{
+    also multiple
+    lines
+  }';
+  qliteral3a clob := q'% test abc %';
+  qliteral3b clob := q'% test % abc %';
+
+
+  qliteral3c clob := q'% test'test %';
+  qliteral4 clob := nq'!name LIKE '%DBMS_%%'!';
+
+
+
+begin
+  null;
+end;
+/


### PR DESCRIPTION
StringLiterals can use a custom quote delimiter that
marks the end of a string literal. This quote delimiter
is only effective together with the quote character.
A single quote character, that is not preceded by the
delimiter, should be allowed.

Additionally, the ASTStringLiteral node gives
now access to the plain string value of the
literal without the quoting.

Fixes #2008

This partly obsoletes PR #1988 
<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

