### PR TITLE
[java] Fix JUnitSpellingRule false positive

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJUnitRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJUnitRule.java
@@ -89,7 +89,7 @@ public abstract class AbstractJUnitRule extends AbstractJavaRule {
         return isJUnit3Class && method.isVoid() && method.getName().startsWith("test");
     }
 
-    private boolean isJUnit3Class(ASTCompilationUnit node) {
+    protected boolean isJUnit3Class(ASTCompilationUnit node) {
         ASTClassOrInterfaceDeclaration cid = node.getFirstDescendantOfType(ASTClassOrInterfaceDeclaration.class);
         if (cid == null) {
             return false;
@@ -105,19 +105,19 @@ public abstract class AbstractJUnitRule extends AbstractJavaRule {
             if (((ASTClassOrInterfaceType) extendsList.getChild(0)).getImage().endsWith("TestCase")) {
                 return true;
             }
-            String className = cid.getImage();
+            String className = cid.getSimpleName();
             return className.endsWith("Test");
         } else if (hasImports(node, JUNIT3_CLASS_NAME)) {
-            return cid.getImage().endsWith("Test");
+            return cid.getSimpleName().endsWith("Test");
         }
         return false;
     }
 
-    private boolean isJUnit4Class(ASTCompilationUnit node) {
+    protected boolean isJUnit4Class(ASTCompilationUnit node) {
         return doesNodeContainJUnitAnnotation(node, JUNIT4_CLASS_NAME);
     }
 
-    private boolean isJUnit5Class(ASTCompilationUnit node) {
+    protected boolean isJUnit5Class(ASTCompilationUnit node) {
         return doesNodeContainJUnitAnnotation(node, JUNIT5_CLASS_NAME);
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJUnitRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJUnitRule.java
@@ -24,9 +24,9 @@ public abstract class AbstractJUnitRule extends AbstractJavaRule {
     protected static final String JUNIT4_CLASS_NAME = "org.junit.Test";
     protected static final String JUNIT5_CLASS_NAME = "org.junit.jupiter.api.Test";
 
-    private boolean isJUnit3Class;
-    private boolean isJUnit4Class;
-    private boolean isJUnit5Class;
+    protected boolean isJUnit3Class;
+    protected boolean isJUnit4Class;
+    protected boolean isJUnit5Class;
 
     @Override
     public Object visit(ASTCompilationUnit node, Object data) {
@@ -89,7 +89,7 @@ public abstract class AbstractJUnitRule extends AbstractJavaRule {
         return isJUnit3Class && method.isVoid() && method.getName().startsWith("test");
     }
 
-    protected boolean isJUnit3Class(ASTCompilationUnit node) {
+    private boolean isJUnit3Class(ASTCompilationUnit node) {
         ASTClassOrInterfaceDeclaration cid = node.getFirstDescendantOfType(ASTClassOrInterfaceDeclaration.class);
         if (cid == null) {
             return false;
@@ -113,11 +113,11 @@ public abstract class AbstractJUnitRule extends AbstractJavaRule {
         return false;
     }
 
-    protected boolean isJUnit4Class(ASTCompilationUnit node) {
+    private boolean isJUnit4Class(ASTCompilationUnit node) {
         return doesNodeContainJUnitAnnotation(node, JUNIT4_CLASS_NAME);
     }
 
-    protected boolean isJUnit5Class(ASTCompilationUnit node) {
+    private boolean isJUnit5Class(ASTCompilationUnit node) {
         return doesNodeContainJUnitAnnotation(node, JUNIT5_CLASS_NAME);
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnitSpellingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnitSpellingRule.java
@@ -5,6 +5,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 
+import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.rule.AbstractJUnitRule;
 
@@ -12,6 +13,11 @@ public class JUnitSpellingRule extends AbstractJUnitRule {
 
     @Override
     public Object visit(ASTMethodDeclaration node, Object data) {
+        ASTCompilationUnit acu = node.getFirstParentOfType(ASTCompilationUnit.class);
+        if (isJUnit5Class(acu) || (isJUnit4Class(acu))) {
+            return super.visit(node, data);
+        }
+
         if (node.getArity() != 0) {
             return super.visit(node, data);
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnitSpellingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnitSpellingRule.java
@@ -14,7 +14,7 @@ public class JUnitSpellingRule extends AbstractJUnitRule {
     @Override
     public Object visit(ASTMethodDeclaration node, Object data) {
         ASTCompilationUnit acu = node.getFirstParentOfType(ASTCompilationUnit.class);
-        if (isJUnit5Class(acu) || (isJUnit4Class(acu))) {
+        if (isJUnit5Class(acu) || isJUnit4Class(acu)) {
             return super.visit(node, data);
         }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnitSpellingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnitSpellingRule.java
@@ -5,7 +5,6 @@
 
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 
-import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.rule.AbstractJUnitRule;
 
@@ -13,8 +12,7 @@ public class JUnitSpellingRule extends AbstractJUnitRule {
 
     @Override
     public Object visit(ASTMethodDeclaration node, Object data) {
-        ASTCompilationUnit acu = node.getFirstParentOfType(ASTCompilationUnit.class);
-        if (isJUnit5Class(acu) || isJUnit4Class(acu)) {
+        if (isJUnit5Class || isJUnit4Class) {
             return super.visit(node, data);
         }
 

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2175,7 +2175,9 @@ public class JumbledIncrementerRule1 {
           class="net.sourceforge.pmd.lang.java.rule.errorprone.JUnitSpellingRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#junitspelling">
         <description>
-Some JUnit framework methods are easy to misspell.
+            In JUnit 3, the setUp method is used to set up all data entities required in running tests.
+            The tearDown method is used to clean up all data entities required in running tests.
+            You should not misspell method name if you want your test to set up and clean up everything correctly.
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/JUnitSpelling.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/JUnitSpelling.xml
@@ -79,4 +79,41 @@ public class Foo {
 }
      ]]></code>
     </test-code>
+    <test-code>
+        <description><![CDATA[
+No problem - usual JUnit5 test
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class BTest {
+
+    @BeforeEach
+    void setup() {}
+
+    @Test
+    void test() {}
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description><![CDATA[
+No problem - usual JUnit4 test
+     ]]></description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.junit.Before;
+import org.junit.Test;
+public class BTest {
+
+    @Before
+    void setup() {}
+
+    @Test
+    void test() {}
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION


## Describe the PR

    Do not trigger if it's a junit5 class (isJUnit5Class from AbstractJUnitRule can be used).
    Do not trigger if junit4 doesn't extend TestCase

It'd be probably good to add more explanation to the rule itself.
<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #2477

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

