### PR TITLE
[java] Fix UseAssertEqualsInsteadOfAssertTrue Example

### DIFF
--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -1445,7 +1445,7 @@ public class FooTest extends TestCase {
     void testCode() {
         Object a, b;
         assertTrue(a.equals(b));                    // bad usage
-        assertEquals(?a should equals b?, a, b);    // good usage
+        assertEquals("a should equals b", a, b);    // good usage
     }
 }
 ]]>


### PR DESCRIPTION
<!--
Please, prefix the PR title with the language it applies to within brackets, such as *[java]* or *[apex]*. If not specific to a language, you can use *[core]*
-->

Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
The message string used `?` instead of `"`, which resulted in invalid syntax and hence code which would not compile. This PR replaces the `?` character with `"`.
