### PR TITLE
[core] Update maven-compiler-plugin to 3.8.1

### DIFF
--- a/pmd-apex-jorje/pom.xml
+++ b/pmd-apex-jorje/pom.xml
@@ -13,9 +13,6 @@
 
   <properties>
     <java.version>8</java.version>
-    <!-- Workaround for https://youtrack.jetbrains.com/issue/IDEA-188690 -->
-    <maven.compiler.source>1.${java.version}</maven.compiler.source>
-    <maven.compiler.target>1.${java.version}</maven.compiler.target>
     <apex.jorje.version>2019-11-07-964d4a</apex.jorje.version>
   </properties>
 

--- a/pmd-apex/pom.xml
+++ b/pmd-apex/pom.xml
@@ -12,9 +12,6 @@
 
   <properties>
     <java.version>8</java.version>
-    <!-- Workaround for https://youtrack.jetbrains.com/issue/IDEA-188690 -->
-    <maven.compiler.source>1.${java.version}</maven.compiler.source>
-    <maven.compiler.target>1.${java.version}</maven.compiler.target>
   </properties>
 
   <build>

--- a/pmd-doc/pom.xml
+++ b/pmd-doc/pom.xml
@@ -13,9 +13,6 @@
 
     <properties>
         <java.version>8</java.version>
-        <!-- Workaround for https://youtrack.jetbrains.com/issue/IDEA-188690 -->
-        <maven.compiler.source>1.${java.version}</maven.compiler.source>
-        <maven.compiler.target>1.${java.version}</maven.compiler.target>
     </properties>
 
     <profiles>

--- a/pmd-java8/pom.xml
+++ b/pmd-java8/pom.xml
@@ -12,9 +12,6 @@
 
     <properties>
         <java.version>8</java.version>
-        <!-- Workaround for https://youtrack.jetbrains.com/issue/IDEA-188690 -->
-        <maven.compiler.source>1.${java.version}</maven.compiler.source>
-        <maven.compiler.target>1.${java.version}</maven.compiler.target>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -77,9 +77,6 @@
 
     <properties>
         <java.version>7</java.version>
-        <!-- Workaround for https://youtrack.jetbrains.com/issue/IDEA-188690 -->
-        <maven.compiler.source>1.${java.version}</maven.compiler.source>
-        <maven.compiler.target>1.${java.version}</maven.compiler.target>
 
         <maven.compiler.test.source>1.8</maven.compiler.test.source>
         <maven.compiler.test.target>1.8</maven.compiler.test.target>
@@ -189,7 +186,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.7.0</version>
+                    <version>3.8.1</version>
                     <configuration>
                         <release>${java.version}</release>
                     </configuration>


### PR DESCRIPTION
## Describe the PR
Update maven-compiler-plugin to 3.8.1 and remove workaround for IDEA (those bug is closed in Youtrack)
<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

No issues

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

