### PR TITLE
[apex] Support top-level enums in rules

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/multifile/ApexMultifileVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/multifile/ApexMultifileVisitor.java
@@ -8,6 +8,7 @@ import java.util.Stack;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClassOrInterface;
+import net.sourceforge.pmd.lang.apex.ast.ASTUserEnum;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserTrigger;
 import net.sourceforge.pmd.lang.apex.ast.ApexParserVisitorReducedAdapter;
 
@@ -37,6 +38,12 @@ public class ApexMultifileVisitor extends ApexParserVisitorReducedAdapter {
 
     @Override
     public Object visit(ASTUserTrigger node, Object data) {
+        return data; // ignore
+    }
+
+
+    @Override
+    public Object visit(ASTUserEnum node, Object data) {
         return data; // ignore
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexRule.java
@@ -137,12 +137,17 @@ public abstract class AbstractApexRule extends AbstractRule
 
     protected void visitAll(List<? extends Node> nodes, RuleContext ctx) {
         for (Object element : nodes) {
+            // all nodes of type ApexRootNode...
             if (element instanceof ASTUserClass) {
                 visit((ASTUserClass) element, ctx);
             } else if (element instanceof ASTUserInterface) {
                 visit((ASTUserInterface) element, ctx);
             } else if (element instanceof ASTUserTrigger) {
                 visit((ASTUserTrigger) element, ctx);
+            } else if (element instanceof ASTUserEnum) {
+                visit((ASTUserEnum) element, ctx);
+            } else if (element instanceof ASTAnonymousClass) {
+                visit((ASTAnonymousClass) element, ctx);
             }
         }
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/StdCyclomaticComplexityRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/StdCyclomaticComplexityRule.java
@@ -129,13 +129,6 @@ public class StdCyclomaticComplexityRule extends AbstractApexRule {
 
     @Override
     public Object visit(ASTUserEnum node, Object data) {
-        entryStack.push(new Entry());
-        super.visit(node, data);
-        Entry classEntry = entryStack.pop();
-        if (classEntry.getComplexityAverage() >= reportLevel || classEntry.highestDecisionPoints >= reportLevel) {
-            addViolation(data, node, new String[] { "class", node.getImage(),
-                classEntry.getComplexityAverage() + "(Highest = " + classEntry.highestDecisionPoints + ')', });
-        }
         return data;
     }
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexRuleTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexRuleTest.java
@@ -1,0 +1,86 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.rule;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Collections;
+
+import org.junit.Test;
+
+import net.sourceforge.pmd.RuleContext;
+import net.sourceforge.pmd.lang.apex.ast.ASTAnonymousClass;
+import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
+import net.sourceforge.pmd.lang.apex.ast.ASTUserEnum;
+import net.sourceforge.pmd.lang.apex.ast.ASTUserInterface;
+import net.sourceforge.pmd.lang.apex.ast.ASTUserTrigger;
+import net.sourceforge.pmd.lang.apex.ast.ApexNode;
+import net.sourceforge.pmd.lang.apex.ast.ApexParserTestBase;
+
+import apex.jorje.semantic.ast.compilation.Compilation;
+
+public class AbstractApexRuleTest extends ApexParserTestBase {
+
+    @Test
+    public void shouldVisitTopLevelClass() {
+        run("class Foo { }");
+    }
+
+    @Test
+    public void shouldVisitTopLevelInterface() {
+        run("interface Foo { }");
+    }
+
+    @Test
+    public void shouldVisitTopLevelTrigger() {
+        run("trigger Foo on Account (before insert, before update) { }");
+    }
+
+    @Test
+    public void shouldVisitTopLevelEnum() {
+        run("enum Foo { }");
+    }
+
+    private void run(String code) {
+        ApexNode<Compilation> node = parse(code);
+        RuleContext ctx = new RuleContext();
+        ctx.setLanguageVersion(apex.getDefaultVersion());
+        TopLevelRule rule = new TopLevelRule();
+        rule.apply(Collections.singletonList(node), ctx);
+        assertEquals(1, ctx.getReport().size());
+    }
+
+    private static class TopLevelRule extends AbstractApexRule {
+        @Override
+        public Object visit(ASTUserClass node, Object data) {
+            addViolation(data, node);
+            return data;
+        }
+
+        @Override
+        public Object visit(ASTUserInterface node, Object data) {
+            addViolation(data, node);
+            return data;
+        }
+
+        @Override
+        public Object visit(ASTUserTrigger node, Object data) {
+            addViolation(data, node);
+            return data;
+        }
+
+        @Override
+        public Object visit(ASTUserEnum node, Object data) {
+            addViolation(data, node);
+            return data;
+        }
+
+        @Override
+        public Object visit(ASTAnonymousClass node, Object data) {
+            addViolation(data, node);
+            return data;
+        }
+    }
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/ClassNamingConventions.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/ClassNamingConventions.xml
@@ -64,6 +64,14 @@ public class Foo {
     </test-code>
 
     <test-code>
+        <description>top-level enum all is well</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public enum FooEnum { }
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>test class default is title case</description>
         <expected-problems>1</expected-problems>
         <expected-messages>
@@ -122,6 +130,17 @@ public class Foo {
     </test-code>
 
     <test-code>
+        <description>top-level enum default is title case</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>The enum name 'fooEnum' doesn't match '[A-Z][a-zA-Z0-9_]*'</message>
+        </expected-messages>
+        <code><![CDATA[
+public enum fooEnum { }
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>custom test class pattern</description>
         <rule-property name="testClassPattern">[a-zA-Z0-9_]+</rule-property>
         <expected-problems>0</expected-problems>
@@ -155,6 +174,24 @@ public class FOO_CLASS { }
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public interface FOO_INTERFACE { }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>custom enum pattern</description>
+        <rule-property name="enumPattern">E[a-zA-Z0-9_]+</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public enum EFOO_ENUM { }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>custom enum pattern</description>
+        <rule-property name="enumPattern">E[a-zA-Z0-9_]+</rule-property>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public enum FooEnum { }
         ]]></code>
     </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Top-Level enums where never visited in rules, only nested/inner enums.
Since ClassNamingConventions uses rulechain, it was not affected by this bug.

## Related issues

- on PMD 7, this is fixed in general via #2491 . The root problem is, that Apex has multiple root nodes...

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

