### PR TITLE
[java] JavaRuleViolation reports wrong class name

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -46,6 +46,8 @@ the implementation based on your feedback.
     *   [#2006](https://github.com/pmd/pmd/issues/2006): \[core] PMD should warn about multiple instances of the same rule in a ruleset
     *   [#2161](https://github.com/pmd/pmd/issues/2161): \[core] ResourceLoader is deprecated and marked as internal but is exposed
     *   [#2170](https://github.com/pmd/pmd/issues/2170): \[core] DocumentFile doesn't preserve newlines
+*   java
+    *   [#2212](https://github.com/pmd/pmd/issues/2212): \[java] JavaRuleViolation reports wrong class name
 *   java-bestpractices
     *   [#2149](https://github.com/pmd/pmd/issues/2149): \[java] JUnitAssertionsShouldIncludeMessage - False positive with assertEquals and JUnit5
 *   java-codestyle

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolation.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolation.java
@@ -105,7 +105,7 @@ public class JavaRuleViolation extends ParametricRuleViolation<JavaNode> {
     private void setClassNameFrom(JavaNode node) {
         String qualifiedName = null;
 
-        if (node.getScope() instanceof ClassScope) {
+        if (node instanceof AbstractAnyTypeDeclaration && node.getScope() instanceof ClassScope) {
             qualifiedName = ((ClassScope) node.getScope()).getClassName();
         }
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/JavaRuleViolationTest.java
@@ -18,6 +18,7 @@ import net.sourceforge.pmd.lang.ParserOptions;
 import net.sourceforge.pmd.lang.java.JavaLanguageModule;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
@@ -84,11 +85,27 @@ public class JavaRuleViolationTest {
      * @see <a href="https://sourceforge.net/p/pmd/bugs/1529/">#1529</a>
      */
     @Test
-    public void testPackageAndClassName() {
+    public void testPackageAndClassNameForImport() {
         ASTCompilationUnit ast = parse("package pkg; import java.util.List; public class Foo { }");
         ASTImportDeclaration importNode = ast.getFirstDescendantOfType(ASTImportDeclaration.class);
 
         JavaRuleViolation violation = new JavaRuleViolation(null, new RuleContext(), importNode, null);
+        assertEquals("pkg", violation.getPackageName());
+        assertEquals("Foo", violation.getClassName());
+    }
+
+    @Test
+    public void testPackageAndClassNameForField() {
+        ASTCompilationUnit ast = parse("package pkg; public class Foo { int a; }");
+        ASTClassOrInterfaceDeclaration classDeclaration = ast.getFirstDescendantOfType(ASTClassOrInterfaceDeclaration.class);
+        ASTFieldDeclaration field = ast.getFirstDescendantOfType(ASTFieldDeclaration.class);
+
+        JavaRuleViolation violation;
+        violation = new JavaRuleViolation(null, new RuleContext(), classDeclaration, null);
+        assertEquals("pkg", violation.getPackageName());
+        assertEquals("Foo", violation.getClassName());
+
+        violation = new JavaRuleViolation(null, new RuleContext(), field, null);
         assertEquals("pkg", violation.getPackageName());
         assertEquals("Foo", violation.getClassName());
     }
@@ -135,17 +152,27 @@ public class JavaRuleViolationTest {
 
     /**
      * Test that the name of the inner class is taken correctly.
+     * Also check fields.
      */
     @Test
     public void testInnerClass() {
-        ASTCompilationUnit ast = parse("class Foo { class Bar { } }");
+        ASTCompilationUnit ast = parse("class Foo { int a; class Bar { int a; } }");
         List<ASTClassOrInterfaceDeclaration> classes = ast.findDescendantsOfType(ASTClassOrInterfaceDeclaration.class);
         assertEquals(2, classes.size());
 
         JavaRuleViolation fooViolation = new JavaRuleViolation(null, new RuleContext(), classes.get(0), null);
         assertEquals("Foo", fooViolation.getClassName());
-        
+
         JavaRuleViolation barViolation = new JavaRuleViolation(null, new RuleContext(), classes.get(1), null);
         assertEquals("Foo$Bar", barViolation.getClassName());
+
+        List<ASTFieldDeclaration> fields = ast.findDescendantsOfType(ASTFieldDeclaration.class, true);
+        assertEquals(2, fields.size());
+
+        JavaRuleViolation fieldViolation = new JavaRuleViolation(null, new RuleContext(), fields.get(0), null);
+        assertEquals("Foo", fieldViolation.getClassName());
+
+        JavaRuleViolation innerFieldViolation = new JavaRuleViolation(null, new RuleContext(), fields.get(1), null);
+        assertEquals("Foo$Bar", innerFieldViolation.getClassName());
     }
 }


### PR DESCRIPTION
Fixes #2212

<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

