### PR TITLE
[core] Add support for rule chain execution for XPath 2.0

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRuleChainVisitor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRuleChainVisitor.java
@@ -157,9 +157,13 @@ public abstract class AbstractRuleChainVisitor implements RuleChainVisitor {
                 Rule rule = ruleIterator.next();
                 if (rule.isRuleChain()) {
                     visitedNodes.addAll(rule.getRuleChainVisits());
+
+                    logXPathRuleChainUsage(true, rule);
                 } else {
                     // Drop rules which do not participate in the rule chain.
                     ruleIterator.remove();
+
+                    logXPathRuleChainUsage(false, rule);
                 }
             }
             // Drop RuleSets in which all Rules have been dropped.
@@ -175,6 +179,23 @@ public abstract class AbstractRuleChainVisitor implements RuleChainVisitor {
         for (String s : visitedNodes) {
             List<Node> nodes = new ArrayList<>(100);
             nodeNameToNodes.put(s, nodes);
+        }
+    }
+
+    private void logXPathRuleChainUsage(boolean usesRuleChain, Rule rule) {
+        if (LOG.isLoggable(Level.FINE)) {
+            Rule r;
+            if (rule instanceof RuleReference) {
+                r = ((RuleReference) rule).getRule();
+            } else {
+                r = rule;
+            }
+            if (r instanceof XPathRule) {
+                String message = (usesRuleChain ? "Using " : "no ")
+                        + "rule chain for XPath " + rule.getProperty(XPathRule.VERSION_DESCRIPTOR)
+                        + " rule: " + rule.getName() + " (" + rule.getRuleSetName() + ")";
+                LOG.fine(message);
+            }
         }
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/JaxenXPathRuleQuery.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/JaxenXPathRuleQuery.java
@@ -45,11 +45,11 @@ public class JaxenXPathRuleQuery extends AbstractXPathRuleQuery {
         NONE, PARTIAL, FULL
     }
 
-    // Mapping from Node name to applicable XPath queries
     private InitializationStatus initializationStatus = InitializationStatus.NONE;
-    private Map<String, List<XPath>> nodeNameToXPaths;
+    // Mapping from Node name to applicable XPath queries
+    Map<String, List<XPath>> nodeNameToXPaths;
 
-    private static final String AST_ROOT = "_AST_ROOT_";
+    static final String AST_ROOT = "_AST_ROOT_";
 
     @Override
     public boolean isSupportedVersion(String version) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQuery.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQuery.java
@@ -20,7 +20,6 @@ import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.ast.xpath.saxon.DocumentNode;
 import net.sourceforge.pmd.lang.ast.xpath.saxon.ElementNode;
 import net.sourceforge.pmd.lang.rule.xpath.internal.RuleChainAnalyzer;
-import net.sourceforge.pmd.lang.rule.xpath.internal.SplitUnions;
 import net.sourceforge.pmd.lang.xpath.Initializer;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 
@@ -263,14 +262,7 @@ public class SaxonXPathRuleQuery extends AbstractXPathRuleQuery {
         boolean useRuleChain = true;
 
         // First step: Split the union venn expressions into single expressions
-        List<Expression> subexpressions = new ArrayList<>();
-        SplitUnions unions = new SplitUnions();
-        unions.visit(expr);
-        if (unions.getExpressions().isEmpty()) {
-            subexpressions.add(expr);
-        } else {
-            subexpressions.addAll(unions.getExpressions());
-        }
+        Iterable<Expression> subexpressions = RuleChainAnalyzer.splitUnions(expr);
 
         // Second step: Analyze each expression separately
         for (Expression subexpression : subexpressions) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQuery.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQuery.java
@@ -19,7 +19,6 @@ import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.ast.xpath.saxon.DocumentNode;
 import net.sourceforge.pmd.lang.ast.xpath.saxon.ElementNode;
-import net.sourceforge.pmd.lang.rule.xpath.internal.DocumentSorter;
 import net.sourceforge.pmd.lang.rule.xpath.internal.RuleChainAnalyzer;
 import net.sourceforge.pmd.lang.rule.xpath.internal.SplitUnions;
 import net.sourceforge.pmd.lang.xpath.Initializer;
@@ -124,7 +123,7 @@ public class SaxonXPathRuleQuery extends AbstractXPathRuleQuery {
             for (final ElementNode elementNode : nodes) {
                 results.add((Node) elementNode.getUnderlyingNode());
             }
-            Collections.sort(results, new DocumentSorter());
+            Collections.sort(results, RuleChainAnalyzer.documentOrderComparator());
             return results;
         } catch (final XPathException e) {
             throw new RuntimeException(super.xpath + " had problem: " + e.getMessage(), e);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/DocumentSorter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/DocumentSorter.java
@@ -1,0 +1,31 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+
+package net.sourceforge.pmd.lang.rule.xpath.internal;
+
+import java.util.Comparator;
+
+import net.sourceforge.pmd.lang.ast.Node;
+
+/**
+ * Sorts nodes by document order.
+ */
+public class DocumentSorter implements Comparator<Node> {
+    @Override
+    public int compare(Node node1, Node node2) {
+        if (node1 == null && node2 == null) {
+            return 0;
+        } else if (node1 == null) {
+            return -1;
+        } else if (node2 == null) {
+            return 1;
+        }
+        int result = node1.getBeginLine() - node2.getBeginLine();
+        if (result == 0) {
+            result = node1.getBeginColumn() - node2.getBeginColumn();
+        }
+        return result;
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/DocumentSorter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/DocumentSorter.java
@@ -12,7 +12,14 @@ import net.sourceforge.pmd.lang.ast.Node;
 /**
  * Sorts nodes by document order.
  */
-public class DocumentSorter implements Comparator<Node> {
+class DocumentSorter implements Comparator<Node> {
+
+    public static final DocumentSorter INSTANCE = new DocumentSorter();
+
+    private DocumentSorter() {
+
+    }
+
     @Override
     public int compare(Node node1, Node node2) {
         if (node1 == null && node2 == null) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/DocumentSorter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/DocumentSorter.java
@@ -12,7 +12,7 @@ import net.sourceforge.pmd.lang.ast.Node;
 /**
  * Sorts nodes by document order.
  */
-class DocumentSorter implements Comparator<Node> {
+final class DocumentSorter implements Comparator<Node> {
 
     public static final DocumentSorter INSTANCE = new DocumentSorter();
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/ExpressionPrinter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/ExpressionPrinter.java
@@ -1,0 +1,53 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.rule.xpath.internal;
+
+import net.sf.saxon.expr.AxisExpression;
+import net.sf.saxon.expr.Expression;
+import net.sf.saxon.expr.RootExpression;
+import net.sf.saxon.expr.Token;
+import net.sf.saxon.expr.VennExpression;
+import net.sf.saxon.om.Axis;
+
+/**
+ * Simple printer for saxon expressions. Might be useful for debugging / during development.
+ */
+public class ExpressionPrinter extends Visitor {
+    private int depth = 0;
+
+    private void print(String s) {
+        for (int i = 0; i < depth; i++) {
+            System.out.print("    ");
+        }
+        System.out.println(s);
+    }
+
+    @Override
+    public Expression visit(AxisExpression e) {
+        print("axis=" + Axis.axisName[e.getAxis()] + "(test=" + e.getNodeTest() + ")");
+        return super.visit(e);
+    }
+
+    @Override
+    public Expression visit(RootExpression e) {
+        print("/");
+        return super.visit(e);
+    }
+
+    @Override
+    public Expression visit(VennExpression e) {
+        print("venn=" + Token.tokens[e.getOperator()]);
+        return super.visit(e);
+    }
+
+    @Override
+    public Expression visit(Expression expr) {
+        depth++;
+        print(expr.getClass().getSimpleName());
+        Expression result = super.visit(expr);
+        depth--;
+        return result;
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/RuleChainAnalyzer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/RuleChainAnalyzer.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.rule.xpath.internal;
 
+import java.util.Collections;
 import java.util.Comparator;
 
 import net.sourceforge.pmd.lang.ast.Node;
@@ -97,6 +98,19 @@ public class RuleChainAnalyzer extends Visitor {
 
     public static Comparator<Node> documentOrderComparator() {
         return net.sourceforge.pmd.lang.rule.xpath.internal.DocumentSorter.INSTANCE;
+    }
+
+    /**
+     * Split union expressions into their components.
+     */
+    public static Iterable<Expression> splitUnions(Expression expr) {
+        SplitUnions unions = new SplitUnions();
+        unions.visit(expr);
+        if (unions.getExpressions().isEmpty()) {
+            return Collections.singletonList(expr);
+        } else {
+            return unions.getExpressions();
+        }
     }
 
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/RuleChainAnalyzer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/RuleChainAnalyzer.java
@@ -4,6 +4,10 @@
 
 package net.sourceforge.pmd.lang.rule.xpath.internal;
 
+import java.util.Comparator;
+
+import net.sourceforge.pmd.lang.ast.Node;
+
 import net.sf.saxon.Configuration;
 import net.sf.saxon.expr.AxisExpression;
 import net.sf.saxon.expr.Expression;
@@ -90,4 +94,9 @@ public class RuleChainAnalyzer extends Visitor {
         }
         return super.visit(e);
     }
+
+    public static Comparator<Node> documentOrderComparator() {
+        return net.sourceforge.pmd.lang.rule.xpath.internal.DocumentSorter.INSTANCE;
+    }
+
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/RuleChainAnalyzer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/RuleChainAnalyzer.java
@@ -1,0 +1,93 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.rule.xpath.internal;
+
+import net.sf.saxon.Configuration;
+import net.sf.saxon.expr.AxisExpression;
+import net.sf.saxon.expr.Expression;
+import net.sf.saxon.expr.FilterExpression;
+import net.sf.saxon.expr.PathExpression;
+import net.sf.saxon.expr.RootExpression;
+import net.sf.saxon.om.Axis;
+import net.sf.saxon.pattern.NameTest;
+import net.sf.saxon.sort.DocumentSorter;
+import net.sf.saxon.type.Type;
+
+/**
+ * Analyzes the xpath expression to find the root path selector for a element. If found,
+ * the element name is available via {@link RuleChainAnalyzer#getRootElement()} and the
+ * expression is rewritten to start at "node::self()" instead.
+ *
+ * <p>It uses a visitor to visit all the different expressions.
+ *
+ * <p>Example: The XPath expression <code>//A[condition()]/B</code> results the rootElement "A"
+ * and the expression is rewritten to be <code>self::node[condition()]/B</code>.
+ *
+ * <p>DocumentSorter expression is removed. The sorting of the resulting nodes needs to be done
+ * after all (sub)expressions have been executed.
+ */
+public class RuleChainAnalyzer extends Visitor {
+    private final Configuration configuration;
+    private String rootElement;
+    private boolean rootElementReplaced;
+
+    public RuleChainAnalyzer(Configuration currentConfiguration) {
+        this.configuration = currentConfiguration;
+    }
+
+    public String getRootElement() {
+        return rootElement;
+    }
+
+    @Override
+    public Expression visit(DocumentSorter e) {
+        DocumentSorter result = (DocumentSorter) super.visit(e);
+        // sorting of the nodes must be done after all nodes have been found
+        return result.getBaseExpression();
+    }
+
+    @Override
+    public Expression visit(PathExpression e) {
+        if (rootElement == null) {
+            Expression result = super.visit(e);
+            if (rootElement != null && !rootElementReplaced) {
+                if (result instanceof PathExpression) {
+                    PathExpression newPath = (PathExpression) result;
+                    if (newPath.getStepExpression() instanceof FilterExpression) {
+                        FilterExpression filterExpression = (FilterExpression) newPath.getStepExpression();
+                        result = new FilterExpression(new AxisExpression(Axis.SELF, null), filterExpression.getFilter());
+                        rootElementReplaced = true;
+                    } else if (newPath.getStepExpression() instanceof AxisExpression) {
+                        if (newPath.getStartExpression() instanceof RootExpression) {
+                            result = new AxisExpression(Axis.SELF, null);
+                        } else {
+                            result = new PathExpression(newPath.getStartExpression(), new AxisExpression(Axis.SELF, null));
+                        }
+                        rootElementReplaced = true;
+                    }
+                } else {
+                    result = new AxisExpression(Axis.DESCENDANT_OR_SELF, null);
+                    rootElementReplaced = true;
+                }
+            }
+            return result;
+        } else {
+            return super.visit(e);
+        }
+    }
+
+    @Override
+    public Expression visit(AxisExpression e) {
+        if (rootElement == null && e.getNodeTest() instanceof NameTest) {
+            NameTest test = (NameTest) e.getNodeTest();
+            if (test.getPrimitiveType() == Type.ELEMENT && e.getAxis() == Axis.DESCENDANT) {
+                rootElement = configuration.getNamePool().getClarkName(test.getFingerprint());
+            } else if (test.getPrimitiveType() == Type.ELEMENT && e.getAxis() == Axis.CHILD) {
+                rootElement = configuration.getNamePool().getClarkName(test.getFingerprint());
+            }
+        }
+        return super.visit(e);
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SplitUnions.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SplitUnions.java
@@ -17,7 +17,7 @@ import net.sf.saxon.expr.VennExpression;
  * 
  * <p>E.g. "//A | //B | //C" will result in 3 expressions "//A", "//B", and "//C".
  */
-public class SplitUnions extends Visitor {
+class SplitUnions extends Visitor {
     private List<Expression> expressions = new ArrayList<>();
 
     @Override

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SplitUnions.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SplitUnions.java
@@ -1,0 +1,40 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+
+package net.sourceforge.pmd.lang.rule.xpath.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.sf.saxon.expr.Expression;
+import net.sf.saxon.expr.Token;
+import net.sf.saxon.expr.VennExpression;
+
+/**
+ * Splits a venn expression with the union operator into single expressions.
+ * 
+ * <p>E.g. "//A | //B | //C" will result in 3 expressions "//A", "//B", and "//C".
+ */
+public class SplitUnions extends Visitor {
+    private List<Expression> expressions = new ArrayList<>();
+
+    @Override
+    public Expression visit(VennExpression e) {
+        if (e.getOperator() == Token.UNION) {
+            for (Expression operand : e.getOperands()) {
+                if (operand instanceof VennExpression) {
+                    visit(operand);
+                } else {
+                    expressions.add(operand);
+                }
+            }
+        }
+        return e;
+    }
+
+    public List<Expression> getExpressions() {
+        return expressions;
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/Visitor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/Visitor.java
@@ -1,0 +1,89 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.rule.xpath.internal;
+
+import net.sf.saxon.expr.AxisExpression;
+import net.sf.saxon.expr.Expression;
+import net.sf.saxon.expr.FilterExpression;
+import net.sf.saxon.expr.LetExpression;
+import net.sf.saxon.expr.PathExpression;
+import net.sf.saxon.expr.QuantifiedExpression;
+import net.sf.saxon.expr.RootExpression;
+import net.sf.saxon.expr.VennExpression;
+import net.sf.saxon.sort.DocumentSorter;
+
+abstract class Visitor {
+    public Expression visit(DocumentSorter e) {
+        Expression base = visit(e.getBaseExpression());
+        return new DocumentSorter(base);
+    }
+
+    public Expression visit(PathExpression e) {
+        Expression start = visit(e.getStartExpression());
+        Expression step = visit(e.getStepExpression());
+        return new PathExpression(start, step);
+    }
+
+    public Expression visit(RootExpression e) {
+        return e;
+    }
+
+    public Expression visit(AxisExpression e) {
+        return e;
+    }
+
+    public Expression visit(VennExpression e) {
+        final Expression[] operands = e.getOperands();
+        Expression operand0 = visit(operands[0]);
+        Expression operand1 = visit(operands[1]);
+        return new VennExpression(operand0, e.getOperator(), operand1);
+    }
+
+    public Expression visit(FilterExpression e) {
+        Expression base = visit(e.getBaseExpression());
+        Expression filter = visit(e.getFilter());
+        return new FilterExpression(base, filter);
+    }
+
+    public Expression visit(QuantifiedExpression e) {
+        return e;
+    }
+
+    public Expression visit(LetExpression e) {
+        Expression action = visit(e.getAction());
+        Expression sequence = visit(e.getSequence());
+        LetExpression result = new LetExpression();
+        result.setAction(action);
+        result.setSequence(sequence);
+        result.setVariableQName(e.getVariableQName());
+        result.setRequiredType(e.getRequiredType());
+        result.setSlotNumber(e.getLocalSlotNumber());
+        return result;
+    }
+
+    public Expression visit(Expression expr) {
+        Expression result;
+        if (expr instanceof DocumentSorter) {
+            result = visit((DocumentSorter) expr);
+        } else if (expr instanceof PathExpression) {
+            result = visit((PathExpression) expr);
+        } else if (expr instanceof RootExpression) {
+            result = visit((RootExpression) expr);
+        } else if (expr instanceof AxisExpression) {
+            result = visit((AxisExpression) expr);
+        } else if (expr instanceof VennExpression) {
+            result = visit((VennExpression) expr);
+        } else if (expr instanceof FilterExpression) {
+            result = visit((FilterExpression) expr);
+        } else if (expr instanceof QuantifiedExpression) {
+            result = visit((QuantifiedExpression) expr);
+        } else if (expr instanceof LetExpression) {
+            result = visit((LetExpression) expr);
+        } else {
+            result = expr;
+        }
+        return result;
+    }
+}

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/JaxenXPathRuleQueryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/JaxenXPathRuleQueryTest.java
@@ -34,6 +34,31 @@ public class JaxenXPathRuleQueryTest {
         assertQuery(0, "//dummyNode[@EmptyList = \"A\"]", dummy);
     }
 
+    @Test
+    public void ruleChainVisits() {
+        JaxenXPathRuleQuery query = createQuery("//dummyNode[@Image='baz']/foo | //bar[@Public = 'true'] | //dummyNode[@Public = 'false'] | //dummyNode");
+        List<String> ruleChainVisits = query.getRuleChainVisits();
+        Assert.assertEquals(3, ruleChainVisits.size());
+        Assert.assertTrue(ruleChainVisits.contains("dummyNode"));
+        Assert.assertTrue(ruleChainVisits.contains("bar"));
+        // Note: Having AST_ROOT in the rule chain visits is probably a mistake. But it doesn't hurt, it shouldn't
+        // match a real node name.
+        Assert.assertTrue(ruleChainVisits.contains(JaxenXPathRuleQuery.AST_ROOT));
+
+        DummyNodeWithListAndEnum dummy = new DummyNodeWithListAndEnum(1);
+        RuleContext data = new RuleContext();
+        data.setLanguageVersion(LanguageRegistry.findLanguageByTerseName("dummy").getDefaultVersion());
+
+        query.evaluate(dummy, data);
+        // note: the actual xpath queries are only available after evaluating
+        Assert.assertEquals(3, query.nodeNameToXPaths.size());
+        Assert.assertTrue(query.nodeNameToXPaths.containsKey(JaxenXPathRuleQuery.AST_ROOT));
+        Assert.assertEquals("self::node()", query.nodeNameToXPaths.get("dummyNode").get(0).toString());
+        Assert.assertEquals("self::node()[(attribute::Public = \"false\")]", query.nodeNameToXPaths.get("dummyNode").get(1).toString());
+        Assert.assertEquals("self::node()[(attribute::Image = \"baz\")]/child::foo", query.nodeNameToXPaths.get("dummyNode").get(2).toString());
+        Assert.assertEquals("self::node()[(attribute::Public = \"true\")]", query.nodeNameToXPaths.get("bar").get(0).toString());
+    }
+
     private static void assertQuery(int resultSize, String xpath, Node node) {
         JaxenXPathRuleQuery query = createQuery(xpath);
         RuleContext data = new RuleContext();

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/JaxenXPathRuleQueryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/JaxenXPathRuleQueryTest.java
@@ -36,7 +36,8 @@ public class JaxenXPathRuleQueryTest {
 
     @Test
     public void ruleChainVisits() {
-        JaxenXPathRuleQuery query = createQuery("//dummyNode[@Image='baz']/foo | //bar[@Public = 'true'] | //dummyNode[@Public = 'false'] | //dummyNode");
+        final String xpath = "//dummyNode[@Image='baz']/foo | //bar[@Public = 'true'] | //dummyNode[@Public = 'false'] | //dummyNode";
+        JaxenXPathRuleQuery query = createQuery(xpath);
         List<String> ruleChainVisits = query.getRuleChainVisits();
         Assert.assertEquals(3, ruleChainVisits.size());
         Assert.assertTrue(ruleChainVisits.contains("dummyNode"));
@@ -52,11 +53,77 @@ public class JaxenXPathRuleQueryTest {
         query.evaluate(dummy, data);
         // note: the actual xpath queries are only available after evaluating
         Assert.assertEquals(3, query.nodeNameToXPaths.size());
-        Assert.assertTrue(query.nodeNameToXPaths.containsKey(JaxenXPathRuleQuery.AST_ROOT));
         Assert.assertEquals("self::node()", query.nodeNameToXPaths.get("dummyNode").get(0).toString());
         Assert.assertEquals("self::node()[(attribute::Public = \"false\")]", query.nodeNameToXPaths.get("dummyNode").get(1).toString());
         Assert.assertEquals("self::node()[(attribute::Image = \"baz\")]/child::foo", query.nodeNameToXPaths.get("dummyNode").get(2).toString());
         Assert.assertEquals("self::node()[(attribute::Public = \"true\")]", query.nodeNameToXPaths.get("bar").get(0).toString());
+        Assert.assertEquals(xpath, query.nodeNameToXPaths.get(JaxenXPathRuleQuery.AST_ROOT).get(0).toString());
+    }
+
+    @Test
+    public void ruleChainVisitsMultipleFilters() {
+        final String xpath = "//dummyNode[@Test1 = 'false'][@Test2 = 'true']";
+        JaxenXPathRuleQuery query = createQuery(xpath);
+        List<String> ruleChainVisits = query.getRuleChainVisits();
+        Assert.assertEquals(2, ruleChainVisits.size());
+        Assert.assertTrue(ruleChainVisits.contains("dummyNode"));
+        // Note: Having AST_ROOT in the rule chain visits is probably a mistake. But it doesn't hurt, it shouldn't
+        // match a real node name.
+        Assert.assertTrue(ruleChainVisits.contains(JaxenXPathRuleQuery.AST_ROOT));
+
+        DummyNodeWithListAndEnum dummy = new DummyNodeWithListAndEnum(1);
+        RuleContext data = new RuleContext();
+        data.setLanguageVersion(LanguageRegistry.findLanguageByTerseName("dummy").getDefaultVersion());
+
+        query.evaluate(dummy, data);
+        // note: the actual xpath queries are only available after evaluating
+        Assert.assertEquals(2, query.nodeNameToXPaths.size());
+        Assert.assertEquals("self::node()[(attribute::Test1 = \"false\")][(attribute::Test2 = \"true\")]", query.nodeNameToXPaths.get("dummyNode").get(0).toString());
+        Assert.assertEquals(xpath, query.nodeNameToXPaths.get(JaxenXPathRuleQuery.AST_ROOT).get(0).toString());
+    }
+
+    @Test
+    public void ruleChainVisitsNested() {
+        final String xpath = "//dummyNode/foo/*/bar[@Test = 'false']";
+        JaxenXPathRuleQuery query = createQuery(xpath);
+        List<String> ruleChainVisits = query.getRuleChainVisits();
+        Assert.assertEquals(2, ruleChainVisits.size());
+        Assert.assertTrue(ruleChainVisits.contains("dummyNode"));
+        // Note: Having AST_ROOT in the rule chain visits is probably a mistake. But it doesn't hurt, it shouldn't
+        // match a real node name.
+        Assert.assertTrue(ruleChainVisits.contains(JaxenXPathRuleQuery.AST_ROOT));
+
+        DummyNodeWithListAndEnum dummy = new DummyNodeWithListAndEnum(1);
+        RuleContext data = new RuleContext();
+        data.setLanguageVersion(LanguageRegistry.findLanguageByTerseName("dummy").getDefaultVersion());
+
+        query.evaluate(dummy, data);
+        // note: the actual xpath queries are only available after evaluating
+        Assert.assertEquals(2, query.nodeNameToXPaths.size());
+        Assert.assertEquals("self::node()/child::foo/child::*/child::bar[(attribute::Test = \"false\")]", query.nodeNameToXPaths.get("dummyNode").get(0).toString());
+        Assert.assertEquals(xpath, query.nodeNameToXPaths.get(JaxenXPathRuleQuery.AST_ROOT).get(0).toString());
+    }
+
+    @Test
+    public void ruleChainVisitsNested2() {
+        final String xpath = "//dummyNode/foo[@Baz = 'a']/*/bar[@Test = 'false']";
+        JaxenXPathRuleQuery query = createQuery(xpath);
+        List<String> ruleChainVisits = query.getRuleChainVisits();
+        Assert.assertEquals(2, ruleChainVisits.size());
+        Assert.assertTrue(ruleChainVisits.contains("dummyNode"));
+        // Note: Having AST_ROOT in the rule chain visits is probably a mistake. But it doesn't hurt, it shouldn't
+        // match a real node name.
+        Assert.assertTrue(ruleChainVisits.contains(JaxenXPathRuleQuery.AST_ROOT));
+
+        DummyNodeWithListAndEnum dummy = new DummyNodeWithListAndEnum(1);
+        RuleContext data = new RuleContext();
+        data.setLanguageVersion(LanguageRegistry.findLanguageByTerseName("dummy").getDefaultVersion());
+
+        query.evaluate(dummy, data);
+        // note: the actual xpath queries are only available after evaluating
+        Assert.assertEquals(2, query.nodeNameToXPaths.size());
+        Assert.assertEquals("self::node()/child::foo[(attribute::Baz = \"a\")]/child::*/child::bar[(attribute::Test = \"false\")]", query.nodeNameToXPaths.get("dummyNode").get(0).toString());
+        Assert.assertEquals(xpath, query.nodeNameToXPaths.get(JaxenXPathRuleQuery.AST_ROOT).get(0).toString());
     }
 
     private static void assertQuery(int resultSize, String xpath, Node node) {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQueryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQueryTest.java
@@ -31,6 +31,42 @@ public class SaxonXPathRuleQueryTest {
         assertQuery(0, "//dummyNode[@EmptyList = (\"A\")]", dummy);
     }
 
+    @Test
+    public void ruleChainVisits() {
+        SaxonXPathRuleQuery query = createQuery("//dummyNode[@Image='baz']/foo | //bar[@Public = 'true'] | //dummyNode[@Public = false()] | //dummyNode");
+        List<String> ruleChainVisits = query.getRuleChainVisits();
+        Assert.assertEquals(2, ruleChainVisits.size());
+        Assert.assertTrue(ruleChainVisits.contains("dummyNode"));
+        Assert.assertTrue(ruleChainVisits.contains("bar"));
+
+        Assert.assertEquals(3, query.nodeNameToXPaths.size());
+        assertExpression("self::node()", query.nodeNameToXPaths.get("dummyNode").get(0).toString());
+        assertExpression("(self::node()[QuantifiedExpression(Atomizer(attribute::attribute(Public, xs:anyAtomicType)), ($qq:qq609962972 singleton eq false()))])", query.nodeNameToXPaths.get("dummyNode").get(1).toString());
+        assertExpression("((self::node()[QuantifiedExpression(Atomizer(attribute::attribute(Image, xs:anyAtomicType)), ($qq:qq106374177 singleton eq \"baz\"))])/child::element(foo, xs:anyType))", query.nodeNameToXPaths.get("dummyNode").get(2).toString());
+        assertExpression("(self::node()[QuantifiedExpression(Atomizer(attribute::attribute(Public, xs:anyAtomicType)), ($qq:qq232307208 singleton eq \"true\"))])", query.nodeNameToXPaths.get("bar").get(0).toString());
+        assertExpression("(((DocumentSorter(((((/)/descendant::element(dummyNode, xs:anyType))[QuantifiedExpression(Atomizer(attribute::attribute(Image, xs:anyAtomicType)), ($qq:qq000 singleton eq \"baz\"))])/child::element(foo, xs:anyType))) | (((/)/descendant::element(bar, xs:anyType))[QuantifiedExpression(Atomizer(attribute::attribute(Public, xs:anyAtomicType)), ($qq:qq000 singleton eq \"true\"))])) | (((/)/descendant::element(dummyNode, xs:anyType))[QuantifiedExpression(Atomizer(attribute::attribute(Public, xs:anyAtomicType)), ($qq:qq000 singleton eq false()))])) | ((/)/descendant::element(dummyNode, xs:anyType)))", query.nodeNameToXPaths.get(SaxonXPathRuleQuery.AST_ROOT).get(0).toString());
+    }
+
+    private static void assertExpression(String expected, String actual) {
+        Assert.assertEquals(expected.replaceAll("\\$qq:qq\\d+", "\\$qq:qq000"), actual.replaceAll("\\$qq:qq\\d+", "\\$qq:qq000"));
+    }
+
+    @Test
+    public void ruleChainVisitsCompatibilityMode() {
+        SaxonXPathRuleQuery query = createQuery("//dummyNode[@Image='baz']/foo | //bar[@Public = 'true'] | //dummyNode[@Public = 'false']");
+        query.setVersion(XPathRuleQuery.XPATH_1_0_COMPATIBILITY);
+        List<String> ruleChainVisits = query.getRuleChainVisits();
+        Assert.assertEquals(2, ruleChainVisits.size());
+        Assert.assertTrue(ruleChainVisits.contains("dummyNode"));
+        Assert.assertTrue(ruleChainVisits.contains("bar"));
+
+        Assert.assertEquals(3, query.nodeNameToXPaths.size());
+        assertExpression("(self::node()[QuantifiedExpression(Atomizer(attribute::attribute(Public, xs:anyAtomicType)), ($qq:qq609962972 singleton eq \"false\"))])", query.nodeNameToXPaths.get("dummyNode").get(0).toString());
+        assertExpression("((self::node()[QuantifiedExpression(Atomizer(attribute::attribute(Image, xs:anyAtomicType)), ($qq:qq106374177 singleton eq \"baz\"))])/child::element(foo, xs:anyType))", query.nodeNameToXPaths.get("dummyNode").get(1).toString());
+        assertExpression("(self::node()[QuantifiedExpression(Atomizer(attribute::attribute(Public, xs:anyAtomicType)), ($qq:qq232307208 singleton eq \"true\"))])", query.nodeNameToXPaths.get("bar").get(0).toString());
+        assertExpression("((DocumentSorter(((((/)/descendant::element(dummyNode, xs:anyType))[QuantifiedExpression(Atomizer(attribute::attribute(Image, xs:anyAtomicType)), ($qq:qq106374177 singleton eq \"baz\"))])/child::element(foo, xs:anyType))) | (((/)/descendant::element(bar, xs:anyType))[QuantifiedExpression(Atomizer(attribute::attribute(Public, xs:anyAtomicType)), ($qq:qq232307208 singleton eq \"true\"))])) | (((/)/descendant::element(dummyNode, xs:anyType))[QuantifiedExpression(Atomizer(attribute::attribute(Public, xs:anyAtomicType)), ($qq:qq609962972 singleton eq \"false\"))]))", query.nodeNameToXPaths.get(SaxonXPathRuleQuery.AST_ROOT).get(0).toString());
+    }
+
     private static void assertQuery(int resultSize, String xpath, Node node) {
         SaxonXPathRuleQuery query = createQuery(xpath);
         List<Node> result = query.evaluate(node, new RuleContext());
@@ -39,7 +75,7 @@ public class SaxonXPathRuleQueryTest {
 
     private static SaxonXPathRuleQuery createQuery(String xpath) {
         SaxonXPathRuleQuery query = new SaxonXPathRuleQuery();
-        query.setVersion("2.0");
+        query.setVersion(XPathRuleQuery.XPATH_2_0);
         query.setProperties(Collections.<PropertyDescriptor<?>, Object>emptyMap());
         query.setXPath(xpath);
         return query;

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQueryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQueryTest.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import net.sourceforge.pmd.RuleContext;
@@ -45,6 +46,40 @@ public class SaxonXPathRuleQueryTest {
         assertExpression("((self::node()[QuantifiedExpression(Atomizer(attribute::attribute(Image, xs:anyAtomicType)), ($qq:qq106374177 singleton eq \"baz\"))])/child::element(foo, xs:anyType))", query.nodeNameToXPaths.get("dummyNode").get(2).toString());
         assertExpression("(self::node()[QuantifiedExpression(Atomizer(attribute::attribute(Public, xs:anyAtomicType)), ($qq:qq232307208 singleton eq \"true\"))])", query.nodeNameToXPaths.get("bar").get(0).toString());
         assertExpression("(((DocumentSorter(((((/)/descendant::element(dummyNode, xs:anyType))[QuantifiedExpression(Atomizer(attribute::attribute(Image, xs:anyAtomicType)), ($qq:qq000 singleton eq \"baz\"))])/child::element(foo, xs:anyType))) | (((/)/descendant::element(bar, xs:anyType))[QuantifiedExpression(Atomizer(attribute::attribute(Public, xs:anyAtomicType)), ($qq:qq000 singleton eq \"true\"))])) | (((/)/descendant::element(dummyNode, xs:anyType))[QuantifiedExpression(Atomizer(attribute::attribute(Public, xs:anyAtomicType)), ($qq:qq000 singleton eq false()))])) | ((/)/descendant::element(dummyNode, xs:anyType)))", query.nodeNameToXPaths.get(SaxonXPathRuleQuery.AST_ROOT).get(0).toString());
+    }
+
+    @Test
+    public void ruleChainVisitsMultipleFilters() {
+        SaxonXPathRuleQuery query = createQuery("//dummyNode[@Test1 = false()][@Test2 = true()]");
+        List<String> ruleChainVisits = query.getRuleChainVisits();
+        Assert.assertEquals(1, ruleChainVisits.size());
+        Assert.assertTrue(ruleChainVisits.contains("dummyNode"));
+        Assert.assertEquals(2, query.nodeNameToXPaths.size());
+        assertExpression("((self::node()[QuantifiedExpression(Atomizer(attribute::attribute(Test2, xs:anyAtomicType)), ($qq:qq1741979653 singleton eq true()))])[QuantifiedExpression(Atomizer(attribute::attribute(Test1, xs:anyAtomicType)), ($qq:qq1529060733 singleton eq false()))])", query.nodeNameToXPaths.get("dummyNode").get(0).toString());
+        assertExpression("((((/)/descendant::element(dummyNode, xs:anyType))[QuantifiedExpression(Atomizer(attribute::attribute(Test2, xs:anyAtomicType)), ($qq:qq1741979653 singleton eq true()))])[QuantifiedExpression(Atomizer(attribute::attribute(Test1, xs:anyAtomicType)), ($qq:qq1529060733 singleton eq false()))])", query.nodeNameToXPaths.get(SaxonXPathRuleQuery.AST_ROOT).get(0).toString());
+    }
+
+    @Test
+    public void ruleChainVisitsNested() {
+        SaxonXPathRuleQuery query = createQuery("//dummyNode/foo/*/bar[@Test = 'false']");
+        List<String> ruleChainVisits = query.getRuleChainVisits();
+        Assert.assertEquals(1, ruleChainVisits.size());
+        Assert.assertTrue(ruleChainVisits.contains("dummyNode"));
+        Assert.assertEquals(2, query.nodeNameToXPaths.size());
+        assertExpression("((((self::node()/child::element(foo, xs:anyType))/child::element())/child::element(bar, xs:anyType))[QuantifiedExpression(Atomizer(attribute::attribute(Test, xs:anyAtomicType)), ($qq:qq166794956 singleton eq \"false\"))])", query.nodeNameToXPaths.get("dummyNode").get(0).toString());
+        assertExpression("DocumentSorter(((((((/)/descendant::element(dummyNode, xs:anyType))/child::element(foo, xs:anyType))/child::element())/child::element(bar, xs:anyType))[QuantifiedExpression(Atomizer(attribute::attribute(Test, xs:anyAtomicType)), ($qq:qq166794956 singleton eq \"false\"))]))", query.nodeNameToXPaths.get(SaxonXPathRuleQuery.AST_ROOT).get(0).toString());
+    }
+
+    @Test
+    @Ignore("this case is not implemented yet")
+    public void ruleChainVisitsNested2() {
+        SaxonXPathRuleQuery query = createQuery("//dummyNode/foo[@Baz = 'a']/*/bar[@Test = 'false']");
+        List<String> ruleChainVisits = query.getRuleChainVisits();
+        Assert.assertEquals(1, ruleChainVisits.size());
+        Assert.assertTrue(ruleChainVisits.contains("dummyNode"));
+        Assert.assertEquals(2, query.nodeNameToXPaths.size());
+        assertExpression("(((((self::node()/child::element(foo, xs:anyType))[QuantifiedExpression(Atomizer(attribute::attribute(Baz, xs:anyAtomicType)), ($qq:qq306612792 singleton eq \"a\"))])/child::element())/child::element(bar, xs:anyType))[QuantifiedExpression(Atomizer(attribute::attribute(Test, xs:anyAtomicType)), ($qq:qq1803669141 singleton eq \"false\"))])", query.nodeNameToXPaths.get("dummyNode").get(0).toString());
+        assertExpression("DocumentSorter((((((((/)/descendant::element(dummyNode, xs:anyType))/child::element(foo, xs:anyType))[QuantifiedExpression(Atomizer(attribute::attribute(Baz, xs:anyAtomicType)), ($qq:qq306612792 singleton eq \"a\"))])/child::element())/child::element(bar, xs:anyType))[QuantifiedExpression(Atomizer(attribute::attribute(Test, xs:anyAtomicType)), ($qq:qq1803669141 singleton eq \"false\"))]))", query.nodeNameToXPaths.get(SaxonXPathRuleQuery.AST_ROOT).get(0).toString());
     }
 
     private static void assertExpression(String expected, String actual) {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQueryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQueryTest.java
@@ -117,9 +117,14 @@ public class SaxonXPathRuleQueryTest {
     }
 
     private static void assertExpression(String expected, Expression actual) {
-        Assert.assertEquals(expected.replaceAll("\\$qq:qq\\d+", "\\$qq:qq000").replaceAll("\\$zz:zz\\d+", "\\$zz:zz000"),
-                actual.toString().replaceAll("\\$qq:qq\\d+", "\\$qq:qq000").replaceAll("\\$zz:zz\\d+", "\\$zz:zz000"));
+        Assert.assertEquals(normalizeExprDump(expected),
+                            normalizeExprDump(actual.toString()));
         //Assert.assertEquals(expected, actual);
+    }
+
+    private static String normalizeExprDump(String dump) {
+        return dump.replaceAll("\\$qq:qq-?\\d+", "\\$qq:qq000")
+                   .replaceAll("\\$zz:zz-?\\d+", "\\$zz:zz000");
     }
 
     @Test


### PR DESCRIPTION
**PR Description:**

This uses now a custom visitor for Saxon expressions to analyze and modify the expression tree.
The existing rules still work as before.

Having this done would allow us, to migrate our own XPath 1.0 rules to XPath 2.0, without loosing any performance. Then we could issue a deprecation warning when XPath 1.0 is still used.

Note: I didn't do any performance comparisons... so I don't know, whether rulechain is really necessary here.

Refs #1687 

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)
