### PR TITLE
[core] Fix odd logic in test runner

### DIFF
--- a/pmd-test/src/main/java/net/sourceforge/pmd/testframework/PMDTestRunner.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/testframework/PMDTestRunner.java
@@ -66,7 +66,7 @@ public class PMDTestRunner extends Runner implements Filterable, Sortable {
         try {
             unitTests.filter(filter);
         } catch (NoTestsRemainException e) {
-            noUnitTests = false;
+            noUnitTests = true;
         }
 
         if (noRuleTests && noUnitTests) {


### PR DESCRIPTION
Condition `noRuleTests && noUnitTests` is always false when reached here. `noUnitTests` should be probably set to `true`, not `false`.
(I found this with the [data-flow analyzer](https://github.com/Egor18/jdataflow) I'm working on.)