### PR TITLE
[doc] Corrected XML attributes in release notes

### DIFF
--- a/docs/pages/release_notes_old.md
+++ b/docs/pages/release_notes_old.md
@@ -66,9 +66,9 @@ If a CPD language doesn't provide these exact information, then these additional
 
 Each `<file>` element in the XML format now has 3 new attributes:
 
-*   attribute `endLine`
-*   attribute `beginColumn` (if there is column information available)
-*   attribute `endColumn` (if there is column information available)
+*   attribute `endline`
+*   attribute `column` (if there is column information available)
+*   attribute `endcolumn` (if there is column information available)
 
 #### Modified Rules
 


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
In the PMD 6.21.0 release notes, the XML properties that are specified are not consistent with the implementation.

Example of the format:
`<?xml version="1.0" encoding="UTF-8"?>
<pmd-cpd>
   <duplication lines="8" tokens="68">
      <file column="26" endcolumn="9" endline="14" line="7" path="..."/>
...`