### PR TITLE
[core] Internalize API that exposes ResourceLoader

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -76,6 +76,11 @@ You can identify them with the `@InternalApi` annotation. You'll also get a depr
   eg {% jdoc java::lang.java.rule.JavaRuleViolation %}. See javadoc of
   {% jdoc core::RuleViolation %}.
 
+* {% jdoc core::rules.RuleFactory %}
+* {% jdoc core::rules.RuleBuilder %}
+* Constructors of {% jdoc core::RuleSetFactory %}, use factory methods from {% jdoc core::RulesetsFactoryUtils %} instead
+* {% jdoc core::RulesetsFactoryUtils#getRulesetFactory(core::PMDConfiguration, core::util.ResourceLoader) %}
+
 ##### For removal
 
 * {% jdoc java::lang.java.AbstractJavaParser %}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
@@ -60,22 +60,31 @@ public class RuleSetFactory {
     private final boolean warnDeprecated;
     private final RuleSetFactoryCompatibility compatibilityFilter;
 
+    /**
+     * @deprecated Use {@link RulesetsFactoryUtils#defaultFactory()}
+     */
+    @Deprecated // to be removed with PMD 7.0.0.
     public RuleSetFactory() {
         this(new ResourceLoader(), RulePriority.LOW, false, true);
     }
 
     /**
-     * @deprecated Use {@link #RuleSetFactory(ResourceLoader, RulePriority, boolean, boolean)} with
-     * {@link ResourceLoader} instead of a {@link ClassLoader}.
+     * @deprecated Use {@link RulesetsFactoryUtils#createFactory(ClassLoader, RulePriority, boolean, boolean)}
+     *     or {@link RulesetsFactoryUtils#createFactory(RulePriority, boolean, boolean)}
      */
     @Deprecated // to be removed with PMD 7.0.0.
     public RuleSetFactory(final ClassLoader classLoader, final RulePriority minimumPriority,
-            final boolean warnDeprecated, final boolean enableCompatibility) {
+                          final boolean warnDeprecated, final boolean enableCompatibility) {
         this(new ResourceLoader(classLoader), minimumPriority, warnDeprecated, enableCompatibility);
     }
 
+    /**
+     * @deprecated Use {@link RulesetsFactoryUtils#createFactory(ClassLoader, RulePriority, boolean, boolean)}
+     *     or {@link RulesetsFactoryUtils#createFactory(RulePriority, boolean, boolean)}
+     */
+    @Deprecated // to be hidden with PMD 7.0.0.
     public RuleSetFactory(final ResourceLoader resourceLoader, final RulePriority minimumPriority,
-            final boolean warnDeprecated, final boolean enableCompatibility) {
+                          final boolean warnDeprecated, final boolean enableCompatibility) {
         this.resourceLoader = resourceLoader;
         this.minimumPriority = minimumPriority;
         this.warnDeprecated = warnDeprecated;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RulesetsFactoryUtils.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RulesetsFactoryUtils.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.benchmark.TimeTracker;
 import net.sourceforge.pmd.benchmark.TimedOperation;
 import net.sourceforge.pmd.benchmark.TimedOperationCategory;
@@ -61,24 +62,62 @@ public final class RulesetsFactoryUtils {
      * @throws IllegalArgumentException
      *             if rulesets is empty (means, no rules have been found) or if
      *             a ruleset couldn't be found.
+     * @deprecated Is internal API
      */
+    @InternalApi
+    @Deprecated
     public static RuleSets getRuleSetsWithBenchmark(String rulesets, RuleSetFactory factory) {
         try (TimedOperation to = TimeTracker.startOperation(TimedOperationCategory.LOAD_RULES)) {
             return getRuleSets(rulesets, factory);
         }
     }
 
+    /**
+     * @deprecated Use {@link #createFactory(PMDConfiguration)} or {@link #createFactory(PMDConfiguration, ClassLoader)}
+     */
+    @InternalApi
+    @Deprecated
     public static RuleSetFactory getRulesetFactory(final PMDConfiguration configuration,
-            final ResourceLoader resourceLoader) {
+                                                   final ResourceLoader resourceLoader) {
         return new RuleSetFactory(resourceLoader, configuration.getMinimumPriority(), true,
-                configuration.isRuleSetFactoryCompatibilityEnabled());
+                                  configuration.isRuleSetFactoryCompatibilityEnabled());
+    }
+
+    /**
+     * Returns a ruleset factory which uses the classloader for PMD
+     * classes to resolve resource references.
+     *
+     * @param configuration PMD configuration, contains info about the
+     *                      factory parameters
+     *
+     * @return A ruleset factory
+     *
+     * @see #createFactory(PMDConfiguration, ClassLoader)
+     */
+    public static RuleSetFactory createFactory(final PMDConfiguration configuration) {
+        return getRulesetFactory(configuration, new ResourceLoader());
+    }
+
+    /**
+     * Returns a ruleset factory which uses the provided {@link ClassLoader}
+     * to resolve resource references.
+     *
+     * @param configuration PMD configuration, contains info about the
+     *                      factory parameters
+     * @param classLoader   Class loader to load resources
+     *
+     * @return A ruleset factory
+     *
+     * @see #createFactory(PMDConfiguration)
+     */
+    public static RuleSetFactory createFactory(final PMDConfiguration configuration, ClassLoader classLoader) {
+        return getRulesetFactory(configuration, new ResourceLoader(classLoader));
     }
 
     /**
      * If in debug modus, print the names of the rules.
      *
-     * @param rulesets
-     *            the RuleSets to print
+     * @param rulesets the RuleSets to print
      */
     private static void printRuleNamesInDebug(RuleSets rulesets) {
         if (LOG.isLoggable(Level.FINER)) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RulesetsFactoryUtils.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RulesetsFactoryUtils.java
@@ -95,12 +95,24 @@ public final class RulesetsFactoryUtils {
      * @see #createFactory(PMDConfiguration, ClassLoader)
      */
     public static RuleSetFactory createFactory(final PMDConfiguration configuration) {
-        return getRulesetFactory(configuration, new ResourceLoader());
+        return createFactory(configuration, RulesetsFactoryUtils.class.getClassLoader());
+    }
+
+    /**
+     * Returns a ruleset factory with default parameters. It doesn't prune
+     * rules based on priority, and doesn't warn for deprecations.
+     *
+     * @return A ruleset factory
+     *
+     * @see #createFactory(PMDConfiguration, ClassLoader)
+     */
+    public static RuleSetFactory defaultFactory() {
+        return new RuleSetFactory();
     }
 
     /**
      * Returns a ruleset factory which uses the provided {@link ClassLoader}
-     * to resolve resource references.
+     * to resolve resource references. It warns for deprecated rule usages.
      *
      * @param configuration PMD configuration, contains info about the
      *                      factory parameters
@@ -111,7 +123,52 @@ public final class RulesetsFactoryUtils {
      * @see #createFactory(PMDConfiguration)
      */
     public static RuleSetFactory createFactory(final PMDConfiguration configuration, ClassLoader classLoader) {
-        return getRulesetFactory(configuration, new ResourceLoader(classLoader));
+        return createFactory(classLoader,
+                             configuration.getMinimumPriority(),
+                             true,
+                             configuration.isRuleSetFactoryCompatibilityEnabled());
+    }
+
+    /**
+     * Returns a ruleset factory which uses the provided {@link ClassLoader}
+     * to resolve resource references.
+     *
+     * @param minimumPriority     Minimum priority for rules to be included
+     * @param warnDeprecated      If true, print warnings when deprecated rules are included
+     * @param enableCompatibility If true, rule references to moved rules are mapped to their
+     *                            new location if they are known
+     * @param classLoader         Class loader to load resources
+     *
+     * @return A ruleset factory
+     *
+     * @see #createFactory(PMDConfiguration)
+     */
+    public static RuleSetFactory createFactory(ClassLoader classLoader,
+                                               RulePriority minimumPriority,
+                                               boolean warnDeprecated,
+                                               boolean enableCompatibility) {
+
+        return new RuleSetFactory(new ResourceLoader(classLoader), minimumPriority, warnDeprecated, enableCompatibility);
+    }
+
+    /**
+     * Returns a ruleset factory which uses the classloader for PMD
+     * classes to resolve resource references.
+     *
+     * @param minimumPriority     Minimum priority for rules to be included
+     * @param warnDeprecated      If true, print warnings when deprecated rules are included
+     * @param enableCompatibility If true, rule references to moved rules are mapped to their
+     *                            new location if they are known
+     *
+     * @return A ruleset factory
+     *
+     * @see #createFactory(PMDConfiguration)
+     */
+    public static RuleSetFactory createFactory(RulePriority minimumPriority,
+                                               boolean warnDeprecated,
+                                               boolean enableCompatibility) {
+
+        return new RuleSetFactory(new ResourceLoader(), minimumPriority, warnDeprecated, enableCompatibility);
     }
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/Benchmarker.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/Benchmarker.java
@@ -27,6 +27,7 @@ import net.sourceforge.pmd.RuleSet;
 import net.sourceforge.pmd.RuleSetFactory;
 import net.sourceforge.pmd.RuleSetNotFoundException;
 import net.sourceforge.pmd.RuleSets;
+import net.sourceforge.pmd.RulesetsFactoryUtils;
 import net.sourceforge.pmd.SourceCodeProcessor;
 import net.sourceforge.pmd.lang.Language;
 import net.sourceforge.pmd.lang.LanguageFilenameFilter;
@@ -116,7 +117,7 @@ public final class Benchmarker {
                 System.out.println("Checking directory " + srcDir);
             }
             Set<RuleDuration> results = new TreeSet<>();
-            RuleSetFactory factory = new RuleSetFactory();
+            RuleSetFactory factory = RulesetsFactoryUtils.defaultFactory();
             if (StringUtils.isNotBlank(ruleset)) {
                 stress(languageVersion, factory.createRuleSet(ruleset), dataSources, results, debug);
             } else {
@@ -174,7 +175,7 @@ public final class Benchmarker {
     private static void stress(LanguageVersion languageVersion, RuleSet ruleSet, List<DataSource> dataSources,
             Set<RuleDuration> results, boolean debug) throws PMDException, IOException {
 
-        final RuleSetFactory factory = new RuleSetFactory();
+        final RuleSetFactory factory = RulesetsFactoryUtils.defaultFactory();
         for (Rule rule: ruleSet.getRules()) {
             if (debug) {
                 System.out.println("Starting " + rule.getName());

--- a/pmd-core/src/main/java/net/sourceforge/pmd/rules/RuleBuilder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/rules/RuleBuilder.java
@@ -13,6 +13,7 @@ import org.w3c.dom.Element;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RulePriority;
 import net.sourceforge.pmd.RuleSetReference;
+import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.Language;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersion;
@@ -27,6 +28,8 @@ import net.sourceforge.pmd.util.ResourceLoader;
  * @author Clément Fournier
  * @since 6.0.0
  */
+@InternalApi
+@Deprecated
 public class RuleBuilder {
 
     private List<PropertyDescriptor<?>> definedProperties = new ArrayList<>();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/rules/RuleFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/rules/RuleFactory.java
@@ -26,6 +26,7 @@ import org.w3c.dom.NodeList;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RulePriority;
 import net.sourceforge.pmd.RuleSetReference;
+import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.rule.RuleReference;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyDescriptorField;
@@ -40,6 +41,8 @@ import net.sourceforge.pmd.util.ResourceLoader;
  * @author Clément Fournier
  * @since 6.0.0
  */
+@InternalApi
+@Deprecated
 public class RuleFactory {
 
     private static final Logger LOG = Logger.getLogger(RuleFactory.class.getName());
@@ -57,7 +60,7 @@ public class RuleFactory {
     private static final String DESCRIPTION = "description";
     private static final String PROPERTY = "property";
     private static final String CLASS = "class";
-    
+
     private static final List<String> REQUIRED_ATTRIBUTES = Collections.unmodifiableList(Arrays.asList(NAME, CLASS));
 
     private final ResourceLoader resourceLoader;
@@ -337,7 +340,7 @@ public class RuleFactory {
             Attr a = (Attr) atts.item(i);
             values.put(PropertyDescriptorField.getConstant(a.getName()), a.getValue());
         }
-        
+
         if (StringUtils.isBlank(values.get(DEFAULT_VALUE))) {
             NodeList children = propertyElement.getElementsByTagName(DEFAULT_VALUE.attributeName());
             if (children.getLength() == 1) {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryCompatibilityTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryCompatibilityTest.java
@@ -28,7 +28,7 @@ public class RuleSetFactoryCompatibilityTest {
                 + "  <description>Test</description>\n" + "\n"
                 + " <rule ref=\"rulesets/dummy/notexisting.xml/DummyBasicMockRule\" />\n" + "</ruleset>\n";
 
-        RuleSetFactory factory = new RuleSetFactory();
+        RuleSetFactory factory = RulesetsFactoryUtils.defaultFactory();
         factory.getCompatibilityFilter().addFilterRuleMoved("dummy", "notexisting", "basic", "DummyBasicMockRule");
 
         RuleSet createdRuleSet = createRulesetFromString(ruleset, factory);
@@ -66,7 +66,7 @@ public class RuleSetFactoryCompatibilityTest {
                 + "  <description>Test</description>\n" + "\n" + " <rule ref=\"rulesets/dummy/basic.xml\">\n"
                 + "   <exclude name=\"OldNameOfSampleXPathRule\"/>\n" + " </rule>\n" + "</ruleset>\n";
 
-        RuleSetFactory factory = new RuleSetFactory();
+        RuleSetFactory factory = RulesetsFactoryUtils.defaultFactory();
         factory.getCompatibilityFilter().addFilterRuleRenamed("dummy", "basic", "OldNameOfSampleXPathRule",
                 "SampleXPathRule");
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryDuplicatedRuleLoggingTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryDuplicatedRuleLoggingTest.java
@@ -75,7 +75,7 @@ public class RuleSetFactoryDuplicatedRuleLoggingTest {
     }
 
     private RuleSet loadRuleSet(String ruleSetFilename) throws RuleSetNotFoundException {
-        RuleSetFactory rsf = new RuleSetFactory();
+        RuleSetFactory rsf = RulesetsFactoryUtils.defaultFactory();
         return rsf.createRuleSet("net/sourceforge/pmd/rulesets/duplicatedRuleLoggingTest/" + ruleSetFilename);
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryTest.java
@@ -45,7 +45,7 @@ public class RuleSetFactoryTest {
         RuleSet rs = loadRuleSet(EMPTY_RULESET);
         assertNull("RuleSet file name not expected", rs.getFileName());
 
-        RuleSetFactory rsf = new RuleSetFactory();
+        RuleSetFactory rsf = RulesetsFactoryUtils.defaultFactory();
         rs = rsf.createRuleSet("net/sourceforge/pmd/TestRuleset1.xml");
         assertEquals("wrong RuleSet file name", rs.getFileName(), "net/sourceforge/pmd/TestRuleset1.xml");
     }
@@ -58,7 +58,7 @@ public class RuleSetFactoryTest {
 
     @Test
     public void testRefs() throws Exception {
-        RuleSetFactory rsf = new RuleSetFactory();
+        RuleSetFactory rsf = RulesetsFactoryUtils.defaultFactory();
         RuleSet rs = rsf.createRuleSet("net/sourceforge/pmd/TestRuleset1.xml");
         assertNotNull(rs.getRuleByName("TestRuleRef"));
     }
@@ -69,7 +69,7 @@ public class RuleSetFactoryTest {
         assertNotNull("Test ruleset not found - can't continue with test!", in);
         in.close();
 
-        RuleSetFactory rsf = new RuleSetFactory();
+        RuleSetFactory rsf = RulesetsFactoryUtils.defaultFactory();
         RuleSets rs = rsf.createRuleSets("net/sourceforge/pmd/rulesets/reference-ruleset.xml");
         // added by referencing a complete ruleset (TestRuleset1.xml)
         assertNotNull(rs.getRuleByName("MockRule1"));
@@ -127,7 +127,7 @@ public class RuleSetFactoryTest {
 
     @Test(expected = RuleSetNotFoundException.class)
     public void testRuleSetNotFound() throws RuleSetNotFoundException {
-        RuleSetFactory rsf = new RuleSetFactory();
+        RuleSetFactory rsf = RulesetsFactoryUtils.defaultFactory();
         rsf.createRuleSet("fooooo");
     }
 
@@ -534,7 +534,7 @@ public class RuleSetFactoryTest {
         assertNotNull(ruleset.getRuleByName("SampleXPathRule"));
 
         // now, load with default minimum priority
-        rsf = new RuleSetFactory();
+        rsf = RulesetsFactoryUtils.defaultFactory();
         ruleset = rsf.createRuleSet("net/sourceforge/pmd/rulesets/ruleset-minimum-priority.xml");
         assertEquals("Number of Rules", 2, ruleset.getRules().size());
         Rule dummyBasicMockRule = ruleset.getRuleByName("DummyBasicMockRule");
@@ -543,13 +543,13 @@ public class RuleSetFactoryTest {
 
     @Test
     public void testExcludeWithMinimumPriority() throws RuleSetNotFoundException {
-        RuleSetFactory rsf = new RuleSetFactory(new ResourceLoader(), RulePriority.HIGH, true, true);
+        RuleSetFactory rsf = RulesetsFactoryUtils.createFactory(RulePriority.HIGH, true, true);
         RuleSet ruleset = rsf.createRuleSet("net/sourceforge/pmd/rulesets/ruleset-minimum-priority-exclusion.xml");
         // no rules should be loaded
         assertEquals("Number of Rules", 0, ruleset.getRules().size());
 
         // now, load with default minimum priority
-        rsf = new RuleSetFactory();
+        rsf = RulesetsFactoryUtils.defaultFactory();
         ruleset = rsf.createRuleSet("net/sourceforge/pmd/rulesets/ruleset-minimum-priority-exclusion.xml");
         // only one rule, we have excluded one...
         assertEquals("Number of Rules", 1, ruleset.getRules().size());
@@ -658,7 +658,7 @@ public class RuleSetFactoryTest {
 
     @Test
     public void testDeprecatedRuleSetReference() throws RuleSetNotFoundException {
-        RuleSetFactory ruleSetFactory = new RuleSetFactory();
+        RuleSetFactory ruleSetFactory = RulesetsFactoryUtils.defaultFactory();
         RuleSet ruleSet = ruleSetFactory.createRuleSet("net/sourceforge/pmd/rulesets/ruleset-deprecated.xml");
         assertEquals(2, ruleSet.getRules().size());
     }
@@ -700,7 +700,7 @@ public class RuleSetFactoryTest {
                 + "    <properties>\n" + "      <property name=\"xpath\" value=\"//TypeDeclaration\" />\n"
                 + "      <property name=\"message\" value=\"Foo\" />\n" + "    </properties>\n" + "  </rule>\n"
                 + "</ruleset>\n");
-        RuleSetFactory ruleSetFactory = new RuleSetFactory();
+        RuleSetFactory ruleSetFactory = RulesetsFactoryUtils.defaultFactory();
         ruleSetFactory.createRuleSet(ref);
     }
 
@@ -718,7 +718,7 @@ public class RuleSetFactoryTest {
                 + "    xsi:schemaLocation=\"http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd\">\n"
                 + "    <description>PMD Ruleset.</description>\n" + "\n"
                 + "    <exclude-pattern>.*Test.*</exclude-pattern>\n" + "\n" + "</ruleset>\n");
-        RuleSetFactory ruleSetFactory = new RuleSetFactory();
+        RuleSetFactory ruleSetFactory = RulesetsFactoryUtils.defaultFactory();
         RuleSet ruleset = ruleSetFactory.createRuleSet(ref);
         assertEquals(0, ruleset.getRules().size());
     }
@@ -761,7 +761,7 @@ public class RuleSetFactoryTest {
                 + "    xsi:schemaLocation=\"http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd\">\n"
                 + "  <description>Custom ruleset for tests</description>\n"
                 + "  <rule ref=\"net/sourceforge/pmd/TestRuleset1.xml/ThisRuleDoesNotExist\"/>\n" + "</ruleset>\n");
-        RuleSetFactory ruleSetFactory = new RuleSetFactory();
+        RuleSetFactory ruleSetFactory = RulesetsFactoryUtils.defaultFactory();
         ruleSetFactory.createRuleSet(ref);
     }
 
@@ -781,7 +781,7 @@ public class RuleSetFactoryTest {
                 + "   <description>PMD Plugin preferences rule set</description>\n" + "\n"
                 + "<rule name=\"OverriddenDummyBasicMockRule\"\n"
                 + "    ref=\"rulesets/dummy/basic.xml/DummyBasicMockRule\">\n" + "</rule>\n" + "\n" + "</ruleset>");
-        RuleSetFactory ruleSetFactory = new RuleSetFactory();
+        RuleSetFactory ruleSetFactory = RulesetsFactoryUtils.defaultFactory();
         RuleSet rs = ruleSetFactory.createRuleSet(ref);
 
         Rule r = rs.getRules().toArray(new Rule[1])[0];
@@ -808,7 +808,7 @@ public class RuleSetFactoryTest {
                         + "  <description>Custom ruleset for tests</description>\n"
                         + "  <rule ref=\"net/sourceforge/pmd/TestRuleset1.xml\">\n"
                         + "    <exclude name=\"ThisRuleDoesNotExist\"/>\n" + "  </rule>\n" + "</ruleset>\n");
-        RuleSetFactory ruleSetFactory = new RuleSetFactory();
+        RuleSetFactory ruleSetFactory = RulesetsFactoryUtils.defaultFactory();
         RuleSet ruleset = ruleSetFactory.createRuleSet(ref);
         assertEquals(4, ruleset.getRules().size());
     }
@@ -838,7 +838,7 @@ public class RuleSetFactoryTest {
                         + "  <description>Custom ruleset for tests</description>\n"
                         + "  <rule ref=\"rulesets/dummy/basic.xml\">\n" + "    <exclude name=\"DummyBasicMockRule\"/>\n"
                         + "  </rule>\n" + "</ruleset>\n");
-        RuleSetFactory ruleSetFactory = new RuleSetFactory();
+        RuleSetFactory ruleSetFactory = RulesetsFactoryUtils.defaultFactory();
         RuleSet ruleset = ruleSetFactory.createRuleSet(ref1);
         assertNull(ruleset.getRuleByName("DummyBasicMockRule"));
 
@@ -850,7 +850,7 @@ public class RuleSetFactoryTest {
                         + "  <description>Custom ruleset for tests</description>\n"
                         + "  <rule ref=\"rulesets/dummy/basic.xml\">\n" + "    <exclude name=\"DummyBasicMockRule\"/>\n"
                         + "  </rule>\n" + "  <rule ref=\"rulesets/dummy/basic.xml\"/>\n" + "</ruleset>\n");
-        RuleSetFactory ruleSetFactory2 = new RuleSetFactory();
+        RuleSetFactory ruleSetFactory2 = RulesetsFactoryUtils.defaultFactory();
         RuleSet ruleset2 = ruleSetFactory2.createRuleSet(ref2);
         assertNotNull(ruleset2.getRuleByName("DummyBasicMockRule"));
 
@@ -862,7 +862,7 @@ public class RuleSetFactoryTest {
                         + "  <description>Custom ruleset for tests</description>\n"
                         + "  <rule ref=\"rulesets/dummy/basic.xml\"/>\n" + "  <rule ref=\"rulesets/dummy/basic.xml\">\n"
                         + "    <exclude name=\"DummyBasicMockRule\"/>\n" + "  </rule>\n" + "</ruleset>\n");
-        RuleSetFactory ruleSetFactory3 = new RuleSetFactory();
+        RuleSetFactory ruleSetFactory3 = RulesetsFactoryUtils.defaultFactory();
         RuleSet ruleset3 = ruleSetFactory3.createRuleSet(ref3);
         assertNotNull(ruleset3.getRuleByName("DummyBasicMockRule"));
     }
@@ -880,7 +880,7 @@ public class RuleSetFactoryTest {
                         + "  <description>Custom ruleset for tests</description>\n"
                         + "  <rule ref=\"rulesets/dummy/basic.xml\"/>\n"
                         + "  </ruleset>\n");
-        RuleSetFactory ruleSetFactory = new RuleSetFactory();
+        RuleSetFactory ruleSetFactory = RulesetsFactoryUtils.defaultFactory();
         ruleSetFactory.createRuleSet(ref);
 
         assertTrue(logging.getLog().contains("RuleSet name is missing."));
@@ -895,7 +895,7 @@ public class RuleSetFactoryTest {
                         + "    xsi:schemaLocation=\"http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd\">\n"
                         + "  <rule ref=\"rulesets/dummy/basic.xml\"/>\n"
                         + "  </ruleset>\n");
-        RuleSetFactory ruleSetFactory = new RuleSetFactory();
+        RuleSetFactory ruleSetFactory = RulesetsFactoryUtils.defaultFactory();
         ruleSetFactory.createRuleSet(ref);
         assertTrue(logging.getLog().contains("RuleSet description is missing."));
     }
@@ -1095,12 +1095,12 @@ public class RuleSetFactoryTest {
     }
 
     private RuleSet loadRuleSet(String ruleSetXml) throws RuleSetNotFoundException {
-        RuleSetFactory rsf = new RuleSetFactory();
+        RuleSetFactory rsf = RulesetsFactoryUtils.defaultFactory();
         return rsf.createRuleSet(createRuleSetReferenceId(ruleSetXml));
     }
 
     private RuleSet loadRuleSetWithDeprecationWarnings(String ruleSetXml) throws RuleSetNotFoundException {
-        RuleSetFactory rsf = new RuleSetFactory(new ResourceLoader(), RulePriority.LOW, true, false);
+        RuleSetFactory rsf = RulesetsFactoryUtils.createFactory(RulePriority.LOW, true, false);
         return rsf.createRuleSet(createRuleSetReferenceId(ruleSetXml));
     }
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetTest.java
@@ -59,7 +59,7 @@ public class RuleSetTest {
     public void testNoDFA() {
         MockRule mock = new MockRule("name", "desc", "msg", "rulesetname");
         mock.setLanguage(LanguageRegistry.getLanguage(DummyLanguageModule.NAME));
-        RuleSet rs = new RuleSetFactory().createSingleRuleRuleSet(mock);
+        RuleSet rs = RulesetsFactoryUtils.defaultFactory().createSingleRuleRuleSet(mock);
         assertFalse(rs.usesDFA(LanguageRegistry.getLanguage(DummyLanguageModule.NAME)));
     }
 
@@ -68,7 +68,7 @@ public class RuleSetTest {
         MockRule mock = new MockRule("name", "desc", "msg", "rulesetname");
         mock.setLanguage(LanguageRegistry.getLanguage(DummyLanguageModule.NAME));
         mock.setDfa(true);
-        RuleSet rs = new RuleSetFactory().createSingleRuleRuleSet(mock);
+        RuleSet rs = RulesetsFactoryUtils.defaultFactory().createSingleRuleRuleSet(mock);
         assertTrue(rs.usesDFA(LanguageRegistry.getLanguage(DummyLanguageModule.NAME)));
     }
 
@@ -87,21 +87,21 @@ public class RuleSetTest {
     @Test
     public void testGetRuleByName() {
         MockRule mock = new MockRule("name", "desc", "msg", "rulesetname");
-        RuleSet rs = new RuleSetFactory().createSingleRuleRuleSet(mock);
+        RuleSet rs = RulesetsFactoryUtils.defaultFactory().createSingleRuleRuleSet(mock);
         assertEquals("unable to fetch rule by name", mock, rs.getRuleByName("name"));
     }
 
     @Test
     public void testGetRuleByName2() {
         MockRule mock = new MockRule("name", "desc", "msg", "rulesetname");
-        RuleSet rs = new RuleSetFactory().createSingleRuleRuleSet(mock);
+        RuleSet rs = RulesetsFactoryUtils.defaultFactory().createSingleRuleRuleSet(mock);
         assertNull("the rule FooRule must not be found!", rs.getRuleByName("FooRule"));
     }
 
     @Test
     public void testRuleList() {
         MockRule rule = new MockRule("name", "desc", "msg", "rulesetname");
-        RuleSet ruleset = new RuleSetFactory().createSingleRuleRuleSet(rule);
+        RuleSet ruleset = RulesetsFactoryUtils.defaultFactory().createSingleRuleRuleSet(rule);
 
         assertEquals("Size of RuleSet isn't one.", 1, ruleset.size());
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetWriterTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetWriterTest.java
@@ -51,7 +51,7 @@ public class RuleSetWriterTest {
      */
     @Test
     public void testWrite() throws Exception {
-        RuleSet braces = new RuleSetFactory().createRuleSet("net/sourceforge/pmd/TestRuleset1.xml");
+        RuleSet braces = RulesetsFactoryUtils.defaultFactory().createRuleSet("net/sourceforge/pmd/TestRuleset1.xml");
         RuleSet ruleSet = new RuleSetBuilder(new Random().nextLong())
                 .withName("ruleset")
                 .withDescription("ruleset description")
@@ -72,7 +72,7 @@ public class RuleSetWriterTest {
      */
     @Test
     public void testRuleReferenceOverriddenName() throws Exception {
-        RuleSetFactory ruleSetFactory = new RuleSetFactory();
+        RuleSetFactory ruleSetFactory = RulesetsFactoryUtils.defaultFactory();
         RuleSet rs = ruleSetFactory.createRuleSet("dummy-basic");
         RuleSetReference ruleSetReference = new RuleSetReference("rulesets/dummy/basic.xml");
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/processor/MultiThreadProcessorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/processor/MultiThreadProcessorTest.java
@@ -22,6 +22,7 @@ import net.sourceforge.pmd.Report.ConfigurationError;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.RuleSetFactory;
 import net.sourceforge.pmd.RuleViolation;
+import net.sourceforge.pmd.RulesetsFactoryUtils;
 import net.sourceforge.pmd.ThreadSafeReportListener;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.rule.AbstractRule;
@@ -52,9 +53,9 @@ public class MultiThreadProcessorTest {
         ctx.getReport().addListener(reportListener);
 
         processor = new MultiThreadProcessor(configuration);
-        ruleSetFactory = new RuleSetFactory();
+        ruleSetFactory = RulesetsFactoryUtils.defaultFactory();
     }
-    
+
     @Test
     public void testRulesDysnfunctionalLog() throws IOException {
         setUpForTest("rulesets/MultiThreadProcessorTest/dysfunctional.xml");

--- a/pmd-core/src/test/java/net/sourceforge/pmd/properties/PropertyDescriptorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/properties/PropertyDescriptorTest.java
@@ -30,7 +30,7 @@ import org.junit.rules.ExpectedException;
 
 import net.sourceforge.pmd.FooRule;
 import net.sourceforge.pmd.RuleSet;
-import net.sourceforge.pmd.RuleSetFactory;
+import net.sourceforge.pmd.RulesetsFactoryUtils;
 import net.sourceforge.pmd.properties.constraints.PropertyConstraint;
 
 
@@ -57,7 +57,7 @@ public class PropertyDescriptorTest {
         FooRule rule = new FooRule();
         rule.definePropertyDescriptor(intProperty);
         rule.setProperty(intProperty, 1000);
-        RuleSet ruleSet = new RuleSetFactory().createSingleRuleRuleSet(rule);
+        RuleSet ruleSet = RulesetsFactoryUtils.defaultFactory().createSingleRuleRuleSet(rule);
 
         List<net.sourceforge.pmd.Rule> dysfunctional = new ArrayList<>();
         ruleSet.removeDysfunctionalRules(dysfunctional);
@@ -78,7 +78,7 @@ public class PropertyDescriptorTest {
         FooRule rule = new FooRule();
         rule.definePropertyDescriptor(descriptor);
         rule.setProperty(descriptor, Collections.singletonList(1000d)); // not in range
-        RuleSet ruleSet = new RuleSetFactory().createSingleRuleRuleSet(rule);
+        RuleSet ruleSet = RulesetsFactoryUtils.defaultFactory().createSingleRuleRuleSet(rule);
 
         List<net.sourceforge.pmd.Rule> dysfunctional = new ArrayList<>();
         ruleSet.removeDysfunctionalRules(dysfunctional);

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/docs/GenerateRuleDocsCmd.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/docs/GenerateRuleDocsCmd.java
@@ -22,6 +22,7 @@ import org.apache.commons.io.FilenameUtils;
 import net.sourceforge.pmd.RuleSet;
 import net.sourceforge.pmd.RuleSetFactory;
 import net.sourceforge.pmd.RuleSetNotFoundException;
+import net.sourceforge.pmd.RulesetsFactoryUtils;
 
 public final class GenerateRuleDocsCmd {
     private GenerateRuleDocsCmd() {
@@ -33,7 +34,7 @@ public final class GenerateRuleDocsCmd {
         Path output = FileSystems.getDefault().getPath(args[0]).resolve("..").toAbsolutePath().normalize();
         System.out.println("Generating docs into " + output);
 
-        RuleSetFactory ruleSetFactory = new RuleSetFactory();
+        RuleSetFactory ruleSetFactory = RulesetsFactoryUtils.defaultFactory();
         Iterator<RuleSet> registeredRuleSets = ruleSetFactory.getRegisteredRuleSets();
         List<String> additionalRulesets = findAdditionalRulesets(output);
 

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleDocGenerator.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleDocGenerator.java
@@ -38,6 +38,7 @@ import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleSet;
 import net.sourceforge.pmd.RuleSetFactory;
 import net.sourceforge.pmd.RuleSetNotFoundException;
+import net.sourceforge.pmd.RulesetsFactoryUtils;
 import net.sourceforge.pmd.lang.Language;
 import net.sourceforge.pmd.lang.rule.RuleReference;
 import net.sourceforge.pmd.lang.rule.XPathRule;
@@ -111,7 +112,7 @@ public class RuleDocGenerator {
         }
 
         List<RuleSet> rulesets = new ArrayList<>();
-        RuleSetFactory ruleSetFactory = new RuleSetFactory();
+        RuleSetFactory ruleSetFactory = RulesetsFactoryUtils.defaultFactory();
         for (String filename : additionalRulesets) {
             try {
                 // do not take rulesets from pmd-test or pmd-core

--- a/pmd-doc/src/test/java/net/sourceforge/pmd/docs/RuleDocGeneratorTest.java
+++ b/pmd-doc/src/test/java/net/sourceforge/pmd/docs/RuleDocGeneratorTest.java
@@ -26,6 +26,7 @@ import org.junit.Test;
 import net.sourceforge.pmd.RuleSet;
 import net.sourceforge.pmd.RuleSetFactory;
 import net.sourceforge.pmd.RuleSetNotFoundException;
+import net.sourceforge.pmd.RulesetsFactoryUtils;
 import net.sourceforge.pmd.docs.MockedFileWriter.FileEntry;
 
 public class RuleDocGeneratorTest {
@@ -76,7 +77,7 @@ public class RuleDocGeneratorTest {
     public void testSingleRuleset() throws RuleSetNotFoundException, IOException {
         RuleDocGenerator generator = new RuleDocGenerator(writer, root);
 
-        RuleSetFactory rsf = new RuleSetFactory();
+        RuleSetFactory rsf = RulesetsFactoryUtils.defaultFactory();
         RuleSet ruleset = rsf.createRuleSet("rulesets/ruledoctest/sample.xml");
 
         generator.generate(Arrays.asList(ruleset).iterator(),

--- a/pmd-doc/src/test/java/net/sourceforge/pmd/docs/RuleSetResolverTest.java
+++ b/pmd-doc/src/test/java/net/sourceforge/pmd/docs/RuleSetResolverTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 
 import net.sourceforge.pmd.RuleSetFactory;
 import net.sourceforge.pmd.RuleSetNotFoundException;
+import net.sourceforge.pmd.RulesetsFactoryUtils;
 
 public class RuleSetResolverTest {
 
@@ -30,10 +31,10 @@ public class RuleSetResolverTest {
     public void resolveAllRulesets() {
         Path basePath = FileSystems.getDefault().getPath(".").resolve("..").toAbsolutePath().normalize();
         List<String> additionalRulesets = GenerateRuleDocsCmd.findAdditionalRulesets(basePath);
-    
+
         filterRuleSets(additionalRulesets);
 
-        RuleSetFactory ruleSetFactory = new RuleSetFactory();
+        RuleSetFactory ruleSetFactory = RulesetsFactoryUtils.defaultFactory();
         for (String filename : additionalRulesets) {
             try {
                 ruleSetFactory.createRuleSet(filename);

--- a/pmd-doc/src/test/java/net/sourceforge/pmd/docs/SidebarGeneratorTest.java
+++ b/pmd-doc/src/test/java/net/sourceforge/pmd/docs/SidebarGeneratorTest.java
@@ -25,7 +25,7 @@ import org.yaml.snakeyaml.DumperOptions.LineBreak;
 import org.yaml.snakeyaml.Yaml;
 
 import net.sourceforge.pmd.RuleSet;
-import net.sourceforge.pmd.RuleSetFactory;
+import net.sourceforge.pmd.RulesetsFactoryUtils;
 import net.sourceforge.pmd.lang.Language;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 
@@ -40,8 +40,8 @@ public class SidebarGeneratorTest {
     @Test
     public void testSidebar() throws IOException {
         Map<Language, List<RuleSet>> rulesets = new HashMap<>();
-        RuleSet ruleSet1 = new RuleSetFactory().createNewRuleSet("test", "test", "bestpractices.xml", Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
-        RuleSet ruleSet2 = new RuleSetFactory().createNewRuleSet("test2", "test", "codestyle.xml", Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        RuleSet ruleSet1 = RulesetsFactoryUtils.defaultFactory().createNewRuleSet("test", "test", "bestpractices.xml", Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+        RuleSet ruleSet2 = RulesetsFactoryUtils.defaultFactory().createNewRuleSet("test2", "test", "codestyle.xml", Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
         rulesets.put(LanguageRegistry.findLanguageByTerseName("java"), Arrays.asList(ruleSet1, ruleSet2));
         rulesets.put(LanguageRegistry.findLanguageByTerseName("ecmascript"), Arrays.asList(ruleSet1));
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/ExcludeLinesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/ExcludeLinesTest.java
@@ -41,7 +41,7 @@ public class ExcludeLinesTest extends RuleTst {
         ctx.setReport(r);
         ctx.setSourceCodeFile(new File("n/a"));
         ctx.setLanguageVersion(LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getDefaultVersion());
-        RuleSet rules = new RuleSetFactory().createSingleRuleRuleSet(rule);
+        RuleSet rules = RulesetsFactoryUtils.defaultFactory().createSingleRuleRuleSet(rule);
         p.getSourceCodeProcessor().processSourceCode(new StringReader(TEST3), new RuleSets(rules), ctx);
         assertTrue(r.isEmpty());
         assertEquals(r.getSuppressedRuleViolations().size(), 1);

--- a/pmd-java/src/test/java/net/sourceforge/pmd/RuleSetFactoryTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/RuleSetFactoryTest.java
@@ -23,7 +23,7 @@ public class RuleSetFactoryTest extends AbstractRuleSetFactoryTest {
                         + "  <description>Custom ruleset for tests</description>\n"
                         + "  <rule ref=\"category/java/codestyle.xml\">\n"
                         + "    <exclude name=\"UselessParentheses\"/>\n" + "  </rule>\n" + "</ruleset>\n");
-        RuleSetFactory ruleSetFactory = new RuleSetFactory();
+        RuleSetFactory ruleSetFactory = RulesetsFactoryUtils.defaultFactory();
         RuleSet ruleset = ruleSetFactory.createRuleSet(ref);
         Rule rule = ruleset.getRuleByName("UselessParentheses");
         assertNull(rule);

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/xpath/XPathMetricFunctionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/xpath/XPathMetricFunctionTest.java
@@ -19,9 +19,9 @@ import net.sourceforge.pmd.Report;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.RuleSet;
-import net.sourceforge.pmd.RuleSetFactory;
 import net.sourceforge.pmd.RuleSets;
 import net.sourceforge.pmd.RuleViolation;
+import net.sourceforge.pmd.RulesetsFactoryUtils;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.java.JavaLanguageModule;
 import net.sourceforge.pmd.lang.java.xpath.MetricFunction;
@@ -55,7 +55,7 @@ public class XPathMetricFunctionTest {
         ctx.setReport(report);
         ctx.setSourceCodeFile(new File("n/a"));
         ctx.setIgnoreExceptions(false); // for test, we want immediate exceptions thrown and not collect them
-        RuleSet rules = new RuleSetFactory().createSingleRuleRuleSet(rule);
+        RuleSet rules = RulesetsFactoryUtils.defaultFactory().createSingleRuleRuleSet(rule);
         p.getSourceCodeProcessor().processSourceCode(new StringReader(code), new RuleSets(rules), ctx);
         return report.iterator();
     }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/XPathRuleTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/XPathRuleTest.java
@@ -21,9 +21,9 @@ import net.sourceforge.pmd.Report;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.RuleSet;
-import net.sourceforge.pmd.RuleSetFactory;
 import net.sourceforge.pmd.RuleSets;
 import net.sourceforge.pmd.RuleViolation;
+import net.sourceforge.pmd.RulesetsFactoryUtils;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.lang.Parser;
@@ -211,7 +211,7 @@ public class XPathRuleTest extends RuleTst {
         Report report = new Report();
         ctx.setReport(report);
         ctx.setSourceCodeFile(new File("n/a"));
-        RuleSet rules = new RuleSetFactory().createSingleRuleRuleSet(r);
+        RuleSet rules = RulesetsFactoryUtils.defaultFactory().createSingleRuleRuleSet(r);
         p.getSourceCodeProcessor().processSourceCode(new StringReader(test), new RuleSets(rules), ctx);
         return report;
     }

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/XPathJspRuleTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/XPathJspRuleTest.java
@@ -16,9 +16,9 @@ import net.sourceforge.pmd.Report;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.RuleSet;
-import net.sourceforge.pmd.RuleSetFactory;
 import net.sourceforge.pmd.RuleSets;
 import net.sourceforge.pmd.RuleViolation;
+import net.sourceforge.pmd.RulesetsFactoryUtils;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.jsp.JspLanguageModule;
 import net.sourceforge.pmd.lang.rule.XPathRule;
@@ -28,14 +28,14 @@ public class XPathJspRuleTest extends RuleTst {
 
     /**
      * Test matching a XPath expression against a JSP source.
-     * @throws PMDException 
+     * @throws PMDException
      */
     @Test
     public void testExpressionMatching() throws PMDException {
         Rule rule = new XPathRule(XPATH_EXPRESSION);
         rule.setMessage("Test");
         rule.setLanguage(LanguageRegistry.getLanguage(JspLanguageModule.NAME));
-        RuleSet rules = new RuleSetFactory().createSingleRuleRuleSet(rule);
+        RuleSet rules = RulesetsFactoryUtils.defaultFactory().createSingleRuleRuleSet(rule);
 
         RuleContext ctx = new RuleContext();
         Report report = new Report();

--- a/pmd-scala/src/test/java/net/sourceforge/pmd/lang/scala/rule/ScalaRuleTest.java
+++ b/pmd-scala/src/test/java/net/sourceforge/pmd/lang/scala/rule/ScalaRuleTest.java
@@ -19,8 +19,8 @@ import net.sourceforge.pmd.Report;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.RuleSet;
-import net.sourceforge.pmd.RuleSetFactory;
 import net.sourceforge.pmd.RuleSets;
+import net.sourceforge.pmd.RulesetsFactoryUtils;
 import net.sourceforge.pmd.internal.util.IteratorUtil;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersionHandler;
@@ -77,7 +77,7 @@ public class ScalaRuleTest {
         Report report = new Report();
         ctx.setReport(report);
         ctx.setSourceCodeFile(new File("test.scala"));
-        RuleSet rules = new RuleSetFactory().createSingleRuleRuleSet(r);
+        RuleSet rules = RulesetsFactoryUtils.defaultFactory().createSingleRuleRuleSet(r);
         p.getSourceCodeProcessor().processSourceCode(new StringReader(test), new RuleSets(rules), ctx);
         return report;
     }

--- a/pmd-scala/src/test/java/net/sourceforge/pmd/lang/scala/rule/XPathRuleTest.java
+++ b/pmd-scala/src/test/java/net/sourceforge/pmd/lang/scala/rule/XPathRuleTest.java
@@ -19,9 +19,9 @@ import net.sourceforge.pmd.Report;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.RuleSet;
-import net.sourceforge.pmd.RuleSetFactory;
 import net.sourceforge.pmd.RuleSets;
 import net.sourceforge.pmd.RuleViolation;
+import net.sourceforge.pmd.RulesetsFactoryUtils;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.rule.XPathRule;
 import net.sourceforge.pmd.lang.rule.xpath.XPathRuleQuery;
@@ -57,7 +57,7 @@ public class XPathRuleTest extends RuleTst {
         Report report = new Report();
         ctx.setReport(report);
         ctx.setSourceCodeFile(new File("test.scala"));
-        RuleSet rules = new RuleSetFactory().createSingleRuleRuleSet(r);
+        RuleSet rules = RulesetsFactoryUtils.defaultFactory().createSingleRuleRuleSet(r);
         p.getSourceCodeProcessor().processSourceCode(new StringReader(test), new RuleSets(rules), ctx);
         return report;
     }

--- a/pmd-test/src/main/java/net/sourceforge/pmd/AbstractLanguageVersionTest.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/AbstractLanguageVersionTest.java
@@ -156,7 +156,7 @@ public class AbstractLanguageVersionTest {
         String rulesetFilenames = props.getProperty("rulesets.filenames");
         assertNotNull(rulesetFilenames);
 
-        RuleSetFactory factory = new RuleSetFactory();
+        RuleSetFactory factory = RulesetsFactoryUtils.defaultFactory();
 
         if (rulesetFilenames.trim().isEmpty()) {
             return;

--- a/pmd-test/src/main/java/net/sourceforge/pmd/AbstractRuleSetFactoryTest.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/AbstractRuleSetFactoryTest.java
@@ -261,7 +261,7 @@ public abstract class AbstractRuleSetFactoryTest {
     }
 
     private RuleSet loadRuleSetByFileName(String ruleSetFileName) throws RuleSetNotFoundException {
-        RuleSetFactory rsf = new RuleSetFactory();
+        RuleSetFactory rsf = RulesetsFactoryUtils.defaultFactory();
         return rsf.createRuleSet(ruleSetFileName);
     }
 
@@ -360,7 +360,7 @@ public abstract class AbstractRuleSetFactoryTest {
         // System.out.println("xml2: " + xml2);
 
         // Read RuleSet from XML, first time
-        RuleSetFactory ruleSetFactory = new RuleSetFactory();
+        RuleSetFactory ruleSetFactory = RulesetsFactoryUtils.defaultFactory();
         RuleSet ruleSet2 = ruleSetFactory.createRuleSet(createRuleSetReferenceId(xml2));
 
         // Do write/read a 2nd time, just to be sure

--- a/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
@@ -40,10 +40,10 @@ import net.sourceforge.pmd.Report;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.RuleSet;
-import net.sourceforge.pmd.RuleSetFactory;
 import net.sourceforge.pmd.RuleSetNotFoundException;
 import net.sourceforge.pmd.RuleSets;
 import net.sourceforge.pmd.RuleViolation;
+import net.sourceforge.pmd.RulesetsFactoryUtils;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
@@ -99,7 +99,7 @@ public abstract class RuleTst {
      */
     public Rule findRule(String ruleSet, String ruleName) {
         try {
-            Rule rule = new RuleSetFactory().createRuleSets(ruleSet).getRuleByName(ruleName);
+            Rule rule = RulesetsFactoryUtils.defaultFactory().createRuleSets(ruleSet).getRuleByName(ruleName);
             if (rule == null) {
                 fail("Rule " + ruleName + " not found in ruleset " + ruleSet);
             } else {
@@ -280,7 +280,7 @@ public abstract class RuleTst {
             ctx.setSourceCodeFile(new File("n/a"));
             ctx.setLanguageVersion(languageVersion);
             ctx.setIgnoreExceptions(false);
-            RuleSet rules = new RuleSetFactory().createSingleRuleRuleSet(rule);
+            RuleSet rules = RulesetsFactoryUtils.defaultFactory().createSingleRuleRuleSet(rule);
             p.getSourceCodeProcessor().processSourceCode(new StringReader(code), new RuleSets(rules), ctx);
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
This fixes #2161 
* Introduces methods  in RulesetFactoryUtils to create a ruleset factory from a PMD configuration with/without ClassLoader, but without ResourceLoader
* Deprecate the factory method that takes a ResourceLoader as parameter in RulesetFactoryUtils.
* Deprecate all RulesetFactory constructors, replace them with factory methods on RulesetFactoryUtils

Rationale for internalizing ResourceLoader is that it's just a helper object for RulesetFactory. Its error handling logic is tightly coupled to RulesetFactory, so it can't reliably be implemented outside of PMD. For clients of PMD it's enough to pass a ClassLoader or use the default. Alternatively we could redesign ResourceLoader to be extension-friendly, but for now it doesn't look worth the effort and added published API.