### PR TITLE
[java] MethodNamingConventions - Add support for JUnit 5 method naming

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/MethodNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/MethodNamingConventionsRule.java
@@ -37,6 +37,7 @@ public class MethodNamingConventionsRule extends AbstractNamingConventionRule<AS
     private final PropertyDescriptor<Pattern> nativeRegex = defaultProp("native").build();
     private final PropertyDescriptor<Pattern> junit3Regex = defaultProp("JUnit 3 test").defaultValue("test[A-Z0-9][a-zA-Z0-9]*").build();
     private final PropertyDescriptor<Pattern> junit4Regex = defaultProp("JUnit 4 test").build();
+    private final PropertyDescriptor<Pattern> junit5Regex = defaultProp("JUnit 5 test").build();
 
 
     public MethodNamingConventionsRule() {
@@ -47,6 +48,11 @@ public class MethodNamingConventionsRule extends AbstractNamingConventionRule<AS
         definePropertyDescriptor(nativeRegex);
         definePropertyDescriptor(junit3Regex);
         definePropertyDescriptor(junit4Regex);
+        definePropertyDescriptor(junit5Regex);
+    }
+
+    private boolean isJunit5Test(ASTMethodDeclaration node) {
+        return node.isAnnotationPresent("org.junit.jupiter.api.Test");
     }
 
     private boolean isJunit4Test(ASTMethodDeclaration node) {
@@ -87,6 +93,8 @@ public class MethodNamingConventionsRule extends AbstractNamingConventionRule<AS
             }
         } else if (node.isStatic()) {
             checkMatches(node, staticRegex, data);
+        } else if (isJunit5Test(node)) {
+            checkMatches(node, junit5Regex, data);
         } else if (isJunit4Test(node)) {
             checkMatches(node, junit4Regex, data);
         } else if (isJunit3Test(node)) {


### PR DESCRIPTION
## Describe the PR

Rule: [MethodNamingConventions](https://pmd.github.io/latest/pmd_rules_java_codestyle.html#methodnamingconventions)

Tests that are annotated with org.junit.jupiter.api.Test were not
recognized as unit tests.

Provide detection for JUnit 5 style tests and also provide the possibility
to customize the method naming regex similar to the existing ones.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)


