### PR TITLE
[core] Call SymbolFacade without classloader by default

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -92,6 +92,7 @@ should give more accurate results and especially fixes the problems with the usi
 *   java-performance
     *   [#2275](https://github.com/pmd/pmd/issues/2275): \[java] AppendCharacterWithChar flags literals in an expression
 *   plsql
+    *   [#2325](https://github.com/pmd/pmd/issues/2325): \[plsql] NullPointerException while running parsing test for CREATE TRIGGER
     *   [#2327](https://github.com/pmd/pmd/pull/2327): \[plsql] Parsing of WHERE CURRENT OF
     *   [#2328](https://github.com/pmd/pmd/issues/2328): \[plsql] Support XMLROOT
     *   [#2331](https://github.com/pmd/pmd/pull/2331): \[plsql] Fix in Comment statement

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/AbstractLanguageVersionHandler.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/AbstractLanguageVersionHandler.java
@@ -45,7 +45,7 @@ public abstract class AbstractLanguageVersionHandler implements LanguageVersionH
 
     @Override
     public VisitorStarter getSymbolFacade(ClassLoader classLoader) {
-        return VisitorStarter.DUMMY;
+        return getSymbolFacade();
     }
 
     @Override

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/AbstractPLSQLNode.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/AbstractPLSQLNode.java
@@ -143,8 +143,3 @@ public abstract class AbstractPLSQLNode extends AbstractJjtreeNode<PLSQLNode> im
         this.scope = scope;
     }
 }
-
-/*
- * JavaCC - OriginalChecksum=3f651517d5069f856891d89230562ac4 (do not edit this
- * line)
- */

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ASTExtractExpressionTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ASTExtractExpressionTest.java
@@ -7,15 +7,14 @@ package net.sourceforge.pmd.lang.plsql.ast;
 import org.junit.Assert;
 import org.junit.Test;
 
-import net.sourceforge.pmd.lang.plsql.PlsqlParsingHelper;
+import net.sourceforge.pmd.lang.plsql.AbstractPLSQLParserTst;
 
-public class ASTExtractExpressionTest {
+public class ASTExtractExpressionTest extends AbstractPLSQLParserTst {
 
 
     @Test
     public void testXml() {
-        PlsqlParsingHelper parser = PlsqlParsingHelper.JUST_PARSE;
-        ASTInput unit = parser.parse("SELECT warehouse_name, EXTRACT(warehouse_spec, '/Warehouse/Docks', "
+        ASTInput unit = plsql.parse("SELECT warehouse_name, EXTRACT(warehouse_spec, '/Warehouse/Docks', "
                 + "'xmlns:a=\"http://warehouse/1\" xmlns:b=\"http://warehouse/2\"') \"Number of Docks\" "
                 + " FROM warehouses WHERE warehouse_spec IS NOT NULL;");
         ASTExtractExpression extract = unit.getFirstDescendantOfType(ASTExtractExpression.class);

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/TriggerTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/TriggerTest.java
@@ -1,0 +1,28 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+
+package net.sourceforge.pmd.lang.plsql.ast;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.sourceforge.pmd.lang.plsql.AbstractPLSQLParserTst;
+
+
+public class TriggerTest extends AbstractPLSQLParserTst {
+
+    /**
+     * Parsing a trigger should not result in a NPE.
+     *
+     * @see <a href="https://github.com/pmd/pmd/issues/2325">#2325 [plsql] NullPointerException while running parsing test for CREATE TRIGGER</a>
+     */
+    @Test
+    public void parseCreateTrigger() {
+        ASTInput input = plsql.parseResource("TriggerUnit.pls");
+        PLSQLNode trigger = input.getChild(0);
+        Assert.assertEquals(ASTTriggerUnit.class, trigger.getClass());
+        Assert.assertNotNull(trigger.getScope());
+    }
+}

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/StringLiterals.pls
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/StringLiterals.pls
@@ -23,10 +23,10 @@ declare
   qliteral1f clob := Nq'[a"b"c]';
   qliteral1g clob := nQ'[ab']cd]';
 
-  qliteral1 clob := q'!name LIKE '%DBMS_%%'!';
-  qliteral2 clob := Q'{SELECT * FROM employees WHERE last_name = 'Smith';}';
-  qliteral1a clob := q'! test !';
-  qliteral2a clob := q'{
+  qliteral2a clob := q'!name LIKE '%DBMS_%%'!';
+  qliteral2b clob := Q'{SELECT * FROM employees WHERE last_name = 'Smith';}';
+  qliteral2c clob := q'! test !';
+  qliteral2d clob := q'{
     also multiple
     lines
   }';

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/TriggerUnit.pls
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/TriggerUnit.pls
@@ -1,0 +1,8 @@
+create or replace trigger test_trigger
+instead of update
+on test_table
+for each row
+begin
+  test.clr;
+end;
+/


### PR DESCRIPTION
This allows languages, that don't need a classloader while creating
symbol table to just override the one method.
In the test, we call always the overloaded method with class loader
which made the symbol table processing not being run for tests
in plsql.
    
Fixes #2325