### PR TITLE
[core] Fix XPath 2.0 Rule Chain Analyzer with Unions

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -63,6 +63,8 @@ The command line version of PMD continues to use **scala 2.13**.
 
 ### Fixed Issues
 
+*   core
+    *   [#2599](https://github.com/pmd/pmd/pull/2599): \[core] Fix XPath 2.0 Rule Chain Analyzer with Unions
 *   c#
     *   [#2551](https://github.com/pmd/pmd/issues/2551): \[c#] CPD suppression with comments doesn't work
 *   java-codestyle

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/RuleChainAnalyzer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/RuleChainAnalyzer.java
@@ -66,17 +66,16 @@ public class RuleChainAnalyzer extends SaxonExprVisitor {
             if (rootElement != null && !rootElementReplaced) {
                 if (result instanceof PathExpression) {
                     PathExpression newPath = (PathExpression) result;
-                    if (newPath.getStepExpression() instanceof FilterExpression) {
+                    Expression step = newPath.getStepExpression();
+                    if (step instanceof FilterExpression) {
                         FilterExpression filterExpression = (FilterExpression) newPath.getStepExpression();
                         result = new FilterExpression(new AxisExpression(Axis.SELF, null), filterExpression.getFilter());
                         rootElementReplaced = true;
-                    } else if (newPath.getStepExpression() instanceof AxisExpression) {
+                    } else if (step instanceof AxisExpression) {
                         if (newPath.getStartExpression() instanceof RootExpression) {
                             result = new AxisExpression(Axis.SELF, null);
-                        } else {
-                            result = new PathExpression(newPath.getStartExpression(), new AxisExpression(Axis.SELF, null));
+                            rootElementReplaced = true;
                         }
-                        rootElementReplaced = true;
                     }
                 } else {
                     result = new AxisExpression(Axis.DESCENDANT_OR_SELF, null);

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQueryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQueryTest.java
@@ -195,4 +195,11 @@ public class SaxonXPathRuleQueryTest {
         query.setXPath(xpath);
         return query;
     }
+
+    @Test
+    public void ruleChainWithUnions() {
+        SaxonXPathRuleQuery query = createQuery("(//ForStatement | //WhileStatement | //DoStatement)//AssignmentOperator");
+        List<String> ruleChainVisits = query.getRuleChainVisits();
+        Assert.assertEquals(0, ruleChainVisits.size());
+    }
 }


### PR DESCRIPTION
## Describe the PR

For the XPath expression

`(//ForStatement | //WhileStatement | //DoStatement)//AssignmentOperator`

we threw away "AssignmentOperator" and started visiting at this node.
But that's not possible, because that's not at the root of the expr.

## Related issues

That's the fix for the problem found in #2575 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

