### PR TITLE
[java] fix UnusedImports rule for ambiguous static on-demand imports

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
@@ -152,14 +152,27 @@ public class UnusedImportsRule extends AbstractJavaRule {
             return;
         }
         ImportWrapper candidate = getImportWrapper(node);
+
+        // check exact imports
         Iterator<ImportWrapper> it = imports.iterator();
         while (it.hasNext()) {
             ImportWrapper i = it.next();
-            if (i.matches(candidate)) {
+            if (!i.isStaticOnDemand() && i.matches(candidate)) {
                 it.remove();
                 return;
             }
         }
+
+        // check static on-demand imports
+        it = imports.iterator();
+        while (it.hasNext()) {
+            ImportWrapper i = it.next();
+            if (i.isStaticOnDemand() && i.matches(candidate)) {
+                it.remove();
+                return;
+            }
+        }
+
         if (TypeNode.class.isAssignableFrom(node.getClass()) && ((TypeNode) node).getType() != null) {
             Class<?> c = ((TypeNode) node).getType();
             if (c.getPackage() != null) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedImports.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedImports.xml
@@ -552,4 +552,30 @@ public class Issue2016 {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description><![CDATA[
+resolve ambiguous static on-demand imports (#2277)
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import static java.lang.Integer.*;
+import static java.lang.Long.valueOf;
+import static java.lang.Long.*;
+
+public class Foo {
+    public void foo() {
+        // the "valueOf" method is both in Integer.* and Long.*
+        // we need an explicit static import to specify one of them, e.g. Long.valueOf
+        valueOf("123", 10);
+
+        // covered by Integer.*
+        int i = parseInt("123");
+
+        // covered by Long.*
+        long l = parseLong("123");
+    }
+}
+     ]]></code>
+        <source-type>java 1.5</source-type>
+    </test-code>
 </test-data>


### PR DESCRIPTION
UnusedImports rule now matches regular static imports first and on-demand static imports after that

this fixes #2277 