### PR TITLE
[doc] Update DoNotUseThreads rule documentation

### DIFF
--- a/pmd-java/src/main/resources/category/java/multithreading.xml
+++ b/pmd-java/src/main/resources/category/java/multithreading.xml
@@ -147,10 +147,28 @@ public class UsingThread extends Thread {
 }
 
 // Neither this,
-public class OtherThread implements Runnable {
-    // Nor this ...
-    public void methode() {
-        Runnable thread = new Thread(); thread.run();
+public class UsingExecutorService {
+
+    public void methodX() {
+        ExecutorService executorService = Executors.newFixedThreadPool(5);
+    }
+}
+
+// Nor this,
+public class Example implements ExecutorService {
+
+}
+
+// Nor this,
+public class Example extends AbstractExecutorService {
+
+}
+
+// Nor this
+public class UsingExecutors {
+
+    public void methodX() {
+        Executors.newSingleThreadExecutor().submit(() -> System.out.println("Hello!"));
     }
 }
 ]]>


### PR DESCRIPTION
[java] Fixes #2313 Documentation for DoNotUseThreads is outdated

The [current rule description for DoNotUseThreads](https://pmd.github.io/pmd/pmd_rules_java_multithreading.html#donotusethreads) shows implementing `Runnable` as a violation but PMD was updated few months back to ignore this.



