### PR TITLE
[java] Deprecate redundant String Comparison rules 

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AbstractPositionLiteralsFirstInComparisons.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AbstractPositionLiteralsFirstInComparisons.java
@@ -20,6 +20,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
+@Deprecated
 class AbstractPositionLiteralsFirstInComparisons extends AbstractJavaRule {
 
     private final String equalsImage;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PositionLiteralsFirstInCaseInsensitiveComparisonsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PositionLiteralsFirstInCaseInsensitiveComparisonsRule.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
+@Deprecated
 public class PositionLiteralsFirstInCaseInsensitiveComparisonsRule extends AbstractPositionLiteralsFirstInComparisons {
 
     public PositionLiteralsFirstInCaseInsensitiveComparisonsRule() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PositionLiteralsFirstInComparisonsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PositionLiteralsFirstInComparisonsRule.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
+@Deprecated
 public class PositionLiteralsFirstInComparisonsRule extends AbstractPositionLiteralsFirstInComparisons {
 
     public PositionLiteralsFirstInComparisonsRule() {

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -1051,10 +1051,11 @@ String name,
           since="5.1"
           message="Position literals first in String comparisons for EqualsIgnoreCase"
           class="net.sourceforge.pmd.lang.java.rule.bestpractices.PositionLiteralsFirstInCaseInsensitiveComparisonsRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_bestpractices.html#positionliteralsfirstincaseinsensitivecomparisons">
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_bestpractices.html#positionliteralsfirstincaseinsensitivecomparisons"
+          deprecated="true">
         <description>
 Position literals first in comparisons, if the second argument is null then NullPointerExceptions
-can be avoided, they will just return false.
+can be avoided, they will just return false. This rule is replaced by the more general LiteralsFirstInComparisons rule.
         </description>
         <priority>3</priority>
         <example>
@@ -1073,10 +1074,11 @@ class Foo {
           since="3.3"
           message="Position literals first in String comparisons"
           class="net.sourceforge.pmd.lang.java.rule.bestpractices.PositionLiteralsFirstInComparisonsRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_bestpractices.html#positionliteralsfirstincomparisons">
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_bestpractices.html#positionliteralsfirstincomparisons"
+          deprecated="true">
         <description>
 Position literals first in comparisons, if the second argument is null then NullPointerExceptions
-can be avoided, they will just return false.
+can be avoided, they will just return false.  This rule is replaced by the more general LiteralsFirstInComparisons rule.
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/main/resources/rulesets/java/quickstart.xml
+++ b/pmd-java/src/main/resources/rulesets/java/quickstart.xml
@@ -51,7 +51,7 @@
     <rule ref="category/java/bestpractices.xml/UseAssertSameInsteadOfAssertTrue"/>
     <rule ref="category/java/bestpractices.xml/UseAssertTrueInsteadOfAssertEquals"/>
     <rule ref="category/java/bestpractices.xml/UseCollectionIsEmpty"/>
-    <!-- <rule ref="category/java/bestpractices.xml/UseTryWithResources" /> -->
+    <!-- <rule ref="qqcategory/java/bestpractices.xml/UseTryWithResources" /> -->
     <!-- <rule ref="category/java/bestpractices.xml/UseVarargs" /> -->
     <!-- <rule ref="category/java/bestpractices.xml/WhileLoopWithLiteralBoolean" /> -->
 

--- a/pmd-java/src/main/resources/rulesets/java/quickstart.xml
+++ b/pmd-java/src/main/resources/rulesets/java/quickstart.xml
@@ -51,7 +51,7 @@
     <rule ref="category/java/bestpractices.xml/UseAssertSameInsteadOfAssertTrue"/>
     <rule ref="category/java/bestpractices.xml/UseAssertTrueInsteadOfAssertEquals"/>
     <rule ref="category/java/bestpractices.xml/UseCollectionIsEmpty"/>
-    <!-- <rule ref="qqcategory/java/bestpractices.xml/UseTryWithResources" /> -->
+    <!-- <rule ref="category/java/bestpractices.xml/UseTryWithResources" /> -->
     <!-- <rule ref="category/java/bestpractices.xml/UseVarargs" /> -->
     <!-- <rule ref="category/java/bestpractices.xml/WhileLoopWithLiteralBoolean" /> -->
 


### PR DESCRIPTION
## Describe the PR
The `AbstractPositionLiteralsFirstInComparisons`, `PositionLiteralsFirstInComparisons`, and `PositionLiteralsFirstInCaseInsensitiveComparisons` Java rules are replaced with a more general rule (`LiteralsFirstInComparisons`) that checks all forms of String comparisons.

This PR adds deprecated tags to the rules and the rulesets.

## Related issues
Added new replacement rule: #2478 
Original thread: #2145 

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

