### PR TITLE
[java] InefficientStringBuffering/AppendCharacterWithChar: Fix false negatives with concats in appends

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -54,6 +54,8 @@ The command line version of PMD continues to use **scala 2.13**.
     *   [#2551](https://github.com/pmd/pmd/issues/2551): \[c#] CPD suppression with comments doesn't work
 *   java-design
     *   [#2563](https://github.com/pmd/pmd/pull/2563): \[java] UselessOverridingMethod false negative with already public methods
+*   java-performance
+    *   [#2591](https://github.com/pmd/pmd/pull/2591): \[java] InefficientStringBuffering/AppendCharacterWithChar: Fix false negatives with concats in appends
 *   scala
     *   [#2547](https://github.com/pmd/pmd/pull/2547): \[scala] Add cross compilation for scala 2.12 and 2.13
 
@@ -61,6 +63,10 @@ The command line version of PMD continues to use **scala 2.13**.
 
 *   The maven module `net.sourceforge.pmd:pmd-scala` is deprecated. Use `net.sourceforge.pmd:pmd-scala_2.13`
     or `net.sourceforge.pmd:pmd-scala_2.12` instead.
+
+#### Deprecated APIs
+
+*   {% jdoc !!java::lang.java.rule.performance.InefficientStringBufferingRule#isInStringBufferOperation(net.sourceforge.pmd.lang.ast.Node, int, java.lang.String) %}
 
 ### External Contributions
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/AppendCharacterWithCharRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/AppendCharacterWithCharRule.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.performance;
 
+import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTBlockStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTLiteral;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
@@ -33,13 +34,17 @@ public class AppendCharacterWithCharRule extends AbstractJavaRule {
         }
 
         if (node.isSingleCharacterStringLiteral()) {
-            if (!InefficientStringBufferingRule.isInStringBufferOperation(node, 8, "append")) {
+            if (!InefficientStringBufferingRule.isInStringBufferOperationChain(node, "append")) {
                 return data;
             }
 
             // ignore, if the literal is part of an expression, such as "X".repeat(5)
             final ASTPrimaryExpression primaryExpression = (ASTPrimaryExpression) node.getNthParent(2);
             if (primaryExpression != null && primaryExpression.getFirstChildOfType(ASTPrimarySuffix.class) != null) {
+                return data;
+            }
+            // ignore, if this literal is part of a different expression, e.g. "X" + something else
+            if (primaryExpression != null && !(primaryExpression.getNthParent(2) instanceof ASTArgumentList)) {
                 return data;
             }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/AppendCharacterWithCharRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/AppendCharacterWithCharRule.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.performance;
 
+import net.sourceforge.pmd.lang.java.ast.ASTAllocationExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTBlockStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTLiteral;
@@ -26,6 +27,10 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
  */
 public class AppendCharacterWithCharRule extends AbstractJavaRule {
 
+    public AppendCharacterWithCharRule() {
+        addRuleChainVisit(ASTLiteral.class);
+    }
+
     @Override
     public Object visit(ASTLiteral node, Object data) {
         ASTBlockStatement bs = node.getFirstParentOfType(ASTBlockStatement.class);
@@ -45,6 +50,10 @@ public class AppendCharacterWithCharRule extends AbstractJavaRule {
             }
             // ignore, if this literal is part of a different expression, e.g. "X" + something else
             if (primaryExpression != null && !(primaryExpression.getNthParent(2) instanceof ASTArgumentList)) {
+                return data;
+            }
+            // ignore if this string literal is used as a constructor argument
+            if (primaryExpression != null && primaryExpression.getNthParent(4) instanceof ASTAllocationExpression) {
                 return data;
             }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveLiteralAppendsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveLiteralAppendsRule.java
@@ -21,6 +21,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTDoStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTFinallyStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTForStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTLambdaExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTLiteral;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
@@ -78,6 +79,7 @@ public class ConsecutiveLiteralAppendsRule extends AbstractJavaRule {
         BLOCK_PARENTS.add(ASTMethodDeclaration.class);
         BLOCK_PARENTS.add(ASTCatchStatement.class);
         BLOCK_PARENTS.add(ASTFinallyStatement.class);
+        BLOCK_PARENTS.add(ASTLambdaExpression.class);
     }
 
     private static final PropertyDescriptor<Integer> THRESHOLD_DESCRIPTOR
@@ -119,7 +121,7 @@ public class ConsecutiveLiteralAppendsRule extends AbstractJavaRule {
 
             currentBlock = getFirstParentBlock(n);
 
-            if (InefficientStringBufferingRule.isInStringBufferOperation(n, 3, "append")) {
+            if (InefficientStringBufferingRule.isInStringBufferOperationChain(n, "append")) {
                 // append method call detected
                 ASTPrimaryExpression s = n.getFirstParentOfType(ASTPrimaryExpression.class);
                 int numChildren = s.getNumChildren();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientStringBufferingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientStringBufferingRule.java
@@ -14,6 +14,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTAllocationExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTBlockStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
+import net.sourceforge.pmd.lang.java.ast.ASTConditionalExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTLiteral;
 import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
@@ -39,8 +40,17 @@ import net.sourceforge.pmd.lang.java.typeresolution.TypeHelper;
  */
 public class InefficientStringBufferingRule extends AbstractJavaRule {
 
+    public InefficientStringBufferingRule() {
+        addRuleChainVisit(ASTAdditiveExpression.class);
+    }
+
     @Override
     public Object visit(ASTAdditiveExpression node, Object data) {
+        if (node.getParent() instanceof ASTConditionalExpression) {
+            // ignore concats in ternary expressions
+            return data;
+        }
+
         ASTBlockStatement bs = node.getFirstParentOfType(ASTBlockStatement.class);
         if (bs == null) {
             return data;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientStringBufferingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientStringBufferingRule.java
@@ -46,7 +46,7 @@ public class InefficientStringBufferingRule extends AbstractJavaRule {
 
     @Override
     public Object visit(ASTAdditiveExpression node, Object data) {
-        if (node.getParent() instanceof ASTConditionalExpression) {
+        if (node.getParent() instanceof ASTConditionalExpression || node.getNthParent(2) instanceof ASTConditionalExpression) {
             // ignore concats in ternary expressions
             return data;
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientStringBufferingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientStringBufferingRule.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.performance;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
@@ -17,6 +18,9 @@ import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTLiteral;
 import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimitiveType;
 import net.sourceforge.pmd.lang.java.ast.ASTStatementExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTType;
@@ -58,17 +62,19 @@ public class InefficientStringBufferingRule extends AbstractJavaRule {
             }
         }
 
-        if (immediateLiterals > 1) {
+        boolean onlyStringLiterals = immediateLiterals == immediateStringLiterals
+                && immediateLiterals == node.getNumChildren();
+        if (onlyStringLiterals) {
             return data;
         }
 
-        // if literal + public static final, return
+        // if literal + final, return
         List<ASTName> nameNodes = node.findDescendantsOfType(ASTName.class);
         for (ASTName name : nameNodes) {
             if (name.getNameDeclaration() != null && name.getNameDeclaration() instanceof VariableNameDeclaration) {
                 VariableNameDeclaration vnd = (VariableNameDeclaration) name.getNameDeclaration();
                 AccessNode accessNodeParent = vnd.getAccessNodeParent();
-                if (accessNodeParent.isFinal() && accessNodeParent.isStatic()) {
+                if (accessNodeParent.isFinal()) {
                     return data;
                 }
             }
@@ -98,8 +104,10 @@ public class InefficientStringBufferingRule extends AbstractJavaRule {
 
             if (isAllocatedStringBuffer(node)) {
                 addViolation(data, node);
+            } else if (isInStringBufferOperationChain(node, "append")) {
+                addViolation(data, node);
             }
-        } else if (isInStringBufferOperation(node, 6, "append")) {
+        } else if (isInStringBufferOperationChain(node, "append")) {
             addViolation(data, node);
         }
         return data;
@@ -111,7 +119,7 @@ public class InefficientStringBufferingRule extends AbstractJavaRule {
             List<ASTClassOrInterfaceType> types = type.findDescendantsOfType(ASTClassOrInterfaceType.class);
             if (!types.isEmpty()) {
                 ASTClassOrInterfaceType typeDeclaration = types.get(0);
-                if (String.class == typeDeclaration.getType() || "String".equals(typeDeclaration.getImage())) {
+                if (TypeHelper.isA(typeDeclaration, String.class)) {
                     return true;
                 }
             }
@@ -125,19 +133,39 @@ public class InefficientStringBufferingRule extends AbstractJavaRule {
     }
 
     private ASTType getTypeNode(ASTName name) {
+        ASTType result = null;
         if (name.getNameDeclaration() instanceof VariableNameDeclaration) {
             VariableNameDeclaration vnd = (VariableNameDeclaration) name.getNameDeclaration();
             if (vnd.getAccessNodeParent() instanceof ASTLocalVariableDeclaration) {
                 ASTLocalVariableDeclaration l = (ASTLocalVariableDeclaration) vnd.getAccessNodeParent();
-                return l.getTypeNode();
+                result = l.getTypeNode();
             } else if (vnd.getAccessNodeParent() instanceof ASTFormalParameter) {
                 ASTFormalParameter p = (ASTFormalParameter) vnd.getAccessNodeParent();
-                return p.getTypeNode();
+                result = p.getTypeNode();
             }
         }
-        return null;
+        return result;
     }
 
+    static boolean isInStringBufferOperationChain(Node node, String methodName) {
+        ASTPrimaryExpression expr = node.getFirstParentOfType(ASTPrimaryExpression.class);
+        MethodCallChain methodCalls = MethodCallChain.wrap(expr);
+        while (expr != null && methodCalls == null) {
+            expr = expr.getFirstParentOfType(ASTPrimaryExpression.class);
+            methodCalls = MethodCallChain.wrap(expr);
+        }
+
+        if (methodCalls != null && !methodCalls.isExactlyOfAnyType(StringBuffer.class, StringBuilder.class)) {
+            methodCalls = null;
+        }
+
+        return methodCalls != null && methodCalls.getMethodNames().contains(methodName);
+    }
+
+    /**
+     * @deprecated will be removed with PMD 7
+     */
+    @Deprecated
     protected static boolean isInStringBufferOperation(Node node, int length, String methodName) {
         if (!(node.getNthParent(length) instanceof ASTStatementExpression)) {
             return false;
@@ -173,5 +201,71 @@ public class InefficientStringBufferingRule extends AbstractJavaRule {
         // java.lang.FloatingDecimal: t = new int[ nWords+wordcount+1 ];
         ASTClassOrInterfaceType an = ao.getFirstChildOfType(ASTClassOrInterfaceType.class);
         return an != null && TypeHelper.isEither(an, StringBuffer.class, StringBuilder.class);
+    }
+
+    private static class MethodCallChain {
+        private final ASTPrimaryExpression primary;
+
+        private MethodCallChain(ASTPrimaryExpression primary) {
+            this.primary = primary;
+        }
+
+        // Note: The impl here is technically not correct: The type of a method call
+        // chain is the result of the last method called, not the type of the
+        // first receiver object (== PrimaryPrefix).
+        boolean isExactlyOfAnyType(Class<?> clazz, Class<?> ... clazzes) {
+            ASTPrimaryPrefix typeNode = getTypeNode();
+
+            if (TypeHelper.isExactlyA(typeNode, clazz.getName())) {
+                return true;
+            }
+            if (clazzes != null) {
+                for (Class<?> c : clazzes) {
+                    if (TypeHelper.isExactlyA(typeNode, c.getName())) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        ASTPrimaryPrefix getTypeNode() {
+            return primary.getFirstChildOfType(ASTPrimaryPrefix.class);
+        }
+
+        List<String> getMethodNames() {
+            List<String> methodNames = new ArrayList<>();
+
+            ASTPrimaryPrefix prefix = getTypeNode();
+            ASTName name = prefix.getFirstChildOfType(ASTName.class);
+            if (name != null) {
+                String firstMethod = name.getImage();
+                int dot = firstMethod.lastIndexOf('.');
+                if (dot != -1) {
+                    firstMethod = firstMethod.substring(dot + 1);
+                }
+                methodNames.add(firstMethod);
+            }
+
+            for (ASTPrimarySuffix suffix : primary.findChildrenOfType(ASTPrimarySuffix.class)) {
+                if (suffix.getImage() != null) {
+                    methodNames.add(suffix.getImage());
+                }
+            }
+            return methodNames;
+        }
+
+        static MethodCallChain wrap(ASTPrimaryExpression primary) {
+            if (primary != null && isMethodCall(primary)) {
+                return new MethodCallChain(primary);
+            }
+            return null;
+        }
+
+        private static boolean isMethodCall(ASTPrimaryExpression primary) {
+            return primary.getNumChildren() >= 2
+                    && primary.getChild(0) instanceof ASTPrimaryPrefix
+                    && primary.getChild(1) instanceof ASTPrimarySuffix;
+        }
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
@@ -73,10 +73,10 @@ public class InsufficientStringBufferDeclarationRule extends AbstractJavaRule {
         for (NameOccurrence no : usage) {
             JavaNameOccurrence jno = (JavaNameOccurrence) no;
             Node n = jno.getLocation();
-            if (!InefficientStringBufferingRule.isInStringBufferOperation(n, 3, "append")) {
+            if (!InefficientStringBufferingRule.isInStringBufferOperationChain(n, "append")) {
 
                 if (!jno.isOnLeftHandSide()
-                        && !InefficientStringBufferingRule.isInStringBufferOperation(n, 3, "setLength")) {
+                        && !InefficientStringBufferingRule.isInStringBufferOperationChain(n, "setLength")) {
                     continue;
                 }
                 if (constructorLength != -1 && anticipatedLength > constructorLength) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/AppendCharacterWithChar.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/AppendCharacterWithChar.xml
@@ -207,4 +207,18 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>false positive with string as constructor arg in StringBuilder method chain</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    private String name = "bar";
+    public String toString() {
+        StringBuilder sb = new StringBuilder("#").append("Foo").append('#').append(this.name);
+        return sb.toString();
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/AppendCharacterWithChar.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/AppendCharacterWithChar.xml
@@ -193,4 +193,18 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>append single character string in constructor chain</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,4</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public void bar() {
+        StringBuilder sb = new StringBuilder().append("a");
+        sb = new StringBuilder().append("c");
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/ConsecutiveLiteralAppends.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/ConsecutiveLiteralAppends.xml
@@ -1449,4 +1449,22 @@ public final class Test {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>StringBuilder chains</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,6</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public void bar() {
+        StringBuilder sb1 = new StringBuilder().append("abc").append("def"); // bad
+        StringBuilder sb2 = new StringBuilder().append("abc"); // ok
+        StringBuilder sb3 = new StringBuilder();
+        sb3.append("abc").append("def"); // bad
+        StringBuilder sb4 = new StringBuilder();
+        sb4.append("abc"); // ok
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/InefficientStringBuffering.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/InefficientStringBuffering.xml
@@ -437,4 +437,20 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>false positive with ternary</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    private int someInt = 1;
+    public String toString() {
+        StringBuilder sb = new StringBuilder("Foo{");
+        sb.append("someInt=").append(this.someInt < 0 ? "n/a" : this.someInt + "ms");
+        sb.append('}');
+        return sb.toString();
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/InefficientStringBuffering.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/InefficientStringBuffering.xml
@@ -447,6 +447,7 @@ public class Foo {
     public String toString() {
         StringBuilder sb = new StringBuilder("Foo{");
         sb.append("someInt=").append(this.someInt < 0 ? "n/a" : this.someInt + "ms");
+        sb.append("someInt2=").append(this.someInt >= 0 ? this.someInt + "ms" : "n/a");
         sb.append('}');
         return sb.toString();
     }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/InefficientStringBuffering.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/InefficientStringBuffering.xml
@@ -343,4 +343,82 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Violation: Avoid contact in append method invocations</description>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>9,18,24</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+
+    private static final String STATIC_FINAL_F = "static_final_field";
+    private static String static_f = "static_field";
+    private final String FINAL_F = "final_field";
+
+    private void concatIsBad(String arg) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("arg='" + arg + "'"); // bad
+    }
+
+    private void concatNumericIsBad() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(1 + 2); // bad
+    }
+
+    private String testStaticBad() {
+        StringBuilder sb = new StringBuilder().append("fld:" + static_f); // bad
+        return sb.toString();
+    }
+
+    private String testFinalLocalBad() {
+        String local = "local"; // non-final, jdk9+ optimized with indified Strings, assumed still worse
+        return new StringBuilder().append("fld:" + local).toString(); // assumed bad
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>No violation: Avoid contact in append method invocations</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+
+    private static final String STATIC_FINAL_F = "static_final_field";
+    private final String FINAL_F = "final_field";
+
+    private void good(String arg) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("arg='").append(arg).append("'");
+    }
+
+    public void testAddInSecondOrThirdArgAppendGood() {
+        StringBuilder wrappedLine = new StringBuilder();
+        String str = "bar";
+        int offset = 1;
+        int wrapLength = 2;
+        wrappedLine.append(str, offset + 1, wrapLength + offset + 1); // + but no string concat
+    }
+
+    private String testLiteralsGood(String arg) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("lit:" + "etc");
+        return sb.toString();
+    }
+
+    private String testFinalFieldGood() { // final assumed a constant expression
+        return new StringBuilder().append("fld:" + FINAL_F).toString(); //good
+    }
+
+    private String testStaticFinalFieldGood() {
+        return new StringBuilder().append("fld:" + STATIC_FINAL_F).toString(); // good
+    }
+
+    private String testFinalLocalGood() {
+        final String local = "local"; // final assumed a constant expression
+        return new StringBuilder().append("fld:" + local).toString(); // good
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/InefficientStringBuffering.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/InefficientStringBuffering.xml
@@ -345,9 +345,9 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>Violation: Avoid contact in append method invocations</description>
-        <expected-problems>3</expected-problems>
-        <expected-linenumbers>9,18,24</expected-linenumbers>
+        <description>Violation: Avoid concat in append method invocations</description>
+        <expected-problems>5</expected-problems>
+        <expected-linenumbers>9,13,18,27,33</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
 
@@ -360,9 +360,18 @@ public class Foo {
         sb.append("arg='" + arg + "'"); // bad
     }
 
-    private void concatNumericIsBad() {
+    private void concatIsBad2(String arg) {
+        StringBuilder sb = new StringBuilder().append("arg='" + arg + "'"); // bad
+    }
+
+    private void concatIsBad3(String arg) {
+        StringBuilder sb;
+        sb = new StringBuilder().append("arg='" + arg + "'"); // bad
+    }
+
+    private void concatNumeric() {
         StringBuilder sb = new StringBuilder();
-        sb.append(1 + 2); // bad
+        sb.append(1 + 2);
     }
 
     private String testStaticBad() {
@@ -379,7 +388,7 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>No violation: Avoid contact in append method invocations</description>
+        <description>No violation: Avoid concat in append method invocations</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -417,6 +426,13 @@ public class Foo {
     private String testFinalLocalGood() {
         final String local = "local"; // final assumed a constant expression
         return new StringBuilder().append("fld:" + local).toString(); // good
+    }
+
+    private String testFinalLocalGood2() {
+        final String local = "local"; // final assumed a constant expression
+        StringBuilder sb = new StringBuilder();
+        sb.append("local:" + local); // good
+        return sb.toString;
     }
 }
         ]]></code>


### PR DESCRIPTION
## Describe the PR

This originated from #1932 and merged the test cases in [InefficientStringBuffering](https://pmd.github.io/latest/pmd_rules_java_performance.html#inefficientstringbuffering).

Example false-negative, that is fixed:

```java
String someString = getSomeString();
StringBuilder sb = new StringBuilder();
sb.append("a" + someString + "b"); // bad - false negative
sb.append('a').append(someString).append('b'); // good
```

Note: This also fixes a false-negative with [AppendCharacterWithChar](https://pmd.github.io/latest/pmd_rules_java_performance.html#appendcharacterwithchar):
```java
StringBuilder sb = new StringBuilder(message).append("\n");
```
https://github.com/spring-projects/spring-framework/tree/v5.0.6.RELEASE/spring-context/src/main/java/org/springframework/context/event/ApplicationListenerMethodAdapter.java#L308

## Related issues

- Refs #1932 - this is the last PR from 1932

## Ready?

- [x] Fix false positive in InefficientStringBuffering with ternary expression: https://github.com/spring-projects/spring-framework/blob/v5.0.6.RELEASE/spring-core/src/main/java/org/springframework/util/backoff/ExponentialBackOff.java#L222
- [x] Fix false positive in AppendCharacterWithChar for constructors: https://github.com/spring-projects/spring-framework/blob/v5.0.6.RELEASE/spring-expression/src/main/java/org/springframework/expression/spel/ast/FunctionReference.java#L145
- [x] Update release notes - mention this PR under fixed issues
- [x] Add deprecation notice for `InefficientStringBuffering::isInStringBufferOperation`
- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

