### PR TITLE
[cs] CPD: Fixed CPD --ignore-usings option

### DIFF
--- a/pmd-cs/src/main/java/net/sourceforge/pmd/cpd/CsTokenizer.java
+++ b/pmd-cs/src/main/java/net/sourceforge/pmd/cpd/CsTokenizer.java
@@ -75,11 +75,13 @@ public class CsTokenizer extends AntlrTokenizer {
         }
 
         private void skipUsingDirectives(final AntlrToken currentToken, final Iterable<AntlrToken> remainingTokens) {
-            final int type = currentToken.getType();
-            if (type == CSharpLexer.USING && isUsingDirective(remainingTokens)) {
-                discardingUsings = true;
-            } else if (type == CSharpLexer.SEMICOLON) {
-                discardingUsings = false;
+            if (ignoreUsings) {
+                final int type = currentToken.getType();
+                if (type == CSharpLexer.USING && isUsingDirective(remainingTokens)) {
+                    discardingUsings = true;
+                } else if (type == CSharpLexer.SEMICOLON) {
+                    discardingUsings = false;
+                }
             }
         }
 

--- a/pmd-cs/src/test/java/net/sourceforge/pmd/cpd/CsTokenizerTest.java
+++ b/pmd-cs/src/test/java/net/sourceforge/pmd/cpd/CsTokenizerTest.java
@@ -117,6 +117,14 @@ public class CsTokenizerTest {
     }
 
     @Test
+    public void testDoNotIgnoreUsingDirectives() {
+        tokenizer.setIgnoreUsings(false);
+        tokenizer.tokenize(toSourceCode("using System.Text;\n"), tokens);
+        assertEquals(6, tokens.size());
+        assertEquals("using", tokens.getTokens().get(0).toString());
+    }
+
+    @Test
     public void testIgnoreUsingDirectives() {
         tokenizer.setIgnoreUsings(true);
         tokenizer.tokenize(toSourceCode("using System.Text;\n"), tokens);


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
The --ignore-usings option was no longer respected because of a regression introduced by PR #2280. Instead, using directives were filtered regardless of whether the option was used.