### PR TITLE
[core] Require Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -442,7 +442,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[10,)</version>
+                                    <version>[11,)</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>


### PR DESCRIPTION
This was outdated, still enforcing Java 10, which would not work anymore.

Our wiki is already updated to require Java 11.

Fixes #2484