### PR TITLE
[java] Fix InvalidLogMessageFormat false-positive with lambda arguments

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -23,6 +23,7 @@ For the changes, see [PMD Designer Changelog](https://github.com/pmd/pmd-designe
 
 *   java-errorprone
     *   [#2250](https://github.com/pmd/pmd/issues/2250): \[java] InvalidLogMessageFormat flags logging calls using a slf4j-Marker
+    *   [#2255](https://github.com/pmd/pmd/issues/2255): \[java] InvalidLogMessageFormat false-positive for a lambda argument
 
 ### API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidLogMessageFormatRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidLogMessageFormatRule.java
@@ -158,9 +158,30 @@ public class InvalidLogMessageFormatRule extends AbstractJavaRule {
         int lastIndex = params.size() - 1;
         ASTPrimaryExpression last = params.get(lastIndex).getFirstDescendantOfType(ASTPrimaryExpression.class);
 
-        if (isNewThrowable(last) || hasTypeThrowable(last) || isReferencingThrowable(last)) {
+        if (isNewThrowable(last) || hasTypeThrowable(last) || isReferencingThrowable(last) || isLambdaParameter(last)) {
             params.remove(lastIndex);
         }
+    }
+
+    private boolean isLambdaParameter(ASTPrimaryExpression last) {
+        String varName = null;
+        ASTPrimaryPrefix prefix = last.getFirstChildOfType(ASTPrimaryPrefix.class);
+        if (prefix != null) {
+            ASTName name = prefix.getFirstChildOfType(ASTName.class);
+            if (name != null) {
+                varName = name.getImage();
+            }
+        }
+        for (NameDeclaration decl : prefix.getScope().getDeclarations().keySet()) {
+            if (decl.getName().equals(varName)) {
+                if (decl.getNode().getParent() instanceof ASTLambdaExpression) {
+                    // If the last parameter is a lambda parameter, then we also ignore it - regardless of the type.
+                    // This is actually a workaround, since type resolution doesn't resolve the types of lambda parameters.
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     private String getExpectedMessage(final List<ASTExpression> params, final int expectedArguments) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidLogMessageFormat.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidLogMessageFormat.xml
@@ -834,4 +834,34 @@ class InvalidLogMessageFormatTest {
 }
         ]]></code>
     </test-code>
+
+    <test-code regressionTest="false">
+        <description>[java] InvalidLogMessageFormat false-negative for a lambda argument #2255</description>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>11,13,16</expected-linenumbers>
+        <code><![CDATA[
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class InvalidLogMessageFormatTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(InvalidLogMessageFormatTest.class);
+
+    private InvalidLogMessageFormatTest() {
+    }
+
+    public static void main(String[] args) {
+        foo(arg -> LOGGER.error("Foo", arg)); // missing violation: extra argument, that is not a exception
+        // explicit cast helps type resolution
+        foo((String arg) -> LOGGER.error("Foo", arg)); // violation: extra argument, that is not a exception
+        foo((String arg) -> LOGGER.error("Foo {}", arg)); // no violation: correct number of arguments
+        foo(arg -> LOGGER.error("Foo {}", arg)); // no violation: correct number of arguments
+        foo(arg -> LOGGER.error("Foo {} {}", arg)); // violation: missing argument
+    }
+
+    private static void foo(Consumer<String> consumer) {
+        consumer.accept("bar");
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidLogMessageFormat.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidLogMessageFormat.xml
@@ -785,7 +785,7 @@ public class InvalidLogMessageFormatTest {
     </test-code>
 
     <test-code>
-        <description>ignore slf4j-Markers when detecting the number of arguments</description>
+        <description>ignore slf4j-Markers when detecting the number of arguments #2250</description>
         <expected-problems>2</expected-problems>
         <expected-linenumbers>11,17</expected-linenumbers>
         <code><![CDATA[
@@ -806,6 +806,30 @@ public class InvalidLogMessageFormatTest {
 
         final var otherMarker = MarkerFactory.getMarker("OTHER_MARKER");
         logger.warn(otherMarker, "foo"); // gets flagged as we can't statically determine the type of the "otherMarker" variable
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] InvalidLogMessageFormat false-positive for a lambda argument #2255</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class InvalidLogMessageFormatTest {
+    private static final Logger LOGGER = LoggerFactory.getLogger(InvalidLogMessageFormatTest.class);
+
+    private InvalidLogMessageFormatTest() {
+    }
+
+    public static void main(String[] args) {
+        foo(exception -> LOGGER.error("Foo", exception));
+    }
+
+    private static void foo(Consumer<Throwable> consumer) {
+        consumer.accept(new IllegalArgumentException());
     }
 }
         ]]></code>


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

Fixes #2255 

This doesn't really solve the underlying problem (we don't know the type of the lambda parameter), but merely ignores lambda parameters altogether - basically restoring the behavior before #2196 was fixed.
