### PR TITLE
[core] CPD: report endLine / column informations for found duplications

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/AntlrTokenizer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/AntlrTokenizer.java
@@ -59,7 +59,7 @@ public abstract class AntlrTokenizer implements Tokenizer {
     }
 
     private void processToken(final Tokens tokenEntries, final String fileName, final AntlrToken token) {
-        final TokenEntry tokenEntry = new TokenEntry(token.getImage(), fileName, token.getBeginLine());
+        final TokenEntry tokenEntry = new TokenEntry(token.getImage(), fileName, token.getBeginLine(), token.getBeginColumn() + 1, token.getEndColumn() + 1);
         tokenEntries.add(tokenEntry);
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/Mark.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/Mark.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.cpd;
 
 public class Mark implements Comparable<Mark> {
     private TokenEntry token;
+    private TokenEntry endToken;
     private int lineCount;
     private SourceCode code;
 
@@ -25,8 +26,18 @@ public class Mark implements Comparable<Mark> {
         return this.token.getBeginLine();
     }
 
+    @Deprecated
+    public int getBeginColumn() {
+        return this.token.getBeginColumn(); // TODO Java 1.8 make optional
+    }
+
     public int getEndLine() {
         return getBeginLine() + getLineCount() - 1;
+    }
+
+    @Deprecated
+    public int getEndColumn() {
+        return this.endToken == null ? -1 : this.endToken.getEndColumn(); // TODO Java 1.8 make optional
     }
 
     public int getLineCount() {
@@ -35,6 +46,10 @@ public class Mark implements Comparable<Mark> {
 
     public void setLineCount(int lineCount) {
         this.lineCount = lineCount;
+    }
+
+    public void setEndToken(TokenEntry endToken) {
+        this.endToken = endToken;
     }
 
     public String getSourceCodeSlice() {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/MatchAlgorithm.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/MatchAlgorithm.java
@@ -78,8 +78,10 @@ public class MatchAlgorithm {
             for (Mark mark : match) {
                 TokenEntry token = mark.getToken();
                 int lineCount = tokens.getLineCount(token, match);
+                TokenEntry endToken = tokens.getEndToken(token, match);
 
                 mark.setLineCount(lineCount);
+                mark.setEndToken(endToken);
                 SourceCode sourceCode = source.get(token.getTokenSrcID());
                 mark.setSourceCode(sourceCode);
             }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/TokenEntry.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/TokenEntry.java
@@ -16,6 +16,8 @@ public class TokenEntry implements Comparable<TokenEntry> {
 
     private String tokenSrcID;
     private int beginLine;
+    private int beginColumn;
+    private int endColumn;
     private int index;
     private int identifier;
     private int hashCode;
@@ -48,6 +50,25 @@ public class TokenEntry implements Comparable<TokenEntry> {
         setImage(image);
         this.tokenSrcID = tokenSrcID;
         this.beginLine = beginLine;
+        this.beginColumn = -1;
+        this.endColumn = -1;
+        this.index = TOKEN_COUNT.get().getAndIncrement();
+    }
+
+    /**
+     * Creates a new token entry with the given informations.
+     * @param image
+     * @param tokenSrcID
+     * @param beginLine the linenumber, 1-based.
+     * @param beginColumn the column number, 1-based
+     * @param endColumn the column number, 1-based
+     */
+    public TokenEntry(String image, String tokenSrcID, int beginLine, int beginColumn, int endColumn) {
+        setImage(image);
+        this.tokenSrcID = tokenSrcID;
+        this.beginLine = beginLine;
+        this.beginColumn = beginColumn;
+        this.endColumn = endColumn;
         this.index = TOKEN_COUNT.get().getAndIncrement();
     }
 
@@ -91,6 +112,16 @@ public class TokenEntry implements Comparable<TokenEntry> {
 
     public int getBeginLine() {
         return beginLine;
+    }
+
+    @Deprecated
+    public int getBeginColumn() {
+        return beginColumn; // TODO Java 1.8 make optional
+    }
+
+    @Deprecated
+    public int getEndColumn() {
+        return endColumn; // TODO Java 1.8 make optional
     }
 
     public int getIdentifier() {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/TokenEntry.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/TokenEntry.java
@@ -47,12 +47,7 @@ public class TokenEntry implements Comparable<TokenEntry> {
      * @param beginLine the linenumber, 1-based.
      */
     public TokenEntry(String image, String tokenSrcID, int beginLine) {
-        setImage(image);
-        this.tokenSrcID = tokenSrcID;
-        this.beginLine = beginLine;
-        this.beginColumn = -1;
-        this.endColumn = -1;
-        this.index = TOKEN_COUNT.get().getAndIncrement();
+        this(image, tokenSrcID, beginLine, -1, -1);
     }
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/Tokens.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/Tokens.java
@@ -28,8 +28,12 @@ public class Tokens {
         return tokens.size();
     }
 
+    public TokenEntry getEndToken(TokenEntry mark, Match match) {
+        return get(mark.getIndex() + match.getTokenCount() - 1);
+    }
+
     public int getLineCount(TokenEntry mark, Match match) {
-        TokenEntry endTok = get(mark.getIndex() + match.getTokenCount() - 1);
+        TokenEntry endTok = getEndToken(mark, match);
         if (endTok == TokenEntry.EOF) {
             endTok = get(mark.getIndex() + match.getTokenCount() - 2);
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLRenderer.java
@@ -117,9 +117,18 @@ public final class XMLRenderer implements Renderer, CPDRenderer {
         Mark mark;
         for (Iterator<Mark> iterator = match.iterator(); iterator.hasNext();) {
             mark = iterator.next();
-            Element file = doc.createElement("file");
+            final Element file = doc.createElement("file");
             file.setAttribute("line", String.valueOf(mark.getBeginLine()));
             file.setAttribute("path", mark.getFilename());
+            file.setAttribute("endline", String.valueOf(mark.getEndLine()));
+            final int beginCol = mark.getBeginColumn();
+            final int endCol = mark.getEndColumn();
+            if (beginCol != -1) {
+                file.setAttribute("column", String.valueOf(mark.getBeginColumn()));
+            }
+            if (endCol != -1) {
+                file.setAttribute("endcolumn", String.valueOf(mark.getEndColumn()));
+            }
             duplication.appendChild(file);
         }
         return duplication;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/internal/JavaCCTokenizer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/internal/JavaCCTokenizer.java
@@ -24,7 +24,7 @@ public abstract class JavaCCTokenizer implements Tokenizer {
     }
 
     protected TokenEntry processToken(Tokens tokenEntries, GenericToken currentToken, String filename) {
-        return new TokenEntry(currentToken.getImage(), filename, currentToken.getBeginLine());
+        return new TokenEntry(currentToken.getImage(), filename, currentToken.getBeginLine(), currentToken.getBeginColumn(), currentToken.getEndColumn());
     }
     
     @Override

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/MarkTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/MarkTest.java
@@ -29,6 +29,34 @@ public class MarkTest {
         assertEquals(beginLine, mark.getBeginLine());
         assertEquals(lineCount, mark.getLineCount());
         assertEquals(beginLine + lineCount - 1, mark.getEndLine());
+        assertEquals(-1, mark.getBeginColumn());
+        assertEquals(-1, mark.getEndColumn());
+        assertEquals(codeFragment, mark.getSourceCodeSlice());
+    }
+
+    @Test
+    public void testColumns() {
+        final String filename = "/var/Foo.java";
+        final int beginLine = 1;
+        final int beginColumn = 2;
+        final int endColumn = 3;
+        final TokenEntry token = new TokenEntry("public", "/var/Foo.java", 1, beginColumn, 0);
+        final TokenEntry endToken = new TokenEntry("}", "/var/Foo.java", 5, 0, endColumn);
+
+        final Mark mark = new Mark(token);
+        final int lineCount = 10;
+        mark.setLineCount(lineCount);
+        mark.setEndToken(endToken);
+        final String codeFragment = "code fragment";
+        mark.setSourceCode(new SourceCode(new StringCodeLoader(codeFragment)));
+
+        assertEquals(token, mark.getToken());
+        assertEquals(filename, mark.getFilename());
+        assertEquals(beginLine, mark.getBeginLine());
+        assertEquals(lineCount, mark.getLineCount());
+        assertEquals(beginLine + lineCount - 1, mark.getEndLine());
+        assertEquals(beginColumn, mark.getBeginColumn());
+        assertEquals(endColumn, mark.getEndColumn());
         assertEquals(codeFragment, mark.getSourceCodeSlice());
     }
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/TokenEntryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/TokenEntryTest.java
@@ -17,6 +17,19 @@ public class TokenEntryTest {
         assertEquals(1, mark.getBeginLine());
         assertEquals("/var/Foo.java", mark.getTokenSrcID());
         assertEquals(0, mark.getIndex());
+        assertEquals(-1, mark.getBeginColumn());
+        assertEquals(-1, mark.getEndColumn());
+    }
+
+    @Test
+    public void testColumns() {
+        TokenEntry.clearImages();
+        TokenEntry mark = new TokenEntry("public", "/var/Foo.java", 1, 2, 3);
+        assertEquals(1, mark.getBeginLine());
+        assertEquals("/var/Foo.java", mark.getTokenSrcID());
+        assertEquals(0, mark.getIndex());
+        assertEquals(2, mark.getBeginColumn());
+        assertEquals(3, mark.getEndColumn());
     }
 
     public static junit.framework.Test suite() {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/XMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/XMLRendererTest.java
@@ -78,6 +78,9 @@ public class XMLRendererTest {
             if (file != null) {
                 assertEquals("1", file.getAttributes().getNamedItem("line").getNodeValue());
                 assertEquals("/var/Foo.java", file.getAttributes().getNamedItem("path").getNodeValue());
+                assertEquals("6", file.getAttributes().getNamedItem("endline").getNodeValue());
+                assertEquals(null, file.getAttributes().getNamedItem("column"));
+                assertEquals(null, file.getAttributes().getNamedItem("endcolumn"));
                 file = file.getNextSibling();
                 while (file != null && file.getNodeType() != Node.ELEMENT_NODE) {
                     file = file.getNextSibling();
@@ -85,6 +88,9 @@ public class XMLRendererTest {
             }
             if (file != null) {
                 assertEquals("73", file.getAttributes().getNamedItem("line").getNodeValue());
+                assertEquals("78", file.getAttributes().getNamedItem("endline").getNodeValue());
+                assertEquals(null, file.getAttributes().getNamedItem("column"));
+                assertEquals(null, file.getAttributes().getNamedItem("endcolumn"));
             }
             assertEquals(1, doc.getElementsByTagName("codefragment").getLength());
             assertEquals(codeFragment, doc.getElementsByTagName("codefragment").item(0).getTextContent());
@@ -127,6 +133,54 @@ public class XMLRendererTest {
     }
 
     @Test
+    public void testWithOneDuplicationWithColumns() throws IOException {
+        CPDRenderer renderer = new XMLRenderer();
+        List<Match> list = new ArrayList<>();
+        int lineCount = 6;
+        String codeFragment = "code\nfragment";
+        Mark mark1 = createMark("public", "/var/Foo.java", 1, lineCount, codeFragment, 2, 3);
+        Mark mark2 = createMark("stuff", "/var/Foo.java", 73, lineCount, codeFragment, 4, 5);
+        Match match = new Match(75, mark1, mark2);
+
+        list.add(match);
+        StringWriter sw = new StringWriter();
+        renderer.render(list.iterator(), sw);
+        String report = sw.toString();
+        try {
+            Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+                    .parse(new ByteArrayInputStream(report.getBytes(ENCODING)));
+            NodeList dupes = doc.getElementsByTagName("duplication");
+            assertEquals(1, dupes.getLength());
+            Node file = dupes.item(0).getFirstChild();
+            while (file != null && file.getNodeType() != Node.ELEMENT_NODE) {
+                file = file.getNextSibling();
+            }
+            if (file != null) {
+                assertEquals("1", file.getAttributes().getNamedItem("line").getNodeValue());
+                assertEquals("/var/Foo.java", file.getAttributes().getNamedItem("path").getNodeValue());
+                assertEquals("6", file.getAttributes().getNamedItem("endline").getNodeValue());
+                assertEquals("2", file.getAttributes().getNamedItem("column").getNodeValue());
+                assertEquals("3", file.getAttributes().getNamedItem("endcolumn").getNodeValue());
+                file = file.getNextSibling();
+                while (file != null && file.getNodeType() != Node.ELEMENT_NODE) {
+                    file = file.getNextSibling();
+                }
+            }
+            if (file != null) {
+                assertEquals("73", file.getAttributes().getNamedItem("line").getNodeValue());
+                assertEquals("78", file.getAttributes().getNamedItem("endline").getNodeValue());
+                assertEquals("4", file.getAttributes().getNamedItem("column").getNodeValue());
+                assertEquals("5", file.getAttributes().getNamedItem("endcolumn").getNodeValue());
+            }
+            assertEquals(1, doc.getElementsByTagName("codefragment").getLength());
+            assertEquals(codeFragment, doc.getElementsByTagName("codefragment").item(0).getTextContent());
+        } catch (Exception e) {
+            e.printStackTrace();
+            fail(e.getMessage());
+        }
+    }
+
+    @Test
     public void testRendererEncodedPath() throws IOException {
         CPDRenderer renderer = new XMLRenderer();
         List<Match> list = new ArrayList<>();
@@ -135,7 +189,7 @@ public class XMLRendererTest {
         Mark mark2 = createMark("void", "/var/F<oo.java", 73, 6, "code fragment");
         Match match1 = new Match(75, mark1, mark2);
         list.add(match1);
-        
+
         StringWriter sw = new StringWriter();
         renderer.render(list.iterator(), sw);
         String report = sw.toString();
@@ -146,6 +200,17 @@ public class XMLRendererTest {
         Mark result = new Mark(new TokenEntry(image, tokenSrcID, beginLine));
 
         result.setLineCount(lineCount);
+        result.setSourceCode(new SourceCode(new SourceCode.StringCodeLoader(code)));
+        return result;
+    }
+
+    private Mark createMark(String image, String tokenSrcID, int beginLine, int lineCount, String code, int beginColumn, int endColumn) {
+        final TokenEntry beginToken = new TokenEntry(image, tokenSrcID, beginLine, beginColumn, beginColumn + 1);
+        final TokenEntry endToken = new TokenEntry(image, tokenSrcID, beginLine + lineCount, endColumn - 1, endColumn);
+        final Mark result = new Mark(beginToken);
+
+        result.setLineCount(lineCount);
+        result.setEndToken(endToken);
         result.setSourceCode(new SourceCode(new SourceCode.StringCodeLoader(code)));
         return result;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/cpd/JavaTokenizer.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/cpd/JavaTokenizer.java
@@ -72,7 +72,7 @@ public class JavaTokenizer extends JavaCCTokenizer {
 
         constructorDetector.processToken(javaToken);
 
-        return new TokenEntry(image, fileName, currentToken.getBeginLine());
+        return new TokenEntry(image, fileName, currentToken.getBeginLine(), currentToken.getBeginColumn(), currentToken.getEndColumn());
     }
 
     public void setIgnoreLiterals(boolean ignore) {


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
Currently, CPD only reports a single line number for the begin of each duplication. In order to pinpoint exactly which tokens are considered duplicate, it can be useful to also include the line where the duplication ends and column positions for the start and end of the duplication.

This PR adjust CPD to optionally include column information for languages for which the tokenizer supports it. If this information is available, it is added to the XML output. If not, these fields are omitted. In addition, the line where the duplication ends is added in all cases.

The languages that provide column information are those that use a JavaCC-based tokenizer (C++, EmcaScript/JavaScript, Java, Matlab, Modelica, Objective-C, PL/SQL and Python) or an Antlr-based tokenizer (Dart, Go, Kotlin, Lua, Swift). For other languages, column information will be omitted because it's not available.

This includes **changes to the XML format that CPD produces**:
Each `<file>` element has now a
* new attribute `endLine`
* new attribute `beginColumn` (if there is column information available)
* new attribute `endColumn` (if there is column information available)
