### PR TITLE
[java] Fix UseDiamondOperator false positive inside lambda

### DIFF
--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1977,7 +1977,7 @@ which makes the code also more readable.
 //StatementExpression[AssignmentOperator and PrimaryExpression/PrimaryPrefix[not(Expression)]]
 )
 /Expression/PrimaryExpression[not(PrimarySuffix) and not(ancestor::ArgumentList)]
-/PrimaryPrefix/AllocationExpression[@AnonymousClass=false() and ClassOrInterfaceType/TypeArguments[@Diamond=false()]]
+/PrimaryPrefix/AllocationExpression[@AnonymousClass=false() and ClassOrInterfaceType/TypeArguments[@Diamond=false() and not(TypeArgument//TypeArguments)]]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1977,7 +1977,11 @@ which makes the code also more readable.
 //StatementExpression[AssignmentOperator and PrimaryExpression/PrimaryPrefix[not(Expression)]]
 )
 /Expression/PrimaryExpression[not(PrimarySuffix) and not(ancestor::ArgumentList)]
-/PrimaryPrefix/AllocationExpression[@AnonymousClass=false() and ClassOrInterfaceType/TypeArguments[@Diamond=false() and not(TypeArgument//TypeArguments)]]
+/PrimaryPrefix
+/AllocationExpression
+    [@AnonymousClass=false()]
+    [ClassOrInterfaceType/TypeArguments[@Diamond=false() and not(TypeArgument//TypeArguments)]]
+    [not(ArrayDimsAndInits)]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1967,18 +1967,17 @@ which makes the code also more readable.
         </description>
         <priority>3</priority>
         <properties>
+            <property name="version" value="2.0" />
             <property name="xpath">
                 <value>
                     <![CDATA[
-//VariableInitializer[preceding-sibling::VariableDeclaratorId[1]/@TypeInferred="false"]
-//PrimaryExpression[not(PrimarySuffix)]
-[not(ancestor::ArgumentList)]
-/PrimaryPrefix/AllocationExpression[ClassOrInterfaceType[@AnonymousClass='false']/TypeArguments//ReferenceType[not(.//TypeArguments)]]
+(
+//VariableInitializer[preceding-sibling::VariableDeclaratorId[1]/@TypeInferred=false()]
 |
-//StatementExpression[AssignmentOperator][PrimaryExpression/PrimaryPrefix[not(Expression)]]
-//PrimaryExpression[not(PrimarySuffix)]
-[not(ancestor::ArgumentList)]
-/PrimaryPrefix/AllocationExpression[ClassOrInterfaceType[@AnonymousClass='false']/TypeArguments//ReferenceType[not(.//TypeArguments)]]
+//StatementExpression[AssignmentOperator and PrimaryExpression/PrimaryPrefix[not(Expression)]]
+)
+/Expression/PrimaryExpression[not(PrimarySuffix) and not(ancestor::ArgumentList)]
+/PrimaryPrefix/AllocationExpression[@AnonymousClass=false() and ClassOrInterfaceType/TypeArguments[@Diamond=false()]]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UseDiamondOperator.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UseDiamondOperator.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<test-data
-        xmlns="http://pmd.sourceforge.net/rule-tests"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
-    <test-code>
-        <description>Use Diamond</description>
-        <expected-problems>2</expected-problems>
-        <expected-linenumbers>6,8</expected-linenumbers>
-        <code><![CDATA[
+<test-data xmlns="http://pmd.sourceforge.net/rule-tests"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+   <test-code>
+      <description>Use Diamond</description>
+      <expected-problems>3</expected-problems>
+      <expected-linenumbers>6,9,10</expected-linenumbers>
+      <code><![CDATA[
 import java.util.ArrayList;
 import java.util.List;
 public class Foo {
@@ -15,15 +14,19 @@ public class Foo {
     public void foo() {
        List<String> strings = new ArrayList<String>();
        List<String> strings2 = new ArrayList<>();
+       List<List<String>> strings3 = new ArrayList<>();
+       List<List<String>> strings4 = new ArrayList<List<List<String>>>();
        this.field = new ArrayList<String>();
     }
 }
-     ]]></code>
-    </test-code>
-    <test-code>
-        <description>False positive cases: anonymous classes, methods calls</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
+        ]]></code>
+   </test-code>
+
+   <test-code>
+      <description>False positive cases: anonymous classes, methods calls</description>
+      <expected-problems>1</expected-problems>
+      <expected-linenumbers>27</expected-linenumbers>
+      <code><![CDATA[
 public class Foo {
     private WeakReference<Class<?>> typeReference;
     public void foo() {
@@ -58,12 +61,13 @@ public class Foo {
     }
 }
         ]]></code>
-    </test-code>
-     <test-code>
-        <description>#1624[java] UseDiamondOperator doesn't work with var</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>6</expected-linenumbers>
-        <code><![CDATA[
+   </test-code>
+
+   <test-code>
+      <description>#1624[java] UseDiamondOperator doesn't work with var</description>
+      <expected-problems>1</expected-problems>
+      <expected-linenumbers>6</expected-linenumbers>
+      <code><![CDATA[
 import java.util.ArrayList;
 public class Buzz {
     public void buzz() {
@@ -72,13 +76,14 @@ public class Buzz {
         f = new ArrayList<String>(); // flagged by rule
     }
 }
-     ]]></code>
-    </test-code>
-     <test-code>
-        <description>Multiple initializations in a single declaration</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>6</expected-linenumbers>
-        <code><![CDATA[
+        ]]></code>
+   </test-code>
+
+   <test-code>
+      <description>Multiple initializations in a single declaration</description>
+      <expected-problems>1</expected-problems>
+      <expected-linenumbers>6</expected-linenumbers>
+      <code><![CDATA[
 import java.util.ArrayList;
 import java.util.List;
 public class Buzz {
@@ -88,6 +93,38 @@ public class Buzz {
             baz = new ArrayList<>(); // ok
     }
 }
-     ]]></code>
-    </test-code>
+        ]]></code>
+   </test-code>
+
+   <test-code>
+      <description>#1723 FP with var inside lambda (declaration)</description>
+      <expected-problems>0</expected-problems>
+      <code><![CDATA[
+class Foo {
+  {
+    Runnable someAction = () -> {
+  	  var foo = new ArrayList<String>(5); // ok
+  		System.err.println(foo);
+    };
+  }
+}
+        ]]></code>
+   </test-code>
+
+   <test-code>
+      <description>#1723 FP with var inside lambda (assignment)</description>
+      <expected-problems>0</expected-problems>
+      <code><![CDATA[
+class Foo {
+  {
+    Runnable someAction;
+    someAction = () -> {
+      var foo = new ArrayList<String>(5); // ok
+      System.err.println(foo);
+    };
+  }
+}
+        ]]></code>
+   </test-code>
+
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UseDiamondOperator.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UseDiamondOperator.xml
@@ -124,6 +124,18 @@ class Foo {
         ]]></code>
    </test-code>
 
+   <test-code>
+      <description>FP with array creation</description>
+      <expected-problems>0</expected-problems>
+      <code><![CDATA[
+class Foo {
+  {
+    Class<?> c = new Class<?>[0];
+  }
+}
+        ]]></code>
+   </test-code>
+
     <!-- These tests depend on the Java version used -->
     <!-- For now we keep the old behaviour of ignoring type
      arguments that have type arguments themselves, ie we have
@@ -147,7 +159,7 @@ public class Foo {
     }
 }
         ]]></code>
-       <source-type>java 1.7</source-type>
+      <source-type>java 1.7</source-type>
    </test-code>
 
    <test-code regressionTest="false">
@@ -164,7 +176,7 @@ public class Foo {
     }
 }
         ]]></code>
-       <source-type>java 1.8</source-type>
+      <source-type>java 1.8</source-type>
    </test-code>
 
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UseDiamondOperator.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UseDiamondOperator.xml
@@ -4,8 +4,8 @@
            xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
    <test-code>
       <description>Use Diamond</description>
-      <expected-problems>3</expected-problems>
-      <expected-linenumbers>6,9,10</expected-linenumbers>
+      <expected-problems>2</expected-problems>
+      <expected-linenumbers>6,11</expected-linenumbers>
       <code><![CDATA[
 import java.util.ArrayList;
 import java.util.List;
@@ -15,6 +15,7 @@ public class Foo {
        List<String> strings = new ArrayList<String>();
        List<String> strings2 = new ArrayList<>();
        List<List<String>> strings3 = new ArrayList<>();
+       // this is a known false negative, see at the bottom
        List<List<String>> strings4 = new ArrayList<List<List<String>>>();
        this.field = new ArrayList<String>();
     }
@@ -24,11 +25,9 @@ public class Foo {
 
    <test-code>
       <description>False positive cases: anonymous classes, methods calls</description>
-      <expected-problems>1</expected-problems>
-      <expected-linenumbers>27</expected-linenumbers>
+      <expected-problems>0</expected-problems>
       <code><![CDATA[
 public class Foo {
-    private WeakReference<Class<?>> typeReference;
     public void foo() {
         Collections.sort(files, new Comparator<DataSource>() {
             @Override
@@ -52,8 +51,6 @@ public class Foo {
             }
         };
         Iterator<Node> EMPTY_ITERATOR = new ArrayList<Node>().iterator();
-        Class<?> type = null;
-        typeReference = new WeakReference<Class<?>>(type);
         ((ListNode<E>) rev).reverseCache = new SoftReference<ImmutableList<E>>(this);
     }
     public Map<PropertyDescriptor<?>, Object> getOverriddenPropertiesByPropertyDescriptor() {
@@ -125,6 +122,49 @@ class Foo {
   }
 }
         ]]></code>
+   </test-code>
+
+    <!-- These tests depend on the Java version used -->
+    <!-- For now we keep the old behaviour of ignoring type
+     arguments that have type arguments themselves, ie we have
+     false negatives. We can improve that with better type resolution
+     in PMD 7. -->
+
+    <test-code regressionTest="false">
+      <description>(J7) Version sensitive tests</description>
+      <expected-problems>1</expected-problems>
+      <expected-linenumbers>6</expected-linenumbers>
+      <code><![CDATA[
+public class Foo {
+    private WeakReference<Class<?>> typeReference;
+    public void foo() {
+        // this should be positive in Java 8, negative in Java 7
+        // this is because in java 7, new WeakReference<>(String.class) types as WeakReference<Class<String>>
+        // which is incompatible with WeakReference<Class<?>>, whereas Java 8's type inference is better.
+        typeReference = new WeakReference<Class<?>>(String.class);
+        Class<?> type = null;
+        typeReference = new WeakReference<Class<?>>(type); // this should be positive on all versions
+    }
+}
+        ]]></code>
+       <source-type>java 1.7</source-type>
+   </test-code>
+
+   <test-code regressionTest="false">
+      <description>(J8) Version sensitive tests</description>
+      <expected-problems>2</expected-problems>
+      <expected-linenumbers>4,6</expected-linenumbers>
+      <code><![CDATA[
+public class Foo {
+    private WeakReference<Class<?>> typeReference;
+    public void foo() {
+        typeReference = new WeakReference<Class<?>>(String.class); // pos
+        Class<?> type = null;
+        typeReference = new WeakReference<Class<?>>(type); // pos
+    }
+}
+        ]]></code>
+       <source-type>java 1.8</source-type>
    </test-code>
 
 </test-data>


### PR DESCRIPTION
Fixes #1723

I found a false negative, that depends on the java version. Java 8's type inference algorithm makes more type arguments redundant than with java 7. See the bottom of the test file for an example. The problem is that we need more insight into the type arguments to find out whether they are really redundant or not (and we need access to the java version used). I think this will be easily solved with PMD 7's improved type resolution, and for that reason I don't think it's worth patching together a solution on master, so I kept the current behaviour but added some tests to be enabled later.
