### PR TITLE
[java] New Performance Rule AvoidCalendarDateCreation

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -48,6 +48,10 @@ The command line version of PMD continues to use **scala 2.13**.
 *   The new Java Rule {% rule "java/codestyle/UnnecessaryCast" %} (`java-codestyle`)
     finds casts that are unnecessary while accessing collection elements.
 
+*   The new Java Rule {% rule "java/performance/AvoidCalendarDateCreation" %} (`java-performance`)
+    finds usages of `java.util.Calendar` whose purpose is just to get the current date. This
+    can be done in a more lightweight way.
+
 ### Fixed Issues
 
 *   c#
@@ -64,6 +68,7 @@ The command line version of PMD continues to use **scala 2.13**.
 
 ### External Contributions
 
+*   [#1932](https://github.com/pmd/pmd/pull/1932): \[java] Added 4 performance rules originating from PMD-jPinpoint-rules - [Jeroen Borgers](https://github.com/jborgers)
 *   [#2349](https://github.com/pmd/pmd/pull/2349): \[java] Optimize UnusedPrivateMethodRule - [shilko2013](https://github.com/shilko2013)
 *   [#2547](https://github.com/pmd/pmd/pull/2547): \[scala] Add cross compilation for scala 2.12 and 2.13 - [João Ferreira](https://github.com/jtjeferreira)
 *   [#2567](https://github.com/pmd/pmd/pull/2567): \[c#] Fix CPD suppression with comments doesn't work - [Lixon Lookose](https://github.com/LixonLookose)

--- a/pmd-core/src/main/resources/rulesets/releases/6250.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6250.xml
@@ -9,5 +9,6 @@ This ruleset contains links to rules that are new in PMD v6.25.0
   </description>
 
     <rule ref="category/java/codestyle.xml/UnnecessaryCast" />
+    <rule ref="category/java/performance.xml/AvoidCalendarDateCreation" />
 
 </ruleset>

--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -115,27 +115,29 @@ public class Test {
     </rule>
 
     <rule name="AvoidCalendarDateCreation"
-          since="6.17.0"
+          since="6.25.0"
           language="java"
           message="A Calendar is used to create a Date or DateTime, this is expensive."
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           typeResolution="true"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_performance.html#avoidcalendardatecreation">
-        <description>Problem: A Calendar is a heavyweight object and expensive to create. &#13;
-            Solution: Use 'new Date()', Java 8+ java.time.[Local/Zoned]DateTime.now() or joda time '[Local]DateTime.now()'.
+        <description>
+Problem: A Calendar is a heavyweight object and expensive to create.
+
+Solution: Use `new Date()`, Java 8+ `java.time.LocalDateTime.now()` or `ZonedDateTime.now()`.
         </description>
         <priority>2</priority>
         <properties>
-            <property name="version" value="1.0"/>
+            <property name="version" value="2.0"/>
             <property name="xpath">
                 <value><![CDATA[
 //PrimaryPrefix[Name[ends-with(@Image, 'Calendar.getInstance')]] [count(../PrimarySuffix) > 2 and ../PrimarySuffix[last()-1][@Image = 'getTime' or @Image='getTimeInMillis']]
 |
 //Block/BlockStatement//Expression/PrimaryExpression/
-PrimaryPrefix/Name[typeIs('java.util.Calendar') and (ends-with(@Image,'.getTime') or ends-with(@Image,'.getTimeInMillis'))]
+PrimaryPrefix/Name[pmd-java:typeIs('java.util.Calendar') and (ends-with(@Image,'.getTime') or ends-with(@Image,'.getTimeInMillis'))]
 |
-//ClassOrInterfaceType[typeIs('org.joda.time.DateTime') or typeIs('org.joda.time.LocalDateTime')][../Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image, 'Calendar.getInstance')]]
-	         ]]></value>
+//ClassOrInterfaceType[pmd-java:typeIs('org.joda.time.DateTime') or pmd-java:typeIs('org.joda.time.LocalDateTime')][../Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image, 'Calendar.getInstance')]]
+                ]]></value>
             </property>
         </properties>
         <example>

--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -134,8 +134,21 @@ Solution: Use `new Date()`, Java 8+ `java.time.LocalDateTime.now()` or `ZonedDat
 //PrimaryPrefix[Name[ends-with(@Image, 'Calendar.getInstance')]] [count(../PrimarySuffix) > 2 and ../PrimarySuffix[last()-1][@Image = 'getTime' or @Image='getTimeInMillis']]
 |
 //MethodDeclaration[not(MethodDeclarator/FormalParameters//ClassOrInterfaceType[pmd-java:typeIs('java.util.Calendar')])]
-  /Block/BlockStatement//Expression/PrimaryExpression
-  /PrimaryPrefix/Name[pmd-java:typeIs('java.util.Calendar') and (ends-with(@Image,'.getTime') or ends-with(@Image,'.getTimeInMillis'))]
+  /Block/BlockStatement//PrimaryExpression
+  /PrimaryPrefix/Name
+    [pmd-java:typeIs('java.util.Calendar')]
+    [every $var in @Image satisfies (
+       (ends-with($var, '.getTime') or ends-with($var, '.getTimeInMillis'))
+       and
+       (: ignore if .set* or .add* or .clear is called on the variable :)
+       not(ancestor::Block/BlockStatement//Name[
+          starts-with(@Image, concat((tokenize($var, '\.'), $var)[1], '.set'))
+          or
+          starts-with(@Image, concat((tokenize($var, '\.'), $var)[1], '.add'))
+          or
+          starts-with(@Image, concat((tokenize($var, '\.'), $var)[1], '.clear'))
+       ])
+    )]
 |
 //ClassOrInterfaceType[pmd-java:typeIs('org.joda.time.DateTime') or pmd-java:typeIs('org.joda.time.LocalDateTime')][../Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image, 'Calendar.getInstance')]]
                 ]]></value>

--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -133,8 +133,9 @@ Solution: Use `new Date()`, Java 8+ `java.time.LocalDateTime.now()` or `ZonedDat
                 <value><![CDATA[
 //PrimaryPrefix[Name[ends-with(@Image, 'Calendar.getInstance')]] [count(../PrimarySuffix) > 2 and ../PrimarySuffix[last()-1][@Image = 'getTime' or @Image='getTimeInMillis']]
 |
-//Block/BlockStatement//Expression/PrimaryExpression/
-PrimaryPrefix/Name[pmd-java:typeIs('java.util.Calendar') and (ends-with(@Image,'.getTime') or ends-with(@Image,'.getTimeInMillis'))]
+//MethodDeclaration[not(MethodDeclarator/FormalParameters//ClassOrInterfaceType[pmd-java:typeIs('java.util.Calendar')])]
+  /Block/BlockStatement//Expression/PrimaryExpression
+  /PrimaryPrefix/Name[pmd-java:typeIs('java.util.Calendar') and (ends-with(@Image,'.getTime') or ends-with(@Image,'.getTimeInMillis'))]
 |
 //ClassOrInterfaceType[pmd-java:typeIs('org.joda.time.DateTime') or pmd-java:typeIs('org.joda.time.LocalDateTime')][../Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image, 'Calendar.getInstance')]]
                 ]]></value>
@@ -142,6 +143,10 @@ PrimaryPrefix/Name[pmd-java:typeIs('java.util.Calendar') and (ends-with(@Image,'
         </properties>
         <example>
             <![CDATA[
+import java.time.LocalDateTime;
+import java.util.Calendar;
+import java.util.Date;
+
 public class DateStuff {
     private Date bad1() {
         return Calendar.getInstance().getTime(); // now

--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -114,6 +114,53 @@ public class Test {
         </example>
     </rule>
 
+    <rule name="AvoidCalendarDateCreation"
+          since="6.17.0"
+          language="java"
+          message="A Calendar is used to create a Date or DateTime, this is expensive."
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          typeResolution="true"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_performance.html#avoidcalendardatecreation">
+        <description>Problem: A Calendar is a heavyweight object and expensive to create. &#13;
+            Solution: Use 'new Date()', Java 8+ java.time.[Local/Zoned]DateTime.now() or joda time '[Local]DateTime.now()'.
+        </description>
+        <priority>2</priority>
+        <properties>
+            <property name="version" value="1.0"/>
+            <property name="xpath">
+                <value><![CDATA[
+//PrimaryPrefix[Name[ends-with(@Image, 'Calendar.getInstance')]] [count(../PrimarySuffix) > 2 and ../PrimarySuffix[last()-1][@Image = 'getTime' or @Image='getTimeInMillis']]
+|
+//Block/BlockStatement//Expression/PrimaryExpression/
+PrimaryPrefix/Name[typeIs('java.util.Calendar') and (ends-with(@Image,'.getTime') or ends-with(@Image,'.getTimeInMillis'))]
+|
+//ClassOrInterfaceType[typeIs('org.joda.time.DateTime') or typeIs('org.joda.time.LocalDateTime')][../Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Name[ends-with(@Image, 'Calendar.getInstance')]]
+	         ]]></value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
+public class DateStuff {
+    private Date bad1() {
+        return Calendar.getInstance().getTime(); // now
+    }
+    private Date good1a() {
+        return new Date(); // now
+    }
+    private LocalDateTime good1b() {
+        return LocalDateTime.now();
+    }
+    private long bad2() {
+        return Calendar.getInstance().getTimeInMillis();
+    }
+    private long good2() {
+        return System.currentTimeMillis();
+    }
+}
+            ]]>
+        </example>
+    </rule>
+
     <rule name="AvoidFileStream"
           since="6.0.0"
           message="Avoid instantiating FileInputStream, FileOutputStream, FileReader, or FileWriter"

--- a/pmd-java/src/main/resources/rulesets/java/quickstart.xml
+++ b/pmd-java/src/main/resources/rulesets/java/quickstart.xml
@@ -293,6 +293,7 @@
     <!-- <rule ref="category/java/performance.xml/AddEmptyString" /> -->
     <!-- <rule ref="category/java/performance.xml/AppendCharacterWithChar" /> -->
     <!-- <rule ref="category/java/performance.xml/AvoidArrayLoops" /> -->
+    <!-- <rule ref="category/java/performance.xml/AvoidCalendarDateCreation" /> -->
     <!-- <rule ref="category/java/performance.xml/AvoidFileStream" /> -->
     <!-- <rule ref="category/java/performance.xml/AvoidInstantiatingObjectsInLoops" /> -->
     <!-- <rule ref="category/java/performance.xml/AvoidUsingShortType"/> -->

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/AvoidCalendarDateCreationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/AvoidCalendarDateCreationTest.java
@@ -1,0 +1,10 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.performance;
+
+import net.sourceforge.pmd.testframework.PmdRuleTst;
+
+public class AvoidCalendarDateCreationTest extends PmdRuleTst {
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/AvoidCalendarDateCreation.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/AvoidCalendarDateCreation.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+    <test-code>
+        <description>violation: [Gregorian]Calendar.getInstance().getTime()</description>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>7,8,9,12</expected-linenumbers>
+        <code><![CDATA[
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+public class Foo {
+	void foo() {
+		Date now = Calendar.getInstance().getTime();
+		setDate(Calendar.getInstance().getTime());
+		setDate(GregorianCalendar.getInstance().getTime());
+
+		Calendar cal = Calendar.getInstance();
+		Date now2 = cal.getTime();
+	}
+	private void setDate(Date when){
+	}
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>violation: joda-time: new DateTime([Gregorian]Calendar.getInstance())</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>7,8</expected-linenumbers>
+        <code><![CDATA[
+import org.joda.time.DateTime;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
+
+public class Foo {
+	void foo() {
+		DateTime nowDT1 = new DateTime(GregorianCalendar.getInstance());
+		DateTime nowDT2 = new DateTime(Calendar.getInstance());
+	}
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>violation: Calendar.getInstance().getTimeInMillis()</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>5,6</expected-linenumbers>
+        <code><![CDATA[
+import java.util.Calendar;
+
+public class Foo {
+	void foo() {
+		long time = Calendar.getInstance().getTimeInMillis();
+		String timeStr = Long.toString(Calendar.getInstance().getTimeInMillis());
+	}
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>violation: cal.getTimeInMillis()</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>7,8</expected-linenumbers>
+        <code><![CDATA[
+import java.util.Calendar;
+
+public class Foo {
+	void foo() {
+		long time1 = 0;
+		Calendar cal = Calendar.getInstance();
+		long time2 = cal.getTimeInMillis();
+		time1 = cal.getTimeInMillis();
+	}
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>no violation</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.Calendar;
+import java.util.Date;
+
+public class Foo {
+	void foo() {
+		int warmestMonth = Calendar.getInstance().AUGUST;
+		long time = System.currentTimeMillis();
+		Date now = new Date();
+	}
+}
+     ]]></code>
+    </test-code>
+
+
+
+</test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/AvoidCalendarDateCreation.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/AvoidCalendarDateCreation.xml
@@ -96,4 +96,36 @@ public class Foo {
 }
      ]]></code>
     </test-code>
+
+    <test-code>
+        <description>false positive when Calendar is not created here</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.time.ZonedDateTime;
+import java.time.Instant;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+public class Foo {
+    public Date convertToDate(Calendar source) {
+        return source.getTime(); // ok
+    }
+
+    public Long convertToLong(Calendar source) {
+        return source.getTimeInMillis(); // ok
+    }
+
+    public ZonedDateTime calendarToZonedDateTime(Calendar source) {
+        if (source instanceof GregorianCalendar) {
+            return ((GregorianCalendar) source).toZonedDateTime();
+        }
+        else {
+            return ZonedDateTime.ofInstant(Instant.ofEpochMilli(source.getTimeInMillis()), // ok
+                    source.getTimeZone().toZoneId());
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/AvoidCalendarDateCreation.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/AvoidCalendarDateCreation.xml
@@ -128,4 +128,37 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>false positive if Calendar is modified via set</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.Calendar;
+import java.util.Date;
+
+public class Foo {
+    public Date onlySet(Date date) {
+        Calendar calendar = new GregorianCalendar();
+        calendar.setTime(date);
+        calendar.set(Calendar.MILLISECOND, 0);
+        long originalTimestamp = calendar.getTimeInMillis();
+        return calendar.getTime();
+    }
+
+    public Date onlyAdd(Date date) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.SECOND, 1);
+        long originalTimestamp = calendar.getTimeInMillis();
+        return calendar.getTime();
+    }
+
+    public Date onlyClear(Date date) {
+        Calendar calendar = Calendar.getInstance();
+        calendar.clear(Calendar.MILLISECOND);
+        long originalTimestamp = calendar.getTimeInMillis();
+        return calendar.getTime();
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/AvoidCalendarDateCreation.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/AvoidCalendarDateCreation.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <test-data
-        xmlns="http://pmd.sourceforge.net/rule-tests"
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
     <test-code>
         <description>violation: [Gregorian]Calendar.getInstance().getTime()</description>
         <expected-problems>4</expected-problems>
@@ -13,18 +14,18 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 
 public class Foo {
-	void foo() {
-		Date now = Calendar.getInstance().getTime();
-		setDate(Calendar.getInstance().getTime());
-		setDate(GregorianCalendar.getInstance().getTime());
+    void foo() {
+        Date now = Calendar.getInstance().getTime();
+        setDate(Calendar.getInstance().getTime());
+        setDate(GregorianCalendar.getInstance().getTime());
 
-		Calendar cal = Calendar.getInstance();
-		Date now2 = cal.getTime();
-	}
-	private void setDate(Date when){
-	}
+        Calendar cal = Calendar.getInstance();
+        Date now2 = cal.getTime();
+    }
+    private void setDate(Date when){
+    }
 }
-     ]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -37,12 +38,12 @@ import java.util.Calendar;
 import java.util.GregorianCalendar;
 
 public class Foo {
-	void foo() {
-		DateTime nowDT1 = new DateTime(GregorianCalendar.getInstance());
-		DateTime nowDT2 = new DateTime(Calendar.getInstance());
-	}
+    void foo() {
+        DateTime nowDT1 = new DateTime(GregorianCalendar.getInstance());
+        DateTime nowDT2 = new DateTime(Calendar.getInstance());
+    }
 }
-     ]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -53,12 +54,12 @@ public class Foo {
 import java.util.Calendar;
 
 public class Foo {
-	void foo() {
-		long time = Calendar.getInstance().getTimeInMillis();
-		String timeStr = Long.toString(Calendar.getInstance().getTimeInMillis());
-	}
+    void foo() {
+        long time = Calendar.getInstance().getTimeInMillis();
+        String timeStr = Long.toString(Calendar.getInstance().getTimeInMillis());
+    }
 }
-     ]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -69,14 +70,14 @@ public class Foo {
 import java.util.Calendar;
 
 public class Foo {
-	void foo() {
-		long time1 = 0;
-		Calendar cal = Calendar.getInstance();
-		long time2 = cal.getTimeInMillis();
-		time1 = cal.getTimeInMillis();
-	}
+    void foo() {
+        long time1 = 0;
+        Calendar cal = Calendar.getInstance();
+        long time2 = cal.getTimeInMillis();
+        time1 = cal.getTimeInMillis();
+    }
 }
-     ]]></code>
+        ]]></code>
     </test-code>
 
     <test-code>
@@ -87,15 +88,12 @@ import java.util.Calendar;
 import java.util.Date;
 
 public class Foo {
-	void foo() {
-		int warmestMonth = Calendar.getInstance().AUGUST;
-		long time = System.currentTimeMillis();
-		Date now = new Date();
-	}
+    void foo() {
+        int warmestMonth = Calendar.getInstance().AUGUST;
+        long time = System.currentTimeMillis();
+        Date now = new Date();
+    }
 }
      ]]></code>
     </test-code>
-
-
-
 </test-data>


### PR DESCRIPTION
## Describe the PR

This is the rule "AvoidCalendarDateCreation" split from original PR #1932 .


## Related issues

- Refs #1932 - note: other PRs will follow and eventually replace 1932.

## Ready?

- [x] possible false positive: https://github.com/pmd/pmd/pull/1932/files#r307540504 , e.g.
https://github.com/spring-projects/spring-framework/tree/v5.0.6.RELEASE/spring-context/src/main/java/org/springframework/format/datetime/DateFormatterRegistrar.java#L112
- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

