### PR TITLE
[java] Fix odd logic in AvoidUsingHardCodedIPRule

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidUsingHardCodedIPRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidUsingHardCodedIPRule.java
@@ -104,11 +104,11 @@ public class AvoidUsingHardCodedIPRule extends AbstractJavaRule {
     }
 
     protected boolean isLatinDigit(char c) {
-        return '0' <= c || c <= '9';
+        return '0' <= c && c <= '9';
     }
 
     protected boolean isHexCharacter(char c) {
-        return isLatinDigit(c) || 'A' <= c || c <= 'F' || 'a' <= c || c <= 'f';
+        return isLatinDigit(c) || 'A' <= c && c <= 'F' || 'a' <= c && c <= 'f';
     }
 
     protected boolean isIPv4(final char firstChar, final String s) {


### PR DESCRIPTION
Condition `('0' <= c) || (c <= '9')` is always true and makes no sense. Looks like `&&` should be used here instead of `||`.
(I found this with the [data-flow analyzer](https://github.com/Egor18/jdataflow) I'm working on.)