### PR TITLE
[plsql] fix for parsing / as divide or execute

### DIFF
--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -3191,7 +3191,7 @@ ASTMultiplicativeExpression MultiplicativeExpression() #MultiplicativeExpression
   //UnaryExpression() ( ( "*" | "/" | <MOD> ) UnaryExpression() )*
  (
   (simpleNode = UnaryExpression(true) ) { sb.append(simpleNode.getImage()); }
-  ( LOOKAHEAD(2)
+  ( LOOKAHEAD("**" | "*" | "/" | <MOD> , {getToken(1).specialToken == null || getToken(1).specialToken.kind != EOL})
     ( ("**"  ) { sb.append(" ** "); } //Exponentiation
     | ("*"  ) { sb.append(" * "); }
     | ("/"  ) { sb.append(" / "); }

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SlashAsDivisionTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/SlashAsDivisionTest.java
@@ -1,0 +1,18 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.plsql.ast;
+
+import org.junit.Test;
+
+import net.sourceforge.pmd.lang.plsql.AbstractPLSQLParserTst;
+
+public class SlashAsDivisionTest extends AbstractPLSQLParserTst {
+
+    @Test
+    public void parseSlashAsDivision() {
+        plsql.parseResource("SlashAsDivision.sql");
+    }
+
+}

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/SlashAsDivision.sql
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/SlashAsDivision.sql
@@ -5,3 +5,13 @@ set street = 'Main Street'
 update name
 set n01 = 2/2
 /
+
+update name
+set n01 = 2
+/
+
+update name
+set n01 = 2/2;
+
+update name
+set n01 = 2;

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/SlashAsDivision.sql
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/SlashAsDivision.sql
@@ -1,0 +1,7 @@
+update name
+set street = 'Main Street'
+/
+
+update name
+set n01 = 2/2
+/


### PR DESCRIPTION
<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [ ] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [ ] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
Sometimes slash used as divide operator may be parsed as execute and vice versa.
