### PR TITLE
[modelica] Normalize invalid node ranges

### DIFF
--- a/pmd-modelica/pom.xml
+++ b/pmd-modelica/pom.xml
@@ -22,6 +22,13 @@
                 </configuration>
             </plugin>
 
+
+            <plugin>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <groupId>org.jetbrains.kotlin</groupId>
+            </plugin>
+
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-antrun-plugin</artifactId>
@@ -72,7 +79,17 @@
 
         <dependency>
             <groupId>net.sourceforge.pmd</groupId>
+            <artifactId>pmd-lang-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/AbstractModelicaNode.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/AbstractModelicaNode.java
@@ -115,7 +115,7 @@ abstract class AbstractModelicaNode extends AbstractNode implements Node, Modeli
     @Override
     public void jjtSetLastToken(GenericToken token) {
         // don't let jjtree override tokens we've chosen
-        if (lastToken != null) {
+        if (lastToken == null) {
             super.jjtSetLastToken(token);
         }
     }

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/AbstractModelicaNode.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/AbstractModelicaNode.java
@@ -86,7 +86,7 @@ abstract class AbstractModelicaNode extends AbstractNode implements Node, Modeli
 
             Token next = parser.token.next;
 
-            Token implicit = new Token(IMPLICIT_TOKEN);
+            Token implicit = new Token(IMPLICIT_TOKEN, "");
             implicit.beginColumn = next.beginColumn;
             implicit.endColumn = next.beginColumn - 1; // because of inclusive columns..
             implicit.beginLine = next.beginLine;

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/AbstractModelicaNode.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/AbstractModelicaNode.java
@@ -66,6 +66,14 @@ abstract class AbstractModelicaNode extends AbstractNode implements Node, Modeli
         }
         endLine = parser.token.endLine;
         endColumn = parser.token.endColumn;
+
+        if (endLine < beginLine) {
+            beginLine = endLine;
+            beginColumn = endColumn;
+        }
+        if (endLine == beginLine && endColumn < beginColumn) {
+            beginColumn = endColumn;
+        }
     }
 
     @Override

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/AbstractModelicaNode.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/AbstractModelicaNode.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.modelica.ast;
 
 import net.sourceforge.pmd.lang.ast.AbstractNode;
+import net.sourceforge.pmd.lang.ast.GenericToken;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.modelica.resolver.ModelicaScope;
 
@@ -18,6 +19,13 @@ import net.sourceforge.pmd.lang.modelica.resolver.ModelicaScope;
  * @see ModelicaNode for public API.
  */
 abstract class AbstractModelicaNode extends AbstractNode implements Node, ModelicaNode {
+
+    /**
+     * Kind for implicit tokens. Negative because JavaCC only picks
+     * positive numbers for token kinds.
+     */
+    private static final int IMPLICIT_TOKEN = -1;
+
     private ModelicaParser parser;
     private ModelicaScope ownScope;
 
@@ -49,30 +57,66 @@ abstract class AbstractModelicaNode extends AbstractNode implements Node, Modeli
     }
 
     @Override
-    public void jjtOpen() {
-        if (beginLine == -1 && parser.token.next != null) {
-            beginLine = parser.token.next.beginLine;
-            beginColumn = parser.token.next.beginColumn;
-        }
+    public int getBeginLine() {
+        return jjtGetFirstToken().getBeginLine();
+    }
+
+    @Override
+    public int getBeginColumn() {
+        return jjtGetFirstToken().getBeginColumn();
+    }
+
+    @Override
+    public int getEndLine() {
+        return jjtGetLastToken().getEndLine();
+    }
+
+    @Override
+    public int getEndColumn() {
+        return jjtGetLastToken().getEndColumn();
     }
 
     @Override
     public void jjtClose() {
-        if (beginLine == -1 && (children == null || children.length == 0)) {
-            beginColumn = parser.token.beginColumn;
-        }
-        if (beginLine == -1) {
-            beginLine = parser.token.beginLine;
-        }
-        endLine = parser.token.endLine;
-        endColumn = parser.token.endColumn;
 
-        if (endLine < beginLine) {
-            beginLine = endLine;
-            beginColumn = endColumn;
+        // in jjtClose, jjtSetLastToken has not been called yet, so we use parser.token.next
+        if (parser.token.next == jjtGetFirstToken()) {
+            // Reversed, this node consumed no token.
+            // Forge a token with the correct coordinates, and zero length
+
+            Token next = parser.token.next;
+
+            Token implicit = new Token(IMPLICIT_TOKEN);
+            implicit.beginColumn = next.beginColumn;
+            implicit.endColumn = next.beginColumn - 1; // because of inclusive columns..
+            implicit.beginLine = next.beginLine;
+            implicit.endLine = next.beginLine;
+
+            // insert it right before the next token
+            // as a special token
+            implicit.next = next;
+
+            if (next.specialToken != null) {
+                next.specialToken.next = implicit;
+                implicit.specialToken = next.specialToken;
+            }
+
+            next.specialToken = implicit;
+
+
+            // set it as both first and last
+            // beware, JJTree calls jjtSetLastToken after this routine..
+            // hence the override below
+            jjtSetFirstToken(implicit);
+            jjtSetLastToken(implicit);
         }
-        if (endLine == beginLine && endColumn < beginColumn) {
-            beginColumn = endColumn;
+    }
+
+    @Override
+    public void jjtSetLastToken(GenericToken token) {
+        // don't let jjtree override tokens we've chosen
+        if (lastToken != null) {
+            super.jjtSetLastToken(token);
         }
     }
 

--- a/pmd-modelica/src/test/kotlin/net/sourceforge/pmd/lang/modelica/ast/ModelicaCoordsTest.kt
+++ b/pmd-modelica/src/test/kotlin/net/sourceforge/pmd/lang/modelica/ast/ModelicaCoordsTest.kt
@@ -1,0 +1,123 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.modelica.ast
+
+import io.kotlintest.should
+import io.kotlintest.shouldBe
+import io.kotlintest.specs.FunSpec
+import net.sourceforge.pmd.lang.LanguageRegistry
+import net.sourceforge.pmd.lang.ast.Node
+import net.sourceforge.pmd.lang.ast.test.matchNode
+import net.sourceforge.pmd.lang.ast.test.shouldBe
+import java.io.StringReader
+
+class ModelicaCoordsTest : FunSpec({
+
+
+    test("Test line/column numbers for implicit nodes") {
+
+        """
+package TestPackage
+  package EmptyPackage
+  end EmptyPackage;
+end TestPackage;
+      """.trim().parseModelica() should matchNode<ASTStoredDefinition> {
+
+            it.assertBounds(1, 1, 4, 16)
+
+            child<ASTClassDefinition> {
+                it.assertBounds(1, 1, 4, 15)
+
+                child<ASTClassPrefixes> {
+                    it.assertBounds(1, 1, 1, 7)
+
+                    child<ASTPackageClause> {
+                        it.assertBounds(1, 1, 1, 7)
+                    }
+                }
+                child<ASTClassSpecifier> {
+                    it.assertBounds(1, 9, 4, 15)
+
+                    child<ASTSimpleLongClassSpecifier> {
+                        it.assertBounds(1, 9, 4, 15)
+
+                        child<ASTSimpleName> {
+                            it.assertBounds(1, 9, 1, 19)
+                        }
+                        child<ASTComposition> {
+                            it.assertBounds(2, 3, 3, 19)
+
+                            child<ASTElementList> {
+                                it.assertBounds(2, 3, 3, 19)
+
+                                child<ASTRegularElement> {
+                                    it.assertBounds(2, 3, 3, 18)
+
+                                    child<ASTClassDefinition> {
+                                        it.assertBounds(2, 3, 3, 18)
+                                        it.isPartial shouldBe false
+
+                                        child<ASTClassPrefixes> {
+                                            it.assertBounds(2, 3, 2, 9)
+
+                                            child<ASTPackageClause> {
+                                                it.assertBounds(2, 3, 2, 9)
+                                            }
+                                        }
+                                        child<ASTClassSpecifier> {
+                                            it.assertBounds(2, 11, 3, 18)
+
+                                            child<ASTSimpleLongClassSpecifier> {
+                                                it.assertBounds(2, 11, 3, 18)
+                                                it.simpleClassName shouldBe "EmptyPackage"
+
+                                                child<ASTSimpleName> {
+                                                    it.assertBounds(2, 11, 2, 22)
+
+                                                }
+                                                child<ASTComposition> {
+
+                                                    it.assertBounds(3, 3, 3, 2)
+
+                                                    child<ASTElementList> {
+                                                        /*
+                                                            This ElementList is empty and has no explicit token.
+                                                         */
+
+                                                        it.assertBounds(3, 3, 3, 2)
+                                                    }
+                                                }
+                                                child<ASTSimpleName> {
+                                                    it.assertBounds(3, 7, 3, 18)
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        child<ASTSimpleName> {
+                            it.assertBounds(4, 5, 4, 15)
+                        }
+                    }
+                }
+            }
+        }
+    }
+})
+
+fun String.parseModelica(): ASTStoredDefinition {
+    val ver = LanguageRegistry.getLanguage("Modelica").defaultVersion.languageVersionHandler
+    val parser = ver.getParser(ver.defaultParserOptions)
+
+    return parser.parse(":dummy:", StringReader(this)) as ASTStoredDefinition
+}
+
+fun Node.assertBounds(bline: Int, bcol: Int, eline: Int, ecol: Int) {
+    this::getBeginLine shouldBe bline
+    this::getBeginColumn shouldBe bcol
+    this::getEndLine shouldBe eline
+    this::getEndColumn shouldBe ecol
+}


### PR DESCRIPTION
Some files were parsed into ASTs with nodes having negative ranges.
For example:

```modelica
package TestPackage
  package EmptyPackage
  end EmptyPackage;
end TestPackage;
```

has subtree:

```
  SimpleLongClassSpecifier "EmptyPackage"
    SimpleName "EmptyPackage"
    Composition
      ElementList <-- start = 3:3, end = 2:22
    SimpleName "EmptyPackage"
```