### PR TITLE
[plsql] xmlforest with optional AS

### DIFF
--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -1644,7 +1644,7 @@ ASTFunctionCall FunctionCall() :
       | LOOKAHEAD({"XMLCAST".equalsIgnoreCase(token.getImage())}) "(" Expression() <AS> Datatype() ")"
       | LOOKAHEAD({"XMLQUERY".equalsIgnoreCase(token.getImage())}) "(" StringLiteral() [ LOOKAHEAD({isKeyword("PASSING")}) XMLPassingClause() ] <RETURNING> KEYWORD("CONTENT") [ <NULL> <ON> <EMPTY> ] ")"
       | LOOKAHEAD({"CAST".equalsIgnoreCase(token.getImage())}) "(" ( <MULTISET> "(" Subquery() ")" | Expression() ) <AS> Datatype() ")"
-      | LOOKAHEAD({"XMLFOREST".equalsIgnoreCase(token.getImage())}) "(" SqlExpression() [ <AS> ID() ] ( "," SqlExpression() [ <AS> ID() ] )* ")"
+      | LOOKAHEAD({"XMLFOREST".equalsIgnoreCase(token.getImage())}) "(" SqlExpression() [ <AS> ] [ ID() ] ( "," SqlExpression() [ <AS> ] [ ID() ] )* ")"
       | LOOKAHEAD({"XMLELEMENT".equalsIgnoreCase(token.getImage())}) XMLElement()
       | LOOKAHEAD({"XMLROOT".equalsIgnoreCase(token.getImage())})
              "(" Expression() "," KEYWORD("VERSION") (<NO> KEYWORD("VALUE") | Expression() )

--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -1644,7 +1644,7 @@ ASTFunctionCall FunctionCall() :
       | LOOKAHEAD({"XMLCAST".equalsIgnoreCase(token.getImage())}) "(" Expression() <AS> Datatype() ")"
       | LOOKAHEAD({"XMLQUERY".equalsIgnoreCase(token.getImage())}) "(" StringLiteral() [ LOOKAHEAD({isKeyword("PASSING")}) XMLPassingClause() ] <RETURNING> KEYWORD("CONTENT") [ <NULL> <ON> <EMPTY> ] ")"
       | LOOKAHEAD({"CAST".equalsIgnoreCase(token.getImage())}) "(" ( <MULTISET> "(" Subquery() ")" | Expression() ) <AS> Datatype() ")"
-      | LOOKAHEAD({"XMLFOREST".equalsIgnoreCase(token.getImage())}) "(" SqlExpression() [ <AS> ] [ ID() ] ( "," SqlExpression() [ <AS> ] [ ID() ] )* ")"
+      | LOOKAHEAD({"XMLFOREST".equalsIgnoreCase(token.getImage())}) "(" SqlExpression() [ [ <AS> ] ID() ] ( "," SqlExpression() [ [ <AS> ] ID() ] )* ")"
       | LOOKAHEAD({"XMLELEMENT".equalsIgnoreCase(token.getImage())}) XMLElement()
       | LOOKAHEAD({"XMLROOT".equalsIgnoreCase(token.getImage())})
              "(" Expression() "," KEYWORD("VERSION") (<NO> KEYWORD("VALUE") | Expression() )

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/XMLTable.pls
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/XMLTable.pls
@@ -99,7 +99,7 @@ SELECT XMLQuery('declare default element namespace
   FROM DUAL;
 
 SELECT XMLELEMENT("Emp", 
-   XMLFOREST(e.employee_id AS foo, e.last_name, e.salary))
+   XMLFOREST(e.employee_id AS foo, e.last_name last_name, e.salary))
    "Emp Element"
    FROM employees e WHERE employee_id = 204;
 


### PR DESCRIPTION
<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [ ] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [ ] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
In reference to [comment](https://github.com/pmd/pmd/pull/2326#discussion_r388178966).
It looks like there is a mistake in Oracle doc, because code compiles and works both with and without AS (on Oracle 12c).
For example
`SELECT XMLELEMENT("Emp", 
   XMLFOREST(e.dummy AS foo, e.dummy last_name))
   "Emp Element"
   FROM dual e;` 
I modified parser and test case.