### PR TITLE
[apex] New rule: field declarations should be at start

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
@@ -58,9 +58,9 @@ public class FieldDeclarationsShouldBeAtStartRule extends AbstractApexRule {
     }
 
     private List<ApexNode<?>> getMethodNodes(ASTUserClass node) {
-        // The method <clinit> represents static initializer blocks, of which there can be many. Given that the
-        // <clinit> method doesn't contain location information, only the containing ASTBlockStatements, we fetch
-        // them for that method only.
+        // The method <clinit> represents static initializer blocks, of which there can be many. The
+        // <clinit> method doesn't contain location information, however the containing ASTBlockStatements do,
+        // so we fetch them for that method only.
         return node.findChildrenOfType(ASTMethod.class).stream()
             .flatMap(method -> method.getImage().equals("<clinit>")
                 ? method.findChildrenOfType(ASTBlockStatement.class).stream() : Stream.of(method))

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
@@ -20,7 +20,7 @@ import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 
 public class FieldDeclarationsShouldBeAtStartRule extends AbstractApexRule {
-    private static final Comparator<ApexNode<?>> nodeBySourceLocationComparator =
+    private static final Comparator<ApexNode<?>> NODE_BY_SOURCE_LOCATION_COMPARATOR =
         Comparator
             .<ApexNode<?>>comparingInt(ApexNode::getBeginLine)
             .thenComparing(ApexNode::getBeginColumn);
@@ -41,7 +41,7 @@ public class FieldDeclarationsShouldBeAtStartRule extends AbstractApexRule {
 
         Optional<ApexNode<?>> firstNonFieldDeclaration = nonFieldDeclarations.stream()
             .filter(ApexNode::hasRealLoc)
-            .min(nodeBySourceLocationComparator);
+            .min(NODE_BY_SOURCE_LOCATION_COMPARATOR);
 
         if (!firstNonFieldDeclaration.isPresent()) {
             // there is nothing except field declaration, so that has to come first
@@ -49,7 +49,7 @@ public class FieldDeclarationsShouldBeAtStartRule extends AbstractApexRule {
         }
 
         for (ASTField field : fields) {
-            if (nodeBySourceLocationComparator.compare(field, firstNonFieldDeclaration.get()) > 0) {
+            if (NODE_BY_SOURCE_LOCATION_COMPARATOR.compare(field, firstNonFieldDeclaration.get()) > 0) {
                 addViolation(data, field, field.getName());
             }
         }
@@ -62,8 +62,8 @@ public class FieldDeclarationsShouldBeAtStartRule extends AbstractApexRule {
         // <clinit> method doesn't contain location information, only the containing ASTBlockStatements, we fetch
         // them for that method only.
         return node.findChildrenOfType(ASTMethod.class).stream()
-            .flatMap(method -> method.getImage().equals("<clinit>") ?
-                method.findChildrenOfType(ASTBlockStatement.class).stream() : Stream.of(method))
+            .flatMap(method -> method.getImage().equals("<clinit>")
+                ? method.findChildrenOfType(ASTBlockStatement.class).stream() : Stream.of(method))
             .collect(Collectors.toList());
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
@@ -26,6 +26,10 @@ public class FieldDeclarationsShouldBeAtStartRule extends AbstractApexRule {
             .thenComparing(ApexNode::getBeginColumn);
     public static final String STATIC_INITIALIZER_METHOD_NAME = "<clinit>";
 
+    public FieldDeclarationsShouldBeAtStartRule() {
+        addRuleChainVisit(ASTUserClass.class);
+    }
+
     @Override
     public Object visit(ASTUserClass node, Object data) {
         // Unfortunately the parser re-orders the AST to put field declarations before method declarations
@@ -46,7 +50,7 @@ public class FieldDeclarationsShouldBeAtStartRule extends AbstractApexRule {
 
         if (!firstNonFieldDeclaration.isPresent()) {
             // there is nothing except field declaration, so that has to come first
-            return super.visit(node, data);
+            return data;
         }
 
         for (ASTField field : fields) {
@@ -55,7 +59,7 @@ public class FieldDeclarationsShouldBeAtStartRule extends AbstractApexRule {
             }
         }
 
-        return super.visit(node, data);
+        return data;
     }
 
     private List<ApexNode<?>> getMethodNodes(ASTUserClass node) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTField;
 import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
+import net.sourceforge.pmd.lang.apex.ast.ASTProperty;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
@@ -32,6 +33,7 @@ public class FieldDeclarationsShouldBeAtStartRule extends AbstractApexRule {
 
         nonFieldDeclarations.addAll(node.findChildrenOfType(ASTMethod.class));
         nonFieldDeclarations.addAll(node.findChildrenOfType(ASTUserClass.class));
+        nonFieldDeclarations.addAll(node.findChildrenOfType(ASTProperty.class));
 
         Optional<ApexNode<?>> firstNonFieldDeclaration = nonFieldDeclarations.stream()
             .filter(ApexNode::hasRealLoc)

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
@@ -8,7 +8,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
-import net.sourceforge.pmd.lang.apex.ast.ASTFieldDeclaration;
+import net.sourceforge.pmd.lang.apex.ast.ASTField;
 import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
@@ -25,8 +25,8 @@ public class FieldDeclarationsShouldBeAtStartRule extends AbstractApexRule {
         // Unfortunately the parser re-orders the AST to put field declarations before method declarations
         // so we have to rely on line numbers / positions to work out where the first method starts so we
         // can check if the fields are in acceptable places.
-        List<ASTFieldDeclaration> fields = node.findDescendantsOfType(ASTFieldDeclaration.class);
-        List<ASTMethod> methods = node.findDescendantsOfType(ASTMethod.class);
+        List<ASTField> fields = node.findChildrenOfType(ASTField.class);
+        List<ASTMethod> methods = node.findChildrenOfType(ASTMethod.class);
 
         Optional<ASTMethod> firstMethod = methods.stream()
             .filter(ApexNode::hasRealLoc)
@@ -37,7 +37,7 @@ public class FieldDeclarationsShouldBeAtStartRule extends AbstractApexRule {
             return data;
         }
 
-        for (ASTFieldDeclaration field : fields) {
+        for (ASTField field : fields) {
             if (nodeBySourceLocationComparator.compare(field, firstMethod.get()) > 0) {
                 addViolation(data, field, field.getName());
             }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
@@ -24,6 +24,7 @@ public class FieldDeclarationsShouldBeAtStartRule extends AbstractApexRule {
         Comparator
             .<ApexNode<?>>comparingInt(ApexNode::getBeginLine)
             .thenComparing(ApexNode::getBeginColumn);
+    public static final String STATIC_INITIALIZER_METHOD_NAME = "<clinit>";
 
     @Override
     public Object visit(ASTUserClass node, Object data) {
@@ -62,7 +63,7 @@ public class FieldDeclarationsShouldBeAtStartRule extends AbstractApexRule {
         // <clinit> method doesn't contain location information, however the containing ASTBlockStatements do,
         // so we fetch them for that method only.
         return node.findChildrenOfType(ASTMethod.class).stream()
-            .flatMap(method -> method.getImage().equals("<clinit>")
+            .flatMap(method -> method.getImage().equals(STATIC_INITIALIZER_METHOD_NAME)
                 ? method.findChildrenOfType(ASTBlockStatement.class).stream() : Stream.of(method))
             .collect(Collectors.toList());
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
@@ -37,7 +37,7 @@ public class FieldDeclarationsShouldBeAtStartRule extends AbstractApexRule {
         for (ASTFieldDeclaration field : fields) {
             NodeAndLocation fieldPosition = new NodeAndLocation(field);
             if (fieldPosition.compareTo(firstMethod.get()) > 0) {
-                addViolation(data, field);
+                addViolation(data, field, field.getName());
             }
         }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
@@ -24,7 +24,9 @@ public class FieldDeclarationsShouldBeAtStartRule extends AbstractApexRule {
         List<ASTMethod> methods = node.findDescendantsOfType(ASTMethod.class);
 
         Optional<NodeAndLocation> firstMethod =
-            methods.stream().map(NodeAndLocation::new)
+            methods.stream()
+                .filter(method -> method.hasRealLoc())
+                .map(method -> new NodeAndLocation(method))
                 .min(Comparator.naturalOrder());
 
         if (!firstMethod.isPresent()) {
@@ -47,7 +49,7 @@ public class FieldDeclarationsShouldBeAtStartRule extends AbstractApexRule {
         public int column;
         public ApexNode<?> node;
 
-        public NodeAndLocation(ApexNode<?> node) {
+        NodeAndLocation(ApexNode<?> node) {
             this.node = node;
 
             line = node.getBeginLine();

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
@@ -34,7 +34,7 @@ public class FieldDeclarationsShouldBeAtStartRule extends AbstractApexRule {
 
         if (!firstMethod.isPresent()) {
             // there are no methods so the field declaration has to come first
-            return data;
+            return super.visit(node, data);
         }
 
         for (ASTField field : fields) {
@@ -43,6 +43,6 @@ public class FieldDeclarationsShouldBeAtStartRule extends AbstractApexRule {
             }
         }
 
-        return data;
+        return super.visit(node, data);
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
@@ -1,0 +1,67 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.rule.codestyle;
+
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+import net.sourceforge.pmd.lang.apex.ast.ASTFieldDeclaration;
+import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
+import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
+import net.sourceforge.pmd.lang.apex.ast.ApexNode;
+import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+
+public class FieldDeclarationsShouldBeAtStartRule extends AbstractApexRule {
+    @Override
+    public Object visit(ASTUserClass node, Object data) {
+        // Unfortunately the parser re-orders the AST to put field declarations before method declarations
+        // so we have to rely on line numbers / positions to work out where the first method starts so we
+        // can check if the fields are in acceptable places.
+        List<ASTFieldDeclaration> fields = node.findDescendantsOfType(ASTFieldDeclaration.class);
+        List<ASTMethod> methods = node.findDescendantsOfType(ASTMethod.class);
+
+        Optional<NodeAndLocation> firstMethod =
+            methods.stream().map(NodeAndLocation::new)
+                .min(Comparator.naturalOrder());
+
+        if (!firstMethod.isPresent()) {
+            // there are no methods so the field declaration has to come first
+            return data;
+        }
+
+        for (ASTFieldDeclaration field : fields) {
+            NodeAndLocation fieldPosition = new NodeAndLocation(field);
+            if (fieldPosition.compareTo(firstMethod.get()) > 0) {
+                addViolation(data, field);
+            }
+        }
+
+        return data;
+    }
+
+    private static class NodeAndLocation implements Comparable<NodeAndLocation> {
+        public int line;
+        public int column;
+        public ApexNode<?> node;
+
+        public NodeAndLocation(ApexNode<?> node) {
+            this.node = node;
+
+            line = node.getBeginLine();
+            column = node.getBeginColumn();
+        }
+
+        @Override
+        public int compareTo(NodeAndLocation other) {
+            int lineCompare = Integer.compare(line, other.line);
+            if (lineCompare != 0) {
+                return lineCompare;
+            }
+
+            return Integer.compare(column, other.column);
+        }
+    }
+}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartRule.java
@@ -9,6 +9,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
+import net.sourceforge.pmd.lang.apex.ast.ASTBlockStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTField;
 import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
 import net.sourceforge.pmd.lang.apex.ast.ASTProperty;
@@ -34,6 +35,7 @@ public class FieldDeclarationsShouldBeAtStartRule extends AbstractApexRule {
         nonFieldDeclarations.addAll(node.findChildrenOfType(ASTMethod.class));
         nonFieldDeclarations.addAll(node.findChildrenOfType(ASTUserClass.class));
         nonFieldDeclarations.addAll(node.findChildrenOfType(ASTProperty.class));
+        nonFieldDeclarations.addAll(node.findChildrenOfType(ASTBlockStatement.class));
 
         Optional<ApexNode<?>> firstNonFieldDeclaration = nonFieldDeclarations.stream()
             .filter(ApexNode::hasRealLoc)

--- a/pmd-apex/src/main/resources/category/apex/codestyle.xml
+++ b/pmd-apex/src/main/resources/category/apex/codestyle.xml
@@ -365,4 +365,27 @@ while (true) {  // preferred approach
         </example>
     </rule>
 
+    <rule name="FieldDeclarationsShouldBeAtStart"
+          language="apex"
+          since="5.23.0"
+          message="Field declarations should be before method declarations in a class"
+          class="net.sourceforge.pmd.lang.apex.rule.codestyle.FieldDeclarationsShouldBeAtStartRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_codestyle.html#fielddeclarationsshouldbeatstart">
+        <description>
+            Field declarations should appear before method declarations within a class.
+        </description>
+        <priority>3</priority>
+        <example>
+<![CDATA[
+class Foo {
+    public Integer someField; // good
+
+    public void someMethod() {
+    }
+
+    public Integer anotherField; // bad
+}
+]]>
+        </example>
+    </rule>
 </ruleset>

--- a/pmd-apex/src/main/resources/category/apex/codestyle.xml
+++ b/pmd-apex/src/main/resources/category/apex/codestyle.xml
@@ -368,7 +368,7 @@ while (true) {  // preferred approach
     <rule name="FieldDeclarationsShouldBeAtStart"
           language="apex"
           since="5.23.0"
-          message="Field declarations should be before method declarations in a class"
+          message="Field declaration for ''{0}'' should be before method declarations in its class"
           class="net.sourceforge.pmd.lang.apex.rule.codestyle.FieldDeclarationsShouldBeAtStartRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_codestyle.html#fielddeclarationsshouldbeatstart">
         <description>

--- a/pmd-apex/src/main/resources/category/apex/codestyle.xml
+++ b/pmd-apex/src/main/resources/category/apex/codestyle.xml
@@ -367,7 +367,7 @@ while (true) {  // preferred approach
 
     <rule name="FieldDeclarationsShouldBeAtStart"
           language="apex"
-          since="5.23.0"
+          since="6.23.0"
           message="Field declaration for ''{0}'' should be before method declarations in its class"
           class="net.sourceforge.pmd.lang.apex.rule.codestyle.FieldDeclarationsShouldBeAtStartRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_codestyle.html#fielddeclarationsshouldbeatstart">

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/codestyle/FieldDeclarationsShouldBeAtStartTest.java
@@ -1,0 +1,11 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.rule.codestyle;
+
+import net.sourceforge.pmd.testframework.PmdRuleTst;
+
+public class FieldDeclarationsShouldBeAtStartTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/FieldDeclarationsShouldBeAtStart.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/FieldDeclarationsShouldBeAtStart.xml
@@ -170,4 +170,21 @@ class Foo {
 ]]>
         </code>
     </test-code>
+
+    <test-code>
+        <description>Fields should go before block statements</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code>
+            <![CDATA[
+class Foo {
+    {
+        System.debug('Hello');
+    }
+
+    public Integer thisIsNotOkay;
+}
+]]>
+        </code>
+    </test-code>
 </test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/FieldDeclarationsShouldBeAtStart.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/FieldDeclarationsShouldBeAtStart.xml
@@ -187,4 +187,21 @@ class Foo {
 ]]>
         </code>
     </test-code>
+
+    <test-code>
+        <description>Fields should go before static block statements</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code>
+            <![CDATA[
+class Foo {
+    static {
+        System.debug('Hello');
+    }
+
+    public Integer thisIsNotOkay;
+}
+]]>
+        </code>
+    </test-code>
 </test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/FieldDeclarationsShouldBeAtStart.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/FieldDeclarationsShouldBeAtStart.xml
@@ -20,6 +20,9 @@ class Foo {
         <description>Does warn if a field is after a method</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>Field declaration for 'thisIsNotOkay' should be before method declarations in its class</message>
+        </expected-messages>
         <code>
 <![CDATA[
 class Foo {
@@ -35,6 +38,9 @@ class Foo {
         <description>Warns if field is after constructor</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>6</expected-linenumbers>
+        <expected-messages>
+            <message>Field declaration for 'someField' should be before method declarations in its class</message>
+        </expected-messages>
         <code>
 <![CDATA[
 class Foo {
@@ -52,6 +58,9 @@ class Foo {
         <description>Warns only for fields after the first method declaration</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>8</expected-linenumbers>
+        <expected-messages>
+            <message>Field declaration for 'thisFieldIsNotOkay' should be before method declarations in its class</message>
+        </expected-messages>
         <code>
 <![CDATA[
 class Foo {
@@ -71,6 +80,9 @@ class Foo {
         <description>Warns for fields defined on the same line after a method</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>2</expected-linenumbers>
+        <expected-messages>
+            <message>Field declaration for 'thisFieldIsNotOkay' should be before method declarations in its class</message>
+        </expected-messages>
         <code>
 <![CDATA[
 class Foo {

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/FieldDeclarationsShouldBeAtStart.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/FieldDeclarationsShouldBeAtStart.xml
@@ -140,4 +140,19 @@ class Foo {
 ]]>
         </code>
     </test-code>
+
+    <test-code>
+        <description>Fields should go before inner classes too</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <code>
+<![CDATA[
+class Foo {
+    private class InnerFoo {}
+
+    public Integer thisIsNotOkay;
+}
+]]>
+        </code>
+    </test-code>
 </test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/FieldDeclarationsShouldBeAtStart.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/FieldDeclarationsShouldBeAtStart.xml
@@ -119,4 +119,25 @@ class Foo {
 ]]>
         </code>
     </test-code>
+
+    <test-code>
+        <description>Allows nested classes to have fields</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>9</expected-linenumbers>
+        <code>
+            <![CDATA[
+class Foo {
+    void bar() { }
+
+    private class InnerFoo {
+        public Integer thisIsOkay;
+
+        public void bar() {}
+
+        public Integer thisIsNotOkay;
+    }
+}
+]]>
+        </code>
+    </test-code>
 </test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/FieldDeclarationsShouldBeAtStart.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/FieldDeclarationsShouldBeAtStart.xml
@@ -155,4 +155,19 @@ class Foo {
 ]]>
         </code>
     </test-code>
+
+    <test-code>
+        <description>Fields should go before properties too</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <code>
+            <![CDATA[
+class Foo {
+    public Integer someProperty { get; }
+
+    public Integer thisIsNotOkay;
+}
+]]>
+        </code>
+    </test-code>
 </test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/FieldDeclarationsShouldBeAtStart.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/FieldDeclarationsShouldBeAtStart.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<test-data
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+    <test-code>
+        <description>Does not warn if there are no methods</description>
+        <expected-problems>0</expected-problems>
+        <code>
+<![CDATA[
+class Foo {
+    public Integer thisIsOkay;
+}
+]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>Does warn if a field is after a method</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <code>
+<![CDATA[
+class Foo {
+    public void someMethod() {}
+
+    public Integer thisIsNotOkay;
+}
+]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>Warns if field is after constructor</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code>
+<![CDATA[
+class Foo {
+    public Foo(Integer someValue) {
+        someField = someValue;
+    }
+
+    private Integer someField;
+}
+]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>Warns only for fields after the first method declaration</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>8</expected-linenumbers>
+        <code>
+<![CDATA[
+class Foo {
+    private Integer thisFieldIsOkay;
+
+    public Foo(Integer someValue) {
+        someField = someValue;
+    }
+
+    private Integer thisFieldIsNotOkay;
+}
+]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>Warns for fields defined on the same line after a method</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>2</expected-linenumbers>
+        <code>
+<![CDATA[
+class Foo {
+    public Foo(Integer someValue) { someField = someValue; } private Integer thisFieldIsNotOkay;
+}
+]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>Does not warn for fields defined on the same line before a method</description>
+        <expected-problems>0</expected-problems>
+        <code>
+            <![CDATA[
+class Foo {
+    private Integer thisFieldIsOkay; public Foo(Integer someValue) { someField = someValue; }
+}
+]]>
+        </code>
+    </test-code>
+</test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/FieldDeclarationsShouldBeAtStart.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/FieldDeclarationsShouldBeAtStart.xml
@@ -103,4 +103,20 @@ class Foo {
 ]]>
         </code>
     </test-code>
+
+    <test-code>
+        <description>Allows nested classes to have fields</description>
+        <expected-problems>0</expected-problems>
+        <code>
+            <![CDATA[
+class Foo {
+    void bar() { }
+
+    private class InnerFoo {
+        public Integer thisIsOkay;
+    }
+}
+]]>
+        </code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**

A rule discussed in #2322 was field declarations should be at the start of a class. This adds that rule.

I first tried to implement this using an xpath rule, but unfortunately the apex parser seems to always put all the field definitions first in the AST, so I had to resort to using line number information and writing the rule in java.