### PR TITLE
[apex] Support switch statements correctly in Cognitive Complexity

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
@@ -16,6 +16,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTIfElseBlockStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
 import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTPrefixExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTSwitchStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTTernaryExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTWhileLoopStatement;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
@@ -230,5 +231,16 @@ public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
         State state = (State) data;
         state.methodCall(node.getNode().getMethodName());
         return super.visit(node, data);
+    }
+
+    @Override
+    public Object visit(ASTSwitchStatement node, Object data) {
+        State state = (State) data;
+
+        state.increaseNestingLevel();
+        super.visit(node, data);
+        state.decreaseNestingLevel();
+
+        return state;
     }
 }

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/metrics/impl/xml/CognitiveComplexityTest.xml
@@ -359,4 +359,35 @@
             ]]>
         </code>
     </test-code>
+
+    <test-code>
+        <description>Switch statements only gain 1 complexity regardless of the number of cases</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>'c__Foo#foo(Integer)' has value 3.</message>
+        </expected-messages>
+        <code>
+            <![CDATA[
+            class Foo {
+              void foo(Integer n) {
+                switch on n {                       // +1
+                  when 1 {
+                    System.debug('when block 1');
+                  }
+                  when 2, 3, 4, 5 {
+                    if (n <= 3) {                   // +2
+                      System.debug('n <= 3');
+                    }
+
+                    System.debug('when block 2');
+                  }
+                  when else {
+                    System.debug('default');
+                  }
+                }
+              }
+            }
+            ]]>
+        </code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - x ] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

Switch statements were not correctly counted in #2297 due to them not being fully implemented by the parser. This was fixed in #2307, so now we can correctly handle switch statements when calculating cognitive complexity for apex.