### PR TITLE
[apex] fix false positive unused variable if only a method is called

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableRule.java
@@ -36,7 +36,8 @@ public class UnusedLocalVariableRule extends AbstractApexRule {
             if (usage.getParent() == node) {
                 continue;
             }
-            if (usage.getImage().equals(variableName)) {
+
+            if (usage.hasImageEqualTo(variableName)) {
                 return data;
             }
         }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableRule.java
@@ -4,11 +4,14 @@
 
 package net.sourceforge.pmd.lang.apex.rule.bestpractices;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTBlockStatement;
+import net.sourceforge.pmd.lang.apex.ast.ASTReferenceExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration;
 import net.sourceforge.pmd.lang.apex.ast.ASTVariableExpression;
+import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 
 public class UnusedLocalVariableRule extends AbstractApexRule {
@@ -21,9 +24,15 @@ public class UnusedLocalVariableRule extends AbstractApexRule {
         String variableName = node.getImage();
 
         ASTBlockStatement variableContext = node.getFirstParentOfType(ASTBlockStatement.class);
-        List<ASTVariableExpression> potentialUsages = variableContext.findDescendantsOfType(ASTVariableExpression.class);
 
-        for (ASTVariableExpression usage : potentialUsages) {
+        List<ApexNode<?>> potentialUsages = new ArrayList<>();
+
+        // Variable expression catch things like the `a` in `a + b`
+        potentialUsages.addAll(variableContext.findDescendantsOfType(ASTVariableExpression.class));
+        // Reference expressions catch things like the `a` in `a.foo()`
+        potentialUsages.addAll(variableContext.findDescendantsOfType(ASTReferenceExpression.class));
+
+        for (ApexNode<?> usage : potentialUsages) {
             if (usage.getParent() == node) {
                 continue;
             }

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/UnusedLocalVariable.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/UnusedLocalVariable.xml
@@ -51,6 +51,11 @@ public class Foo {
             return 'some other string';
         }
     }
+
+    public void hasMethodCalledOnIt() {
+        String foo = 'foobar';
+        foo.substringAfter('foo');
+    }
 }
 ]]>
         </code>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/UnusedLocalVariable.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/UnusedLocalVariable.xml
@@ -56,6 +56,11 @@ public class Foo {
         String foo = 'foobar';
         foo.substringAfter('foo');
     }
+
+    public void handlesChainedMethods() {
+        String foo = 'foobar';
+        foo.substringAfter('f').substringAfter('b');
+    }
 }
 ]]>
         </code>


### PR DESCRIPTION
## Describe the PR

In the following example, `used` would be considered unused even though a method is called on it (and the result is returned, but we don't check that at the moment).

```apex
public String foo() {
    String used = 'foobar';
    return used.substringAfter('b');
}
```

This fixes that issue.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #2468 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)
(don't think it is needed)
