### PR TITLE
[doc] Fix "Making Rulesets" doc sample code indentation

### DIFF
--- a/docs/pages/pmd/userdocs/making_rulesets.md
+++ b/docs/pages/pmd/userdocs/making_rulesets.md
@@ -18,7 +18,7 @@ author: Tom Copeland <tomcopeland@users.sourceforge.net>, Clément Fournier <cle
 
 The first step is to create a new empty ruleset. You can use the following template:
 
-``` xml
+```xml
 <?xml version="1.0"?>
 
 <ruleset name="Custom Rules"
@@ -44,7 +44,7 @@ To use the built-in rules PMD provides, you need to add some *references* to the
 basic rule reference:
 
 ```xml
-    <rule ref="category/java/errorprone.xml/EmptyCatchBlock" />
+<rule ref="category/java/errorprone.xml/EmptyCatchBlock" />
 ```
 
 Adding that element into the `ruleset` element adds the rule [EmptyCatchBlock](pmd_rules_java_errorprone.html#emptycatchblock)
@@ -80,10 +80,10 @@ How you can configure individual rules is described on [Configuring Rules](pmd_u
 You can also reference rules in bulk by referencing a complete category or ruleset, possibly excluding certain rules, like in the following:
 
 ```xml
-  <rule ref="category/java/codestyle.xml">
+<rule ref="category/java/codestyle.xml">
     <exclude name="WhileLoopsMustUseBraces"/>
     <exclude name="IfElseStmtsMustUseBraces"/>
-  </rule>
+</rule>
 ```
 
 Here, the `ref` attribute references a whole category. You can also use a file system path or classpath relative path. In any case, the path must address an accessible ruleset XML file.
@@ -108,13 +108,13 @@ You can exclude some files from being processed by a ruleset using **exclude pat
 		xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
 		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 		xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
-	<description>My ruleset</description>
+    <description>My ruleset</description>
 
-	<exclude-pattern>.*/some/package/.*</exclude-pattern>
-	<exclude-pattern>.*/some/other/package/FunkyClassNamePrefix.*</exclude-pattern>
-	<include-pattern>.*/some/package/ButNotThisClass.*</include-pattern>
+    <exclude-pattern>.*/some/package/.*</exclude-pattern>
+    <exclude-pattern>.*/some/other/package/FunkyClassNamePrefix.*</exclude-pattern>
+    <include-pattern>.*/some/package/ButNotThisClass.*</include-pattern>
 
-	<!-- Rules here ... -->
+    <!-- Rules here ... -->
 
 </ruleset>
 ```


### PR DESCRIPTION
Noticed that [the documentation](https://pmd.github.io/latest/pmd_userdocs_making_rulesets.html) has indentations a bit off. Removed excessive ones and changed to 4 spaces everywhere.