### PR TITLE
[java] InvalidLogMessageFormat: handle zero placeholders correctly

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -54,6 +54,7 @@ the implementation based on your feedback.
     *   [#1683](https://github.com/pmd/pmd/issues/1683): \[java] CommentRequired property names are inconsistent
 *   java-errorprone
     *   [#2140](https://github.com/pmd/pmd/issues/2140): \[java] AvoidLiteralsInIfCondition: false negative for expressions
+    *   [#2196](https://github.com/pmd/pmd/issues/2196): \[java] InvalidLogMessageFormat does not detect extra parameters when no placeholders
 *   java-performance
     *   [#2141](https://github.com/pmd/pmd/issues/2141): \[java] StringInstatiation: False negative with String-array access
 *   plsql

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidLogMessageFormat.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidLogMessageFormat.xml
@@ -745,4 +745,42 @@ public final class Main {
             }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>log4j2: #2196 [java] InvalidLogMessageFormat does not detect extra parameters when no placeholders</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>8,9</expected-linenumbers>
+        <code><![CDATA[
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
+public class InvalidLogMessageFormatTest {
+    private static final Logger logger = LogManager.getLogger("MyLogger");
+
+    public static void main(String[] args) {
+        logger.warn("foo {}", "flibble", "moo", "blah", "blah"); // PMD flags this
+        logger.warn("foo", "flibble", "moo", "blah", "blah"); // PMD doesn't flag this
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>slf4j: #2196 [java] InvalidLogMessageFormat does not detect extra parameters when no placeholders</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>8,9</expected-linenumbers>
+        <code><![CDATA[
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InvalidLogMessageFormatTest {
+    private static final Logger logger = LoggerFactory.getLogger("MyLogger");
+
+    public static void main(String[] args) {
+        logger.warn("foo {}", "flibble", "moo", "blah", "blah"); // PMD flags this
+        logger.warn("foo", "flibble", "moo", "blah", "blah"); // PMD doesn't flag this
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Fixes #2196

Also refactors the implementation to not use a XPath query anymore.

<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

