### PR TITLE
[apex] Cognitive complexity metrics

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/api/ApexClassMetricKey.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/api/ApexClassMetricKey.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.apex.metrics.api;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClassOrInterface;
+import net.sourceforge.pmd.lang.apex.metrics.impl.ClassCognitiveComplexityMetric;
 import net.sourceforge.pmd.lang.apex.metrics.impl.WmcMetric;
 import net.sourceforge.pmd.lang.metrics.MetricKey;
 
@@ -12,6 +13,7 @@ import net.sourceforge.pmd.lang.metrics.MetricKey;
  * @author Clément Fournier
  */
 public enum ApexClassMetricKey implements MetricKey<ASTUserClassOrInterface<?>> {
+    COGNITIVE(new ClassCognitiveComplexityMetric()),
     WMC(new WmcMetric());
 
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/api/ApexOperationMetricKey.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/api/ApexOperationMetricKey.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.apex.metrics.api;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
+import net.sourceforge.pmd.lang.apex.metrics.impl.CognitiveComplexityMetric;
 import net.sourceforge.pmd.lang.apex.metrics.impl.CycloMetric;
 import net.sourceforge.pmd.lang.metrics.MetricKey;
 
@@ -12,7 +13,8 @@ import net.sourceforge.pmd.lang.metrics.MetricKey;
  * @author Clément Fournier
  */
 public enum ApexOperationMetricKey implements MetricKey<ASTMethod> {
-    CYCLO(new CycloMetric());
+    CYCLO(new CycloMetric()),
+    COGNITIVE(new CognitiveComplexityMetric());
 
 
     private final ApexOperationMetric calculator;

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/ClassCognitiveComplexityMetric.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/ClassCognitiveComplexityMetric.java
@@ -1,0 +1,19 @@
+package net.sourceforge.pmd.lang.apex.metrics.impl;
+
+import net.sourceforge.pmd.lang.apex.ast.ASTUserClassOrInterface;
+import net.sourceforge.pmd.lang.apex.metrics.ApexMetrics;
+import net.sourceforge.pmd.lang.apex.metrics.api.ApexOperationMetricKey;
+import net.sourceforge.pmd.lang.metrics.MetricOptions;
+import net.sourceforge.pmd.lang.metrics.ResultOption;
+
+/**
+ * The sum of the cognitive complexities of all the methods within a class.
+ *
+ * @author Gwilym Kuiper
+ */
+public class ClassCognitiveComplexityMetric extends AbstractApexClassMetric {
+    @Override
+    public double computeFor(ASTUserClassOrInterface<?> node, MetricOptions options) {
+        return ApexMetrics.get(ApexOperationMetricKey.COGNITIVE, node, ResultOption.SUM);
+    }
+}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/ClassCognitiveComplexityMetric.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/ClassCognitiveComplexityMetric.java
@@ -1,3 +1,7 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
 package net.sourceforge.pmd.lang.apex.metrics.impl;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClassOrInterface;

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/CognitiveComplexityMetric.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/CognitiveComplexityMetric.java
@@ -1,0 +1,20 @@
+package net.sourceforge.pmd.lang.apex.metrics.impl;
+
+import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
+import net.sourceforge.pmd.lang.apex.metrics.impl.visitors.CognitiveComplexityVisitor;
+import net.sourceforge.pmd.lang.metrics.MetricOptions;
+
+/**
+ * Measures the cognitive complexity of a Class / Method in Apex.
+ *
+ * See https://www.sonarsource.com/docs/CognitiveComplexity.pdf for information about the metric
+ *
+ * @author Gwilym Kuiper
+ */
+public class CognitiveComplexityMetric extends AbstractApexOperationMetric {
+    @Override
+    public double computeFor(ASTMethod node, MetricOptions options) {
+        CognitiveComplexityVisitor.State resultingState = (CognitiveComplexityVisitor.State) node.jjtAccept(new CognitiveComplexityVisitor(), new CognitiveComplexityVisitor.State());
+        return resultingState.getComplexity();
+    }
+}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/CognitiveComplexityMetric.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/CognitiveComplexityMetric.java
@@ -1,3 +1,7 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
 package net.sourceforge.pmd.lang.apex.metrics.impl;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTMethod;

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
@@ -111,4 +111,15 @@ public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
 
         return data;
     }
+
+    @Override
+    public Object visit(ASTDoLoopStatement node, Object data) {
+        State state = (State) data;
+
+        state.increaseNestingLevel();
+        super.visit(node, data);
+        state.decreaseNestingLevel();
+
+        return data;
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
@@ -122,4 +122,15 @@ public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
 
         return data;
     }
+
+    @Override
+    public Object visit(ASTTernaryExpression node, Object data) {
+        State state = (State) data;
+
+        state.increaseNestingLevel();
+        super.visit(node, data);
+        state.decreaseNestingLevel();
+
+        return data;
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
@@ -73,4 +73,12 @@ public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
 
         return data;
     }
+
+    @Override
+    public Object visit(ASTContinueStatement node, Object data) {
+        State state = (State) data;
+
+        state.structureComplexity();
+        return super.visit(node, data);
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
@@ -1,0 +1,14 @@
+package net.sourceforge.pmd.lang.apex.metrics.impl.visitors;
+
+import net.sourceforge.pmd.lang.apex.ast.*;
+
+/**
+ * @author Gwilym Kuiper
+ */
+public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
+    public static class State {
+        public double getComplexity() {
+            return 0.0;
+        }
+    }
+}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
@@ -89,4 +89,15 @@ public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
         state.structureComplexity();
         return super.visit(node, data);
     }
+
+    @Override
+    public Object visit(ASTWhileLoopStatement node, Object data) {
+        State state = (State) data;
+
+        state.increaseNestingLevel();
+        super.visit(node, data);
+        state.decreaseNestingLevel();
+
+        return data;
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
@@ -7,8 +7,22 @@ import net.sourceforge.pmd.lang.apex.ast.*;
  */
 public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
     public static class State {
+        private int complexity = 0;
+
         public double getComplexity() {
-            return 0.0;
+            return complexity;
         }
+
+        void increaseComplexity() {
+            complexity += 1;
+        }
+    }
+
+    @Override
+    public Object visit(ASTIfBlockStatement node, Object data) {
+        State state = (State) data;
+        state.increaseComplexity();
+        super.visit(node, data);
+        return data;
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
@@ -100,4 +100,15 @@ public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
 
         return data;
     }
+
+    @Override
+    public Object visit(ASTCatchBlockStatement node, Object data) {
+        State state = (State) data;
+
+        state.increaseNestingLevel();
+        super.visit(node, data);
+        state.decreaseNestingLevel();
+
+        return data;
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
@@ -170,4 +170,19 @@ public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
 
         return super.visit(node, data);
     }
+
+    @Override
+    public Object visit(ASTBlockStatement node, Object data) {
+        State state = (State) data;
+
+        for (ApexNode<?> child : node.children()) {
+            child.jjtAccept(this, data);
+
+            // This needs to happen because the current 'run' of boolean operations is terminated
+            // once we finish a statement.
+            state.booleanOperation(null);
+        }
+
+        return data;
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
@@ -8,21 +8,39 @@ import net.sourceforge.pmd.lang.apex.ast.*;
 public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
     public static class State {
         private int complexity = 0;
+        private int nestingLevel = 0;
 
         public double getComplexity() {
             return complexity;
         }
 
-        void increaseComplexity() {
+        void structureComplexity() {
             complexity += 1;
+        }
+
+        void nestingComplexity() {
+            complexity += nestingLevel;
+        }
+
+        void increaseNestingLevel() {
+            nestingLevel++;
+        }
+
+        void decreaseNestingLevel() {
+            nestingLevel--;
         }
     }
 
     @Override
     public Object visit(ASTIfBlockStatement node, Object data) {
         State state = (State) data;
-        state.increaseComplexity();
+        state.structureComplexity();
+        state.nestingComplexity();
+
+        state.increaseNestingLevel();
         super.visit(node, data);
+        state.decreaseNestingLevel();
+
         return data;
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
@@ -11,7 +11,9 @@ public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
     public static class State {
         private int complexity = 0;
         private int nestingLevel = 0;
+
         private BooleanOp currentBooleanOperation = null;
+        private String methodName = null;
 
         public double getComplexity() {
             return complexity;
@@ -43,6 +45,16 @@ public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
 
         void decreaseNestingLevel() {
             nestingLevel--;
+        }
+
+        void methodCall(String methodCalledName) {
+            if (methodCalledName.equals(methodName)) {
+                structureComplexity();
+            }
+        }
+
+        void setMethodName(String name) {
+            methodName = name;
         }
     }
 
@@ -184,5 +196,19 @@ public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
         }
 
         return data;
+    }
+
+    @Override
+    public Object visit(ASTMethod node, Object data) {
+        State state = (State) data;
+        state.setMethodName(node.getNode().getMethodInfo().getCanonicalName());
+        return super.visit(node, data);
+    }
+
+    @Override
+    public Object visit(ASTMethodCallExpression node, Object data) {
+        State state = (State) data;
+        state.methodCall(node.getNode().getMethodName());
+        return super.visit(node, data);
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
@@ -51,4 +51,17 @@ public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
 
         return data;
     }
+
+    @Override
+    public Object visit(ASTForLoopStatement node, Object data) {
+        State state = (State) data;
+
+        state.structureComplexity();
+        state.nestingComplexity();
+        state.increaseNestingLevel();
+        super.visit(node, data);
+        state.decreaseNestingLevel();
+
+        return data;
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
@@ -1,8 +1,28 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
 package net.sourceforge.pmd.lang.apex.metrics.impl.visitors;
+
+import net.sourceforge.pmd.lang.apex.ast.ASTBlockStatement;
+import net.sourceforge.pmd.lang.apex.ast.ASTBooleanExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTBreakStatement;
+import net.sourceforge.pmd.lang.apex.ast.ASTCatchBlockStatement;
+import net.sourceforge.pmd.lang.apex.ast.ASTContinueStatement;
+import net.sourceforge.pmd.lang.apex.ast.ASTDoLoopStatement;
+import net.sourceforge.pmd.lang.apex.ast.ASTForEachStatement;
+import net.sourceforge.pmd.lang.apex.ast.ASTForLoopStatement;
+import net.sourceforge.pmd.lang.apex.ast.ASTIfElseBlockStatement;
+import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
+import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTPrefixExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTTernaryExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTWhileLoopStatement;
+import net.sourceforge.pmd.lang.apex.ast.ApexNode;
+import net.sourceforge.pmd.lang.apex.ast.ApexParserVisitorAdapter;
 
 import apex.jorje.data.ast.BooleanOp;
 import apex.jorje.data.ast.PrefixOp;
-import net.sourceforge.pmd.lang.apex.ast.*;
 
 /**
  * @author Gwilym Kuiper

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
@@ -23,6 +23,8 @@ public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
         }
 
         void increaseNestingLevel() {
+            structureComplexity();
+            nestingComplexity();
             nestingLevel++;
         }
 
@@ -42,8 +44,6 @@ public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
                 break;
             }
 
-            state.structureComplexity();
-            state.nestingComplexity();
             state.increaseNestingLevel();
             super.visit(child, data);
             state.decreaseNestingLevel();
@@ -56,8 +56,6 @@ public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
     public Object visit(ASTForLoopStatement node, Object data) {
         State state = (State) data;
 
-        state.structureComplexity();
-        state.nestingComplexity();
         state.increaseNestingLevel();
         super.visit(node, data);
         state.decreaseNestingLevel();

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
@@ -32,14 +32,22 @@ public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
     }
 
     @Override
-    public Object visit(ASTIfBlockStatement node, Object data) {
+    public Object visit(ASTIfElseBlockStatement node, Object data) {
         State state = (State) data;
-        state.structureComplexity();
-        state.nestingComplexity();
 
-        state.increaseNestingLevel();
-        super.visit(node, data);
-        state.decreaseNestingLevel();
+        boolean hasElseStatement = node.getNode().hasElseStatement();
+        for (ApexNode<?> child : node.children()) {
+            // If we don't have an else statement, we get an empty block statement which we shouldn't count
+            if (!hasElseStatement && child instanceof ASTBlockStatement) {
+                break;
+            }
+
+            state.structureComplexity();
+            state.nestingComplexity();
+            state.increaseNestingLevel();
+            super.visit(child, data);
+            state.decreaseNestingLevel();
+        }
 
         return data;
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
@@ -62,4 +62,15 @@ public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
 
         return data;
     }
+
+    @Override
+    public Object visit(ASTForEachStatement node, Object data) {
+        State state = (State) data;
+
+        state.increaseNestingLevel();
+        super.visit(node, data);
+        state.decreaseNestingLevel();
+
+        return data;
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
@@ -81,4 +81,12 @@ public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
         state.structureComplexity();
         return super.visit(node, data);
     }
+
+    @Override
+    public Object visit(ASTBreakStatement node, Object data) {
+        State state = (State) data;
+
+        state.structureComplexity();
+        return super.visit(node, data);
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/CognitiveComplexityRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/CognitiveComplexityRule.java
@@ -1,0 +1,99 @@
+package net.sourceforge.pmd.lang.apex.rule.design;
+
+import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
+import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
+import net.sourceforge.pmd.lang.apex.ast.ASTUserTrigger;
+import net.sourceforge.pmd.lang.apex.metrics.ApexMetrics;
+import net.sourceforge.pmd.lang.apex.metrics.api.ApexClassMetricKey;
+import net.sourceforge.pmd.lang.apex.metrics.api.ApexOperationMetricKey;
+import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+import net.sourceforge.pmd.lang.metrics.MetricsUtil;
+import net.sourceforge.pmd.lang.metrics.ResultOption;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
+
+import java.util.Stack;
+
+import static net.sourceforge.pmd.properties.constraints.NumericConstraints.positive;
+
+public class CognitiveComplexityRule extends AbstractApexRule {
+
+    private static final PropertyDescriptor<Integer> CLASS_LEVEL_DESCRIPTOR
+            = PropertyFactory.intProperty("classReportLevel")
+            .desc("Total class cognitive complexity reporting threshold")
+            .require(positive())
+            .defaultValue(40)
+            .build();
+
+    private static final PropertyDescriptor<Integer> METHOD_LEVEL_DESCRIPTOR
+            = PropertyFactory.intProperty("methodReportLevel")
+            .desc("Cognitive complexity reporting threshold")
+            .require(positive())
+            .defaultValue(10)
+            .build();
+
+    private Stack<String> classNames = new Stack<>();
+    private boolean inTrigger;
+
+
+    public CognitiveComplexityRule() {
+        definePropertyDescriptor(CLASS_LEVEL_DESCRIPTOR);
+        definePropertyDescriptor(METHOD_LEVEL_DESCRIPTOR);
+    }
+
+
+    @Override
+    public Object visit(ASTUserTrigger node, Object data) {
+        inTrigger = true;
+        super.visit(node, data);
+        inTrigger = false;
+        return data;
+    }
+
+
+    @Override
+    public Object visit(ASTUserClass node, Object data) {
+
+        classNames.push(node.getImage());
+        super.visit(node, data);
+        classNames.pop();
+
+        if (ApexClassMetricKey.COGNITIVE.supports(node)) {
+            int classCognitive = (int) MetricsUtil.computeMetric(ApexClassMetricKey.COGNITIVE, node);
+
+            if (classCognitive >= getProperty(CLASS_LEVEL_DESCRIPTOR)) {
+                int classHighest = (int) ApexMetrics.get(ApexOperationMetricKey.COGNITIVE, node, ResultOption.HIGHEST);
+
+                String[] messageParams = {"class",
+                        node.getImage(),
+                        " total",
+                        classCognitive + " (highest " + classHighest + ")", };
+
+                addViolation(data, node, messageParams);
+            }
+        }
+        return data;
+    }
+
+
+    @Override
+    public final Object visit(ASTMethod node, Object data) {
+
+        if (ApexOperationMetricKey.COGNITIVE.supports(node)) {
+            int cognitive = (int) MetricsUtil.computeMetric(ApexOperationMetricKey.COGNITIVE, node);
+            if (cognitive >= getProperty(METHOD_LEVEL_DESCRIPTOR)) {
+                String opType = inTrigger ? "trigger"
+                        : node.getImage().equals(classNames.peek()) ? "constructor"
+                        : "method";
+
+                addViolation(data, node, new String[] {opType,
+                        node.getQualifiedName().getOperation(),
+                        "",
+                        "" + cognitive, });
+            }
+        }
+
+        return data;
+    }
+
+}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/CognitiveComplexityRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/CognitiveComplexityRule.java
@@ -1,4 +1,12 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
 package net.sourceforge.pmd.lang.apex.rule.design;
+
+import static net.sourceforge.pmd.properties.constraints.NumericConstraints.positive;
+
+import java.util.Stack;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
@@ -11,10 +19,6 @@ import net.sourceforge.pmd.lang.metrics.MetricsUtil;
 import net.sourceforge.pmd.lang.metrics.ResultOption;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
-
-import java.util.Stack;
-
-import static net.sourceforge.pmd.properties.constraints.NumericConstraints.positive;
 
 public class CognitiveComplexityRule extends AbstractApexRule {
 
@@ -64,10 +68,12 @@ public class CognitiveComplexityRule extends AbstractApexRule {
             if (classCognitive >= getProperty(CLASS_LEVEL_DESCRIPTOR)) {
                 int classHighest = (int) ApexMetrics.get(ApexOperationMetricKey.COGNITIVE, node, ResultOption.HIGHEST);
 
-                String[] messageParams = {"class",
-                        node.getImage(),
-                        " total",
-                        classCognitive + " (highest " + classHighest + ")", };
+                String[] messageParams = {
+                    "class",
+                    node.getImage(),
+                    " total",
+                    classCognitive + " (highest " + classHighest + ")",
+                };
 
                 addViolation(data, node, messageParams);
             }
@@ -86,10 +92,12 @@ public class CognitiveComplexityRule extends AbstractApexRule {
                         : node.getImage().equals(classNames.peek()) ? "constructor"
                         : "method";
 
-                addViolation(data, node, new String[] {opType,
-                        node.getQualifiedName().getOperation(),
-                        "",
-                        "" + cognitive, });
+                addViolation(data, node, new String[] {
+                    opType,
+                    node.getQualifiedName().getOperation(),
+                    "",
+                    "" + cognitive,
+                });
             }
         }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/CognitiveComplexityRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/CognitiveComplexityRule.java
@@ -26,14 +26,14 @@ public class CognitiveComplexityRule extends AbstractApexRule {
             = PropertyFactory.intProperty("classReportLevel")
             .desc("Total class cognitive complexity reporting threshold")
             .require(positive())
-            .defaultValue(40)
+            .defaultValue(50)
             .build();
 
     private static final PropertyDescriptor<Integer> METHOD_LEVEL_DESCRIPTOR
             = PropertyFactory.intProperty("methodReportLevel")
             .desc("Cognitive complexity reporting threshold")
             .require(positive())
-            .defaultValue(10)
+            .defaultValue(15)
             .build();
 
     private Stack<String> classNames = new Stack<>();

--- a/pmd-apex/src/main/resources/category/apex/design.xml
+++ b/pmd-apex/src/main/resources/category/apex/design.xml
@@ -97,48 +97,7 @@ public class Complicated {
         <priority>3</priority>
         <example>
             <![CDATA[
-public class ExampleClass {
-    // Cognitive complexity of 1, cyclomatic complexity of 5
-    public String SimpleMethod(int number) {
-        switch on number {       // +1
-            when 1 {
-                return "one";
-            }
-            when 2 {
-                return "two";
-            }
-            when 3 {
-                return "three";
-            }
-            when 4 {
-                return "a few";
-            }
-            when else {
-                return "lots";
-            }
-        }
-    }
-
-    // Cognitive complexity of 9, cyclomatic complexity of 5
-    public Integer ComplicatedMethod(Integer n) {
-        Integer total = 0;
-        for (Integer candidatePrime = 0; candidatePrime < n; i++) {   // +1
-            Boolean isPrime = true;
-            for (Integer i = 2; i * i < candidatePrime; j++) {        // +2
-                if (candidatePrime % i == 0) {                        // +3
-                    isPrime = false;
-                    break;                                            // +1
-                }
-            }
-
-            if (isPrime) {                                            // +2
-                total += candidatePrime;
-            }
-        }
-
-        return total;
-    }
-}
+// TODO
 ]]>
         </example>
     </rule>

--- a/pmd-apex/src/main/resources/category/apex/design.xml
+++ b/pmd-apex/src/main/resources/category/apex/design.xml
@@ -92,12 +92,55 @@ public class Complicated {
           class="net.sourceforge.pmd.lang.apex.rule.design.CognitiveComplexityRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_design.html#cognitivecomplexity">
         <description>
-            TODO
+Methods that are highly complex are difficult to read and more costly to maintain. If you include too much decisional
+logic within a single method, you make its behavior hard to understand and more difficult to modify.
+
+Cognitive complexity is a measure of how difficult it is for humans to read and understand a method. Code that contains
+a break in the control flow is more complex, whereas the use of language shorthands doesn't increase the level of
+complexity. Nested control flows can make a method more difficult to understand, with each additional nesting of the
+control flow leading to an increase in cognitive complexity.
+
+Information about Cognitive complexity can be found in the original paper here:
+https://www.sonarsource.com/docs/CognitiveComplexity.pdf
+
+By default, this rule reports methods with a complexity of 15 or more. Reported methods should be broken down into less
+complex components.
         </description>
         <priority>3</priority>
         <example>
             <![CDATA[
-// TODO
+public class Foo {
+    // Has a cognitive complexity of 0
+    public void createAccount() {
+        Account account = new Account(Name = 'PMD');
+        insert account;
+    }
+
+    // Has a cognitive complexity of 1
+    public Boolean setPhoneNumberIfNotExisting(Account a, String phone) {
+        if (a.Phone == null) {                          // +1
+            a.Phone = phone;
+            update a;
+        }
+    }
+
+    // Has a cognitive complexity of 5
+    public void updateContacts(List<Contact> contacts) {
+        List<Contact> contactsToUpdate = new List<Contact>();
+
+        for (Contact contact : contacts) {                           // +1
+            if (contact.Department == 'Finance') {                   // +2
+                contact.Title = 'Finance Specialist';
+                contactsToUpdate.add(contact);
+            } else if (contact.Department == 'Sales') {              // +2
+                contact.Title = 'Sales Specialist';
+                contactsToUpdate.add(contact);
+            }
+        }
+
+        update contactsToUpdate;
+    }
+}
 ]]>
         </example>
     </rule>

--- a/pmd-apex/src/main/resources/category/apex/design.xml
+++ b/pmd-apex/src/main/resources/category/apex/design.xml
@@ -87,7 +87,7 @@ public class Complicated {
     </rule>
 
     <rule name="CognitiveComplexity"
-          message="The {0} ''{1}'' has a{2} cyclomatic complexity of {3}."
+          message="The {0} ''{1}'' has a{2} cognitive complexity of {3}."
           since="6.0.0"
           class="net.sourceforge.pmd.lang.apex.rule.design.CognitiveComplexityRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_design.html#cognitivecomplexity">

--- a/pmd-apex/src/main/resources/category/apex/design.xml
+++ b/pmd-apex/src/main/resources/category/apex/design.xml
@@ -86,6 +86,63 @@ public class Complicated {
         </example>
     </rule>
 
+    <rule name="CognitiveComplexity"
+          message="The {0} ''{1}'' has a{2} cyclomatic complexity of {3}."
+          since="6.0.0"
+          class="net.sourceforge.pmd.lang.apex.rule.design.CognitiveComplexityRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_design.html#cognitivecomplexity">
+        <description>
+            TODO
+        </description>
+        <priority>3</priority>
+        <example>
+            <![CDATA[
+public class ExampleClass {
+    // Cognitive complexity of 1, cyclomatic complexity of 5
+    public String SimpleMethod(int number) {
+        switch on number {       // +1
+            when 1 {
+                return "one";
+            }
+            when 2 {
+                return "two";
+            }
+            when 3 {
+                return "three";
+            }
+            when 4 {
+                return "a few";
+            }
+            when else {
+                return "lots";
+            }
+        }
+    }
+
+    // Cognitive complexity of 9, cyclomatic complexity of 5
+    public Integer ComplicatedMethod(Integer n) {
+        Integer total = 0;
+        for (Integer candidatePrime = 0; candidatePrime < n; i++) {   // +1
+            Boolean isPrime = true;
+            for (Integer i = 2; i * i < candidatePrime; j++) {        // +2
+                if (candidatePrime % i == 0) {                        // +3
+                    isPrime = false;
+                    break;                                            // +1
+                }
+            }
+
+            if (isPrime) {                                            // +2
+                total += candidatePrime;
+            }
+        }
+
+        return total;
+    }
+}
+]]>
+        </example>
+    </rule>
+
     <rule name="ExcessiveClassLength"
           since="5.5.0"
           message="Avoid really long classes."

--- a/pmd-apex/src/main/resources/category/apex/design.xml
+++ b/pmd-apex/src/main/resources/category/apex/design.xml
@@ -88,7 +88,7 @@ public class Complicated {
 
     <rule name="CognitiveComplexity"
           message="The {0} ''{1}'' has a{2} cognitive complexity of {3}."
-          since="6.0.0"
+          since="6.22.0"
           class="net.sourceforge.pmd.lang.apex.rule.design.CognitiveComplexityRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_design.html#cognitivecomplexity">
         <description>

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/metrics/impl/AllMetricsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/metrics/impl/AllMetricsTest.java
@@ -20,6 +20,7 @@ public class AllMetricsTest extends SimpleAggregatorTst {
     public void setUp() {
         addRule(RULESET, "CycloTest");
         addRule(RULESET, "WmcTest");
+        addRule(RULESET, "CognitiveComplexityTest");
     }
 
 }

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/metrics/impl/CognitiveComplexityTestRule.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/metrics/impl/CognitiveComplexityTestRule.java
@@ -1,3 +1,7 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
 package net.sourceforge.pmd.lang.apex.metrics.impl;
 
 import net.sourceforge.pmd.lang.apex.metrics.api.ApexClassMetricKey;

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/metrics/impl/CognitiveComplexityTestRule.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/metrics/impl/CognitiveComplexityTestRule.java
@@ -1,0 +1,19 @@
+package net.sourceforge.pmd.lang.apex.metrics.impl;
+
+import net.sourceforge.pmd.lang.apex.metrics.api.ApexClassMetricKey;
+import net.sourceforge.pmd.lang.apex.metrics.api.ApexOperationMetricKey;
+
+/**
+ * @author Gwilym Kuiper
+ */
+public class CognitiveComplexityTestRule extends AbstractApexMetricTestRule {
+    @Override
+    protected ApexClassMetricKey getClassKey() {
+        return null;
+    }
+
+    @Override
+    protected ApexOperationMetricKey getOpKey() {
+        return ApexOperationMetricKey.COGNITIVE;
+    }
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
@@ -121,4 +121,28 @@
             ]]>
         </code>
     </test-code>
+
+    <test-code>
+        <description>Foreach loops increment nesting</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>'c__Foo#foo()' has value 3.</message>
+        </expected-messages>
+        <code>
+            <![CDATA[
+            class Foo {
+              string foo() {
+                Integer[] myInts = new Integer[] {1, 2, 3};
+                for (Integer i : myInts) {         // +1
+                  if (i == 3) {                    // +2
+                    return "three";
+                  }
+                }
+
+                return "done";
+              }
+            }
+            ]]>
+        </code>
+    </test-code>
 </test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
@@ -293,13 +293,14 @@
 
     <test-code>
         <description>Boolean operators</description>
-        <expected-problems>5</expected-problems>
+        <expected-problems>6</expected-problems>
         <expected-messages>
             <message>'c__Foo#a(Integer)' has value 1.</message>
             <message>'c__Foo#b(Integer)' has value 1.</message>
             <message>'c__Foo#c(Integer)' has value 1.</message>
             <message>'c__Foo#d(Boolean,Boolean,Boolean,Boolean,Boolean,Boolean)' has value 3.</message>
             <message>'c__Foo#e(Boolean,Boolean,Boolean)' has value 2.</message>
+            <message>'c__Foo#f()' has value 2.</message>
         </expected-messages>
         <code>
             <![CDATA[
@@ -327,6 +328,11 @@
                 return a
                     &&                        // +1
                     !(b && c);                // +1
+              }
+
+              Boolean f() {
+                Boolean a = true && false;    // +1
+                return a && true;             // +1
               }
             }
             ]]>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
@@ -23,4 +23,29 @@
             ]]>
         </code>
     </test-code>
+
+    <test-code>
+        <description>Nested if statements bump complexity level</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>'c__Foo#foo(Integer)' has value 3.</message>
+        </expected-messages>
+        <code>
+            <![CDATA[
+            class Foo {
+              string foo(integer n) {
+                if (n > 0) {           // +1
+                  if (n == 1) {        // +2
+                    return "one";
+                  }
+
+                  return "positive";
+                }
+
+                return "negative or 0";
+              }
+            }
+            ]]>
+        </code>
+    </test-code>
 </test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
@@ -219,4 +219,31 @@
             ]]>
         </code>
     </test-code>
+
+    <test-code>
+        <description>Only the catch statement increases nesting</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>'c__Foo#foo()' has value 4.</message>
+        </expected-messages>
+        <code>
+            <![CDATA[
+            class Foo {
+              void foo() {
+                try {
+                  Merchandise__c m = new Merchandise__c();
+                  insert m;
+                  if (someCondition()) {                           // +1
+                    return;
+                  }
+                } catch(DmlException e) {                          // +1
+                  if (someCondition()) {                           // +2
+                    return;
+                  }
+                }
+              }
+            }
+            ]]>
+        </code>
+    </test-code>
 </test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
@@ -271,4 +271,23 @@
             ]]>
         </code>
     </test-code>
+
+    <test-code>
+        <description>Ternary operators cause nesting</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>'c__Foo#foo(Integer)' has value 3.</message>
+        </expected-messages>
+        <code>
+            <![CDATA[
+            class Foo {
+              Integer foo(Integer n) {
+                return n < 0 ?          // +1
+                  -1 : n > 0 ?          // +2
+                  1 : 0;
+              }
+            }
+            ]]>
+        </code>
+    </test-code>
 </test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<test-data
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+    <test-code>
+        <description>If statements have complexity 1</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>'c__Foo#foo(Integer)' has value 1.</message>
+        </expected-messages>
+        <code>
+            <![CDATA[
+            class Foo {
+              string foo(integer n) {
+                if (n == 1) {
+                  return "one";
+                }
+
+                return "not one";
+              }
+            }
+            ]]>
+        </code>
+    </test-code>
+</test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
@@ -338,4 +338,25 @@
             ]]>
         </code>
     </test-code>
+
+    <test-code>
+        <description>Recursion bumps complexity value</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>'c__Foo#foo(Integer)' has value 3.</message>
+        </expected-messages>
+        <code>
+            <![CDATA[
+            class Foo {
+              Integer foo(Integer n) {
+                if (n == 0 || n == 1) { // +2
+                  return 1;
+                }
+
+                return n * foo(n - 1); // +1
+              }
+            }
+            ]]>
+        </code>
+    </test-code>
 </test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
@@ -75,4 +75,27 @@
             ]]>
         </code>
     </test-code>
+
+    <test-code>
+        <description>Else-if blocks count as non-nested</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>'c__Foo#foo(Integer)' has value 3.</message>
+        </expected-messages>
+        <code>
+            <![CDATA[
+            class Foo {
+              string foo(integer n) {
+                if (n > 0) {           // +1
+                  return "positive";
+                } else if (n < 0) {    // +1
+                  return "negative";
+                } else {               // +1
+                  return "zero";
+                }
+              }
+            }
+            ]]>
+        </code>
+    </test-code>
 </test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
@@ -193,4 +193,30 @@
             ]]>
         </code>
     </test-code>
+
+    <test-code>
+        <description>While statements increase nesting</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>'c__Foo#foo()' has value 3.</message>
+        </expected-messages>
+        <code>
+            <![CDATA[
+            class Foo {
+              string foo() {
+                Integer i = 1;
+                Integer n = 0;
+                while (n < 100) {  // +1
+                  i = i * n;
+                  if (i > 1000) {  // +2
+                    return "big";
+                  }
+                }
+
+                return "small";
+              }
+            }
+            ]]>
+        </code>
+    </test-code>
 </test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
@@ -290,4 +290,46 @@
             ]]>
         </code>
     </test-code>
+
+    <test-code>
+        <description>Boolean operators</description>
+        <expected-problems>5</expected-problems>
+        <expected-messages>
+            <message>'c__Foo#a(Integer)' has value 1.</message>
+            <message>'c__Foo#b(Integer)' has value 1.</message>
+            <message>'c__Foo#c(Integer)' has value 1.</message>
+            <message>'c__Foo#d(Boolean,Boolean,Boolean,Boolean,Boolean,Boolean)' has value 3.</message>
+            <message>'c__Foo#e(Boolean,Boolean,Boolean)' has value 2.</message>
+        </expected-messages>
+        <code>
+            <![CDATA[
+            class Foo {
+              Boolean a(Integer n) {
+                return n > 0 && n > 1;          // +1
+              }
+
+              Boolean b(Integer n) {
+                return n > 0 && n > 1 && n > 2; // +1
+              }
+
+              Boolean c(Integer n) {
+                return n > 0 || n < 0;          // +1
+              }
+
+              Boolean d(Boolean a, Boolean b, Boolean c, Boolean d, Boolean e, Boolean f) {
+                return (a
+                    && b && c)                 // +1
+                    || (d || e)                // +1
+                    && f;                      // +1
+              }
+
+              Boolean e(Boolean a, Boolean b, Boolean c) {
+                return a
+                    &&                        // +1
+                    !(b && c);                // +1
+              }
+            }
+            ]]>
+        </code>
+    </test-code>
 </test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
@@ -145,4 +145,28 @@
             ]]>
         </code>
     </test-code>
+
+    <test-code>
+        <description>Continue statements increase complexity</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>'c__Foo#foo()' has value 4.</message>
+        </expected-messages>
+        <code>
+            <![CDATA[
+            class Foo {
+              string foo() {
+                Integer[] myInts = new Integer[] {1, 2, 3};
+                for (Integer i : myInts) {         // +1
+                  if (i == 3) {                    // +2
+                    continue;                      // +1
+                  }
+                }
+
+                return "done";
+              }
+            }
+            ]]>
+        </code>
+    </test-code>
 </test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
@@ -246,4 +246,29 @@
             ]]>
         </code>
     </test-code>
+
+    <test-code>
+        <description>Do-while loops cause nesting</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>'c__Foo#foo()' has value 5.</message>
+        </expected-messages>
+        <code>
+            <![CDATA[
+            class Foo {
+              void foo() {
+                Integer n = 0;
+                do {                            // +1
+                  if (n == 3) {                 // +2
+                    System.debug("n is 3");
+                  } else {                      // +2
+                    System.debug("n is not 3");
+                  }
+                  n++;
+                } while (n < 100);
+              }
+            }
+            ]]>
+        </code>
+    </test-code>
 </test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
@@ -98,4 +98,27 @@
             ]]>
         </code>
     </test-code>
+
+    <test-code>
+        <description>For loops increment nesting</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>'c__Foo#foo()' has value 3.</message>
+        </expected-messages>
+        <code>
+            <![CDATA[
+            class Foo {
+              string foo() {
+                for (integer i = 0; i < 10; i++) { // +1
+                  if (i == 3) {                    // +2
+                    return "three";
+                  }
+                }
+
+                return "done";
+              }
+            }
+            ]]>
+        </code>
+    </test-code>
 </test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
@@ -169,4 +169,28 @@
             ]]>
         </code>
     </test-code>
+
+    <test-code>
+        <description>Break statements increase complexity</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>'c__Foo#foo()' has value 4.</message>
+        </expected-messages>
+        <code>
+            <![CDATA[
+            class Foo {
+              string foo() {
+                Integer[] myInts = new Integer[] {1, 2, 3};
+                for (Integer i : myInts) {         // +1
+                  if (i == 3) {                    // +2
+                    break;                      // +1
+                  }
+                }
+
+                return "done";
+              }
+            }
+            ]]>
+        </code>
+    </test-code>
 </test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
@@ -48,4 +48,31 @@
             ]]>
         </code>
     </test-code>
+
+    <test-code>
+        <description>Non nested if statements don't incur a penalty</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>'c__Foo#foo(Integer)' has value 3.</message>
+        </expected-messages>
+        <code>
+            <![CDATA[
+            class Foo {
+              string foo(integer n) {
+                if (n > 0) {           // +1
+                  return "positive";
+                }
+
+                if (n == 0) {          // +1
+                  return "zero";
+                }
+
+                if (n < 0) {           // +1
+                  return "negative";
+                }
+              }
+            }
+            ]]>
+        </code>
+    </test-code>
 </test-data>

--- a/pmd-apex/src/test/resources/rulesets/apex/metrics_test.xml
+++ b/pmd-apex/src/test/resources/rulesets/apex/metrics_test.xml
@@ -19,4 +19,9 @@
           class="net.sourceforge.pmd.lang.apex.metrics.impl.WmcTestRule">
     </rule>
 
+    <rule name="CognitiveComplexityTest"
+          message = "''{0}'' has value {1}."
+          class="net.sourceforge.pmd.lang.apex.metrics.impl.CognitiveComplexityTestRule">
+    </rule>
+
 </ruleset>


### PR DESCRIPTION
<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

Fixes https://github.com/pmd/pmd/issues/2162

Adds a cognitive complexity metric for apex allowing you to use either cyclomatic complexity or cognitive complexity (or both). This is work in progress. I still need to run it against some real apex code (not just my tests) to ensure that something reasonable happens here.

I've created the PR early to get some early feedback in case people feel like I'm going in the wrong direction.

Still TODO:
- [x] Whole class rule.
- [x] Fill in the TODO in the `design.xml` file.
- [x] Test against real apex classes.

Not done:
* Mutual recursion. This is probably quite hard so unless it is really wanted, I won't do this yet.
* Switch statements. It seems like these don't parse in the current version of PMD?
* Boolean expressions. The way I've done it here doesn't 100% line up with the version in the paper - this uses the AST rather then as it's written so `a && b || c && d` gets complexity 2 rather than 3 because it parses as `(a && b) || (c && d)` which gives traversing order of `||, &&, &&` and therefore complexity 2.

Request for help:
* There is a TODO in `design.xml` for what to fill in as the description and an example. I'm not quite sure what to put there.

Some questions:
* I've put the visitor state in a `State` object because that's what the other visitors do, but it seems like I can make it part of the visitor itself which may be nicer (saves the `State state = (State) data` at the beginning of every line).