### PR TITLE
[cs] CPD: fixes in filtering of using directives

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/token/internal/BaseTokenFilter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/token/internal/BaseTokenFilter.java
@@ -41,9 +41,9 @@ public abstract class BaseTokenFilter<T extends GenericToken> implements TokenFi
         currentToken = null;
         if (!unprocessedTokens.isEmpty()) {
             currentToken = unprocessedTokens.poll();
-            return currentToken;
+        } else {
+            currentToken = (T) tokenManager.getNextToken();
         }
-        currentToken = (T) tokenManager.getNextToken();
         while (!shouldStopProcessing(currentToken)) {
             analyzeToken(currentToken);
             analyzeTokens(currentToken, remainingTokens);
@@ -53,7 +53,11 @@ public abstract class BaseTokenFilter<T extends GenericToken> implements TokenFi
                 return currentToken;
             }
 
-            currentToken = (T) tokenManager.getNextToken();
+            if (!unprocessedTokens.isEmpty()) {
+                currentToken = unprocessedTokens.poll();
+            } else {
+                currentToken = (T) tokenManager.getNextToken();
+            }
         }
 
         return null;

--- a/pmd-cs/src/main/java/net/sourceforge/pmd/cpd/CsTokenizer.java
+++ b/pmd-cs/src/main/java/net/sourceforge/pmd/cpd/CsTokenizer.java
@@ -58,6 +58,7 @@ public class CsTokenizer extends AntlrTokenizer {
         private final boolean ignoreUsings;
         private boolean discardingUsings = false;
         private boolean discardingNL = false;
+        private boolean discardCurrent = false;
 
         CsTokenFilter(final AntlrTokenManager tokenManager, boolean ignoreUsings) {
             super(tokenManager);
@@ -71,6 +72,7 @@ public class CsTokenizer extends AntlrTokenizer {
 
         @Override
         protected void analyzeTokens(final AntlrToken currentToken, final Iterable<AntlrToken> remainingTokens) {
+            discardCurrent = false;
             skipUsingDirectives(currentToken, remainingTokens);
         }
 
@@ -78,8 +80,9 @@ public class CsTokenizer extends AntlrTokenizer {
             final int type = currentToken.getType();
             if (type == CSharpLexer.USING && isUsingDirective(remainingTokens)) {
                 discardingUsings = true;
-            } else if (type == CSharpLexer.SEMICOLON) {
+            } else if (type == CSharpLexer.SEMICOLON && discardingUsings) {
                 discardingUsings = false;
+                discardCurrent = true;
             }
         }
 
@@ -147,7 +150,7 @@ public class CsTokenizer extends AntlrTokenizer {
 
         @Override
         protected boolean isLanguageSpecificDiscarding() {
-            return discardingUsings || discardingNL;
+            return discardingUsings || discardingNL || discardCurrent;
         }
     }
 }

--- a/pmd-cs/src/test/java/net/sourceforge/pmd/cpd/CsTokenizerTest.java
+++ b/pmd-cs/src/test/java/net/sourceforge/pmd/cpd/CsTokenizerTest.java
@@ -126,6 +126,17 @@ public class CsTokenizerTest {
     }
 
     @Test
+    public void testStatementsAfterUsingDirectivesAreNotIgnored() {
+        tokenizer.setIgnoreUsings(true);
+        tokenizer.tokenize(toSourceCode(
+                "using System;\n"
+                        + "public class MyClass {\n"
+                        + "}\n"),
+                tokens);
+        assertEquals(6, tokens.size());
+    }
+
+    @Test
     public void testUsingStatementsAreNotIgnored() {
         tokenizer.setIgnoreUsings(true);
         tokenizer.tokenize(toSourceCode(


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
This fixes two issues with the filtering of using directives in C#.

The first was that tokens that appeared after a using directive that weren't supposed to be filtered, were discarded anyway. This was because the state of the tokenizer was not updated whenever tokens that were used in lookahead before were processed.

Fixing this issue revealed a regression: semicolons following using directives were not filtered out anymore. As a result of this, a big list of using directives would result in a long string of semicolons, essentially rendering the filter useless in some cases.

Both of these are regression introduced by PR #2280.