### PR TITLE
 [java] ClassNamingConventions suggests to add Util for class containing only static constants, fixes #1164

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ClassNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ClassNamingConventionsRule.java
@@ -30,7 +30,7 @@ public class ClassNamingConventionsRule extends AbstractNamingConventionRule<AST
     private final PropertyDescriptor<Pattern> interfaceRegex = defaultProp("interface").build();
     private final PropertyDescriptor<Pattern> enumerationRegex = defaultProp("enum").build();
     private final PropertyDescriptor<Pattern> annotationRegex = defaultProp("annotation").build();
-    private final PropertyDescriptor<Pattern> utilityClassRegex = defaultProp("utility class").defaultValue("[A-Z][a-zA-Z0-9]+(Utils?|Helper)").build();
+    private final PropertyDescriptor<Pattern> utilityClassRegex = defaultProp("utility class").defaultValue("[A-Z][a-zA-Z0-9]+(Utils?|Helper|Constants)").build();
 
 
     public ClassNamingConventionsRule() {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ClassNamingConventions.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ClassNamingConventions.xml
@@ -53,7 +53,7 @@
         <description>Utility class convention</description>
         <expected-problems>1</expected-problems>
         <expected-messages>
-            <message>The utility class name 'Foo' doesn't match '[A-Z][a-zA-Z0-9]+(Utils?|Helper)'</message>
+            <message>The utility class name 'Foo' doesn't match '[A-Z][a-zA-Z0-9]+(Utils?|Helper|Constants)'</message>
         </expected-messages>
         <code><![CDATA[
             public class Foo {
@@ -144,7 +144,7 @@
         <description>Class with only static members except constructors should be a utility class</description>
         <expected-problems>1</expected-problems>
         <expected-messages>
-            <message>The utility class name 'Foo' doesn't match '[A-Z][a-zA-Z0-9]+(Utils?|Helper)'</message>
+            <message>The utility class name 'Foo' doesn't match '[A-Z][a-zA-Z0-9]+(Utils?|Helper|Constants)'</message>
         </expected-messages>
         <code><![CDATA[
             public class Foo {
@@ -249,6 +249,20 @@
                 private static final String foo = "FOOO";
 
                 public static void main(String[] args) {
+                    // whitelisted
+                }
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Utility class can have name constants</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class MyConstants {
+                public static final String FOOO = "FOOO";
+
+                private MyConstants() {
                     // whitelisted
                 }
             }


### PR DESCRIPTION
**PR Description:**
Code has been fixed as per suggestion https://github.com/pmd/pmd/issues/1164#issuecomment-393776672.
Also updated Unit Tests.

Fixes #1164 