### PR TITLE
[java] UselessOverridingMethod false negative with already public methods

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -16,6 +16,9 @@ This is a {{ site.pmd.release_type }} release.
 
 ### Fixed Issues
 
+*   java-design
+    *   [#2563](https://github.com/pmd/pmd/pull/2563): \[java] UselessOverridingMethod false negative with already public methods
+
 ### API Changes
 
 ### External Contributions

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UselessOverridingMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UselessOverridingMethodRule.java
@@ -285,7 +285,8 @@ public class UselessOverridingMethodRule extends AbstractJavaRule {
         boolean elevatingFromProtected = Modifier.isProtected(superMethod.getModifiers())
                 && !overridingMethod.isProtected();
         boolean elevatingFromPackagePrivate = superMethod.getModifiers() == 0 && overridingMethod.getModifiers() != 0;
-        boolean elevatingIntoDifferentPackage = !packageName.equals(superPackageName);
+        boolean elevatingIntoDifferentPackage = !packageName.equals(superPackageName)
+                && !Modifier.isPublic(superMethod.getModifiers());
 
         return elevatingFromProtected
                 || elevatingFromPackagePrivate

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/UselessOverridingMethodHashCode.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/UselessOverridingMethodHashCode.java
@@ -1,0 +1,18 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+
+package net.sourceforge.pmd.lang.java.rule.design.uselessoverridingmethod;
+
+public class UselessOverridingMethodHashCode {
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj);
+    }
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UselessOverridingMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/UselessOverridingMethod.xml
@@ -454,4 +454,25 @@ public class DirectSynchronizingSubclass extends BaseClass {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Useless override with different packages already public (false negative)</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>5,10</expected-linenumbers>
+        <code><![CDATA[
+package net.sourceforge.pmd.lang.java.rule.design.uselessoverridingmethod;
+
+public class UselessOverridingMethodHashCode {
+    @Override
+    public int hashCode() {
+        return super.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return super.equals(obj);
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

The following code doesn't trigger the rule [UselessOverridingMethod](https://pmd.github.io/latest/pmd_rules_java_design.html#uselessoverridingmethod):

```java
public class UselessOverridingMethodHashCode {
    @Override
    public int hashCode() {  // violation expected
        return super.hashCode();
    }

    @Override
    public boolean equals(Object obj) { // violation expected
        return super.equals(obj);
    }
}
```

If the method is already public in the super class, then there is no elevating access ongoing, it's just useless.

## Related issues

- Introduced when fixing #911 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

