### PR TITLE
[core] Fix Language::getVersions duplicating aliased versions

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/BaseLanguageModule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/BaseLanguageModule.java
@@ -56,14 +56,7 @@ public abstract class BaseLanguageModule implements Language {
     }
 
     protected void addVersion(String version, LanguageVersionHandler languageVersionHandler, boolean isDefault) {
-        if (versions == null) {
-            versions = new HashMap<>();
-        }
-        LanguageVersion languageVersion = new LanguageVersion(this, version, languageVersionHandler);
-        versions.put(version, languageVersion);
-        if (isDefault) {
-            defaultVersion = languageVersion;
-        }
+        addVersions(languageVersionHandler, isDefault, version);
     }
 
     @Override

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/BaseLanguageModule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/BaseLanguageModule.java
@@ -23,6 +23,7 @@ public abstract class BaseLanguageModule implements Language {
     protected String terseName;
     protected Class<?> ruleChainVisitorClass;
     protected List<String> extensions;
+    private final List<LanguageVersion> distinctVersions = new ArrayList<>();
     protected Map<String, LanguageVersion> versions;
     protected LanguageVersion defaultVersion;
 
@@ -42,6 +43,8 @@ public abstract class BaseLanguageModule implements Language {
         }
 
         LanguageVersion languageVersion = new LanguageVersion(this, languageVersions[0], languageVersionHandler);
+
+        distinctVersions.add(languageVersion);
 
         for (String version : languageVersions) {
             versions.put(version, languageVersion);
@@ -95,7 +98,7 @@ public abstract class BaseLanguageModule implements Language {
 
     @Override
     public List<LanguageVersion> getVersions() {
-        return new ArrayList<>(versions.values());
+        return new ArrayList<>(distinctVersions);
     }
 
     @Override

--- a/pmd-test/src/main/java/net/sourceforge/pmd/AbstractLanguageVersionTest.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/AbstractLanguageVersionTest.java
@@ -24,7 +24,7 @@ import net.sourceforge.pmd.util.ResourceLoader;
 /**
  * Base test class for {@link LanguageVersion} implementations. <br>
  * Each language implementation should subclass this and provide a data method.
- * 
+ *
  * <pre>
  * &#64;Parameters
  *     public static Collection&lt;Object[]&gt; data() {
@@ -39,7 +39,7 @@ import net.sourceforge.pmd.util.ResourceLoader;
  *              null }
  *       });
  * </pre>
- * 
+ *
  * <p>For the parameters, see the constructor
  * {@link #AbstractLanguageVersionTest(String, String, String, LanguageVersion)}.</p>
  */
@@ -54,7 +54,7 @@ public class AbstractLanguageVersionTest {
 
     /**
      * Creates a new {@link AbstractLanguageVersionTest}
-     * 
+     *
      * @param name
      *            the name under which the language module is registered
      * @param terseName
@@ -105,7 +105,7 @@ public class AbstractLanguageVersionTest {
 
     /**
      * Makes sure, that for each language a "categories.properties" file exists.
-     * 
+     *
      * @throws Exception
      *             any error
      */
@@ -127,7 +127,7 @@ public class AbstractLanguageVersionTest {
 
     /**
      * If a rulesets.properties file still exists, test it as well.
-     * 
+     *
      * @throws Exception
      *             any error
      */
@@ -153,6 +153,9 @@ public class AbstractLanguageVersionTest {
 
     @Test
     public void testVersionsAreDistinct() {
+        if (expected == null) {
+            return;
+        }
 
         Language lang = expected.getLanguage();
 

--- a/pmd-test/src/main/java/net/sourceforge/pmd/AbstractLanguageVersionTest.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/AbstractLanguageVersionTest.java
@@ -151,6 +151,21 @@ public class AbstractLanguageVersionTest {
         }
     }
 
+    @Test
+    public void testVersionsAreDistinct() {
+
+        Language lang = expected.getLanguage();
+
+        int count = 0;
+        for (LanguageVersion lv : lang.getVersions()) {
+            if (lv.equals(expected))
+                count++;
+        }
+
+        assertEquals("Expected exactly one occurrence of " + expected
+                         + " in the language versions of its language",1, count);
+    }
+
     private void assertRulesetsAndCategoriesProperties(ResourceLoader rl, Properties props)
             throws IOException, RuleSetNotFoundException {
         String rulesetFilenames = props.getProperty("rulesets.filenames");

--- a/pmd-test/src/main/java/net/sourceforge/pmd/AbstractLanguageVersionTest.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/AbstractLanguageVersionTest.java
@@ -158,12 +158,13 @@ public class AbstractLanguageVersionTest {
 
         int count = 0;
         for (LanguageVersion lv : lang.getVersions()) {
-            if (lv.equals(expected))
+            if (lv.equals(expected)) {
                 count++;
+            }
         }
 
         assertEquals("Expected exactly one occurrence of " + expected
-                         + " in the language versions of its language",1, count);
+                         + " in the language versions of its language", 1, count);
     }
 
     private void assertRulesetsAndCategoriesProperties(ResourceLoader rl, Properties props)


### PR DESCRIPTION
#2088 didn't change the implementation of `Language::getVersions`, causing the returned list to contain duplicates. Spotted in the designer:

![Capture d’écran de 2020-01-23 10-38-08](https://user-images.githubusercontent.com/24524930/72973110-ebfbec80-3dcc-11ea-9fbf-6d21858a7320.png)
