### PR TITLE
[java] AppendCharacterWithCharRule ignore literals in expressions

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/AppendCharacterWithCharRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/AppendCharacterWithCharRule.java
@@ -6,6 +6,8 @@ package net.sourceforge.pmd.lang.java.rule.performance;
 
 import net.sourceforge.pmd.lang.java.ast.ASTBlockStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTLiteral;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
 /**
@@ -34,6 +36,13 @@ public class AppendCharacterWithCharRule extends AbstractJavaRule {
             if (!InefficientStringBufferingRule.isInStringBufferOperation(node, 8, "append")) {
                 return data;
             }
+
+            // ignore, if the literal is part of an expression, such as "X".repeat(5)
+            final ASTPrimaryExpression primaryExpression = (ASTPrimaryExpression) node.getNthParent(2);
+            if (primaryExpression != null && primaryExpression.getFirstChildOfType(ASTPrimarySuffix.class) != null) {
+                return data;
+            }
+
             addViolation(data, node);
         }
         return data;

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/AppendCharacterWithChar.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/AppendCharacterWithChar.xml
@@ -195,4 +195,17 @@ public class Foo {
 }
      ]]></code>
     </test-code>
+    <test-code>
+        <description><![CDATA[
+append a single character as part of an expression
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ public void bar(StringBuffer sb, int length) {
+  sb.append("a".repeat(length));
+ }
+}
+     ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
**PR Description:**
make AppendCharacterWithCharRule ignore String literals, which are part of an expression, such as in StringBuffer.append("X".repeat(5));

This fixes #2275 