### PR TITLE
[apex] Make FormalComment extend ApexNode

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -102,6 +102,11 @@ You can identify them with the `@InternalApi` annotation. You'll also get a depr
 * Constructors of {% jdoc core::RuleSetFactory %}, use factory methods from {% jdoc core::RulesetsFactoryUtils %} instead
 * {% jdoc core::RulesetsFactoryUtils#getRulesetFactory(core::PMDConfiguration, core::util.ResourceLoader) %}
 
+* {% jdoc apex::lang.apex.ast.AbstractApexNode %}
+* {% jdoc apex::lang.apex.ast.AbstractApexNodeBase %}, and the related `visit`
+methods on {% jdoc apex::lang.apex.ast.ApexParserVisitor %} and its implementations.
+ Use {% jdoc apex::lang.apex.ast.ApexNode %} instead, now considers comments too.
+
 ##### For removal
 
 * pmd-core

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFormalComment.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFormalComment.java
@@ -4,12 +4,35 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-public class ASTFormalComment extends AbstractApexNodeBase {
-    private String token;
 
+import org.antlr.runtime.Token;
+
+import net.sourceforge.pmd.lang.apex.ast.ASTFormalComment.AstComment;
+
+import apex.jorje.data.Location;
+import apex.jorje.data.Locations;
+import apex.jorje.semantic.ast.AstNode;
+import apex.jorje.semantic.ast.context.Emitter;
+import apex.jorje.semantic.ast.visitor.AstVisitor;
+import apex.jorje.semantic.ast.visitor.Scope;
+import apex.jorje.semantic.ast.visitor.ValidationScope;
+import apex.jorje.semantic.symbol.resolver.SymbolResolver;
+import apex.jorje.semantic.symbol.type.TypeInfo;
+import apex.jorje.semantic.symbol.type.TypeInfos;
+
+public class ASTFormalComment extends AbstractApexNode<AstComment> {
+
+    private final String image;
+
+    ASTFormalComment(Token token) {
+        super(new AstComment(token));
+        this.image = token.getText();
+    }
+
+    @Deprecated
     public ASTFormalComment(String token) {
-        super(ASTFormalComment.class);
-        this.token = token;
+        super(new AstComment(null));
+        image = token;
     }
 
     @Override
@@ -19,10 +42,48 @@ public class ASTFormalComment extends AbstractApexNodeBase {
 
     @Override
     public String getImage() {
-        return token;
+        return image;
     }
 
     public String getToken() {
-        return token;
+        return image;
     }
+
+
+    public static final class AstComment implements AstNode {
+
+        private final Location loc;
+
+        private AstComment(Token token) {
+            this.loc = token == null
+                       ? Locations.NONE
+                       : Locations.loc(token.getLine(), token.getCharPositionInLine() + 1);
+        }
+
+        @Override
+        public Location getLoc() {
+            return loc;
+        }
+
+        @Override
+        public <T extends Scope> void traverse(AstVisitor<T> astVisitor, T t) {
+            // do nothing
+        }
+
+        @Override
+        public void validate(SymbolResolver symbolResolver, ValidationScope validationScope) {
+            // do nothing
+        }
+
+        @Override
+        public void emit(Emitter emitter) {
+            // do nothing
+        }
+
+        @Override
+        public TypeInfo getDefiningType() {
+            return TypeInfos.VOID;
+        }
+    }
+
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNode.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.ast.SourceCodePositioner;
 
 import apex.jorje.data.Location;
@@ -11,6 +12,11 @@ import apex.jorje.data.Locations;
 import apex.jorje.semantic.ast.AstNode;
 import apex.jorje.semantic.exception.UnexpectedCodePathException;
 
+/**
+ * @deprecated Use {@link ApexNode}
+ */
+@Deprecated
+@InternalApi
 public abstract class AbstractApexNode<T extends AstNode> extends AbstractApexNodeBase implements ApexNode<T> {
 
     protected final T node;
@@ -18,6 +24,21 @@ public abstract class AbstractApexNode<T extends AstNode> extends AbstractApexNo
     protected AbstractApexNode(T node) {
         super(node.getClass());
         this.node = node;
+    }
+
+    @Override
+    public ApexNode<?> getChild(int index) {
+        return (ApexNode<?>) super.getChild(index);
+    }
+
+    @Override
+    public ApexNode<?> getParent() {
+        return (ApexNode<?>) super.getParent();
+    }
+
+    @Override
+    public Iterable<? extends ApexNode<?>> children() {
+        return (Iterable<? extends ApexNode<?>>) super.children();
     }
 
     void calculateLineNumbers(SourceCodePositioner positioner) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNodeBase.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNodeBase.java
@@ -8,6 +8,10 @@ import net.sourceforge.pmd.lang.ast.AbstractNode;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.ast.SourceCodePositioner;
 
+/**
+ * @deprecated Use {@link ApexNode}
+ */
+@Deprecated
 public abstract class AbstractApexNodeBase extends AbstractNode {
 
     public AbstractApexNodeBase(Class<?> klass) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexNode.java
@@ -8,12 +8,20 @@ import net.sourceforge.pmd.lang.ast.Node;
 
 import apex.jorje.semantic.ast.AstNode;
 
+/**
+ * Root interface implemented by all Apex nodes. Apex nodes wrap a tree
+ * obtained from an external parser (Jorje). The underlying AST node is
+ * available with {@link #getNode()}.
+ *
+ * @param <T> Type of the underlying Jorje node
+ */
 public interface ApexNode<T extends AstNode> extends Node {
 
     /**
-     * Accept the visitor. *
+     * Accept the visitor.
      */
     Object jjtAccept(ApexParserVisitor visitor, Object data);
+
 
     /**
      * Accept the visitor. *
@@ -24,8 +32,21 @@ public interface ApexNode<T extends AstNode> extends Node {
     @Deprecated
     Object childrenAccept(ApexParserVisitor visitor, Object data);
 
+
     /**
      * Get the underlying AST node.
      */
     T getNode();
+
+
+    @Override
+    Iterable<? extends ApexNode<?>> children();
+
+
+    @Override
+    ApexNode<?> getChild(int index);
+
+
+    @Override
+    ApexNode<?> getParent();
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexParserVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexParserVisitor.java
@@ -5,13 +5,13 @@
 package net.sourceforge.pmd.lang.apex.ast;
 
 public interface ApexParserVisitor {
+    /**
+     * @deprecated Use {@link #visit(ApexNode, Object)}. That method
+     *     also visits comments now.
+     */
+    @Deprecated
     Object visit(AbstractApexNodeBase node, Object data);
 
-    /**
-     * @deprecated This visit method will be removed with PMD 7.0.0. Use {@link #visit(AbstractApexNodeBase, Object)}
-     *             instead. This method would not visit all nodes, e.g. ASTFormalComment would not be covered.
-     */
-    @Deprecated // will be removed with PMD 7.0.0
     Object visit(ApexNode<?> node, Object data);
 
     Object visit(ASTAnnotation node, Object data);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexParserVisitorAdapter.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexParserVisitorAdapter.java
@@ -5,463 +5,467 @@
 package net.sourceforge.pmd.lang.apex.ast;
 
 public class ApexParserVisitorAdapter implements ApexParserVisitor {
+
+    /**
+     * @deprecated Use {@link #visit(ApexNode, Object)}. That method
+     *     also visits comments now.
+     */
+    @Deprecated
     @Override
     public Object visit(AbstractApexNodeBase node, Object data) {
         return node.childrenAccept(this, data);
     }
 
-    /**
-     * @deprecated This visit method will be removed with PMD 7.0.0. Use {@link #visit(AbstractApexNodeBase, Object)}
-     *             instead. This method would not visit all nodes, e.g. ASTFormalComment would not be covered.
-     */
-    @Deprecated // will be removed with PMD 7.0.0
     @Override
     public Object visit(ApexNode<?> node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        for (ApexNode<?> child : node.children()) {
+            child.jjtAccept(this, data);
+        }
+        return data;
     }
 
     @Override
     public Object visit(ASTMethod node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTUserClass node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTModifierNode node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTParameter node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTBlockStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTUserClassMethods node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTBridgeMethodCreator node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTReturnStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTLiteralExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTConstructorPreambleStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTUserInterface node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTUserEnum node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTFieldDeclaration node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTWhileLoopStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTTryCatchFinallyBlockStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTForLoopStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTIfElseBlockStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTIfBlockStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTForEachStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTField node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTBreakStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTThrowStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTDoLoopStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTTernaryExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTSoqlExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTBooleanExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTAnnotation node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTAnonymousClass node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTArrayLoadExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTArrayStoreExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTAssignmentExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTBinaryExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTBindExpressions node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTCatchBlockStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTClassRefExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTContinueStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTDmlDeleteStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTDmlInsertStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTDmlMergeStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTDmlUndeleteStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTDmlUpdateStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTDmlUpsertStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTExpressionStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTFieldDeclarationStatements node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTInstanceOfExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTJavaMethodCallExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTJavaVariableExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTMapEntryNode node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTMethodCallExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTModifierOrAnnotation node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTNewListInitExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTNewListLiteralExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTNewMapInitExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTNewMapLiteralExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTNewObjectExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTNewSetInitExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTNewSetLiteralExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTPackageVersionExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTPostfixExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTPrefixExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTProperty node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTReferenceExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTRunAsBlockStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTSoslExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTStandardCondition node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTSuperMethodCallExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTSuperVariableExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTThisMethodCallExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTThisVariableExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTTriggerVariableExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTUserExceptionMethods node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTUserTrigger node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTVariableDeclaration node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTVariableDeclarationStatements node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTVariableExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTAnnotationParameter node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTCastExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTConstructorPreamble node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTIllegalStoreExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTMethodBlockStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTModifier node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTMultiStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTNestedExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTNestedStoreExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTNewKeyValueObjectExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTStatementExecuted node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTFormalComment node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexParserVisitorReducedAdapter.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexParserVisitorReducedAdapter.java
@@ -23,7 +23,7 @@ public class ApexParserVisitorReducedAdapter extends ApexParserVisitorAdapter {
 
 
     public Object visit(ASTUserClassOrInterface<?> node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexTreeBuilder.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexTreeBuilder.java
@@ -288,7 +288,7 @@ public final class ApexTreeBuilder extends AstVisitor<AdditionalPassScope> {
             if (parent != null) {
                 ASTFormalComment comment = new ASTFormalComment(tokenLocation.token);
                 comment.calculateLineNumbers(sourceCodePositioner, tokenLocation.index,
-                        tokenLocation.index + tokenLocation.token.length());
+                        tokenLocation.index + tokenLocation.token.getText().length());
 
                 // move existing nodes so that we can insert the comment as the first node
                 for (int i = parent.jjtGetNumChildren(); i > 0; i--) {
@@ -354,7 +354,7 @@ public final class ApexTreeBuilder extends AstVisitor<AdditionalPassScope> {
             if (token.getType() == ApexLexer.BLOCK_COMMENT) {
                 // Filter only block comments starting with "/**"
                 if (token.getText().startsWith("/**")) {
-                    tokenLocations.add(new ApexDocTokenLocation(startIndex, token.getText()));
+                    tokenLocations.add(new ApexDocTokenLocation(startIndex, token));
                 }
             }
             // TODO : Check other non-doc comments and tokens of type ApexLexer.EOL_COMMENT for "NOPMD" suppressions
@@ -368,11 +368,11 @@ public final class ApexTreeBuilder extends AstVisitor<AdditionalPassScope> {
 
     private static class ApexDocTokenLocation {
         int index;
-        String token;
+        Token token;
         ApexNode<?> nearestNode;
         int nearestNodeDistance;
 
-        ApexDocTokenLocation(int index, String token) {
+        ApexDocTokenLocation(int index, Token token) {
             this.index = index;
             this.token = token;
         }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexRule.java
@@ -140,464 +140,468 @@ public abstract class AbstractApexRule extends AbstractRule
         }
     }
 
+    /**
+     * @deprecated Use {@link #visit(ApexNode, Object)}. That method
+     *     also visits comments now.
+     */
+    @Deprecated
     @Override
     public Object visit(AbstractApexNodeBase node, Object data) {
         node.childrenAccept(this, data);
         return null;
     }
 
-    /**
-     * @deprecated This visit method will be removed with PMD 7.0.0. Use {@link #visit(AbstractApexNodeBase, Object)}
-     *             instead. This method would not visit all nodes, e.g. ASTFormalComment would not be covered.
-     */
-    @Deprecated // will be removed with PMD 7.0.0
+
     @Override
     public Object visit(ApexNode<?> node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        for (ApexNode<?> child : node.children()) {
+            child.jjtAccept(this, data);
+        }
+        return data;
     }
 
     @Override
     public Object visit(ASTMethod node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTUserClass node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTModifierNode node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTParameter node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTBlockStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTUserClassMethods node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTBridgeMethodCreator node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTReturnStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTLiteralExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTConstructorPreambleStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTUserInterface node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTUserEnum node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTFieldDeclaration node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTWhileLoopStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTTryCatchFinallyBlockStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTForLoopStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTIfElseBlockStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTIfBlockStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTForEachStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTField node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTBreakStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTThrowStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTDoLoopStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTTernaryExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTSoqlExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTBooleanExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTAnnotation node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTAnonymousClass node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTArrayLoadExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTArrayStoreExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTAssignmentExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTBinaryExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTBindExpressions node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTCatchBlockStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTClassRefExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTContinueStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTDmlDeleteStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTDmlInsertStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTDmlMergeStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTDmlUndeleteStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTDmlUpdateStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTDmlUpsertStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTExpressionStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTFieldDeclarationStatements node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTInstanceOfExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTJavaMethodCallExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTJavaVariableExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTMapEntryNode node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTMethodCallExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTModifierOrAnnotation node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTNewListInitExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTNewListLiteralExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTNewMapInitExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTNewMapLiteralExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTNewObjectExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTNewSetInitExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTNewSetLiteralExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTPackageVersionExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTPostfixExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTPrefixExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTProperty node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTReferenceExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTRunAsBlockStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTSoslExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTStandardCondition node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTSuperMethodCallExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTSuperVariableExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTThisMethodCallExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTThisVariableExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTTriggerVariableExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTUserExceptionMethods node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTUserTrigger node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTVariableDeclaration node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTVariableDeclarationStatements node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTVariableExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTAnnotationParameter node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTCastExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTConstructorPreamble node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTIllegalStoreExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTMethodBlockStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTModifier node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTMultiStatement node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTNestedExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTNestedStoreExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTNewKeyValueObjectExpression node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTStatementExecuted node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 
     @Override
     public Object visit(ASTFormalComment node, Object data) {
-        return visit((AbstractApexNodeBase) node, data);
+        return visit((ApexNode<?>) node, data);
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/AbstractNcssCountRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/AbstractNcssCountRule.java
@@ -17,16 +17,15 @@ import net.sourceforge.pmd.lang.apex.ast.ASTStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTThrowStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTTryCatchFinallyBlockStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTWhileLoopStatement;
-import net.sourceforge.pmd.lang.apex.ast.AbstractApexNodeBase;
+import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractStatisticalApexRule;
-import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.stat.DataPoint;
 import net.sourceforge.pmd.util.NumericConstants;
 
 /**
  * Abstract superclass for NCSS counting methods. Counts tokens according to
  * <a href="http://www.kclee.de/clemens/java/javancss/">JavaNCSS rules</a>.
- * 
+ *
  * @author ported from Java original of Jason Bennett
  */
 public abstract class AbstractNcssCountRule extends AbstractStatisticalApexRule {
@@ -35,7 +34,7 @@ public abstract class AbstractNcssCountRule extends AbstractStatisticalApexRule 
 
     /**
      * Count the nodes of the given type using NCSS rules.
-     * 
+     *
      * @param nodeClass
      *            class of node to count
      */
@@ -49,13 +48,11 @@ public abstract class AbstractNcssCountRule extends AbstractStatisticalApexRule 
     }
 
     @Override
-    public Object visit(AbstractApexNodeBase node, Object data) {
+    public Object visit(ApexNode<?> node, Object data) {
         int numNodes = 0;
 
-        for (int i = 0; i < node.jjtGetNumChildren(); i++) {
-            AbstractApexNodeBase n = (AbstractApexNodeBase) node.jjtGetChild(i);
-            Integer treeSize = (Integer) n.jjtAccept(this, data);
-            numNodes += treeSize.intValue();
+        for (ApexNode<?> child : node.children()) {
+            numNodes += (Integer) child.jjtAccept(this, data);
         }
 
         if (this.nodeClass.isInstance(node)) {
@@ -74,19 +71,19 @@ public abstract class AbstractNcssCountRule extends AbstractStatisticalApexRule 
     /**
      * Count the number of children of the given node. Adds one to count the
      * node itself.
-     * 
+     *
      * @param node
      *            node having children counted
      * @param data
      *            node data
      * @return count of the number of children of the node, plus one
      */
-    protected Integer countNodeChildren(Node node, Object data) {
+    protected Integer countNodeChildren(ApexNode<?> node, Object data) {
         Integer nodeCount;
         int lineCount = 0;
-        for (int i = 0; i < node.jjtGetNumChildren(); i++) {
-            nodeCount = (Integer) ((AbstractApexNodeBase) node.jjtGetChild(i)).jjtAccept(this, data);
-            lineCount += nodeCount.intValue();
+        for (ApexNode<?> child : node.children()) {
+            nodeCount = (Integer) child.jjtAccept(this, data);
+            lineCount += nodeCount;
         }
         return ++lineCount;
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessiveLengthRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessiveLengthRule.java
@@ -4,7 +4,7 @@
 
 package net.sourceforge.pmd.lang.apex.rule.design;
 
-import net.sourceforge.pmd.lang.apex.ast.AbstractApexNodeBase;
+import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractStatisticalApexRule;
 import net.sourceforge.pmd.stat.DataPoint;
 
@@ -16,7 +16,7 @@ public class ExcessiveLengthRule extends AbstractStatisticalApexRule {
     }
 
     @Override
-    public Object visit(AbstractApexNodeBase node, Object data) {
+    public Object visit(ApexNode<?> node, Object data) {
         if (nodeClass.isInstance(node)) {
             DataPoint point = new DataPoint();
             point.setNode(node);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessiveNodeCountRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessiveNodeCountRule.java
@@ -4,7 +4,7 @@
 
 package net.sourceforge.pmd.lang.apex.rule.design;
 
-import net.sourceforge.pmd.lang.apex.ast.AbstractApexNodeBase;
+import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractStatisticalApexRule;
 import net.sourceforge.pmd.stat.DataPoint;
 
@@ -35,12 +35,11 @@ public class ExcessiveNodeCountRule extends AbstractStatisticalApexRule {
     }
 
     @Override
-    public Object visit(AbstractApexNodeBase node, Object data) {
+    public Object visit(ApexNode<?> node, Object data) {
         int numNodes = 0;
 
-        for (int i = 0; i < node.jjtGetNumChildren(); i++) {
-            Integer treeSize = (Integer) ((AbstractApexNodeBase) node.jjtGetChild(i)).jjtAccept(this, data);
-            numNodes += treeSize;
+        for (ApexNode<?> child : node.children()) {
+            numNodes += (Integer) child.jjtAccept(this, data);
         }
 
         if (nodeClass.isInstance(node)) {

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexParserTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexParserTest.java
@@ -4,7 +4,10 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
@@ -105,6 +108,36 @@ public class ApexParserTest extends ApexParserTestBase {
         Node method2 = rootNode.jjtGetChild(2);
         assertEquals("Wrong begin line", 4, method2.getBeginLine());
         assertEquals("Wrong end line", 5, method2.getEndLine());
+    }
+
+    @Test
+    public void checkComments() {
+
+        String code = "public  /** Comment on Class */ class SimpleClass {\n" // line 1
+            + "    /** Comment on m1 */"
+            + "    public void method1() {\n" // line 2
+            + "    }\n" // line 3
+            + "    public void method2() {\n" // line 4
+            + "    }\n" // line 5
+            + "}\n"; // line 6
+
+        ApexNode<Compilation> root = parse(code);
+
+        assertThat(root, instanceOf(ASTUserClass.class));
+        ApexNode<?> comment = root.getChild(0);
+        assertThat(comment, instanceOf(ASTFormalComment.class));
+
+        assertNotEquals(comment.getNode(), null);
+        assertThat(comment.getNode(), instanceOf(ASTFormalComment.AstComment.class));
+        assertPosition(comment, 1, 9, 1, 31);
+        assertEquals("/** Comment on Class */", ((ASTFormalComment) comment).getToken());
+
+        ApexNode<?> m1 = root.getChild(2);
+        assertThat(m1, instanceOf(ASTMethod.class));
+
+        ApexNode<?> comment2 = m1.getChild(0);
+        assertThat(comment2, instanceOf(ASTFormalComment.class));
+        assertEquals("/** Comment on m1 */", ((ASTFormalComment) comment2).getToken());
     }
 
     @Test


### PR DESCRIPTION
Fixes #2208. We can create a dummy Jorje node to avoid returning null. 