### PR TITLE
[ci] Disable checking for snapshots in jcenter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -852,6 +852,9 @@
         <pluginRepository>
             <id>jcenter</id>
             <name>JCenter</name>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
             <url>https://jcenter.bintray.com/</url>
         </pluginRepository>
     </pluginRepositories>


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
I propose to update `RepositoryPolicy.snapshots.enabled` for pluginRepository jcenter (from default **true** to explicit **false**).
Although
  - it will save only one trip for `pmd-build-tools-config` (https://travis-ci.org/pmd/pmd/jobs/659474901#L4913), which is handled by original jcenter very well

but
  - with jcenter mirrored via nexus - following warning from maven could also be prevented:
```
[WARNING] Could not transfer metadata net.sourceforge.pmd:pmd-build-tools-config:6-SNAPSHOT/maven-metadata.xml from/to nexus-jcenter (...):
 Transfer failed for .../net/sourceforge/pmd/pmd-build-tools-config/6-SNAPSHOT/maven-metadata.xml 400
 Repository version policy: RELEASE does not allow metadata in path: net/sourceforge/pmd/pmd-build-tools-config/6-SNAPSHOT/maven-metadata.xml
[WARNING] Failure to transfer net.sourceforge.pmd:pmd-build-tools-config:6-SNAPSHOT/maven-metadata.xml from ... was cached in the local repository,
 resolution will not be reattempted until the update interval of nexus-jcenter has elapsed or updates are forced.
 Original error: Could not transfer metadata net.sourceforge.pmd:pmd-build-tools-config:6-SNAPSHOT/maven-metadata.xml from/to nexus-jcenter (...):
 Transfer failed for .../net/sourceforge/pmd/pmd-build-tools-config/6-SNAPSHOT/maven-metadata.xml 400
 Repository version policy: RELEASE does not allow metadata in path: net/sourceforge/pmd/pmd-build-tools-config/6-SNAPSHOT/maven-metadata.xml
```
