### PR TITLE
[core] Revamp the language version alias APIs

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/BaseLanguageModule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/BaseLanguageModule.java
@@ -11,6 +11,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import net.sourceforge.pmd.annotation.Experimental;
+
 /**
  * Created by christoferdutz on 21.09.14.
  */
@@ -34,6 +36,7 @@ public abstract class BaseLanguageModule implements Language {
         this.extensions = Arrays.asList(extensions);
     }
 
+    @Experimental
     protected void addVersion(String version, LanguageVersionHandler languageVersionHandler, boolean isDefault, String... versionAliases) {
         if (versions == null) {
             versions = new HashMap<>();
@@ -53,6 +56,10 @@ public abstract class BaseLanguageModule implements Language {
                 : "Default version already set to " + defaultVersion + ", cannot set it to " + languageVersion;
             defaultVersion = languageVersion;
         }
+    }
+    
+    protected void addVersion(String version, LanguageVersionHandler languageVersionHandler, boolean isDefault) {
+        addVersion(version, languageVersionHandler, isDefault, new String[0]);
     }
 
     @Override

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/BaseLanguageModule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/BaseLanguageModule.java
@@ -11,8 +11,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import net.sourceforge.pmd.annotation.Experimental;
-
 /**
  * Created by christoferdutz on 21.09.14.
  */
@@ -36,18 +34,18 @@ public abstract class BaseLanguageModule implements Language {
         this.extensions = Arrays.asList(extensions);
     }
 
-    @Experimental
-    protected void addVersions(LanguageVersionHandler languageVersionHandler, boolean isDefault, String ... languageVersions) {
+    protected void addVersion(String version, LanguageVersionHandler languageVersionHandler, boolean isDefault, String... versionAliases) {
         if (versions == null) {
             versions = new HashMap<>();
         }
 
-        LanguageVersion languageVersion = new LanguageVersion(this, languageVersions[0], languageVersionHandler);
+        LanguageVersion languageVersion = new LanguageVersion(this, version, languageVersionHandler);
 
         distinctVersions.add(languageVersion);
 
-        for (String version : languageVersions) {
-            versions.put(version, languageVersion);
+        versions.put(version, languageVersion);
+        for (String alias : versionAliases) {
+            versions.put(alias, languageVersion);
         }
 
         if (isDefault) {
@@ -55,10 +53,6 @@ public abstract class BaseLanguageModule implements Language {
                 : "Default version already set to " + defaultVersion + ", cannot set it to " + languageVersion;
             defaultVersion = languageVersion;
         }
-    }
-
-    protected void addVersion(String version, LanguageVersionHandler languageVersionHandler, boolean isDefault) {
-        addVersions(languageVersionHandler, isDefault, version);
     }
 
     @Override

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/BaseLanguageModule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/BaseLanguageModule.java
@@ -11,10 +11,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.antlr.v4.runtime.atn.SemanticContext.OR;
-
-import net.sourceforge.pmd.annotation.Experimental;
-
 /**
  * Created by christoferdutz on 21.09.14.
  */

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/BaseLanguageModule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/BaseLanguageModule.java
@@ -11,6 +11,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.antlr.v4.runtime.atn.SemanticContext.OR;
+
 import net.sourceforge.pmd.annotation.Experimental;
 
 /**
@@ -36,8 +38,7 @@ public abstract class BaseLanguageModule implements Language {
         this.extensions = Arrays.asList(extensions);
     }
 
-    @Experimental
-    protected void addVersion(String version, LanguageVersionHandler languageVersionHandler, boolean isDefault, String... versionAliases) {
+    private void addVersion(String version, LanguageVersionHandler languageVersionHandler, boolean isDefault, String... versionAliases) {
         if (versions == null) {
             versions = new HashMap<>();
         }
@@ -57,7 +58,19 @@ public abstract class BaseLanguageModule implements Language {
             defaultVersion = languageVersion;
         }
     }
+
+    protected void addVersion(String version, LanguageVersionHandler languageVersionHandler, String... versionAliases) {
+        addVersion(version, languageVersionHandler, false, versionAliases);
+    }
     
+    protected void addDefaultVersion(String version, LanguageVersionHandler languageVersionHandler, String... versionAliases) {
+        addVersion(version, languageVersionHandler, true, versionAliases);
+    }
+
+    /**
+     * @deprecated use {@link #addVersion(String, LanguageVersionHandler, String...)} or {@link #addDefaultVersion(String, LanguageVersionHandler, String...)}
+     */
+    @Deprecated
     protected void addVersion(String version, LanguageVersionHandler languageVersionHandler, boolean isDefault) {
         addVersion(version, languageVersionHandler, isDefault, new String[0]);
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/rules/RuleBuilder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/rules/RuleBuilder.java
@@ -166,7 +166,7 @@ public class RuleBuilder {
         if (minimumVersion != null) {
             LanguageVersion minimumLanguageVersion = rule.getLanguage().getVersion(minimumVersion);
             if (minimumLanguageVersion == null) {
-                throwUnknownLanguageVersionException("minimum", minimumVersion);
+                throwUnknownLanguageVersionException("minimum", minimumVersion, rule.getLanguage());
             } else {
                 rule.setMinimumLanguageVersion(minimumLanguageVersion);
             }
@@ -175,7 +175,7 @@ public class RuleBuilder {
         if (maximumVersion != null) {
             LanguageVersion maximumLanguageVersion = rule.getLanguage().getVersion(maximumVersion);
             if (maximumLanguageVersion == null) {
-                throwUnknownLanguageVersionException("maximum", maximumVersion);
+                throwUnknownLanguageVersionException("maximum", maximumVersion, rule.getLanguage());
             } else {
                 rule.setMaximumLanguageVersion(maximumLanguageVersion);
             }
@@ -184,12 +184,12 @@ public class RuleBuilder {
         checkLanguageVersionsAreOrdered(rule);
     }
 
-    private void throwUnknownLanguageVersionException(String minOrMax, String unknownVersion) {
+    private void throwUnknownLanguageVersionException(String minOrMax, String unknownVersion, Language lang) {
         throw new IllegalArgumentException("Unknown " + minOrMax + " Language Version '" + unknownVersion
-                                           + "' for Language '" + language.getTerseName()
+                                           + "' for Language '" + lang.getTerseName()
                                            + "' for Rule " + name
                                            + "; supported Language Versions are: "
-                                           + LanguageRegistry.commaSeparatedTerseNamesForLanguageVersion(language.getVersions()));
+                                           + LanguageRegistry.commaSeparatedTerseNamesForLanguageVersion(lang.getVersions()));
     }
 
     public Rule build() throws ClassNotFoundException, IllegalAccessException, InstantiationException {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageModule.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageModule.java
@@ -43,10 +43,10 @@ public class DummyLanguageModule extends BaseLanguageModule {
         addVersion("1.2", new Handler(), false);
         addVersion("1.3", new Handler(), false);
         addVersion("1.4", new Handler(), false);
-        addVersions(new Handler(), false, "1.5", "5");
-        addVersions(new Handler(), false, "1.6", "6");
-        addVersions(new Handler(), true, "1.7", "7");
-        addVersions(new Handler(), false, "1.8", "8");
+        addVersion("1.5", new Handler(), false, "5");
+        addVersion("1.6", new Handler(), false, "6");
+        addVersion("1.7", new Handler(), true, "7");
+        addVersion("1.8", new Handler(), false, "8");
     }
 
     public static class DummyRuleChainVisitor extends AbstractRuleChainVisitor {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageModule.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageModule.java
@@ -38,15 +38,15 @@ public class DummyLanguageModule extends BaseLanguageModule {
 
     public DummyLanguageModule() {
         super(NAME, null, TERSE_NAME, DummyRuleChainVisitor.class, "dummy");
-        addVersion("1.0", new Handler(), false);
-        addVersion("1.1", new Handler(), false);
-        addVersion("1.2", new Handler(), false);
-        addVersion("1.3", new Handler(), false);
-        addVersion("1.4", new Handler(), false);
-        addVersion("1.5", new Handler(), false, "5");
-        addVersion("1.6", new Handler(), false, "6");
-        addVersion("1.7", new Handler(), true, "7");
-        addVersion("1.8", new Handler(), false, "8");
+        addVersion("1.0", new Handler());
+        addVersion("1.1", new Handler());
+        addVersion("1.2", new Handler());
+        addVersion("1.3", new Handler());
+        addVersion("1.4", new Handler());
+        addVersion("1.5", new Handler(), "5");
+        addVersion("1.6", new Handler(), "6");
+        addDefaultVersion("1.7", new Handler(), "7");
+        addVersion("1.8", new Handler(), "8");
     }
 
     public static class DummyRuleChainVisitor extends AbstractRuleChainVisitor {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/JavaLanguageModule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/JavaLanguageModule.java
@@ -19,12 +19,12 @@ public class JavaLanguageModule extends BaseLanguageModule {
         super(NAME, null, TERSE_NAME, JavaRuleChainVisitor.class, "java");
         addVersion("1.3", new JavaLanguageHandler(3), false);
         addVersion("1.4", new JavaLanguageHandler(4), false);
-        addVersions(new JavaLanguageHandler(5), false, "1.5", "5");
-        addVersions(new JavaLanguageHandler(6), false, "1.6", "6");
-        addVersions(new JavaLanguageHandler(7), false, "1.7", "7");
-        addVersions(new JavaLanguageHandler(8), false, "1.8", "8");
-        addVersions(new JavaLanguageHandler(9), false, "9", "1.9");
-        addVersions(new JavaLanguageHandler(10), false, "10", "1.10");
+        addVersion("1.5", new JavaLanguageHandler(5), false, "5");
+        addVersion("1.6", new JavaLanguageHandler(6), false, "6");
+        addVersion("1.7", new JavaLanguageHandler(7), false, "7");
+        addVersion("1.8", new JavaLanguageHandler(8), false, "8");
+        addVersion("9", new JavaLanguageHandler(9), false, "1.9");
+        addVersion("10", new JavaLanguageHandler(10), false, "1.10");
         addVersion("11", new JavaLanguageHandler(11), false);
         addVersion("12", new JavaLanguageHandler(12), false);
         addVersion("13", new JavaLanguageHandler(13), false);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/JavaLanguageModule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/JavaLanguageModule.java
@@ -17,20 +17,20 @@ public class JavaLanguageModule extends BaseLanguageModule {
 
     public JavaLanguageModule() {
         super(NAME, null, TERSE_NAME, JavaRuleChainVisitor.class, "java");
-        addVersion("1.3", new JavaLanguageHandler(3), false);
-        addVersion("1.4", new JavaLanguageHandler(4), false);
-        addVersion("1.5", new JavaLanguageHandler(5), false, "5");
-        addVersion("1.6", new JavaLanguageHandler(6), false, "6");
-        addVersion("1.7", new JavaLanguageHandler(7), false, "7");
-        addVersion("1.8", new JavaLanguageHandler(8), false, "8");
-        addVersion("9", new JavaLanguageHandler(9), false, "1.9");
-        addVersion("10", new JavaLanguageHandler(10), false, "1.10");
-        addVersion("11", new JavaLanguageHandler(11), false);
-        addVersion("12", new JavaLanguageHandler(12), false);
-        addVersion("13", new JavaLanguageHandler(13), false);
-        addVersion("13-preview", new JavaLanguageHandler(13, true), false);
-        addVersion("14", new JavaLanguageHandler(14), true); // 14 is the default
-        addVersion("14-preview", new JavaLanguageHandler(14, true), false);
+        addVersion("1.3", new JavaLanguageHandler(3));
+        addVersion("1.4", new JavaLanguageHandler(4));
+        addVersion("1.5", new JavaLanguageHandler(5), "5");
+        addVersion("1.6", new JavaLanguageHandler(6), "6");
+        addVersion("1.7", new JavaLanguageHandler(7), "7");
+        addVersion("1.8", new JavaLanguageHandler(8), "8");
+        addVersion("9", new JavaLanguageHandler(9), "1.9");
+        addVersion("10", new JavaLanguageHandler(10), "1.10");
+        addVersion("11", new JavaLanguageHandler(11));
+        addVersion("12", new JavaLanguageHandler(12));
+        addVersion("13", new JavaLanguageHandler(13));
+        addVersion("13-preview", new JavaLanguageHandler(13, true));
+        addDefaultVersion("14", new JavaLanguageHandler(14)); // 14 is the default
+        addVersion("14-preview", new JavaLanguageHandler(14, true));
     }
 
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/LanguageVersionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/LanguageVersionTest.java
@@ -35,25 +35,26 @@ public class LanguageVersionTest extends AbstractLanguageVersionTest {
             { JavaLanguageModule.NAME, JavaLanguageModule.TERSE_NAME, "1.8",
                 LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.8"), },
             { JavaLanguageModule.NAME, JavaLanguageModule.TERSE_NAME, "9",
-                    LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("9"), },
+                LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("9"), },
             { JavaLanguageModule.NAME, JavaLanguageModule.TERSE_NAME, "10",
-                        LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("10"), },
+                LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("10"), },
             { JavaLanguageModule.NAME, JavaLanguageModule.TERSE_NAME, "11",
-                            LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("11"), },
+                LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("11"), },
             { JavaLanguageModule.NAME, JavaLanguageModule.TERSE_NAME, "12",
-                                LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("12"), },
+                LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("12"), },
             { JavaLanguageModule.NAME, JavaLanguageModule.TERSE_NAME, "12-preview",
-                                    LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("12-preview"), },
+                LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("12-preview"), },
             { JavaLanguageModule.NAME, JavaLanguageModule.TERSE_NAME, "13",
-                                        LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("13"), },
+                LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("13"), },
             { JavaLanguageModule.NAME, JavaLanguageModule.TERSE_NAME, "13-preview",
-                                            LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("13-preview"), },
+                LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("13-preview"), },
             { JavaLanguageModule.NAME, JavaLanguageModule.TERSE_NAME, "14",
-                                                LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("14"), },
+                LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("14"), },
             { JavaLanguageModule.NAME, JavaLanguageModule.TERSE_NAME, "14-preview",
-                                                LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("14-preview"), },
+                LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("14-preview"), },
 
             // this one won't be found: case sensitive!
-            { "JAVA", "JAVA", "1.7", null, }, });
+            { "JAVA", "JAVA", "1.7", null, },
+        });
     }
 }


### PR DESCRIPTION
Builds on top of #2088 with an improved API 

The old experimental API allowed calls such as `addVersions(langHandler, false)` which were not only invalid, but would throw an `ArrayIndexOutOfBoundsException`, so we split the name
(required) and the aliases (varargs, and therefore optional). We now had:

```java
addVersion("1.4", java4Handler, false);
addVersions(java6Handler, false, "1.6", "6");
```

In doing so, I was bothered by parameter order. The version name is the most significant change when setting 2 versions for a language, so I liked it being first as the old `addVersion` method did, so I moved that ahead. I know had:

```java
addVersion("1.4", java4Handler, false);
addVersions("1.6", java6Handler, false, "6");
```

With that, I now had 2 methods that where equivalent, except one allowed for varargs and the other didn't… so I made them overloads. We now had:

```java
addVersion("1.4", java4Handler, false);
addVersion("1.6", java6Handler, false, "6");
```

I do keep the old method for binary compatibility, but with the current API we could completely remove it and still be source compatible (all calls to `addVersion` would still be valid and compile, only reflection calls would break).

With this API I think we could aim to deprecate / remove the old method in master (do we even care about reflection calls?) and promote the varargs one to non-experimental, but would love your insight into this.