### PR TITLE
[core] Add wildcards to node stream API

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AbstractNode.java
@@ -290,10 +290,7 @@ public abstract class AbstractNode implements Node {
      */
     public final boolean hasDescendantOfAnyType(final Class<? extends Node>... types) {
         // TODO consider implementing that with a single traversal!
-        // hasDescendantOfType could then be a special case of this one
-        // But to really share implementations, getFirstDescendantOfType's
-        // internal helper could have to give up some type safety to rely
-        // instead on a getFirstDescendantOfAnyType, then cast to the correct type
+        // -> this is done if you use node streams
         for (final Class<? extends Node> type : types) {
             if (hasDescendantOfType(type)) {
                 return true;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/Node.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/Node.java
@@ -276,8 +276,8 @@ public interface Node {
      * @param <T> The type you want to find
      * @return Node of type parentType. Returns null if none found.
      */
-    default <T extends Node> T getFirstParentOfType(Class<T> parentType) {
-        return ancestors(parentType).first();
+    default <T extends Node> T getFirstParentOfType(Class<? extends T> parentType) {
+        return this.<T>ancestors(parentType).first();
     }
 
     /**
@@ -288,8 +288,8 @@ public interface Node {
      * @param <T> The type you want to find
      * @return List of parentType instances found.
      */
-    default <T extends Node> List<T> getParentsOfType(Class<T> parentType) {
-        return ancestors(parentType).toList();
+    default <T extends Node> List<T> getParentsOfType(Class<? extends T> parentType) {
+        return this.<T>ancestors(parentType).toList();
     }
 
     /**
@@ -317,8 +317,8 @@ public interface Node {
      * @return List of all children of type childType. Returns an empty list if none found.
      * @see #findDescendantsOfType(Class) if traversal of the entire tree is needed.
      */
-    default <T extends Node> List<T> findChildrenOfType(Class<T> childType) {
-        return children(childType).toList();
+    default <T extends Node> List<T> findChildrenOfType(Class<? extends T> childType) {
+        return this.<T>children(childType).toList();
     }
 
 
@@ -329,8 +329,8 @@ public interface Node {
      * @param targetType class which you want to find.
      * @return List of all children of type targetType. Returns an empty list if none found.
      */
-    default <T extends Node> List<T> findDescendantsOfType(Class<T> targetType) {
-        return descendants(targetType).toList();
+    default <T extends Node> List<T> findDescendantsOfType(Class<? extends T> targetType) {
+        return this.<T>descendants(targetType).toList();
     }
 
     /**
@@ -344,8 +344,8 @@ public interface Node {
      * returns a result list.
      */
     @Deprecated
-    default <T extends Node> void findDescendantsOfType(Class<T> targetType, List<T> results, boolean crossFindBoundaries) {
-        descendants(targetType).crossFindBoundaries(crossFindBoundaries).forEach(results::add);
+    default <T extends Node> void findDescendantsOfType(Class<? extends T> targetType, List<? super T> results, boolean crossFindBoundaries) {
+        this.<T>descendants(targetType).crossFindBoundaries(crossFindBoundaries).forEach(results::add);
     }
 
     /**
@@ -359,8 +359,8 @@ public interface Node {
      *            {@link #isFindBoundary()} is <code>true</code>
      * @return List of all matching descendants
      */
-    default <T extends Node> List<T> findDescendantsOfType(Class<T> targetType, boolean crossFindBoundaries) {
-        return descendants(targetType).crossFindBoundaries(crossFindBoundaries).toList();
+    default <T extends Node> List<T> findDescendantsOfType(Class<? extends T> targetType, boolean crossFindBoundaries) {
+        return this.<T>descendants(targetType).crossFindBoundaries(crossFindBoundaries).toList();
     }
 
     /**
@@ -370,7 +370,7 @@ public interface Node {
      * @return Node of type childType. Returns <code>null</code> if none found.
      * @see #getFirstDescendantOfType(Class) if traversal of the entire tree is needed.
      */
-    default <T extends Node> T getFirstChildOfType(Class<T> childType) {
+    default <T extends Node> T getFirstChildOfType(Class<? extends T> childType) {
         return children(childType).first();
     }
 
@@ -381,7 +381,7 @@ public interface Node {
      * @param descendantType class which you want to find.
      * @return Node of type descendantType. Returns <code>null</code> if none found.
      */
-    default <T extends Node> T getFirstDescendantOfType(Class<T> descendantType) {
+    default <T extends Node> T getFirstDescendantOfType(Class<? extends T> descendantType) {
         return descendants(descendantType).first();
     }
 
@@ -391,7 +391,7 @@ public interface Node {
      * @param type the node type to search
      * @return <code>true</code> if there is at least one descendant of the given type
      */
-    default <T extends Node> boolean hasDescendantOfType(Class<T> type) {
+    default <T extends Node> boolean hasDescendantOfType(Class<? extends T> type) {
         return descendants(type).nonEmpty();
     }
 
@@ -536,9 +536,6 @@ public interface Node {
      * Returns the index of this node in its parent's children. If this
      * node is a {@linkplain RootNode root node}, returns -1.
      *
-     * <p>This method replaces {@link #jjtGetChildIndex()}, whose name was
-     * JJTree-specific.
-     *
      * @return The index of this node in its parent's children
      */
     int getIndexInParent();
@@ -651,7 +648,7 @@ public interface Node {
      *
      * @see NodeStream#children(Class)
      */
-    default <R extends Node> NodeStream<R> children(Class<R> rClass) {
+    default <R extends Node> NodeStream<R> children(Class<? extends R> rClass) {
         return StreamImpl.children(this, rClass);
     }
 
@@ -668,7 +665,7 @@ public interface Node {
      *
      * @see NodeStream#descendants(Class)
      */
-    default <R extends Node> DescendantNodeStream<R> descendants(Class<R> rClass) {
+    default <R extends Node> DescendantNodeStream<R> descendants(Class<? extends R> rClass) {
         return StreamImpl.descendants(this, rClass);
     }
 
@@ -684,7 +681,7 @@ public interface Node {
      *
      * @see NodeStream#ancestors(Class)
      */
-    default <R extends Node> NodeStream<R> ancestors(Class<R> rClass) {
+    default <R extends Node> NodeStream<R> ancestors(Class<? extends R> rClass) {
         return StreamImpl.ancestors(this, rClass);
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/NodeStream.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/NodeStream.java
@@ -978,7 +978,35 @@ public interface NodeStream<T extends Node> extends Iterable<@NonNull T> {
         return upstream.cached().flatMap(aggregate);
     }
 
+    /**
+     * Filters the input stream down to those nodes that are instances
+     * of any of the specified classes.
+     *
+     * @param input Input node stream
+     * @param c1    First type to test
+     * @param rest  Other types to test
+     * @param <N>   Type of the returned stream
+     *
+     * @return A filtered node stream
+     */
+    @SafeVarargs // this method is static because of the generic varargs
+    @SuppressWarnings("unchecked")
+    static <N extends Node> NodeStream<N> filterIsAny(NodeStream<?> input, Class<? extends N> c1, Class<? extends N>... rest) {
+        return (NodeStream<N>) input.filter(
+            node -> {
+                if (c1.isInstance(node)) {
+                    return true;
+                }
 
+                for (Class<? extends N> aClass : rest) {
+                    if (aClass.isInstance(node)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        );
+    }
 
     /**
      * A specialization of {@link NodeStream} that allows configuring

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/NodeStream.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/NodeStream.java
@@ -1017,17 +1017,17 @@ public interface NodeStream<T extends Node> extends Iterable<@NonNull T> {
      * explicit type arguments:
      *
      * <pre>{@code
-     *    NodeStream<ASTAnyTypeDeclaration> ts =
+     *    ASTAnyTypeDeclaration ts =
      *       node.ancestors()
-     *       .<ASTAnyTypeDeclaration>map(asInstanceOf(ASTClassOrInterfaceDeclaration.class, ASTEnumDeclaration.class))
-     *       .first(); // would not compile without the explicit type arguments
+     *           .<ASTAnyTypeDeclaration>map(asInstanceOf(ASTClassOrInterfaceDeclaration.class, ASTEnumDeclaration.class))
+     *           .first(); // would not compile without the explicit type arguments
      * }</pre>
      *
      * <p>For this use case the {@link #firstNonNull(Function)} method
      * may be used, which reduces the above to
      *
      * <pre>{@code
-     *    NodeStream<ASTAnyTypeDeclaration> ts =
+     *    ASTAnyTypeDeclaration ts =
      *       node.ancestors().firstNonNull(asInstanceOf(ASTClassOrInterfaceDeclaration.class, ASTEnumDeclaration.class));
      * }</pre>
      *

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/NodeStream.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/NodeStream.java
@@ -110,7 +110,10 @@ import net.sourceforge.pmd.lang.ast.internal.StreamImpl;
  * of the receiver stream. This extends to methods defined in terms of map or flatMap, e.g.
  * {@link #descendants()} or {@link #children()}.
  *
- * @param <T> Type of nodes this stream contains
+ * @param <T> Type of nodes this stream contains. This parameter is
+ *           covariant, which means for maximum flexibility, methods
+ *           taking a node stream argument should declare it with an
+ *           "extends" wildcard.
  *
  * @author Clément Fournier
  * @implNote Choosing to wrap a stream instead of extending the interface is to
@@ -432,7 +435,7 @@ public interface NodeStream<T extends Node> extends Iterable<@NonNull T> {
      * @see #filterIs(Class)
      * @see Node#children(Class)
      */
-    default <R extends Node> NodeStream<R> children(Class<R> rClass) {
+    default <R extends Node> NodeStream<R> children(Class<? extends R> rClass) {
         return flatMap(it -> it.children(rClass));
     }
 
@@ -449,7 +452,7 @@ public interface NodeStream<T extends Node> extends Iterable<@NonNull T> {
      *
      * @see Node#children(Class)
      */
-    default <R extends Node> NodeStream<R> firstChild(Class<R> rClass) {
+    default <R extends Node> NodeStream<R> firstChild(Class<? extends R> rClass) {
         return flatMap(it -> it.children(rClass).take(1));
     }
 
@@ -469,7 +472,7 @@ public interface NodeStream<T extends Node> extends Iterable<@NonNull T> {
      * @see #filterIs(Class)
      * @see Node#descendants(Class)
      */
-    <R extends Node> DescendantNodeStream<R> descendants(Class<R> rClass);
+    <R extends Node> DescendantNodeStream<R> descendants(Class<? extends R> rClass);
 
 
     /**
@@ -486,7 +489,7 @@ public interface NodeStream<T extends Node> extends Iterable<@NonNull T> {
      * @see #filterIs(Class)
      * @see Node#ancestors(Class)
      */
-    default <R extends Node> NodeStream<R> ancestors(Class<R> rClass) {
+    default <R extends Node> NodeStream<R> ancestors(Class<? extends R> rClass) {
         return flatMap(it -> it.ancestors(rClass));
     }
 
@@ -545,7 +548,7 @@ public interface NodeStream<T extends Node> extends Iterable<@NonNull T> {
      * @see #filter(Predicate)
      */
     @SuppressWarnings("unchecked")
-    default <R extends Node> NodeStream<R> filterIs(Class<R> rClass) {
+    default <R extends Node> NodeStream<R> filterIs(Class<? extends R> rClass) {
         return (NodeStream<R>) filter(rClass::isInstance);
     }
 
@@ -732,7 +735,7 @@ public interface NodeStream<T extends Node> extends Iterable<@NonNull T> {
      * @see #first()
      * @see #first(Predicate)
      */
-    default <R extends Node> @Nullable R first(Class<R> rClass) {
+    default <R extends Node> @Nullable R first(Class<? extends R> rClass) {
         return filterIs(rClass).first();
     }
 
@@ -758,7 +761,7 @@ public interface NodeStream<T extends Node> extends Iterable<@NonNull T> {
      *
      * @see #last()
      */
-    default <R extends Node> @Nullable R last(Class<R> rClass) {
+    default <R extends Node> @Nullable R last(Class<? extends R> rClass) {
         return filterIs(rClass).last();
     }
 
@@ -864,7 +867,7 @@ public interface NodeStream<T extends Node> extends Iterable<@NonNull T> {
      *
      * @return A new node stream
      */
-    static <T extends Node> NodeStream<T> fromIterable(Iterable<@Nullable T> iterable) {
+    static <T extends Node> NodeStream<T> fromIterable(Iterable<? extends @Nullable T> iterable) {
         return StreamImpl.fromIterable(iterable);
     }
 
@@ -880,8 +883,8 @@ public interface NodeStream<T extends Node> extends Iterable<@NonNull T> {
      *
      * @see #of(Node)
      */
-    static <T extends Node> NodeStream<T> ofOptional(Optional<T> optNode) {
-        return optNode.map(StreamImpl::singleton).orElseGet(StreamImpl::empty);
+    static <T extends Node> NodeStream<T> ofOptional(Optional<? extends T> optNode) {
+        return optNode.map(StreamImpl::<T>singleton).orElseGet(StreamImpl::empty);
     }
 
 
@@ -956,7 +959,7 @@ public interface NodeStream<T extends Node> extends Iterable<@NonNull T> {
      * @return A merged node stream
      */
     @SafeVarargs // this method is static because of the generic varargs
-    static <T extends Node, R extends Node> NodeStream<R> forkJoin(NodeStream<T> upstream,
+    static <T extends Node, R extends Node> NodeStream<R> forkJoin(NodeStream<? extends T> upstream,
                                                                    Function<? super @NonNull T, ? extends NodeStream<? extends R>> fst,
                                                                    Function<? super @NonNull T, ? extends NodeStream<? extends R>> snd,
                                                                    Function<? super @NonNull T, ? extends NodeStream<? extends R>>... rest) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/AxisStream.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/AxisStream.java
@@ -31,9 +31,9 @@ abstract class AxisStream<T extends Node> extends IteratorBasedNStream<T> {
     /** Spec of this field depends on the subclass. */
     protected final Node node;
     /** Filter, for no filter, this is {@link Filtermap#NODE_IDENTITY}. */
-    protected final Filtermap<Node, T> filter;
+    protected final Filtermap<Node, ? extends T> filter;
 
-    AxisStream(@NonNull Node root, Filtermap<Node, T> filter) {
+    AxisStream(@NonNull Node root, Filtermap<Node, ? extends T> filter) {
         super();
         this.node = root;
         this.filter = filter;
@@ -41,7 +41,7 @@ abstract class AxisStream<T extends Node> extends IteratorBasedNStream<T> {
 
     @Override
     public final Iterator<T> iterator() {
-        return filter.filterMap(baseIterator());
+        return Filtermap.apply(baseIterator(), filter);
     }
 
     protected abstract Iterator<Node> baseIterator();
@@ -58,7 +58,7 @@ abstract class AxisStream<T extends Node> extends IteratorBasedNStream<T> {
     }
 
     @Override
-    public <S extends Node> NodeStream<S> filterIs(Class<S> r1Class) {
+    public <S extends Node> NodeStream<S> filterIs(Class<? extends S> r1Class) {
         return copyWithFilter(filter.thenCast(r1Class));
     }
 
@@ -76,7 +76,7 @@ abstract class AxisStream<T extends Node> extends IteratorBasedNStream<T> {
         return IteratorUtil.last(iter);
     }
 
-    protected <O> List<O> toListImpl(Filtermap<? super Node, O> filter) {
+    protected <O> List<O> toListImpl(Filtermap<? super Node, ? extends O> filter) {
         Iterator<? extends O> iter = filter.filterMap(baseIterator());
         return IteratorUtil.toList(iter);
     }
@@ -87,7 +87,7 @@ abstract class AxisStream<T extends Node> extends IteratorBasedNStream<T> {
     }
 
     @Override
-    public <R extends Node> @Nullable R first(Class<R> r1Class) {
+    public <R extends Node> @Nullable R first(Class<? extends R> r1Class) {
         return firstImpl(filter.thenCast(r1Class));
     }
 
@@ -113,7 +113,7 @@ abstract class AxisStream<T extends Node> extends IteratorBasedNStream<T> {
     }
 
     @Override
-    public <R extends Node> @Nullable R last(Class<R> rClass) {
+    public <R extends Node> @Nullable R last(Class<? extends R> rClass) {
         return lastImpl(filter.thenCast(rClass));
     }
 
@@ -127,11 +127,11 @@ abstract class AxisStream<T extends Node> extends IteratorBasedNStream<T> {
      * Implementations of this method should not compose the given filter
      * with their current filter.
      */
-    protected abstract <S extends Node> NodeStream<S> copyWithFilter(Filtermap<Node, S> filterMap);
+    protected abstract <S extends Node> NodeStream<S> copyWithFilter(Filtermap<Node, ? extends S> filterMap);
 
     static class FilteredAncestorOrSelfStream<T extends Node> extends AxisStream<T> {
 
-        FilteredAncestorOrSelfStream(@NonNull Node node, Filtermap<Node, T> target) {
+        FilteredAncestorOrSelfStream(@NonNull Node node, Filtermap<Node, ? extends T> target) {
             super(node, target);
         }
 
@@ -156,7 +156,7 @@ abstract class AxisStream<T extends Node> extends IteratorBasedNStream<T> {
         }
 
         @Override
-        protected <S extends Node> NodeStream<S> copyWithFilter(Filtermap<Node, S> filterMap) {
+        protected <S extends Node> NodeStream<S> copyWithFilter(Filtermap<Node, ? extends S> filterMap) {
             return new FilteredAncestorOrSelfStream<>(node, filterMap);
         }
 
@@ -199,12 +199,12 @@ abstract class AxisStream<T extends Node> extends IteratorBasedNStream<T> {
 
         DescendantStreamBase(@NonNull Node root,
                              TreeWalker walker,
-                             Filtermap<Node, T> filter) {
+                             Filtermap<Node, ? extends T> filter) {
             super(root, filter);
             this.walker = walker;
         }
 
-        protected abstract <S extends Node> DescendantNodeStream<S> copyWithWalker(Filtermap<Node, S> filterMap, TreeWalker walker);
+        protected abstract <S extends Node> DescendantNodeStream<S> copyWithWalker(Filtermap<Node, ? extends S> filterMap, TreeWalker walker);
 
         @Override
         public DescendantNodeStream<T> crossFindBoundaries(boolean cross) {
@@ -214,7 +214,7 @@ abstract class AxisStream<T extends Node> extends IteratorBasedNStream<T> {
         }
 
         @Override
-        protected <S extends Node> NodeStream<S> copyWithFilter(Filtermap<Node, S> filterMap) {
+        protected <S extends Node> NodeStream<S> copyWithFilter(Filtermap<Node, ? extends S> filterMap) {
             return copyWithWalker(filterMap, walker);
         }
     }
@@ -223,7 +223,7 @@ abstract class AxisStream<T extends Node> extends IteratorBasedNStream<T> {
 
         FilteredDescendantStream(Node node,
                                  TreeWalker walker,
-                                 Filtermap<Node, T> target) {
+                                 Filtermap<Node, ? extends T> target) {
             super(node, walker, target);
         }
 
@@ -233,7 +233,7 @@ abstract class AxisStream<T extends Node> extends IteratorBasedNStream<T> {
         }
 
         @Override
-        protected <S extends Node> DescendantNodeStream<S> copyWithWalker(Filtermap<Node, S> filterMap, TreeWalker walker) {
+        protected <S extends Node> DescendantNodeStream<S> copyWithWalker(Filtermap<Node, ? extends S> filterMap, TreeWalker walker) {
             return new FilteredDescendantStream<>(node, walker, filterMap);
         }
 
@@ -248,7 +248,7 @@ abstract class AxisStream<T extends Node> extends IteratorBasedNStream<T> {
         }
 
         @Override
-        protected <O> List<O> toListImpl(Filtermap<? super Node, O> filter) {
+        protected <O> List<O> toListImpl(Filtermap<? super Node, ? extends O> filter) {
             return walker.findDescendantsMatching(node, filter);
         }
     }
@@ -275,7 +275,7 @@ abstract class AxisStream<T extends Node> extends IteratorBasedNStream<T> {
 
         FilteredDescendantOrSelfStream(Node node,
                                        TreeWalker walker,
-                                       Filtermap<Node, T> filtermap) {
+                                       Filtermap<Node, ? extends T> filtermap) {
             super(node, walker, filtermap);
         }
 
@@ -285,12 +285,12 @@ abstract class AxisStream<T extends Node> extends IteratorBasedNStream<T> {
         }
 
         @Override
-        protected <S extends Node> DescendantNodeStream<S> copyWithWalker(Filtermap<Node, S> filterMap, TreeWalker walker) {
+        protected <S extends Node> DescendantNodeStream<S> copyWithWalker(Filtermap<Node, ? extends S> filterMap, TreeWalker walker) {
             return new FilteredDescendantOrSelfStream<>(node, walker, filterMap);
         }
 
         @Override
-        protected <O> List<O> toListImpl(Filtermap<? super Node, O> filter) {
+        protected <O> List<O> toListImpl(Filtermap<? super Node, ? extends O> filter) {
             List<O> result = new ArrayList<>();
             O top = filter.apply(node);
             if (top != null) {
@@ -333,7 +333,7 @@ abstract class AxisStream<T extends Node> extends IteratorBasedNStream<T> {
         final int low; // inclusive
         final int len;
 
-        FilteredChildrenStream(@NonNull Node root, Filtermap<Node, T> filtermap, int low, int len) {
+        FilteredChildrenStream(@NonNull Node root, Filtermap<Node, ? extends T> filtermap, int low, int len) {
             super(root, filtermap);
             this.low = low;
             this.len = len;
@@ -349,7 +349,7 @@ abstract class AxisStream<T extends Node> extends IteratorBasedNStream<T> {
         }
 
         @Override
-        protected <S extends Node> NodeStream<S> copyWithFilter(Filtermap<Node, S> filterMap) {
+        protected <S extends Node> NodeStream<S> copyWithFilter(Filtermap<Node, ? extends S> filterMap) {
             return new FilteredChildrenStream<>(node, filterMap, low, len);
         }
 
@@ -384,7 +384,7 @@ abstract class AxisStream<T extends Node> extends IteratorBasedNStream<T> {
         }
 
         @Override
-        protected <O> List<O> toListImpl(Filtermap<? super Node, O> filter) {
+        protected <O> List<O> toListImpl(Filtermap<? super Node, ? extends O> filter) {
             return TraversalUtils.findChildrenMatching(node, filter, low, len);
         }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/AxisStream.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/AxisStream.java
@@ -41,7 +41,7 @@ abstract class AxisStream<T extends Node> extends IteratorBasedNStream<T> {
 
     @Override
     public final Iterator<T> iterator() {
-        return Filtermap.apply(baseIterator(), filter);
+        return Filtermap.applyIterator(baseIterator(), filter);
     }
 
     protected abstract Iterator<Node> baseIterator();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/Filtermap.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/Filtermap.java
@@ -18,6 +18,9 @@ import net.sourceforge.pmd.lang.ast.Node;
 
 /**
  * Combined filter/map predicate. Cannot accept null values.
+ *
+ * @param <I> Input type, contravariant
+ * @param <O> Output type, covariant
  */
 @FunctionalInterface
 interface Filtermap<I, O> extends Function<@NonNull I, @Nullable O>, Predicate<@NonNull I> {
@@ -41,7 +44,11 @@ interface Filtermap<I, O> extends Function<@NonNull I, @Nullable O>, Predicate<@
 
     /** Filter an iterator. */
     default Iterator<O> filterMap(Iterator<? extends I> iter) {
-        return IteratorUtil.mapNotNull(iter, this);
+        return apply(iter, this);
+    }
+
+    static <I, O> Iterator<O> apply(Iterator<? extends I> iter, Filtermap<? super I, ? extends O> filtermap) {
+        return IteratorUtil.mapNotNull(iter, filtermap);
     }
 
 
@@ -58,7 +65,7 @@ interface Filtermap<I, O> extends Function<@NonNull I, @Nullable O>, Predicate<@
     }
 
 
-    default <R> Filtermap<I, R> thenCast(Class<R> rClass) {
+    default <R> Filtermap<I, R> thenCast(Class<? extends R> rClass) {
         return thenApply(isInstance(rClass));
     }
 
@@ -95,12 +102,12 @@ interface Filtermap<I, O> extends Function<@NonNull I, @Nullable O>, Predicate<@
     }
 
 
-    static <I> Filtermap<I, I> filter(Predicate<? super @NonNull I> pred) {
+    static <I extends O, O> Filtermap<I, O> filter(Predicate<? super @NonNull I> pred) {
         return i -> i != null && pred.test(i) ? i : null;
     }
 
 
-    static <I, O> Filtermap<I, O> isInstance(Class<O> oClass) {
+    static <I, O> Filtermap<I, O> isInstance(Class<? extends O> oClass) {
         if (oClass == Node.class) {
             return (Filtermap<I, O>) NODE_IDENTITY;
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/Filtermap.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/Filtermap.java
@@ -44,10 +44,10 @@ interface Filtermap<I, O> extends Function<@NonNull I, @Nullable O>, Predicate<@
 
     /** Filter an iterator. */
     default Iterator<O> filterMap(Iterator<? extends I> iter) {
-        return apply(iter, this);
+        return applyIterator(iter, this);
     }
 
-    static <I, O> Iterator<O> apply(Iterator<? extends I> iter, Filtermap<? super I, ? extends O> filtermap) {
+    static <I, O> Iterator<O> applyIterator(Iterator<? extends I> iter, Filtermap<? super I, ? extends O> filtermap) {
         return IteratorUtil.mapNotNull(iter, filtermap);
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/IteratorBasedNStream.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/IteratorBasedNStream.java
@@ -70,7 +70,7 @@ abstract class IteratorBasedNStream<T extends Node> implements NodeStream<T> {
     }
 
     @Override
-    public <R extends Node> NodeStream<R> filterIs(Class<R> rClass) {
+    public <R extends Node> NodeStream<R> filterIs(Class<? extends R> rClass) {
         return mapIter(it -> IteratorUtil.mapNotNull(it, Filtermap.isInstance(rClass)));
     }
 
@@ -85,7 +85,7 @@ abstract class IteratorBasedNStream<T extends Node> implements NodeStream<T> {
     }
 
     @Override
-    public <R extends Node> DescendantNodeStream<R> descendants(Class<R> rClass) {
+    public <R extends Node> DescendantNodeStream<R> descendants(Class<? extends R> rClass) {
         return flatMapDescendants(node -> node.descendants(rClass));
     }
 
@@ -199,7 +199,7 @@ abstract class IteratorBasedNStream<T extends Node> implements NodeStream<T> {
     }
 
     @Override
-    public <R extends Node> @Nullable R first(Class<R> r1Class) {
+    public <R extends Node> @Nullable R first(Class<? extends R> r1Class) {
         for (T t : this) {
             if (r1Class.isInstance(t)) {
                 return r1Class.cast(t);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/SingletonNodeStream.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/SingletonNodeStream.java
@@ -154,12 +154,12 @@ final class SingletonNodeStream<T extends Node> extends IteratorBasedNStream<T> 
     }
 
     @Override
-    public <R extends Node> NodeStream<R> children(Class<R> rClass) {
+    public <R extends Node> NodeStream<R> children(Class<? extends R> rClass) {
         return StreamImpl.children(node, rClass);
     }
 
     @Override
-    public <R extends Node> NodeStream<R> firstChild(Class<R> rClass) {
+    public <R extends Node> NodeStream<R> firstChild(Class<? extends R> rClass) {
         return NodeStream.of(TraversalUtils.getFirstChildMatching(node, Filtermap.isInstance(rClass), 0, node.getNumChildren()));
     }
 
@@ -174,7 +174,7 @@ final class SingletonNodeStream<T extends Node> extends IteratorBasedNStream<T> 
     }
 
     @Override
-    public <R extends Node> NodeStream<R> ancestors(Class<R> rClass) {
+    public <R extends Node> NodeStream<R> ancestors(Class<? extends R> rClass) {
         return StreamImpl.ancestors(node, rClass);
     }
 
@@ -189,7 +189,7 @@ final class SingletonNodeStream<T extends Node> extends IteratorBasedNStream<T> 
     }
 
     @Override
-    public <R extends Node> DescendantNodeStream<R> descendants(Class<R> rClass) {
+    public <R extends Node> DescendantNodeStream<R> descendants(Class<? extends R> rClass) {
         return StreamImpl.descendants(node, rClass);
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/StreamImpl.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/StreamImpl.java
@@ -42,9 +42,9 @@ public final class StreamImpl {
         return new SingletonNodeStream<>(node);
     }
 
-    public static <T extends Node> NodeStream<T> fromIterable(Iterable<@Nullable T> iterable) {
+    public static <T extends Node> NodeStream<T> fromIterable(Iterable<? extends @Nullable T> iterable) {
         if (iterable instanceof Collection) {
-            Collection<@Nullable T> coll = (Collection<T>) iterable;
+            Collection<? extends @Nullable T> coll = (Collection<T>) iterable;
             if (coll.isEmpty()) {
                 return empty();
             } else if (coll.size() == 1) {
@@ -70,7 +70,7 @@ public final class StreamImpl {
         return EMPTY;
     }
 
-    public static <R extends Node> NodeStream<R> children(@NonNull Node node, Class<R> target) {
+    public static <R extends Node> NodeStream<R> children(@NonNull Node node, Class<? extends R> target) {
         return sliceChildren(node, Filtermap.isInstance(target), 0, node.getNumChildren());
     }
 
@@ -82,7 +82,7 @@ public final class StreamImpl {
         return node.getNumChildren() == 0 ? empty() : new DescendantStream(node, TreeWalker.DEFAULT);
     }
 
-    public static <R extends Node> DescendantNodeStream<R> descendants(@NonNull Node node, Class<R> rClass) {
+    public static <R extends Node> DescendantNodeStream<R> descendants(@NonNull Node node, Class<? extends R> rClass) {
         return node.getNumChildren() == 0 ? empty()
                                              : new FilteredDescendantStream<>(node, TreeWalker.DEFAULT, Filtermap.isInstance(rClass));
     }
@@ -110,7 +110,7 @@ public final class StreamImpl {
         return sliceChildren(parent, Filtermap.NODE_IDENTITY, 0, node.getIndexInParent());
     }
 
-    static <T extends Node> NodeStream<T> sliceChildren(Node parent, Filtermap<Node, T> filtermap, int from, int length) {
+    static <T extends Node> NodeStream<T> sliceChildren(Node parent, Filtermap<Node, ? extends T> filtermap, int from, int length) {
         // these assertions are just for tests
         assert parent != null;
         assert from >= 0 && from <= parent.getNumChildren() : "from should be a valid index";
@@ -139,7 +139,7 @@ public final class StreamImpl {
         return ancestorsOrSelf(node, Filtermap.NODE_IDENTITY);
     }
 
-    static <T extends Node> NodeStream<T> ancestorsOrSelf(@Nullable Node node, Filtermap<Node, T> target) {
+    static <T extends Node> NodeStream<T> ancestorsOrSelf(@Nullable Node node, Filtermap<Node, ? extends T> target) {
         if (node == null) {
             return empty();
         } else if (node.getParent() == null) {
@@ -154,11 +154,11 @@ public final class StreamImpl {
         return ancestorsOrSelf(node.getParent());
     }
 
-    static <R extends Node> NodeStream<R> ancestors(@NonNull Node node, Filtermap<Node, R> target) {
+    static <R extends Node> NodeStream<R> ancestors(@NonNull Node node, Filtermap<Node, ? extends R> target) {
         return ancestorsOrSelf(node.getParent(), target);
     }
 
-    public static <R extends Node> NodeStream<R> ancestors(@NonNull Node node, Class<R> target) {
+    public static <R extends Node> NodeStream<R> ancestors(@NonNull Node node, Class<? extends R> target) {
         return ancestorsOrSelf(node.getParent(), Filtermap.isInstance(target));
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/StreamImpl.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/StreamImpl.java
@@ -84,7 +84,7 @@ public final class StreamImpl {
 
     public static <R extends Node> DescendantNodeStream<R> descendants(@NonNull Node node, Class<? extends R> rClass) {
         return node.getNumChildren() == 0 ? empty()
-                                             : new FilteredDescendantStream<>(node, TreeWalker.DEFAULT, Filtermap.isInstance(rClass));
+                                          : new FilteredDescendantStream<>(node, TreeWalker.DEFAULT, Filtermap.isInstance(rClass));
     }
 
     public static DescendantNodeStream<Node> descendantsOrSelf(@NonNull Node node) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/TreeWalker.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/TreeWalker.java
@@ -112,10 +112,12 @@ final class TreeWalker {
 
         private final Deque<Node> queue = new ArrayDeque<>();
         private final TreeWalker config;
+        private boolean isFirst;
 
         /** Always {@link #hasNext()} after exiting the constructor. */
         DescendantOrSelfIterator(Node top, TreeWalker walker) {
             this.config = walker;
+            this.isFirst = true;
             queue.addFirst(top);
         }
 
@@ -129,12 +131,14 @@ final class TreeWalker {
         public @NonNull Node next() {
             Node node = queue.removeFirst();
             enqueueChildren(node);
+            isFirst = false;
             return node;
         }
 
 
         private void enqueueChildren(Node n) {
-            if (config.isCrossFindBoundaries() || !n.isFindBoundary()) {
+            // on the first node, we must cross find boundaries anyway
+            if (config.isCrossFindBoundaries() || !n.isFindBoundary() || isFirst) {
                 for (int i = n.getNumChildren() - 1; i >= 0; i--) {
                     queue.addFirst(n.getChild(i));
                 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/BoundaryTraversalTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/BoundaryTraversalTest.java
@@ -59,6 +59,15 @@ public class BoundaryTraversalTest {
     }
 
     @Test
+    public void testSearchFromBoundaryFromNonOptimisedStream() {
+        addChild(rootNode, addChild(newDummyNode(true), newDummyNode(false)));
+
+        List<DummyNode> descendantsOfType = rootNode.descendants(DummyNode.class).take(1).descendants(DummyNode.class).toList();
+        assertEquals(1, descendantsOfType.size());
+        assertFalse(descendantsOfType.get(0).isFindBoundary());
+    }
+
+    @Test
     public void testSearchIgnoringBoundary() {
         addChild(rootNode, addChild(newDummyNode(true), newDummyNode(false)));
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaQualifiableNode.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaQualifiableNode.java
@@ -12,7 +12,7 @@ package net.sourceforge.pmd.lang.java.ast;
  * @deprecated See {@link JavaQualifiedName}
  */
 @Deprecated
-public interface JavaQualifiableNode {
+public interface JavaQualifiableNode extends JavaNode {
 
     /**
      * Returns a qualified name for this node.

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/dfa/VariableAccessVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/dfa/VariableAccessVisitor.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.dfa;
 
+import static net.sourceforge.pmd.lang.ast.NodeStream.asInstanceOf;
+
 import java.util.AbstractMap.SimpleEntry;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -86,13 +88,11 @@ public class VariableAccessVisitor extends JavaParserVisitorAdapter {
                 List<SimpleEntry<Node, NameOccurrence>> occurrencesWithAssignmentExp = new ArrayList<>();
                 for (NameOccurrence occurrence : entry.getValue()) {
                     // find the nearest assignment, if any
-                    Node potentialAssignment = occurrence.getLocation().getFirstParentOfAnyType(ASTStatementExpression.class,
-                                                                                            ASTExpression.class);
+                    Node potentialAssignment = occurrence.getLocation().ancestors().firstNonNull(asInstanceOf(ASTStatementExpression.class, ASTExpression.class));
                     while (potentialAssignment != null
                             && (potentialAssignment.getNumChildren() < 2
                                     || !(potentialAssignment.getChild(1) instanceof ASTAssignmentOperator))) {
-                        potentialAssignment = potentialAssignment.getFirstParentOfAnyType(ASTStatementExpression.class,
-                                ASTExpression.class);
+                        potentialAssignment = potentialAssignment.ancestors().firstNonNull(asInstanceOf(ASTStatementExpression.class, ASTExpression.class));
                     }
                     // at this point, potentialAssignment is either a assignment or null
                     occurrencesWithAssignmentExp.add(new SimpleEntry<>(potentialAssignment, occurrence));

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/internal/visitors/AtfdBaseVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/internal/visitors/AtfdBaseVisitor.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.metrics.internal.visitors;
 
+import static net.sourceforge.pmd.lang.ast.NodeStream.asInstanceOf;
+
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
@@ -80,7 +82,7 @@ public class AtfdBaseVisitor extends JavaParserVisitorAdapter {
             result = false;
         } else if (nameImage == null && node.getFirstDescendantOfType(ASTPrimaryPrefix.class).usesThisModifier()) {
             result = false;
-        } else if (nameImage == null && node.hasDescendantOfAnyType(ASTLiteral.class, ASTAllocationExpression.class)) {
+        } else if (nameImage == null && node.descendants().map(asInstanceOf(ASTLiteral.class, ASTAllocationExpression.class)).nonEmpty()) {
             result = false;
         } else {
             result = true;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/PrematureDeclarationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/PrematureDeclarationRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
+import static net.sourceforge.pmd.lang.ast.NodeStream.asInstanceOf;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -60,7 +62,7 @@ public class PrematureDeclarationRule extends AbstractJavaRule {
      * Exclude blocks that have these things as part of an inner class.
      */
     private boolean hasExit(ASTBlockStatement block) {
-        return block.hasDescendantOfAnyType(ASTThrowStatement.class, ASTReturnStatement.class);
+        return block.descendants().map(asInstanceOf(ASTThrowStatement.class, ASTReturnStatement.class)).nonEmpty();
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentInOperandRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AssignmentInOperandRule.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 
+import static net.sourceforge.pmd.lang.ast.NodeStream.asInstanceOf;
 import static net.sourceforge.pmd.properties.PropertyFactory.booleanProperty;
 
 import net.sourceforge.pmd.lang.ast.Node;
@@ -62,8 +63,9 @@ public class AssignmentInOperandRule extends AbstractJavaRule {
                         && !getProperty(ALLOW_FOR_DESCRIPTOR))
                 && (node.hasDescendantOfType(ASTAssignmentOperator.class)
                         || !getProperty(ALLOW_INCREMENT_DECREMENT_DESCRIPTOR)
-                                && (node.hasDescendantOfAnyType(ASTPreIncrementExpression.class,
-                                                                ASTPreDecrementExpression.class, ASTPostfixExpression.class)))) {
+                                && node.descendants()
+                                       .map(asInstanceOf(ASTPreIncrementExpression.class, ASTPreDecrementExpression.class, ASTPostfixExpression.class))
+                                       .nonEmpty())) {
 
             addViolation(data, node);
             return data;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidLogMessageFormatRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidLogMessageFormatRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 
+import static net.sourceforge.pmd.lang.ast.NodeStream.filterIsAny;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -198,12 +200,10 @@ public class InvalidLogMessageFormatRule extends AbstractJavaRule {
             final String variableName = node.getFirstDescendantOfType(ASTName.class).getImage();
             // look if the message is defined locally in a method/constructor, initializer block or lambda expression
             final NodeStream<ASTVariableDeclarator> parentBlock =
-                NodeStream.filterIsAny(node.ancestors(),
-                                       ASTMethodOrConstructorDeclaration.class,
-                                       ASTInitializer.class,
-                                       ASTLambdaExpression.class)
-                          .take(1)
-                          .descendants(ASTVariableDeclarator.class);
+                node.ancestors()
+                    .map(filterIsAny(ASTMethodOrConstructorDeclaration.class, ASTInitializer.class, ASTLambdaExpression.class))
+                    .take(1)
+                    .descendants(ASTVariableDeclarator.class);
 
             count = getAmountOfExpectedArguments(variableName, parentBlock);
 
@@ -211,10 +211,11 @@ public class InvalidLogMessageFormatRule extends AbstractJavaRule {
                 // look if the message is defined in a field
                 // only look for ASTVariableDeclarator that are Fields
                 final NodeStream<ASTVariableDeclarator> fields =
-                    NodeStream.filterIsAny(node.ancestors(), ASTClassOrInterfaceBody.class, ASTEnumBody.class)
-                              .take(1)
-                              .descendants(ASTFieldDeclaration.class)
-                              .firstChild(ASTVariableDeclarator.class);
+                    node.ancestors()
+                        .map(filterIsAny(ASTClassOrInterfaceBody.class, ASTEnumBody.class))
+                        .take(1)
+                        .descendants(ASTFieldDeclaration.class)
+                        .firstChild(ASTVariableDeclarator.class);
                 count = getAmountOfExpectedArguments(variableName, fields);
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidLogMessageFormatRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidLogMessageFormatRule.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 
 import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.ast.NodeStream;
 import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBody;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
@@ -33,7 +34,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableInitializer;
-import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
 import net.sourceforge.pmd.lang.java.typeresolution.TypeHelper;
@@ -197,28 +197,31 @@ public class InvalidLogMessageFormatRule extends AbstractJavaRule {
         } else if (node.getFirstDescendantOfType(ASTName.class) != null) {
             final String variableName = node.getFirstDescendantOfType(ASTName.class).getImage();
             // look if the message is defined locally in a method/constructor, initializer block or lambda expression
-            final JavaNode parentBlock = node.getFirstParentOfAnyType(ASTMethodOrConstructorDeclaration.class, ASTInitializer.class, ASTLambdaExpression.class);
-            if (parentBlock != null) {
-                final List<ASTVariableDeclarator> localVariables = parentBlock.findDescendantsOfType(ASTVariableDeclarator.class);
-                count = getAmountOfExpectedArguments(variableName, localVariables);
-            }
+            final NodeStream<ASTVariableDeclarator> parentBlock =
+                NodeStream.filterIsAny(node.ancestors(),
+                                       ASTMethodOrConstructorDeclaration.class,
+                                       ASTInitializer.class,
+                                       ASTLambdaExpression.class)
+                          .take(1)
+                          .descendants(ASTVariableDeclarator.class);
+
+            count = getAmountOfExpectedArguments(variableName, parentBlock);
 
             if (count == -1) {
                 // look if the message is defined in a field
-                final List<ASTFieldDeclaration> fieldlist = node.getFirstParentOfAnyType(ASTClassOrInterfaceBody.class, ASTEnumBody.class)
-                        .findDescendantsOfType(ASTFieldDeclaration.class);
                 // only look for ASTVariableDeclarator that are Fields
-                final List<ASTVariableDeclarator> fields = new ArrayList<>(fieldlist.size());
-                for (final ASTFieldDeclaration astFieldDeclaration : fieldlist) {
-                    fields.add(astFieldDeclaration.getFirstChildOfType(ASTVariableDeclarator.class));
-                }
+                final NodeStream<ASTVariableDeclarator> fields =
+                    NodeStream.filterIsAny(node.ancestors(), ASTClassOrInterfaceBody.class, ASTEnumBody.class)
+                              .take(1)
+                              .descendants(ASTFieldDeclaration.class)
+                              .firstChild(ASTVariableDeclarator.class);
                 count = getAmountOfExpectedArguments(variableName, fields);
             }
         }
         return count;
     }
 
-    private int getAmountOfExpectedArguments(final String variableName, final List<ASTVariableDeclarator> variables) {
+    private int getAmountOfExpectedArguments(final String variableName, final Iterable<ASTVariableDeclarator> variables) {
         for (final ASTVariableDeclarator astVariableDeclarator : variables) {
             if (astVariableDeclarator.getFirstChildOfType(ASTVariableDeclaratorId.class).getImage()
                     .equals(variableName)) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidLogMessageFormatRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidLogMessageFormatRule.java
@@ -4,7 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 
-import static net.sourceforge.pmd.lang.ast.NodeStream.filterIsAny;
+import static net.sourceforge.pmd.lang.ast.NodeStream.asInstanceOf;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -201,7 +201,7 @@ public class InvalidLogMessageFormatRule extends AbstractJavaRule {
             // look if the message is defined locally in a method/constructor, initializer block or lambda expression
             final NodeStream<ASTVariableDeclarator> parentBlock =
                 node.ancestors()
-                    .map(filterIsAny(ASTMethodOrConstructorDeclaration.class, ASTInitializer.class, ASTLambdaExpression.class))
+                    .map(asInstanceOf(ASTMethodOrConstructorDeclaration.class, ASTInitializer.class, ASTLambdaExpression.class))
                     .take(1)
                     .descendants(ASTVariableDeclarator.class);
 
@@ -212,7 +212,7 @@ public class InvalidLogMessageFormatRule extends AbstractJavaRule {
                 // only look for ASTVariableDeclarator that are Fields
                 final NodeStream<ASTVariableDeclarator> fields =
                     node.ancestors()
-                        .map(filterIsAny(ASTClassOrInterfaceBody.class, ASTEnumBody.class))
+                        .map(asInstanceOf(ASTClassOrInterfaceBody.class, ASTEnumBody.class))
                         .take(1)
                         .descendants(ASTFieldDeclaration.class)
                         .firstChild(ASTVariableDeclarator.class);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/StringInstantiationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/StringInstantiationRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.performance;
 
+import static net.sourceforge.pmd.lang.ast.NodeStream.asInstanceOf;
+
 import java.util.List;
 
 import net.sourceforge.pmd.lang.ast.Node;
@@ -48,7 +50,7 @@ public class StringInstantiationRule extends AbstractJavaRule {
             return data;
         }
 
-        if (node.hasDescendantOfAnyType(ASTArrayDimsAndInits.class, ASTAdditiveExpression.class)) {
+        if (node.descendants().map(asInstanceOf(ASTArrayDimsAndInits.class, ASTAdditiveExpression.class)).nonEmpty()) {
             return data;
         }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.typeresolution;
 
+import static net.sourceforge.pmd.lang.ast.NodeStream.asInstanceOf;
 import static net.sourceforge.pmd.lang.java.typeresolution.MethodTypeResolution.getApplicableMethods;
 import static net.sourceforge.pmd.lang.java.typeresolution.MethodTypeResolution.getBestMethodReturnType;
 import static net.sourceforge.pmd.lang.java.typeresolution.MethodTypeResolution.getMethodExplicitTypeArugments;
@@ -263,7 +264,7 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter implements Nulla
         String typeName = node.getImage();
 
         if (node.isAnonymousClass()) {
-            JavaQualifiableNode parent = node.getFirstParentOfAnyType(ASTAllocationExpression.class, ASTEnumConstant.class);
+            JavaQualifiableNode parent = node.ancestors().firstNonNull(asInstanceOf(ASTAllocationExpression.class, ASTEnumConstant.class));
 
             if (parent != null) {
                 typeName = parent.getQualifiedName().toString();


### PR DESCRIPTION
Followup on https://github.com/pmd/pmd/pull/2385#discussion_r403494429

Indeed this change is a contagious, but it maximises the usability of the API. 

I also checked out filterIsAny from the java-grammar branch and used it in one rule to see if it works. This discovered a bug with find boundaries. I changed this API a bit, now it's called asInstanceOf.

Also I think we should deprecate `Node::getFirstParentOfAnyType` on master. This causes an unchecked warning because of the generic varargs creation. In 7.0 you can now just do `node.ancestors().map(asInstanceOf(....))` without a warning
