### PR TITLE
[java] Fix UselessOverridingMethod when evelating access modifier

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -34,6 +34,8 @@ the suppressions with a `NOPMD` comment. See [Suppressing warnings](pmd_userdocs
     *   [#2268](https://github.com/pmd/pmd/issues/2268): \[java] Improve TypeHelper resilience
 *   java-bestpractices
     *   [#2277](https://github.com/pmd/pmd/issues/2277): \[java] FP in UnusedImports for ambiguous static on-demand imports
+*   java-design
+    *   [#911](https://github.com/pmd/pmd/issues/911): \[java] UselessOverridingMethod false positive when elevating access modifier
 *   java-errorprone
     *   [#2250](https://github.com/pmd/pmd/issues/2250): \[java] InvalidLogMessageFormat flags logging calls using a slf4j-Marker
     *   [#2255](https://github.com/pmd/pmd/issues/2255): \[java] InvalidLogMessageFormat false-positive for a lambda argument

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UselessOverridingMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UselessOverridingMethodRule.java
@@ -17,12 +17,10 @@ import net.sourceforge.pmd.lang.java.ast.ASTArguments;
 import net.sourceforge.pmd.lang.java.ast.ASTBlock;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBodyDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTFormalParameters;
 import net.sourceforge.pmd.lang.java.ast.ASTMarkerAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclarator;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
 import net.sourceforge.pmd.lang.java.ast.ASTNameList;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
@@ -30,6 +28,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
 import net.sourceforge.pmd.lang.java.ast.ASTResultType;
 import net.sourceforge.pmd.lang.java.ast.ASTStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTType;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
@@ -40,31 +39,19 @@ import net.sourceforge.pmd.properties.PropertyDescriptor;
  *         UselessOverridingMethod
  */
 public class UselessOverridingMethodRule extends AbstractJavaRule {
-    private final List<String> exceptions;
-    private boolean ignoreAnnotations;
-    private static final String CLONE = "clone";
-    private static final String OBJECT = "Object";
+    private static final String CLONE_METHOD_NAME = "clone";
 
-    // TODO extend AbstractIgnoredAnnotationsRule node
+    // TODO extend AbstractIgnoredAnnotationRule node
     // TODO ignore if there is javadoc
-    private static final PropertyDescriptor<Boolean> IGNORE_ANNOTATIONS_DESCRIPTOR = booleanProperty("ignoreAnnotations").defaultValue(false).desc("Ignore annotations").build();
+    private static final PropertyDescriptor<Boolean> IGNORE_ANNOTATIONS_DESCRIPTOR =
+            booleanProperty("ignoreAnnotations")
+            .defaultValue(false)
+            .desc("Ignore annotations")
+            .build();
 
 
     public UselessOverridingMethodRule() {
         definePropertyDescriptor(IGNORE_ANNOTATIONS_DESCRIPTOR);
-
-        exceptions = new ArrayList<>(1);
-        exceptions.add("CloneNotSupportedException");
-    }
-
-    @Override
-    public Object visit(ASTCompilationUnit node, Object data) {
-        init();
-        return super.visit(node, data);
-    }
-
-    private void init() {
-        ignoreAnnotations = getProperty(IGNORE_ANNOTATIONS_DESCRIPTOR);
     }
 
     @Override
@@ -76,35 +63,27 @@ public class UselessOverridingMethodRule extends AbstractJavaRule {
     }
 
     // TODO: this method should be externalize into an utility class, shouldn't it ?
-    private boolean isMethodType(ASTMethodDeclaration node, String methodType) {
-        boolean result = false;
+    private boolean isMethodResultType(ASTMethodDeclaration node, Class<?> resultType) {
         ASTResultType type = node.getResultType();
-        if (type != null) {
-            result = type.hasDescendantMatchingXPath(
-                    "./Type/ReferenceType/ClassOrInterfaceType[@Image = '" + methodType + "']");
+        if (type != null && type.getChild(0) instanceof ASTType) {
+            Class<?> resolvedResultType = ((ASTType) type.getChild(0)).getType();
+            return resultType.equals(resolvedResultType);
         }
-        return result;
+        return false;
     }
 
     // TODO: this method should be externalize into an utility class, shouldn't it ?
-    private boolean isMethodThrowingType(ASTMethodDeclaration node, List<String> exceptedExceptions) {
-        boolean result = false;
-        ASTNameList thrownsExceptions = node.getFirstChildOfType(ASTNameList.class);
+    private boolean isMethodThrowingType(ASTMethodDeclaration node, Class<? extends Exception> exceptionType) {
+        ASTNameList thrownsExceptions = node.getThrows();
         if (thrownsExceptions != null) {
             List<ASTName> names = thrownsExceptions.findChildrenOfType(ASTName.class);
             for (ASTName name : names) {
-                for (String exceptedException : exceptedExceptions) {
-                    if (exceptedException.equals(name.getImage())) {
-                        result = true;
-                    }
+                if (name.getType() != null && name.getType() == exceptionType) {
+                    return true;
                 }
             }
         }
-        return result;
-    }
-
-    private boolean hasArguments(ASTMethodDeclaration node) {
-        return node.hasDescendantMatchingXPath("./MethodDeclarator/FormalParameters/*");
+        return false;
     }
 
     @Override
@@ -118,8 +97,7 @@ public class UselessOverridingMethodRule extends AbstractJavaRule {
         // We can also skip the 'clone' method as they are generally
         // 'useless' but as it is considered a 'good practice' to
         // implement them anyway ( see bug 1522517)
-        if (CLONE.equals(node.getName()) && node.isPublic() && !this.hasArguments(node)
-                && this.isMethodType(node, OBJECT) && this.isMethodThrowingType(node, exceptions)) {
+        if (isCloneMethod(node)) {
             return super.visit(node, data);
         }
 
@@ -142,41 +120,38 @@ public class UselessOverridingMethodRule extends AbstractJavaRule {
         if (statementGrandChild instanceof ASTPrimaryExpression) {
             primaryExpression = (ASTPrimaryExpression) statementGrandChild;
         } else {
-            List<ASTPrimaryExpression> primaryExpressions = findFirstDegreeChildrenOfType(statementGrandChild,
-                    ASTPrimaryExpression.class);
+            List<ASTPrimaryExpression> primaryExpressions = statementGrandChild
+                    .findChildrenOfType(ASTPrimaryExpression.class);
             if (primaryExpressions.size() != 1) {
                 return super.visit(node, data);
             }
             primaryExpression = primaryExpressions.get(0);
         }
 
-        ASTPrimaryPrefix primaryPrefix = findFirstDegreeChildrenOfType(primaryExpression, ASTPrimaryPrefix.class)
-                .get(0);
+        ASTPrimaryPrefix primaryPrefix = primaryExpression.getFirstChildOfType(ASTPrimaryPrefix.class);
         if (!primaryPrefix.usesSuperModifier()) {
             return super.visit(node, data);
         }
 
-        List<ASTPrimarySuffix> primarySuffixList = findFirstDegreeChildrenOfType(primaryExpression,
-                ASTPrimarySuffix.class);
+        List<ASTPrimarySuffix> primarySuffixList = primaryExpression.findChildrenOfType(ASTPrimarySuffix.class);
         if (primarySuffixList.size() != 2) {
             // extra method call on result of super method
             return super.visit(node, data);
         }
 
-        ASTMethodDeclarator methodDeclarator = findFirstDegreeChildrenOfType(node, ASTMethodDeclarator.class).get(0);
         ASTPrimarySuffix primarySuffix = primarySuffixList.get(0);
-        if (!primarySuffix.hasImageEqualTo(methodDeclarator.getImage())) {
+        if (!primarySuffix.hasImageEqualTo(node.getName())) {
             return super.visit(node, data);
         }
         // Process arguments
         primarySuffix = primarySuffixList.get(1);
         ASTArguments arguments = (ASTArguments) primarySuffix.getChild(0);
-        ASTFormalParameters formalParameters = (ASTFormalParameters) methodDeclarator.getChild(0);
+        ASTFormalParameters formalParameters = node.getFormalParameters();
         if (formalParameters.getNumChildren() != arguments.getNumChildren()) {
             return super.visit(node, data);
         }
 
-        if (!ignoreAnnotations) {
+        if (!getProperty(IGNORE_ANNOTATIONS_DESCRIPTOR)) {
             ASTClassOrInterfaceBodyDeclaration parent = (ASTClassOrInterfaceBodyDeclaration) node.getParent();
             for (int i = 0; i < parent.getNumChildren(); i++) {
                 Node n = parent.getChild(i);
@@ -190,6 +165,11 @@ public class UselessOverridingMethodRule extends AbstractJavaRule {
                     return super.visit(node, data);
                 }
             }
+        }
+
+        // different number of args
+        if (arguments.size() != node.getArity()) {
+            return super.visit(node, data);
         }
 
         if (arguments.size() > 0) {
@@ -213,14 +193,9 @@ public class UselessOverridingMethodRule extends AbstractJavaRule {
                     return super.visit(node, data);
                 }
 
-                if (formalParameters.getNumChildren() < i + 1) {
-                    return super.visit(node, data); // different number of args
-                }
-
                 ASTName argumentName = (ASTName) argumentPrimaryPrefixChild;
                 ASTFormalParameter formalParameter = (ASTFormalParameter) formalParameters.getChild(i);
-                ASTVariableDeclaratorId variableId = findFirstDegreeChildrenOfType(formalParameter,
-                        ASTVariableDeclaratorId.class).get(0);
+                ASTVariableDeclaratorId variableId = formalParameter.getFirstChildOfType(ASTVariableDeclaratorId.class);
                 if (!argumentName.hasImageEqualTo(variableId.getImage())) {
                     // The arguments are not simply passed through
                     return super.visit(node, data);
@@ -236,6 +211,15 @@ public class UselessOverridingMethodRule extends AbstractJavaRule {
         addViolation(data, node, getMessage());
 
         return super.visit(node, data);
+    }
+
+    private boolean isCloneMethod(ASTMethodDeclaration node) {
+        boolean isCloneAndPublic = CLONE_METHOD_NAME.equals(node.getName()) && node.isPublic();
+        boolean hasNoParameters = node.getArity() == 0;
+        return isCloneAndPublic
+                && hasNoParameters
+                && this.isMethodResultType(node, Object.class)
+                && this.isMethodThrowingType(node, CloneNotSupportedException.class);
     }
 
     private boolean modifiersChanged(ASTMethodDeclaration node) {
@@ -275,31 +259,11 @@ public class UselessOverridingMethodRule extends AbstractJavaRule {
         return declaredMethod != null && overriddenModifiers != declaredMethod.getModifiers();
     }
 
-    public <T> List<T> findFirstDegreeChildrenOfType(Node n, Class<T> targetType) {
-        List<T> l = new ArrayList<>();
-        lclFindChildrenOfType(n, targetType, l);
-        return l;
-    }
-
-    private <T> void lclFindChildrenOfType(Node node, Class<T> targetType, List<T> results) {
-        if (node.getClass().equals(targetType)) {
-            results.add((T) node);
-        }
-
-        if (node instanceof ASTClassOrInterfaceDeclaration && ((ASTClassOrInterfaceDeclaration) node).isNested()) {
-            return;
-        }
-
-        if (node instanceof ASTClassOrInterfaceBodyDeclaration
-                && ((ASTClassOrInterfaceBodyDeclaration) node).isAnonymousInnerClass()) {
-            return;
-        }
-
-        for (int i = 0; i < node.getNumChildren(); i++) {
-            Node child = node.getChild(i);
-            if (child.getClass().equals(targetType)) {
-                results.add((T) child);
-            }
-        }
+    /**
+     * @deprecated this method will be removed. Just use {@link Node#findChildrenOfType(Class)} directly.
+     */
+    @Deprecated
+    public <T> List<T> findFirstDegreeChaildrenOfType(Node n, Class<T> targetType) {
+        return n.findChildrenOfType(targetType);
     }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/BaseClass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/BaseClass.java
@@ -1,0 +1,16 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.design.uselessoverridingmethod;
+
+public class BaseClass {
+
+
+    protected void doBase() {
+    }
+
+
+    protected void doBaseWithArg(String foo) {
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/DirectSubclass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/DirectSubclass.java
@@ -1,0 +1,20 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.design.uselessoverridingmethod;
+
+public class DirectSubclass extends BaseClass {
+
+
+    @Override
+    public void doBase() {
+        super.doBase();
+    }
+
+
+    @Override
+    public void doBaseWithArg(String foo) {
+        super.doBaseWithArg(foo);
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/DirectSubclass2.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/DirectSubclass2.java
@@ -1,0 +1,12 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.design.uselessoverridingmethod;
+
+public class DirectSubclass2 extends DirectSubclass {
+    @Override
+    public void doBase() {
+        super.doBase();
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/DirectSynchronizingSubclass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/DirectSynchronizingSubclass.java
@@ -1,0 +1,14 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.design.uselessoverridingmethod;
+
+public class DirectSynchronizingSubclass extends BaseClass {
+
+    @Override
+    protected synchronized void doBase() {
+        // overriding for synchronized
+        super.doBase();
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/ExposingSerializer.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/ExposingSerializer.java
@@ -1,0 +1,31 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.design.uselessoverridingmethod;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+
+import org.w3c.dom.Node;
+
+class ExposingSerializer extends Serializer {
+
+
+    ExposingSerializer(OutputStream out, String encoding) throws UnsupportedEncodingException {
+        super(out, encoding);
+    }
+
+
+    /**
+     * Overriding in order to change the access modifier from protected to public - so: not only merely calling super.
+     *
+     * <p>Method signature in super class: protected void writeChild(nu.xom.Node arg0) throws java.io.IOException;
+     *
+     * <p>See: https://sourceforge.net/tracker/?func=detail&aid=1415525&group_id=56262&atid=479921
+     */
+    public void writeChild(Node node) throws IOException {
+        super.writeChild(node);
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/OtherSubclass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/OtherSubclass.java
@@ -1,0 +1,8 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.design.uselessoverridingmethod;
+
+public class OtherSubclass extends BaseClass {
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/Serializer.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/Serializer.java
@@ -1,0 +1,20 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.design.uselessoverridingmethod;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.w3c.dom.Node;
+
+public class Serializer {
+
+    public Serializer(OutputStream out, String encoding) {
+    }
+
+    protected void writeChild(Node node) throws IOException {
+    }
+
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/TransitiveSubclass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/TransitiveSubclass.java
@@ -7,7 +7,7 @@ package net.sourceforge.pmd.lang.java.rule.design.uselessoverridingmethod;
 public class TransitiveSubclass extends OtherSubclass {
 
     @Override
-    protected void doBase() {
+    public void doBase() {
         super.doBase();
     }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/TransitiveSubclass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/TransitiveSubclass.java
@@ -1,0 +1,13 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.design.uselessoverridingmethod;
+
+public class TransitiveSubclass extends OtherSubclass {
+
+    @Override
+    protected void doBase() {
+        super.doBase();
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/other/DirectSubclassInOtherPackage.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/other/DirectSubclassInOtherPackage.java
@@ -1,0 +1,15 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.design.uselessoverridingmethod.other;
+
+import net.sourceforge.pmd.lang.java.rule.design.uselessoverridingmethod.BaseClass;
+
+public class DirectSubclassInOtherPackage extends BaseClass {
+
+    @Override
+    protected void doBase() {
+        super.doBase();
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/other/OtherClassInOtherPackage.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/other/OtherClassInOtherPackage.java
@@ -1,0 +1,16 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.design.uselessoverridingmethod.other;
+
+public class OtherClassInOtherPackage {
+
+
+    public void foo() {
+        DirectSubclassInOtherPackage instance = new DirectSubclassInOtherPackage();
+        // this call is only possible, because DirectSubclassInOtherPackage makes this
+        // method available in this package as well.
+        instance.doBase();
+    }
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UselessOverridingMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UselessOverridingMethod.xml
@@ -182,7 +182,7 @@ public class Foo extends Bar {
     </test-code>
 
     <test-code>
-        <description>adding synchronized is OK</description>
+        <description>adding synchronized is OK, see sf-bug #423</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo extends Bar {
@@ -443,6 +443,23 @@ package net.sourceforge.pmd.lang.java.rule.design.uselessoverridingmethod;
 public class DirectSubclass2 extends DirectSubclass {
     @Override
     public void doBase() { // it's already public in DirectSubclass
+        super.doBase();
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Make sure, overriding to add synchronized is Ok, see sf-bug #423</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+package net.sourceforge.pmd.lang.java.rule.design.uselessoverridingmethod;
+
+public class DirectSynchronizingSubclass extends BaseClass {
+
+    @Override
+    protected synchronized void doBase() {
+        // overriding for synchronized
         super.doBase();
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UselessOverridingMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UselessOverridingMethod.xml
@@ -3,10 +3,9 @@
     xmlns="http://pmd.sourceforge.net/rule-tests"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
     <test-code>
-        <description><![CDATA[
-call super
-     ]]></description>
+        <description>call super</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Foo extends Bar {
@@ -16,10 +15,9 @@ public class Foo extends Bar {
 }
      ]]></code>
     </test-code>
+
     <test-code>
-        <description><![CDATA[
-call super with same argument
-     ]]></description>
+        <description>call super with same argument</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Foo extends Bar {
@@ -29,10 +27,9 @@ public class Foo extends Bar {
 }
      ]]></code>
     </test-code>
+
     <test-code>
-        <description><![CDATA[
-call super with different argument
-     ]]></description>
+        <description>call super with different argument</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo extends Bar {
@@ -43,10 +40,9 @@ public class Foo extends Bar {
 }
      ]]></code>
     </test-code>
+
     <test-code>
-        <description><![CDATA[
-call super with different argument 2
-     ]]></description>
+        <description>call super with different argument 2</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo extends Bar {
@@ -56,10 +52,9 @@ public class Foo extends Bar {
 }
      ]]></code>
     </test-code>
+
     <test-code>
-        <description><![CDATA[
-call super with different argument 3
-     ]]></description>
+        <description>call super with different argument 3</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Buz{
@@ -69,10 +64,9 @@ public class Buz{
 }
      ]]></code>
     </test-code>
+
     <test-code>
-        <description><![CDATA[
-call super with inverted arguments
-     ]]></description>
+        <description>call super with inverted arguments</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo extends Bar {
@@ -82,10 +76,9 @@ public class Foo extends Bar {
 }
      ]]></code>
     </test-code>
+
     <test-code>
-        <description><![CDATA[
-return value of super
-     ]]></description>
+        <description>return value of super</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Foo extends Bar {
@@ -95,10 +88,9 @@ public class Foo extends Bar {
 }
      ]]></code>
     </test-code>
+
     <test-code>
-        <description><![CDATA[
-return value of super with argument
-     ]]></description>
+        <description>return value of super with argument</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Foo extends Bar {
@@ -108,10 +100,9 @@ public class Foo extends Bar {
 }
      ]]></code>
     </test-code>
+
     <test-code>
-        <description><![CDATA[
-return value of super after adding a string
-     ]]></description>
+        <description>return value of super after adding a string</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo extends Bar {
@@ -121,10 +112,9 @@ public class Foo extends Bar {
 }
      ]]></code>
     </test-code>
+
     <test-code>
-        <description><![CDATA[
-do not crash on abstract methods
-     ]]></description>
+        <description>do not crash on abstract methods</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo extends Bar {
@@ -132,10 +122,9 @@ public class Foo extends Bar {
 }
      ]]></code>
     </test-code>
+
     <test-code>
-        <description><![CDATA[
-do not crash on interfaces
-     ]]></description>
+        <description>do not crash on interfaces</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public interface Foo extends Bar {
@@ -143,10 +132,9 @@ public interface Foo extends Bar {
 }
      ]]></code>
     </test-code>
+
     <test-code>
-        <description><![CDATA[
-do not crash on empty returns
-     ]]></description>
+        <description>do not crash on empty returns</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -156,10 +144,9 @@ public class Foo {
 }
      ]]></code>
     </test-code>
+
     <test-code>
-        <description><![CDATA[
-do not crash on super
-     ]]></description>
+        <description>do not crash on super</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -169,10 +156,9 @@ public class Foo {
 }
      ]]></code>
     </test-code>
+
     <test-code>
-        <description><![CDATA[
-call super with different argument 4
-     ]]></description>
+        <description>call super with different argument 4</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Buz{
@@ -182,10 +168,9 @@ public class Buz{
 }
      ]]></code>
     </test-code>
+
     <test-code>
-        <description><![CDATA[
-adding final is OK
-     ]]></description>
+        <description>adding final is OK</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo extends Bar {
@@ -195,10 +180,9 @@ public class Foo extends Bar {
 }
      ]]></code>
     </test-code>
+
     <test-code>
-        <description><![CDATA[
-adding synchronized is OK
-     ]]></description>
+        <description>adding synchronized is OK</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo extends Bar {
@@ -208,10 +192,9 @@ public class Foo extends Bar {
 }
      ]]></code>
     </test-code>
+
     <test-code>
-        <description><![CDATA[
-Constructors are OK
-     ]]></description>
+        <description>Constructors are OK</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo extends Bar {
@@ -221,49 +204,43 @@ public class Foo extends Bar {
 }
      ]]></code>
     </test-code>
+
     <test-code>
-        <description><![CDATA[
-Should ignore clone implementation ( see bug 1522517)
-     ]]></description>
+        <description>Should ignore clone implementation ( see bug 1522517)</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo extends Bar {
    public Object clone() throws CloneNotSupportedException {
-	 return super.clone();
+     return super.clone();
    }
 }
      ]]></code>
     </test-code>
+
     <test-code>
-        <description><![CDATA[
-clone method with arguments should not be ignored
-     ]]></description>
+        <description>clone method with arguments should not be ignored</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Foo extends Bar {
    public Object clone(Object o) throws CloneNotSupportedException {
-	  return super.clone(o);
+     return super.clone(o);
    }
 }
      ]]></code>
     </test-code>
+
     <test-code regressionTest="false">
-        <description>
-        	<![CDATA[
-False +: Overriding method merely calls super (see bug 1415525)
-     		]]>
-     	</description>
+        <description>False +: Overriding method merely calls super (see bug 1415525)</description>
         <expected-problems>0</expected-problems>
-        <code>
-        	<![CDATA[
+        <code><![CDATA[
 import nu.xom.Serializer;
 
 private static class ExposingSerializer extends Serializer {
 
-	ExposingSerializer(OutputStream out, String encoding)
-	throws UnsupportedEncodingException {
-		super(out, encoding);
-	}
+    ExposingSerializer(OutputStream out, String encoding)
+    throws UnsupportedEncodingException {
+        super(out, encoding);
+    }
 
   /**
    * Overriding in order to change the access modifier from
@@ -274,56 +251,50 @@ private static class ExposingSerializer extends Serializer {
    *
    * See: https://sourceforge.net/tracker/?func=detail&aid=1415525&group_id=56262&atid=479921
    */
-	public void writeChild(Node node) throws IOException {
-	    super.writeChild(node);
-	}
+    public void writeChild(Node node) throws IOException {
+        super.writeChild(node);
+    }
 
-	public void exposedWriteRaw(String text) throws IOException {
-		writeRaw(text);
-	}
+    public void exposedWriteRaw(String text) throws IOException {
+        writeRaw(text);
+    }
 
-	public void exposedWriteEscaped(String text) throws IOException {
-		writeEscaped(text);
-	}
+    public void exposedWriteEscaped(String text) throws IOException {
+        writeEscaped(text);
+    }
 
-	public void exposedWriteAttributeValue(String text) throws IOException {
-		writeAttributeValue(text);
-	}
+    public void exposedWriteAttributeValue(String text) throws IOException {
+        writeAttributeValue(text);
+    }
 }
      ]]></code>
     </test-code>
+
     <test-code>
-        <description>
-        	<![CDATA[
-[ 1977230 ] false positive: UselessOverridingMethod
-     		]]>
-     	</description>
+        <description>[ 1977230 ] false positive: UselessOverridingMethod</description>
         <expected-problems>0</expected-problems>
         <code>
-        	<![CDATA[
+            <![CDATA[
 public class Foo extends Bar {
 
-	public BigDecimal getBalance(Date date) {
-		return super.getBalance(date).negate();
-	}
+    public BigDecimal getBalance(Date date) {
+        return super.getBalance(date).negate();
+    }
 }
 
 class Bar {
-	public BigDecimal getBalance(Date date) {
-	}
+    public BigDecimal getBalance(Date date) {
+    }
 }
      ]]></code>
     </test-code>
-    <test-code reinitializeRule="1">
-        <description>
-        	<![CDATA[
-[ 2142986 ] UselessOverridingMethod doesn't consider annotations, ignoreAnnotations property set to true
-     		]]>
-     	</description>
+
+    <test-code>
+        <description>[ 2142986 ] UselessOverridingMethod doesn't consider annotations, ignoreAnnotations property set to true</description>
         <rule-property name="ignoreAnnotations">true</rule-property>
         <expected-problems>1</expected-problems>
         <code>
-        	<![CDATA[
+            <![CDATA[
 class PersistentObject {
   public Long getId() { return 1L; } 
 }
@@ -336,15 +307,12 @@ public class Example extends PersistentObject {
 }
      ]]></code>
     </test-code>
-    <test-code reinitializeRule="1">
-        <description>
-        	<![CDATA[
-[ 2142986 ] UselessOverridingMethod doesn't consider annotations
-     		]]>
-     	</description>
+
+    <test-code>
+        <description>[ 2142986 ] UselessOverridingMethod doesn't consider annotations</description>
         <expected-problems>0</expected-problems>
         <code>
-        	<![CDATA[
+            <![CDATA[
 class PersistentObject {
   public Long getId() { return 1L; } 
 }
@@ -357,15 +325,12 @@ public class Example extends PersistentObject {
 }
      ]]></code>
     </test-code>
-    <test-code reinitializeRule="1">
-        <description>
-        	<![CDATA[
-[ 2142986 ] UselessOverridingMethod doesn't consider annotations, @Override only
-     		]]>
-     	</description>
+
+    <test-code>
+        <description>[ 2142986 ] UselessOverridingMethod doesn't consider annotations, @Override only</description>
         <expected-problems>1</expected-problems>
         <code>
-        	<![CDATA[
+            <![CDATA[
 class PersistentObject {
   public Long getId() { return 1L; } 
 }
@@ -376,10 +341,9 @@ public class Example extends PersistentObject {
 }
      ]]></code>
     </test-code>
+
     <test-code>
-        <description><![CDATA[
-ClassCastException in statement cast
-     ]]></description>
+        <description>ClassCastException in statement cast</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 import java.util.Comparator;
@@ -387,16 +351,16 @@ import javax.annotation.Nonnull;
 
 public class AnonymousClassConstructor {
 
-	public void method() {
-		@SuppressWarnings("unused")
-		final Comparator<Long> comparator = new Comparator<Long>() {
+    public void method() {
+        @SuppressWarnings("unused")
+        final Comparator<Long> comparator = new Comparator<Long>() {
 
-			@Override
-			public int compare(@Nonnull Long o1, @Nonnull Long o2) {
-				return 0;
-			}
-		};
-	}
+            @Override
+            public int compare(@Nonnull Long o1, @Nonnull Long o2) {
+                return 0;
+            }
+        };
+    }
 }
      ]]></code>
     </test-code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UselessOverridingMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UselessOverridingMethod.xml
@@ -399,6 +399,25 @@ public class DirectSubclass extends BaseClass {
     </test-code>
 
     <test-code>
+        <description>[java] UselessOverridingMethod false positive when elevating access modifier #911 - direct different package, same visibility</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+package net.sourceforge.pmd.lang.java.rule.design.uselessoverridingmethod.other;
+
+import net.sourceforge.pmd.lang.java.rule.design.uselessoverridingmethod.BaseClass;
+
+public class DirectSubclassInOtherPackage extends BaseClass {
+
+
+    @Override
+    protected void doBase() {
+        super.doBase();
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>[java] UselessOverridingMethod false positive when elevating access modifier #911 - transitive</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
@@ -407,7 +426,7 @@ package net.sourceforge.pmd.lang.java.rule.design.uselessoverridingmethod;
 public class TransitiveSubclass extends OtherSubclass {
 
     @Override
-    protected void doBase() {
+    public void doBase() {
         super.doBase();
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UselessOverridingMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UselessOverridingMethod.xml
@@ -229,42 +229,35 @@ public class Foo extends Bar {
      ]]></code>
     </test-code>
 
-    <test-code regressionTest="false">
+    <test-code>
         <description>False +: Overriding method merely calls super (see bug 1415525)</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-import nu.xom.Serializer;
+package net.sourceforge.pmd.lang.java.rule.design.uselessoverridingmethod;
 
-private static class ExposingSerializer extends Serializer {
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 
-    ExposingSerializer(OutputStream out, String encoding)
-    throws UnsupportedEncodingException {
+import org.w3c.dom.Node;
+
+class ExposingSerializer extends Serializer {
+
+
+    ExposingSerializer(OutputStream out, String encoding) throws UnsupportedEncodingException {
         super(out, encoding);
     }
 
-  /**
-   * Overriding in order to change the access modifier from
-   * protected to public - so: not only merely calling super.
-   *
-   * Method signature in super class:
-   * protected void writeChild(nu.xom.Node arg0) throws java.io.IOException;
-   *
-   * See: https://sourceforge.net/tracker/?func=detail&aid=1415525&group_id=56262&atid=479921
-   */
+
+    /**
+     * Overriding in order to change the access modifier from protected to public - so: not only merely calling super.
+     *
+     * <p>Method signature in super class: protected void writeChild(nu.xom.Node arg0) throws java.io.IOException;
+     *
+     * <p>See: https://sourceforge.net/tracker/?func=detail&aid=1415525&group_id=56262&atid=479921
+     */
     public void writeChild(Node node) throws IOException {
         super.writeChild(node);
-    }
-
-    public void exposedWriteRaw(String text) throws IOException {
-        writeRaw(text);
-    }
-
-    public void exposedWriteEscaped(String text) throws IOException {
-        writeEscaped(text);
-    }
-
-    public void exposedWriteAttributeValue(String text) throws IOException {
-        writeAttributeValue(text);
     }
 }
      ]]></code>
@@ -363,5 +356,77 @@ public class AnonymousClassConstructor {
     }
 }
      ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] UselessOverridingMethod false positive when elevating access modifier #911 - direct</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+package net.sourceforge.pmd.lang.java.rule.design.uselessoverridingmethod;
+
+public class DirectSubclass extends BaseClass {
+
+
+    @Override
+    public void doBase() {
+        super.doBase();
+    }
+
+
+    @Override
+    public void doBaseWithArg(String foo) {
+        super.doBaseWithArg(foo);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] UselessOverridingMethod false positive when elevating access modifier #911 - direct but changing arguments</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+package net.sourceforge.pmd.lang.java.rule.design.uselessoverridingmethod;
+
+public class DirectSubclass extends BaseClass {
+
+
+    @Override
+    public void doBaseWithArg(String foo) {
+        super.doBaseWithArg(foo.toString());
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] UselessOverridingMethod false positive when elevating access modifier #911 - transitive</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+package net.sourceforge.pmd.lang.java.rule.design.uselessoverridingmethod;
+
+public class TransitiveSubclass extends OtherSubclass {
+
+    @Override
+    protected void doBase() {
+        super.doBase();
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] UselessOverridingMethod false positive when elevating access modifier #911 - direct2</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+package net.sourceforge.pmd.lang.java.rule.design.uselessoverridingmethod;
+
+public class DirectSubclass2 extends DirectSubclass {
+    @Override
+    public void doBase() { // it's already public in DirectSubclass
+        super.doBase();
+    }
+}
+        ]]></code>
     </test-code>
 </test-data>


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

Fixes #911 
