### PR TITLE
[apex] New Rule: Unused local variables

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableRule.java
@@ -1,0 +1,27 @@
+package net.sourceforge.pmd.lang.apex.rule.bestpractices;
+
+import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
+import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration;
+import net.sourceforge.pmd.lang.apex.ast.ASTVariableExpression;
+import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+
+import java.util.List;
+
+public class UnusedLocalVariableRule extends AbstractApexRule {
+    @Override
+    public Object visit(ASTVariableDeclaration node, Object data) {
+        String variableName = node.getImage();
+
+        ASTMethod containerMethod = node.getFirstParentOfType(ASTMethod.class);
+        List<ASTVariableExpression> potentialUsages = containerMethod.findChildrenOfType(ASTVariableExpression.class);
+
+        for (ASTVariableExpression usage : potentialUsages) {
+            if (usage.getImage().equals(variableName)) {
+                return data;
+            }
+        }
+
+        addViolation(data, node);
+        return data;
+    }
+}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableRule.java
@@ -1,6 +1,6 @@
 package net.sourceforge.pmd.lang.apex.rule.bestpractices;
 
-import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
+import net.sourceforge.pmd.lang.apex.ast.ASTBlockStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration;
 import net.sourceforge.pmd.lang.apex.ast.ASTVariableExpression;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
@@ -12,10 +12,13 @@ public class UnusedLocalVariableRule extends AbstractApexRule {
     public Object visit(ASTVariableDeclaration node, Object data) {
         String variableName = node.getImage();
 
-        ASTMethod containerMethod = node.getFirstParentOfType(ASTMethod.class);
-        List<ASTVariableExpression> potentialUsages = containerMethod.findChildrenOfType(ASTVariableExpression.class);
+        ASTBlockStatement variableContext = node.getFirstParentOfType(ASTBlockStatement.class);
+        List<ASTVariableExpression> potentialUsages = variableContext.findDescendantsOfType(ASTVariableExpression.class);
 
         for (ASTVariableExpression usage : potentialUsages) {
+            if (usage.getParent() == node) {
+                continue;
+            }
             if (usage.getImage().equals(variableName)) {
                 return data;
             }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableRule.java
@@ -1,11 +1,15 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
 package net.sourceforge.pmd.lang.apex.rule.bestpractices;
+
+import java.util.List;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTBlockStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration;
 import net.sourceforge.pmd.lang.apex.ast.ASTVariableExpression;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
-
-import java.util.List;
 
 public class UnusedLocalVariableRule extends AbstractApexRule {
     @Override

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableRule.java
@@ -28,7 +28,7 @@ public class UnusedLocalVariableRule extends AbstractApexRule {
             }
         }
 
-        addViolation(data, node);
+        addViolation(data, node, variableName);
         return data;
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableRule.java
@@ -12,6 +12,10 @@ import net.sourceforge.pmd.lang.apex.ast.ASTVariableExpression;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 
 public class UnusedLocalVariableRule extends AbstractApexRule {
+    public UnusedLocalVariableRule() {
+        addRuleChainVisit(ASTVariableDeclaration.class);
+    }
+
     @Override
     public Object visit(ASTVariableDeclaration node, Object data) {
         String variableName = node.getImage();

--- a/pmd-apex/src/main/resources/category/apex/bestpractices.xml
+++ b/pmd-apex/src/main/resources/category/apex/bestpractices.xml
@@ -211,7 +211,7 @@ public class Foo {
     <rule name="UnusedLocalVariable"
           since="6.23.0"
           language="apex"
-          message="Variable defined but not used"
+          message="Variable ''{0}'' defined but not used"
           class="net.sourceforge.pmd.lang.apex.rule.bestpractices.UnusedLocalVariableRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_bestpractices.html#unusedlocalvariable">
         <description>

--- a/pmd-apex/src/main/resources/category/apex/bestpractices.xml
+++ b/pmd-apex/src/main/resources/category/apex/bestpractices.xml
@@ -208,4 +208,25 @@ public class Foo {
         </example>
     </rule>
 
+    <rule name="UnusedLocalVariable"
+          since="6.23.0"
+          language="apex"
+          message="Variable defined but not used"
+          class="net.sourceforge.pmd.lang.apex.rule.bestpractices.UnusedLocalVariableRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_bestpractices.html#unusedlocalvariable">
+        <description>
+Detects when a local variable is declared and/or assigned but not used.
+        </description>
+        <example>
+<![CDATA[
+    public Boolean bar(String z) {
+        String x = 'some string'; // not used
+
+        String y = 'some other string'; // used in the next line
+        return z.equals(y);
+    }
+]]>
+        </example>
+    </rule>
+
 </ruleset>

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableTest.java
@@ -1,0 +1,7 @@
+package net.sourceforge.pmd.lang.apex.rule.bestpractices;
+
+import net.sourceforge.pmd.testframework.PmdRuleTst;
+
+public class UnusedLocalVariableTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableTest.java
@@ -1,3 +1,7 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
 package net.sourceforge.pmd.lang.apex.rule.bestpractices;
 
 import net.sourceforge.pmd.testframework.PmdRuleTst;

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/UnusedLocalVariable.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/UnusedLocalVariable.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<test-data
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+    <test-code>
+        <description>Unused variables should result in errors</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,7</expected-linenumbers>
+        <code>
+<![CDATA[
+public class Foo {
+    public void assignedVariable() {
+        String foo = 'unused string';
+    }
+
+    public void justADeclaration() {
+        String foo;
+    }
+}
+]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>Used variables should not result in errors</description>
+        <expected-problems>0</expected-problems>
+        <code>
+<![CDATA[
+public class Foo {
+    public String basicUsage() {
+        String x = 'used variable';
+        return x;
+    }
+
+    public Account moreComplexUsage() {
+        String x = 'blah';
+        return [SELECT Id FROM Account WHERE Name = :x];
+    }
+}
+]]>
+        </code>
+    </test-code>
+</test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/UnusedLocalVariable.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/UnusedLocalVariable.xml
@@ -37,6 +37,16 @@ public class Foo {
         String x = 'blah';
         return [SELECT Id FROM Account WHERE Name = :x];
     }
+
+    public String usageInBlocks(Boolean y) {
+        String x = 'used variable';
+
+        if (y) {
+            return x;
+        } else {
+            return 'some other string';
+        }
+    }
 }
 ]]>
         </code>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/UnusedLocalVariable.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/UnusedLocalVariable.xml
@@ -7,6 +7,10 @@
         <description>Unused variables should result in errors</description>
         <expected-problems>2</expected-problems>
         <expected-linenumbers>3,7</expected-linenumbers>
+        <expected-messages>
+            <message>Variable 'foo' defined but not used</message>
+            <message>Variable 'foo' defined but not used</message>
+        </expected-messages>
         <code>
 <![CDATA[
 public class Foo {


### PR DESCRIPTION
<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
Variables that are only ever assigned but never otherwise used.

This was discussed in https://github.com/pmd/pmd/issues/2322

Adds a basic implementation of detecting variables that are assigned but not used. I believe it does not get any false positives, just false negatives in the case of variable shadowing. I'm not sure if that is acceptable so I've left this as a draft for now until I get an opinion on that.

A way to fix shadowing issue would be to make sure the parser's variable resolver runs so we can work out which variables are the same. This information would probably be helpful for other rules, so it may be worth doing as a separate PR prior to this going in?