### PR TITLE
[core] Deprecate support for List attributes with XPath 2.0

### DIFF
--- a/docs/pages/pmd/userdocs/extending/writing_xpath_rules.md
+++ b/docs/pages/pmd/userdocs/extending/writing_xpath_rules.md
@@ -88,7 +88,10 @@ The same `conv` function is used to translate rule property values to XDM values
 {% include warning.html content="Support for attributes of type `List<E>` has been deprecated
 with PMD 6.25.0 and will be removed completely with PMD 7. The reason is that newer Saxon
 versions don't support sequences as attributes anymore. Lists are still possible in Java-based
-rules but not with XPath." %}
+rules but not with XPath.
+
+[Multivalued rule properties](pmd_userdocs_extending_defining_properties.html#multivalued-properties)
+are still supported." %}
 
 
 ## Migrating from 1.0 to 2.0

--- a/docs/pages/pmd/userdocs/extending/writing_xpath_rules.md
+++ b/docs/pages/pmd/userdocs/extending/writing_xpath_rules.md
@@ -80,10 +80,15 @@ function from Java types to XDM types.
 |`String`         | `xs:string`
 |`Character`      | `xs:string`
 |`Enum<E>`        | `xs:string` (uses `Object::toString`)
-|`List<E>`        | `conv(E)*` (a sequence type)
+|`List<E>`        | `conv(E)*` (a sequence type) <br> ⚠️ List support is deprecated with 6.25.0. See below.
 
 
 The same `conv` function is used to translate rule property values to XDM values.
+
+{% include warning.html content="Support for attributes of type `List<E>` has been deprecated
+with PMD 6.25.0 and will be removed completely with PMD 7. The reason is that newer Saxon
+versions don't support sequences as attributes anymore. Lists are still possible in Java-based
+rules but not with XPath." %}
 
 
 ## Migrating from 1.0 to 2.0

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -66,6 +66,7 @@ The command line version of PMD continues to use **scala 2.13**.
 *   apex-bestpractices
     *   [#2554](https://github.com/pmd/pmd/issues/2554): \[apex] Exception applying rule UnusedLocalVariable on trigger
 *   core
+    *   [#2451](https://github.com/pmd/pmd/issues/2451): \[core] Deprecate support for List attributes with XPath 2.0
     *   [#2599](https://github.com/pmd/pmd/pull/2599): \[core] Fix XPath 2.0 Rule Chain Analyzer with Unions
     *   [#2483](https://github.com/pmd/pmd/issues/2483): \[lang-test] Support cpd tests based on text comparison.
         For details see

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/Attribute.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/Attribute.java
@@ -75,11 +75,16 @@ public class Attribute {
             return null;
         } else {
             DeprecatedAttribute annot = method.getAnnotation(DeprecatedAttribute.class);
-            return annot != null
+            String result = annot != null
                    ? annot.replaceWith()
                    : method.isAnnotationPresent(Deprecated.class)
                      ? DeprecatedAttribute.NO_REPLACEMENT
                      : null;
+            if (result == null && List.class.isAssignableFrom(method.getReturnType())) {
+                // Lists are generally deprecated, see #2451
+                result = "";
+            }
+            return result;
         }
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/Attribute.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/Attribute.java
@@ -82,7 +82,7 @@ public class Attribute {
                      : null;
             if (result == null && List.class.isAssignableFrom(method.getReturnType())) {
                 // Lists are generally deprecated, see #2451
-                result = "";
+                result = DeprecatedAttribute.NO_REPLACEMENT;
             }
             return result;
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/AttributeAxisIterator.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/xpath/AttributeAxisIterator.java
@@ -96,6 +96,9 @@ public class AttributeAxisIterator implements Iterator<Attribute> {
         return CONSIDERED_RETURN_TYPES.contains(klass) || klass.isEnum();
     }
 
+    // Note: Lists are deprecated with 6.25.0, see #2451
+    // we still allow them here for compatibility, but this can be removed with PMD 7.
+    @Deprecated
     private boolean isSequence(Type returnType) {
         if (returnType instanceof ParameterizedType && ((ParameterizedType) returnType).getRawType() == List.class) {
             Type[] actualTypeArguments = ((ParameterizedType) returnType).getActualTypeArguments();

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNodeWithListAndEnum.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNodeWithListAndEnum.java
@@ -1,14 +1,12 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
-package net.sourceforge.pmd.lang.rule.xpath;
+package net.sourceforge.pmd.lang.ast;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-
-import net.sourceforge.pmd.lang.ast.DummyNode;
 
 public class DummyNodeWithListAndEnum extends DummyNode {
     public DummyNodeWithListAndEnum(int id) {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/JaxenXPathRuleQueryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/JaxenXPathRuleQueryTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.LanguageRegistry;
+import net.sourceforge.pmd.lang.ast.DummyNodeWithListAndEnum;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQueryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQueryTest.java
@@ -13,6 +13,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import net.sourceforge.pmd.RuleContext;
+import net.sourceforge.pmd.lang.ast.DummyNodeWithListAndEnum;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;


### PR DESCRIPTION
## Describe the PR

Deprecates any access to List attributes with XPath queries.
I decided against marking the 3 getters in apex with `@DeprecatedAttribute`, since that would not cover any new getter that might be created in the future.

I don't think, we need to put this more prominently in the release notes, since this feature is probably not used very often (if at all).

## Related issues

- Fixes #2451

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

