### PR TITLE
[java] Don't use ClassNotFoundException to report unresolved classes

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/PMDASMClassLoader.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/PMDASMClassLoader.java
@@ -30,7 +30,7 @@ import net.sourceforge.pmd.lang.java.typeresolution.visitors.PMDASMVisitor;
  * the negative cases only. The cache is shared between loadClass and getImportedClasses,
  * as they are using the same (parent) class loader, e.g. if the class foo.Bar cannot be loaded,
  * then the resource foo/Bar.class will not exist, too.
- * 
+ *
  * Note: since git show 46ad3a4700b7a233a177fa77d08110127a85604c the cache is using
  * a concurrent hash map to avoid synchronizing on the class loader instance.
  */
@@ -70,21 +70,27 @@ public final class PMDASMClassLoader extends ClassLoader {
 
     @Override
     public Class<?> loadClass(String name) throws ClassNotFoundException {
-        if (dontBother.containsKey(name)) {
+        Class<?> aClass = loadClassOrNull(name);
+        if (aClass == null) {
             throw new ClassNotFoundException(name);
+        }
+        return aClass;
+    }
+
+    /**
+     * Not throwing CNFEs to represent failure makes a huge performance
+     * difference. Typeres as a whole is 2x faster.
+     */
+    public Class<?> loadClassOrNull(String name) {
+        if (dontBother.containsKey(name)) {
+            return null;
         }
 
         try {
             return super.loadClass(name);
-        } catch (ClassNotFoundException e) {
+        } catch (ClassNotFoundException | LinkageError e) {
             dontBother.put(name, Boolean.TRUE);
-            throw e;
-        } catch (NoClassDefFoundError e) {
-            dontBother.put(name, Boolean.TRUE);
-            // rethrow as ClassNotFoundException, as the remaining part just
-            // deals with that
-            // see also: https://sourceforge.net/p/pmd/bugs/1319/
-            throw new ClassNotFoundException(name, e);
+            return null;
         }
     }
 
@@ -93,7 +99,7 @@ public final class PMDASMClassLoader extends ClassLoader {
      * doesn't know for sure it will fail). Notice, that the ability to resolve
      * a class does not imply that the class will actually be found and
      * resolved.
-     * 
+     *
      * @param name
      *            the name of the class
      * @return whether the class can be resolved

--- a/pmd-java/src/main/resources/category/java/security.xml
+++ b/pmd-java/src/main/resources/category/java/security.xml
@@ -53,7 +53,7 @@ public class Foo {
     void bad() {
         byte[] iv = new byte[] { 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, 00, };
     }
-    
+
     void alsoBad() {
         byte[] iv = "secret iv in here".getBytes();
     }


### PR DESCRIPTION
So I was fiddling with Intellij's profiler, and found out that the constructor of ClassNotFoundException slows down classloading by a huge factor. In all usages that matter, the exception is immediately caught by the caller and ignored.

With this change we return null instead. This speeds up type resolution by a factor of 2.

Here's a comparison on the sources of OpenJDK 12 (around 17700 source files):

* Master:
```java

17700
Resolved: 18006988, unresolved 2591866
Resolved 88.0%
Errors 5

--------------------------------------------<<< Rule >>>--------------------------------------------
Label                                              Time (secs) Self Time (secs)  # Calls     Counter

TypeResTest                                             2,4144           2,4144   17 742

Total Rule                                              2,4144           2,4144

------------------------------------------<<< Summary  >>>------------------------------------------
Label                                              Time (secs) Self Time (secs)  # Calls     Counter

Rule                                                    2,4265           0,0122   17 742
Rulechain Rule                                          0,0065           0,0065   17 742
Collect Files                                           0,1902           0,1902        1
Load Rules                                              0,0587           0,0587        1
Parser                                                 38,6618          38,6618   17 743
Qualified Name Resolution                               6,5715           6,5715   17 743
Symbol Table                                           25,9257          25,9257   17 743
Type Resolution                                       175,0367         175,0367   17 742
Rulechain Visit                                         1,6539           1,6539   17 742
Reporting                                               0,0525           0,0525   17 746
File Processing                                       252,8111         252,7726        1
Unaccounted                                             0,8519           0,8519

-------------------------------------------<<< Total  >>>-------------------------------------------
Label                                              Time (secs) Self Time (secs)  # Calls     Counter

Wall Clock Time                                       253,1100
```

* Now:
```java

17700
Resolved: 18006855, unresolved 2591999
Resolved 88.0%
Errors 5
--------------------------------------------<<< Rule >>>--------------------------------------------


Summary:

Label                                              Time (secs) Self Time (secs)  # Calls     Counter

TypeResTest                                             2,4051           2,4051   17 742

Total Rule                                              2,4051           2,4051

------------------------------------------<<< Summary  >>>------------------------------------------
Label                                              Time (secs) Self Time (secs)  # Calls     Counter

Rule                                                    2,4164           0,0113   17 742
Rulechain Rule                                          0,0058           0,0058   17 742
Collect Files                                           0,3163           0,3163        1
Load Rules                                              0,1324           0,1324        1
Parser                                                 43,7286          43,7286   17 743
Qualified Name Resolution                               7,0715           7,0715   17 743
Symbol Table                                           27,5194          27,5194   17 743
Type Resolution                                        91,8995          91,8995   17 742
Rulechain Visit                                         1,7523           1,7523   17 742
Reporting                                               0,1810           0,1810   17 746
File Processing                                       177,2106         177,0803        1
Unaccounted                                             0,9306           0,9306


-------------------------------------------<<< Total  >>>-------------------------------------------
Label                                              Time (secs) Self Time (secs)  # Calls     Counter

Wall Clock Time                                       177,7950
```

Bonus: I tried the same thing with my prototype for 7.0, and got these results:

```java
17700
Resolved: 7276268, unresolved 1161416
Resolved 87.0%
Errors 811
--------------------------------------------<<< Rule >>>--------------------------------------------
Label                                              Time (secs) Self Time (secs)  # Calls     Counter

TypeResTest                                            49,6563          49,6563   17 742

Total Rule                                             49,6563          49,6563

--------------------------------<<< Language Specific Processing >>>--------------------------------
Label                                              Time (secs) Self Time (secs)  # Calls     Counter

Java: Java processing                                   7,6579           0,0738   17 742
Qualified name resolution                               3,5481           3,5481   17 742
Symbol table resolution                                 4,0360           4,0360   17 742

Total Language Specific Processing                     15,2660           7,6819

------------------------------------------<<< Summary  >>>------------------------------------------
Label                                              Time (secs) Self Time (secs)  # Calls     Counter

Rule                                                   49,6796           0,0233   17 742
Rulechain Rule                                          0,0096           0,0096   17 742
Collect Files                                           0,3966           0,3966        1
Load Rules                                              0,1217           0,1217        1
Parser                                                 49,5277          49,5277   17 743
Rulechain Ast Indexation                                1,6956           1,6956   17 742
Reporting                                               0,0867           0,0867   17 746
File Processing                                       111,6540         111,5844        1
Unaccounted                                             1,0617           1,0617

-------------------------------------------<<< Total  >>>-------------------------------------------
Label                                              Time (secs) Self Time (secs)  # Calls     Counter

Wall Clock Time                                       112,2610
```
So it's nearly 4 times faster than current master. Note that the time is spent in the rule rather than in the processing stage. That's because it's done on demand by the rule. This sample rule resolves all TypeNodes in the tree though. "Qualified name resolution" and "Symbol table resolution" are sub tasks of "Java Processing".
