### PR TITLE
[java] Fix octal literals

### DIFF
--- a/pmd-java/etc/grammar/Java.jjt
+++ b/pmd-java/etc/grammar/Java.jjt
@@ -521,66 +521,52 @@ TOKEN :
 TOKEN :
 {
   < INTEGER_LITERAL:
-        <DECIMAL_LITERAL> (["l","L"])?
-      | <HEX_LITERAL> (["l","L"])?
-      | <BINARY_LITERAL> (["l","L"])?
-      | <OCTAL_LITERAL> (["l","L"])?
+        <DECIMAL_NUMERAL> (["l","L"])?
+      | <HEX_NUMERAL>     (["l","L"])?
+      | <BINARY_NUMERAL>  (["l","L"])?
+      | <OCTAL_NUMERAL>   (["l","L"])?
   >
-|
-  < #DECIMAL_LITERAL: (["0"-"9"]((["0"-"9","_"])*["0"-"9"])?) >
-|
-  < #HEX_LITERAL: "0" ["x","X"] (["0"-"9","a"-"f","A"-"F"]((["0"-"9","a"-"f","A"-"F","_"])*["0"-"9","a"-"f","A"-"F"])?) >
-|
-  < #BINARY_LITERAL: "0" ["b","B"] (["0","1"]((["0","1","_"])*["0","1"])?) >
-|
-  < #OCTAL_LITERAL: "0" (["0"-"7"]((["0"-"7","_"])*["0"-"7"])?) >
+| < #DECIMAL_NUMERAL:               ["1"-"9"]  (("_")* ["0"-"9"])* >
+| < #HEX_NUMERAL:     "0" ["x","X"] <HEX_DIGIT_SEQ>                >
+| < #BINARY_NUMERAL:  "0" ["b","B"] ["0","1"]  (("_")* ["0","1"])* >
+| < #OCTAL_NUMERAL:   "0"                      (("_")* ["0"-"7"])* >
 |
   < FLOATING_POINT_LITERAL:
-        (["0"-"9"]((["0"-"9","_"])*["0"-"9"])?) "." (["0"-"9"]((["0"-"9","_"])*["0"-"9"])?)? (<EXPONENT>)? (["f","F","d","D"])?
-      | "." (["0"-"9"]((["0"-"9","_"])*["0"-"9"])?) (<EXPONENT>)? (["f","F","d","D"])?
-      | (["0"-"9"]((["0"-"9","_"])*["0"-"9"])?) <EXPONENT> (["f","F","d","D"])?
-      | (["0"-"9"]((["0"-"9","_"])*["0"-"9"])?) (<EXPONENT>)? ["f","F","d","D"]
+      <DECIMAL_FLOATING_POINT_LITERAL>
+    | <HEX_FLOATING_POINT_LITERAL>
   >
-|
-  < HEX_FLOATING_POINT_LITERAL:
-      (<HEX_LITERAL> (".")? | "0" ["x","X"] (["0"-"9","a"-"f","A"-"F"]((["0"-"9","a"-"f","A"-"F","_"])*["0"-"9","a"-"f","A"-"F"])?)? "." (["0"-"9","a"-"f","A"-"F"]((["0"-"9","a"-"f","A"-"F","_"])*["0"-"9","a"-"f","A"-"F"])?)) ["p","P"] (["+","-"])? (["0"-"9"]((["0"-"9","_"])*["0"-"9"])?) (["f","F","d","D"])?
+| < #DECIMAL_FLOATING_POINT_LITERAL:
+      <DIGIT_SEQ> "." (<DIGIT_SEQ>)? (<EXPONENT>)? (["f","F", "d","D"])?
+    |             "."  <DIGIT_SEQ>   (<EXPONENT>)? (["f","F", "d","D"])?
+    | <DIGIT_SEQ>                     <EXPONENT>   (["f","F", "d","D"])?
+    | <DIGIT_SEQ>                    (<EXPONENT>)?  ["f","F", "d","D"]
   >
-|
-  < #EXPONENT: ["e","E"] (["+","-"])? (["0"-"9"]((["0"-"9","_"])*["0"-"9"])?) >
-|
-  < CHARACTER_LITERAL:
-      "'"
-      (   (~["'","\\","\n","\r"])
-        | ("\\"
-            ( ["n","t","b","r","f","\\","'","\""]
-            | ["0"-"7"] ( ["0"-"7"] )?
-            | ["0"-"3"] ["0"-"7"] ["0"-"7"]
-            )
-          )
-      )
-      "'"
+| < #HEX_FLOATING_POINT_LITERAL:
+      "0" ["x","X"]  <HEX_DIGIT_SEQ>   (".")?               <HEX_EXPONENT> (["f","F", "d","D"])?
+    | "0" ["x","X"] (<HEX_DIGIT_SEQ>)?  "." <HEX_DIGIT_SEQ> <HEX_EXPONENT> (["f","F", "d","D"])?
   >
-| < #STRING_ESCAPE:
-      "\\"
-      ( ["n","t","b","r","f","\\","'","\""]
-      // octal escapes
-      | ["0"-"7"] ( ["0"-"7"] )?
-      | ["0"-"3"] ["0"-"7"] ["0"-"7"]
-      )
-  >
-|
-  < STRING_LITERAL:
-      "\""
-      (   (~["\"","\\","\n","\r"])
-        | <STRING_ESCAPE>
-      )*
-      "\""
-  >
+| < #DIGIT_SEQ:     ["0"-"9"]                 (("_")* ["0"-"9"])*                 >
+| < #HEX_DIGIT_SEQ: ["0"-"9","a"-"f","A"-"F"] (("_")* ["0"-"9","a"-"f","A"-"F"])* >
+
+| < #EXPONENT:      ["e","E"] <EXPONENT_TAIL> >
+| < #HEX_EXPONENT:  ["p","P"] <EXPONENT_TAIL> >
+| < #EXPONENT_TAIL: (["+","-"])? <DIGIT_SEQ>  >
+
+| < CHARACTER_LITERAL: "'"  ( ~["'", "\\","\n","\r"] | <STRING_ESCAPE> )  "'"  >
+| < STRING_LITERAL:    "\"" ( ~["\"","\\","\n","\r"] | <STRING_ESCAPE> )* "\"" >
 |
   < TEXT_BLOCK_LITERAL:
      "\"\"\"" (<HORIZONTAL_WHITESPACE>)* <LINE_TERMINATOR>
         ( ~["\"", "\\"] | "\"" ~["\""] | "\"\"" ~["\""] | <STRING_ESCAPE> )*
      "\"\"\""
+  >
+| < #STRING_ESCAPE:
+        "\\"
+        ( ["n","t","b","r","f","\\","'","\""]
+        // octal escapes
+        | ["0"-"7"] ( ["0"-"7"] )?
+        | ["0"-"3"] ["0"-"7"] ["0"-"7"]
+        )
   >
 }
 
@@ -1829,7 +1815,6 @@ void NumericLiteral():
 {
   ( t=<INTEGER_LITERAL>             { jjtThis.setIntLiteral(); }
   | t=<FLOATING_POINT_LITERAL>      { jjtThis.setFloatLiteral(); }
-  | t=<HEX_FLOATING_POINT_LITERAL>  { jjtThis.setFloatLiteral(); }
   )
   { jjtThis.setImage(t.image); }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/cpd/JavaTokenizer.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/cpd/JavaTokenizer.java
@@ -62,7 +62,7 @@ public class JavaTokenizer extends JavaCCTokenizer {
 
         if (ignoreLiterals && (javaToken.kind == JavaTokenKinds.STRING_LITERAL
                 || javaToken.kind == JavaTokenKinds.CHARACTER_LITERAL
-                || javaToken.kind == JavaTokenKinds.DECIMAL_LITERAL
+                || javaToken.kind == JavaTokenKinds.INTEGER_LITERAL
                 || javaToken.kind == JavaTokenKinds.FLOATING_POINT_LITERAL)) {
             image = String.valueOf(javaToken.kind);
         }

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTLiteralTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTLiteralTest.kt
@@ -331,8 +331,11 @@ $delim
 
             // this starts with zero so is octal,
             // but 9 is too big for an octal digit
-            // "099" shouldNot parse()
-            // "099" shouldNot parse()
+            "099" shouldNot parse()
+            "00_8" shouldNot parse()
+            "08_" shouldNot parse()
+            "0x8_" shouldNot parse()
+            "8_" shouldNot parse()
             "0b" shouldNot parse()
             "0x" shouldNot parse()
             "0" should parseAs {


### PR DESCRIPTION
* There was a problem with the token specs for decimal literals. They allowed eg `09`, which is supposed to be an invalid octal literal (starts with zero, but a digit is greater than 7), but was lexed as a decimal literal.
* This also cleans up the regexes for other numeric literals. This is a cleaned up version of what the [Javacc parser](https://javacc.github.io/javacc/documentation/bnf.html#reserved-and-literals) currently uses
* This can't be done on master, since adding some token regexes breaks the binary API (token ids are inlined compile-time constants)

