### PR TITLE
[java] Make TypeHelper use the class loading cache of ClassTypeResolver

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCompilationUnit.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCompilationUnit.java
@@ -60,6 +60,11 @@ public class ASTCompilationUnit extends AbstractJavaTypeNode implements RootNode
         return null;
     }
 
+    @Override
+    public ASTCompilationUnit getRoot() {
+        return this;
+    }
+
     /**
      * Returns the package name of this compilation unit. If this is in
      * the default package, returns the empty string.

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractJavaNode.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractJavaNode.java
@@ -15,6 +15,7 @@ public abstract class AbstractJavaNode extends AbstractJjtreeNode<JavaNode> impl
     protected JavaParser parser;
     private Scope scope;
     private Comment comment;
+    private ASTCompilationUnit root;
 
     @InternalApi
     @Deprecated
@@ -62,6 +63,14 @@ public abstract class AbstractJavaNode extends AbstractJjtreeNode<JavaNode> impl
             }
         }
         return data;
+    }
+
+    @Override
+    public ASTCompilationUnit getRoot() {
+        if (root == null) {
+            root = getParent().getRoot();
+        }
+        return root;
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaNode.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaNode.java
@@ -41,6 +41,7 @@ public interface JavaNode extends ScopedNode {
     @Deprecated
     Object childrenAccept(JavaParserVisitor visitor, Object data);
 
+    ASTCompilationUnit getRoot();
 
     @Override
     JavaNode getChild(int index);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/DuplicateImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/DuplicateImportsRule.java
@@ -66,7 +66,7 @@ public class DuplicateImportsRule extends AbstractJavaRule {
                         return true;
                     }
                 } else {
-                    Class<?> importClass = node.getClassTypeResolver().loadClass(thisImportOnDemand.getName());
+                    Class<?> importClass = node.getClassTypeResolver().loadClassOrNull(thisImportOnDemand.getName());
                     if (importClass != null) {
                         for (Method m : importClass.getMethods()) {
                             if (Modifier.isStatic(m.getModifiers()) && m.getName().equals(singleTypeName)) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -99,6 +99,7 @@ import net.sourceforge.pmd.lang.java.ast.JavaParserVisitorAdapter;
 import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.symboltable.ClassScope;
 import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
+import net.sourceforge.pmd.lang.java.typeresolution.internal.NullableClassLoader;
 import net.sourceforge.pmd.lang.java.typeresolution.typedefinition.JavaTypeDefinition;
 import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
 import net.sourceforge.pmd.lang.symboltable.Scope;
@@ -112,7 +113,7 @@ import net.sourceforge.pmd.lang.symboltable.Scope;
 
 @Deprecated
 @InternalApi
-public class ClassTypeResolver extends JavaParserVisitorAdapter {
+public class ClassTypeResolver extends JavaParserVisitorAdapter implements NullableClassLoader {
 
     private static final Logger LOG = Logger.getLogger(ClassTypeResolver.class.getName());
 
@@ -1487,8 +1488,13 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
         return pmdClassLoader.loadClassOrNull(fullyQualifiedClassName) != null;
     }
 
-    public Class<?> loadClass(String fullyQualifiedClassName) {
+    @Override
+    public Class<?> loadClassOrNull(String fullyQualifiedClassName) {
         return pmdClassLoader.loadClassOrNull(fullyQualifiedClassName);
+    }
+
+    public Class<?> loadClass(String fullyQualifiedClassName) {
+        return loadClassOrNull(fullyQualifiedClassName);
     }
 
     private Class<?> processOnDemand(String qualifiedName) {
@@ -1533,12 +1539,12 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter {
             String strPackage = anImportDeclaration.getPackageName();
             if (anImportDeclaration.isStatic()) {
                 if (anImportDeclaration.isImportOnDemand()) {
-                    importOnDemandStaticClasses.add(JavaTypeDefinition.forClass(loadClass(strPackage)));
+                    importOnDemandStaticClasses.add(JavaTypeDefinition.forClass(loadClassOrNull(strPackage)));
                 } else { // not import on-demand
                     String strName = anImportDeclaration.getImportedName();
                     String fieldName = strName.substring(strName.lastIndexOf('.') + 1);
 
-                    Class<?> staticClassWithField = loadClass(strPackage);
+                    Class<?> staticClassWithField = loadClassOrNull(strPackage);
                     if (staticClassWithField != null) {
                         JavaTypeDefinition typeDef = getFieldType(JavaTypeDefinition.forClass(staticClassWithField),
                                                                   fieldName, currentAcu.getType());

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/PMDASMClassLoader.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/PMDASMClassLoader.java
@@ -15,6 +15,7 @@ import java.util.concurrent.ConcurrentMap;
 import org.objectweb.asm.ClassReader;
 
 import net.sourceforge.pmd.annotation.InternalApi;
+import net.sourceforge.pmd.lang.java.typeresolution.internal.NullableClassLoader;
 import net.sourceforge.pmd.lang.java.typeresolution.visitors.PMDASMVisitor;
 
 /*
@@ -36,7 +37,7 @@ import net.sourceforge.pmd.lang.java.typeresolution.visitors.PMDASMVisitor;
  */
 @InternalApi
 @Deprecated
-public final class PMDASMClassLoader extends ClassLoader {
+public final class PMDASMClassLoader extends ClassLoader implements NullableClassLoader {
 
     private static PMDASMClassLoader cachedPMDASMClassLoader;
     private static ClassLoader cachedClassLoader;
@@ -81,6 +82,7 @@ public final class PMDASMClassLoader extends ClassLoader {
      * Not throwing CNFEs to represent failure makes a huge performance
      * difference. Typeres as a whole is 2x faster.
      */
+    @Override
     public Class<?> loadClassOrNull(String name) {
         if (dontBother.containsKey(name)) {
             return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelper.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelper.java
@@ -78,6 +78,10 @@ public final class TypeHelper {
      * @return <code>true</code> if type node n is of type clazzName or a subtype of clazzName
      */
     public static boolean isA(final TypeNode n, final String clazzName) {
+        if (n.getType() != null && n.getType().isAnnotation()) {
+            return isAnnotationSubtype(n, clazzName);
+        }
+
         final Class<?> clazz = loadClassWithNodeClassloader(n, clazzName);
 
         if (clazz != null || n.getType() != null) {
@@ -85,6 +89,15 @@ public final class TypeHelper {
         }
 
         return fallbackIsA(n, clazzName);
+    }
+
+    private static boolean isAnnotationSubtype(TypeNode n, String clazzName) {
+        // then, the supertype may only be Object, j.l.Annotation, or the class name
+        // this avoids classloading altogether
+        // this is used e.g. by the typeIs function in XPath
+        return clazzName.equals("java.lang.annotation.Annotation")
+            || clazzName.equals("java.lang.Object")
+            || clazzName.equals(n.getType().getName());
     }
 
     private static boolean fallbackIsA(TypeNode n, String clazzName) {
@@ -134,6 +147,11 @@ public final class TypeHelper {
      * @return <code>true</code> if type node n is exactly of type clazzName.
      */
     public static boolean isExactlyA(final TypeNode n, final String clazzName) {
+        if (n.getType() != null && n.getType().getName().equals(clazzName)) {
+            // fast path avoiding classloading
+            return true;
+        }
+
         final Class<?> clazz = loadClassWithNodeClassloader(n, clazzName);
 
         if (clazz != null) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelper.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelper.java
@@ -130,9 +130,11 @@ public final class TypeHelper {
             return "java.lang.Enum".equals(clazzName)
                 // supertypes of Enum
                 || "java.lang.Comparable".equals(clazzName)
-                || "java.io.Serializable".equals(clazzName);
+                || "java.io.Serializable".equals(clazzName)
+                || "java.lang.Object".equals(clazzName);
         } else if (n instanceof ASTAnnotationTypeDeclaration) {
-            return "java.lang.annotation.Annotation".equals(clazzName);
+            return "java.lang.annotation.Annotation".equals(clazzName)
+                || "java.lang.Object".equals(clazzName);
         }
 
         return false;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelper.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelper.java
@@ -276,7 +276,7 @@ public final class TypeHelper {
     public static boolean isA(TypedNameDeclaration vnd, String className) {
         Class<?> type = vnd.getType();
         if (type != null) {
-            Class<?> clazz = loadClass(new ClassLoaderWrapper(type.getClassLoader()), className);
+            Class<?> clazz = loadClass(ClassLoaderWrapper.wrapNullable(type.getClassLoader()), className);
             if (clazz != null) {
                 return clazz.isAssignableFrom(type);
             }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/internal/NullableClassLoader.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/internal/NullableClassLoader.java
@@ -13,7 +13,8 @@ public interface NullableClassLoader {
 
         private final ClassLoader classLoader;
 
-        public ClassLoaderWrapper(ClassLoader classLoader) {
+        private ClassLoaderWrapper(ClassLoader classLoader) {
+            assert classLoader != null : "Null classloader";
             this.classLoader = classLoader;
         }
 
@@ -24,6 +25,13 @@ public interface NullableClassLoader {
             } catch (ClassNotFoundException e) {
                 return null;
             }
+        }
+
+        public static ClassLoaderWrapper wrapNullable(ClassLoader classLoader) {
+            if (classLoader == null) {
+                classLoader = ClassLoader.getSystemClassLoader();
+            }
+            return new ClassLoaderWrapper(classLoader);
         }
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/internal/NullableClassLoader.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/internal/NullableClassLoader.java
@@ -1,0 +1,29 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.typeresolution.internal;
+
+public interface NullableClassLoader {
+
+    Class<?> loadClassOrNull(String binaryName);
+
+
+    class ClassLoaderWrapper implements NullableClassLoader {
+
+        private final ClassLoader classLoader;
+
+        public ClassLoaderWrapper(ClassLoader classLoader) {
+            this.classLoader = classLoader;
+        }
+
+        @Override
+        public Class<?> loadClassOrNull(String binaryName) {
+            try {
+                return classLoader.loadClass(binaryName);
+            } catch (ClassNotFoundException e) {
+                return null;
+            }
+        }
+    }
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/internal/NullableClassLoader.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/internal/NullableClassLoader.java
@@ -4,8 +4,20 @@
 
 package net.sourceforge.pmd.lang.java.typeresolution.internal;
 
+import net.sourceforge.pmd.lang.java.typeresolution.PMDASMClassLoader;
+
+/**
+ * A classloader that doesn't throw a {@link ClassNotFoundException}
+ * to report unresolved classes. This is a big performance improvement
+ * for {@link PMDASMClassLoader}, which caches negative cases.
+ *
+ * <p>See https://github.com/pmd/pmd/pull/2236
+ */
 public interface NullableClassLoader {
 
+    /**
+     * Load a class from its binary name. Returns null if not found.
+     */
     Class<?> loadClassOrNull(String binaryName);
 
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelperTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelperTest.java
@@ -4,20 +4,30 @@
 
 package net.sourceforge.pmd.lang.java.typeresolution;
 
+import static net.sourceforge.pmd.lang.java.typeresolution.internal.NullableClassLoader.ClassLoaderWrapper.wrapNullable;
+
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotationTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTEnumDeclaration;
 import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.symboltable.BaseNonParserTest;
+import net.sourceforge.pmd.lang.java.typeresolution.internal.NullableClassLoader;
 
 public class TypeHelperTest extends BaseNonParserTest {
 
+    private static final NullableClassLoader LOADER = wrapNullable(TypeHelperTest.class.getClassLoader());
+
+    @Rule
+    public final ExpectedException expect = ExpectedException.none();
 
     @Test
     public void testIsAFallback() {
@@ -69,13 +79,53 @@ public class TypeHelperTest extends BaseNonParserTest {
     }
 
     private void assertIsA(TypeNode node, Class<?> type) {
-        Assert.assertTrue(TypeHelper.isA(node, type));
-        Assert.assertTrue(TypeHelper.isA(node, type.getCanonicalName()));
+        Assert.assertTrue("TypeHelper::isA with class arg: " + type.getCanonicalName(),
+                          TypeHelper.isA(node, type));
+        Assert.assertTrue("TypeHelper::isA with string arg: " + type.getCanonicalName(),
+                          TypeHelper.isA(node, type.getCanonicalName()));
     }
 
     private void assertIsExactlyA(TypeNode node, Class<?> type) {
         Assert.assertTrue(TypeHelper.isExactlyA(node, type.getCanonicalName()));
         assertIsA(node, type);
+    }
+
+
+    @Test
+    public void testNestedClass() {
+        Class<?> c = TypeHelper.loadClass(LOADER, "java.util.Map.Entry");
+        Assert.assertEquals(Map.Entry.class, c);
+    }
+
+
+    @Test
+    public void testPrimitiveArray() {
+        Class<?> c = TypeHelper.loadClass(LOADER, "int[ ]");
+        Assert.assertEquals(int[].class, c);
+    }
+
+    @Test
+    public void testNestedClassArray() {
+        Class<?> c = TypeHelper.loadClass(LOADER, "java.util.Map.Entry[ ]");
+        Assert.assertEquals(Map.Entry[].class, c);
+    }
+
+    @Test
+    public void testInvalidName() {
+        expect.expect(IllegalArgumentException.class);
+        TypeHelper.loadClass(LOADER, "java.util.Map ]");
+    }
+
+    @Test
+    public void testInvalidName2() {
+        expect.expect(IllegalArgumentException.class);
+        TypeHelper.loadClass(LOADER, "[]");
+    }
+
+    @Test
+    public void testNullName() {
+        expect.expect(NullPointerException.class);
+        TypeHelper.loadClass(LOADER, null);
     }
 
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelperTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelperTest.java
@@ -13,6 +13,7 @@ import org.junit.Test;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotationTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTEnumDeclaration;
+import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.symboltable.BaseNonParserTest;
 
 public class TypeHelperTest extends BaseNonParserTest {
@@ -46,11 +47,10 @@ public class TypeHelperTest extends BaseNonParserTest {
 
         Assert.assertNull(klass.getType());
         Assert.assertTrue(TypeHelper.isA(klass, "org.FooBar"));
-        Assert.assertTrue(TypeHelper.isA(klass, "java.lang.Iterable"));
-        Assert.assertTrue(TypeHelper.isA(klass, Iterable.class));
-        Assert.assertTrue(TypeHelper.isA(klass, Enum.class));
-        Assert.assertTrue(TypeHelper.isA(klass, Serializable.class));
-        Assert.assertTrue(TypeHelper.isA(klass, Comparable.class));
+        assertIsA(klass, Iterable.class);
+        assertIsA(klass, Enum.class);
+        assertIsA(klass, Serializable.class);
+        assertIsA(klass, Object.class);
     }
 
     @Test
@@ -64,8 +64,18 @@ public class TypeHelperTest extends BaseNonParserTest {
 
         Assert.assertNull(klass.getType());
         Assert.assertTrue(TypeHelper.isA(klass, "org.FooBar"));
-        Assert.assertTrue(TypeHelper.isA(klass, Annotation.class));
+        assertIsA(klass, Annotation.class);
+        assertIsA(klass, Object.class);
     }
 
+    private void assertIsA(TypeNode node, Class<?> type) {
+        Assert.assertTrue(TypeHelper.isA(node, type));
+        Assert.assertTrue(TypeHelper.isA(node, type.getCanonicalName()));
+    }
+
+    private void assertIsExactlyA(TypeNode node, Class<?> type) {
+        Assert.assertTrue(TypeHelper.isExactlyA(node, type.getCanonicalName()));
+        assertIsA(node, type);
+    }
 
 }


### PR DESCRIPTION
* Makes TypeHelper profit from #2236, by making it reuse the ClassTypeResolver cache. This improves performance when the classpath is *incomplete* (fewer ClassNotFoundExceptions thrown)
* Also add a fast-path for subtyping checks for annotations. An annotation only has Object and j.l.annotation.Annotation as strict supertypes. This applies only when the classpath is reasonably complete, ie when the annotation type is resolved. Note that for a project that doesn't use annotation-heavy frameworks, the `@Override` annotation is overwhelmingly the most used, and it is always resolved since it's in java.base

This should fix #2378 


### Comparison on PMD sources
(meaning, classpath is complete)

* master:
```
* errors:   30
* warnings: 1551
--------------------------------------------<<< Rule >>>--------------------------------------------
Label                                              Time (secs) Self Time (secs)  # Calls     Counter

JUnitAssertionsShouldIncludeMessage                     5,8922           5,8922    2 404
JUnitTestsShouldIncludeAssert                           6,3667           6,3667    2 404

Total Rule                                             12,2589          12,2589
```

![Capture d’écran de 2020-03-23 21-11-36](https://user-images.githubusercontent.com/24524930/77359488-ed558100-6d4b-11ea-90f0-b477580b06e6.png)

* this branch
```

* errors:   30
* warnings: 1551
--------------------------------------------<<< Rule >>>--------------------------------------------
Label                                              Time (secs) Self Time (secs)  # Calls     Counter

JUnitAssertionsShouldIncludeMessage                     0,3643           0,3643    2 405
JUnitTestsShouldIncludeAssert                           0,6443           0,6443    2 405

Total Rule                                              1,0086           1,0086
```
![Capture d’écran de 2020-03-23 21-11-16](https://user-images.githubusercontent.com/24524930/77359479-ea5a9080-6d4b-11ea-8b0d-c67a8b169a9f.png)

### Comparison on Spring framework sources

without setting the classpath (many unresolved annotations)

* master
```
* warnings: 34919
--------------------------------------------<<< Rule >>>--------------------------------------------
Label                                              Time (secs) Self Time (secs)  # Calls     Counter

JUnitAssertionsShouldIncludeMessage                    10,1484          10,1484    6 921
JUnitTestsShouldIncludeAssert                          12,9338          12,9338    6 921

Total Rule                                             23,0822          23,0822
```

![Capture d’écran de 2020-03-23 21-31-40](https://user-images.githubusercontent.com/24524930/77360626-fe06f680-6d4d-11ea-820f-73fdaefe6da6.png)

![Capture d’écran de 2020-03-23 21-32-11](https://user-images.githubusercontent.com/24524930/77360596-f2b3cb00-6d4d-11ea-9e0e-21dce40469b0.png)

* this branch
```

* warnings: 34919
--------------------------------------------<<< Rule >>>--------------------------------------------
Label                                              Time (secs) Self Time (secs)  # Calls     Counter

JUnitAssertionsShouldIncludeMessage                     1,2688           1,2688    6 921
JUnitTestsShouldIncludeAssert                           3,0035           3,0035    6 921

Total Rule                                              4,2723           4,2723
```



![Capture d’écran de 2020-03-23 21-34-14](https://user-images.githubusercontent.com/24524930/77360774-3eff0b00-6d4e-11ea-826d-8b8faa90a2a6.png)
![Capture d’écran de 2020-03-23 21-35-28](https://user-images.githubusercontent.com/24524930/77360796-4faf8100-6d4e-11ea-8622-c273019ad20a.png)
 