### PR TITLE
[modelica] Fix Javadoc tags

### DIFF
--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/AbstractModelicaImportClause.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/AbstractModelicaImportClause.java
@@ -34,14 +34,14 @@ abstract class AbstractModelicaImportClause extends AbstractModelicaNode impleme
     abstract boolean isQualified();
 
     /**
-     * A template method to be used by {@link resolveSimpleName}. Usually used to fetch the lexically referenced
+     * A template method to be used by {@link #resolveSimpleName}. Usually used to fetch the lexically referenced
      * class in the corresponding import statement.
      */
     protected abstract ResolutionResult<ModelicaDeclaration> getCacheableImportSources(ResolutionState state, ModelicaScope scope);
 
     /**
-     * A template method to be used by {@link resolveSimpleName}. Usually used to try to fetch declarations for
-     * <code>simpleName</code> from particular <i>source</i> returned by {@link getCacheableImportSources}.
+     * A template method to be used by {@link #resolveSimpleName}. Usually used to try to fetch declarations for
+     * <code>simpleName</code> from particular <i>source</i> returned by {@link #getCacheableImportSources}.
      */
     protected abstract void fetchImportedClassesFromSource(ResolutionContext result, ModelicaDeclaration source, String simpleName) throws Watchdog.CountdownException;
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ModelicaNode.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ModelicaNode.java
@@ -19,7 +19,7 @@ public interface ModelicaNode extends Node {
     /**
      * Returns the most specific lexical scope naturally associated with this node.
      *
-     * @return the scope defined by this node itself or the same as {@link getContainingScope} otherwise
+     * @return the scope defined by this node itself or the same as {@link #getContainingScope} otherwise
      */
     ModelicaScope getMostSpecificScope();
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/CompositeName.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/CompositeName.java
@@ -69,7 +69,7 @@ public final class CompositeName {
     /**
      * Tries to match the <code>prefix</code> argument with the first elements of this name
      *
-     * @returns the remaining elements on success or null on failure
+     * @return the remaining elements on success or null on failure
      */
     public CompositeName matchPrefix(String[] prefix) {
         return matchPrefix(prefix, 0);

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/Watchdog.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/Watchdog.java
@@ -5,7 +5,7 @@
 package net.sourceforge.pmd.lang.modelica.resolver;
 
 /**
- * A watchdog counter initialized with some value. Throws an exception after the specified {@link decrement} calls.
+ * A watchdog counter initialized with some value. Throws an exception after the specified {@link #decrement} calls.
  *
  * Is used to break possible resolution loops.
  */


### PR DESCRIPTION
* fix one `@return` tag misspelled as `@returns`
* fix several method references initially written without `#` sign prepended