### PR TITLE
[apex] Fix invalid apex in documentation

### DIFF
--- a/pmd-apex/src/main/resources/category/apex/bestpractices.xml
+++ b/pmd-apex/src/main/resources/category/apex/bestpractices.xml
@@ -24,7 +24,7 @@ improves the readability of test output.
             <![CDATA[
 @isTest
 public class Foo {
-     @isTest
+    @isTest
     static void methodATest() {
         System.assertNotEquals('123', o.StageName); // not good
         System.assertEquals('123', o.StageName, 'Opportunity stageName is wrong.'); // good
@@ -50,12 +50,12 @@ with messages provide the developer a clearer idea of what the test does.
 <![CDATA[
 @isTest
 public class Foo {
-   public static testMethod void testSomething() {
-      Account a = null;
-   // This is better than having a NullPointerException
-   // System.assertNotEquals(a, null, 'account not found');
-   a.toString();
-   }
+    public static testMethod void testSomething() {
+        Account a = null;
+        // This is better than having a NullPointerException
+        // System.assertNotEquals(a, null, 'account not found');
+        a.toString();
+    }
 }
 ]]>
         </example>
@@ -106,12 +106,12 @@ Apex unit tests should not use @isTest(seeAllData=true) because it opens up the 
 <![CDATA[
 @isTest(seeAllData = true)
 public class Foo {
-   public static testMethod void testSomething() {
-      Account a = null;
-   // This is better than having a NullPointerException
-   // System.assertNotEquals(a, null, 'account not found');
-   a.toString();
-   }
+    public static testMethod void testSomething() {
+        Account a = null;
+        // This is better than having a NullPointerException
+        // System.assertNotEquals(a, null, 'account not found');
+        a.toString();
+    }
 }
 ]]>
         </example>

--- a/pmd-apex/src/main/resources/category/apex/design.xml
+++ b/pmd-apex/src/main/resources/category/apex/design.xml
@@ -385,11 +385,11 @@ city/state/zip fields could park them within a single Address field.
 <![CDATA[
 public class Person {
     // too many separate fields
-    int birthYear;
-    int birthMonth;
-    int birthDate;
-    float height;
-    float weight;
+    Integer birthYear;
+    Integer birthMonth;
+    Integer birthDate;
+    Double height;
+    Double weight;
 }
 
 public class Person {

--- a/pmd-apex/src/main/resources/category/apex/design.xml
+++ b/pmd-apex/src/main/resources/category/apex/design.xml
@@ -192,7 +192,7 @@ same datatype. These situations usually denote the need for new objects to wrap 
         <example>
 <![CDATA[
 // too many arguments liable to be mixed up
-public void addPerson(int birthYear, int birthMonth, int birthDate, int height, int weight, int ssn) {
+public void addPerson(Integer birthYear, Integer birthMonth, Integer birthDate, Integer height, Integer weight, Integer ssn) {
     // ...
 }
 // preferred approach

--- a/pmd-apex/src/main/resources/category/apex/design.xml
+++ b/pmd-apex/src/main/resources/category/apex/design.xml
@@ -121,7 +121,10 @@ public class Foo {
         if (a.Phone == null) {                          // +1
             a.Phone = phone;
             update a;
+            return true;
         }
+
+        return false;
     }
 
     // Has a cognitive complexity of 5

--- a/pmd-apex/src/main/resources/category/apex/design.xml
+++ b/pmd-apex/src/main/resources/category/apex/design.xml
@@ -275,8 +275,8 @@ lines of code that are split are counted as one.
 <![CDATA[
 public class Foo extends Bar {
     //this method only has 1 NCSS lines
-    public Integer methd() {
-        super.methd();
+    public Integer method() {
+        super.method();
 
 
 

--- a/pmd-apex/src/main/resources/category/apex/errorprone.xml
+++ b/pmd-apex/src/main/resources/category/apex/errorprone.xml
@@ -199,9 +199,9 @@ Empty block statements serve no purpose and should be removed.
 <![CDATA[
 public class Foo {
 
-   private int _bar;
+   private Integer _bar;
 
-   public void setBar(int bar) {
+   public void setBar(Integer bar) {
         // empty
    }
 
@@ -244,7 +244,7 @@ public class Foo {
 public class Foo {
     public void bar() {
         try {
-            int x=2;
+            Integer x=2;
         } finally {
             // empty!
         }

--- a/pmd-apex/src/main/resources/category/apex/errorprone.xml
+++ b/pmd-apex/src/main/resources/category/apex/errorprone.xml
@@ -72,7 +72,7 @@ Avoid directly accessing Trigger.old and Trigger.new as it can lead to a bug. Tr
 trigger AccountTrigger on Account (before insert, before update) {
    Account a = Trigger.new[0]; //Bad: Accessing the trigger array directly is not recommended.
 
-   for ( Account a : Trigger.new ){
+   for ( Account a : Trigger.new ) {
         //Good: Iterate through the trigger.new array instead.
    }
 }
@@ -96,9 +96,9 @@ the logic can dynamically identify the proper data to operate against and not fa
 public without sharing class Foo {
     void foo() {
         //Error - hardcoded the record type id
-        if(a.RecordTypeId == '012500000009WAr'){
+        if (a.RecordTypeId == '012500000009WAr') {
             //do some logic here.....
-        } else if(a.RecordTypeId == '0123000000095Km'){
+        } else if (a.RecordTypeId == '0123000000095Km') {
             //do some logic here for a different record type...
         }
     }
@@ -131,12 +131,12 @@ or reported.
         <example>
 <![CDATA[
 public void doSomething() {
-  ...
-  try {
-    insert accounts;
-  } catch (DmlException dmle) {
-    // not good
-  }
+    ...
+    try {
+        insert accounts;
+    } catch (DmlException dmle) {
+        // not good
+    }
 }
 ]]>
         </example>
@@ -165,11 +165,11 @@ Empty If Statement finds instances where a condition is checked but nothing is d
         <example>
 <![CDATA[
 public class Foo {
-  public void bar(Integer x) {
-    if (x == 0) {
-      // empty!
+    public void bar(Integer x) {
+        if (x == 0) {
+            // empty!
+        }
     }
-  }
 }
 ]]>
         </example>


### PR DESCRIPTION
<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

@rsoesemann spotted in #2358 that some of the examples in the apex rules documentation are wrong. This fixes all the ones I spotted (there are some more that won't compile because they refer to variables that don't exist, but I think they are okay to leave as is).

Closes #2358.
