### PR TITLE
[core] Saxon rulechain excludes for path expressions

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQuery.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQuery.java
@@ -77,7 +77,7 @@ public class SaxonXPathRuleQuery extends AbstractXPathRuleQuery {
     /**
      * Representation of an XPath query, created at {@link #initializeXPathExpression()} using {@link #xpath}.
      */
-    private XPathExpression xpathExpression;
+    XPathExpression xpathExpression;
 
     /**
      * Holds the static context later used to match the variables in the dynamic context in

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/ExpressionPrinter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/ExpressionPrinter.java
@@ -20,7 +20,7 @@ import net.sf.saxon.om.Axis;
  * printer.visit(query.xpathExpression.getInternalExpression());
  * </pre>
  */
-public class ExpressionPrinter extends Visitor {
+public class ExpressionPrinter extends SaxonExprVisitor {
     private int depth = 0;
 
     private void print(String s) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/ExpressionPrinter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/ExpressionPrinter.java
@@ -13,6 +13,12 @@ import net.sf.saxon.om.Axis;
 
 /**
  * Simple printer for saxon expressions. Might be useful for debugging / during development.
+ *
+ * <p>Example:
+ * <pre>
+ * ExpressionPrinter printer = new ExpressionPrinter();
+ * printer.visit(query.xpathExpression.getInternalExpression());
+ * </pre>
  */
 public class ExpressionPrinter extends Visitor {
     private int depth = 0;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/RuleChainAnalyzer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/RuleChainAnalyzer.java
@@ -34,7 +34,7 @@ import net.sf.saxon.type.Type;
  * <p>DocumentSorter expression is removed. The sorting of the resulting nodes needs to be done
  * after all (sub)expressions have been executed.
  */
-public class RuleChainAnalyzer extends Visitor {
+public class RuleChainAnalyzer extends SaxonExprVisitor {
     private final Configuration configuration;
     private String rootElement;
     private boolean rootElementReplaced;
@@ -107,9 +107,10 @@ public class RuleChainAnalyzer extends Visitor {
 
     @Override
     public Expression visit(LazyExpression e) {
+        boolean prevCtx = insideLazyExpression;
         insideLazyExpression = true;
         Expression result = super.visit(e);
-        insideLazyExpression = false;
+        insideLazyExpression = prevCtx;
         return result;
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/RuleChainAnalyzer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/RuleChainAnalyzer.java
@@ -13,6 +13,7 @@ import net.sf.saxon.Configuration;
 import net.sf.saxon.expr.AxisExpression;
 import net.sf.saxon.expr.Expression;
 import net.sf.saxon.expr.FilterExpression;
+import net.sf.saxon.expr.LazyExpression;
 import net.sf.saxon.expr.PathExpression;
 import net.sf.saxon.expr.RootExpression;
 import net.sf.saxon.om.Axis;
@@ -92,6 +93,15 @@ public class RuleChainAnalyzer extends Visitor {
             } else if (test.getPrimitiveType() == Type.ELEMENT && e.getAxis() == Axis.CHILD) {
                 rootElement = configuration.getNamePool().getClarkName(test.getFingerprint());
             }
+        }
+        return super.visit(e);
+    }
+
+    @Override
+    public Expression visit(LazyExpression e) {
+        if (e.getBaseExpression() instanceof PathExpression) {
+            this.rootElement = null;
+            return e;
         }
         return super.visit(e);
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonExprVisitor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonExprVisitor.java
@@ -16,7 +16,7 @@ import net.sf.saxon.expr.RootExpression;
 import net.sf.saxon.expr.VennExpression;
 import net.sf.saxon.sort.DocumentSorter;
 
-abstract class Visitor {
+abstract class SaxonExprVisitor {
     public Expression visit(DocumentSorter e) {
         Expression base = visit(e.getBaseExpression());
         return new DocumentSorter(base);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SplitUnions.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SplitUnions.java
@@ -17,7 +17,7 @@ import net.sf.saxon.expr.VennExpression;
  * 
  * <p>E.g. "//A | //B | //C" will result in 3 expressions "//A", "//B", and "//C".
  */
-class SplitUnions extends Visitor {
+class SplitUnions extends SaxonExprVisitor {
     private List<Expression> expressions = new ArrayList<>();
 
     @Override

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/Visitor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/Visitor.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.rule.xpath.internal;
 
 import net.sf.saxon.expr.AxisExpression;
+import net.sf.saxon.expr.BooleanExpression;
 import net.sf.saxon.expr.Expression;
 import net.sf.saxon.expr.FilterExpression;
 import net.sf.saxon.expr.LazyExpression;
@@ -69,6 +70,13 @@ abstract class Visitor {
         return LazyExpression.makeLazyExpression(base);
     }
 
+    public Expression visit(BooleanExpression e) {
+        final Expression[] operands = e.getOperands();
+        Expression operand0 = visit(operands[0]);
+        Expression operand1 = visit(operands[1]);
+        return new BooleanExpression(operand0, e.getOperator(), operand1);
+    }
+
     public Expression visit(Expression expr) {
         Expression result;
         if (expr instanceof DocumentSorter) {
@@ -89,6 +97,8 @@ abstract class Visitor {
             result = visit((LetExpression) expr);
         } else if (expr instanceof LazyExpression) {
             result = visit((LazyExpression) expr);
+        } else if (expr instanceof BooleanExpression) {
+            result = visit((BooleanExpression) expr);
         } else {
             result = expr;
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/Visitor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/Visitor.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.rule.xpath.internal;
 import net.sf.saxon.expr.AxisExpression;
 import net.sf.saxon.expr.Expression;
 import net.sf.saxon.expr.FilterExpression;
+import net.sf.saxon.expr.LazyExpression;
 import net.sf.saxon.expr.LetExpression;
 import net.sf.saxon.expr.PathExpression;
 import net.sf.saxon.expr.QuantifiedExpression;
@@ -63,6 +64,11 @@ abstract class Visitor {
         return result;
     }
 
+    public Expression visit(LazyExpression e) {
+        Expression base = visit(e.getBaseExpression());
+        return LazyExpression.makeLazyExpression(base);
+    }
+
     public Expression visit(Expression expr) {
         Expression result;
         if (expr instanceof DocumentSorter) {
@@ -81,6 +87,8 @@ abstract class Visitor {
             result = visit((QuantifiedExpression) expr);
         } else if (expr instanceof LetExpression) {
             result = visit((LetExpression) expr);
+        } else if (expr instanceof LazyExpression) {
+            result = visit((LazyExpression) expr);
         } else {
             result = expr;
         }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageModule.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageModule.java
@@ -19,11 +19,13 @@ import net.sourceforge.pmd.RuleViolation;
 import net.sourceforge.pmd.lang.ast.DummyNode;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.ast.ParseException;
+import net.sourceforge.pmd.lang.ast.xpath.AbstractASTXPathHandler;
 import net.sourceforge.pmd.lang.ast.xpath.DocumentNavigator;
 import net.sourceforge.pmd.lang.rule.AbstractRuleChainVisitor;
 import net.sourceforge.pmd.lang.rule.AbstractRuleViolationFactory;
 import net.sourceforge.pmd.lang.rule.ParametricRuleViolation;
 
+import net.sf.saxon.expr.XPathContext;
 import net.sf.saxon.sxpath.IndependentContext;
 
 /**
@@ -67,11 +69,18 @@ public class DummyLanguageModule extends BaseLanguageModule {
     }
 
     public static class Handler extends AbstractLanguageVersionHandler {
+        public static class TestFunctions {
+            public static boolean typeIs(final XPathContext context, final String fullTypeName) {
+                return false;
+            }
+        }
+
         @Override
         public XPathHandler getXPathHandler() {
-            return new XPathHandler() {
+            return new AbstractASTXPathHandler() {
                 @Override
                 public void initialize(IndependentContext context) {
+                    super.initialize(context, LanguageRegistry.getLanguage(DummyLanguageModule.NAME), TestFunctions.class);
                 }
 
                 @Override

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQueryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQueryTest.java
@@ -70,7 +70,6 @@ public class SaxonXPathRuleQueryTest {
         Assert.assertEquals(1, ruleChainVisits.size());
         Assert.assertTrue(ruleChainVisits.contains("dummyNode"));
         Assert.assertEquals(2, query.nodeNameToXPaths.size());
-        System.out.println(query.nodeNameToXPaths);
         assertExpression("(self::node()[pmd-dummy:typeIs(CardinalityChecker(ItemChecker(UntypedAtomicConverter(Atomizer(attribute::attribute(Image, xs:anyAtomicType))))))])", query.nodeNameToXPaths.get("dummyNode").get(0));
         assertExpression("DocumentSorter((((/)/descendant-or-self::node())/(child::element(dummyNode, xs:anyType)[pmd-dummy:typeIs(CardinalityChecker(ItemChecker(UntypedAtomicConverter(Atomizer(attribute::attribute(Image, xs:anyAtomicType))))))])))", query.nodeNameToXPaths.get(SaxonXPathRuleQuery.AST_ROOT).get(0));
     }
@@ -93,6 +92,13 @@ public class SaxonXPathRuleQueryTest {
         Assert.assertEquals(0, ruleChainVisits.size());
         Assert.assertEquals(1, query.nodeNameToXPaths.size());
         assertExpression("LetExpression(LazyExpression(((/)/descendant::element(ClassOrInterfaceType, xs:anyType))), (((/)/descendant::element(dummyNode, xs:anyType))[(ancestor::element(ClassOrInterfaceDeclaration, xs:anyType)[$zz:zz106374177])]))", query.nodeNameToXPaths.get(SaxonXPathRuleQuery.AST_ROOT).get(0));
+
+        // third example, with boolean expr
+        query = createQuery("//dummyNode[//ClassOrInterfaceType or //OtherNode]");
+        ruleChainVisits = query.getRuleChainVisits();
+        Assert.assertEquals(0, ruleChainVisits.size());
+        Assert.assertEquals(1, query.nodeNameToXPaths.size());
+        assertExpression("LetExpression(LazyExpression((((/)/descendant::element(ClassOrInterfaceType, xs:anyType)) or ((/)/descendant::element(OtherNode, xs:anyType)))), (((/)/descendant::element(dummyNode, xs:anyType))[$zz:zz1364913072]))", query.nodeNameToXPaths.get(SaxonXPathRuleQuery.AST_ROOT).get(0));
     }
 
     @Test

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQueryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQueryTest.java
@@ -18,7 +18,6 @@ import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
 
 import net.sf.saxon.expr.Expression;
-import net.sf.saxon.expr.XPathContext;
 
 public class SaxonXPathRuleQueryTest {
 
@@ -64,10 +63,36 @@ public class SaxonXPathRuleQueryTest {
         assertExpression("((((/)/descendant::element(dummyNode, xs:anyType))[QuantifiedExpression(Atomizer(attribute::attribute(Test2, xs:anyAtomicType)), ($qq:qq1741979653 singleton eq true()))])[QuantifiedExpression(Atomizer(attribute::attribute(Test1, xs:anyAtomicType)), ($qq:qq1529060733 singleton eq false()))])", query.nodeNameToXPaths.get(SaxonXPathRuleQuery.AST_ROOT).get(0));
     }
 
-    public static class TestFunctions {
-        public static boolean typeIs(final XPathContext context, final String fullTypeName) {
-            return false;
-        }
+    @Test
+    public void ruleChainVisitsCustomFunctions() {
+        SaxonXPathRuleQuery query = createQuery("//dummyNode[pmd-dummy:typeIs(@Image)]");
+        List<String> ruleChainVisits = query.getRuleChainVisits();
+        Assert.assertEquals(1, ruleChainVisits.size());
+        Assert.assertTrue(ruleChainVisits.contains("dummyNode"));
+        Assert.assertEquals(2, query.nodeNameToXPaths.size());
+        System.out.println(query.nodeNameToXPaths);
+        assertExpression("(self::node()[pmd-dummy:typeIs(CardinalityChecker(ItemChecker(UntypedAtomicConverter(Atomizer(attribute::attribute(Image, xs:anyAtomicType))))))])", query.nodeNameToXPaths.get("dummyNode").get(0));
+        assertExpression("DocumentSorter((((/)/descendant-or-self::node())/(child::element(dummyNode, xs:anyType)[pmd-dummy:typeIs(CardinalityChecker(ItemChecker(UntypedAtomicConverter(Atomizer(attribute::attribute(Image, xs:anyAtomicType))))))])))", query.nodeNameToXPaths.get(SaxonXPathRuleQuery.AST_ROOT).get(0));
+    }
+
+    /**
+     * If a query contains another unbounded path expression other than the first one, it must be
+     * excluded from rule chain execution. Saxon itself optimizes this quite good already.
+     */
+    @Test
+    public void ruleChainVisitsUnboundedPathExpressions() {
+        SaxonXPathRuleQuery query = createQuery("//dummyNode[//ClassOrInterfaceType]");
+        List<String> ruleChainVisits = query.getRuleChainVisits();
+        Assert.assertEquals(0, ruleChainVisits.size());
+        Assert.assertEquals(1, query.nodeNameToXPaths.size());
+        assertExpression("LetExpression(LazyExpression(((/)/descendant::element(ClassOrInterfaceType, xs:anyType))), (((/)/descendant::element(dummyNode, xs:anyType))[$zz:zz771775563]))", query.nodeNameToXPaths.get(SaxonXPathRuleQuery.AST_ROOT).get(0));
+
+        // second sample, more complex
+        query = createQuery("//dummyNode[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType]]");
+        ruleChainVisits = query.getRuleChainVisits();
+        Assert.assertEquals(0, ruleChainVisits.size());
+        Assert.assertEquals(1, query.nodeNameToXPaths.size());
+        assertExpression("LetExpression(LazyExpression(((/)/descendant::element(ClassOrInterfaceType, xs:anyType))), (((/)/descendant::element(dummyNode, xs:anyType))[(ancestor::element(ClassOrInterfaceDeclaration, xs:anyType)[$zz:zz106374177])]))", query.nodeNameToXPaths.get(SaxonXPathRuleQuery.AST_ROOT).get(0));
     }
 
     @Test


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

This doesn't optimize rules that use a separate unbounded path expression. It assumes, that Saxon has factored it out already into a own let/lazyexpression. In that case, if any path expression in such a lazy expression is found, rule chain is not used.

This fixes the performance issues found in #2377 
