### PR TITLE
[c#] Support for interpolated verbatim strings

### DIFF
--- a/pmd-cs/src/main/antlr4/net/sourceforge/pmd/lang/cs/antlr4/CSharpLexer.g4
+++ b/pmd-cs/src/main/antlr4/net/sourceforge/pmd/lang/cs/antlr4/CSharpLexer.g4
@@ -148,7 +148,7 @@ REGULAR_STRING:                      '"'  (~["\\\r\n\u0085\u2028\u2029] | Common
 VERBATIUM_STRING:                    '@"' (~'"' | '""')* '"';
 INTERPOLATED_REGULAR_STRING_START:   '$"'
     { interpolatedStringLevel++; interpolatedVerbatiums.push(false); verbatium = false; } -> pushMode(INTERPOLATION_STRING);
-INTERPOLATED_VERBATIUM_STRING_START: '$@"'
+INTERPOLATED_VERBATIUM_STRING_START: ('$@"' | '@$"')
     { interpolatedStringLevel++; interpolatedVerbatiums.push(true); verbatium = true; }  -> pushMode(INTERPOLATION_STRING);
 
 //B.1.9 Operators And Punctuators

--- a/pmd-cs/src/test/java/net/sourceforge/pmd/cpd/CsTokenizerTest.java
+++ b/pmd-cs/src/test/java/net/sourceforge/pmd/cpd/CsTokenizerTest.java
@@ -162,6 +162,17 @@ public class CsTokenizerTest {
         assertEquals("using", tokens.getTokens().get(0).toString());
     }
 
+    @Test
+    public void testInterpolatedVerbatimStrings() {
+        tokenizer.setIgnoreUsings(true);
+        tokenizer.tokenize(toSourceCode(
+                "var test = $@\"test\";\n"
+                + "var test2 = @$\"test\";"),
+                tokens
+        );
+        assertEquals(15, tokens.size());
+    }
+
     private SourceCode toSourceCode(String source) {
         return new SourceCode(new SourceCode.StringCodeLoader(source));
     }


### PR DESCRIPTION
Before submitting a PR, please check that:
 - [x] The PR is submitted against `master`. The PMD team will merge back to support branches as needed.
 - [x] `./mvnw clean verify` passes. This will [build](https://github.com/pmd/pmd/blob/master/BUILDING.md) and test PMD, execute PMD and checkstyle rules. [Check this for more info](https://github.com/pmd/pmd/blob/master/CONTRIBUTING.md#code-style)

**PR Description:**
See [the C# documentation](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-8#enhancement-of-interpolated-verbatim-strings) about changes to the syntax for interpolated verbatim strings in C# 8. In the past, these strings could only have the `$@` prefix, but now the `@$` prefix (where the characters are reversed) is also allowed.