### PR TITLE
[apex] Internalize AST constructors and helper implementations

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -80,7 +80,7 @@ You can identify them with the `@InternalApi` annotation. You'll also get a depr
 
 As part of the changes we'd like to do to AST classes for 7.0.0, we would like to
 hide some methods and constructors that rule writers should not have access to.
-The following usages are now deprecated in the **Visualforce** and **PLSQL** ASTs:
+The following usages are now deprecated in the **Apex**, **Visualforce** and **PLSQL** ASTs:
 
 *   Manual instantiation of nodes. **Constructors of node classes are deprecated** and
     marked {% jdoc core::annotation.InternalApi %}. Nodes should only be obtained from the parser,
@@ -101,6 +101,7 @@ The following usages are now deprecated in the **Visualforce** and **PLSQL** AST
 
 These deprecations are added to the following language modules in this release.
 Please look at the package documentation to find out the full list of deprecations.
+* Apex: **{% jdoc_package apex::lang.apex.ast %}**
 * Visualforce: **{% jdoc_package visualforce::lang.vf.ast %}**
 * PL/SQL: **{% jdoc_package plsql::lang.plsql.ast %}**
 
@@ -113,17 +114,18 @@ following languages:
 Outside of these packages, these changes also concern the following TokenManager
 implementations, and their corresponding Parser if it exists (in the same package):
 
-*   {% jdoc vm::lang.vm.VmTokenManager %}
+*   {% jdoc cpp::lang.cpp.CppTokenManager %}
 *   {% jdoc java::lang.java.JavaTokenManager %}
+*   {% jdoc javascript::lang.ecmascript5.Ecmascript5TokenManager %}
+*   {% jdoc jsp::lang.jsp.JspTokenManager %}
+*   {% jdoc matlab::lang.matlab.MatlabTokenManager %}
+*   {% jdoc modelica::lang.modelica.ModelicaTokenManager %}
+*   {% jdoc objectivec::lang.objectivec.ObjectiveCTokenManager %}
+*   {% jdoc plsql::lang.plsql.PLSQLTokenManager %}
 *   {% jdoc python::lang.python.PythonTokenManager %}
 *   {% jdoc visualforce::lang.vf.VfTokenManager %}
-*   {% jdoc plsql::lang.plsql.PLSQLTokenManager %}
-*   {% jdoc jsp::lang.jsp.JspTokenManager %}
-*   {% jdoc modelica::lang.modelica.ModelicaTokenManager %}
-*   {% jdoc cpp::lang.cpp.CppTokenManager %}
-*   {% jdoc javascript::lang.ecmascript5.Ecmascript5TokenManager %}
-*   {% jdoc matlab::lang.matlab.MatlabTokenManager %}
-*   {% jdoc objectivec::lang.objectivec.ObjectiveCTokenManager %}
+*   {% jdoc vm::lang.vm.VmTokenManager %}
+
 
 ##### For removal
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotation.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotation.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -9,11 +9,14 @@ import java.util.Set;
 import java.util.TreeSet;
 
 import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.annotation.InternalApi;
 
 import apex.jorje.semantic.ast.modifier.Annotation;
 
 public class ASTAnnotation extends AbstractApexNode<Annotation> {
 
+    @Deprecated
+    @InternalApi
     public ASTAnnotation(Annotation annotation) {
         super(annotation);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotationParameter.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotationParameter.java
@@ -1,14 +1,18 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
+
+import net.sourceforge.pmd.annotation.InternalApi;
 
 import apex.jorje.semantic.ast.modifier.AnnotationParameter;
 
 public class ASTAnnotationParameter extends AbstractApexNode<AnnotationParameter> {
     public static final String SEE_ALL_DATA = "seeAllData";
 
+    @Deprecated
+    @InternalApi
     public ASTAnnotationParameter(AnnotationParameter annotationParameter) {
         super(annotationParameter);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnonymousClass.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnonymousClass.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.compilation.AnonymousClass;
 
 public class ASTAnonymousClass extends ApexRootNode<AnonymousClass> {
 
+    @Deprecated
+    @InternalApi
     public ASTAnonymousClass(AnonymousClass anonymousClass) {
         super(anonymousClass);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTArrayLoadExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTArrayLoadExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.ArrayLoadExpression;
 
 public class ASTArrayLoadExpression extends AbstractApexNode<ArrayLoadExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTArrayLoadExpression(ArrayLoadExpression arrayLoadExpression) {
         super(arrayLoadExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTArrayStoreExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTArrayStoreExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.ArrayStoreExpression;
 
 public class ASTArrayStoreExpression extends AbstractApexNode<ArrayStoreExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTArrayStoreExpression(ArrayStoreExpression arrayStoreExpression) {
         super(arrayStoreExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAssignmentExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAssignmentExpression.java
@@ -1,14 +1,18 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
+
+import net.sourceforge.pmd.annotation.InternalApi;
 
 import apex.jorje.data.ast.AssignmentOp;
 import apex.jorje.semantic.ast.expression.AssignmentExpression;
 
 public class ASTAssignmentExpression extends AbstractApexNode<AssignmentExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTAssignmentExpression(AssignmentExpression assignmentExpression) {
         super(assignmentExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBinaryExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBinaryExpression.java
@@ -1,14 +1,18 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
+
+import net.sourceforge.pmd.annotation.InternalApi;
 
 import apex.jorje.data.ast.BinaryOp;
 import apex.jorje.semantic.ast.expression.BinaryExpression;
 
 public class ASTBinaryExpression extends AbstractApexNode<BinaryExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTBinaryExpression(BinaryExpression binaryExpression) {
         super(binaryExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBindExpressions.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBindExpressions.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.BindExpressions;
 
 public class ASTBindExpressions extends AbstractApexNode<BindExpressions> {
 
+    @Deprecated
+    @InternalApi
     public ASTBindExpressions(BindExpressions bindExpressions) {
         super(bindExpressions);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBlockStatement.java
@@ -1,14 +1,18 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
+
+import net.sourceforge.pmd.annotation.InternalApi;
 
 import apex.jorje.semantic.ast.statement.BlockStatement;
 
 public class ASTBlockStatement extends AbstractApexNode<BlockStatement> {
     private boolean curlyBrace;
 
+    @Deprecated
+    @InternalApi
     public ASTBlockStatement(BlockStatement blockStatement) {
         super(blockStatement);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBooleanExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBooleanExpression.java
@@ -1,8 +1,10 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
+
+import net.sourceforge.pmd.annotation.InternalApi;
 
 import apex.jorje.data.ast.BooleanOp;
 import apex.jorje.semantic.ast.expression.BooleanExpression;
@@ -10,6 +12,8 @@ import apex.jorje.semantic.ast.expression.BooleanExpression;
 
 public class ASTBooleanExpression extends AbstractApexNode<BooleanExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTBooleanExpression(BooleanExpression booleanExpression) {
         super(booleanExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBreakStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBreakStatement.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.BreakStatement;
 
 public class ASTBreakStatement extends AbstractApexNode<BreakStatement> {
 
+    @Deprecated
+    @InternalApi
     public ASTBreakStatement(BreakStatement breakStatement) {
         super(breakStatement);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBridgeMethodCreator.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBridgeMethodCreator.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.member.bridge.BridgeMethodCreator;
 
 public class ASTBridgeMethodCreator extends AbstractApexNode<BridgeMethodCreator> {
 
+    @Deprecated
+    @InternalApi
     public ASTBridgeMethodCreator(BridgeMethodCreator bridgeMethodCreator) {
         super(bridgeMethodCreator);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTCastExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTCastExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.CastExpression;
 
 public class ASTCastExpression extends AbstractApexNode<CastExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTCastExpression(CastExpression node) {
         super(node);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTCatchBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTCatchBlockStatement.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.CatchBlockStatement;
 
 public class ASTCatchBlockStatement extends AbstractApexNode<CatchBlockStatement> {
 
+    @Deprecated
+    @InternalApi
     public ASTCatchBlockStatement(CatchBlockStatement catchBlockStatement) {
         super(catchBlockStatement);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTClassRefExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTClassRefExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.ClassRefExpression;
 
 public class ASTClassRefExpression extends AbstractApexNode<ClassRefExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTClassRefExpression(ClassRefExpression classRefExpression) {
         super(classRefExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTConstructorPreamble.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTConstructorPreamble.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.compilation.ConstructorPreamble;
 
 public class ASTConstructorPreamble extends AbstractApexNode<ConstructorPreamble> {
 
+    @Deprecated
+    @InternalApi
     public ASTConstructorPreamble(ConstructorPreamble node) {
         super(node);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTConstructorPreambleStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTConstructorPreambleStatement.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.ConstructorPreambleStatement;
 
 public class ASTConstructorPreambleStatement extends AbstractApexNode<ConstructorPreambleStatement> {
 
+    @Deprecated
+    @InternalApi
     public ASTConstructorPreambleStatement(ConstructorPreambleStatement constructorPreambleStatement) {
         super(constructorPreambleStatement);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTContinueStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTContinueStatement.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.ContinueStatement;
 
 public class ASTContinueStatement extends AbstractApexNode<ContinueStatement> {
 
+    @Deprecated
+    @InternalApi
     public ASTContinueStatement(ContinueStatement continueStatement) {
         super(continueStatement);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlDeleteStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlDeleteStatement.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.DmlDeleteStatement;
 
 public class ASTDmlDeleteStatement extends AbstractApexNode<DmlDeleteStatement> {
 
+    @Deprecated
+    @InternalApi
     public ASTDmlDeleteStatement(DmlDeleteStatement dmlDeleteStatement) {
         super(dmlDeleteStatement);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlInsertStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlInsertStatement.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.DmlInsertStatement;
 
 public class ASTDmlInsertStatement extends AbstractApexNode<DmlInsertStatement> {
 
+    @Deprecated
+    @InternalApi
     public ASTDmlInsertStatement(DmlInsertStatement dmlInsertStatement) {
         super(dmlInsertStatement);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlMergeStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlMergeStatement.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.DmlMergeStatement;
 
 public class ASTDmlMergeStatement extends AbstractApexNode<DmlMergeStatement> {
 
+    @Deprecated
+    @InternalApi
     public ASTDmlMergeStatement(DmlMergeStatement dmlMergeStatement) {
         super(dmlMergeStatement);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlUndeleteStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlUndeleteStatement.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.DmlUndeleteStatement;
 
 public class ASTDmlUndeleteStatement extends AbstractApexNode<DmlUndeleteStatement> {
 
+    @Deprecated
+    @InternalApi
     public ASTDmlUndeleteStatement(DmlUndeleteStatement dmlUndeleteStatement) {
         super(dmlUndeleteStatement);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlUpdateStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlUpdateStatement.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.DmlUpdateStatement;
 
 public class ASTDmlUpdateStatement extends AbstractApexNode<DmlUpdateStatement> {
 
+    @Deprecated
+    @InternalApi
     public ASTDmlUpdateStatement(DmlUpdateStatement dmlUpdateStatement) {
         super(dmlUpdateStatement);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlUpsertStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlUpsertStatement.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.DmlUpsertStatement;
 
 public class ASTDmlUpsertStatement extends AbstractApexNode<DmlUpsertStatement> {
 
+    @Deprecated
+    @InternalApi
     public ASTDmlUpsertStatement(DmlUpsertStatement dmlUpsertStatement) {
         super(dmlUpsertStatement);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDoLoopStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDoLoopStatement.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.DoLoopStatement;
 
 public class ASTDoLoopStatement extends AbstractApexNode<DoLoopStatement> {
 
+    @Deprecated
+    @InternalApi
     public ASTDoLoopStatement(DoLoopStatement doLoopStatement) {
         super(doLoopStatement);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.Expression;
 
 public class ASTExpression extends AbstractApexNode<Expression> {
 
+    @Deprecated
+    @InternalApi
     public ASTExpression(Expression expression) {
         super(expression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTExpressionStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTExpressionStatement.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.ExpressionStatement;
 
 public class ASTExpressionStatement extends AbstractApexNode<ExpressionStatement> {
 
+    @Deprecated
+    @InternalApi
     public ASTExpressionStatement(ExpressionStatement expressionStatement) {
         super(expressionStatement);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTField.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTField.java
@@ -1,15 +1,18 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
 import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.annotation.InternalApi;
 
 import apex.jorje.semantic.ast.member.Field;
 
 public class ASTField extends AbstractApexNode<Field> implements CanSuppressWarnings {
 
+    @Deprecated
+    @InternalApi
     public ASTField(Field field) {
         super(field);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclaration.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclaration.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.FieldDeclaration;
 
 public class ASTFieldDeclaration extends AbstractApexNode<FieldDeclaration> {
 
+    @Deprecated
+    @InternalApi
     public ASTFieldDeclaration(FieldDeclaration fieldDeclaration) {
         super(fieldDeclaration);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclarationStatements.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclarationStatements.java
@@ -1,16 +1,19 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
 import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.annotation.InternalApi;
 
 import apex.jorje.semantic.ast.statement.FieldDeclarationStatements;
 
 public class ASTFieldDeclarationStatements extends AbstractApexNode<FieldDeclarationStatements>
         implements CanSuppressWarnings {
 
+    @Deprecated
+    @InternalApi
     public ASTFieldDeclarationStatements(FieldDeclarationStatements fieldDeclarationStatements) {
         super(fieldDeclarationStatements);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclarationStatements.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclarationStatements.java
@@ -4,9 +4,17 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.annotation.InternalApi;
 
+import apex.jorje.data.Identifier;
+import apex.jorje.data.ast.TypeRef;
+import apex.jorje.data.ast.TypeRefs.ArrayTypeRef;
+import apex.jorje.data.ast.TypeRefs.ClassTypeRef;
 import apex.jorje.semantic.ast.statement.FieldDeclarationStatements;
 
 public class ASTFieldDeclarationStatements extends AbstractApexNode<FieldDeclarationStatements>
@@ -37,5 +45,37 @@ public class ASTFieldDeclarationStatements extends AbstractApexNode<FieldDeclara
 
     public ASTModifierNode getModifiers() {
         return getFirstChildOfType(ASTModifierNode.class);
+    }
+
+    public String getTypeName() {
+        if (node.getTypeName() != null) {
+            List<Identifier> names = node.getTypeName().getNames();
+            return names.stream().map(Identifier::getValue).collect(Collectors.joining("."));
+        }
+        return null;
+    }
+
+    private static String identifiersToString(List<Identifier> identifiers) {
+        return identifiers.stream().map(Identifier::getValue).collect(Collectors.joining("."));
+    }
+
+    public List<String> getTypeArguments() {
+        List<String> result = new ArrayList<>();
+
+        if (node.getTypeName() != null) {
+            List<TypeRef> typeArgs = node.getTypeName().getTypeArguments();
+            for (TypeRef arg : typeArgs) {
+                if (arg instanceof ClassTypeRef) {
+                    result.add(identifiersToString(arg.getNames()));
+                } else if (arg instanceof ArrayTypeRef) {
+                    ArrayTypeRef atr = (ArrayTypeRef) arg;
+                    if (atr.getHeldType() instanceof ClassTypeRef) {
+                        result.add(identifiersToString(atr.getHeldType().getNames()));
+                    }
+                }
+            }
+        }
+
+        return result;
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTForEachStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTForEachStatement.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.ForEachStatement;
 
 public class ASTForEachStatement extends AbstractApexNode<ForEachStatement> {
 
+    @Deprecated
+    @InternalApi
     public ASTForEachStatement(ForEachStatement forEachStatement) {
         super(forEachStatement);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTForLoopStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTForLoopStatement.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.ForLoopStatement;
 
 public class ASTForLoopStatement extends AbstractApexNode<ForLoopStatement> {
 
+    @Deprecated
+    @InternalApi
     public ASTForLoopStatement(ForLoopStatement forLoopStatement) {
         super(forLoopStatement);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFormalComment.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFormalComment.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 
 import org.antlr.runtime.Token;
 
+import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.apex.ast.ASTFormalComment.AstComment;
 
 import apex.jorje.data.Location;
@@ -50,6 +51,8 @@ public class ASTFormalComment extends AbstractApexNode<AstComment> {
     }
 
 
+    @Deprecated
+    @InternalApi
     public static final class AstComment implements AstNode {
 
         private final Location loc;

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTIfBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTIfBlockStatement.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.IfBlockStatement;
 
 public class ASTIfBlockStatement extends AbstractApexNode<IfBlockStatement> {
 
+    @Deprecated
+    @InternalApi
     public ASTIfBlockStatement(IfBlockStatement ifBlockStatement) {
         super(ifBlockStatement);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTIfElseBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTIfElseBlockStatement.java
@@ -20,4 +20,8 @@ public class ASTIfElseBlockStatement extends AbstractApexNode<IfElseBlockStateme
     public Object jjtAccept(ApexParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
     }
+
+    public boolean hasElseStatement() {
+        return node.hasElseStatement();
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTIfElseBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTIfElseBlockStatement.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.IfElseBlockStatement;
 
 public class ASTIfElseBlockStatement extends AbstractApexNode<IfElseBlockStatement> {
 
+    @Deprecated
+    @InternalApi
     public ASTIfElseBlockStatement(IfElseBlockStatement ifElseBlockStatement) {
         super(ifElseBlockStatement);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTIllegalStoreExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTIllegalStoreExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.IllegalStoreExpression;
 
 public class ASTIllegalStoreExpression extends AbstractApexNode<IllegalStoreExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTIllegalStoreExpression(IllegalStoreExpression node) {
         super(node);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTInstanceOfExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTInstanceOfExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.InstanceOfExpression;
 
 public class ASTInstanceOfExpression extends AbstractApexNode<InstanceOfExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTInstanceOfExpression(InstanceOfExpression instanceOfExpression) {
         super(instanceOfExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTJavaMethodCallExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTJavaMethodCallExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.JavaMethodCallExpression;
 
 public class ASTJavaMethodCallExpression extends AbstractApexNode<JavaMethodCallExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTJavaMethodCallExpression(JavaMethodCallExpression javaMethodCallExpression) {
         super(javaMethodCallExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTJavaVariableExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTJavaVariableExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.JavaVariableExpression;
 
 public class ASTJavaVariableExpression extends AbstractApexNode<JavaVariableExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTJavaVariableExpression(JavaVariableExpression javaVariableExpression) {
         super(javaVariableExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -6,6 +6,8 @@ package net.sourceforge.pmd.lang.apex.ast;
 
 import java.lang.reflect.Field;
 import java.util.Optional;
+
+import net.sourceforge.pmd.annotation.InternalApi;
 
 import apex.jorje.data.Identifier;
 import apex.jorje.data.ast.LiteralType;
@@ -15,6 +17,8 @@ import apex.jorje.semantic.ast.expression.NewKeyValueObjectExpression.NameValueP
 
 public class ASTLiteralExpression extends AbstractApexNode<LiteralExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTLiteralExpression(LiteralExpression literalExpression) {
         super(literalExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMapEntryNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMapEntryNode.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.MapEntryNode;
 
 public class ASTMapEntryNode extends AbstractApexNode<MapEntryNode> {
 
+    @Deprecated
+    @InternalApi
     public ASTMapEntryNode(MapEntryNode mapEntryNode) {
         super(mapEntryNode);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethod.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethod.java
@@ -30,6 +30,10 @@ public class ASTMethod extends AbstractApexNode<Method> implements ApexQualifiab
         return node.getMethodInfo().getName();
     }
 
+    public String getCanonicalName() {
+        return node.getMethodInfo().getCanonicalName();
+    }
+
     @Override
     public int getEndLine() {
         ASTBlockStatement block = getFirstChildOfType(ASTBlockStatement.class);
@@ -82,6 +86,10 @@ public class ASTMethod extends AbstractApexNode<Method> implements ApexQualifiab
     }
 
     public String getReturnType() {
-        return node.getReturnTypeRef().toString();
+        return node.getMethodInfo().getEmitSignature().getReturnType().getApexName();
+    }
+
+    public int getArity() {
+        return node.getMethodInfo().getParameterTypes().size();
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethod.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethod.java
@@ -1,10 +1,11 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
 import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.apex.metrics.signature.ApexOperationSignature;
 import net.sourceforge.pmd.lang.ast.SignedNode;
 
@@ -13,6 +14,8 @@ import apex.jorje.semantic.ast.member.Method;
 public class ASTMethod extends AbstractApexNode<Method> implements ApexQualifiableNode,
        SignedNode<ASTMethod>, CanSuppressWarnings {
 
+    @Deprecated
+    @InternalApi
     public ASTMethod(Method method) {
         super(method);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodBlockStatement.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.MethodBlockStatement;
 
 public class ASTMethodBlockStatement extends AbstractApexNode<MethodBlockStatement> {
 
+    @Deprecated
+    @InternalApi
     public ASTMethodBlockStatement(MethodBlockStatement node) {
         super(node);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodCallExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodCallExpression.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -6,11 +6,15 @@ package net.sourceforge.pmd.lang.apex.ast;
 
 import java.util.Iterator;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.data.Identifier;
 import apex.jorje.semantic.ast.expression.MethodCallExpression;
 
 public class ASTMethodCallExpression extends AbstractApexNode<MethodCallExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTMethodCallExpression(MethodCallExpression methodCallExpression) {
         super(methodCallExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodCallExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodCallExpression.java
@@ -11,8 +11,8 @@ import net.sourceforge.pmd.annotation.InternalApi;
 import apex.jorje.data.Identifier;
 import apex.jorje.semantic.ast.expression.MethodCallExpression;
 
-public class ASTMethodCallExpression extends AbstractApexNode<MethodCallExpression> {
 
+public class ASTMethodCallExpression extends AbstractApexNode<MethodCallExpression> {
     @Deprecated
     @InternalApi
     public ASTMethodCallExpression(MethodCallExpression methodCallExpression) {
@@ -35,5 +35,9 @@ public class ASTMethodCallExpression extends AbstractApexNode<MethodCallExpressi
             typeName.append(it.next().getValue()).append('.');
         }
         return typeName.toString() + methodName;
+    }
+
+    public int getInputParametersSize() {
+        return node.getInputParameters().size();
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTModifier.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTModifier.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.modifier.Modifier;
 
 public class ASTModifier extends AbstractApexNode<Modifier> {
 
+    @Deprecated
+    @InternalApi
     public ASTModifier(Modifier node) {
         super(node);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTModifierNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTModifierNode.java
@@ -1,14 +1,18 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
+
+import net.sourceforge.pmd.annotation.InternalApi;
 
 import apex.jorje.semantic.ast.modifier.ModifierNode;
 import apex.jorje.semantic.symbol.type.ModifierTypeInfos;
 
 public class ASTModifierNode extends AbstractApexNode<ModifierNode> implements AccessNode {
 
+    @Deprecated
+    @InternalApi
     public ASTModifierNode(ModifierNode modifierNode) {
         super(modifierNode);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTModifierOrAnnotation.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTModifierOrAnnotation.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.modifier.ModifierOrAnnotation;
 
 public class ASTModifierOrAnnotation extends AbstractApexNode<ModifierOrAnnotation> {
 
+    @Deprecated
+    @InternalApi
     public ASTModifierOrAnnotation(ModifierOrAnnotation modifierOrAnnotation) {
         super(modifierOrAnnotation);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMultiStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMultiStatement.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.MultiStatement;
 
 public class ASTMultiStatement extends AbstractApexNode<MultiStatement> {
 
+    @Deprecated
+    @InternalApi
     public ASTMultiStatement(MultiStatement node) {
         super(node);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNestedExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNestedExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.NestedExpression;
 
 public class ASTNestedExpression extends AbstractApexNode<NestedExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTNestedExpression(NestedExpression node) {
         super(node);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNestedStoreExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNestedStoreExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.NestedStoreExpression;
 
 public class ASTNestedStoreExpression extends AbstractApexNode<NestedStoreExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTNestedStoreExpression(NestedStoreExpression node) {
         super(node);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewKeyValueObjectExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewKeyValueObjectExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.NewKeyValueObjectExpression;
 
 public class ASTNewKeyValueObjectExpression extends AbstractApexNode<NewKeyValueObjectExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTNewKeyValueObjectExpression(NewKeyValueObjectExpression node) {
         super(node);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewListInitExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewListInitExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.NewListInitExpression;
 
 public class ASTNewListInitExpression extends AbstractApexNode<NewListInitExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTNewListInitExpression(NewListInitExpression newListInitExpression) {
         super(newListInitExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewListLiteralExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewListLiteralExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.NewListLiteralExpression;
 
 public class ASTNewListLiteralExpression extends AbstractApexNode<NewListLiteralExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTNewListLiteralExpression(NewListLiteralExpression newListLiteralExpression) {
         super(newListLiteralExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewMapInitExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewMapInitExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.NewMapInitExpression;
 
 public class ASTNewMapInitExpression extends AbstractApexNode<NewMapInitExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTNewMapInitExpression(NewMapInitExpression newMapInitExpression) {
         super(newMapInitExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewMapLiteralExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewMapLiteralExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.NewMapLiteralExpression;
 
 public class ASTNewMapLiteralExpression extends AbstractApexNode<NewMapLiteralExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTNewMapLiteralExpression(NewMapLiteralExpression newMapLiteralExpression) {
         super(newMapLiteralExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewObjectExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewObjectExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.NewObjectExpression;
 
 public class ASTNewObjectExpression extends AbstractApexNode<NewObjectExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTNewObjectExpression(NewObjectExpression newObjectExpression) {
         super(newObjectExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewSetInitExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewSetInitExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.NewSetInitExpression;
 
 public class ASTNewSetInitExpression extends AbstractApexNode<NewSetInitExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTNewSetInitExpression(NewSetInitExpression newSetInitExpression) {
         super(newSetInitExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewSetLiteralExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewSetLiteralExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.NewSetLiteralExpression;
 
 public class ASTNewSetLiteralExpression extends AbstractApexNode<NewSetLiteralExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTNewSetLiteralExpression(NewSetLiteralExpression newSetLiteralExpression) {
         super(newSetLiteralExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPackageVersionExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPackageVersionExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.PackageVersionExpression;
 
 public class ASTPackageVersionExpression extends AbstractApexNode<PackageVersionExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTPackageVersionExpression(PackageVersionExpression packageVersionExpression) {
         super(packageVersionExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTParameter.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTParameter.java
@@ -1,15 +1,18 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
 import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.annotation.InternalApi;
 
 import apex.jorje.semantic.ast.member.Parameter;
 
 public class ASTParameter extends AbstractApexNode<Parameter> implements CanSuppressWarnings {
 
+    @Deprecated
+    @InternalApi
     public ASTParameter(Parameter parameter) {
         super(parameter);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPostfixExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPostfixExpression.java
@@ -1,8 +1,10 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
+
+import net.sourceforge.pmd.annotation.InternalApi;
 
 import apex.jorje.data.ast.PostfixOp;
 import apex.jorje.semantic.ast.expression.PostfixExpression;
@@ -10,6 +12,8 @@ import apex.jorje.semantic.ast.expression.PostfixExpression;
 
 public class ASTPostfixExpression extends AbstractApexNode<PostfixExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTPostfixExpression(PostfixExpression postfixExpression) {
         super(postfixExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPrefixExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPrefixExpression.java
@@ -1,14 +1,18 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
+
+import net.sourceforge.pmd.annotation.InternalApi;
 
 import apex.jorje.data.ast.PrefixOp;
 import apex.jorje.semantic.ast.expression.PrefixExpression;
 
 public class ASTPrefixExpression extends AbstractApexNode<PrefixExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTPrefixExpression(PrefixExpression prefixExpression) {
         super(prefixExpression);
     }
@@ -22,5 +26,4 @@ public class ASTPrefixExpression extends AbstractApexNode<PrefixExpression> {
     public PrefixOp getOperator() {
         return node.getOp();
     }
-
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTProperty.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTProperty.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.member.Property;
 
 public class ASTProperty extends AbstractApexNode<Property> {
 
+    @Deprecated
+    @InternalApi
     public ASTProperty(Property property) {
         super(property);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTReferenceExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTReferenceExpression.java
@@ -1,8 +1,10 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
+
+import net.sourceforge.pmd.annotation.InternalApi;
 
 import apex.jorje.semantic.ast.expression.IdentifierContext;
 import apex.jorje.semantic.ast.expression.ReferenceExpression;
@@ -11,6 +13,8 @@ import apex.jorje.semantic.ast.expression.ReferenceType;
 
 public class ASTReferenceExpression extends AbstractApexNode<ReferenceExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTReferenceExpression(ReferenceExpression referenceExpression) {
         super(referenceExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTReferenceExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTReferenceExpression.java
@@ -4,8 +4,13 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import net.sourceforge.pmd.annotation.InternalApi;
 
+import apex.jorje.data.Identifier;
 import apex.jorje.semantic.ast.expression.IdentifierContext;
 import apex.jorje.semantic.ast.expression.ReferenceExpression;
 import apex.jorje.semantic.ast.expression.ReferenceType;
@@ -41,5 +46,13 @@ public class ASTReferenceExpression extends AbstractApexNode<ReferenceExpression
             return node.getNames().get(0).getValue();
         }
         return null;
+    }
+
+    public List<String> getNames() {
+        List<Identifier> identifiers = node.getNames();
+        if (identifiers != null) {
+            return identifiers.stream().map(id -> id.getValue()).collect(Collectors.toList());
+        }
+        return Collections.emptyList();
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTReturnStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTReturnStatement.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.ReturnStatement;
 
 public class ASTReturnStatement extends AbstractApexNode<ReturnStatement> {
 
+    @Deprecated
+    @InternalApi
     public ASTReturnStatement(ReturnStatement returnStatement) {
         super(returnStatement);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTRunAsBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTRunAsBlockStatement.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.RunAsBlockStatement;
 
 public class ASTRunAsBlockStatement extends AbstractApexNode<RunAsBlockStatement> {
 
+    @Deprecated
+    @InternalApi
     public ASTRunAsBlockStatement(RunAsBlockStatement runAsBlockStatement) {
         super(runAsBlockStatement);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSoqlExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSoqlExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.SoqlExpression;
 
 public class ASTSoqlExpression extends AbstractApexNode<SoqlExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTSoqlExpression(SoqlExpression soqlExpression) {
         super(soqlExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSoqlExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSoqlExpression.java
@@ -22,6 +22,10 @@ public class ASTSoqlExpression extends AbstractApexNode<SoqlExpression> {
     }
 
     public String getQuery() {
-        return getNode().getRawQuery();
+        return node.getRawQuery();
+    }
+
+    public String getCanonicalQuery() {
+        return node.getCanonicalQuery();
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSoslExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSoslExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.SoslExpression;
 
 public class ASTSoslExpression extends AbstractApexNode<SoslExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTSoslExpression(SoslExpression soslExpression) {
         super(soslExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTStandardCondition.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTStandardCondition.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.condition.StandardCondition;
 
 public class ASTStandardCondition extends AbstractApexNode<StandardCondition> {
 
+    @Deprecated
+    @InternalApi
     public ASTStandardCondition(StandardCondition standardCondition) {
         super(standardCondition);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTStatement.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.Statement;
 
 public class ASTStatement extends AbstractApexNode<Statement> {
 
+    @Deprecated
+    @InternalApi
     public ASTStatement(Statement statement) {
         super(statement);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTStatementExecuted.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTStatementExecuted.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.StatementExecuted;
 
 public class ASTStatementExecuted extends AbstractApexNode<StatementExecuted> {
 
+    @Deprecated
+    @InternalApi
     public ASTStatementExecuted(StatementExecuted node) {
         super(node);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSuperMethodCallExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSuperMethodCallExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.SuperMethodCallExpression;
 
 public class ASTSuperMethodCallExpression extends AbstractApexNode<SuperMethodCallExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTSuperMethodCallExpression(SuperMethodCallExpression superMethodCallExpression) {
         super(superMethodCallExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSuperVariableExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSuperVariableExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.SuperVariableExpression;
 
 public class ASTSuperVariableExpression extends AbstractApexNode<SuperVariableExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTSuperVariableExpression(SuperVariableExpression superVariableExpression) {
         super(superVariableExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTernaryExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTernaryExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.TernaryExpression;
 
 public class ASTTernaryExpression extends AbstractApexNode<TernaryExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTTernaryExpression(TernaryExpression ternaryExpression) {
         super(ternaryExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThisMethodCallExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThisMethodCallExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.ThisMethodCallExpression;
 
 public class ASTThisMethodCallExpression extends AbstractApexNode<ThisMethodCallExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTThisMethodCallExpression(ThisMethodCallExpression thisMethodCallExpression) {
         super(thisMethodCallExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThisVariableExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThisVariableExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.ThisVariableExpression;
 
 public class ASTThisVariableExpression extends AbstractApexNode<ThisVariableExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTThisVariableExpression(ThisVariableExpression thisVariableExpression) {
         super(thisVariableExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThrowStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThrowStatement.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.ThrowStatement;
 
 public class ASTThrowStatement extends AbstractApexNode<ThrowStatement> {
 
+    @Deprecated
+    @InternalApi
     public ASTThrowStatement(ThrowStatement throwStatement) {
         super(throwStatement);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTriggerVariableExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTriggerVariableExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.TriggerVariableExpression;
 
 public class ASTTriggerVariableExpression extends AbstractApexNode<TriggerVariableExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTTriggerVariableExpression(TriggerVariableExpression triggerVariableExpression) {
         super(triggerVariableExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTryCatchFinallyBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTryCatchFinallyBlockStatement.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.TryCatchFinallyBlockStatement;
 
 public class ASTTryCatchFinallyBlockStatement extends AbstractApexNode<TryCatchFinallyBlockStatement> {
 
+    @Deprecated
+    @InternalApi
     public ASTTryCatchFinallyBlockStatement(TryCatchFinallyBlockStatement tryCatchFinallyBlockStatement) {
         super(tryCatchFinallyBlockStatement);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClass.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClass.java
@@ -34,7 +34,7 @@ public class ASTUserClass extends ApexRootNode<UserClass> implements ASTUserClas
 
     @Override
     public String getImage() {
-        String apexName = node.getDefiningType().getApexName();
+        String apexName = getDefiningType();
         return apexName.substring(apexName.lastIndexOf('.') + 1);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClass.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClass.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.annotation.InternalApi;
 
 import apex.jorje.data.Identifier;
 import apex.jorje.data.ast.TypeRef;
@@ -18,6 +19,8 @@ public class ASTUserClass extends ApexRootNode<UserClass> implements ASTUserClas
 
     private ApexQualifiedName qname;
 
+    @Deprecated
+    @InternalApi
     public ASTUserClass(UserClass userClass) {
         super(userClass);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClassMethods.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClassMethods.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.compilation.UserClassMethods;
 
 public class ASTUserClassMethods extends AbstractApexNode<UserClassMethods> {
 
+    @Deprecated
+    @InternalApi
     public ASTUserClassMethods(UserClassMethods userClassMethods) {
         super(userClassMethods);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClassOrInterface.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClassOrInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserEnum.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserEnum.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.compilation.UserEnum;
 
 public class ASTUserEnum extends ApexRootNode<UserEnum> {
 
+    @Deprecated
+    @InternalApi
     public ASTUserEnum(UserEnum userEnum) {
         super(userEnum);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserEnum.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserEnum.java
@@ -23,7 +23,7 @@ public class ASTUserEnum extends ApexRootNode<UserEnum> {
 
     @Override
     public String getImage() {
-        String apexName = node.getDefiningType().getApexName();
+        String apexName = getDefiningType();
         return apexName.substring(apexName.lastIndexOf('.') + 1);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserExceptionMethods.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserExceptionMethods.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.compilation.UserExceptionMethods;
 
 public class ASTUserExceptionMethods extends AbstractApexNode<UserExceptionMethods> {
 
+    @Deprecated
+    @InternalApi
     public ASTUserExceptionMethods(UserExceptionMethods userExceptionMethods) {
         super(userExceptionMethods);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserInterface.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserInterface.java
@@ -31,7 +31,7 @@ public class ASTUserInterface extends ApexRootNode<UserInterface> implements AST
 
     @Override
     public String getImage() {
-        String apexName = node.getDefiningType().getApexName();
+        String apexName = getDefiningType();
         return apexName.substring(apexName.lastIndexOf('.') + 1);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserInterface.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserInterface.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.apex.ast;
 import java.util.stream.Collectors;
 
 import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.annotation.InternalApi;
 
 import apex.jorje.data.Identifier;
 import apex.jorje.data.ast.TypeRef;
@@ -17,6 +18,8 @@ public class ASTUserInterface extends ApexRootNode<UserInterface> implements AST
 
     private ApexQualifiedName qname;
 
+    @Deprecated
+    @InternalApi
     public ASTUserInterface(UserInterface userInterface) {
         super(userInterface);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserTrigger.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserTrigger.java
@@ -27,7 +27,7 @@ public class ASTUserTrigger extends ApexRootNode<UserTrigger> {
 
     @Override
     public String getImage() {
-        return node.getDefiningType().getApexName();
+        return getDefiningType();
     }
 
     public ASTModifierNode getModifiers() {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserTrigger.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserTrigger.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -7,11 +7,15 @@ package net.sourceforge.pmd.lang.apex.ast;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.data.Identifier;
 import apex.jorje.semantic.ast.compilation.UserTrigger;
 
 public class ASTUserTrigger extends ApexRootNode<UserTrigger> {
 
+    @Deprecated
+    @InternalApi
     public ASTUserTrigger(UserTrigger userTrigger) {
         super(userTrigger);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableDeclaration.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableDeclaration.java
@@ -1,15 +1,18 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
 import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.annotation.InternalApi;
 
 import apex.jorje.semantic.ast.statement.VariableDeclaration;
 
 public class ASTVariableDeclaration extends AbstractApexNode<VariableDeclaration> implements CanSuppressWarnings {
 
+    @Deprecated
+    @InternalApi
     public ASTVariableDeclaration(VariableDeclaration variableDeclaration) {
         super(variableDeclaration);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableDeclarationStatements.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableDeclarationStatements.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.VariableDeclarationStatements;
 
 public class ASTVariableDeclarationStatements extends AbstractApexNode<VariableDeclarationStatements> {
 
+    @Deprecated
+    @InternalApi
     public ASTVariableDeclarationStatements(VariableDeclarationStatements variableDeclarationStatements) {
         super(variableDeclarationStatements);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableExpression.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.VariableExpression;
 
 public class ASTVariableExpression extends AbstractApexNode<VariableExpression> {
 
+    @Deprecated
+    @InternalApi
     public ASTVariableExpression(VariableExpression variableExpression) {
         super(variableExpression);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTWhileLoopStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTWhileLoopStatement.java
@@ -1,13 +1,17 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.statement.WhileLoopStatement;
 
 public class ASTWhileLoopStatement extends AbstractApexNode<WhileLoopStatement> {
 
+    @Deprecated
+    @InternalApi
     public ASTWhileLoopStatement(WhileLoopStatement whileLoopStatement) {
         super(whileLoopStatement);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNode.java
@@ -81,4 +81,20 @@ public abstract class AbstractApexNode<T extends AstNode> extends AbstractApexNo
             return "no location";
         }
     }
+
+    @Override
+    public String getDefiningType() {
+        if (node.getDefiningType() != null) {
+            return node.getDefiningType().getApexName();
+        }
+        return null;
+    }
+
+    @Override
+    public String getNamespace() {
+        if (node.getDefiningType() != null) {
+            return node.getDefiningType().getNamespace().toString();
+        }
+        return null;
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -54,6 +54,8 @@ public abstract class AbstractApexNode<T extends AstNode> extends AbstractApexNo
         // default implementation does nothing
     }
 
+    @Deprecated
+    @InternalApi
     @Override
     public T getNode() {
         return node;

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNodeBase.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNodeBase.java
@@ -1,9 +1,10 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.ast.AbstractNode;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.ast.SourceCodePositioner;
@@ -12,6 +13,7 @@ import net.sourceforge.pmd.lang.ast.SourceCodePositioner;
  * @deprecated Use {@link ApexNode}
  */
 @Deprecated
+@InternalApi
 public abstract class AbstractApexNodeBase extends AbstractNode {
 
     public AbstractApexNodeBase(Class<?> klass) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AccessNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AccessNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -35,7 +35,11 @@ public interface ApexNode<T extends AstNode> extends Node {
 
     /**
      * Get the underlying AST node.
+     * @deprecated the underlying AST node should not be available outside of the AST node.
+     *      If information is needed from the underlying node, then PMD's AST node need to expose
+     *      this information.
      */
+    @Deprecated
     T getNode();
 
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexNode.java
@@ -55,4 +55,8 @@ public interface ApexNode<T extends AstNode> extends Node {
     ApexNode<?> getParent();
 
     boolean hasRealLoc();
+
+    String getDefiningType();
+
+    String getNamespace();
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexParser.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexParser.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexParserVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexParserVisitor.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexParserVisitorAdapter.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexParserVisitorAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexParserVisitorReducedAdapter.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexParserVisitorReducedAdapter.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexQualifiableNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexQualifiableNode.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexQualifiedName.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexQualifiedName.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexQualifiedName.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexQualifiedName.java
@@ -133,8 +133,8 @@ public final class ApexQualifiedName implements QualifiedName {
     }
 
 
-    static ApexQualifiedName ofOuterClass(ASTUserClassOrInterface astUserClass) {
-        String ns = astUserClass.getNode().getDefiningType().getNamespace().toString();
+    static ApexQualifiedName ofOuterClass(ASTUserClassOrInterface<?> astUserClass) {
+        String ns = astUserClass.getNamespace();
         String[] classes = {astUserClass.getImage()};
         return new ApexQualifiedName(StringUtils.isEmpty(ns) ? "c" : ns, classes, null);
     }
@@ -153,7 +153,7 @@ public final class ApexQualifiedName implements QualifiedName {
         sb.append(node.getImage()).append('(');
 
 
-        List<TypeInfo> paramTypes = node.getNode().getMethodInfo().getParameterTypes();
+        List<TypeInfo> paramTypes = node.node.getMethodInfo().getParameterTypes();
 
         if (!paramTypes.isEmpty()) {
             sb.append(paramTypes.get(0).getApexName());
@@ -174,8 +174,8 @@ public final class ApexQualifiedName implements QualifiedName {
         ASTUserClassOrInterface<?> parent = node.getFirstParentOfType(ASTUserClassOrInterface.class);
         if (parent == null) {
             ASTUserTrigger trigger = node.getFirstParentOfType(ASTUserTrigger.class);
-            String ns = trigger.getNode().getDefiningType().getNamespace().toString();
-            String targetObj = trigger.getNode().getTargetName().get(0).getValue();
+            String ns = trigger.getNamespace();
+            String targetObj = trigger.getTargetName();
 
             return new ApexQualifiedName(StringUtils.isEmpty(ns) ? "c" : ns, new String[]{"trigger", targetObj}, trigger.getImage()); // uses a reserved word as a class name to prevent clashes
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexRootNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexRootNode.java
@@ -35,6 +35,6 @@ public abstract class ApexRootNode<T extends AstNode> extends AbstractApexNode<T
      * @return the apex version
      */
     public double getApexVersion() {
-        return getNode().getDefiningType().getCodeUnitDetails().getVersion().getExternal();
+        return node.getDefiningType().getCodeUnitDetails().getVersion().getExternal();
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexRootNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexRootNode.java
@@ -1,16 +1,21 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.ast.RootNode;
 import net.sourceforge.pmd.lang.ast.SourceCodePositioner;
 
 import apex.jorje.semantic.ast.AstNode;
 import apex.jorje.services.Version;
 
+@Deprecated
+@InternalApi
 public abstract class ApexRootNode<T extends AstNode> extends AbstractApexNode<T> implements RootNode {
+    @Deprecated
+    @InternalApi
     public ApexRootNode(T node) {
         super(node);
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexTreeBuilder.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexTreeBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -15,6 +15,7 @@ import java.util.Stack;
 import org.antlr.runtime.ANTLRStringStream;
 import org.antlr.runtime.Token;
 
+import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.apex.ApexParserOptions;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.ast.SourceCodePositioner;
@@ -122,6 +123,8 @@ import apex.jorje.semantic.ast.visitor.AdditionalPassScope;
 import apex.jorje.semantic.ast.visitor.AstVisitor;
 import apex.jorje.semantic.exception.Errors;
 
+@Deprecated
+@InternalApi
 public final class ApexTreeBuilder extends AstVisitor<AdditionalPassScope> {
 
     private static final Map<Class<? extends AstNode>, Constructor<? extends AbstractApexNode<?>>>

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/CanSuppressWarnings.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/CanSuppressWarnings.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/CompilerService.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/CompilerService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.reflect.FieldUtils;
+
+import net.sourceforge.pmd.annotation.InternalApi;
 
 import apex.jorje.semantic.ast.visitor.AdditionalPassScope;
 import apex.jorje.semantic.ast.visitor.AstVisitor;
@@ -36,6 +38,8 @@ import com.google.common.collect.ImmutableList;
  * @author nchen
  *
  */
+@Deprecated
+@InternalApi
 public class CompilerService {
     public static final CompilerService INSTANCE = new CompilerService();
     private final SymbolProvider symbolProvider;

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/EmptySymbolProvider.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/EmptySymbolProvider.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 // Note: taken from https://github.com/forcedotcom/idecore/blob/3083815933c2d015d03417986f57bd25786d58ce/com.salesforce.ide.apex.core/src/com/salesforce/ide/apex/internal/core/EmptySymbolProvider.java
@@ -21,6 +21,8 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.compiler.Namespace;
 import apex.jorje.semantic.compiler.sfdc.SymbolProvider;
 import apex.jorje.semantic.symbol.resolver.SymbolResolver;
@@ -29,6 +31,8 @@ import apex.jorje.semantic.symbol.type.TypeInfo;
 /**
  * @author jspagnola
  */
+@Deprecated
+@InternalApi
 public final class EmptySymbolProvider implements SymbolProvider {
 
     private static final EmptySymbolProvider INSTANCE = new EmptySymbolProvider();

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/TestAccessEvaluator.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/TestAccessEvaluator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 // Note: taken from https://github.com/forcedotcom/idecore/blob/3083815933c2d015d03417986f57bd25786d58ce/com.salesforce.ide.apex.core/src/apex/jorje/semantic/common/TestAccessEvaluator.java
@@ -26,6 +26,8 @@ import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.compiler.Namespace;
 import apex.jorje.semantic.compiler.StructuredVersion;
 import apex.jorje.semantic.compiler.sfdc.AccessEvaluator;
@@ -45,6 +47,8 @@ import com.google.common.collect.SetMultimap;
  *
  * @author jspagnola
  */
+@Deprecated
+@InternalApi
 public class TestAccessEvaluator implements AccessEvaluator {
 
     private final SetMultimap<Namespace, StructuredVersion> validPageVersions;

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/TestQueryValidators.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/TestQueryValidators.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 // Note: taken from https://github.com/forcedotcom/idecore/blob/3083815933c2d015d03417986f57bd25786d58ce/com.salesforce.ide.apex.core/src/apex/jorje/semantic/common/TestQueryValidators.java
@@ -22,6 +22,8 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 import apex.jorje.semantic.ast.expression.SoqlExpression;
 import apex.jorje.semantic.ast.expression.SoslExpression;
 import apex.jorje.semantic.ast.visitor.ValidationScope;
@@ -35,6 +37,8 @@ import apex.jorje.semantic.symbol.resolver.SymbolResolver;
  * @author jspagnola
  */
 @SuppressWarnings("PMD.MissingStaticMethodInNonInstantiatableClass") // this class provides utility classes
+@Deprecated
+@InternalApi
 public final class TestQueryValidators {
 
     private TestQueryValidators() {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/TriggerUsage.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/TriggerUsage.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/impl/visitors/CognitiveComplexityVisitor.java
@@ -83,7 +83,7 @@ public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
     public Object visit(ASTIfElseBlockStatement node, Object data) {
         State state = (State) data;
 
-        boolean hasElseStatement = node.getNode().hasElseStatement();
+        boolean hasElseStatement = node.hasElseStatement();
         for (ApexNode<?> child : node.children()) {
             // If we don't have an else statement, we get an empty block statement which we shouldn't count
             if (!hasElseStatement && child instanceof ASTBlockStatement) {
@@ -184,7 +184,7 @@ public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
     public Object visit(ASTBooleanExpression node, Object data) {
         State state = (State) data;
 
-        BooleanOp op = node.getNode().getOp();
+        BooleanOp op = node.getOperator();
         if (op == BooleanOp.AND || op == BooleanOp.OR) {
             state.booleanOperation(op);
         }
@@ -196,7 +196,7 @@ public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
     public Object visit(ASTPrefixExpression node, Object data) {
         State state = (State) data;
 
-        PrefixOp op = node.getNode().getOp();
+        PrefixOp op = node.getOperator();
         if (op == PrefixOp.NOT) {
             state.booleanOperation(null);
         }
@@ -222,14 +222,14 @@ public class CognitiveComplexityVisitor extends ApexParserVisitorAdapter {
     @Override
     public Object visit(ASTMethod node, Object data) {
         State state = (State) data;
-        state.setMethodName(node.getNode().getMethodInfo().getCanonicalName());
+        state.setMethodName(node.getCanonicalName());
         return super.visit(node, data);
     }
 
     @Override
     public Object visit(ASTMethodCallExpression node, Object data) {
         State state = (State) data;
-        state.methodCall(node.getNode().getMethodName());
+        state.methodCall(node.getMethodName());
         return super.visit(node, data);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
@@ -45,10 +45,6 @@ import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.apex.rule.internal.Helper;
 import net.sourceforge.pmd.lang.ast.Node;
 
-import apex.jorje.data.Identifier;
-import apex.jorje.data.ast.TypeRef;
-import apex.jorje.data.ast.TypeRefs.ArrayTypeRef;
-import apex.jorje.data.ast.TypeRefs.ClassTypeRef;
 import com.google.common.base.Objects;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ListMultimap;
@@ -108,9 +104,9 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
         className = node.getImage();
 
         for (ASTMethod n : node.findDescendantsOfType(ASTMethod.class)) {
-            StringBuilder sb = new StringBuilder().append(n.getNode().getDefiningType().getApexName()).append(":")
-                    .append(n.getNode().getMethodInfo().getCanonicalName()).append(":")
-                    .append(n.getNode().getMethodInfo().getParameterTypes().size());
+            StringBuilder sb = new StringBuilder().append(n.getDefiningType()).append(":")
+                    .append(n.getCanonicalName()).append(":")
+                    .append(n.getArity());
             classMethods.put(sb.toString(), n);
         }
 
@@ -166,7 +162,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
 
     @Override
     public Object visit(final ASTVariableDeclaration node, Object data) {
-        String type = node.getNode().getLocalInfo().getType().getApexName();
+        String type = node.getType();
         addVariableToMapping(Helper.getFQVariableName(node), type);
 
         final ASTSoqlExpression soql = node.getFirstChildOfType(ASTSoqlExpression.class);
@@ -182,23 +178,18 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     public Object visit(final ASTFieldDeclaration node, Object data) {
         ASTFieldDeclarationStatements field = node.getFirstParentOfType(ASTFieldDeclarationStatements.class);
         if (field != null) {
-            TypeRef a = field.getNode().getTypeName();
-            List<Identifier> names = a.getNames();
-            List<TypeRef> typeArgs = a.getTypeArguments();
+            String namesString = field.getTypeName();
 
-            if (!names.isEmpty()) {
-                String namesString = names.stream().map(Identifier::getValue).collect(Collectors.joining("."));
-
-                switch (namesString.toLowerCase(Locale.ROOT)) {
-                case "list":
-                case "map":
-                    addParametersToMapping(node, typeArgs);
-                    break;
-                default:
-                    varToTypeMapping.put(Helper.getFQVariableName(node), getSimpleType(namesString));
-                    break;
+            switch (namesString.toLowerCase(Locale.ROOT)) {
+            case "list":
+            case "map":
+                for (String typeArg : field.getTypeArguments()) {
+                    varToTypeMapping.put(Helper.getFQVariableName(node), typeArg);
                 }
-
+                break;
+            default:
+                varToTypeMapping.put(Helper.getFQVariableName(node), getSimpleType(namesString));
+                break;
             }
         }
         final ASTSoqlExpression soql = node.getFirstChildOfType(ASTSoqlExpression.class);
@@ -208,30 +199,6 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
 
         return data;
 
-    }
-
-    private void addParametersToMapping(final ASTFieldDeclaration node, List<TypeRef> typeArgs) {
-        for (int i = 0; i < typeArgs.size(); i++) {
-            if (typeArgs.get(i) instanceof ClassTypeRef) {
-                innerAddParametrizedClassToMapping(node, (ClassTypeRef) typeArgs.get(i));
-            }
-            if (typeArgs.get(i) instanceof ArrayTypeRef) {
-                ArrayTypeRef atr = (ArrayTypeRef) typeArgs.get(i);
-                if (atr.getHeldType() instanceof ClassTypeRef) {
-                    innerAddParametrizedClassToMapping(node, (ClassTypeRef) atr.getHeldType());
-                }
-            }
-        }
-    }
-
-    private void innerAddParametrizedClassToMapping(final ASTFieldDeclaration node, final ClassTypeRef innerClassRef) {
-        List<Identifier> ids = innerClassRef.getNames();
-        StringBuffer argType = new StringBuffer();
-        for (Identifier id : ids) {
-            argType.append(id.getValue()).append(".");
-        }
-        argType.deleteCharAt(argType.length() - 1);
-        addVariableToMapping(Helper.getFQVariableName(node), argType.toString());
     }
 
     @Override
@@ -286,9 +253,9 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
             return;
         }
 
-        List<Identifier> a = ref.getNode().getNames();
+        List<String> a = ref.getNames();
         if (!a.isEmpty()) {
-            extractObjectAndFields(a, method, node.getNode().getDefiningType().getApexName());
+            extractObjectAndFields(a, method, node.getDefiningType());
         } else {
             // see if ESAPI
             if (Helper.isMethodCallChain(node, ESAPI_ISAUTHORIZED_TO_VIEW)) {
@@ -325,8 +292,8 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     private boolean isLastMethodName(final ASTMethodCallExpression methodNode, final String className,
             final String methodName) {
         final ASTReferenceExpression reference = methodNode.getFirstChildOfType(ASTReferenceExpression.class);
-        if (reference != null && reference.getNode().getNames().size() > 0) {
-            if (reference.getNode().getNames().get(reference.getNode().getNames().size() - 1).getValue()
+        if (reference != null && reference.getNames().size() > 0) {
+            if (reference.getNames().get(reference.getNames().size() - 1)
                     .equalsIgnoreCase(className) && Helper.isMethodName(methodNode, methodName)) {
                 return true;
             }
@@ -344,20 +311,19 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
 
     private String getType(final ASTMethodCallExpression methodNode) {
         final ASTReferenceExpression reference = methodNode.getFirstChildOfType(ASTReferenceExpression.class);
-        if (reference.getNode().getNames().size() > 0) {
-            return new StringBuilder().append(reference.getNode().getDefiningType().getApexName()).append(":")
-                    .append(reference.getNode().getNames().get(0).getValue()).toString();
+        if (reference.getNames().size() > 0) {
+            return new StringBuilder().append(reference.getDefiningType()).append(":")
+                    .append(reference.getNames().get(0)).toString();
         }
         return "";
     }
 
-    private void extractObjectAndFields(final List<Identifier> listIdentifiers, final String method,
+    private void extractObjectAndFields(final List<String> listIdentifiers, final String method,
             final String definingType) {
-        final List<String> strings = listIdentifiers.stream().map(id -> id.getValue()).collect(Collectors.toList());
 
-        int flsIndex = Collections.lastIndexOfSubList(strings, Arrays.asList(RESERVED_KEYS_FLS));
+        int flsIndex = Collections.lastIndexOfSubList(listIdentifiers, Arrays.asList(RESERVED_KEYS_FLS));
         if (flsIndex != -1) {
-            String objectTypeName = strings.get(flsIndex + RESERVED_KEYS_FLS.length);
+            String objectTypeName = listIdentifiers.get(flsIndex + RESERVED_KEYS_FLS.length);
             if (!typeToDMLOperationMapping.get(definingType + ":" + objectTypeName).contains(method)) {
                 typeToDMLOperationMapping.put(definingType + ":" + objectTypeName, method);
             }
@@ -388,7 +354,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
         if (variable != null) {
             final String type = varToTypeMapping.get(Helper.getFQVariableName(variable));
             if (type != null) {
-                StringBuilder typeCheck = new StringBuilder().append(node.getNode().getDefiningType().getApexName())
+                StringBuilder typeCheck = new StringBuilder().append(node.getDefiningType())
                         .append(":").append(type);
 
                 validateCRUDCheckPresent(node, data, crudMethod, typeCheck.toString());
@@ -471,8 +437,8 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     }
 
     private ASTMethod resolveMethodCalls(final ASTMethodCallExpression node) {
-        StringBuilder sb = new StringBuilder().append(node.getNode().getDefiningType().getApexName()).append(":")
-                .append(node.getNode().getMethodName()).append(":").append(node.getNode().getInputParameters().size());
+        StringBuilder sb = new StringBuilder().append(node.getDefiningType()).append(":")
+                .append(node.getMethodName()).append(":").append(node.getInputParametersSize());
         return classMethods.get(sb.toString());
     }
 
@@ -495,10 +461,10 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
         if (var != null) {
             final ASTReferenceExpression reference = var.getFirstChildOfType(ASTReferenceExpression.class);
             if (reference != null) {
-                List<Identifier> identifiers = reference.getNode().getNames();
+                List<String> identifiers = reference.getNames();
                 if (identifiers.size() == 1) {
-                    StringBuilder sb = new StringBuilder().append(node.getNode().getDefiningType().getApexName())
-                            .append(":").append(identifiers.get(0).getValue());
+                    StringBuilder sb = new StringBuilder().append(node.getDefiningType())
+                            .append(":").append(identifiers.get(0));
                     checkedTypeToDMLOperationViaESAPI.put(sb.toString(), dmlOperation);
                 }
 
@@ -540,7 +506,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     }
 
     private void checkForAccessibility(final ASTSoqlExpression node, Object data) {
-        final boolean isCount = node.getNode().getCanonicalQuery().startsWith("SELECT COUNT()");
+        final boolean isCount = node.getCanonicalQuery().startsWith("SELECT COUNT()");
         final Set<String> typesFromSOQL = getTypesFromSOQLQuery(node);
 
         final Set<ASTMethodCallExpression> prevCalls = getPreviousMethodCalls(node);
@@ -567,9 +533,9 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
 
         final ASTVariableDeclaration variableDecl = node.getFirstParentOfType(ASTVariableDeclaration.class);
         if (variableDecl != null) {
-            String type = variableDecl.getNode().getLocalInfo().getType().getApexName();
+            String type = variableDecl.getType();
             type = getSimpleType(type);
-            StringBuilder typeCheck = new StringBuilder().append(variableDecl.getNode().getDefiningType().getApexName())
+            StringBuilder typeCheck = new StringBuilder().append(variableDecl.getDefiningType())
                     .append(":").append(type);
 
             if (!isGetter) {
@@ -622,25 +588,25 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
 
     private Set<String> getTypesFromSOQLQuery(final ASTSoqlExpression node) {
         final Set<String> retVal = new HashSet<>();
-        final String canonQuery = node.getNode().getCanonicalQuery();
+        final String canonQuery = node.getCanonicalQuery();
 
         Matcher m = SELECT_FROM_PATTERN.matcher(canonQuery);
         while (m.find()) {
-            retVal.add(new StringBuffer().append(node.getNode().getDefiningType().getApexName()).append(":")
+            retVal.add(new StringBuffer().append(node.getDefiningType()).append(":")
                     .append(m.group(1)).toString());
         }
         return retVal;
     }
 
     private String getReturnType(final ASTMethod method) {
-        return new StringBuilder().append(method.getNode().getDefiningType().getApexName()).append(":")
-                .append(method.getNode().getMethodInfo().getEmitSignature().getReturnType().getApexName()).toString();
+        return new StringBuilder().append(method.getDefiningType()).append(":")
+                .append(method.getReturnType()).toString();
     }
 
     private boolean isMethodAGetter(final ASTMethod method) {
-        final boolean startsWithGet = method.getNode().getMethodInfo().getCanonicalName().startsWith("get");
+        final boolean startsWithGet = method.getCanonicalName().startsWith("get");
         final boolean voidOrString = VOID_OR_STRING_PATTERN
-                .matcher(method.getNode().getMethodInfo().getEmitSignature().getReturnType().getApexName()).matches();
+                .matcher(method.getReturnType()).matches();
         final boolean noParams = method.findChildrenOfType(ASTParameter.class).isEmpty();
 
         return startsWithGet && noParams && !voidOrString;

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/Helper.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.lang.apex.rule.security;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTDmlDeleteStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTDmlInsertStatement;
@@ -17,7 +16,6 @@ import net.sourceforge.pmd.lang.apex.ast.ASTDmlUpsertStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTField;
 import net.sourceforge.pmd.lang.apex.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
-import net.sourceforge.pmd.lang.apex.ast.ASTModifierNode;
 import net.sourceforge.pmd.lang.apex.ast.ASTNewKeyValueObjectExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTParameter;
 import net.sourceforge.pmd.lang.apex.ast.ASTReferenceExpression;
@@ -28,13 +26,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration;
 import net.sourceforge.pmd.lang.apex.ast.ASTVariableExpression;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 
-import apex.jorje.data.Identifier;
-import apex.jorje.data.ast.TypeRef;
-import apex.jorje.semantic.ast.expression.MethodCallExpression;
-import apex.jorje.semantic.ast.expression.VariableExpression;
-import apex.jorje.semantic.ast.member.Field;
 import apex.jorje.semantic.ast.member.Parameter;
-import apex.jorje.semantic.ast.statement.VariableDeclaration;
 
 /**
  * Helper methods
@@ -52,15 +44,7 @@ public final class Helper {
     }
 
     static boolean isTestMethodOrClass(final ApexNode<?> node) {
-        final List<ASTModifierNode> modifierNode = node.findChildrenOfType(ASTModifierNode.class);
-        for (final ASTModifierNode m : modifierNode) {
-            if (m.isTest()) {
-                return true;
-            }
-        }
-
-        final String className = node.getNode().getDefiningType().getApexName();
-        return className.endsWith("Test");
+        return net.sourceforge.pmd.lang.apex.rule.internal.Helper.isTestMethodOrClass(node);
     }
 
     static boolean foundAnySOQLorSOSL(final ApexNode<?> node) {
@@ -95,16 +79,12 @@ public final class Helper {
             final String methodName) {
         final ASTReferenceExpression reference = methodNode.getFirstChildOfType(ASTReferenceExpression.class);
 
-        return reference != null && reference.getNode().getNames().size() == 1
-                && reference.getNode().getNames().get(0).getValue().equalsIgnoreCase(className)
+        return reference != null && reference.getNames().size() == 1
+                && reference.getNames().get(0).equalsIgnoreCase(className)
                 && (methodName.equals(ANY_METHOD) || isMethodName(methodNode, methodName));
     }
 
     static boolean isMethodName(final ASTMethodCallExpression m, final String methodName) {
-        return isMethodName(m.getNode(), methodName);
-    }
-
-    static boolean isMethodName(final MethodCallExpression m, final String methodName) {
         return m.getMethodName().equalsIgnoreCase(methodName);
     }
 
@@ -131,100 +111,44 @@ public final class Helper {
     }
 
     static String getFQVariableName(final ASTVariableExpression variable) {
-        final ASTReferenceExpression ref = variable.getFirstChildOfType(ASTReferenceExpression.class);
-        String objectName = "";
-        if (ref != null) {
-            if (ref.getNode().getNames().size() == 1) {
-                objectName = ref.getNode().getNames().get(0).getValue() + ".";
-            }
-        }
-
-        VariableExpression n = variable.getNode();
-        StringBuilder sb = new StringBuilder().append(n.getDefiningType().getApexName()).append(":").append(objectName)
-                .append(n.getIdentifier().getValue());
-        return sb.toString();
+        return net.sourceforge.pmd.lang.apex.rule.internal.Helper.getFQVariableName(variable);
     }
 
     static String getFQVariableName(final ASTVariableDeclaration variable) {
-        VariableDeclaration n = variable.getNode();
-        StringBuilder sb = new StringBuilder().append(n.getDefiningType().getApexName()).append(":")
-                .append(n.getLocalInfo().getName());
-        return sb.toString();
+        return net.sourceforge.pmd.lang.apex.rule.internal.Helper.getFQVariableName(variable);
     }
 
     static String getFQVariableName(final ASTField variable) {
-        Field n = variable.getNode();
-        StringBuilder sb = new StringBuilder()
-                .append(n.getDefiningType().getApexName()).append(":")
-                .append(n.getFieldInfo().getName());
-        return sb.toString();
+        return net.sourceforge.pmd.lang.apex.rule.internal.Helper.getFQVariableName(variable);
     }
 
     static String getVariableType(final ASTField variable) {
-        Field n = variable.getNode();
-        StringBuilder sb = new StringBuilder().append(n.getDefiningType().getApexName()).append(":")
-                .append(n.getFieldInfo().getName());
+        StringBuilder sb = new StringBuilder().append(variable.getDefiningType()).append(":")
+                .append(variable.getName());
         return sb.toString();
     }
 
     static String getFQVariableName(final ASTFieldDeclaration variable) {
-        StringBuilder sb = new StringBuilder()
-                .append(variable.getNode().getDefiningType().getApexName()).append(":")
-                .append(variable.getImage());
-        return sb.toString();
+        return net.sourceforge.pmd.lang.apex.rule.internal.Helper.getFQVariableName(variable);
     }
 
     static String getFQVariableName(final ASTNewKeyValueObjectExpression variable) {
-        StringBuilder sb = new StringBuilder()
-                .append(variable.getNode().getDefiningType().getApexName()).append(":")
-                .append(variable.getType());
-        return sb.toString();
+        return net.sourceforge.pmd.lang.apex.rule.internal.Helper.getFQVariableName(variable);
     }
 
     static boolean isSystemLevelClass(ASTUserClass node) {
-        List<TypeRef> interfaces = node.getNode().getDefiningType().getCodeUnitDetails().getInterfaceTypeRefs();
-
-        for (TypeRef intObject : interfaces) {
-            if (isWhitelisted(intObject.getNames())) {
-                return true;
-            }
-        }
-
-        return false;
+        return net.sourceforge.pmd.lang.apex.rule.internal.Helper.isSystemLevelClass(node);
     }
 
-    private static boolean isWhitelisted(List<Identifier> ids) {
-        StringBuffer sb = new StringBuffer();
-
-        for (int i = 0; i < ids.size(); i++) {
-            sb.append(ids.get(i).getValue());
-
-            if (i != ids.size() - 1) {
-                sb.append(".");
-            }
-        }
-
-        switch (sb.toString().toLowerCase(Locale.ROOT)) {
-        case "queueable":
-        case "database.batchable":
-        case "installhandler":
-            return true;
-        default:
-            break;
-        }
-        return false;
-    }
-
+    @Deprecated
     public static String getFQVariableName(Parameter p) {
-        StringBuffer sb = new StringBuffer();
+        StringBuilder sb = new StringBuilder();
         sb.append(p.getDefiningType()).append(":").append(p.getName().getValue());
         return sb.toString();
     }
 
     static String getFQVariableName(ASTParameter p) {
-        StringBuffer sb = new StringBuffer();
-        sb.append(p.getNode().getDefiningType()).append(":").append(p.getImage());
-        return sb.toString();
+        return net.sourceforge.pmd.lang.apex.rule.internal.Helper.getFQVariableName(p);
     }
 
 }

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -19,6 +19,7 @@ public class ASTMethodTest extends ApexParserTestBase {
         Assert.assertSame(ASTUserClass.class, node.getClass());
         List<ASTMethod> methods = node.findChildrenOfType(ASTMethod.class);
         Assert.assertEquals("Foo", methods.get(0).getImage()); // constructor
+        Assert.assertEquals("<init>", methods.get(0).getCanonicalName());
         Assert.assertEquals("bar", methods.get(1).getImage()); // normal method
     }
 }

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexParserTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexParserTest.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.lang.apex.ast;
 
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -127,8 +126,6 @@ public class ApexParserTest extends ApexParserTestBase {
         ApexNode<?> comment = root.getChild(0);
         assertThat(comment, instanceOf(ASTFormalComment.class));
 
-        assertNotEquals(comment.getNode(), null);
-        assertThat(comment.getNode(), instanceOf(ASTFormalComment.AstComment.class));
         assertPosition(comment, 1, 9, 1, 31);
         assertEquals("/** Comment on Class */", ((ASTFormalComment) comment).getToken());
 


### PR DESCRIPTION
The second commit refactors usage of `getNode()` - the internal jorje node should not be exposed/used.
We still expose some jorje internals via Enums...