### PR TITLE
[java] MethodNamingConventions - Add support for JUnit 5 method naming

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/MethodNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/MethodNamingConventionsRule.java
@@ -35,6 +35,7 @@ public class MethodNamingConventionsRule extends AbstractNamingConventionRule<AS
     private final PropertyDescriptor<Pattern> nativeRegex = defaultProp("native").build();
     private final PropertyDescriptor<Pattern> junit3Regex = defaultProp("JUnit 3 test").defaultValue("test[A-Z0-9][a-zA-Z0-9]*").build();
     private final PropertyDescriptor<Pattern> junit4Regex = defaultProp("JUnit 4 test").build();
+    private final PropertyDescriptor<Pattern> junit5Regex = defaultProp("JUnit 5 test").build();
 
 
     public MethodNamingConventionsRule() {
@@ -45,6 +46,11 @@ public class MethodNamingConventionsRule extends AbstractNamingConventionRule<AS
         definePropertyDescriptor(nativeRegex);
         definePropertyDescriptor(junit3Regex);
         definePropertyDescriptor(junit4Regex);
+        definePropertyDescriptor(junit5Regex);
+    }
+
+    private boolean isJunit5Test(ASTMethodDeclaration node) {
+        return node.isAnnotationPresent("org.junit.jupiter.api.Test");
     }
 
     private boolean isJunit4Test(ASTMethodDeclaration node) {
@@ -85,6 +91,8 @@ public class MethodNamingConventionsRule extends AbstractNamingConventionRule<AS
             }
         } else if (node.isStatic()) {
             checkMatches(node, staticRegex, data);
+        } else if (isJunit5Test(node)) {
+            checkMatches(node, junit5Regex, data);
         } else if (isJunit4Test(node)) {
             checkMatches(node, junit4Regex, data);
         } else if (isJunit3Test(node)) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelper.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelper.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.java.typeresolution;
 
 import java.lang.reflect.Array;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
@@ -16,6 +17,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
 import net.sourceforge.pmd.lang.java.ast.ASTEnumDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTImplementsList;
+import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
 import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.symboltable.TypedNameDeclaration;
 import net.sourceforge.pmd.lang.java.typeresolution.internal.NullableClassLoader;
@@ -85,6 +87,18 @@ public final class TypeHelper {
     }
 
     private static boolean fallbackIsA(TypeNode n, String clazzName) {
+        if (n.getImage() != null && !n.getImage().contains(".")) {
+            // simple name detected, check the imports to get the full name and use that for fallback
+            List<ASTImportDeclaration> imports = n.getRoot().findChildrenOfType(ASTImportDeclaration.class);
+            for (ASTImportDeclaration importDecl : imports) {
+                if (n.hasImageEqualTo(importDecl.getImportedSimpleName())) {
+                    // found the import, compare the full names
+                    return clazzName.equals(importDecl.getImportedName());
+                }
+            }
+        }
+
+        // fall back on using the simple name of the class only
         if (clazzName.equals(n.getImage()) || clazzName.endsWith("." + n.getImage())) {
             return true;
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelper.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelper.java
@@ -87,7 +87,7 @@ public final class TypeHelper {
     }
 
     private static boolean fallbackIsA(TypeNode n, String clazzName) {
-        if (n.getImage() != null && !n.getImage().contains(".")) {
+        if (n.getImage() != null && !n.getImage().contains(".") && clazzName.contains(".")) {
             // simple name detected, check the imports to get the full name and use that for fallback
             List<ASTImportDeclaration> imports = n.getRoot().findChildrenOfType(ASTImportDeclaration.class);
             for (ASTImportDeclaration importDecl : imports) {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelperTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelperTest.java
@@ -18,6 +18,8 @@ import org.junit.rules.ExpectedException;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotationTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTEnumDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTMarkerAnnotation;
+import net.sourceforge.pmd.lang.java.ast.ASTName;
 import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.symboltable.BaseNonParserTest;
 import net.sourceforge.pmd.lang.java.typeresolution.internal.NullableClassLoader;
@@ -76,6 +78,22 @@ public class TypeHelperTest extends BaseNonParserTest {
         Assert.assertTrue(TypeHelper.isA(klass, "org.FooBar"));
         assertIsA(klass, Annotation.class);
         assertIsA(klass, Object.class);
+    }
+
+    /**
+     * If we don't have the annotation on the classpath,
+     * we should resolve the full name via the import, if possible
+     * and compare then. Only after that, we should compare the
+     * simple names.
+     */
+    @Test
+    public void testIsAFallbackAnnotationSimpleNameImport() {
+        ASTName annotation = java.parse("package org; import foo.Stuff; @Stuff public class FooBar {}")
+                .getFirstDescendantOfType(ASTMarkerAnnotation.class).getFirstChildOfType(ASTName.class);
+
+        Assert.assertNull(annotation.getType());
+        Assert.assertTrue(TypeHelper.isA(annotation, "foo.Stuff"));
+        Assert.assertFalse(TypeHelper.isA(annotation, "other.Stuff"));
     }
 
     private void assertIsA(TypeNode node, Class<?> type) {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelperTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelperTest.java
@@ -94,6 +94,8 @@ public class TypeHelperTest extends BaseNonParserTest {
         Assert.assertNull(annotation.getType());
         Assert.assertTrue(TypeHelper.isA(annotation, "foo.Stuff"));
         Assert.assertFalse(TypeHelper.isA(annotation, "other.Stuff"));
+        // if the searched class name is not fully qualified, then the search should still be successfull
+        Assert.assertTrue(TypeHelper.isA(annotation, "Stuff"));
     }
 
     private void assertIsA(TypeNode node, Class<?> type) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/MethodNamingConventions.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/MethodNamingConventions.xml
@@ -188,6 +188,36 @@ public class MethodNamingConventions implements SomeInterface {
     </test-code>
 
     <test-code>
+        <description>JUnit 5 test detection</description>
+        <rule-property name="junit5TestPattern">[a-z][A-Za-z]*Test</rule-property>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>5,9</expected-linenumbers>
+        <expected-messages>
+            <message>The JUnit 5 test method name 'testGetBestTeam' doesn't match '[a-z][A-Za-z]*Test'</message>
+            <message>The JUnit 5 test method name 'getBestTeam' doesn't match '[a-z][A-Za-z]*Test'</message>
+        </expected-messages>
+        <code><![CDATA[
+            import org.junit.jupiter.api.Test;
+
+            public class TournamentTest {
+                @Test // note that this is also a junit 3 test, but the junit 5 rule applies
+                public void testGetBestTeam() {
+                }
+
+                @Test // this is just a junit 5 test
+                public void getBestTeam() {
+                }
+
+                // this is ok
+                @Test
+                public void getBestTeamTest() {
+                }
+            }
+            ]]>
+        </code>
+    </test-code>
+
+    <test-code>
         <description>Instance method custom convention</description>
         <rule-property name="methodPattern">m_[a-z][A-Za-z]*</rule-property>
         <expected-problems>1</expected-problems>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/MethodNamingConventions.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/MethodNamingConventions.xml
@@ -150,41 +150,63 @@ public class MethodNamingConventions implements SomeInterface {
             ]]>
         </code>
     </test-code>
+
     <test-code>
         <description>JUnit 4 test detection</description>
         <rule-property name="junit4TestPattern">[a-z][A-Za-z]*Test</rule-property>
         <expected-problems>2</expected-problems>
-        <expected-linenumbers>12,16</expected-linenumbers>
+        <expected-linenumbers>8,12</expected-linenumbers>
         <expected-messages>
             <message>The JUnit 4 test method name 'testGetBestTeam' doesn't match '[a-z][A-Za-z]*Test'</message>
             <message>The JUnit 4 test method name 'getBestTeam' doesn't match '[a-z][A-Za-z]*Test'</message>
         </expected-messages>
         <code><![CDATA[
-            import junit.framework.Assert;
-            import junit.framework.TestCase;
+import junit.framework.TestCase;
+import org.junit.Test;
 
-            import org.junit.Test;
+public class TournamentTest extends TestCase {
+    Tournament tournament;
 
+    @Test // note that this is also a junit 3 test, but the junit4 rule applies
+    public void testGetBestTeam() {
+    }
 
-            public class TournamentTest extends TestCase {
-                Tournament tournament;
+    @Test // this is just a junit 4 test
+    public void getBestTeam() {
+    }
 
+    // this is ok
+    @Test
+    public void getBestTeamTest() {
+    }
+}
+        ]]></code>
+    </test-code>
 
-                @Test // note that this is also a junit 3 test, but the junit4 rule applies
-                public void testGetBestTeam() {
-                }
+    <test-code useAuxClasspath="false">
+        <description>JUnit 4 test detection without proper auxclasspath</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>8</expected-linenumbers>
+        <expected-messages>
+            <message>The JUnit 4 test method name 'get_best_team' doesn't match '[a-z][a-zA-Z0-9]*'</message>
+        </expected-messages>
+        <code><![CDATA[
+import org.junit.Test; // note: test case uses "useAuxClasspath=false"!!
 
-                @Test // this is just a junit 4 test
-                public void getBestTeam() {
-                }
+public class TournamentTest {
+    Tournament tournament;
 
-                // this is ok
-                @Test
-                public void getBestTeamTest() {
-                }
-            }
-            ]]>
-        </code>
+    // wrong test name pattern
+    @Test
+    public void get_best_team() {
+    }
+
+    // this is ok
+    @Test
+    public void getBestTeam() {
+    }
+}
+        ]]></code>
     </test-code>
 
     <test-code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ProperLogger.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ProperLogger.xml
@@ -236,4 +236,21 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>false negative with apache commons logging</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+public class ProperLoggerSample {
+    private final Log log;
+
+    public PropperLoggerSample() {
+        log = LogFactory.getLog(ProperLoggerSample.class);
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
@@ -274,6 +274,20 @@ public abstract class RuleTst {
             if (isUseAuxClasspath) {
                 // configure the "auxclasspath" option for unit testing
                 p.getConfiguration().prependClasspath(".");
+            } else {
+                // simple class loader, that doesn't delegate to parent.
+                // this allows us in the tests to simulate PMD run without
+                // auxclasspath, not even the classes from the test dependencies
+                // will be found.
+                p.getConfiguration().setClassLoader(new ClassLoader() {
+                    @Override
+                    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+                        if (name.startsWith("java.") || name.startsWith("javax.")) {
+                            return super.loadClass(name, resolve);
+                        }
+                        throw new ClassNotFoundException(name);
+                    }
+                });
             }
             RuleContext ctx = new RuleContext();
             ctx.setReport(report);


### PR DESCRIPTION
Rule: MethodNamingConventions

Provide a `junit5TestPattern` property that allows customisation of test method naming in JUnit 5 tests.

The motivation behind this PR was to allow method naming conventions for JUnit5 style tests. These can be annotated using the `org.junit.jupiter.api.Test`. The current implementation is checking for the JUnit 4 annotations (`org.junit.Test`) only.

I discovered this because we are using the Osherove naming pattern for our JUnit 5 tests and therefore need to allow additional characters (namely underscores) in the method names. After setting the JUnit 4 style pattern, I simply noted that these were not applied.

## Ready?
- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

