### PR TITLE
[core] XPath warnings for deprecated attributes

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/XPathHandler.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/XPathHandler.java
@@ -38,7 +38,8 @@ public interface XPathHandler {
      * Get a Jaxen Navigator for this Language. May return <code>null</code> if
      * there is no Jaxen Navigation for this language.
      *
-     * @deprecated Support for Jaxen will be removed come 7.0.0
+     * @deprecated Support for Jaxen will be removed come 7.0.0. This isn't used
+     *             anymore
      */
     @Deprecated
     Navigator getNavigator();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/Attribute.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/Attribute.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Objects;
 
 import net.sourceforge.pmd.annotation.Experimental;
+import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.ast.xpath.internal.DeprecatedAttribute;
 
@@ -64,9 +65,28 @@ public class Attribute {
         return method == null ? String.class : method.getReturnType();
     }
 
+    @InternalApi
     public boolean isAttributeDeprecated() {
         return method != null && (method.isAnnotationPresent(Deprecated.class)
             || method.isAnnotationPresent(DeprecatedAttribute.class));
+    }
+
+    /**
+     * Returns null for "not deprecated", empty string for "deprecated for removal",
+     * otherwise name of replacement attribute.
+     */
+    @InternalApi
+    public String replacementIfDeprecated() {
+        if (method == null) {
+            return null;
+        } else {
+            DeprecatedAttribute annot = method.getAnnotation(DeprecatedAttribute.class);
+            if (annot == null) {
+                return method.isAnnotationPresent(Deprecated.class) ? DeprecatedAttribute.NO_REPLACEMENT
+                                                                    : null;
+            }
+            return annot.replaceWith();
+        }
     }
 
     public Object getValue() {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/Attribute.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/Attribute.java
@@ -65,14 +65,8 @@ public class Attribute {
         return method == null ? String.class : method.getReturnType();
     }
 
-    @InternalApi
-    public boolean isAttributeDeprecated() {
-        return method != null && (method.isAnnotationPresent(Deprecated.class)
-            || method.isAnnotationPresent(DeprecatedAttribute.class));
-    }
-
     /**
-     * Returns null for "not deprecated", empty string for "deprecated for removal",
+     * Returns null for "not deprecated", empty string for "deprecated without replacement",
      * otherwise name of replacement attribute.
      */
     @InternalApi
@@ -81,11 +75,11 @@ public class Attribute {
             return null;
         } else {
             DeprecatedAttribute annot = method.getAnnotation(DeprecatedAttribute.class);
-            if (annot == null) {
-                return method.isAnnotationPresent(Deprecated.class) ? DeprecatedAttribute.NO_REPLACEMENT
-                                                                    : null;
-            }
-            return annot.replaceWith();
+            return annot != null
+                   ? annot.replaceWith()
+                   : method.isAnnotationPresent(Deprecated.class)
+                     ? DeprecatedAttribute.NO_REPLACEMENT
+                     : null;
         }
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/Attribute.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/Attribute.java
@@ -9,10 +9,6 @@ import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 import net.sourceforge.pmd.annotation.Experimental;
 import net.sourceforge.pmd.lang.ast.Node;
@@ -29,11 +25,6 @@ import net.sourceforge.pmd.lang.ast.xpath.internal.DeprecatedAttribute;
  * @author daniels
  */
 public class Attribute {
-
-
-    private static final Logger LOG = Logger.getLogger(Attribute.class.getName());
-    static final ConcurrentMap<String, Boolean> DETECTED_DEPRECATED_ATTRIBUTES = new ConcurrentHashMap<>();
-
     private static final Object[] EMPTY_OBJ_ARRAY = new Object[0];
 
     private final Node parent;
@@ -73,20 +64,14 @@ public class Attribute {
         return method == null ? String.class : method.getReturnType();
     }
 
-    private boolean isAttributeDeprecated() {
+    public boolean isAttributeDeprecated() {
         return method != null && (method.isAnnotationPresent(Deprecated.class)
-                || method.isAnnotationPresent(DeprecatedAttribute.class));
+            || method.isAnnotationPresent(DeprecatedAttribute.class));
     }
 
     public Object getValue() {
         if (value != null) {
             return value.get(0);
-        }
-
-        if (LOG.isLoggable(Level.WARNING) && isAttributeDeprecated()
-                && DETECTED_DEPRECATED_ATTRIBUTES.putIfAbsent(getLoggableAttributeName(), Boolean.TRUE) == null) {
-            // this message needs to be kept in sync with PMDCoverageTest / BinaryDistributionIT
-            LOG.warning("Use of deprecated attribute '" + getLoggableAttributeName() + "' in XPath query");
         }
 
         // this lazy loading reduces calls to Method.invoke() by about 90%
@@ -127,11 +112,6 @@ public class Attribute {
     @Override
     public int hashCode() {
         return Objects.hash(parent, name);
-    }
-
-
-    private String getLoggableAttributeName() {
-        return parent.getXPathNodeName() + "/@" + name;
     }
 
     @Override

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/internal/ContextualizedNavigator.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/internal/ContextualizedNavigator.java
@@ -1,0 +1,26 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+package net.sourceforge.pmd.lang.ast.xpath.internal;
+
+import net.sourceforge.pmd.lang.ast.xpath.Attribute;
+import net.sourceforge.pmd.lang.ast.xpath.DocumentNavigator;
+
+/**
+ * Navigator that records attribute usages.
+ */
+public class ContextualizedNavigator extends DocumentNavigator {
+
+    private final DeprecatedAttrLogger ctx;
+
+    public ContextualizedNavigator(DeprecatedAttrLogger ctx) {
+        this.ctx = ctx;
+    }
+
+    @Override
+    public String getAttributeStringValue(Object arg0) {
+        Attribute attr = (Attribute) arg0;
+        ctx.recordUsageOf(attr);
+        return attr.getStringValue();
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/internal/DeprecatedAttrLogger.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/internal/DeprecatedAttrLogger.java
@@ -70,14 +70,11 @@ public abstract class DeprecatedAttrLogger {
                 Boolean b = deprecated.putIfAbsent(name, Boolean.TRUE);
                 if (b == null) {
                     // this message needs to be kept in sync with PMDCoverageTest / BinaryDistributionIT
-                    String msg = "Use of deprecated attribute '" + name + "' by rule " + ruleToString();
+                    String msg = "Use of deprecated attribute '" + name + "' by XPath rule " + ruleToString();
                     if (!replacement.isEmpty()) {
                         msg += ", please use " + replacement + " instead";
                     }
-                    // ok this circumvents the logger, because otherwise
-                    // messages get lost in ugly header lines
-                    System.err.println("WARNING: " + msg);
-                    // LOG.warning(msg);
+                    LOG.warning(msg);
                 }
             }
         }
@@ -85,9 +82,9 @@ public abstract class DeprecatedAttrLogger {
         public String ruleToString() {
             // we can't compute that beforehand because the name is set
             // outside of the rule constructor
-            String name = rule.getName();
+            String name = "'" + rule.getName() + "'";
             if (rule.getRuleSetName() != null) {
-                name = rule.getRuleSetName() + "/" + name;
+                name += " (in ruleset '" + rule.getRuleSetName() + "')";
             }
             return name;
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/internal/DeprecatedAttrLogger.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/internal/DeprecatedAttrLogger.java
@@ -74,7 +74,10 @@ public abstract class DeprecatedAttrLogger {
                     if (!replacement.isEmpty()) {
                         msg += ", please use " + replacement + " instead";
                     }
-                    LOG.warning(msg);
+                    // ok this circumvents the logger, because otherwise
+                    // messages get lost in ugly header lines
+                    System.err.println("WARNING: " + msg);
+                    // LOG.warning(msg);
                 }
             }
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/internal/DeprecatedAttrLogger.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/internal/DeprecatedAttrLogger.java
@@ -1,0 +1,87 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.ast.xpath.internal;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import net.sourceforge.pmd.lang.ast.xpath.Attribute;
+import net.sourceforge.pmd.lang.rule.XPathRule;
+
+/**
+ * Records usages of deprecated attributes in XPath rules. This needs
+ * to be threadsafe, XPath rules have one each (and share it).
+ */
+public abstract class DeprecatedAttrLogger {
+
+    private static final Logger LOG = Logger.getLogger(Attribute.class.getName());
+
+
+    public abstract void recordUsageOf(Attribute attribute);
+
+    /**
+     * Create a new context for the given rule, returns a noop implementation
+     * if the warnings would be ignored anyway.
+     */
+    public static DeprecatedAttrLogger create(XPathRule rule) {
+        if (LOG.isLoggable(Level.WARNING)) {
+            return new AttrLoggerImpl(rule);
+        } else {
+            return noop();
+        }
+    }
+
+    public static Noop noop() {
+        return Noop.INSTANCE;
+    }
+
+    private static String getLoggableAttributeName(Attribute attr) {
+        return attr.getParent().getXPathNodeName() + "/@" + attr.getName();
+    }
+
+    private static class Noop extends DeprecatedAttrLogger {
+
+        static final Noop INSTANCE = new Noop();
+
+        @Override
+        public void recordUsageOf(Attribute attribute) {
+            // do nothing
+        }
+    }
+
+    private static class AttrLoggerImpl extends DeprecatedAttrLogger {
+
+        private final ConcurrentMap<String, Boolean> deprecated = new ConcurrentHashMap<>();
+        private final XPathRule rule;
+
+        private AttrLoggerImpl(XPathRule rule) {
+            this.rule = rule;
+        }
+
+        @Override
+        public void recordUsageOf(Attribute attribute) {
+            if (attribute.isAttributeDeprecated()) {
+                String name = getLoggableAttributeName(attribute);
+                Boolean b = deprecated.putIfAbsent(name, Boolean.TRUE);
+                if (b == null) {
+                    // this message needs to be kept in sync with PMDCoverageTest / BinaryDistributionIT
+                    LOG.warning("Use of deprecated attribute '" + name + "' by rule " + ruleToString());
+                }
+            }
+        }
+
+        public String ruleToString() {
+            // we can't compute that beforehand because the name is set
+            // outside of the rule constructor
+            String name = rule.getName();
+            if (rule.getRuleSetName() != null) {
+                name = rule.getRuleSetName() + "/" + name;
+            }
+            return name;
+        }
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/internal/DeprecatedAttrLogger.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/internal/DeprecatedAttrLogger.java
@@ -64,12 +64,17 @@ public abstract class DeprecatedAttrLogger {
 
         @Override
         public void recordUsageOf(Attribute attribute) {
-            if (attribute.isAttributeDeprecated()) {
+            String replacement = attribute.replacementIfDeprecated();
+            if (replacement != null) {
                 String name = getLoggableAttributeName(attribute);
                 Boolean b = deprecated.putIfAbsent(name, Boolean.TRUE);
                 if (b == null) {
                     // this message needs to be kept in sync with PMDCoverageTest / BinaryDistributionIT
-                    LOG.warning("Use of deprecated attribute '" + name + "' by rule " + ruleToString());
+                    String msg = "Use of deprecated attribute '" + name + "' by rule " + ruleToString();
+                    if (!replacement.isEmpty()) {
+                        msg += ", please use " + replacement + " instead";
+                    }
+                    LOG.warning(msg);
                 }
             }
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/internal/DeprecatedAttribute.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/internal/DeprecatedAttribute.java
@@ -22,4 +22,13 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface DeprecatedAttribute {
+
+    String NO_REPLACEMENT = "";
+
+
+    /**
+     * The simple name of the attribute to use for replacement.
+     * If empty, then the attribute is deprecated for removal.
+     */
+    String replaceWith() default NO_REPLACEMENT;
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/internal/DeprecatedAttribute.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/internal/DeprecatedAttribute.java
@@ -27,7 +27,7 @@ public @interface DeprecatedAttribute {
 
 
     /**
-     * The simple name of the attribute to use for replacement.
+     * The simple name of the attribute to use for replacement (with '@' prefix).
      * If empty, then the attribute is deprecated for removal.
      */
     String replaceWith() default NO_REPLACEMENT;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/saxon/AttributeNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/saxon/AttributeNode.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.ast.xpath.Attribute;
+import net.sourceforge.pmd.lang.ast.xpath.internal.DeprecatedAttrLogger;
 import net.sourceforge.pmd.lang.rule.xpath.SaxonXPathRuleQuery;
 
 import net.sf.saxon.om.NodeInfo;
@@ -47,8 +48,19 @@ public class AttributeNode extends BaseNodeInfo {
         return attribute.getName();
     }
 
+    private DeprecatedAttrLogger getAttrCtx() {
+        return parent == null ? DeprecatedAttrLogger.noop()
+                              : parent.document.getAttrCtx();
+    }
+
+    @Override
+    public ElementNode getParent() {
+        return parent;
+    }
+
     @Override
     public Value atomize() {
+        getAttrCtx().recordUsageOf(attribute);
         if (value == null) {
             Object data = attribute.getValue();
             if (data instanceof List) {
@@ -72,6 +84,7 @@ public class AttributeNode extends BaseNodeInfo {
 
     @Override
     public int compareOrder(NodeInfo other) {
+
         return Integer.signum(this.id - ((AttributeNode) other).id);
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/saxon/AttributeNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/saxon/AttributeNode.java
@@ -54,11 +54,6 @@ public class AttributeNode extends BaseNodeInfo {
     }
 
     @Override
-    public ElementNode getParent() {
-        return parent;
-    }
-
-    @Override
     public Value atomize() {
         getAttrCtx().recordUsageOf(attribute);
         if (value == null) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/saxon/DocumentNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/saxon/DocumentNode.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.ast.xpath.internal.DeprecatedAttrLogger;
 import net.sourceforge.pmd.lang.rule.xpath.SaxonXPathRuleQuery;
 
 import net.sf.saxon.om.Axis;
@@ -37,6 +38,8 @@ public class DocumentNode extends BaseNodeInfo implements DocumentInfo {
      * Mapping from AST Node to corresponding ElementNode.
      */
     public final Map<Node, ElementNode> nodeToElementNode = new HashMap<>();
+
+    private DeprecatedAttrLogger attrCtx;
 
     /**
      * Construct a DocumentNode, with the given AST Node serving as the root
@@ -94,5 +97,13 @@ public class DocumentNode extends BaseNodeInfo implements DocumentInfo {
         default:
             return super.iterateAxis(axisNumber);
         }
+    }
+
+    public DeprecatedAttrLogger getAttrCtx() {
+        return attrCtx == null ? DeprecatedAttrLogger.noop() : attrCtx;
+    }
+
+    public void setAttrCtx(DeprecatedAttrLogger attrCtx) {
+        this.attrCtx = attrCtx;
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/XPathRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/XPathRule.java
@@ -16,8 +16,10 @@ import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
 
+import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.ast.xpath.internal.DeprecatedAttrLogger;
 import net.sourceforge.pmd.lang.rule.xpath.JaxenXPathRuleQuery;
 import net.sourceforge.pmd.lang.rule.xpath.SaxonXPathRuleQuery;
 import net.sourceforge.pmd.lang.rule.xpath.XPathRuleQuery;
@@ -68,6 +70,9 @@ public class XPathRule extends AbstractRule {
      */
     private XPathRuleQuery xpathRuleQuery;
 
+    // this is shared with rules forked by deepCopy, used by the XPathRuleQuery
+    private DeprecatedAttrLogger attrLogger = DeprecatedAttrLogger.create(this);
+
     /**
      * Creates a new XPathRule without the corresponding XPath query.
      *
@@ -104,6 +109,14 @@ public class XPathRule extends AbstractRule {
         Objects.requireNonNull(expression, "XPath expression is null");
         setXPath(expression);
         setVersion(version.getXmlName());
+    }
+
+
+    @Override
+    public Rule deepCopy() {
+        XPathRule rule = (XPathRule) super.deepCopy();
+        rule.attrLogger = this.attrLogger;
+        return rule;
     }
 
     /**
@@ -179,9 +192,9 @@ public class XPathRule extends AbstractRule {
         }
 
         if (version == XPathVersion.XPATH_1_0) {
-            xpathRuleQuery = new JaxenXPathRuleQuery();
+            xpathRuleQuery = new JaxenXPathRuleQuery(attrLogger);
         } else {
-            xpathRuleQuery = new SaxonXPathRuleQuery();
+            xpathRuleQuery = new SaxonXPathRuleQuery(attrLogger);
         }
 
         xpathRuleQuery.setXPath(xpath);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/JaxenXPathRuleQuery.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/JaxenXPathRuleQuery.java
@@ -33,6 +33,8 @@ import org.jaxen.saxpath.Axis;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.ast.xpath.internal.ContextualizedNavigator;
+import net.sourceforge.pmd.lang.ast.xpath.internal.DeprecatedAttrLogger;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 
 /**
@@ -46,15 +48,21 @@ public class JaxenXPathRuleQuery extends AbstractXPathRuleQuery {
 
     private static final Logger LOG = Logger.getLogger(JaxenXPathRuleQuery.class.getName());
 
-    private enum InitializationStatus {
-        NONE, PARTIAL, FULL
-    }
+    static final String AST_ROOT = "_AST_ROOT_";
 
     private InitializationStatus initializationStatus = InitializationStatus.NONE;
     // Mapping from Node name to applicable XPath queries
     Map<String, List<XPath>> nodeNameToXPaths;
 
-    static final String AST_ROOT = "_AST_ROOT_";
+    private final DeprecatedAttrLogger attrCtx;
+
+    public JaxenXPathRuleQuery() {
+        this(DeprecatedAttrLogger.noop());
+    }
+
+    public JaxenXPathRuleQuery(DeprecatedAttrLogger attrCtx) {
+        this.attrCtx = attrCtx;
+    }
 
     @Override
     public boolean isSupportedVersion(String version) {
@@ -66,7 +74,7 @@ public class JaxenXPathRuleQuery extends AbstractXPathRuleQuery {
         final List<Node> results = new ArrayList<>();
 
         try {
-            initializeExpressionIfStatusIsNoneOrPartial(data.getLanguageVersion().getLanguageVersionHandler().getXPathHandler().getNavigator());
+            initializeExpressionIfStatusIsNoneOrPartial(new ContextualizedNavigator(attrCtx));
 
             List<XPath> xPaths = getXPathsForNodeOrDefault(node.getXPathNodeName());
             for (XPath xpath : xPaths) {
@@ -265,5 +273,10 @@ public class JaxenXPathRuleQuery extends AbstractXPathRuleQuery {
             xpath.setVariableContext(vc);
         }
         return xpath;
+    }
+
+
+    private enum InitializationStatus {
+        NONE, PARTIAL, FULL
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQuery.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQuery.java
@@ -17,6 +17,7 @@ import java.util.regex.Pattern;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.ast.xpath.internal.DeprecatedAttrLogger;
 import net.sourceforge.pmd.lang.ast.xpath.saxon.DocumentNode;
 import net.sourceforge.pmd.lang.ast.xpath.saxon.ElementNode;
 import net.sourceforge.pmd.lang.rule.xpath.internal.RuleChainAnalyzer;
@@ -73,7 +74,6 @@ public class SaxonXPathRuleQuery extends AbstractXPathRuleQuery {
     /** Cache key for the wrapped tree for saxon. */
     private static final SimpleDataKey<DocumentNode> SAXON_TREE_CACHE_KEY = DataMap.simpleDataKey("saxon.tree");
 
-
     /**
      * Contains for each nodeName a sub expression, used for implementing rule chain.
      */
@@ -91,6 +91,17 @@ public class SaxonXPathRuleQuery extends AbstractXPathRuleQuery {
      */
     private List<XPathVariable> xpathVariables;
 
+    private final DeprecatedAttrLogger attrCtx;
+
+    @Deprecated
+    public SaxonXPathRuleQuery() {
+        this(DeprecatedAttrLogger.noop());
+    }
+
+    public SaxonXPathRuleQuery(DeprecatedAttrLogger attrCtx) {
+        this.attrCtx = attrCtx;
+    }
+
     @Override
     public boolean isSupportedVersion(String version) {
         return XPATH_1_0_COMPATIBILITY.equals(version) || XPATH_2_0.equals(version);
@@ -102,9 +113,11 @@ public class SaxonXPathRuleQuery extends AbstractXPathRuleQuery {
 
         try {
             final DocumentNode documentNode = getDocumentNodeForRootNode(node);
+            documentNode.setAttrCtx(attrCtx); //
 
             // Map AST Node -> Saxon Node
             final ElementNode rootElementNode = documentNode.nodeToElementNode.get(node);
+            assert rootElementNode != null : "Cannot find " + node;
             final XPathDynamicContext xpathDynamicContext = createDynamicContext(rootElementNode);
 
             final List<ElementNode> nodes = new LinkedList<>();

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/AbstractNodeTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/AbstractNodeTest.java
@@ -6,10 +6,8 @@ package net.sourceforge.pmd.lang.ast;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import org.jaxen.JaxenException;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -227,25 +225,5 @@ public class AbstractNodeTest {
         // Check that this node still does not have any children
         assertEquals(0, grandChild.getNumChildren());
     }
-
-
-    @Test
-    public void testDeprecatedAttributeXPathQuery() throws JaxenException {
-        class MyRootNode extends DummyNode implements RootNode {
-
-            private MyRootNode(int id) {
-                super(id);
-            }
-        }
-
-        addChild(new MyRootNode(nextId()), new DummyNodeWithDeprecatedAttribute(2)).findChildNodesWithXPath("//dummyNode[@Size=1]");
-
-        String log = loggingRule.getLog();
-
-        assertTrue(log.contains("deprecated"));
-        assertTrue(log.contains("attribute"));
-        assertTrue(log.contains("dummyNode/@Size"));
-    }
-
 
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNode.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNode.java
@@ -26,6 +26,21 @@ public class DummyNode extends AbstractNode {
         this.xpathName = xpathName;
     }
 
+    public void setBeginColumn(int i) {
+        beginColumn = i;
+    }
+
+    public void setBeginLine(int i) {
+        beginLine = i;
+    }
+
+    public void setCoords(int bline, int bcol, int eline, int ecol) {
+        beginLine = bline;
+        beginColumn = bcol;
+        endLine = eline;
+        endColumn = ecol;
+    }
+
     @Override
     public String toString() {
         return xpathName;

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNodeWithDeprecatedAttribute.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNodeWithDeprecatedAttribute.java
@@ -25,7 +25,7 @@ public class DummyNodeWithDeprecatedAttribute extends DummyNode {
 
     // this is a attribute that is deprecated for xpath, because it will be removed.
     // it should still be available via Java.
-    @DeprecatedAttribute
+    @DeprecatedAttribute(replaceWith = "@Image")
     public String getName() {
         return "foo";
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/xpath/AttributeAxisIteratorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/xpath/AttributeAxisIteratorTest.java
@@ -5,7 +5,6 @@
 package net.sourceforge.pmd.lang.ast.xpath;
 
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -16,15 +15,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.hamcrest.Matchers;
-import org.hamcrest.collection.IsMapContaining;
 import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
 
-import net.sourceforge.pmd.junit.JavaUtilLoggingRule;
 import net.sourceforge.pmd.lang.ast.DummyNode;
-import net.sourceforge.pmd.lang.ast.DummyNodeWithDeprecatedAttribute;
 import net.sourceforge.pmd.lang.ast.Node;
 
 
@@ -32,32 +26,6 @@ import net.sourceforge.pmd.lang.ast.Node;
  * Unit test for {@link AttributeAxisIterator}
  */
 public class AttributeAxisIteratorTest {
-
-    @Rule
-    public JavaUtilLoggingRule loggingRule = new JavaUtilLoggingRule(Attribute.class.getName());
-
-    /**
-     * Verifies that attributes are returned, even if they are deprecated.
-     * Deprecated attributes are still accessible, but a warning is logged, when
-     * the value is used.
-     */
-    @Test
-    public void testAttributeDeprecation() {
-        // make sure, we log
-        Attribute.DETECTED_DEPRECATED_ATTRIBUTES.clear();
-
-        Node dummy = new DummyNodeWithDeprecatedAttribute(2);
-        Map<String, Attribute> attributes = toMap(new AttributeAxisIterator(dummy));
-        assertThat(attributes, IsMapContaining.hasKey("Size"));
-        assertThat(attributes, IsMapContaining.hasKey("Name"));
-
-        assertThat(attributes.get("Size").getStringValue(), Matchers.is("2"));
-        assertThat(attributes.get("Name").getStringValue(), Matchers.is("foo"));
-
-        String log = loggingRule.getLog();
-        assertThat(log, Matchers.containsString("Use of deprecated attribute 'dummyNode/@Size' in XPath query"));
-        assertThat(log, Matchers.containsString("Use of deprecated attribute 'dummyNode/@Name' in XPath query"));
-    }
 
     /**
      * Test hasNext and next.
@@ -103,7 +71,7 @@ public class AttributeAxisIteratorTest {
         assertFalse(atts.containsKey("NodeList"));
     }
 
-    private Map<String, Attribute> toMap(AttributeAxisIterator it) {
+    public Map<String, Attribute> toMap(AttributeAxisIterator it) {
         Map<String, Attribute> atts = new HashMap<>();
         while (it.hasNext()) {
             Attribute attribute = it.next();

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/XPathRuleTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/XPathRuleTest.java
@@ -4,10 +4,28 @@
 
 package net.sourceforge.pmd.lang.rule;
 
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
+
+import org.hamcrest.Matchers;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
 
+import net.sourceforge.pmd.RuleContext;
+import net.sourceforge.pmd.junit.JavaUtilLoggingRule;
+import net.sourceforge.pmd.lang.DummyLanguageModule;
+import net.sourceforge.pmd.lang.LanguageRegistry;
+import net.sourceforge.pmd.lang.ast.DummyNode;
+import net.sourceforge.pmd.lang.ast.DummyNodeWithDeprecatedAttribute;
+import net.sourceforge.pmd.lang.ast.xpath.Attribute;
+import net.sourceforge.pmd.lang.rule.xpath.XPathVersion;
+
 public class XPathRuleTest {
+
+    @Rule
+    public JavaUtilLoggingRule loggingRule = new JavaUtilLoggingRule(Attribute.class.getName());
 
     /**
      * It's easy to forget the attribute "typeResolution=true" when
@@ -15,7 +33,8 @@ public class XPathRuleTest {
      * typeresolution. For Java rules, type resolution was enabled by
      * default long time ago.
      *
-     * @see <a href="https://github.com/pmd/pmd/issues/2048">#2048 [core] Enable type resolution by default for XPath rules</a>
+     * @see <a href="https://github.com/pmd/pmd/issues/2048">#2048 [core] Enable type resolution by default for XPath
+     *     rules</a>
      */
     @Test
     public void typeResolutionShouldBeEnabledByDefault() {
@@ -25,5 +44,76 @@ public class XPathRuleTest {
         XPathRule rule2 = new XPathRule(".");
         Assert.assertTrue(rule2.isTypeResolution());
     }
+
+
+    @Test
+    public void testAttributeDeprecation10() {
+        testDeprecation(XPathVersion.XPATH_1_0);
+    }
+
+    @Test
+    public void testAttributeDeprecation20() {
+        testDeprecation(XPathVersion.XPATH_2_0);
+    }
+
+    public void testDeprecation(XPathVersion version) {
+        XPathRule xpr = makeRule(version, "SomeRule");
+
+        loggingRule.clear();
+
+        RuleContext ctx = new RuleContext();
+        ctx.setLanguageVersion(LanguageRegistry.getLanguage(DummyLanguageModule.NAME).getDefaultVersion());
+        DummyNode firstNode = newNode();
+        eval(ctx, xpr, firstNode);
+        assertEquals(1, ctx.getReport().size());
+
+        String log = loggingRule.getLog();
+        assertThat(log, Matchers.containsString("Use of deprecated attribute 'dummyNode/@Size' by rule SomeRule"));
+        assertThat(log, Matchers.containsString("Use of deprecated attribute 'dummyNode/@Name' by rule SomeRule"));
+
+
+        loggingRule.clear();
+
+        eval(ctx, xpr, newNode()); // with another node
+        assertEquals(2, ctx.getReport().size());
+
+        assertEquals("", loggingRule.getLog()); // no additional warnings
+
+
+        // with another rule forked from the same one (in multithreaded processor)
+        eval(ctx, xpr.deepCopy(), newNode());
+        assertEquals(3, ctx.getReport().size());
+
+        assertEquals("", loggingRule.getLog()); // no additional warnings
+
+        // with another rule on the same node, new warnings
+        XPathRule otherRule = makeRule(version, "OtherRule");
+        otherRule.setRuleSetName("rset.xml");
+        eval(ctx, otherRule, firstNode);
+        assertEquals(4, ctx.getReport().size());
+
+        log = loggingRule.getLog();
+        assertThat(log, Matchers.containsString("Use of deprecated attribute 'dummyNode/@Size' by rule rset.xml/OtherRule"));
+        assertThat(log, Matchers.containsString("Use of deprecated attribute 'dummyNode/@Name' by rule rset.xml/OtherRule"));
+
+    }
+
+    public XPathRule makeRule(XPathVersion version, String name) {
+        XPathRule xpr = new XPathRule(version, "//dummyNode[@Size >= 2 and @Name='foo']");
+        xpr.setName(name);
+        xpr.setMessage("gotcha");
+        return xpr;
+    }
+
+    public void eval(RuleContext ctx, net.sourceforge.pmd.Rule rule, DummyNode node) {
+        rule.apply(singletonList(node), ctx);
+    }
+
+    public DummyNode newNode() {
+        DummyNode dummy = new DummyNodeWithDeprecatedAttribute(2);
+        dummy.setCoords(1, 1, 1, 2);
+        return dummy;
+    }
+
 
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/XPathRuleTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/XPathRuleTest.java
@@ -68,8 +68,8 @@ public class XPathRuleTest {
         assertEquals(1, ctx.getReport().size());
 
         String log = loggingRule.getLog();
-        assertThat(log, Matchers.containsString("Use of deprecated attribute 'dummyNode/@Size' by rule SomeRule"));
-        assertThat(log, Matchers.containsString("Use of deprecated attribute 'dummyNode/@Name' by rule SomeRule"));
+        assertThat(log, Matchers.containsString("Use of deprecated attribute 'dummyNode/@Size' by XPath rule 'SomeRule'"));
+        assertThat(log, Matchers.containsString("Use of deprecated attribute 'dummyNode/@Name' by XPath rule 'SomeRule', please use @Image instead"));
 
 
         loggingRule.clear();
@@ -93,8 +93,8 @@ public class XPathRuleTest {
         assertEquals(4, ctx.getReport().size());
 
         log = loggingRule.getLog();
-        assertThat(log, Matchers.containsString("Use of deprecated attribute 'dummyNode/@Size' by rule rset.xml/OtherRule"));
-        assertThat(log, Matchers.containsString("Use of deprecated attribute 'dummyNode/@Name' by rule rset.xml/OtherRule"));
+        assertThat(log, Matchers.containsString("Use of deprecated attribute 'dummyNode/@Size' by XPath rule 'OtherRule' (in ruleset 'rset.xml')"));
+        assertThat(log, Matchers.containsString("Use of deprecated attribute 'dummyNode/@Name' by XPath rule 'OtherRule' (in ruleset 'rset.xml'), please use @Image instead"));
 
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAdditiveExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAdditiveExpression.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.java.ast;
 
 import net.sourceforge.pmd.annotation.InternalApi;
+import net.sourceforge.pmd.lang.ast.xpath.internal.DeprecatedAttribute;
 
 /**
  * Represents an addition operation on two or more values, or string concatenation.
@@ -39,6 +40,16 @@ public class ASTAdditiveExpression extends AbstractJavaTypeNode {
         return visitor.visit(this, data);
     }
 
+
+    /**
+     * @deprecated Use {@link #getOperator()}
+     */
+    @Override
+    @Deprecated
+    @DeprecatedAttribute(replaceWith = "@Operator")
+    public String getImage() {
+        return super.getImage();
+    }
 
     /**
      * Returns the image of the operator, i.e. "+" or "-".

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnyTypeDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnyTypeDeclaration.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.java.ast;
 import java.util.List;
 import java.util.Locale;
 
+import net.sourceforge.pmd.lang.ast.xpath.internal.DeprecatedAttribute;
 import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.lang.java.qname.JavaTypeQualifiedName;
 
@@ -32,6 +33,7 @@ public interface ASTAnyTypeDeclaration extends TypeNode, JavaQualifiableNode, Ac
      * @deprecated Use {@link #getSimpleName()}
      */
     @Deprecated
+    @DeprecatedAttribute(replaceWith = "@SimpleName")
     @Override
     String getImage();
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodDeclaration.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.java.ast;
 
 import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.ast.xpath.internal.DeprecatedAttribute;
 import net.sourceforge.pmd.lang.dfa.DFAGraphMethod;
 
 
@@ -42,6 +43,7 @@ public class ASTMethodDeclaration extends AbstractMethodOrConstructorDeclaration
      * @deprecated Use {@link #getName()}
      */
     @Deprecated
+    @DeprecatedAttribute(replaceWith = "@Name")
     public String getMethodName() {
         return getName();
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodDeclarator.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodDeclarator.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.java.ast;
 
 import net.sourceforge.pmd.annotation.InternalApi;
+import net.sourceforge.pmd.lang.ast.xpath.internal.DeprecatedAttribute;
 
 /**
  * @deprecated This node will be removed with 7.0.0. You
@@ -29,6 +30,7 @@ public class ASTMethodDeclarator extends AbstractJavaNode {
     /**
      * @deprecated Use {@link ASTMethodDeclaration#getArity()}
      */
+    @DeprecatedAttribute(replaceWith = "MethodDeclaration/@Arity")
     @Deprecated
     public int getParameterCount() {
         return getFirstChildOfType(ASTFormalParameters.class).size();
@@ -38,6 +40,7 @@ public class ASTMethodDeclarator extends AbstractJavaNode {
      * @deprecated Use {@link ASTMethodDeclaration#getName()}
      */
     @Deprecated
+    @DeprecatedAttribute(replaceWith = "MethodDeclaration/@Name")
     @Override
     public String getImage() {
         return super.getImage();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclaratorId.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclaratorId.java
@@ -9,6 +9,7 @@ import java.util.List;
 import net.sourceforge.pmd.annotation.Experimental;
 import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.ast.xpath.internal.DeprecatedAttribute;
 import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
 import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
 
@@ -98,6 +99,21 @@ public class ASTVariableDeclaratorId extends AbstractJavaTypeNode implements Dim
         return arrayDepth > 0;
     }
 
+    /**
+     * @deprecated Use {@link #getName()}
+     * @return
+     */
+    @Override
+    @DeprecatedAttribute(replaceWith = "@Name")
+    @Deprecated
+    public String getImage() {
+        return super.getImage();
+    }
+
+    /** Returns the name of the variable. */
+    public String getName() {
+        return getImage();
+    }
 
     /**
      * Returns true if the declared variable has an array type.
@@ -161,9 +177,13 @@ public class ASTVariableDeclaratorId extends AbstractJavaTypeNode implements Dim
 
     /**
      * Returns the name of the variable.
+     *
+     * @deprecated Use {@link #getName()}
      */
+    @Deprecated
+    @DeprecatedAttribute(replaceWith = "@Name")
     public String getVariableName() {
-        return getImage();
+        return getName();
     }
 
 

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1236,7 +1236,7 @@ Fields, formal arguments, or local variable names that are too long can make the
             <property name="xpath">
                 <value>
 <![CDATA[
-//VariableDeclaratorId[string-length(@Image) > $minimum]
+//VariableDeclaratorId[string-length(@Name) > $minimum]
 ]]>
                 </value>
             </property>
@@ -1704,7 +1704,7 @@ Fields, local variables, or parameter names that are very short are not helpful 
             <property name="xpath">
                 <value>
 <![CDATA[
-//VariableDeclaratorId[string-length(@Image) < $minimum]
+//VariableDeclaratorId[string-length(@Name) < $minimum]
  (: ForStatement :)
  [not(../../..[self::ForInit])]
  (: Foreach statement :)

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -140,7 +140,7 @@ Use of the term 'assert' will conflict with newer versions of Java since it is a
         <properties>
             <property name="version" value="2.0"/>
             <property name="xpath">
-                <value>//VariableDeclaratorId[@Image='assert']</value>
+                <value>//VariableDeclaratorId[@Name='assert']</value>
             </property>
         </properties>
         <example>
@@ -347,7 +347,7 @@ Use of the term 'enum' will conflict with newer versions of Java since it is a r
         <properties>
             <property name="version" value="2.0"/>
             <property name="xpath">
-                <value>//VariableDeclaratorId[@Image='enum']</value>
+                <value>//VariableDeclaratorId[@Name='enum']</value>
             </property>
         </properties>
         <example>
@@ -546,15 +546,15 @@ only add to code size.  Either remove the invocation, or use the return result.
 <![CDATA[
 //CatchStatement/Block/BlockStatement/Statement/StatementExpression/PrimaryExpression/PrimaryPrefix/Name
 [
-   @Image = concat(../../../../../../../FormalParameter/VariableDeclaratorId/@Image, '.getMessage')
+   @Image = concat(../../../../../../../FormalParameter/VariableDeclaratorId/@Name, '.getMessage')
    or
-   @Image = concat(../../../../../../../FormalParameter/VariableDeclaratorId/@Image, '.getLocalizedMessage')
+   @Image = concat(../../../../../../../FormalParameter/VariableDeclaratorId/@Name, '.getLocalizedMessage')
    or
-   @Image = concat(../../../../../../../FormalParameter/VariableDeclaratorId/@Image, '.getCause')
+   @Image = concat(../../../../../../../FormalParameter/VariableDeclaratorId/@Name, '.getCause')
    or
-   @Image = concat(../../../../../../../FormalParameter/VariableDeclaratorId/@Image, '.getStackTrace')
+   @Image = concat(../../../../../../../FormalParameter/VariableDeclaratorId/@Name, '.getStackTrace')
    or
-   @Image = concat(../../../../../../../FormalParameter/VariableDeclaratorId/@Image, '.toString')
+   @Image = concat(../../../../../../../FormalParameter/VariableDeclaratorId/@Name, '.toString')
 ]
 ]]>
                 </value>
@@ -1487,7 +1487,7 @@ or reported.
  [FormalParameter/Type/ReferenceType
    /ClassOrInterfaceType[@Image != 'InterruptedException' and @Image != 'CloneNotSupportedException']
  ]
- [FormalParameter/VariableDeclaratorId[not(matches(@Image, $allowExceptionNameRegex))]]
+ [FormalParameter/VariableDeclaratorId[not(matches(@Name, $allowExceptionNameRegex))]]
 ]]>
                 </value>
             </property>
@@ -2147,7 +2147,7 @@ Avoid jumbled loop incrementers - its usually a mistake, and is confusing even i
   [
     ForUpdate/StatementExpressionList/StatementExpression/PostfixExpression/PrimaryExpression/PrimaryPrefix/Name/@Image
     =
-    ancestor::ForStatement/ForInit//VariableDeclaratorId/@Image
+    ancestor::ForStatement/ForInit//VariableDeclaratorId/@Name
   ]
 ]]>
                 </value>
@@ -2702,8 +2702,8 @@ with the restriction that the logger needs to be passed into the constructor.
     (: check modifiers :)
     (@Private = false() or @Final = false())
     (: check logger name :)
-    or (@Static and VariableDeclarator/VariableDeclaratorId[@Image != $staticLoggerName])
-    or (@Static = false() and VariableDeclarator/VariableDeclaratorId[@Image != $loggerName])
+    or (@Static and VariableDeclarator/VariableDeclaratorId[@Name != $staticLoggerName])
+    or (@Static = false() and VariableDeclarator/VariableDeclaratorId[@Name != $loggerName])
 
     (: check logger argument type matches class or enum name :)
     or .//ArgumentList//ClassOrInterfaceType[@Image != ancestor::ClassOrInterfaceDeclaration/@SimpleName]
@@ -2717,7 +2717,7 @@ with the restriction that the logger needs to be passed into the constructor.
      ancestor::ClassOrInterfaceBody//ConstructorDeclaration//StatementExpression
         [PrimaryExpression[PrimaryPrefix[@ThisModifier]]/PrimarySuffix[@Image=$loggerName]]
         [AssignmentOperator[@Image = '=']]
-        [Expression/PrimaryExpression/PrimaryPrefix/Name[@Image = ancestor::ConstructorDeclaration//FormalParameter/VariableDeclaratorId/@Image]]
+        [Expression/PrimaryExpression/PrimaryPrefix/Name[@Image = ancestor::ConstructorDeclaration//FormalParameter/VariableDeclaratorId/@Name]]
         [not(.//AllocationExpression)]
   )
 ]

--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -878,14 +878,14 @@ You must use new ArrayList<>(Arrays.asList(...)) if that is inconvenient for you
        @Image="ArrayList"
       ]
       )=1
-     ]/@Image
+     ]/@Name
     ]
    and
    PrimaryExpression/PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Name
    [
-     @Image = ancestor::MethodDeclaration[1]//LocalVariableDeclaration/VariableDeclarator/VariableDeclaratorId[@ArrayType=true()]/@Image
+     @Image = ancestor::MethodDeclaration[1]//LocalVariableDeclaration/VariableDeclarator/VariableDeclaratorId[@ArrayType=true()]/@Name
      or
-     @Image = ancestor::MethodDeclaration[1]//FormalParameter/VariableDeclaratorId/@Image
+     @Image = ancestor::MethodDeclaration[1]//FormalParameter/VariableDeclaratorId/@Name
    ]
    /../..[count(.//PrimarySuffix)
    =1]/PrimarySuffix/Expression/PrimaryExpression/PrimaryPrefix


### PR DESCRIPTION
## Describe the PR

Right now, we log only the deprecated attribute usages, but not, in which rule these are used. This is not helpful to find and fix the deprecations.

This PR fixes this by logging additionally the rule name.

## Related issues

- Fixes #2019

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

