### PR TITLE
[java] DefaultPackage: Allow package default JUnit 5 Test methods

### DIFF
--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -553,7 +553,7 @@ while (true) {  // preferred approach
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#defaultpackage">
         <description>
 Use explicit scoping instead of accidental usage of default package private level.
-The rule allows methods and fields annotated with Guava's @VisibleForTesting.
+The rule allows methods and fields annotated with Guava's @VisibleForTesting and JUnit 5's annotations.
         </description>
         <priority>3</priority>
         <properties>
@@ -564,7 +564,17 @@ The rule allows methods and fields annotated with Guava's @VisibleForTesting.
 //ClassOrInterfaceDeclaration[@Interface= false()]
 /ClassOrInterfaceBody
 /ClassOrInterfaceBodyDeclaration
-[not(Annotation//Name[ends-with(@Image, 'VisibleForTesting')])]
+[not(Annotation//Name[
+    pmd-java:typeIs('org.junit.jupiter.api.Test')
+    or pmd-java:typeIs('org.junit.jupiter.api.RepeatedTest')
+    or pmd-java:typeIs('org.junit.jupiter.api.ParameterizedTest')
+    or pmd-java:typeIs('org.junit.jupiter.api.TestFactory')
+    or pmd-java:typeIs('org.junit.jupiter.api.TestTemplate')
+    or pmd-java:typeIs('org.junit.jupiter.api.BeforeAll')
+    or pmd-java:typeIs('org.junit.jupiter.api.AfterAll')
+    or pmd-java:typeIs('org.junit.jupiter.api.BeforeEach')
+    or pmd-java:typeIs('org.junit.jupiter.api.AfterEach')
+    or ends-with(@Image, 'VisibleForTesting')])]
 [
 FieldDeclaration[@PackagePrivate= true()]
 or MethodDeclaration[@PackagePrivate= true()]

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/DefaultPackage.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/DefaultPackage.xml
@@ -64,4 +64,112 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#2573 DefaultPackage triggers on field annotated with JUnit 5 @Test</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @org.junit.jupiter.api.Test
+    void bar() {
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#2573 DefaultPackage triggers on field annotated with JUnit 5 @RepeatedTest</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @org.junit.jupiter.api.RepeatedTest
+    void bar() {
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#2573 DefaultPackage triggers on field annotated with JUnit 5 @ParameterizedTest</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @org.junit.jupiter.api.ParameterizedTest
+    void bar() {
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#2573 DefaultPackage triggers on field annotated with JUnit 5 @TestFactory</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @org.junit.jupiter.api.TestFactory
+    void bar() {
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#2573 DefaultPackage triggers on field annotated with JUnit 5 @TestTemplate</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @org.junit.jupiter.api.TestTemplate
+    void bar() {
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#2573 DefaultPackage triggers on field annotated with JUnit 5 @BeforeAll</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @org.junit.jupiter.api.BeforeAll
+    void bar() {
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#2573 DefaultPackage triggers on field annotated with JUnit 5 @AfterAll</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @org.junit.jupiter.api.AfterAll
+    void bar() {
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#2573 DefaultPackage triggers on field annotated with JUnit 5 @BeforeEach</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @org.junit.jupiter.api.BeforeEach
+    void bar() {
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#2573 DefaultPackage triggers on field annotated with JUnit 5 @AfterEach</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @org.junit.jupiter.api.AfterEach
+    void bar() {
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
JUnit 5 allows test methods to be default / package scoped.

## Describe the PR

This PR adjusts the rule [DefaultPackage](https://pmd.github.io/latest/pmd_rules_java_codestyle.html#defaultpackage)

See https://junit.org/junit5/docs/current/user-guide/#writing-tests-classes-and-methods
Also, Sonar now has a rule, S5786, which requires JUnit 5 method to be package scoped, so it would be nice for PMD and Sonar to be aligned. See https://jira.sonarsource.com/browse/RSPEC-5786

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [X] Added (in-code) documentation (if needed)

