### PR TITLE
[core] Add xml tree renderer

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeRenderer.java
@@ -1,0 +1,34 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.treeexport;
+
+import java.io.IOException;
+
+import net.sourceforge.pmd.annotation.Experimental;
+import net.sourceforge.pmd.lang.ast.Node;
+
+/**
+ * An object that can export a tree to an external text format.
+ *
+ * @see XmlTreeRenderer
+ */
+@Experimental
+public interface TreeRenderer {
+
+
+    /**
+     * Appends the subtree rooted at the given node on the provided
+     * output writer. The implementation is free to filter out some
+     * nodes from the subtree.
+     *
+     * @param node Node to render
+     * @param out  Object onto which the output is appended
+     *
+     * @throws IOException If an IO error occurs while appending to the output
+     */
+    void renderSubtree(Node node, Appendable out) throws IOException;
+
+
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeRendererDescriptor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeRendererDescriptor.java
@@ -1,0 +1,51 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.treeexport;
+
+import net.sourceforge.pmd.annotation.Experimental;
+import net.sourceforge.pmd.properties.PropertySource;
+
+/**
+ * Describes the configuration options of a specific {@link TreeRenderer}.
+ *
+ * @see TreeRenderers
+ */
+@Experimental
+public interface TreeRendererDescriptor {
+
+    /**
+     * Returns a new property bundle, that can be used to configure
+     * the output of {@link #produceRenderer(PropertySource)}. Properties
+     * supported by the renderer are already registered on the returned
+     * bundle.
+     */
+    PropertySource newPropertyBundle();
+
+
+    /**
+     * Returns the ID of this renderer, used to select it.
+     * The ID of a descriptor should never change.
+     *
+     * @see TreeRenderers#findById(String)
+     */
+    String id();
+
+
+    /**
+     * Returns a short description of the format of this renderer's output.
+     */
+    String description();
+
+
+    /**
+     * Builds a new renderer from the given properties.
+     *
+     * @param properties A property bundle, that should have been produced by
+     *                   {@link #newPropertyBundle()}.
+     */
+    TreeRenderer produceRenderer(PropertySource properties);
+
+
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeRendererDescriptorImpl.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeRendererDescriptorImpl.java
@@ -45,10 +45,10 @@ abstract class TreeRendererDescriptorImpl implements TreeRendererDescriptor {
 
     @Override
     public String toString() {
-        return "TreeDescriptorImpl{" +
-            "id='" + id + '\'' +
-            ", description='" + description + '\'' +
-            '}';
+        return "TreeDescriptorImpl{"
+            + "id='" + id + '\''
+            + ", description='" + description + '\''
+            + '}';
     }
 
     private static class PropertyBundle extends AbstractPropertySource {
@@ -56,7 +56,7 @@ abstract class TreeRendererDescriptorImpl implements TreeRendererDescriptor {
 
         private final String name;
 
-        public PropertyBundle(String name,
+        PropertyBundle(String name,
                               Set<PropertyDescriptor<?>> available) {
             this.name = name;
             for (PropertyDescriptor<?> p : available) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeRendererDescriptorImpl.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeRendererDescriptorImpl.java
@@ -1,0 +1,77 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.treeexport;
+
+import java.util.Collections;
+import java.util.Set;
+
+import net.sourceforge.pmd.properties.AbstractPropertySource;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertySource;
+
+abstract class TreeRendererDescriptorImpl implements TreeRendererDescriptor {
+
+    private final String id;
+    private final String description;
+
+
+    protected TreeRendererDescriptorImpl(String id, String description) {
+        this.id = id;
+        this.description = description;
+    }
+
+
+    @Override
+    public PropertySource newPropertyBundle() {
+        return new PropertyBundle(id, availableDescriptors());
+    }
+
+
+    protected Set<PropertyDescriptor<?>> availableDescriptors() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public String id() {
+        return id;
+    }
+
+    @Override
+    public String description() {
+        return description;
+    }
+
+    @Override
+    public String toString() {
+        return "TreeDescriptorImpl{" +
+            "id='" + id + '\'' +
+            ", description='" + description + '\'' +
+            '}';
+    }
+
+    private static class PropertyBundle extends AbstractPropertySource {
+
+
+        private final String name;
+
+        public PropertyBundle(String name,
+                              Set<PropertyDescriptor<?>> available) {
+            this.name = name;
+            for (PropertyDescriptor<?> p : available) {
+                definePropertyDescriptor(p);
+            }
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        protected String getPropertySourceType() {
+            return "tree renderer";
+        }
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeRenderers.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeRenderers.java
@@ -1,0 +1,135 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.treeexport;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import net.sourceforge.pmd.annotation.Experimental;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.properties.PropertySource;
+import net.sourceforge.pmd.util.treeexport.XmlTreeRenderer.XmlRenderingConfig;
+
+/**
+ * Entry point to fetch and register tree renderers. This API is meant
+ * to be be integrated in tools that operate on tree descriptors generically.
+ * For that reason the standard descriptors provided by PMD and their
+ * properties are not public.
+ *
+ * @see #findById(String)
+ * @see #register(TreeRendererDescriptor)
+ */
+@Experimental
+public final class TreeRenderers {
+
+    // descriptors are test only
+
+    static final PropertyDescriptor<Boolean> XML_RENDER_PROLOG =
+        PropertyFactory.booleanProperty("renderProlog")
+                       .desc("True to output a prolog")
+                       .defaultValue(true)
+                       .build();
+
+    static final PropertyDescriptor<Boolean> XML_USE_SINGLE_QUOTES =
+        PropertyFactory.booleanProperty("singleQuoteAttributes")
+                       .desc("Use single quotes to delimit attribute values")
+                       .defaultValue(true)
+                       .build();
+
+
+    static final PropertyDescriptor<String> XML_LINE_SEPARATOR =
+        PropertyFactory.stringProperty("lineSeparator")
+                       .desc("Line separator to use. The default is platform-specific.")
+                       .defaultValue(System.lineSeparator())
+                       .build();
+
+
+    static final TreeRendererDescriptor XML =
+        new TreeRendererDescriptorImpl("xml", "XML format will the same structure as the one used in XPath") {
+
+            private final Set<PropertyDescriptor<?>> myDescriptors
+                = Collections.unmodifiableSet(new LinkedHashSet<>(Arrays.<PropertyDescriptor<?>>asList(
+                XML_USE_SINGLE_QUOTES, XML_LINE_SEPARATOR, XML_RENDER_PROLOG
+            )));
+
+            @Override
+            protected Set<PropertyDescriptor<?>> availableDescriptors() {
+                return myDescriptors;
+            }
+
+            @Override
+            public TreeRenderer produceRenderer(PropertySource properties) {
+
+                XmlRenderingConfig config =
+                    new XmlRenderingConfig()
+                        .singleQuoteAttributes(properties.getProperty(XML_USE_SINGLE_QUOTES))
+                        .renderProlog(properties.getProperty(XML_RENDER_PROLOG))
+                        .lineSeparator(properties.getProperty(XML_LINE_SEPARATOR));
+
+                return new XmlTreeRenderer(config);
+            }
+        };
+
+    private static final Map<String, TreeRendererDescriptor> REGISTRY = new ConcurrentHashMap<>();
+
+
+    static {
+        REGISTRY.put(XML.id(), XML);
+    }
+
+
+    private TreeRenderers() {
+
+    }
+
+    /**
+     * Returns the renderer descriptor registered by the given ID.
+     * Returns null if not found, or the id is null.
+     *
+     * @param id ID of the renderer to find
+     *
+     * @return The descriptor, or null
+     */
+    public static TreeRendererDescriptor findById(String id) {
+        synchronized (REGISTRY) {
+            return REGISTRY.get(id);
+        }
+    }
+
+    /**
+     * Returns the set of renderers currently registered. Order is
+     * undefined.
+     */
+    public static Collection<TreeRendererDescriptor> registeredRenderers() {
+        return Collections.unmodifiableCollection(REGISTRY.values());
+    }
+
+    /**
+     * Registers the given renderer. If registration succeeds (the ID
+     * is not already associated to a descriptor), the descriptor
+     * will be available with {@link #findById(String)}.
+     *
+     * @param descriptor Descriptor to register
+     *
+     * @return True if the registration succeeded, false if there was
+     *     already a registered renderer with the given ID.
+     */
+    public static boolean register(TreeRendererDescriptor descriptor) {
+        synchronized (REGISTRY) {
+            if (REGISTRY.containsKey(descriptor.id())) {
+                return false;
+            }
+            REGISTRY.put(descriptor.id(), descriptor);
+        }
+        return true;
+    }
+
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/XmlTreeRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/XmlTreeRenderer.java
@@ -1,0 +1,248 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.treeexport;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.TreeMap;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+
+import net.sourceforge.pmd.annotation.Experimental;
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.ast.xpath.Attribute;
+
+/**
+ * Renders a tree to XML. The resulting document is as close as possible
+ * to the representation PMD uses to run XPath queries on nodes. This
+ * allows the same XPath queries to match, in theory (it would depend
+ * on the XPath engine used I believe).
+ */
+@Experimental
+public final class XmlTreeRenderer implements TreeRenderer {
+
+    // See https://www.w3.org/TR/2008/REC-xml-20081126/#NT-Name
+    private static final String XML_START_CHAR = "[:A-Z_a-z\\xC0-\\xD6\\xD8-\\xF6\\xF8-\\x{2FF}\\x{370}-\\x{37D}\\x{37F}-\\x{1FFF}\\x{200C}-\\x{200D}\\x{2070}-\\x{218F}\\x{2C00}-\\x{2FEF}\\x{3001}-\\x{D7FF}\\x{F900}-\\x{FDCF}\\x{FDF0}-\\x{FFFD}\\x{10000}-\\x{EFFFF}]";
+    private static final String XML_CHAR = "[" + XML_START_CHAR + ".\\-0-9\\xB7\\x{0300}-\\x{036F}\\x{203F}-\\x{2040}]";
+    private static final Pattern XML_NAME = Pattern.compile(XML_START_CHAR + XML_CHAR + "*");
+
+
+    private final XmlRenderingConfig strategy;
+    private final char attrDelim;
+
+    /*
+        TODO it's unclear to me how the strong typing of XPath 2.0 would
+         impact XPath queries run on the output XML. PMD maps attributes
+         to typed values, the XML only has untyped strings.
+
+         OTOH users should expect differences, and it's even documented
+         on this class.
+
+     */
+
+
+    /**
+     * Creates a new XML renderer.
+     *
+     * @param strategy Strategy to parameterize the output of this instance
+     */
+    public XmlTreeRenderer(XmlRenderingConfig strategy) {
+        this.strategy = strategy;
+        this.attrDelim = strategy.singleQuoteAttributes ? '\'' : '"';
+    }
+
+    /**
+     * Creates a new XML renderer with a default configuration.
+     */
+    public XmlTreeRenderer() {
+        this(new XmlRenderingConfig());
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Each node of the AST has a corresponding XML element, whose
+     * name and attributes are the one the node presents in XPath queries.
+     *
+     * @param node {@inheritDoc}
+     * @param out  {@inheritDoc}
+     *
+     * @throws IllegalArgumentException If some node has attributes or
+     *                                  a name that is not a valid XML name
+     */
+    @Override
+    public void renderSubtree(Node node, Appendable out) throws IOException {
+        if (strategy.renderProlog) {
+            renderProlog(out);
+        }
+        renderSubtree(0, node, out);
+        out.append(strategy.lineSeparator);
+    }
+
+    private void renderProlog(Appendable out) throws IOException {
+        out.append("<?xml version=").append(attrDelim).append("1.0").append(attrDelim)
+           .append(" encoding=").append(attrDelim).append("UTF-8").append(attrDelim)
+           .append(" ?>").append(strategy.lineSeparator);
+    }
+
+    private void renderSubtree(int depth, Node node, Appendable out) throws IOException {
+
+        String eltName = node.getXPathNodeName();
+
+        checkValidName(eltName);
+
+
+        indent(depth, out).append('<').append(eltName);
+
+        Map<String, String> attributes = strategy.getXmlAttributes(node);
+
+        for (String attrName : attributes.keySet()) {
+            appendAttribute(out, attrName, attributes.get(attrName));
+        }
+
+        if (node.jjtGetNumChildren() == 0) {
+            out.append(" />");
+            return;
+        }
+
+
+        out.append(">");
+
+        for (int i = 0; i < node.jjtGetNumChildren(); i++) {
+            out.append(strategy.lineSeparator);
+            renderSubtree(depth + 1, node.jjtGetChild(i), out);
+        }
+
+        out.append(strategy.lineSeparator);
+
+        indent(depth, out).append("</").append(eltName).append('>');
+    }
+
+    private void appendAttribute(Appendable out, String name, String value) throws IOException {
+        checkValidName(name);
+
+        out.append(' ')
+           .append(name)
+           .append('=')
+           .append(attrDelim)
+           .append(escapeXmlAttribute(value, strategy.singleQuoteAttributes))
+           .append(attrDelim);
+    }
+
+    private void checkValidName(String name) {
+        if (!isValidXmlName(name) || isReservedXmlName(name)) {
+            throw new IllegalArgumentException(name + " is not a valid XML name");
+        }
+    }
+
+    private Appendable indent(int depth, Appendable out) throws IOException {
+        while (depth-- > 0) {
+            out.append(strategy.indentString);
+        }
+        return out;
+    }
+
+    private static String escapeXmlText(String xml) {
+        return xml.replaceAll("<", "&lt;")
+                  .replaceAll("&", "&amp;");
+
+    }
+
+    private static String escapeXmlAttribute(String xml, boolean isSingleQuoted) {
+
+        return isSingleQuoted ? escapeXmlText(xml).replaceAll("'", "&apos;")
+                              : escapeXmlText(xml).replaceAll("\"", "&quot;");
+    }
+
+    private static boolean isValidXmlName(String xml) {
+        return XML_NAME.matcher(xml).matches();
+    }
+
+    private static boolean isReservedXmlName(String xml) {
+        return StringUtils.startsWithIgnoreCase(xml, "xml");
+    }
+
+    /**
+     * A strategy to parameterize an {@link XmlTreeRenderer}.
+     */
+    public static class XmlRenderingConfig {
+
+        private String indentString = "    ";
+        private String lineSeparator = System.lineSeparator();
+        private boolean singleQuoteAttributes = true;
+        private boolean renderProlog = true;
+
+        private Map<String, String> getXmlAttributes(Node node) {
+            Map<String, String> attrs = new TreeMap<>();
+            Iterator<Attribute> iter = node.getXPathAttributesIterator();
+            while (iter.hasNext()) {
+                Attribute next = iter.next();
+                if (takeAttribute(node, next)) {
+                    attrs.put(next.getName(), next.getStringValue());
+                }
+            }
+            return attrs;
+        }
+
+        /**
+         * Returns true if the attribute should be included in the element
+         * corresponding to the given node. Subclasses can override this
+         * method to filter out some attributes.
+         *
+         * @param node      Node owning the attribute
+         * @param attribute Attribute to test
+         */
+        protected boolean takeAttribute(Node node, Attribute attribute) {
+            return true;
+        }
+
+        /**
+         * Sets the string that should be used to separate lines. The
+         * default is the platform-specific line separator.
+         *
+         * @throws NullPointerException If the argument is null
+         */
+        public XmlRenderingConfig lineSeparator(String lineSeparator) {
+            this.lineSeparator = Objects.requireNonNull(lineSeparator);
+            return this;
+        }
+
+        /**
+         * Sets the delimiters use for attribute values. The default is
+         * to use single quotes.
+         *
+         * @param useSingleQuote True for single quotes, false for double quotes
+         */
+        public XmlRenderingConfig singleQuoteAttributes(boolean useSingleQuote) {
+            this.singleQuoteAttributes = useSingleQuote;
+            return this;
+        }
+
+        /**
+         * Sets whether to render an XML prolog or not. The default is
+         * true.
+         */
+        public XmlRenderingConfig renderProlog(boolean renderProlog) {
+            this.renderProlog = renderProlog;
+            return this;
+        }
+
+        /**
+         * Sets the string that should be used to indent children elements.
+         * The default is four spaces.
+         *
+         * @throws NullPointerException If the argument is null
+         */
+        public XmlRenderingConfig indentWith(String indentString) {
+            this.indentString = Objects.requireNonNull(indentString);
+            return this;
+        }
+
+    }
+
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/XmlTreeRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/XmlTreeRenderer.java
@@ -184,10 +184,27 @@ public final class XmlTreeRenderer implements TreeRenderer {
             while (iter.hasNext()) {
                 Attribute next = iter.next();
                 if (takeAttribute(node, next)) {
-                    attrs.put(next.getName(), next.getStringValue());
+                    try {
+
+                        attrs.put(next.getName(), next.getStringValue());
+                    } catch (Exception e) {
+                        handleAttributeFetchException(next, e);
+                    }
                 }
             }
             return attrs;
+        }
+
+        /**
+         * Handle an exception that occurred while fetching the value
+         * of an attribute. The default does nothing, it's meant to be
+         * overridden if you want to handle it.
+         *
+         * @param attr Attribute for which the fetch failed
+         * @param e    Exception that occurred
+         */
+        protected void handleAttributeFetchException(Attribute attr, Exception e) {
+            // to be overridden
         }
 
         /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/XmlTreeRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/XmlTreeRenderer.java
@@ -131,7 +131,7 @@ public final class XmlTreeRenderer implements TreeRenderer {
            .append('=')
            .append(attrDelim)
            .append(escapeXmlAttribute(value, strategy.singleQuoteAttributes))
-           .append(attrDelim);
+            .append(attrDelim);
     }
 
     private void checkValidName(String name) {
@@ -170,6 +170,7 @@ public final class XmlTreeRenderer implements TreeRenderer {
     /**
      * A strategy to parameterize an {@link XmlTreeRenderer}.
      */
+    @Experimental
     public static class XmlRenderingConfig {
 
         private String indentString = "    ";

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNode.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNode.java
@@ -4,12 +4,26 @@
 
 package net.sourceforge.pmd.lang.ast;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import net.sourceforge.pmd.lang.ast.xpath.Attribute;
+
 public class DummyNode extends AbstractNode {
     private final boolean findBoundary;
     private final String xpathName;
 
+    private final Map<String, String> attributes = new HashMap<>();
+
     public DummyNode(int id) {
         this(id, false);
+    }
+
+    public DummyNode() {
+        this(0);
     }
 
     public DummyNode(int id, boolean findBoundary) {
@@ -22,6 +36,21 @@ public class DummyNode extends AbstractNode {
         this.xpathName = xpathName;
     }
 
+    public void setXPathAttribute(String name, String value) {
+        attributes.put(name, value);
+    }
+
+    @Override
+    public Iterator<Attribute> getXPathAttributesIterator() {
+
+        List<Attribute> attrs = new ArrayList<>();
+        for (String name : attributes.keySet()) {
+            attrs.add(new Attribute(this, name, attributes.get(name)));
+        }
+
+        return attrs.iterator();
+    }
+
     @Override
     public String toString() {
         return xpathName;
@@ -31,7 +60,7 @@ public class DummyNode extends AbstractNode {
     public String getXPathNodeName() {
         return xpathName;
     }
-    
+
     @Override
     public boolean isFindBoundary() {
         return findBoundary;

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNode.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNode.java
@@ -4,26 +4,16 @@
 
 package net.sourceforge.pmd.lang.ast;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-
-import net.sourceforge.pmd.lang.ast.xpath.Attribute;
-
 public class DummyNode extends AbstractNode {
     private final boolean findBoundary;
     private final String xpathName;
-
-    private final Map<String, String> attributes = new HashMap<>();
 
     public DummyNode(int id) {
         this(id, false);
     }
 
     public DummyNode() {
-        this(0);
+        this(0, false);
     }
 
     public DummyNode(int id, boolean findBoundary) {
@@ -34,21 +24,6 @@ public class DummyNode extends AbstractNode {
         super(id);
         this.findBoundary = findBoundary;
         this.xpathName = xpathName;
-    }
-
-    public void setXPathAttribute(String name, String value) {
-        attributes.put(name, value);
-    }
-
-    @Override
-    public Iterator<Attribute> getXPathAttributesIterator() {
-
-        List<Attribute> attrs = new ArrayList<>();
-        for (String name : attributes.keySet()) {
-            attrs.add(new Attribute(this, name, attributes.get(name)));
-        }
-
-        return attrs.iterator();
     }
 
     @Override

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/TreeRenderersTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/TreeRenderersTest.java
@@ -1,0 +1,115 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.treeexport;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import net.sourceforge.pmd.lang.ast.DummyNode;
+import net.sourceforge.pmd.lang.ast.xpath.Attribute;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertySource;
+
+/**
+ *
+ */
+public class TreeRenderersTest {
+
+    @Rule
+    public ExpectedException expect = ExpectedException.none();
+
+    @Test
+    public void testStandardRenderersAreRegistered() {
+
+        Assert.assertEquals(TreeRenderers.XML, TreeRenderers.findById(TreeRenderers.XML.id()));
+
+    }
+
+    @Test
+    public void testXmlPropertiesAvailable() {
+
+
+        PropertySource properties = TreeRenderers.XML.newPropertyBundle();
+
+        Assert.assertThat(properties.getPropertyDescriptors(),
+                          Matchers.<PropertyDescriptor<?>>containsInAnyOrder(TreeRenderers.XML_LINE_SEPARATOR,
+                                                                             TreeRenderers.XML_RENDER_PROLOG,
+                                                                             TreeRenderers.XML_USE_SINGLE_QUOTES));
+
+    }
+
+    @Test
+    public void testXmlDescriptorDump() throws IOException {
+
+        PropertySource bundle = TreeRenderers.XML.newPropertyBundle();
+
+        bundle.setProperty(TreeRenderers.XML_RENDER_PROLOG, false);
+        bundle.setProperty(TreeRenderers.XML_USE_SINGLE_QUOTES, false);
+
+        TreeRenderer renderer = TreeRenderers.XML.produceRenderer(bundle);
+
+        StringBuilder out = new StringBuilder();
+
+        renderer.renderSubtree(dummyTree1(), out);
+        Assert.assertEquals("<dummyNode foo=\"bar\" ohio=\"4\">\n"
+                                + "    <dummyNode o=\"ha\" />\n"
+                                + "    <dummyNode />\n"
+                                + "</dummyNode>\n", out.toString());
+
+    }
+
+
+    public MyDummyNode dummyTree1() {
+        MyDummyNode dummy = new MyDummyNode();
+
+        dummy.setXPathAttribute("foo", "bar");
+        dummy.setXPathAttribute("ohio", "4");
+
+        MyDummyNode dummy1 = new MyDummyNode();
+
+        dummy1.setXPathAttribute("o", "ha");
+
+        MyDummyNode dummy2 = new MyDummyNode();
+
+        dummy.jjtAddChild(dummy1, 0);
+        dummy.jjtAddChild(dummy2, 1);
+        return dummy;
+    }
+
+    private static class MyDummyNode extends DummyNode {
+
+
+        private final Map<String, String> attributes = new HashMap<>();
+
+        public void setXPathAttribute(String name, String value) {
+            attributes.put(name, value);
+        }
+
+        @Override
+        public Iterator<Attribute> getXPathAttributesIterator() {
+
+            List<Attribute> attrs = new ArrayList<>();
+            for (String name : attributes.keySet()) {
+                attrs.add(new Attribute(this, name, attributes.get(name)));
+            }
+
+            return attrs.iterator();
+        }
+
+
+    }
+
+
+}

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/XmlTreeRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/XmlTreeRendererTest.java
@@ -5,6 +5,11 @@
 package net.sourceforge.pmd.util.treeexport;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Rule;
@@ -145,7 +150,7 @@ public class XmlTreeRendererTest {
     @Test
     public void testInvalidAttributeName() throws IOException {
 
-        DummyNode dummy = dummyTree1();
+        MyDummyNode dummy = dummyTree1();
 
         dummy.setXPathAttribute("&notAName", "foo");
 
@@ -166,7 +171,7 @@ public class XmlTreeRendererTest {
     @Test
     public void testEscapeAttributes() throws IOException {
 
-        DummyNode dummy = dummyTree1();
+        MyDummyNode dummy = dummyTree1();
 
         dummy.setXPathAttribute("eh", " 'a &> b\" ");
 
@@ -189,7 +194,7 @@ public class XmlTreeRendererTest {
     @Test
     public void testEscapeDoubleAttributes() throws IOException {
 
-        DummyNode dummy = dummyTree1();
+        MyDummyNode dummy = dummyTree1();
 
         dummy.setXPathAttribute("eh", " 'a &> b\" ");
 
@@ -252,21 +257,44 @@ public class XmlTreeRendererTest {
     }
 
 
-    public DummyNode dummyTree1() {
-        DummyNode dummy = new DummyNode();
+    public MyDummyNode dummyTree1() {
+        MyDummyNode dummy = new MyDummyNode();
 
         dummy.setXPathAttribute("foo", "bar");
         dummy.setXPathAttribute("ohio", "4");
 
-        DummyNode dummy1 = new DummyNode();
+        MyDummyNode dummy1 = new MyDummyNode();
 
         dummy1.setXPathAttribute("o", "ha");
 
-        DummyNode dummy2 = new DummyNode();
+        MyDummyNode dummy2 = new MyDummyNode();
 
         dummy.jjtAddChild(dummy1, 0);
         dummy.jjtAddChild(dummy2, 1);
         return dummy;
+    }
+
+    private static class MyDummyNode extends DummyNode {
+
+
+        private final Map<String, String> attributes = new HashMap<>();
+
+        public void setXPathAttribute(String name, String value) {
+            attributes.put(name, value);
+        }
+
+        @Override
+        public Iterator<Attribute> getXPathAttributesIterator() {
+
+            List<Attribute> attrs = new ArrayList<>();
+            for (String name : attributes.keySet()) {
+                attrs.add(new Attribute(this, name, attributes.get(name)));
+            }
+
+            return attrs.iterator();
+        }
+
+
     }
 
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/XmlTreeRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/XmlTreeRendererTest.java
@@ -104,7 +104,7 @@ public class XmlTreeRendererTest {
             public boolean takeAttribute(Node node, Attribute attribute) {
                 return false;
             }
-        };
+        }.lineSeparator("\n");
 
         XmlTreeRenderer renderer = new XmlTreeRenderer(strat);
 
@@ -131,7 +131,7 @@ public class XmlTreeRendererTest {
             public boolean takeAttribute(Node node, Attribute attribute) {
                 return attribute.getName().equals("ohio");
             }
-        };
+        }.lineSeparator("\n");
 
         XmlTreeRenderer renderer = new XmlTreeRenderer(strategy);
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/XmlTreeRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/XmlTreeRendererTest.java
@@ -1,0 +1,273 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.treeexport;
+
+import java.io.IOException;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import net.sourceforge.pmd.lang.ast.DummyNode;
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.ast.xpath.Attribute;
+import net.sourceforge.pmd.util.treeexport.XmlTreeRenderer.XmlRenderingConfig;
+
+/**
+ */
+public class XmlTreeRendererTest {
+
+    @Rule
+    public ExpectedException expect = ExpectedException.none();
+
+    @Test
+    public void testRenderWithAttributes() throws IOException {
+
+        DummyNode dummy = dummyTree1();
+
+        XmlRenderingConfig strat = new XmlRenderingConfig();
+        strat.lineSeparator("\n");
+        XmlTreeRenderer renderer = new XmlTreeRenderer(strat);
+
+        StringBuilder out = new StringBuilder();
+
+
+        renderer.renderSubtree(dummy, out);
+
+        Assert.assertEquals("<?xml version='1.0' encoding='UTF-8' ?>\n"
+                                + "<dummyNode foo='bar' ohio='4'>\n"
+                                + "    <dummyNode o='ha' />\n"
+                                + "    <dummyNode />\n"
+                                + "</dummyNode>\n", out.toString());
+
+    }
+
+    @Test
+    public void testRenderWithCustomLineSep() throws IOException {
+
+        DummyNode dummy = dummyTree1();
+
+        XmlRenderingConfig strat = new XmlRenderingConfig();
+        strat.lineSeparator("\r\n");
+        XmlTreeRenderer renderer = new XmlTreeRenderer(strat);
+
+        StringBuilder out = new StringBuilder();
+
+
+        renderer.renderSubtree(dummy, out);
+
+        Assert.assertEquals("<?xml version='1.0' encoding='UTF-8' ?>\r\n"
+                                + "<dummyNode foo='bar' ohio='4'>\r\n"
+                                + "    <dummyNode o='ha' />\r\n"
+                                + "    <dummyNode />\r\n"
+                                + "</dummyNode>\r\n", out.toString());
+
+    }
+
+    @Test
+    public void testRenderWithCustomIndent() throws IOException {
+
+        DummyNode dummy = dummyTree1();
+
+        XmlRenderingConfig strat = new XmlRenderingConfig().lineSeparator("").indentWith("");
+
+        XmlTreeRenderer renderer = new XmlTreeRenderer(strat);
+
+        StringBuilder out = new StringBuilder();
+
+
+        renderer.renderSubtree(dummy, out);
+
+        Assert.assertEquals("<?xml version='1.0' encoding='UTF-8' ?>"
+                                + "<dummyNode foo='bar' ohio='4'>"
+                                + "<dummyNode o='ha' />"
+                                + "<dummyNode />"
+                                + "</dummyNode>", out.toString());
+
+    }
+
+    @Test
+    public void testRenderWithNoAttributes() throws IOException {
+
+        DummyNode dummy = dummyTree1();
+
+        XmlRenderingConfig strat = new XmlRenderingConfig() {
+            @Override
+            public boolean takeAttribute(Node node, Attribute attribute) {
+                return false;
+            }
+        };
+
+        XmlTreeRenderer renderer = new XmlTreeRenderer(strat);
+
+        StringBuilder out = new StringBuilder();
+
+
+        renderer.renderSubtree(dummy, out);
+
+        Assert.assertEquals("<?xml version='1.0' encoding='UTF-8' ?>\n"
+                                + "<dummyNode>\n"
+                                + "    <dummyNode />\n"
+                                + "    <dummyNode />\n"
+                                + "</dummyNode>\n", out.toString());
+
+    }
+
+    @Test
+    public void testRenderFilterAttributes() throws IOException {
+
+        DummyNode dummy = dummyTree1();
+
+        XmlRenderingConfig strategy = new XmlRenderingConfig() {
+            @Override
+            public boolean takeAttribute(Node node, Attribute attribute) {
+                return attribute.getName().equals("ohio");
+            }
+        };
+
+        XmlTreeRenderer renderer = new XmlTreeRenderer(strategy);
+
+        StringBuilder out = new StringBuilder();
+
+        renderer.renderSubtree(dummy, out);
+
+        Assert.assertEquals("<?xml version='1.0' encoding='UTF-8' ?>\n"
+                                + "<dummyNode ohio='4'>\n"
+                                + "    <dummyNode />\n"
+                                + "    <dummyNode />\n"
+                                + "</dummyNode>\n", out.toString());
+
+    }
+
+    @Test
+    public void testInvalidAttributeName() throws IOException {
+
+        DummyNode dummy = dummyTree1();
+
+        dummy.setXPathAttribute("&notAName", "foo");
+
+        XmlRenderingConfig config = new XmlRenderingConfig();
+        config.lineSeparator("\n");
+
+        XmlTreeRenderer renderer = new XmlTreeRenderer(config);
+
+        StringBuilder out = new StringBuilder();
+
+        expect.expect(IllegalArgumentException.class);
+
+        renderer.renderSubtree(dummy, out);
+
+    }
+
+
+    @Test
+    public void testEscapeAttributes() throws IOException {
+
+        DummyNode dummy = dummyTree1();
+
+        dummy.setXPathAttribute("eh", " 'a &> b\" ");
+
+        XmlRenderingConfig strat = new XmlRenderingConfig().lineSeparator("\n");
+        XmlTreeRenderer renderer = new XmlTreeRenderer(strat);
+
+        StringBuilder out = new StringBuilder();
+
+
+        renderer.renderSubtree(dummy, out);
+
+        Assert.assertEquals("<?xml version='1.0' encoding='UTF-8' ?>\n"
+                                + "<dummyNode eh=' &apos;a &amp;> b\" ' foo='bar' ohio='4'>\n"
+                                + "    <dummyNode o='ha' />\n"
+                                + "    <dummyNode />\n"
+                                + "</dummyNode>\n", out.toString());
+
+    }
+
+    @Test
+    public void testEscapeDoubleAttributes() throws IOException {
+
+        DummyNode dummy = dummyTree1();
+
+        dummy.setXPathAttribute("eh", " 'a &> b\" ");
+
+        XmlRenderingConfig strat = new XmlRenderingConfig().lineSeparator("\n").singleQuoteAttributes(false);
+        XmlTreeRenderer renderer = new XmlTreeRenderer(strat);
+
+        StringBuilder out = new StringBuilder();
+
+
+        renderer.renderSubtree(dummy, out);
+
+        Assert.assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
+                                + "<dummyNode eh=\" 'a &amp;> b&quot; \" foo=\"bar\" ohio=\"4\">\n"
+                                + "    <dummyNode o=\"ha\" />\n"
+                                + "    <dummyNode />\n"
+                                + "</dummyNode>\n", out.toString());
+
+    }
+
+    @Test
+    public void testNoProlog() throws IOException {
+
+        DummyNode dummy = dummyTree1();
+
+
+        XmlRenderingConfig strat = new XmlRenderingConfig().lineSeparator("\n").renderProlog(false);
+        XmlTreeRenderer renderer = new XmlTreeRenderer(strat);
+
+        StringBuilder out = new StringBuilder();
+
+
+        renderer.renderSubtree(dummy, out);
+
+        Assert.assertEquals("<dummyNode foo='bar' ohio='4'>\n"
+                                + "    <dummyNode o='ha' />\n"
+                                + "    <dummyNode />\n"
+                                + "</dummyNode>\n", out.toString());
+
+    }
+
+
+    @Test
+    public void testDefaultLineSep() throws IOException {
+
+        DummyNode dummy = dummyTree1();
+
+        XmlTreeRenderer renderer = new XmlTreeRenderer();
+
+        StringBuilder out = new StringBuilder();
+
+
+        renderer.renderSubtree(dummy, out);
+
+        Assert.assertEquals("<?xml version='1.0' encoding='UTF-8' ?>" + System.lineSeparator()
+                                + "<dummyNode foo='bar' ohio='4'>" + System.lineSeparator()
+                                + "    <dummyNode o='ha' />" + System.lineSeparator()
+                                + "    <dummyNode />" + System.lineSeparator()
+                                + "</dummyNode>" + System.lineSeparator(), out.toString());
+
+    }
+
+
+    public DummyNode dummyTree1() {
+        DummyNode dummy = new DummyNode();
+
+        dummy.setXPathAttribute("foo", "bar");
+        dummy.setXPathAttribute("ohio", "4");
+
+        DummyNode dummy1 = new DummyNode();
+
+        dummy1.setXPathAttribute("o", "ha");
+
+        DummyNode dummy2 = new DummyNode();
+
+        dummy.jjtAddChild(dummy1, 0);
+        dummy.jjtAddChild(dummy2, 1);
+        return dummy;
+    }
+
+
+}


### PR DESCRIPTION
Refs #2215. This renderer matches our Node -> DOM mapping. The output is eg
```xml
<?xml version='1.0' encoding='UTF-8' ?>
<CompilationUnit BeginColumn='1' BeginLine='1' EndColumn='12' EndLine='1' FindBoundary='false' Image='' PackageName='' SingleLine='true' declarationsAreInDefaultPackage='true'>
     <TypeDeclaration BeginColumn='1' BeginLine='1' EndColumn='12' EndLine='1' FindBoundary='false' Image='' SingleLine='true'>
        <ClassOrInterfaceDeclaration Abstract='false' BeginColumn='1' BeginLine='1' BinaryName='' Default='false' EndColumn='12' EndLine='1' Final='false' FindBoundary='false' Image='Foo' Interface='false' Local='false' Modifiers='0' Native='false' Nested='false' PackagePrivate='true' Private='false' Protected='false' Public='false' SimpleName='Foo' SingleLine='true' Static='false' Strictfp='false' Synchronized='false' Transient='false' TypeKind='CLASS' Volatile='false'>
            <ClassOrInterfaceBody AnonymousInnerClass='false' BeginColumn='11' BeginLine='1' EndColumn='12' EndLine='1' EnumChild='false' FindBoundary='false' Image='' SingleLine='true' />
        </ClassOrInterfaceDeclaration>
    </TypeDeclaration>
</CompilationUnit>
```

Use it like

```java

    public static void main(String[] args) throws IOException {

        LanguageVersionHandler java = LanguageRegistry.getLanguage("Java").getDefaultVersion().getLanguageVersionHandler();
        Parser parser = java.getParser(java.getDefaultParserOptions());

        Node root = parser.parse("foo", new StringReader("class Foo {}"));

        new XmlTreeRenderer().renderSubtree(root, System.out);
    }
```

One problem is that it causes warnings for deprecated attributes...

The next step would be to build a small CLI program, eg something to use like `run.sh ast-dump --format xml --to-file out.xml --language java  some/Class.java`

The designer could also use this API to have a GUI for those exports.





