### PR TITLE
[plsql] Fix DDLCommands parsing

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -55,6 +55,8 @@ the implementation based on your feedback.
     *   [#2140](https://github.com/pmd/pmd/issues/2140): \[java] AvoidLiteralsInIfCondition: false negative for expressions
 *   java-performance
     *   [#2141](https://github.com/pmd/pmd/issues/2141): \[java] StringInstatiation: False negative with String-array access
+*   plsql
+    *   [#2009](https://github.com/pmd/pmd/issues/2009): \[plsql] Multiple DDL commands are skipped during parsing
 
 ### API Changes
 

--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -227,6 +227,9 @@ public class PLSQLParser {
   /**
    * Semantic lookahead to check if the next identifier is a
    * specific keyword.
+   *
+   * <p>
+   * Usage: <code>LOOKAHEAD({isKeyword("WAIT")}) KEYWORD("WAIT")</code>
    */
   private boolean isKeyword(String keyword) {
     return getToken(1).kind == IDENTIFIER && getToken(1).image.equalsIgnoreCase(keyword);
@@ -259,12 +262,12 @@ ASTInput Input(String sourcecode) : {}
 	 | LOOKAHEAD(6) Directory()
 	 | LOOKAHEAD(6) DatabaseLink()
 	 | LOOKAHEAD(6) Global()
-     | LOOKAHEAD(6) DDLCommand() //Ignore any other DDL Event
+     | (LOOKAHEAD(6) DDLCommand())+
 	 | LOOKAHEAD(2) SqlPlusCommand()
 	 | UpdateStatement()
 	 | DeleteStatement()
 	 | InsertStatement()
-	 | SelectStatement() (";")?
+	 | SelectStatement() [";"]
 	 |(<COMMIT>|<ROLLBACK>|<SAVEPOINT>|<LOCK><TABLE>|<MERGE>|<WITH>) SkipPastNextTokenOccurrence(SQLPLUS_TERMINATOR) //Ignore SQL statements in scripts
 	 )
 	 ("/")*
@@ -279,8 +282,15 @@ ASTDDLCommand DDLCommand() :
 }
 {
   (
-    simpleNode = DDLEvent()
-    SkipPastNextTokenOccurrence(SQLPLUS_TERMINATOR)
+    (
+      LOOKAHEAD({isKeyword("COMMENT")})
+      simpleNode = Comment()
+    )
+    |
+    (
+      simpleNode = DDLEvent()
+      SkipPastNextTokenOccurrence(SQLPLUS_TERMINATOR)
+    )
   )
   { jjtThis.setImage(simpleNode.getImage()) ;  return jjtThis ; }
 }
@@ -315,7 +325,7 @@ ASTSqlPlusCommand SqlPlusCommand() :
   | <VARIABLE>
   | <WHENEVER>
   // DDL that might be encountered
-  | <COMMENT>
+  | LOOKAHEAD({isKeyword("COMMENT")}) KEYWORD("COMMENT")
   | <GRANT>
   | <REVOKE>
   | <DROP>
@@ -3904,19 +3914,22 @@ ASTViewColumn ViewColumn()  :
       { return jjtThis ; }
 }
 
+/**
+ * https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/COMMENT.html#GUID-65F447C4-6914-4823-9691-F15D52DB74D7
+ */
 ASTComment Comment()  :
 {
 }
 {
-  <COMMENT> <ON> (
+  LOOKAHEAD({isKeyword("COMMENT")}) KEYWORD("COMMENT")
+  <ON> (
     ((<TABLE> | <OPERATOR> | <INDEXTYPE>) [LOOKAHEAD(2) ID()"."] ID()) |
     (<COLUMN> [LOOKAHEAD(ID()"."ID()"."ID()) ID()"."] ID() "." ID())
   )
-  <IS> <STRING_LITERAL>
-  [";"]
-      { return jjtThis ; }
+  <IS> StringLiteral()
+  ";"
+  { return jjtThis ; }
 }
-// SRT * /
 
 
 
@@ -4489,23 +4502,26 @@ ASTNonDMLTrigger NonDMLTrigger()  :
       { return jjtThis ; }
 }
 
-
+/**
+ * https://docs.oracle.com/en/database/oracle/oracle-database/18/sqlrf/Types-of-SQL-Statements.html#GUID-FD9A8CB4-6B9A-44E5-B114-EFB8DA76FC88
+ */
 ASTDDLEvent DDLEvent(): {}
 {
   ( <ALTER>
   | <ANALYZE>
   | <ASSOCIATE> <STATISTICS>
   | <AUDIT>
-  | <COMMENT>
+  | LOOKAHEAD({isKeyword("COMMENT")}) KEYWORD("COMMENT")
   | <CREATE>
   | <DISASSOCIATE> <STATISTICS>
   | <DROP>
+  // | <FLASHBACK>
   | <GRANT>
   | <NOAUDIT>
+  // | <PURGE>
   | <RENAME>
   | <REVOKE>
   | <TRUNCATE>
-  | <DDL>
   )
 	{ jjtThis.setImage(token.toString()) ; jjtThis.value = token ; return jjtThis ; }
 }
@@ -4741,7 +4757,6 @@ TOKEN [IGNORE_CASE]:
 <COALESCE: "COALESCE"> |
 <COLLECT: "COLLECT"> |
 <COLUMN: "COLUMN"> |
-<COMMENT: "COMMENT"> |
 <COMMIT: "COMMIT"> |
 <CONSTANT: "CONSTANT"> |
 <CONSTRAINT: "CONSTRAINT"> |
@@ -4997,7 +5012,6 @@ TOKEN [IGNORE_CASE]:
 | <COMPOUND: "COMPOUND">  //11G Trigger Syntax
 | <DATABASE: "DATABASE">  //11G Trigger Syntax
 | <CALL: "CALL"> //11G Trigger Syntax
-| <DDL: "DDL">  //11G Trigger Syntax
 | <DISASSOCIATE: "DISASSOCIATE">  //11G Trigger Syntax
 | <EACH: "EACH">  //11G Trigger Syntax
 | <FOLLOWS: "FOLLOWS">  //11G Trigger Syntax
@@ -5386,7 +5400,6 @@ ASTKEYWORD_UNRESERVED KEYWORD_UNRESERVED (): {}
 //| <COLUMN_STATS>
 //| <COLUMN_VALUE>
 //| <COLUMNS>
-| <COMMENT>
 | <COMMIT>
 //| <COMMITTED>
 //| <COMPACT>
@@ -5447,7 +5460,6 @@ ASTKEYWORD_UNRESERVED KEYWORD_UNRESERVED (): {}
 //| <DBA_RECYCLEBIN>
 //| <DBMS_STATS>
 | <DBTIMEZONE>
-| <DDL>
 //| <DEALLOCATE>
 //| <DEBUG>
 | <DEC>
@@ -6352,7 +6364,7 @@ ASTID ID(): {}
 	        | KEYWORD_UNRESERVED()  //SRT 2011-04-17
 		/*KEYWORDS_UNRESERVED
 		|<EXTRACT> | <FALSE> | <TRUE>  | <SECOND> | <MINUTE> | <HOUR> | <DAY> | <MONTH> | <YEAR>
-		 | <NO> |<ROW>  | <COMMENT> | <CURSOR>
+		 | <NO> |<ROW> | <CURSOR>
 		*/
 		//20120501 | <DEFINER>
 		| <SERIALLY_REUSABLE> | <RESTRICT_REFERENCES>
@@ -6615,7 +6627,6 @@ ASTQualifiedID QualifiedID(): {}
 		//<CLUSTER>
 		//| <COALESCE>
 		//20120501 | <COLLECT>
-		//| <COMMENT>
 		//| <COMMIT>
 		//<COMPRESS>
 		//<CONNECT>

--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -268,7 +268,7 @@ ASTInput Input(String sourcecode) : {}
 	 | DeleteStatement()
 	 | InsertStatement()
 	 | SelectStatement() [";"]
-	 |(<COMMIT>|<ROLLBACK>|<SAVEPOINT>|<LOCK><TABLE>|<MERGE>|<WITH>) SkipPastNextTokenOccurrence(SQLPLUS_TERMINATOR) //Ignore SQL statements in scripts
+	 |(<COMMIT>|<ROLLBACK>|<SAVEPOINT>|<LOCK><TABLE>|<MERGE>|<WITH>) ReadPastNextOccurrence(";") //Ignore SQL statements in scripts
 	 )
 	 ("/")*
 	)*
@@ -289,7 +289,7 @@ ASTDDLCommand DDLCommand() :
     |
     (
       simpleNode = DDLEvent()
-      SkipPastNextTokenOccurrence(SQLPLUS_TERMINATOR)
+      ReadPastNextOccurrence(";")
     )
   )
   { jjtThis.setImage(simpleNode.getImage()) ;  return jjtThis ; }
@@ -1131,6 +1131,7 @@ ASTRead2NextOccurrence Read2NextOccurrence(String target) :
   {
     nextToken = getNextToken();
     sb.append(nextToken.image);
+    sb.append(' ');
     nextToken = getToken(1);
   }
 }
@@ -1143,10 +1144,11 @@ ASTRead2NextOccurrence Read2NextOccurrence(String target) :
 */
 ASTReadPastNextOccurrence ReadPastNextOccurrence(String target) :
 {
+  ASTRead2NextOccurrence skipped = Read2NextOccurrence(target);
+
   StringBuilder sb = new StringBuilder();
-  Token t = null;
-  sb.append(Read2NextOccurrence(target)) ;
-  t = getNextToken(); // Chomp this one
+  sb.append(skipped.getImage()) ;
+  Token t = getNextToken(); // Chomp this one
   sb.append(t.image);
 }
 {
@@ -3921,7 +3923,7 @@ ASTComment Comment()  :
 {
 }
 {
-  LOOKAHEAD({isKeyword("COMMENT")}) KEYWORD("COMMENT")
+  LOOKAHEAD({isKeyword("COMMENT")}) KEYWORD("COMMENT") { jjtThis.setImage(token.image); }
   <ON> (
     ((<TABLE> | <OPERATOR> | <INDEXTYPE>) [LOOKAHEAD(2) ID()"."] ID()) |
     (<COLUMN> [LOOKAHEAD(ID()"."ID()"."ID()) ID()"."] ID() "." ID())
@@ -5157,8 +5159,6 @@ TOKEN :
 < JAVA_INTERFACE_CLASS: ( "SQLData" | "CustomDatum" | "OraData" ) >
 //|
 //< #BOOLEAN_LITERAL: "TRUE" | "FALSE" >
-|
-<SQLPLUS_TERMINATOR: ( ";" | "/" ) >
 }
 
 /**

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/MultipleDDLStatementsTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/MultipleDDLStatementsTest.java
@@ -22,5 +22,8 @@ public class MultipleDDLStatementsTest extends AbstractPLSQLParserTst {
         ASTInput input = parsePLSQL(code);
         List<ASTDDLCommand> ddlcommands = input.findDescendantsOfType(ASTDDLCommand.class);
         Assert.assertEquals(3, ddlcommands.size());
+        List<ASTComment> comments = input.findDescendantsOfType(ASTComment.class);
+        Assert.assertEquals(3, comments.size());
+        Assert.assertEquals("'abbreviated job title'", comments.get(0).getFirstChildOfType(ASTStringLiteral.class).getImage());
     }
 }

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/MultipleDDLStatementsTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/MultipleDDLStatementsTest.java
@@ -21,7 +21,7 @@ public class MultipleDDLStatementsTest extends AbstractPLSQLParserTst {
                 StandardCharsets.UTF_8);
         ASTInput input = parsePLSQL(code);
         List<ASTDDLCommand> ddlcommands = input.findDescendantsOfType(ASTDDLCommand.class);
-        Assert.assertEquals(3, ddlcommands.size());
+        Assert.assertEquals(4, ddlcommands.size());
         List<ASTComment> comments = input.findDescendantsOfType(ASTComment.class);
         Assert.assertEquals(3, comments.size());
         Assert.assertEquals("'abbreviated job title'", comments.get(0).getFirstChildOfType(ASTStringLiteral.class).getImage());

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/MultipleDDLStatementsTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/MultipleDDLStatementsTest.java
@@ -1,0 +1,26 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.plsql.ast;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.sourceforge.pmd.lang.plsql.AbstractPLSQLParserTst;
+
+public class MultipleDDLStatementsTest extends AbstractPLSQLParserTst {
+
+    @Test
+    public void parseDDLCommands() throws Exception {
+        String code = IOUtils.toString(this.getClass().getResourceAsStream("DDLCommands.sql"),
+                StandardCharsets.UTF_8);
+        ASTInput input = parsePLSQL(code);
+        List<ASTDDLCommand> ddlcommands = input.findDescendantsOfType(ASTDDLCommand.class);
+        Assert.assertEquals(3, ddlcommands.size());
+    }
+}

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/DDLCommands.sql
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/DDLCommands.sql
@@ -2,4 +2,6 @@ COMMENT ON COLUMN employees.job_id IS 'abbreviated job title';
 
 COMMENT ON COLUMN employees.job_id IS 'abbreviated job title';
 
+DROP TABLE employees;
+
 COMMENT ON COLUMN employees.job_id IS 'abbreviated job title'; 

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/DDLCommands.sql
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/DDLCommands.sql
@@ -1,0 +1,5 @@
+COMMENT ON COLUMN employees.job_id IS 'abbreviated job title';
+
+COMMENT ON COLUMN employees.job_id IS 'abbreviated job title';
+
+COMMENT ON COLUMN employees.job_id IS 'abbreviated job title'; 


### PR DESCRIPTION
This fixes #2009 

It only adds parsing support for Comments, the other ddl commands are skipped as before.

<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

