### PR TITLE
[c#] Fix CPD suppression with comments doesn't work #2551

### DIFF
--- a/docs/pages/pmd/userdocs/cpd/cpd.md
+++ b/docs/pages/pmd/userdocs/cpd/cpd.md
@@ -370,7 +370,7 @@ Here's a screenshot of CPD after running on the JDK 8 java.lang package:
 ## Suppression
 
 Arbitrary blocks of code can be ignored through comments on **Java**, **C/C++**, **Dart**, **Go**, **Javascript**,
-**Kotlin**, **Lua**, **Matlab**, **Objective-C**, **PL/SQL**, **Python** and **Swift** by including the keywords `CPD-OFF` and `CPD-ON`.
+**Kotlin**, **Lua**, **Matlab**, **Objective-C**, **PL/SQL**, **Python**, **Swift** and **C#** by including the keywords `CPD-OFF` and `CPD-ON`.
 
 ```java
     public Object someParameterizedFactoryMethod(int x) throws Exception {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/token/AntlrToken.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/token/AntlrToken.java
@@ -77,7 +77,7 @@ public class AntlrToken implements GenericToken {
     }
 
     public boolean isHidden() {
-        return token.getChannel() == Lexer.HIDDEN;
+        return !isDefault();
     }
 
     public boolean isDefault() {

--- a/pmd-cs/src/test/java/net/sourceforge/pmd/cpd/CsTokenizerTest.java
+++ b/pmd-cs/src/test/java/net/sourceforge/pmd/cpd/CsTokenizerTest.java
@@ -79,6 +79,18 @@ public class CsTokenizerTest {
     }
 
     @Test
+    public void testIgnoreBetweenSpecialComments() {
+        tokenizer
+                .tokenize(
+                        toSourceCode("// CPD-OFF\n" + "class Foo {\n" + "  void bar() {\n" + "    int a = 1 >> 2; \n"
+                                + "    a += 1; \n" + "    a++; \n" + "    a /= 3e2; \n" + "    float f = -3.1; \n"
+                                + "    f *= 2; \n" + "    bool b = ! (f == 2.0 || f >= 1.0 && f <= 2.0) \n"
+                                + "  }\n" + "// CPD-ON\n" + "}"),
+                        tokens);
+        assertEquals(2, tokens.size()); // "}" + EOF
+    }
+
+    @Test
     public void testCommentsIgnored3() {
         tokenizer.tokenize(toSourceCode("class Foo { /// class X /* aaa */ \n }"), tokens);
         assertEquals(5, tokens.size());


### PR DESCRIPTION
CPD Suppressions for c# fixed
test added

## Describe the PR

CPD suppression with comments CPD-OFF/CPD-ON doesn't work for c#

## Related issues

[c#] CPD suppression with comments doesn't work #2551

- Fixes #2551

## Ready?

- [x] Added unit tests for fixed bug/feature - Yes
- [x] Passing all unit tests - Yes
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis) - Yes
- [x] Added (in-code) documentation (if needed) - No

