### PR TITLE
Update libraries snyk is referring to as `unsafe`

### DIFF
--- a/pmd-apex-jorje/pom.xml
+++ b/pmd-apex-jorje/pom.xml
@@ -54,12 +54,12 @@
     <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.1.7</version>
+        <version>1.2.3</version>
     </dependency>
     <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-core</artifactId>
-        <version>1.1.7</version>
+        <version>1.2.3</version>
     </dependency>
     <dependency>
         <groupId>com.google.code.findbugs</groupId>
@@ -119,7 +119,7 @@
     <dependency>
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
-        <version>1.17</version>
+        <version>1.26</version>
     </dependency>
     <dependency>
         <groupId>aopalliance</groupId>

--- a/pmd-doc/pom.xml
+++ b/pmd-doc/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.19</version>
+            <version>1.26</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -626,7 +626,7 @@
             <dependency>
                 <groupId>com.beust</groupId>
                 <artifactId>jcommander</artifactId>
-                <version>1.72</version>
+                <version>1.78</version>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -626,7 +626,7 @@
             <dependency>
                 <groupId>com.beust</groupId>
                 <artifactId>jcommander</artifactId>
-                <version>1.78</version>
+                <version>1.72</version>
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>


### PR DESCRIPTION
## Describe the PR
I've got snyk pointing to pmd and it keeps complaining about unsafe dependencies. 
<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues
https://app.snyk.io/vuln/SNYK-JAVA-ORGYAML-537645
https://app.snyk.io/vuln/SNYK-JAVA-CHQOSLOGBACK-31407
<!-- PR relates to issues in the `pmd` repo: -->

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

There is still a dependency on jcommander 1.72 which snyk [dislikes](https://app.snyk.io/vuln/SNYK-JAVA-COMBEUST-174815) but latest jcommander deleted some methods PMD is currently using.

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

