### PR TITLE
[apex] fixed WITH SECURITY_ENFORCED regex to recognise line break characters

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
@@ -85,7 +85,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
 
     private static final String[] RESERVED_KEYS_FLS = new String[] { "Schema", S_OBJECT_TYPE, };
 
-    private static final Pattern WITH_SECURITY_ENFORCED = Pattern.compile("(?i).*[^']\\s*WITH\\s+SECURITY_ENFORCED\\s*[^']*");
+    private static final Pattern WITH_SECURITY_ENFORCED = Pattern.compile("(?is).*[^']\\s*WITH\\s+SECURITY_ENFORCED\\s*[^']*");
 
     private final Map<String, String> varToTypeMapping = new HashMap<>();
     private final ListMultimap<String, String> typeToDMLOperationMapping = ArrayListMultimap.create();

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
@@ -276,6 +276,19 @@ public class Foo {
 	</test-code>
 
 	<test-code>
+		<description>Accepts Closure SECURITY ENFORCED Line Break </description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public Contact foo(String tempID) {
+		Contact c = [SELECT Name FROM Contact WHERE Id=: tempID
+		WITH SECURITY_ENFORCED];
+		return c;
+	}
+} ]]></code>
+	</test-code>
+
+	<test-code>
 		<description>Accepts Closure SECURITY ENFORCED in a List </description>
 		<expected-problems>0</expected-problems>
 		<code><![CDATA[
@@ -288,12 +301,38 @@ public class Foo {
 	</test-code>
 
 	<test-code>
+		<description>Accepts Closure SECURITY ENFORCED in a List Line Break</description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public List<Contact> m() {
+		List<Contact> c = [SELECT Name FROM Contact
+		WITH SECURITY_ENFORCED LIMIT 1];
+		return c;
+	}
+} ]]></code>
+	</test-code>
+
+	<test-code>
 		<description>Accepts Closure SECURITY ENFORCED with Case Insensitivity </description>
 		<expected-problems>0</expected-problems>
 		<code><![CDATA[
 public class Foo {
 	public Contact foo(String tempID) {
 		Contact c = [SELECT Name FROM Contact WHERE Id=: tempID WItH SECURITY_ENFORCED];
+		return c;
+	}
+} ]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Accepts Closure SECURITY ENFORCED with Case Insensitivity Line Break </description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public Contact foo(String tempID) {
+		Contact c = [SELECT Name FROM Contact WHERE Id=: tempID
+		WItH SECURITY_ENFORCED];
 		return c;
 	}
 } ]]></code>
@@ -318,6 +357,19 @@ public class Foo {
 public class Foo {
 	public Contact foo() {
 		Contact c = [SELECT Name FROM Contact WHERE Name = 'WITH SECURITY_ENFORCED' WITH SECURITY_ENFORCED];
+		return c;
+	}
+} ]]></code>
+	</test-code>
+
+	<test-code>
+		<description>Accepts Closure SECURITY ENFORCED Secured Line Break </description>
+		<expected-problems>0</expected-problems>
+		<code><![CDATA[
+public class Foo {
+	public Contact foo() {
+		Contact c = [SELECT Name FROM Contact WHERE Name = 'WITH SECURITY_ENFORCED'
+		WITH SECURITY_ENFORCED];
 		return c;
 	}
 } ]]></code>


### PR DESCRIPTION
**PR Description:**

Rule: [ApexCrudViolation](https://pmd.github.io/latest/pmd_rules_apex_security.html#apexcrudviolation)

Modified the regex used when checking if WITH SECURITY_ENFORCED is used to ensure it will account for any extra line break characters due to stylistic choices. Before, newlines would cause a false negative.

This continues to fix https://github.com/pmd/pmd/issues/2210