### PR TITLE
[java] Forbid type params for compact record constructors

### DIFF
--- a/pmd-java/etc/grammar/Java.jjt
+++ b/pmd-java/etc/grammar/Java.jjt
@@ -1160,7 +1160,7 @@ void RecordBodyDeclaration() #void :
 private void RecordCtorLookahead() #void:
 {}
 {
-    Modifiers() [ TypeParameters() ] <IDENTIFIER> ("throws" |  "{")
+    Modifiers() <IDENTIFIER> "{"
 }
 
 void RecordConstructorDeclaration():
@@ -1169,7 +1169,6 @@ void RecordConstructorDeclaration():
 }
 {
   modifiers = Modifiers() { jjtThis.setModifiers(modifiers); }
-  [TypeParameters()]
   <IDENTIFIER> { jjtThis.setImage(token.image); }
   Block()
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTRecordConstructorDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTRecordConstructorDeclaration.java
@@ -14,7 +14,6 @@ import net.sourceforge.pmd.annotation.Experimental;
  *
  * RecordConstructorDeclaration ::=  ({@linkplain ASTAnnotation Annotation})*
  *                                   RecordModifiers
- *                                   {@linkplain ASTTypeParameters TypeParameters}?
  *                                   &lt;IDENTIFIER&gt;
  *                                   {@link ASTBlock Block}
  *


### PR DESCRIPTION
Type parameters are not allowed on compact record constructors. See the [latest JLS draft](https://cr.openjdk.java.net/~gbierman/jep359/jep359-20200115/specs/records-jls.html#jls-8.10.5)