### PR TITLE
[java] New rule: LiteralsFirstInComparisons

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
@@ -1,0 +1,127 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices;
+
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
+import net.sourceforge.pmd.lang.java.ast.ASTArguments;
+import net.sourceforge.pmd.lang.java.ast.ASTConditionalAndExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTConditionalOrExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTEqualityExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTLiteral;
+import net.sourceforge.pmd.lang.java.ast.ASTName;
+import net.sourceforge.pmd.lang.java.ast.ASTNullLiteral;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
+import net.sourceforge.pmd.lang.java.ast.JavaNode;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
+
+public class LiteralsFirstInComparisonsRule extends AbstractJavaRule {
+
+    private static final String[] COMPARISON_OPS = {".equals", ".equalsIgnoreCase", ".compareTo", ".compareToIgnoreCase", ".contentEquals"};
+
+    public LiteralsFirstInComparisonsRule() {
+        addRuleChainVisit(ASTPrimaryExpression.class);
+    }
+
+    @Override
+    public Object visit(ASTPrimaryExpression node, Object data) {
+        ASTPrimaryPrefix primaryPrefix = node.getFirstChildOfType(ASTPrimaryPrefix.class);
+        ASTPrimarySuffix primarySuffix = node.getFirstChildOfType(ASTPrimarySuffix.class);
+        if (primaryPrefix != null && primarySuffix != null) {
+            ASTName name = primaryPrefix.getFirstChildOfType(ASTName.class);
+            if (name == null || isIrrelevantImage(name.getImage())) {
+                return data;
+            }
+            if (!isSingleStringLiteralArgument(primarySuffix)) {
+                return data;
+            }
+            if (isWithinNullComparison(node)) {
+                return data;
+            }
+            addViolation(data, node);
+        }
+        return node;
+    }
+
+    private boolean isIrrelevantImage(String image) {
+        for (String comparisonOp : COMPARISON_OPS) {
+            if (image.endsWith(comparisonOp)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean isWithinNullComparison(ASTPrimaryExpression node) {
+        for (ASTExpression parentExpr : node.getParentsOfType(ASTExpression.class)) {
+            if (isComparisonWithNull(parentExpr, "==", ASTConditionalOrExpression.class)
+                    || isComparisonWithNull(parentExpr, "!=", ASTConditionalAndExpression.class)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /*
+     * Expression/ConditionalAndExpression//EqualityExpression(@Image='!=']//NullLiteral
+     * Expression/ConditionalOrExpression//EqualityExpression(@Image='==']//NullLiteral
+     */
+    private boolean isComparisonWithNull(ASTExpression parentExpr, String equalOperator, Class<? extends JavaNode> condition) {
+        Node condExpr = null;
+        ASTEqualityExpression eqExpr = null;
+        if (parentExpr != null) {
+            condExpr = parentExpr.getFirstChildOfType(condition);
+        }
+        if (condExpr != null) {
+            eqExpr = condExpr.getFirstDescendantOfType(ASTEqualityExpression.class);
+        }
+        if (eqExpr != null) {
+            return eqExpr.hasImageEqualTo(equalOperator) && eqExpr.hasDescendantOfType(ASTNullLiteral.class);
+        }
+        return false;
+    }
+
+    /*
+     * This corresponds to the following XPath expression:
+     * (../PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Literal[@StringLiteral= true()])
+     *       and
+     * ( count(../PrimarySuffix/Arguments/ArgumentList/Expression) = 1 )
+     */
+    private boolean isSingleStringLiteralArgument(ASTPrimarySuffix primarySuffix) {
+        if (!primarySuffix.isArguments() || primarySuffix.getArgumentCount() != 1) {
+            return false;
+        }
+        Node node = primarySuffix;
+        node = node.getFirstChildOfType(ASTArguments.class);
+        if (node != null) {
+            node = node.getFirstChildOfType(ASTArgumentList.class);
+            if (node.getNumChildren() != 1) {
+                return false;
+            }
+        }
+        if (node != null) {
+            node = node.getFirstChildOfType(ASTExpression.class);
+        }
+        if (node != null) {
+            node = node.getFirstChildOfType(ASTPrimaryExpression.class);
+        }
+        if (node != null) {
+            node = node.getFirstChildOfType(ASTPrimaryPrefix.class);
+        }
+        if (node != null) {
+            node = node.getFirstChildOfType(ASTLiteral.class);
+        }
+        if (node != null) {
+            ASTLiteral literal = (ASTLiteral) node;
+            if (literal.isStringLiteral()) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -882,6 +882,43 @@ public class MyTest {
         </example>
     </rule>
 
+    <rule name="LiteralsFirstInComparisons"
+          language="java"
+          since="6.23"
+          message="Position literals first in String comparisons"
+          class="net.sourceforge.pmd.lang.java.rule.bestpractices.LiteralsFirstInComparisonsRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_bestpractices.html#literalsfirstincomparisons">
+        <description>
+            Position literals first in all String comparisons, if the second argument is null then NullPointerExceptions
+            can be avoided, they will just return false. Note that switching literal positions for compareTo and
+            compareToIgnoreCase may change the result, see examples.
+        </description>
+        <priority>3</priority>
+        <example>
+            <![CDATA[
+class Foo {
+  boolean bar(String x) {
+    return x.equals("2"); // should be "2".equals(x)
+  }
+  boolean bar(String x) {
+    return x.equalsIgnoreCase("2"); // should be "2".equalsIgnoreCase(x)
+  }
+  boolean bar(String x) {
+    return (x.compareTo("bar") > 0); // should be: "bar".compareTo(x) < 0
+  }
+  boolean bar(String x) {
+    return (x.compareToIgnoreCase("bar") > 0); // should be: "bar".compareToIgnoreCase(x) < 0
+  }
+  boolean bar(String x) {
+    return x.contentEquals("bar"); // should be "bar".contentEquals(x)
+   }
+}
+
+}
+]]>
+        </example>
+    </rule>
+
     <rule name="LooseCoupling"
           since="0.7"
           message="Avoid using implementation types like ''{0}''; use the interface instead"

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -884,7 +884,7 @@ public class MyTest {
 
     <rule name="LiteralsFirstInComparisons"
           language="java"
-          since="6.23"
+          since="6.24.0"
           message="Position literals first in String comparisons"
           class="net.sourceforge.pmd.lang.java.rule.bestpractices.LiteralsFirstInComparisonsRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_bestpractices.html#literalsfirstincomparisons">

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsTest.java
@@ -1,0 +1,11 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices;
+
+import net.sourceforge.pmd.testframework.PmdRuleTst;
+
+public class LiteralsFirstInComparisonsTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LiteralsFirstInComparisons.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LiteralsFirstInComparisons.xml
@@ -1,0 +1,297 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+    <test-code>
+        <description><![CDATA[
+ok, literal comes first in .equals comparison
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ boolean bar(String x) {
+  return "2".equals(x);
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+bad, literal comes last in .equals comparison
+     ]]></description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ boolean bar(String x) {
+  return x.equals("2");
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+ok, empty literal in .equals comparison
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ void bar() {
+  if((str == null) || (str.equals(""))) {
+   str = "snafu";
+  }
+  if(str == null || str.equals("")) {
+   str = "snafu";
+  }
+  if((str != null) && (str.equals(""))) {
+   str = "snafu";
+  }
+  if(str != null && str.equals("")) {
+   str = "snafu";
+  }
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+Test case from bug [1472195] - PositionLiteralsFirstInComparisons gives many .equals false positives
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo
+{
+	public void bug()
+	{
+		if (number.equals(new BigDecimal("123"))) {}
+	}
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+Test case from bug [1472195] - PositionLiteralsFirstInComparisons gives many .equals false positives
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo
+{
+	public void testMethod(String str)
+	{
+		if (str.equals(getAnotherString("abc"))){}
+  	}
+
+  	private String getAnotherString(String str)
+	{
+		return "xyz";
+	}
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description>#1256 PositionLiteralsFirstInComparisons .equals false positive with Characters</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class LiteralTest {
+    protected final boolean check;
+    public LiteralTest(Character c) {
+        check = c.equals('x');
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description><![CDATA[
+ok, literal comes first in .equalsIgnoreCase comparison
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ boolean bar(String x) {
+  return "2".equalsIgnoreCase(x);
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+bad, literal comes last in .equalsIgnoreCase comparison
+     ]]></description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ boolean bar(String x) {
+  return x.equalsIgnoreCase("2");
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+ok, testing .equalsIgnoreCase false positive
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ void bar() {
+  if((str == null) || (equalsIgnoreCase(""))) {
+   str = "snafu";
+  }
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+Test case from bug [1472195] - PositionLiteralsFirstInComparisons gives many .equalsIgnoreCase false positives
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo
+{
+	public void bug()
+	{
+		if (equalsIgnoreCase(new BigDecimal("123"))) {}
+	}
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+Test case from bug [1472195] - PositionLiteralsFirstInComparisons gives many .equalsIgnoreCase false positives
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo
+{
+	public void testMethod(String str)
+	{
+		if (equalsIgnoreCase(getAnotherString("abc"))){}
+  	}
+
+  	private String getAnotherString(String str)
+	{
+		return "xyz";
+	}
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+ok, literal comes first in .compareTo comparison
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ boolean bar(String x) {
+  return "2".compareTo(x) < 0;
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+bad, literal comes last in .compareTo comparison
+     ]]></description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ boolean bar(String x) {
+  return x.compareTo("2") > 0;
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+ok, testing for .compareTo false positive
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ boolean bar() {
+    return compareTo("randomStringArg");
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+ok, literal comes first in .compareToIgnoreCase comparison
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ boolean bar(String x) {
+    return "2".compareToIgnoreCase(x) < 0;
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+bad, literal comes last in .compareToIgnoreCase comparison
+     ]]></description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ boolean bar(String x) {
+    return x.compareToIgnoreCase("2") > 0;
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+ok, testing ,compareToIgnoreCase false positive
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ String bar() {
+    return compareToIgnoreCase("randomStringArg");
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+ok, literal comes first in .contentEquals comparison
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ boolean bar(String x) {
+    return "2".contentEquals(x);
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+bad, literal comes last in .contentEquals comparison
+     ]]></description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ boolean bar(String x) {
+    return x.contentEquals("2");
+ }
+}
+     ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+ok, testing .contentEquals false positive
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+ boolean bar(String x) {
+    return contentEquals("2");
+ }
+}
+     ]]></code>
+    </test-code>
+</test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LiteralsFirstInComparisons.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LiteralsFirstInComparisons.xml
@@ -4,9 +4,9 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
     <test-code>
-        <description><![CDATA[
+        <description>
 ok, literal comes first in .equals comparison
-     ]]></description>
+        </description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -17,9 +17,9 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
+        <description>
 bad, literal comes last in .equals comparison
-     ]]></description>
+        </description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -30,9 +30,9 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
+        <description>
 ok, empty literal in .equals comparison
-     ]]></description>
+        </description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -54,9 +54,9 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
+        <description>
 Test case from bug [1472195] - PositionLiteralsFirstInComparisons gives many .equals false positives
-     ]]></description>
+        </description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo
@@ -69,9 +69,9 @@ public class Foo
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
+        <description>
 Test case from bug [1472195] - PositionLiteralsFirstInComparisons gives many .equals false positives
-     ]]></description>
+        </description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo
@@ -102,9 +102,9 @@ public class LiteralTest {
     </test-code>
 
     <test-code>
-        <description><![CDATA[
+        <description>
 ok, literal comes first in .equalsIgnoreCase comparison
-     ]]></description>
+        </description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -115,9 +115,9 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
+        <description>
 bad, literal comes last in .equalsIgnoreCase comparison
-     ]]></description>
+        </description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -128,9 +128,9 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
+        <description>
 ok, testing .equalsIgnoreCase false positive
-     ]]></description>
+        </description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -143,9 +143,9 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
+        <description>
 Test case from bug [1472195] - PositionLiteralsFirstInComparisons gives many .equalsIgnoreCase false positives
-     ]]></description>
+        </description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo
@@ -158,9 +158,9 @@ public class Foo
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
+        <description>
 Test case from bug [1472195] - PositionLiteralsFirstInComparisons gives many .equalsIgnoreCase false positives
-     ]]></description>
+        </description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo
@@ -178,9 +178,9 @@ public class Foo
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
+        <description>
 ok, literal comes first in .compareTo comparison
-     ]]></description>
+        </description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -191,9 +191,9 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
+        <description>
 bad, literal comes last in .compareTo comparison
-     ]]></description>
+        </description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -204,9 +204,9 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
+        <description>
 ok, testing for .compareTo false positive
-     ]]></description>
+        </description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -217,9 +217,9 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
+        <description>
 ok, literal comes first in .compareToIgnoreCase comparison
-     ]]></description>
+        </description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -230,9 +230,9 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
+        <description>
 bad, literal comes last in .compareToIgnoreCase comparison
-     ]]></description>
+        </description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -243,9 +243,9 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
+        <description>
 ok, testing ,compareToIgnoreCase false positive
-     ]]></description>
+        </description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -256,9 +256,9 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
+        <description>
 ok, literal comes first in .contentEquals comparison
-     ]]></description>
+        </description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -269,9 +269,9 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
+        <description>
 bad, literal comes last in .contentEquals comparison
-     ]]></description>
+        </description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -282,9 +282,9 @@ public class Foo {
      ]]></code>
     </test-code>
     <test-code>
-        <description><![CDATA[
+        <description>
 ok, testing .contentEquals false positive
-     ]]></description>
+        </description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {


### PR DESCRIPTION
## Describe the PR

Adds a new rule `LiteralsFirstInComparisons` that examines the positioning of literals for all String comparison operations. This rule's logic is identical to `AbstractPositionLiteralsFirstInComparisons` with the exception of the `AbstractNode.image` check.
The following comparisons are supported:
- `.equals`
- `.equalsIgnoreCase`
- `.compareTo`
- `.compareToIgnoreCase`
- `.contentEquals`

This is a generalization of the previously defined rules `PositionLiteralsFirstInComparisons` and `PositionLiteralsFirstInCaseInsensitiveComparisons`. These now redundant rules will be deprecated in a separate PR.

Included all the original test cases for the original rules, as well as test cases for the new comparisons as well.

## Related issues

- Ref #2145 - this rule will replace the two old rules

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

