### PR TITLE
[javascript] Fix issue with Rhino localization and trailing commas

### DIFF
--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/EcmascriptTreeBuilder.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/EcmascriptTreeBuilder.java
@@ -72,7 +72,6 @@ import net.sourceforge.pmd.lang.ast.SourceCodePositioner;
 public final class EcmascriptTreeBuilder implements NodeVisitor {
 
     private static final Map<Class<? extends AstNode>, Constructor<? extends EcmascriptNode<?>>> NODE_TYPE_TO_NODE_ADAPTER_TYPE = new HashMap<>();
-    private static String trailingCommaLocalizedMessage = null;
 
     static {
         register(ArrayComprehension.class, ASTArrayComprehension.class);
@@ -222,14 +221,12 @@ public final class EcmascriptTreeBuilder implements NodeVisitor {
             TrailingCommaNode trailingCommaNode = (TrailingCommaNode) node;
             int nodeStart = node.getNode().getAbsolutePosition();
             int nodeEnd = nodeStart + node.getNode().getLength() - 1;
-            for (ParseProblem parseProblem : parseProblems) {
 
-                if (trailingCommaLocalizedMessage == null) {
-                    // This will fetch the localized message, at most once, and only if there are
-                    // some problems (so we avoid parsing the message bundle for nothing)
-                    // See https://github.com/pmd/pmd/issues/384
-                    trailingCommaLocalizedMessage = ScriptRuntime.getMessage0("msg.extra.trailing.comma");
-                }
+            // This will fetch the localized message
+            // See https://github.com/pmd/pmd/issues/384
+            String trailingCommaLocalizedMessage = ScriptRuntime.getMessage0("msg.extra.trailing.comma");
+
+            for (ParseProblem parseProblem : parseProblems) {
 
                 // The node overlaps the comma (i.e. end of the problem)?
                 int problemStart = parseProblem.getFileOffset();

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/DefaultLocale.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/DefaultLocale.java
@@ -1,0 +1,56 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.ecmascript.ast;
+
+import java.util.Locale;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * A JUnit rule to change the system locale during a test.
+ */
+public class DefaultLocale implements TestRule {
+
+    private boolean statementIsExecuting = false;
+    private Locale loc = Locale.getDefault();
+
+    /** Set the locale value (overwrites previously set value). */
+    public void set(Locale locale) {
+        if (statementIsExecuting) {
+            Locale.setDefault(locale);
+        } else {
+            this.loc = locale;
+        }
+    }
+
+    @Override
+    public Statement apply(Statement base, Description description) {
+        return new EnvironmentVariablesStatement(base);
+    }
+
+    private class EnvironmentVariablesStatement extends Statement {
+
+        final Statement baseStatement;
+
+        EnvironmentVariablesStatement(Statement baseStatement) {
+            this.baseStatement = baseStatement;
+        }
+
+        @Override
+        public void evaluate() throws Throwable {
+            Locale prev = Locale.getDefault();
+            statementIsExecuting = true;
+            try {
+                Locale.setDefault(loc);
+                baseStatement.evaluate();
+            } finally {
+                statementIsExecuting = false;
+                Locale.setDefault(prev);
+            }
+        }
+    }
+}

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/TrailingCommaTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/TrailingCommaTest.java
@@ -17,18 +17,18 @@ public class TrailingCommaTest extends EcmascriptParserTestBase {
 
 
     @Test
-    public void testTrailingComma_DefaultLocale() {
+    public void testTrailingCommaDefaultLocale() {
         testTrailingComma();
     }
 
     @Test
-    public void testTrailingComma_FrFr() {
+    public void testTrailingCommaFrFr() {
         defaultLocale.set(Locale.FRANCE);
         testTrailingComma();
     }
 
     @Test
-    public void testTrailingComma_RootLocale() {
+    public void testTrailingCommaRootLocale() {
         defaultLocale.set(Locale.ROOT);
         testTrailingComma();
     }

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/TrailingCommaTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/TrailingCommaTest.java
@@ -1,0 +1,41 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.ecmascript.ast;
+
+import java.util.Locale;
+
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class TrailingCommaTest extends EcmascriptParserTestBase {
+
+    @Rule
+    public DefaultLocale defaultLocale = new DefaultLocale();
+
+
+    @Test
+    public void testTrailingComma_DefaultLocale() {
+        testTrailingComma();
+    }
+
+    @Test
+    public void testTrailingComma_FrFr() {
+        defaultLocale.set(Locale.FRANCE);
+        testTrailingComma();
+    }
+
+    @Test
+    public void testTrailingComma_RootLocale() {
+        defaultLocale.set(Locale.ROOT);
+        testTrailingComma();
+    }
+
+    public void testTrailingComma() {
+        ASTAstRoot node = js.parse("x = {a : 1, };\n");
+        ASTObjectLiteral fn = node.getFirstDescendantOfType(ASTObjectLiteral.class);
+        Assert.assertTrue(fn.isTrailingComma());
+    }
+}


### PR DESCRIPTION
Fixes #384 

Edit: this solution is a bit patchy, because the default locale may have changed between the time the message is reported by the parser, and the time we read it later. Maybe a slightly more robust solution would be to replace the MessageProvider of ScriptRuntime with something that takes a fixed locale (and even then, the message provider can be overwritten by anyone). Since this looks like a very very rare situation, I'm reluctant to go the extra step