### PR TITLE
[java] Make enum body track trailing comma/semi

### DIFF
--- a/pmd-java/etc/grammar/Java.jjt
+++ b/pmd-java/etc/grammar/Java.jjt
@@ -923,9 +923,9 @@ void EnumBody():
 {}
 {
    "{"
-   [ EnumConstant() ( LOOKAHEAD(2) "," EnumConstant() )* ]
-	[ "," ]
-   [ ";" ( ClassOrInterfaceBodyDeclaration() )* ]
+    [ EnumConstant() ( LOOKAHEAD(2) "," EnumConstant() )* ]
+    [ "," { jjtThis.setTrailingComma(); } ]
+    [ ";" { jjtThis.setSeparatorSemi(); } ( ClassOrInterfaceBodyDeclaration() )* ]
    "}"
 }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTEnumBody.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTEnumBody.java
@@ -10,7 +10,7 @@ package net.sourceforge.pmd.lang.java.ast;
  * <pre class="grammar">
  *
  * EnumBody ::= "{"
- *              [( {@link ASTAnnotation Annotation} )* {@link ASTEnumConstant EnumConstant} ( "," ( {@link ASTAnnotation Annotation} )* {@link ASTEnumConstant EnumConstant} )* ]
+ *              [ {@link ASTEnumConstant EnumConstant} ( "," ( {@link ASTEnumConstant EnumConstant} )* ]
  *              [ "," ]
  *              [ ";" ( {@link ASTClassOrInterfaceBodyDeclaration ClassOrInterfaceBodyDeclaration} )* ]
  *              "}"
@@ -20,6 +20,9 @@ package net.sourceforge.pmd.lang.java.ast;
  *
  */
 public final class ASTEnumBody extends AbstractJavaNode implements ASTTypeBody {
+
+    private boolean trailingComma;
+    private boolean separatorSemi;
 
     ASTEnumBody(int id) {
         super(id);
@@ -34,5 +37,44 @@ public final class ASTEnumBody extends AbstractJavaNode implements ASTTypeBody {
     @Override
     public <T> void jjtAccept(SideEffectingVisitor<T> visitor, T data) {
         visitor.visit(this, data);
+    }
+
+    void setTrailingComma() {
+        this.trailingComma = true;
+    }
+
+    void setSeparatorSemi() {
+        this.separatorSemi = true;
+    }
+
+    /**
+     * Returns true if the last enum constant has a trailing comma.
+     * For example:
+     * <pre>{@code
+     * enum Foo { A, B, C, }
+     * enum Bar { , }
+     * }</pre>
+     */
+    public boolean hasTrailingComma() {
+        return trailingComma;
+    }
+
+    /**
+     * Returns true if the last enum constant has a trailing semi-colon.
+     * This semi is not optional when the enum has other members.
+     * For example:
+     * <pre>{@code
+     * enum Foo {
+     *   A(2);
+     *
+     *   Foo(int i) {...}
+     * }
+     *
+     * enum Bar { A; }
+     * enum Baz { ; }
+     * }</pre>
+     */
+    public boolean hasSeparatorSemi() {
+        return separatorSemi;
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaParser.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaParser.java
@@ -57,7 +57,6 @@ public class JavaParser extends JjtreeParserAdapter<ASTCompilationUnit> {
         parser.setPreview(checker.isPreviewEnabled());
 
         ASTCompilationUnit acu = parser.CompilationUnit();
-        acu.setTokenDocument(cs.getTokenDocument());
         acu.setNoPmdComments(parser.getSuppressMap());
         checker.check(acu);
         return acu;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaParser.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaParser.java
@@ -57,6 +57,7 @@ public class JavaParser extends JjtreeParserAdapter<ASTCompilationUnit> {
         parser.setPreview(checker.isPreviewEnabled());
 
         ASTCompilationUnit acu = parser.CompilationUnit();
+        acu.setTokenDocument(cs.getTokenDocument());
         acu.setNoPmdComments(parser.getSuppressMap());
         checker.check(acu);
         return acu;

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTEnumConstantTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTEnumConstantTest.kt
@@ -55,6 +55,75 @@ class ASTEnumConstantTest : ParserTestSpec({
     }
 
 
+    parserTest("Corner cases with separators") {
+
+        inContext(TopLevelTypeDeclarationParsingCtx) {
+
+
+            "enum Foo { A, }" should parseAs {
+
+                enumDecl("Foo") {
+                    modifiers {  }
+                    enumBody {
+                        it::hasTrailingComma shouldBe true
+                        enumConstant("A")
+                    }
+                }
+            }
+
+            "enum Foo { , }" should parseAs {
+
+                enumDecl("Foo") {
+                    modifiers {  }
+
+                    enumBody {
+                        it::hasTrailingComma shouldBe true
+                    }
+                }
+            }
+
+            "enum Foo { ,; }" should parseAs {
+
+                enumDecl("Foo") {
+                    modifiers {  }
+                    enumBody {
+                        it::hasTrailingComma shouldBe true
+                        it::hasSeparatorSemi shouldBe true
+                    }
+                }
+            }
+
+            "enum Foo { ,, }" shouldNot parse()
+
+            "enum Foo { ; }" should parseAs {
+
+                enumDecl("Foo") {
+                    modifiers {  }
+                    enumBody {
+                        it::hasTrailingComma shouldBe false
+                        it::hasSeparatorSemi shouldBe true
+                    }
+                }
+            }
+
+            "enum Foo { ;; }" should parseAs {
+
+                enumDecl("Foo") {
+                    modifiers {  }
+
+                    enumBody {
+                        it::hasTrailingComma shouldBe false
+                        it::hasSeparatorSemi shouldBe true
+                        child<ASTClassOrInterfaceBodyDeclaration> {
+                            child<ASTEmptyDeclaration> {}
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+
     parserTest("Enum constants should have an anonymous class node") {
 
         inContext(TopLevelTypeDeclarationParsingCtx) {
@@ -97,7 +166,8 @@ class ASTEnumConstantTest : ParserTestSpec({
 
                     enumBody {
 
-                        enumConstant("B") {
+
+                enumConstant("B") {
 
                             val c = it
 
@@ -159,11 +229,11 @@ class ASTEnumConstantTest : ParserTestSpec({
                                 stringLit("\"str\"")
                             }
 
-                            it::getAnonymousClass shouldBe null
-                        }
-                    }
+                    it::getAnonymousClass shouldBe null
+
                 }
             }
+        }
 
             "enum Foo { B(\"str\") { } }" should parseAs {
                 enumDecl("Foo") {

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTEnumConstantTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTEnumConstantTest.kt
@@ -63,7 +63,7 @@ class ASTEnumConstantTest : ParserTestSpec({
             "enum Foo { A, }" should parseAs {
 
                 enumDecl("Foo") {
-                    modifiers {  }
+                    modifiers { }
                     enumBody {
                         it::hasTrailingComma shouldBe true
                         enumConstant("A")
@@ -74,7 +74,7 @@ class ASTEnumConstantTest : ParserTestSpec({
             "enum Foo { , }" should parseAs {
 
                 enumDecl("Foo") {
-                    modifiers {  }
+                    modifiers { }
 
                     enumBody {
                         it::hasTrailingComma shouldBe true
@@ -85,7 +85,7 @@ class ASTEnumConstantTest : ParserTestSpec({
             "enum Foo { ,; }" should parseAs {
 
                 enumDecl("Foo") {
-                    modifiers {  }
+                    modifiers { }
                     enumBody {
                         it::hasTrailingComma shouldBe true
                         it::hasSeparatorSemi shouldBe true
@@ -98,7 +98,7 @@ class ASTEnumConstantTest : ParserTestSpec({
             "enum Foo { ; }" should parseAs {
 
                 enumDecl("Foo") {
-                    modifiers {  }
+                    modifiers { }
                     enumBody {
                         it::hasTrailingComma shouldBe false
                         it::hasSeparatorSemi shouldBe true
@@ -109,7 +109,7 @@ class ASTEnumConstantTest : ParserTestSpec({
             "enum Foo { ;; }" should parseAs {
 
                 enumDecl("Foo") {
-                    modifiers {  }
+                    modifiers { }
 
                     enumBody {
                         it::hasTrailingComma shouldBe false
@@ -165,9 +165,7 @@ class ASTEnumConstantTest : ParserTestSpec({
                     it::getModifiers shouldBe modifiers {}
 
                     enumBody {
-
-
-                enumConstant("B") {
+                        enumConstant("B") {
 
                             val c = it
 
@@ -229,11 +227,12 @@ class ASTEnumConstantTest : ParserTestSpec({
                                 stringLit("\"str\"")
                             }
 
-                    it::getAnonymousClass shouldBe null
+                            it::getAnonymousClass shouldBe null
 
+                        }
+                    }
                 }
             }
-        }
 
             "enum Foo { B(\"str\") { } }" should parseAs {
                 enumDecl("Foo") {

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/TestExtensions.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/TestExtensions.kt
@@ -124,7 +124,6 @@ fun TreeNodeWrapper<Node, *>.enumDecl(name: String, spec: NodeSpec<ASTEnumDeclar
             spec()
         }
 
-
 fun TreeNodeWrapper<Node, *>.enumBody(contents: NodeSpec<ASTEnumBody> = EmptyAssertions) =
         child<ASTEnumBody> {
             contents()


### PR DESCRIPTION
This is a minor improvement to EnumBody. In the future we could have a rule to mandate trailing commas or so.