### PR TITLE
[dependencies] Upgrade hamcrest, mockito and JUnit

### DIFF
--- a/pmd-apex/pom.xml
+++ b/pmd-apex/pom.xml
@@ -64,7 +64,11 @@
       <artifactId>saxon</artifactId>
     </dependency>
 
-
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexParserTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexParserTest.java
@@ -4,9 +4,9 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;

--- a/pmd-core/pom.xml
+++ b/pmd-core/pom.xml
@@ -158,7 +158,7 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pmd-core/pom.xml
+++ b/pmd-core/pom.xml
@@ -157,13 +157,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>hamcrest-library</artifactId>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -178,7 +178,7 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pmd-core/src/test/java/net/sourceforge/pmd/properties/PropertyDescriptorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/properties/PropertyDescriptorTest.java
@@ -5,10 +5,10 @@
 package net.sourceforge.pmd.properties;
 
 import static net.sourceforge.pmd.properties.constraints.NumericConstraints.inRange;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.hasItem;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -334,17 +334,11 @@ public class PropertyDescriptorTest {
     }
 
     private static Matcher<String> containsIgnoreCase(final String substring) {
-        return new SubstringMatcher(substring) {
+        return new SubstringMatcher("containing (ignoring case)", true, substring) {
 
             @Override
             protected boolean evalSubstringOf(String string) {
                 return StringUtils.indexOfIgnoreCase(string, substring) != -1;
-            }
-
-
-            @Override
-            protected String relationship() {
-                return "containing (ignoring case)";
             }
         };
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/TreeRenderersTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/TreeRenderersTest.java
@@ -11,6 +11,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Rule;
@@ -43,7 +44,7 @@ public class TreeRenderersTest {
 
         PropertySource properties = TreeRenderers.XML.newPropertyBundle();
 
-        Assert.assertThat(properties.getPropertyDescriptors(),
+        MatcherAssert.assertThat(properties.getPropertyDescriptors(),
                           Matchers.<PropertyDescriptor<?>>containsInAnyOrder(TreeRenderers.XML_LINE_SEPARATOR,
                                                                              TreeRenderers.XML_RENDER_COMMON_ATTRIBUTES,
                                                                              TreeRenderers.XML_RENDER_PROLOG,

--- a/pmd-cpp/pom.xml
+++ b/pmd-cpp/pom.xml
@@ -73,7 +73,11 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/pmd-cs/pom.xml
+++ b/pmd-cs/pom.xml
@@ -38,7 +38,11 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/pmd-dart/pom.xml
+++ b/pmd-dart/pom.xml
@@ -42,7 +42,11 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/pmd-dist/pom.xml
+++ b/pmd-dist/pom.xml
@@ -228,7 +228,11 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/pmd-doc/pom.xml
+++ b/pmd-doc/pom.xml
@@ -101,7 +101,11 @@
             <artifactId>snakeyaml</artifactId>
             <version>1.19</version>
         </dependency>
-
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/pmd-fortran/pom.xml
+++ b/pmd-fortran/pom.xml
@@ -32,7 +32,11 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/pmd-groovy/pom.xml
+++ b/pmd-groovy/pom.xml
@@ -38,7 +38,11 @@
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-core</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/pmd-java/pom.xml
+++ b/pmd-java/pom.xml
@@ -167,6 +167,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/pmd-java/pom.xml
+++ b/pmd-java/pom.xml
@@ -195,6 +195,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
+            <version>3.11.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java14Test.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java14Test.java
@@ -5,11 +5,11 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 
 import java.util.List;
 
+import org.hamcrest.MatcherAssert;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -109,29 +109,29 @@ public class Java14Test {
         Assert.assertEquals(18, stmts.size());
 
         int i = 0;
-        assertThat(stmts.get(i++), instanceOf(ASTLocalVariableDeclaration.class));
-        assertThat(stmts.get(i++), instanceOf(ASTStatementExpression.class));
-        assertThat(stmts.get(i++), instanceOf(ASTStatementExpression.class));
-        assertThat(stmts.get(i++), instanceOf(ASTStatementExpression.class));
+        MatcherAssert.assertThat(stmts.get(i++), instanceOf(ASTLocalVariableDeclaration.class));
+        MatcherAssert.assertThat(stmts.get(i++), instanceOf(ASTStatementExpression.class));
+        MatcherAssert.assertThat(stmts.get(i++), instanceOf(ASTStatementExpression.class));
+        MatcherAssert.assertThat(stmts.get(i++), instanceOf(ASTStatementExpression.class));
 
-        assertThat(stmts.get(i++), instanceOf(ASTStatementExpression.class));
+        MatcherAssert.assertThat(stmts.get(i++), instanceOf(ASTStatementExpression.class));
 
-        assertThat(stmts.get(i++), instanceOf(ASTStatementExpression.class));
-        assertThat(stmts.get(i++), instanceOf(ASTStatementExpression.class));
-        assertThat(stmts.get(i++), instanceOf(ASTYieldStatement.class));
-        assertThat(stmts.get(i++), instanceOf(ASTYieldStatement.class));
-        assertThat(stmts.get(i++), instanceOf(ASTYieldStatement.class));
-        assertThat(stmts.get(i++), instanceOf(ASTStatementExpression.class));
-        assertThat(stmts.get(i++), instanceOf(ASTStatementExpression.class));
+        MatcherAssert.assertThat(stmts.get(i++), instanceOf(ASTStatementExpression.class));
+        MatcherAssert.assertThat(stmts.get(i++), instanceOf(ASTStatementExpression.class));
+        MatcherAssert.assertThat(stmts.get(i++), instanceOf(ASTYieldStatement.class));
+        MatcherAssert.assertThat(stmts.get(i++), instanceOf(ASTYieldStatement.class));
+        MatcherAssert.assertThat(stmts.get(i++), instanceOf(ASTYieldStatement.class));
+        MatcherAssert.assertThat(stmts.get(i++), instanceOf(ASTStatementExpression.class));
+        MatcherAssert.assertThat(stmts.get(i++), instanceOf(ASTStatementExpression.class));
 
-        assertThat(stmts.get(i++), instanceOf(ASTIfStatement.class));
+        MatcherAssert.assertThat(stmts.get(i++), instanceOf(ASTIfStatement.class));
 
-        assertThat(stmts.get(i++), instanceOf(ASTStatementExpression.class));
-        assertThat(stmts.get(i++), instanceOf(ASTYieldStatement.class));
+        MatcherAssert.assertThat(stmts.get(i++), instanceOf(ASTStatementExpression.class));
+        MatcherAssert.assertThat(stmts.get(i++), instanceOf(ASTYieldStatement.class));
 
-        assertThat(stmts.get(i++), instanceOf(ASTYieldStatement.class));
-        assertThat(stmts.get(i++), instanceOf(ASTStatementExpression.class));
-        assertThat(stmts.get(i++), instanceOf(ASTYieldStatement.class));
+        MatcherAssert.assertThat(stmts.get(i++), instanceOf(ASTYieldStatement.class));
+        MatcherAssert.assertThat(stmts.get(i++), instanceOf(ASTStatementExpression.class));
+        MatcherAssert.assertThat(stmts.get(i++), instanceOf(ASTYieldStatement.class));
 
         Assert.assertEquals(i, stmts.size());
     }

--- a/pmd-java8/pom.xml
+++ b/pmd-java8/pom.xml
@@ -55,7 +55,11 @@
             <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-core</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/pmd-javascript/pom.xml
+++ b/pmd-javascript/pom.xml
@@ -86,7 +86,11 @@
             <groupId>net.sourceforge.saxon</groupId>
             <artifactId>saxon</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/pmd-jsp/pom.xml
+++ b/pmd-jsp/pom.xml
@@ -87,7 +87,11 @@
             <groupId>net.sourceforge.saxon</groupId>
             <artifactId>saxon</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/pmd-kotlin/pom.xml
+++ b/pmd-kotlin/pom.xml
@@ -42,7 +42,11 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/pmd-lang-test/pom.xml
+++ b/pmd-lang-test/pom.xml
@@ -94,6 +94,11 @@
              of the pmd-lang-test module
         -->
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>compile</scope>

--- a/pmd-lua/pom.xml
+++ b/pmd-lua/pom.xml
@@ -42,7 +42,11 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/pmd-matlab/pom.xml
+++ b/pmd-matlab/pom.xml
@@ -73,7 +73,11 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>

--- a/pmd-objectivec/pom.xml
+++ b/pmd-objectivec/pom.xml
@@ -75,6 +75,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/pmd-php/pom.xml
+++ b/pmd-php/pom.xml
@@ -30,6 +30,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/pmd-plsql/pom.xml
+++ b/pmd-plsql/pom.xml
@@ -97,6 +97,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/pmd-python/pom.xml
+++ b/pmd-python/pom.xml
@@ -75,6 +75,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/pmd-ruby/pom.xml
+++ b/pmd-ruby/pom.xml
@@ -21,6 +21,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/pmd-scala/pom.xml
+++ b/pmd-scala/pom.xml
@@ -46,6 +46,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/pmd-swift/pom.xml
+++ b/pmd-swift/pom.xml
@@ -44,6 +44,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/pmd-test/pom.xml
+++ b/pmd-test/pom.xml
@@ -13,6 +13,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <!-- overrides the default scope from inherited dependency management. -->
@@ -38,7 +43,6 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pmd-test/src/test/java/net/sourceforge/pmd/testframework/RuleTstTest.java
+++ b/pmd-test/src/test/java/net/sourceforge/pmd/testframework/RuleTstTest.java
@@ -4,8 +4,7 @@
 
 package net.sourceforge.pmd.testframework;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyList;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -16,6 +15,7 @@ import java.util.Arrays;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -55,7 +55,7 @@ public class RuleTstTest {
         verify(rule, times(2)).isRuleChain();
         verify(rule).getMinimumLanguageVersion();
         verify(rule).getMaximumLanguageVersion();
-        verify(rule).apply(anyList(), any(RuleContext.class));
+        verify(rule).apply(ArgumentMatchers.<Node>anyList(), any(RuleContext.class));
         verify(rule, times(4)).getName();
         verify(rule).getPropertiesByPropertyDescriptor();
         verifyNoMoreInteractions(rule);
@@ -76,13 +76,13 @@ public class RuleTstTest {
 
             @Override
             public Void answer(InvocationOnMock invocation) throws Throwable {
-                RuleContext context = invocation.getArgumentAt(1, RuleContext.class);
+                RuleContext context = invocation.getArgument(1, RuleContext.class);
                 // the violations are reported out of order
                 context.getReport().addRuleViolation(createViolation(context, 15, "first reported violation"));
                 context.getReport().addRuleViolation(createViolation(context, 5, "second reported violation"));
                 return null;
             }
-        }).when(rule).apply(Mockito.anyList(), Mockito.any(RuleContext.class));
+        }).when(rule).apply(ArgumentMatchers.<Node>anyList(), Mockito.any(RuleContext.class));
 
         TestDescriptor testDescriptor = new TestDescriptor("the code", "sample test", 2, rule, dummyLanguage);
         testDescriptor.setReinitializeRule(false);

--- a/pmd-visualforce/pom.xml
+++ b/pmd-visualforce/pom.xml
@@ -89,6 +89,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/pmd-vm/pom.xml
+++ b/pmd-vm/pom.xml
@@ -97,6 +97,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/pmd-xml/pom.xml
+++ b/pmd-xml/pom.xml
@@ -51,6 +51,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -139,7 +139,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -664,8 +664,8 @@
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
-                <version>1.10.19</version>
+                <artifactId>mockito-core</artifactId>
+                <version>2.28.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>
@@ -720,16 +720,28 @@
             </dependency>
 
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.12</version>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest</artifactId>
+                <version>2.2</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>org.hamcrest</groupId>
                 <artifactId>hamcrest-library</artifactId>
-                <version>1.3</version>
+                <version>2.2</version>
+            </dependency>
+
+            <dependency>
+                <groupId>junit</groupId>
+                <artifactId>junit</artifactId>
+                <version>4.13</version>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.hamcrest</groupId>
+                        <artifactId>hamcrest-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>pl.pragmatists</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -663,11 +663,6 @@
                 <version>2.6</version>
             </dependency>
             <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-core</artifactId>
-                <version>2.28.2</version>
-            </dependency>
-            <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-lang3</artifactId>
                 <version>3.8.1</version>
@@ -678,30 +673,9 @@
                 <version>1.7.25</version>
             </dependency>
             <dependency>
-                <groupId>com.github.tomakehurst</groupId>
-                <artifactId>wiremock</artifactId>
-                <version>1.57</version>
-                <exclusions>
-                    <exclusion>
-                        <artifactId>commons-lang</artifactId>
-                        <groupId>commons-lang</groupId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
                 <groupId>org.codehaus.groovy</groupId>
                 <artifactId>groovy</artifactId>
                 <version>2.4.7</version>
-            </dependency>
-            <dependency>
-                <groupId>com.github.stefanbirkner</groupId>
-                <artifactId>system-rules</artifactId>
-                <version>1.19.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.assertj</groupId>
-                <artifactId>assertj-core</artifactId>
-                <version>3.11.0</version>
             </dependency>
 
             <!-- TEST DEPENDENCIES -->
@@ -725,11 +699,6 @@
                 <version>2.2</version>
                 <scope>test</scope>
             </dependency>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest-library</artifactId>
-                <version>2.2</version>
-            </dependency>
 
             <dependency>
                 <groupId>junit</groupId>
@@ -741,12 +710,42 @@
                         <groupId>org.hamcrest</groupId>
                         <artifactId>hamcrest-core</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.hamcrest</groupId>
+                        <artifactId>hamcrest-library</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
                 <groupId>pl.pragmatists</groupId>
                 <artifactId>JUnitParams</artifactId>
                 <version>1.1.1</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>2.28.2</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>com.github.tomakehurst</groupId>
+                <artifactId>wiremock</artifactId>
+                <version>1.57</version>
+                <exclusions>
+                    <exclusion>
+                        <artifactId>commons-lang</artifactId>
+                        <groupId>commons-lang</groupId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>com.github.stefanbirkner</groupId>
+                <artifactId>system-rules</artifactId>
+                <version>1.19.0</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
## Describe the PR
According to [JLBP-11](https://jlbp.dev/JLBP-11) I've decided to replace old hamcrest 1.3 version by a new one (2.2). This produced some inconvenience as it's required to define hamcrest *before* junit to resolve new version. This also requires defining hamcrest in every module where JUnit is used. (It can be defined in dependency management with default scope but it'll be exposed then). Information about upgrade tips and tricks is [here](http://hamcrest.org/JavaHamcrest/distributables). Maybe I'm missing something because it doesn't look like very nice.

I've checked by `mvn dependency:tree` that there is only one version of hamcrest left.

Mockito 1.x was exposing hamcrest 1.1 thus it was updated to version 2.x as 1.x is also abandoned.

JUnit was updated from 4.12 to 4.13.

Some methods were replaced:
* `org.junit.Assert.assertThat` that accepts matchers is deprecated
* `SubstringMatcher` ctor now requires more parameters
* `org.hamcrest.CoreMatchers` was replaced by `org.hamcrest.Matchers`
* `org.mockito.Matchers.any` is deprecated, replaced by `org.mockito.ArgumentMatchers.any`
* `org.mockito.Matchers.anyList` is replaced by `org.mockito.ArgumentMatchers.any`
<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

