### PR TITLE
[core] Deprecate missing language attribute on rule definition

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -18,6 +18,12 @@ This is a {{ site.pmd.release_type }} release.
 
 ### API Changes
 
+* In PMD 7, The `language` attribute will be required on all `rule` elements that
+declare a new rule. Some base rule classes set the language implicitly in their
+constructor, and so this is not required in all cases for the rule to work. But this
+behavior will be discontinued in PMD 7, so missing `language` attributes are now
+reported as a forward compatibility warning.
+
 ### External Contributions
 
 {% endtocmaker %}

--- a/pmd-apex/src/main/resources/category/apex/bestpractices.xml
+++ b/pmd-apex/src/main/resources/category/apex/bestpractices.xml
@@ -10,6 +10,7 @@ Rules which enforce generally accepted best practices.
     </description>
 
     <rule name="ApexAssertionsShouldIncludeMessage"
+          language="apex"
           since="6.13.0"
           message="Apex test assert statement should make use of the message parameter."
           class="net.sourceforge.pmd.lang.apex.rule.bestpractices.ApexAssertionsShouldIncludeMessageRule"
@@ -37,6 +38,7 @@ public class Foo {
     </rule>
 
     <rule name="ApexUnitTestClassShouldHaveAsserts"
+          language="apex"
           since="5.5.1"
           message="Apex unit tests should System.assert() or assertEquals() or assertNotEquals()"
           class="net.sourceforge.pmd.lang.apex.rule.bestpractices.ApexUnitTestClassShouldHaveAssertsRule"
@@ -62,6 +64,7 @@ public class Foo {
     </rule>
 
     <rule name="ApexUnitTestMethodShouldHaveIsTestAnnotation"
+          language="apex"
           since="6.13.0"
           message="Apex test methods should have @isTest annotation."
           class="net.sourceforge.pmd.lang.apex.rule.bestpractices.ApexUnitTestMethodShouldHaveIsTestAnnotationRule"
@@ -94,6 +97,7 @@ private class ATest {
     </rule>
 
     <rule name="ApexUnitTestShouldNotUseSeeAllDataTrue"
+          language="apex"
           since="5.5.1"
           message="Apex unit tests should not use @isTest(seeAllData = true)"
           class="net.sourceforge.pmd.lang.apex.rule.bestpractices.ApexUnitTestShouldNotUseSeeAllDataTrueRule"
@@ -118,6 +122,7 @@ public class Foo {
     </rule>
 
     <rule name="AvoidGlobalModifier"
+          language="apex"
           since="5.5.0"
           message="Avoid using global modifier"
           class="net.sourceforge.pmd.lang.apex.rule.bestpractices.AvoidGlobalModifierRule"
@@ -139,6 +144,7 @@ global class Unchangeable {
     </rule>
 
     <rule name="AvoidLogicInTrigger"
+          language="apex"
           since="5.5.0"
           message="Avoid logic in triggers"
           class="net.sourceforge.pmd.lang.apex.rule.bestpractices.AvoidLogicInTriggerRule"

--- a/pmd-apex/src/main/resources/category/apex/codestyle.xml
+++ b/pmd-apex/src/main/resources/category/apex/codestyle.xml
@@ -10,6 +10,7 @@ Rules which enforce a specific coding style.
     </description>
 
     <rule name="ClassNamingConventions"
+          language="apex"
           since="5.5.0"
           message="The {0} name ''{1}'' doesn''t match ''{2}''"
           class="net.sourceforge.pmd.lang.apex.rule.codestyle.ClassNamingConventionsRule"
@@ -129,6 +130,7 @@ class Foo {
     </rule>
 
     <rule name="FieldNamingConventions"
+          language="apex"
           since="6.15.0"
           message="The {0} name ''{1}'' doesn''t match ''{2}''"
           class="net.sourceforge.pmd.lang.apex.rule.codestyle.FieldNamingConventionsRule"
@@ -189,6 +191,7 @@ for (int i = 0; i < 42; i++) { // preferred approach
     </rule>
 
     <rule name="FormalParameterNamingConventions"
+          language="apex"
           since="6.15.0"
           message="The {0} name ''{1}'' doesn''t match ''{2}''"
           class="net.sourceforge.pmd.lang.apex.rule.codestyle.FormalParameterNamingConventionsRule"
@@ -214,6 +217,7 @@ public class Foo {
     </rule>
 
     <rule name="LocalVariableNamingConventions"
+          language="apex"
           since="6.15.0"
           message="The {0} name ''{1}'' doesn''t match ''{2}''"
           class="net.sourceforge.pmd.lang.apex.rule.codestyle.LocalVariableNamingConventionsRule"
@@ -241,6 +245,7 @@ public class Foo {
     </rule>
 
     <rule name="MethodNamingConventions"
+          language="apex"
           since="5.5.0"
           message="The {0} name ''{1}'' doesn''t match ''{2}''"
           class="net.sourceforge.pmd.lang.apex.rule.codestyle.MethodNamingConventionsRule"
@@ -265,6 +270,7 @@ public class Foo {
     </rule>
 
     <rule name="OneDeclarationPerLine"
+          language="apex"
           since="6.7.0"
           message="Use one statement for each line, it enhances code readability."
           class="net.sourceforge.pmd.lang.apex.rule.ApexXPathRule"
@@ -307,6 +313,7 @@ Integer b;
     </rule>
 
     <rule name="PropertyNamingConventions"
+          language="apex"
           since="6.15.0"
           message="The {0} name ''{1}'' doesn''t match ''{2}''"
           class="net.sourceforge.pmd.lang.apex.rule.codestyle.PropertyNamingConventionsRule"
@@ -332,6 +339,7 @@ public class Foo {
     </rule>
 
     <rule name="VariableNamingConventions"
+          language="apex"
           since="5.5.0"
           deprecated="true"
           message="{0} variable {1} should begin with {2}"

--- a/pmd-apex/src/main/resources/category/apex/design.xml
+++ b/pmd-apex/src/main/resources/category/apex/design.xml
@@ -9,7 +9,8 @@
 Rules that help you discover design issues.
     </description>
 
-    <rule name="AvoidDeeplyNestedIfStmts"
+    <rule language="apex"
+          name="AvoidDeeplyNestedIfStmts"
           since="5.5.0"
           message="Deeply nested if..then statements are hard to read"
           class="net.sourceforge.pmd.lang.apex.rule.design.AvoidDeeplyNestedIfStmtsRule"
@@ -35,7 +36,8 @@ public class Foo {
         </example>
     </rule>
 
-    <rule name="CyclomaticComplexity"
+    <rule language="apex"
+          name="CyclomaticComplexity"
           message="The {0} ''{1}'' has a{2} cyclomatic complexity of {3}."
           since="6.0.0"
           class="net.sourceforge.pmd.lang.apex.rule.design.CyclomaticComplexityRule"
@@ -86,7 +88,8 @@ public class Complicated {
         </example>
     </rule>
 
-    <rule name="CognitiveComplexity"
+    <rule language="apex"
+          name="CognitiveComplexity"
           message="The {0} ''{1}'' has a{2} cognitive complexity of {3}."
           since="6.22.0"
           class="net.sourceforge.pmd.lang.apex.rule.design.CognitiveComplexityRule"
@@ -148,7 +151,8 @@ public class Foo {
         </example>
     </rule>
 
-    <rule name="ExcessiveClassLength"
+    <rule language="apex"
+          name="ExcessiveClassLength"
           since="5.5.0"
           message="Avoid really long classes."
           class="net.sourceforge.pmd.lang.apex.rule.design.ExcessiveClassLengthRule"
@@ -179,7 +183,8 @@ public class Foo {
         </example>
     </rule>
 
-    <rule name="ExcessiveParameterList"
+    <rule language="apex"
+          name="ExcessiveParameterList"
           since="5.5.0"
           message="Avoid long parameter lists."
           class="net.sourceforge.pmd.lang.apex.rule.design.ExcessiveParameterListRule"
@@ -203,7 +208,8 @@ public void addPerson(Date birthdate, BodyMeasurements measurements, int ssn) {
         </example>
     </rule>
 
-    <rule name="ExcessivePublicCount"
+    <rule language="apex"
+          name="ExcessivePublicCount"
           since="5.5.0"
           message="This class has a bunch of public methods and attributes"
           class="net.sourceforge.pmd.lang.apex.rule.design.ExcessivePublicCountRule"
@@ -232,7 +238,8 @@ public class Foo {
         </example>
     </rule>
 
-    <rule name="NcssConstructorCount"
+    <rule language="apex"
+          name="NcssConstructorCount"
           since="5.5.0"
           message="The constructor has an NCSS line count of {0}"
           class="net.sourceforge.pmd.lang.apex.rule.design.NcssConstructorCountRule"
@@ -260,7 +267,8 @@ public class Foo extends Bar {
         </example>
     </rule>
 
-    <rule name="NcssMethodCount"
+    <rule language="apex"
+          name="NcssMethodCount"
           since="5.5.0"
           message="The method ''{0}()'' has an NCSS line count of {1}"
           class="net.sourceforge.pmd.lang.apex.rule.design.NcssMethodCountRule"
@@ -287,7 +295,8 @@ public class Foo extends Bar {
         </example>
     </rule>
 
-    <rule name="NcssTypeCount"
+    <rule language="apex"
+          name="NcssTypeCount"
           since="5.5.0"
           message="The type has an NCSS line count of {0}"
           class="net.sourceforge.pmd.lang.apex.rule.design.NcssTypeCountRule"
@@ -316,7 +325,8 @@ public class Foo extends Bar {
         </example>
     </rule>
 
-    <rule name="StdCyclomaticComplexity"
+    <rule language="apex"
+          name="StdCyclomaticComplexity"
           since="5.5.0"
           message="The {0} ''{1}'' has a Standard Cyclomatic Complexity of {2}."
           class="net.sourceforge.pmd.lang.apex.rule.design.StdCyclomaticComplexityRule"
@@ -370,7 +380,8 @@ public class Foo {
         </example>
     </rule>
 
-    <rule name="TooManyFields"
+    <rule language="apex"
+          name="TooManyFields"
           since="5.5.0"
           message="Too many fields"
           class="net.sourceforge.pmd.lang.apex.rule.design.TooManyFieldsRule"

--- a/pmd-apex/src/main/resources/category/apex/design.xml
+++ b/pmd-apex/src/main/resources/category/apex/design.xml
@@ -9,8 +9,8 @@
 Rules that help you discover design issues.
     </description>
 
-    <rule language="apex"
-          name="AvoidDeeplyNestedIfStmts"
+    <rule name="AvoidDeeplyNestedIfStmts"
+          language="apex"
           since="5.5.0"
           message="Deeply nested if..then statements are hard to read"
           class="net.sourceforge.pmd.lang.apex.rule.design.AvoidDeeplyNestedIfStmtsRule"
@@ -36,8 +36,8 @@ public class Foo {
         </example>
     </rule>
 
-    <rule language="apex"
-          name="CyclomaticComplexity"
+    <rule name="CyclomaticComplexity"
+          language="apex"
           message="The {0} ''{1}'' has a{2} cyclomatic complexity of {3}."
           since="6.0.0"
           class="net.sourceforge.pmd.lang.apex.rule.design.CyclomaticComplexityRule"
@@ -88,8 +88,8 @@ public class Complicated {
         </example>
     </rule>
 
-    <rule language="apex"
-          name="CognitiveComplexity"
+    <rule name="CognitiveComplexity"
+          language="apex"
           message="The {0} ''{1}'' has a{2} cognitive complexity of {3}."
           since="6.22.0"
           class="net.sourceforge.pmd.lang.apex.rule.design.CognitiveComplexityRule"
@@ -151,8 +151,8 @@ public class Foo {
         </example>
     </rule>
 
-    <rule language="apex"
-          name="ExcessiveClassLength"
+    <rule name="ExcessiveClassLength"
+          language="apex"
           since="5.5.0"
           message="Avoid really long classes."
           class="net.sourceforge.pmd.lang.apex.rule.design.ExcessiveClassLengthRule"
@@ -183,8 +183,8 @@ public class Foo {
         </example>
     </rule>
 
-    <rule language="apex"
-          name="ExcessiveParameterList"
+    <rule name="ExcessiveParameterList"
+          language="apex"
           since="5.5.0"
           message="Avoid long parameter lists."
           class="net.sourceforge.pmd.lang.apex.rule.design.ExcessiveParameterListRule"
@@ -208,8 +208,8 @@ public void addPerson(Date birthdate, BodyMeasurements measurements, int ssn) {
         </example>
     </rule>
 
-    <rule language="apex"
-          name="ExcessivePublicCount"
+    <rule name="ExcessivePublicCount"
+          language="apex"
           since="5.5.0"
           message="This class has a bunch of public methods and attributes"
           class="net.sourceforge.pmd.lang.apex.rule.design.ExcessivePublicCountRule"
@@ -238,8 +238,8 @@ public class Foo {
         </example>
     </rule>
 
-    <rule language="apex"
-          name="NcssConstructorCount"
+    <rule name="NcssConstructorCount"
+          language="apex"
           since="5.5.0"
           message="The constructor has an NCSS line count of {0}"
           class="net.sourceforge.pmd.lang.apex.rule.design.NcssConstructorCountRule"
@@ -267,8 +267,8 @@ public class Foo extends Bar {
         </example>
     </rule>
 
-    <rule language="apex"
-          name="NcssMethodCount"
+    <rule name="NcssMethodCount"
+          language="apex"
           since="5.5.0"
           message="The method ''{0}()'' has an NCSS line count of {1}"
           class="net.sourceforge.pmd.lang.apex.rule.design.NcssMethodCountRule"
@@ -295,8 +295,8 @@ public class Foo extends Bar {
         </example>
     </rule>
 
-    <rule language="apex"
-          name="NcssTypeCount"
+    <rule name="NcssTypeCount"
+          language="apex"
           since="5.5.0"
           message="The type has an NCSS line count of {0}"
           class="net.sourceforge.pmd.lang.apex.rule.design.NcssTypeCountRule"
@@ -325,8 +325,8 @@ public class Foo extends Bar {
         </example>
     </rule>
 
-    <rule language="apex"
-          name="StdCyclomaticComplexity"
+    <rule name="StdCyclomaticComplexity"
+          language="apex"
           since="5.5.0"
           message="The {0} ''{1}'' has a Standard Cyclomatic Complexity of {2}."
           class="net.sourceforge.pmd.lang.apex.rule.design.StdCyclomaticComplexityRule"
@@ -380,8 +380,8 @@ public class Foo {
         </example>
     </rule>
 
-    <rule language="apex"
-          name="TooManyFields"
+    <rule name="TooManyFields"
+          language="apex"
           since="5.5.0"
           message="Too many fields"
           class="net.sourceforge.pmd.lang.apex.rule.design.TooManyFieldsRule"

--- a/pmd-apex/src/main/resources/category/apex/documentation.xml
+++ b/pmd-apex/src/main/resources/category/apex/documentation.xml
@@ -10,6 +10,7 @@ Rules that are related to code documentation.
     </description>
 
     <rule name="ApexDoc"
+          language="apex"
           since="6.8.0"
           message="ApexDoc comment is missing or incorrect"
           class="net.sourceforge.pmd.lang.apex.rule.documentation.ApexDocRule"

--- a/pmd-apex/src/main/resources/category/apex/errorprone.xml
+++ b/pmd-apex/src/main/resources/category/apex/errorprone.xml
@@ -10,6 +10,7 @@ Rules to detect constructs that are either broken, extremely confusing or prone 
     </description>
 
     <rule name="ApexCSRF"
+          language="apex"
           since="5.5.3"
           message="Avoid making DML operations in Apex class constructor or initializers"
           class="net.sourceforge.pmd.lang.apex.rule.errorprone.ApexCSRFRule"
@@ -50,6 +51,7 @@ public class Foo {
     </rule>
 
     <rule name="AvoidDirectAccessTriggerMap"
+          language="apex"
           since="6.0.0"
           message="Avoid directly accessing Trigger.old and Trigger.new"
           class="net.sourceforge.pmd.lang.apex.rule.ApexXPathRule"
@@ -82,6 +84,7 @@ trigger AccountTrigger on Account (before insert, before update) {
     </rule>
 
     <rule name="AvoidHardcodingId"
+          language="apex"
           since="6.0.0"
           message="Hardcoding Id's is bound to break when changing environments."
           class="net.sourceforge.pmd.lang.apex.rule.errorprone.AvoidHardcodingIdRule"
@@ -293,6 +296,7 @@ public void bar(Integer a, Integer b) {
     </rule>
 
     <rule name="MethodWithSameNameAsEnclosingClass"
+          language="apex"
           since="5.5.0"
           message="Classes should not have non-constructor methods with the same name as the class"
           class="net.sourceforge.pmd.lang.apex.rule.errorprone.MethodWithSameNameAsEnclosingClassRule"
@@ -314,6 +318,7 @@ public class MyClass {
     </rule>
 
     <rule name="AvoidNonExistentAnnotations"
+          language="apex"
           since="6.5.0"
           message="Use of non existent annotations will lead to broken Apex code which will not compile in the future."
           class="net.sourceforge.pmd.lang.apex.rule.errorprone.AvoidNonExistentAnnotationsRule"
@@ -336,6 +341,7 @@ public class MyClass {
     </rule>
 
     <rule name="TestMethodsMustBeInTestClasses"
+          language="apex"
           since="6.22.0"
           message="Test methods must be in test classes"
           class="net.sourceforge.pmd.lang.apex.rule.ApexXPathRule"

--- a/pmd-apex/src/main/resources/category/apex/performance.xml
+++ b/pmd-apex/src/main/resources/category/apex/performance.xml
@@ -10,6 +10,7 @@ Rules that flag suboptimal code.
     </description>
 
     <rule name="AvoidDmlStatementsInLoops"
+          language="apex"
           since="5.5.0"
           message="Avoid DML statements inside loops"
           class="net.sourceforge.pmd.lang.apex.rule.performance.AvoidDmlStatementsInLoopsRule"
@@ -34,6 +35,7 @@ public class Something {
     </rule>
 
     <rule name="AvoidSoqlInLoops"
+          language="apex"
           since="5.5.0"
           message="Avoid Soql queries inside loops"
           class="net.sourceforge.pmd.lang.apex.rule.performance.AvoidSoqlInLoopsRule"
@@ -56,6 +58,7 @@ public class Something {
     </rule>
 
     <rule name="AvoidSoslInLoops"
+          language="apex"
           since="6.0.0"
           message="Avoid Sosl queries inside loops"
           class="net.sourceforge.pmd.lang.apex.rule.performance.AvoidSoslInLoopsRule"

--- a/pmd-apex/src/main/resources/category/apex/security.xml
+++ b/pmd-apex/src/main/resources/category/apex/security.xml
@@ -10,6 +10,7 @@ Rules that flag potential security flaws.
     </description>
 
     <rule name="ApexBadCrypto"
+          language="apex"
           since="5.5.3"
           message="Apex classes should use random IV/key"
           class="net.sourceforge.pmd.lang.apex.rule.security.ApexBadCryptoRule"
@@ -32,6 +33,7 @@ public without sharing class Foo {
     </rule>
 
     <rule name="ApexCRUDViolation"
+          language="apex"
           since="5.5.3"
           message="Validate CRUD permission before SOQL/DML operation"
           class="net.sourceforge.pmd.lang.apex.rule.security.ApexCRUDViolationRule"
@@ -65,6 +67,7 @@ public class Foo {
     <rule name="ApexCSRF" ref="category/apex/errorprone.xml/ApexCSRF" deprecated="true"/>
 
     <rule name="ApexDangerousMethods"
+          language="apex"
           since="5.5.3"
           message="Calling potentially dangerous method"
           class="net.sourceforge.pmd.lang.apex.rule.security.ApexDangerousMethodsRule"
@@ -92,6 +95,7 @@ public class Foo {
     </rule>
 
     <rule name="ApexInsecureEndpoint"
+          language="apex"
           since="5.5.3"
           message="Apex callouts should use encrypted communication channels"
           class="net.sourceforge.pmd.lang.apex.rule.security.ApexInsecureEndpointRule"
@@ -114,6 +118,7 @@ public without sharing class Foo {
     </rule>
 
     <rule name="ApexOpenRedirect"
+          language="apex"
           since="5.5.3"
           message="Apex classes should safely redirect to a known location"
           class="net.sourceforge.pmd.lang.apex.rule.security.ApexOpenRedirectRule"
@@ -136,6 +141,7 @@ public without sharing class Foo {
     </rule>
 
     <rule name="ApexSharingViolations"
+          language="apex"
           since="5.5.3"
           message="Apex classes should declare a sharing model if DML or SOQL/SOSL is used"
           class="net.sourceforge.pmd.lang.apex.rule.security.ApexSharingViolationsRule"
@@ -155,6 +161,7 @@ public without sharing class Foo {
     </rule>
 
     <rule name="ApexSOQLInjection"
+          language="apex"
           since="5.5.3"
           message="Avoid untrusted/unescaped variables in DML query"
           class="net.sourceforge.pmd.lang.apex.rule.security.ApexSOQLInjectionRule"
@@ -175,6 +182,7 @@ public class Foo {
     </rule>
 
     <rule name="ApexSuggestUsingNamedCred"
+          language="apex"
           since="5.5.3"
           message="Suggest named credentials for authentication"
           class="net.sourceforge.pmd.lang.apex.rule.security.ApexSuggestUsingNamedCredRule"
@@ -209,6 +217,7 @@ public class Foo {
     </rule>
 
     <rule name="ApexXSSFromEscapeFalse"
+          language="apex"
           since="5.5.3"
           message="Apex classes should escape Strings in error messages"
           class="net.sourceforge.pmd.lang.apex.rule.security.ApexXSSFromEscapeFalseRule"
@@ -229,6 +238,7 @@ public without sharing class Foo {
     </rule>
 
     <rule name="ApexXSSFromURLParam"
+          language="apex"
           since="5.5.3"
           message="Apex classes should escape/sanitize Strings obtained from URL parameters"
           class="net.sourceforge.pmd.lang.apex.rule.security.ApexXSSFromURLParamRule"

--- a/pmd-apex/src/test/resources/rulesets/apex/metrics_test.xml
+++ b/pmd-apex/src/test/resources/rulesets/apex/metrics_test.xml
@@ -10,16 +10,19 @@
     </description>
 
     <rule name="CycloTest"
+          language="apex"
           message = "''{0}'' has value {1}."
           class="net.sourceforge.pmd.lang.apex.metrics.impl.CycloTestRule">
     </rule>
 
     <rule name="WmcTest"
+          language="apex"
           message = "''{0}'' has value {1}."
           class="net.sourceforge.pmd.lang.apex.metrics.impl.WmcTestRule">
     </rule>
 
     <rule name="CognitiveComplexityTest"
+          language="apex"
           message = "''{0}'' has value {1}."
           class="net.sourceforge.pmd.lang.apex.metrics.impl.CognitiveComplexityTestRule">
     </rule>

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
@@ -345,6 +345,7 @@ public class RuleSetFactory {
             throw new IllegalArgumentException("Cannot parse a single Rule from an all Rule RuleSet reference: <" + ruleSetReferenceId + ">.");
         }
         RuleSet ruleSet;
+        // java8: computeIfAbsent
         if (parsedRulesets.containsKey(ruleSetReferenceId)) {
             ruleSet = parsedRulesets.get(ruleSetReferenceId);
         } else {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
@@ -8,9 +8,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.logging.Level;
@@ -59,6 +61,8 @@ public class RuleSetFactory {
     private final RulePriority minimumPriority;
     private final boolean warnDeprecated;
     private final RuleSetFactoryCompatibility compatibilityFilter;
+
+    private final Map<RuleSetReferenceId, RuleSet> parsedRulesets = new HashMap<>();
 
     /**
      * @deprecated Use {@link RulesetsFactoryUtils#defaultFactory()}
@@ -338,10 +342,15 @@ public class RuleSetFactory {
     private Rule createRule(RuleSetReferenceId ruleSetReferenceId, boolean withDeprecatedRuleReferences)
             throws RuleSetNotFoundException {
         if (ruleSetReferenceId.isAllRules()) {
-            throw new IllegalArgumentException(
-                    "Cannot parse a single Rule from an all Rule RuleSet reference: <" + ruleSetReferenceId + ">.");
+            throw new IllegalArgumentException("Cannot parse a single Rule from an all Rule RuleSet reference: <" + ruleSetReferenceId + ">.");
         }
-        RuleSet ruleSet = createRuleSet(ruleSetReferenceId, withDeprecatedRuleReferences);
+        RuleSet ruleSet;
+        if (parsedRulesets.containsKey(ruleSetReferenceId)) {
+            ruleSet = parsedRulesets.get(ruleSetReferenceId);
+        } else {
+            ruleSet = createRuleSet(ruleSetReferenceId, withDeprecatedRuleReferences);
+            parsedRulesets.put(ruleSetReferenceId, ruleSet);
+        }
         return ruleSet.getRuleByName(ruleSetReferenceId.getRuleName());
     }
 
@@ -610,11 +619,17 @@ public class RuleSetFactory {
         // Stop if we're looking for a particular Rule, and this element is not
         // it.
         if (StringUtils.isNotBlank(ruleSetReferenceId.getRuleName())
-                && !isRuleName(ruleElement, ruleSetReferenceId.getRuleName())) {
+            && !isRuleName(ruleElement, ruleSetReferenceId.getRuleName())) {
             return;
         }
         Rule rule = new RuleFactory(resourceLoader).buildRule(ruleElement);
         rule.setRuleSetName(ruleSetBuilder.getName());
+
+        if (StringUtils.isBlank(ruleElement.getAttribute("language"))) {
+            LOG.warning("Rule " + ruleSetReferenceId.toString() + "/" + rule.getName() + " does not mention attribute"
+                            + " language='" + rule.getLanguage().getTerseName() + "',"
+                            + " please mention it explicitly to be compatible with PMD 7");
+        }
 
         ruleSetBuilder.addRule(rule);
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
@@ -626,7 +626,7 @@ public class RuleSetFactory {
         rule.setRuleSetName(ruleSetBuilder.getName());
 
         if (StringUtils.isBlank(ruleElement.getAttribute("language"))) {
-            LOG.warning("Rule " + ruleSetReferenceId.toString() + "/" + rule.getName() + " does not mention attribute"
+            LOG.warning("Rule " + ruleSetReferenceId.getRuleSetFileName() + "/" + rule.getName() + " does not mention attribute"
                             + " language='" + rule.getLanguage().getTerseName() + "',"
                             + " please mention it explicitly to be compatible with PMD 7");
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/rules/RuleFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/rules/RuleFactory.java
@@ -152,9 +152,9 @@ public class RuleFactory {
         String name = ruleElement.getAttribute(NAME);
 
         RuleBuilder builder = new RuleBuilder(name,
-                resourceLoader,
-                ruleElement.getAttribute(CLASS),
-                ruleElement.getAttribute("language"));
+                                              resourceLoader,
+                                              ruleElement.getAttribute(CLASS),
+                                              ruleElement.getAttribute("language"));
 
         if (ruleElement.hasAttribute(MINIMUM_LANGUAGE_VERSION)) {
             builder.minimumLanguageVersion(ruleElement.getAttribute(MINIMUM_LANGUAGE_VERSION));

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryTest.java
@@ -604,7 +604,7 @@ public class RuleSetFactoryTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testIncorrectMinimumLanugageVersion() throws RuleSetNotFoundException {
+    public void testIncorrectMinimumLanguageVersion() throws RuleSetNotFoundException {
         loadFirstRule(INCORRECT_MINIMUM_LANGUAGE_VERSION);
     }
 
@@ -633,7 +633,7 @@ public class RuleSetFactoryTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testIncorrectMaximumLanugageVersion() throws RuleSetNotFoundException {
+    public void testIncorrectMaximumLanguageVersion() throws RuleSetNotFoundException {
         loadFirstRule(INCORRECT_MAXIMUM_LANGUAGE_VERSION);
     }
 
@@ -985,6 +985,7 @@ public class RuleSetFactoryTest {
         + " <description>testdesc</description>\n"
         + "<rule \n"
         + "\n"
+        + "language=\"dummy\" \n"
         + "name=\"MockRuleName\" \n"
         + "message=\"avoid the mock rule\" \n"
         + "class=\"net.sourceforge.pmd.lang.rule.MockRule\">\n"
@@ -997,6 +998,7 @@ public class RuleSetFactoryTest {
         + " <description>testdesc</description>\n"
         + "<rule \n"
         + "\n"
+        + "language=\"dummy\" \n"
         + "name=\"MockRuleName\" \n"
         + "message=\"avoid the mock rule\" \n"
         + "class=\"net.sourceforge.pmd.lang.rule.MockRule\">\n"
@@ -1034,6 +1036,7 @@ public class RuleSetFactoryTest {
         + "<ruleset name=\"test\">\n"
         + "<description>testdesc</description>\n"
         + "<rule \n"
+        + "language=\"dummy\" \n"
         + "name=\"MockRuleName\" \n"
         + "message=\"avoid the mock rule\" \n"
         + "class=\"net.sourceforge.pmd.lang.rule.MockRule\">\n"
@@ -1045,11 +1048,13 @@ public class RuleSetFactoryTest {
         + "\n"
         + "<description>testdesc</description>\n"
         + "<rule name=\"MockRuleName1\" \n"
+        + "language=\"dummy\" \n"
         + "message=\"avoid the mock rule\" \n"
         + "class=\"net.sourceforge.pmd.lang.rule.MockRule\">\n"
         + "\n"
         + "</rule>\n"
         + "<rule name=\"MockRuleName2\" \n"
+        + "language=\"dummy\" \n"
         + "message=\"avoid the mock rule\" \n"
         + "class=\"net.sourceforge.pmd.lang.rule.MockRule\">\n"
         + "\n"
@@ -1059,6 +1064,7 @@ public class RuleSetFactoryTest {
         + "<ruleset name=\"test\">\n"
         + "<description>testdesc</description>\n"
         + "<rule name=\"MockRuleName\" \n"
+        + "language=\"dummy\" \n"
         + "message=\"avoid the mock rule\" \n"
         + "class=\"net.sourceforge.pmd.lang.rule.MockRule\">\n"
         + "\n"
@@ -1080,6 +1086,7 @@ public class RuleSetFactoryTest {
         + "<ruleset name=\"test\">\n"
         + "<description>testdesc</description>\n"
         + "<rule name=\"MockRuleName\" \n"
+        + "language=\"dummy\" \n"
         + "message=\"avoid the mock rule\" \n"
         + "class=\"net.sourceforge.pmd.lang.rule.MockRule\">\n"
         + "<priority>3</priority>\n"
@@ -1098,6 +1105,7 @@ public class RuleSetFactoryTest {
         + "<ruleset name=\"test\">\n"
         + "<description>testdesc</description>\n"
         + "<rule \n"
+        + "language=\"dummy\" \n"
         + "name=\"MockRuleName\" \n"
         + "message=\"avoid the mock rule\" \n"
         + "class=\"net.sourceforge.pmd.lang.rule.MockRule\">\n"
@@ -1110,7 +1118,8 @@ public class RuleSetFactoryTest {
         + "<rule \n"
         + "name=\"MockRuleName\" \n"
         + "message=\"avoid the mock rule\" \n"
-        + "class=\"net.sourceforge.pmd.lang.rule.MockRule\" language=\"dummy\">\n"
+        + "class=\"net.sourceforge.pmd.lang.rule.MockRule\" "
+        + "language=\"dummy\">\n"
         + "</rule></ruleset>";
 
     private static final String INCORRECT_LANGUAGE = "<?xml version=\"1.0\"?>\n"
@@ -1186,8 +1195,8 @@ public class RuleSetFactoryTest {
         + "\n"
         + "<description>testdesc</description>\n"
         + "<rule \n"
+        + "language=\"dummy\" \n"
         + "name=\"MockRuleName\" \n"
-        + "\n"
         + "message=\"avoid the mock rule\" \n"
         + "class=\"net.sourceforge.pmd.lang.rule.MockRule\" deprecated=\"true\">\n"
         + "</rule></ruleset>";
@@ -1216,6 +1225,7 @@ public class RuleSetFactoryTest {
         + "<ruleset name=\"test\">\n"
         + "<description>testdesc</description>\n"
         + "<rule \n"
+        + "language=\"dummy\" \n"
         + "name=\"MockRuleName\" \n"
         + "message=\"avoid the mock rule\" \n"
         + "dfa=\"true\" \n"

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryTest.java
@@ -1209,17 +1209,17 @@ public class RuleSetFactoryTest {
     // listed here is finally removed.
     private static final String DEPRECATED_RULE_NAME = "MockRule3";
 
-    private static final String REFERENCE_TO_DEPRECATED_RULE =  "<?xml version=\"1.0\"?>\n"
+    private static final String REFERENCE_TO_DEPRECATED_RULE = "<?xml version=\"1.0\"?>\n"
         + "<ruleset name=\"test\">\n"
         + "<description>testdesc</description>\n"
-        + "<rule " + "ref=\"" + DEPRECATED_RULE_RULESET_NAME + "/" + DEPRECATED_RULE_NAME + "\" />\n" +
-        "</ruleset>";
+        + "<rule " + "ref=\"" + DEPRECATED_RULE_RULESET_NAME + "/" + DEPRECATED_RULE_NAME + "\" />\n"
+        + "</ruleset>";
 
     private static final String REFERENCE_TO_RULESET_WITH_DEPRECATED_RULE = "<?xml version=\"1.0\"?>\n"
         + "<ruleset name=\"test\">\n"
         + "<description>testdesc</description>\n"
-        + "<rule " + "ref=\"" + DEPRECATED_RULE_RULESET_NAME + "\" />\n" +
-        "</ruleset>";
+        + "<rule " + "ref=\"" + DEPRECATED_RULE_RULESET_NAME + "\" />\n"
+        + "</ruleset>";
 
     private static final String DFA = "<?xml version=\"1.0\"?>\n"
         + "<ruleset name=\"test\">\n"

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -308,6 +308,7 @@ public class Foo {
     </rule>
 
     <rule name="AvoidUsingHardCodedIP"
+          language="java"
           since="4.1"
           message="Do not hard code the IP address ${variableName}"
           class="net.sourceforge.pmd.lang.java.rule.bestpractices.AvoidUsingHardCodedIPRule"

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -35,6 +35,7 @@ public abstract class Foo {
     </rule>
 
     <rule name="AccessorClassGeneration"
+          language="java"
           since="1.04"
           maximumLanguageVersion="10"
           message="Avoid instantiation through private constructors from outside of the constructor's class."
@@ -96,6 +97,7 @@ public class OuterClass {
     </rule>
 
     <rule name="ArrayIsStoredDirectly"
+          language="java"
           since="2.2"
           message="The user-supplied array ''{0}'' is stored directly."
           class="net.sourceforge.pmd.lang.java.rule.bestpractices.ArrayIsStoredDirectlyRule"
@@ -210,6 +212,7 @@ class Foo {
     </rule>
 
     <rule name="AvoidReassigningLoopVariables"
+          language="java"
           since="6.11.0"
           message="Avoid reassigning the loop control variable ''{0}''"
           class="net.sourceforge.pmd.lang.java.rule.bestpractices.AvoidReassigningLoopVariablesRule"
@@ -258,6 +261,7 @@ public class Foo {
     </rule>
 
     <rule name="AvoidReassigningParameters"
+          language="java"
           since="1.0"
           message="Avoid reassigning parameters such as ''{0}''"
           class="net.sourceforge.pmd.lang.java.rule.bestpractices.AvoidReassigningParametersRule"
@@ -752,6 +756,7 @@ public class MyTest {
     </rule>
 
     <rule name="JUnitAssertionsShouldIncludeMessage"
+          language="java"
           since="1.04"
           message="JUnit assertions should include a message"
           class="net.sourceforge.pmd.lang.java.rule.bestpractices.JUnitAssertionsShouldIncludeMessageRule"
@@ -832,6 +837,7 @@ public class MyTestCase extends TestCase {
     </rule>
 
     <rule name="JUnitTestsShouldIncludeAssert"
+          language="java"
           since="2.0"
           message="JUnit tests should include assert() or fail()"
           class="net.sourceforge.pmd.lang.java.rule.bestpractices.JUnitTestsShouldIncludeAssertRule"
@@ -856,6 +862,7 @@ public class Foo extends TestCase {
     </rule>
 
     <rule name="JUnitUseExpected"
+          language="java"
           since="4.0"
           message="In JUnit4, use the @Test(expected) annotation to denote tests that should throw exceptions"
           class="net.sourceforge.pmd.lang.java.rule.bestpractices.JUnitUseExpectedRule"
@@ -921,6 +928,7 @@ class Foo {
     </rule>
 
     <rule name="LooseCoupling"
+          language="java"
           since="0.7"
           message="Avoid using implementation types like ''{0}''; use the interface instead"
           class="net.sourceforge.pmd.lang.java.rule.bestpractices.LooseCouplingRule"
@@ -957,6 +965,7 @@ public class Bar {
     </rule>
 
     <rule name="MethodReturnsInternalArray"
+          language="java"
           since="2.2"
           message="Returning ''{0}'' may expose an internal array."
           class="net.sourceforge.pmd.lang.java.rule.bestpractices.MethodReturnsInternalArrayRule"
@@ -981,6 +990,7 @@ public class SecureSystem {
 
 
     <rule name="MissingOverride"
+          language="java"
           since="6.2.0"
           minimumLanguageVersion="1.5"
           message="The method ''{0}'' is missing an @Override annotation."
@@ -1100,6 +1110,7 @@ class Foo {
     </rule>
 
     <rule name="PreserveStackTrace"
+          language="java"
           since="3.7"
           message="New exception is thrown in catch block, original stack trace may be lost"
           class="net.sourceforge.pmd.lang.java.rule.bestpractices.PreserveStackTraceRule"
@@ -1324,6 +1335,7 @@ public class Foo {
     </rule>
 
     <rule name="UnusedImports"
+          language="java"
           since="1.0"
           message="Avoid unused imports such as ''{0}''"
           class="net.sourceforge.pmd.lang.java.rule.bestpractices.UnusedImportsRule"
@@ -1612,6 +1624,7 @@ public class MyTestCase extends TestCase {
     </rule>
 
     <rule name="UseCollectionIsEmpty"
+          language="java"
           since="3.9"
           message="Substitute calls to size() == 0 (or size() != 0, size() &gt; 0, size() &lt; 1) with calls to isEmpty()"
           class="net.sourceforge.pmd.lang.java.rule.bestpractices.UseCollectionIsEmptyRule"

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -74,6 +74,7 @@ public class Foo {
     </rule>
 
     <rule name="AvoidDollarSigns"
+          language="java"
           since="1.5"
           message="Avoid using dollar signs in variable/method/class/interface names"
           class="net.sourceforge.pmd.lang.java.rule.codestyle.AvoidDollarSignsRule"
@@ -386,6 +387,7 @@ public class Foo extends Bar{
     </rule>
 
     <rule name="ClassNamingConventions"
+          language="java"
           since="1.2"
           message="The {0} name ''{1}'' doesn''t match ''{2}''"
           class="net.sourceforge.pmd.lang.java.rule.codestyle.ClassNamingConventionsRule"
@@ -419,6 +421,7 @@ public class Éléphant {}
     </rule>
 
     <rule name="CommentDefaultAccessModifier"
+          language="java"
           since="5.4.0"
           class="net.sourceforge.pmd.lang.java.rule.codestyle.CommentDefaultAccessModifierRule"
           message="Missing commented default access modifier"
@@ -458,6 +461,7 @@ public class Foo {
     </rule>
 
     <rule name="ConfusingTernary"
+          language="java"
           since="1.9"
           message="Avoid if (x != y) ..; else ..;"
           class="net.sourceforge.pmd.lang.java.rule.codestyle.ConfusingTernaryRule"
@@ -586,6 +590,7 @@ or MethodDeclaration[@PackagePrivate= true()]
     </rule>
 
     <rule name="DontImportJavaLang"
+          language="java"
           since="0.5"
           message="Avoid importing anything from the package 'java.lang'"
           class="net.sourceforge.pmd.lang.java.rule.codestyle.DontImportJavaLangRule"
@@ -610,6 +615,7 @@ public class Foo {}
     </rule>
 
     <rule name="DuplicateImports"
+          language="java"
           since="0.5"
           message="Avoid duplicate imports such as ''{0}''"
           class="net.sourceforge.pmd.lang.java.rule.codestyle.DuplicateImportsRule"
@@ -733,6 +739,7 @@ public class HelloWorldBean {
 
 
     <rule name="FieldNamingConventions"
+          language="java"
           since="6.7.0"
           message="The {0} name ''{1}'' doesn''t match ''{2}''"
           class="net.sourceforge.pmd.lang.java.rule.codestyle.FieldNamingConventionsRule"
@@ -834,6 +841,7 @@ for (int i = 0; i < 42; i++)
     </rule>
 
     <rule name="FormalParameterNamingConventions"
+          language="java"
           since="6.6.0"
           message="The {0} name ''{1}'' doesn''t match ''{2}''"
           class="net.sourceforge.pmd.lang.java.rule.codestyle.FormalParameterNamingConventionsRule"
@@ -1175,6 +1183,7 @@ public interface MissingProperSuffix extends javax.ejb.EJBLocalObject {}    // n
     </rule>
 
     <rule name="LocalVariableCouldBeFinal"
+          language="java"
           since="2.2"
           message="Local variable ''{0}'' could be declared final"
           class="net.sourceforge.pmd.lang.java.rule.codestyle.LocalVariableCouldBeFinalRule"
@@ -1196,6 +1205,7 @@ public class Bar {
     </rule>
 
     <rule name="LocalVariableNamingConventions"
+          language="java"
           since="6.6.0"
           message="The {0} name ''{1}'' doesn''t match ''{2}''"
           class="net.sourceforge.pmd.lang.java.rule.codestyle.LocalVariableNamingConventionsRule"
@@ -1308,6 +1318,7 @@ public class MissingTheProperSuffix implements SessionBean {}   // non-standard 
     </rule>
 
     <rule name="MethodArgumentCouldBeFinal"
+          language="java"
           since="2.2"
           message="Parameter ''{0}'' is not assigned and could be declared final"
           class="net.sourceforge.pmd.lang.java.rule.codestyle.MethodArgumentCouldBeFinalRule"
@@ -1330,6 +1341,7 @@ public void foo2 (final String param) { // better, do stuff with param never ass
     </rule>
 
     <rule name="MethodNamingConventions"
+          language="java"
           since="1.2"
           message="The {0} name ''{1}'' doesn''t match ''{2}''"
           class="net.sourceforge.pmd.lang.java.rule.codestyle.MethodNamingConventionsRule"
@@ -1476,6 +1488,7 @@ public class Foo {
     </rule>
 
     <rule name="OnlyOneReturn"
+          language="java"
           since="1.0"
           message="A method should have only one exit point, and that should be the last statement in the method"
           class="net.sourceforge.pmd.lang.java.rule.codestyle.OnlyOneReturnRule"
@@ -1823,6 +1836,7 @@ import static Yoko; // Too much !
 
 
     <rule name="UnnecessaryAnnotationValueElement"
+          language="java"
           since="6.2.0"
           message="Avoid the use of value in annotations when it's the only element"
           class="net.sourceforge.pmd.lang.java.rule.codestyle.UnnecessaryAnnotationValueElementRule"
@@ -1935,6 +1949,7 @@ public class Foo {
     </rule>
 
     <rule name="UnnecessaryLocalBeforeReturn"
+          language="java"
           since="3.3"
           message="Consider simply returning the value vs storing it in local variable ''{0}''"
           class="net.sourceforge.pmd.lang.java.rule.codestyle.UnnecessaryLocalBeforeReturnRule"
@@ -1994,6 +2009,7 @@ public class Bar {
     </rule>
 
     <rule name="UnnecessaryReturn"
+          language="java"
           since="1.3"
           message="Avoid unnecessary return statements"
           class="net.sourceforge.pmd.lang.java.rule.codestyle.UnnecessaryReturnRule"
@@ -2240,6 +2256,7 @@ Foo[] x = { ... }; //Equivalent to above line
     </rule>
 
     <rule name="VariableNamingConventions"
+          language="java"
           since="1.2"
           deprecated="true"
           message="{0} variable {1} should begin with {2}"

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -92,6 +92,7 @@ public class PrimitiveType {
     </rule>
 
     <rule name="AvoidDeeplyNestedIfStmts"
+          language="java"
           since="1.0"
           message="Deeply nested if..then statements are hard to read"
           class="net.sourceforge.pmd.lang.java.rule.design.AvoidDeeplyNestedIfStmtsRule"
@@ -410,6 +411,7 @@ void bar() {
     </rule>
 
     <rule name="CouplingBetweenObjects"
+          language="java"
           since="1.04"
           message="High amount of different objects as members denotes a high coupling"
           class="net.sourceforge.pmd.lang.java.rule.design.CouplingBetweenObjectsRule"
@@ -442,6 +444,7 @@ public class Foo {
     </rule>
 
     <rule name="CyclomaticComplexity"
+          language="java"
           message="The {0} ''{1}'' has a{2} cyclomatic complexity of {3}."
           since="1.03"
           class="net.sourceforge.pmd.lang.java.rule.design.CyclomaticComplexityRule"
@@ -495,6 +498,7 @@ class Foo {
     </rule>
 
     <rule name="DataClass"
+          language="java"
           since="6.0.0"
           message="The class ''{0}'' is suspected to be a Data Class (WOC={1}, NOPA={2}, NOAM={3}, WMC={4})"
           class="net.sourceforge.pmd.lang.java.rule.design.DataClassRule"
@@ -562,6 +566,7 @@ public class Foo extends Error { }
     </rule>
 
     <rule name="ExceptionAsFlowControl"
+          language="java"
           since="1.8"
           message="Avoid using exceptions as flow control."
           class="net.sourceforge.pmd.lang.java.rule.design.ExceptionAsFlowControlRule"
@@ -589,6 +594,7 @@ public void bar() {
     </rule>
 
     <rule name="ExcessiveClassLength"
+          language="java"
           since="0.6"
           message="Avoid really long classes."
           class="net.sourceforge.pmd.lang.java.rule.design.ExcessiveClassLengthRule"
@@ -621,6 +627,7 @@ public class Foo {
     </rule>
 
     <rule name="ExcessiveImports"
+          language="java"
           since="1.04"
           message="A high number of imports can indicate a high degree of coupling within an object."
           class="net.sourceforge.pmd.lang.java.rule.design.ExcessiveImportsRule"
@@ -644,6 +651,7 @@ public class Foo {
     </rule>
 
     <rule name="ExcessiveMethodLength"
+          language="java"
           since="0.6"
           message="Avoid really long methods."
           class="net.sourceforge.pmd.lang.java.rule.design.ExcessiveMethodLengthRule"
@@ -667,6 +675,7 @@ public void doSomething() {
     </rule>
 
     <rule name="ExcessiveParameterList"
+          language="java"
           since="0.9"
           message="Avoid long parameter lists."
           class="net.sourceforge.pmd.lang.java.rule.design.ExcessiveParameterListRule"
@@ -694,6 +703,7 @@ public void addPerson(      // preferred approach
     </rule>
 
     <rule name="ExcessivePublicCount"
+          language="java"
           since="1.04"
           message="This class has a bunch of public methods and attributes"
           class="net.sourceforge.pmd.lang.java.rule.design.ExcessivePublicCountRule"
@@ -777,6 +787,7 @@ of Object-Oriented Systems. Springer, Berlin, 1 edition, October 2006. Page 80.
     </rule>
 
     <rule name="ImmutableField"
+          language="java"
           since="2.0"
           message="Private field ''{0}'' could be made final; it is only initialized in the declaration or constructor."
           class="net.sourceforge.pmd.lang.java.rule.design.ImmutableFieldRule"
@@ -885,6 +896,7 @@ public boolean bar(int a, int b) {
     </rule>
 
     <rule name="LoosePackageCoupling"
+          language="java"
           since="5.0"
           message="Use of ''{0}'' outside of package hierarchy ''{1}'' is not recommended; use recommended classes instead"
           class="net.sourceforge.pmd.lang.java.rule.design.LoosePackageCouplingRule"
@@ -908,6 +920,7 @@ public class Bar {
     </rule>
 
     <rule name="ModifiedCyclomaticComplexity"
+          language="java"
           since="5.1.2"
           message = "The {0} ''{1}'' has a Modified Cyclomatic Complexity of {2}."
           class="net.sourceforge.pmd.lang.java.rule.design.ModifiedCyclomaticComplexityRule"
@@ -967,6 +980,7 @@ public class Foo {    // This has a Cyclomatic Complexity = 9
     </rule>
 
     <rule name="NcssConstructorCount"
+          language="java"
           message="The constructor with {0} parameters has an NCSS line count of {1}"
           since="3.9"
           deprecated="true"
@@ -1000,6 +1014,7 @@ public class Foo extends Bar {
     </rule>
 
     <rule name="NcssCount"
+          language="java"
           message="The {0} ''{1}'' has a NCSS line count of {2}."
           since="6.0.0"
           class="net.sourceforge.pmd.lang.java.rule.design.NcssCountRule"
@@ -1043,6 +1058,7 @@ class Foo {                         // +1, total Ncss = 12
     </rule>
 
     <rule name="NcssMethodCount"
+          language="java"
           message="The method {0}() has an NCSS line count of {1}"
           deprecated="true"
           since="3.9"
@@ -1077,6 +1093,7 @@ public class Foo extends Bar {
     </rule>
 
     <rule name="NcssTypeCount"
+          language="java"
           message="The type has an NCSS line count of {0}"
           since="3.9"
           deprecated="true"
@@ -1110,6 +1127,7 @@ public class Foo extends Bar {
     </rule>
 
     <rule name="NPathComplexity"
+          language="java"
           since="3.9"
           message="The {0} ''{1}'' has an NPath complexity of {2}, current threshold is {3}"
           class="net.sourceforge.pmd.lang.java.rule.design.NPathComplexityRule"
@@ -1166,6 +1184,7 @@ public class Foo {
     </rule>
 
     <rule name="SignatureDeclareThrowsException"
+          language="java"
           since="1.2"
           message="A method/constructor should not explicitly throw java.lang.Exception"
           class="net.sourceforge.pmd.lang.java.rule.design.SignatureDeclareThrowsExceptionRule"
@@ -1335,6 +1354,7 @@ public class Bar {
     </rule>
 
     <rule name="SimplifyBooleanReturns"
+          language="java"
           since="0.9"
           message="Avoid unnecessary if..then..else statements when returning booleans"
           class="net.sourceforge.pmd.lang.java.rule.design.SimplifyBooleanReturnsRule"
@@ -1418,6 +1438,7 @@ class Foo {
     </rule>
 
     <rule name="SingularField"
+          language="java"
           since="3.1"
           message="Perhaps ''{0}'' could be replaced by a local variable."
           class="net.sourceforge.pmd.lang.java.rule.design.SingularFieldRule"
@@ -1442,6 +1463,7 @@ public class Foo {
     </rule>
 
     <rule name="StdCyclomaticComplexity"
+          language="java"
           since="5.1.2"
           message = "The {0} ''{1}'' has a Standard Cyclomatic Complexity of {2}."
           class="net.sourceforge.pmd.lang.java.rule.design.StdCyclomaticComplexityRule"
@@ -1500,6 +1522,7 @@ public class Foo {    // This has a Cyclomatic Complexity = 12
     </rule>
 
     <rule name="SwitchDensity"
+          language="java"
           since="1.02"
           message="A high ratio of statements to labels in a switch statement.  Consider refactoring."
           class="net.sourceforge.pmd.lang.java.rule.design.SwitchDensityRule"
@@ -1530,6 +1553,7 @@ public class Foo {
     </rule>
 
     <rule name="TooManyFields"
+          language="java"
           since="3.0"
           message="Too many fields"
           class="net.sourceforge.pmd.lang.java.rule.design.TooManyFieldsRule"
@@ -1614,6 +1638,7 @@ complexity and find a way to have more fine grained objects.
     </rule>
 
     <rule name="UselessOverridingMethod"
+          language="java"
           since="3.3"
           message="Overriding method merely calls super"
           class="net.sourceforge.pmd.lang.java.rule.design.UselessOverridingMethodRule"
@@ -1687,6 +1712,7 @@ public class MyClass {
     </rule>
 
     <rule name="UseUtilityClass"
+          language="java"
           since="0.3"
           message="All methods are static.  Consider using a utility class instead. Alternatively, you could add a private constructor or make the class abstract to silence this warning."
           class="net.sourceforge.pmd.lang.java.rule.design.UseUtilityClassRule"

--- a/pmd-java/src/main/resources/category/java/documentation.xml
+++ b/pmd-java/src/main/resources/category/java/documentation.xml
@@ -10,6 +10,7 @@ Rules that are related to code documentation.
     </description>
 
     <rule name="CommentContent"
+          language="java"
           since="5.0"
           message="Invalid words or phrases found"
           class="net.sourceforge.pmd.lang.java.rule.documentation.CommentContentRule"
@@ -26,6 +27,7 @@ A rule for the politically correct... we don't want to offend anyone.
     </rule>
 
     <rule name="CommentRequired"
+          language="java"
           since="5.1"
           message="Comment is required"
           class="net.sourceforge.pmd.lang.java.rule.documentation.CommentRequiredRule"
@@ -46,6 +48,7 @@ Denotes whether javadoc (formal) comments are required (or unwanted) for specifi
     </rule>
 
     <rule name="CommentSize"
+          language="java"
           since="5.0"
           message="Comment is too large"
           class="net.sourceforge.pmd.lang.java.rule.documentation.CommentSizeRule"

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -10,6 +10,7 @@ Rules to detect constructs that are either broken, extremely confusing or prone 
     </description>
 
     <rule name="AssignmentInOperand"
+          language="java"
           since="1.03"
           message="Avoid assignments in operands"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.AssignmentInOperandRule"
@@ -31,6 +32,7 @@ public void bar() {
     </rule>
 
     <rule name="AssignmentToNonFinalStatic"
+          language="java"
           since="2.2"
           message="Possible unsafe assignment to a non-final static field in a constructor."
           class="net.sourceforge.pmd.lang.java.rule.errorprone.AssignmentToNonFinalStaticRule"
@@ -155,6 +157,7 @@ public class A {
     </rule>
 
     <rule name="AvoidBranchingStatementAsLastInLoop"
+          language="java"
           since="5.0"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.AvoidBranchingStatementAsLastInLoopRule"
           message="Avoid using a branching statement as the last in a loop."
@@ -185,6 +188,7 @@ for (int i = 0; i < 10; i++) {
     </rule>
 
     <rule name="AvoidCallingFinalize"
+          language="java"
           since="3.0"
           message="Avoid calling finalize() explicitly"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.AvoidCallingFinalizeRule"
@@ -243,6 +247,7 @@ public class Foo {
     </rule>
 
     <rule name="AvoidCatchingThrowable"
+          language="java"
           since="1.2"
           message="A catch statement should never catch throwable since it includes errors."
           class="net.sourceforge.pmd.lang.java.rule.errorprone.AvoidCatchingThrowableRule"
@@ -313,6 +318,7 @@ BigDecimal bd = new BigDecimal(12);          // preferred approach, ok for integ
     </rule>
 
     <rule name="AvoidDuplicateLiterals"
+          language="java"
           since="1.0"
           message="The String literal {0} appears {1} times in this file; the first occurrence is on line {2}"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.AvoidDuplicateLiteralsRule"
@@ -362,6 +368,7 @@ public class A {
     </rule>
 
     <rule name="AvoidFieldNameMatchingMethodName"
+          language="java"
           since="3.0"
           message="Field {0} has the same name as a method"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.AvoidFieldNameMatchingMethodNameRule"
@@ -385,6 +392,7 @@ public class Foo {
     </rule>
 
     <rule name="AvoidFieldNameMatchingTypeName"
+          language="java"
           since="3.0"
           message="It is somewhat confusing to have a field name matching the declaring class name"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.AvoidFieldNameMatchingTypeNameRule"
@@ -574,6 +582,7 @@ public void bar() {
     </rule>
 
     <rule name="AvoidMultipleUnaryOperators"
+          language="java"
           since="4.2"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.AvoidMultipleUnaryOperatorsRule"
           message="Using multiple unary operators may be a bug, and/or is confusing."
@@ -607,6 +616,7 @@ int j = -~7;
     </rule>
 
     <rule name="AvoidUsingOctalValues"
+          language="java"
           since="3.9"
           message="Do not start a literal by 0 unless it's an octal value"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.AvoidUsingOctalValuesRule"
@@ -656,6 +666,7 @@ boolean x = (y == Double.NaN);
     </rule>
 
     <rule name="BeanMembersShouldSerialize"
+          language="java"
           since="1.1"
           message="Found non-transient, non-static member. Please mark as transient or provide accessors."
           class="net.sourceforge.pmd.lang.java.rule.errorprone.BeanMembersShouldSerializeRule"
@@ -686,6 +697,7 @@ private int getMoreFoo(){
     </rule>
 
     <rule name="BrokenNullCheck"
+          language="java"
           since="3.8"
           message="Method call on object which may be null"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.BrokenNullCheckRule"
@@ -1032,6 +1044,7 @@ public class MyClass implements Cloneable{
     </rule>
 
     <rule name="CloseResource"
+          language="java"
           since="1.2.2"
           message="Ensure that resources like this {0} object are closed after use"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.CloseResourceRule"
@@ -1081,6 +1094,7 @@ public class Bar {
     </rule>
 
     <rule name="CompareObjectsWithEquals"
+          language="java"
           since="3.2"
           message="Use equals() to compare object references."
           class="net.sourceforge.pmd.lang.java.rule.errorprone.CompareObjectsWithEqualsRule"
@@ -1102,6 +1116,7 @@ class Foo {
     </rule>
 
     <rule name="ConstructorCallsOverridableMethod"
+          language="java"
           since="1.04"
           message="Overridable {0} called during object construction"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.ConstructorCallsOverridableMethodRule"
@@ -1141,6 +1156,7 @@ public class JuniorClass extends SeniorClass {
     </rule>
 
     <rule name="DataflowAnomalyAnalysis"
+          language="java"
           since="3.9"
           message="Found ''{0}''-anomaly for variable ''{1}'' (lines ''{2}''-''{3}'')."
           class="net.sourceforge.pmd.lang.java.rule.errorprone.DataflowAnomalyAnalysisRule"
@@ -1408,6 +1424,7 @@ public class Foo {
     </rule>
 
     <rule name="DontImportSun"
+          language="java"
           since="1.5"
           message="Avoid importing anything from the 'sun.*' packages"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.DontImportSunRule"
@@ -2029,6 +2046,7 @@ public void finalize() {
     </rule>
 
     <rule name="IdempotentOperations"
+          language="java"
           since="2.0"
           message="Avoid idempotent operations (like assigning a variable to itself)."
           class="net.sourceforge.pmd.lang.java.rule.errorprone.IdempotentOperationsRule"
@@ -2050,6 +2068,7 @@ public class Foo {
     </rule>
 
     <rule name="ImportFromSamePackage"
+          language="java"
           since="1.02"
           message="No need to import a type that lives in the same package"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.ImportFromSamePackageRule"
@@ -2256,6 +2275,7 @@ public class Foo{
     </rule>
 
     <rule name="MethodWithSameNameAsEnclosingClass"
+          language="java"
           since="1.5"
           message="Classes should not have non-constructor methods with the same name as the class"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.MethodWithSameNameAsEnclosingClassRule"
@@ -2507,6 +2527,7 @@ public class Foo {
     </rule>
 
     <rule name="MoreThanOneLogger"
+          language="java"
           since="2.0"
           message="Class contains more than one logger."
           class="net.sourceforge.pmd.lang.java.rule.errorprone.MoreThanOneLoggerRule"
@@ -2599,6 +2620,7 @@ public class MyClass {
     </rule>
 
     <rule name="NullAssignment"
+          language="java"
           since="1.02"
           message="Assigning an Object to null is a code smell.  Consider refactoring."
           class="net.sourceforge.pmd.lang.java.rule.errorprone.NullAssignmentRule"
@@ -2855,6 +2877,7 @@ public class Foo {
     </rule>
 
     <rule name="SingleMethodSingleton"
+          language="java"
           since="5.4"
           message="Class contains multiple getInstance methods. Please review."
           class="net.sourceforge.pmd.lang.java.rule.errorprone.SingleMethodSingletonRule"
@@ -2887,6 +2910,7 @@ public class Singleton {
     </rule>
 
     <rule name="SingletonClassReturningNewInstance"
+          language="java"
           since="5.4"
           message="getInstance method always creates a new object and hence does not comply to Singleton Design Pattern behaviour. Please review"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.SingletonClassReturningNewInstanceRule"
@@ -3075,6 +3099,7 @@ public class Foo {
     </rule>
 
     <rule name="SuspiciousHashcodeMethodName"
+          language="java"
           since="1.5"
           message="The method name and return type are suspiciously close to hashCode()"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.SuspiciousHashcodeMethodNameRule"
@@ -3095,6 +3120,7 @@ public class Foo {
     </rule>
 
     <rule name="SuspiciousOctalEscape"
+          language="java"
           since="1.5"
           message="Suspicious decimal characters following octal escape in string literal"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.SuspiciousOctalEscapeRule"
@@ -3123,6 +3149,7 @@ public void foo() {
     </rule>
 
     <rule name="TestClassWithoutTestCases"
+          language="java"
           since="3.0"
           message="This class name ends with 'Test' but contains no test cases"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.TestClassWithoutTestCasesRule"
@@ -3238,6 +3265,7 @@ public class SimpleTest extends TestCase {
     </rule>
 
     <rule name="UnnecessaryCaseChange"
+          language="java"
           since="3.3"
           message="Using equalsIgnoreCase() is cleaner than using toUpperCase/toLowerCase().equals()."
           class="net.sourceforge.pmd.lang.java.rule.errorprone.UnnecessaryCaseChangeRule"
@@ -3256,6 +3284,7 @@ boolean answer2 = buz.toUpperCase().equalsIgnoreCase("baz");    // another unnec
     </rule>
 
     <rule name="UnnecessaryConversionTemporary"
+          language="java"
           since="0.1"
           message="Avoid unnecessary temporaries when converting primitives to Strings"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.UnnecessaryConversionTemporaryRule"
@@ -3427,6 +3456,7 @@ public boolean test(String s) {
     </rule>
 
     <rule name="UselessOperationOnImmutable"
+          language="java"
           since="3.5"
           message="An operation on an Immutable object (String, BigDecimal or BigInteger) won't change the object itself"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.UselessOperationOnImmutableRule"

--- a/pmd-java/src/main/resources/category/java/multithreading.xml
+++ b/pmd-java/src/main/resources/category/java/multithreading.xml
@@ -256,6 +256,7 @@ public class Foo {
     </rule>
 
     <rule name="NonThreadSafeSingleton"
+          language="java"
           since="3.4"
           message="Singleton is not thread safe"
           class="net.sourceforge.pmd.lang.java.rule.multithreading.NonThreadSafeSingletonRule"
@@ -290,6 +291,7 @@ public static Foo getFoo() {
     </rule>
 
     <rule name="UnsynchronizedStaticDateFormatter"
+          language="java"
           since="3.6"
           deprecated="true"
           message="Static DateFormatter objects should be accessed in a synchronized manner"
@@ -321,6 +323,7 @@ public class Foo {
     </rule>
 
     <rule name="UnsynchronizedStaticFormatter"
+          language="java"
           since="6.11.0"
           message="Static Formatter objects should be accessed in a synchronized manner"
           class="net.sourceforge.pmd.lang.java.rule.multithreading.UnsynchronizedStaticFormatterRule"

--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -39,6 +39,7 @@ String t = Integer.toString(456);   // preferred approach
     </rule>
 
     <rule name="AppendCharacterWithChar"
+          language="java"
           since="3.5"
           message="Avoid appending characters as strings in StringBuffer.append."
           class="net.sourceforge.pmd.lang.java.rule.performance.AppendCharacterWithCharRule"
@@ -246,6 +247,7 @@ that one covers both.
     </rule>
 
     <rule name="AvoidInstantiatingObjectsInLoops"
+          language="java"
           since="2.2"
           message="Avoid instantiating new objects inside loops"
           class="net.sourceforge.pmd.lang.java.rule.performance.AvoidInstantiatingObjectsInLoopsRule"
@@ -316,6 +318,7 @@ public class UsingShort {
     </rule>
 
     <rule name="BigIntegerInstantiation"
+          language="java"
           since="3.9"
           message="Don't create instances of already existing BigInteger and BigDecimal (ZERO, ONE, TEN)"
           class="net.sourceforge.pmd.lang.java.rule.performance.BigIntegerInstantiationRule"
@@ -337,6 +340,7 @@ bi4 = new BigInteger(0);                 // reference BigInteger.ZERO instead
     </rule>
 
     <rule name="BooleanInstantiation"
+          language="java"
           since="1.2"
           message="Avoid instantiating Boolean objects; reference Boolean.TRUE or Boolean.FALSE or call Boolean.valueOf() instead."
           class="net.sourceforge.pmd.lang.java.rule.performance.BooleanInstantiationRule"
@@ -415,6 +419,7 @@ buf.append("Hello").append(foo).append("World"); // good
     </rule>
 
     <rule name="ConsecutiveLiteralAppends"
+          language="java"
           since="3.5"
           message="StringBuffer (or StringBuilder).append is called {0} consecutive times with literals. Use a single append with a single combined String."
           class="net.sourceforge.pmd.lang.java.rule.performance.ConsecutiveLiteralAppendsRule"
@@ -441,8 +446,9 @@ buf.append("1m");           // good
     </rule>
 
     <rule name="InefficientEmptyStringCheck"
+          language="java"
           since="3.6"
-	  message="String.trim().length() == 0 / String.trim().isEmpty() is an inefficient way to validate a blank String."
+	        message="String.trim().length() == 0 / String.trim().isEmpty() is an inefficient way to validate a blank String."
           class="net.sourceforge.pmd.lang.java.rule.performance.InefficientEmptyStringCheckRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_performance.html#inefficientemptystringcheck">
         <description>
@@ -483,6 +489,7 @@ public void bar(String string) {
     </rule>
 
     <rule name="InefficientStringBuffering"
+          language="java"
           since="3.4"
           message="Avoid concatenating nonliterals in a StringBuffer/StringBuilder constructor or append()."
           class="net.sourceforge.pmd.lang.java.rule.performance.InefficientStringBufferingRule"
@@ -505,6 +512,7 @@ sb.append(System.getProperty("java.io.tmpdir"));
     </rule>
 
     <rule name="InsufficientStringBufferDeclaration"
+          language="java"
           since="3.6"
           message="StringBuffer constructor is initialized with size {0}, but has at least {1} characters appended."
           class="net.sourceforge.pmd.lang.java.rule.performance.InsufficientStringBufferDeclarationRule"
@@ -764,6 +772,7 @@ public class Foo {
     </rule>
 
     <rule name="StringInstantiation"
+          language="java"
           since="1.0"
           message="Avoid instantiating String objects; this is usually unnecessary."
           class="net.sourceforge.pmd.lang.java.rule.performance.StringInstantiationRule"
@@ -780,6 +789,7 @@ private String bar = new String("bar"); // just do a String bar = "bar";
     </rule>
 
     <rule name="StringToString"
+          language="java"
           since="1.0"
           message="Avoid calling toString() on String objects; this is unnecessary."
           class="net.sourceforge.pmd.lang.java.rule.performance.StringToStringRule"
@@ -842,6 +852,7 @@ public class Foo {
     </rule>
 
     <rule name="UnnecessaryWrapperObjectCreation"
+          language="java"
           since="3.8"
           message="Unnecessary wrapper object creation"
           class="net.sourceforge.pmd.lang.java.rule.performance.UnnecessaryWrapperObjectCreationRule"
@@ -981,6 +992,7 @@ public class Test {
     </rule>
 
     <rule name="UseIndexOfChar"
+          language="java"
           since="3.5"
           message="String.indexOf(char) is faster than String.indexOf(String)."
           class="net.sourceforge.pmd.lang.java.rule.performance.UseIndexOfCharRule"
@@ -1059,6 +1071,7 @@ public class FileStuff {
     </rule>
 
     <rule name="UselessStringValueOf"
+          language="java"
           since="3.8"
           message="No need to call String.valueOf to append to a string."
           class="net.sourceforge.pmd.lang.java.rule.performance.UselessStringValueOfRule"
@@ -1080,6 +1093,7 @@ public String convert(int i) {
     </rule>
 
     <rule name="UseStringBufferForStringAppends"
+          language="java"
           since="3.1"
           message="Prefer StringBuilder (non-synchronized) or StringBuffer (synchronized) over += for concatenating strings"
           class="net.sourceforge.pmd.lang.java.rule.performance.UseStringBufferForStringAppendsRule"
@@ -1107,6 +1121,7 @@ public class Foo {
     </rule>
 
     <rule name="UseStringBufferLength"
+          language="java"
           since="3.4"
           message="This is an inefficient use of StringBuffer.toString; call StringBuffer.length instead."
           class="net.sourceforge.pmd.lang.java.rule.performance.UseStringBufferLengthRule"

--- a/pmd-java/src/main/resources/category/java/security.xml
+++ b/pmd-java/src/main/resources/category/java/security.xml
@@ -9,6 +9,7 @@ Rules that flag potential security flaws.
     </description>
 
     <rule name="HardCodedCryptoKey"
+          language="java"
           since="6.4.0"
           message="Do not use hard coded encryption keys"
           class="net.sourceforge.pmd.lang.java.rule.security.HardCodedCryptoKeyRule"
@@ -33,6 +34,7 @@ public class Foo {
     </rule>
 
     <rule name="InsecureCryptoIv"
+          language="java"
           since="6.3.0"
           message="Do not use hard coded initialization vector in crypto operations"
           class="net.sourceforge.pmd.lang.java.rule.security.InsecureCryptoIvRule"

--- a/pmd-java/src/test/resources/rulesets/java/metrics_test.xml
+++ b/pmd-java/src/test/resources/rulesets/java/metrics_test.xml
@@ -10,56 +10,67 @@
     </description>
 
     <rule name="CycloTest"
+          language="java"
           message = "''{0}'' has value {1}."
           class="net.sourceforge.pmd.lang.java.metrics.impl.CycloTestRule">
     </rule>
 
     <rule name="NcssTest"
+          language="java"
           message = "''{0}'' has value {1}."
           class="net.sourceforge.pmd.lang.java.metrics.impl.NcssTestRule">
     </rule>
 
     <rule name="WmcTest"
+          language="java"
           message = "''{0}'' has value {1}."
           class="net.sourceforge.pmd.lang.java.metrics.impl.WmcTestRule">
     </rule>
 
     <rule name="LocTest"
+          language="java"
           message = "''{0}'' has value {1}."
           class="net.sourceforge.pmd.lang.java.metrics.impl.LocTestRule">
     </rule>
 
     <rule name="NPathTest"
+          language="java"
           message = "''{0}'' has value {1}."
           class="net.sourceforge.pmd.lang.java.metrics.impl.NPathTestRule">
     </rule>
 
     <rule name="NopaTest"
+          language="java"
           message = "''{0}'' has value {1}."
           class="net.sourceforge.pmd.lang.java.metrics.impl.NopaTestRule">
     </rule>
 
     <rule name="NoamTest"
+          language="java"
           message = "''{0}'' has value {1}."
           class="net.sourceforge.pmd.lang.java.metrics.impl.NoamTestRule">
     </rule>
 
     <rule name="WocTest"
+          language="java"
           message = "''{0}'' has value {1}."
           class="net.sourceforge.pmd.lang.java.metrics.impl.WocTestRule">
     </rule>
 
     <rule name="TccTest"
+          language="java"
           message = "''{0}'' has value {1}."
           class="net.sourceforge.pmd.lang.java.metrics.impl.TccTestRule">
     </rule>
 
     <rule name="AtfdTest"
+          language="java"
           message = "''{0}'' has value {1}."
           class="net.sourceforge.pmd.lang.java.metrics.impl.AtfdTestRule">
     </rule>
 
     <rule name="CfoTest"
+          language="java"
           message = "''{0}'' has value {1}."
           class="net.sourceforge.pmd.lang.java.metrics.impl.CfoTestRule">
     </rule>

--- a/pmd-javascript/src/main/resources/category/ecmascript/bestpractices.xml
+++ b/pmd-javascript/src/main/resources/category/ecmascript/bestpractices.xml
@@ -37,6 +37,7 @@ with (object) {
     </rule>
 
     <rule name="ConsistentReturn"
+          language="ecmascript"
           since="5.0"
           message="A function should not mix 'return' statements with and without a result."
           class="net.sourceforge.pmd.lang.ecmascript.rule.bestpractices.ConsistentReturnRule"

--- a/pmd-jsp/src/main/resources/category/jsp/codestyle.xml
+++ b/pmd-jsp/src/main/resources/category/jsp/codestyle.xml
@@ -10,6 +10,7 @@ Rules which enforce a specific coding style.
     </description>
 
     <rule name="DuplicateJspImports"
+          language="jsp"
           since="3.7"
           message="Avoid duplicate imports such as ''{0}''"
           class="net.sourceforge.pmd.lang.jsp.rule.codestyle.DuplicateJspImportsRule"

--- a/pmd-jsp/src/main/resources/category/jsp/design.xml
+++ b/pmd-jsp/src/main/resources/category/jsp/design.xml
@@ -33,6 +33,7 @@ Externalized script could be reused between pages.  Browsers can also cache the 
     </rule>
 
     <rule name="NoInlineStyleInformation"
+          language="jsp"
           since="3.6"
           message="Avoid having style information in JSP files."
           class="net.sourceforge.pmd.lang.jsp.rule.design.NoInlineStyleInformationRule"

--- a/pmd-jsp/src/main/resources/category/jsp/security.xml
+++ b/pmd-jsp/src/main/resources/category/jsp/security.xml
@@ -44,6 +44,7 @@ through SSL. See http://support.microsoft.com/default.aspx?scid=kb;EN-US;Q261188
     </rule>
 
     <rule name="NoUnsanitizedJSPExpression"
+          language="jsp"
           since="5.1.4"
           class="net.sourceforge.pmd.lang.jsp.rule.security.NoUnsanitizedJSPExpressionRule"
           message="Using unsanitized JSP expression can lead to Cross Site Scripting (XSS) attacks"

--- a/pmd-test/pom.xml
+++ b/pmd-test/pom.xml
@@ -44,7 +44,11 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>com.github.stefanbirkner</groupId>
+            <artifactId>system-rules</artifactId>
+            <scope>compile</scope>
+        </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>

--- a/pmd-test/src/main/java/net/sourceforge/pmd/AbstractRuleSetFactoryTest.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/AbstractRuleSetFactoryTest.java
@@ -33,6 +33,7 @@ import javax.xml.parsers.SAXParserFactory;
 import org.apache.commons.io.FilenameUtils;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.SystemErrRule;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
@@ -50,6 +51,9 @@ import net.sourceforge.pmd.util.ResourceLoader;
  * subclassed for each language.
  */
 public abstract class AbstractRuleSetFactoryTest {
+    @org.junit.Rule
+    public final SystemErrRule systemErrRule = new SystemErrRule().enableLog().muteForSuccessfulTests();
+
     private static SAXParserFactory saxParserFactory;
     private static ValidateDefaultHandler validateDefaultHandler;
     private static SAXParser saxParser;

--- a/pmd-visualforce/src/main/resources/category/vf/security.xml
+++ b/pmd-visualforce/src/main/resources/category/vf/security.xml
@@ -10,6 +10,7 @@ Rules that flag potential security flaws.
     </description>
 
     <rule name="VfCsrf"
+          language="vf"
           since="5.6.0"
           message="Avoid calling VF action upon page load"
           class="net.sourceforge.pmd.lang.vf.rule.security.VfCsrfRule"
@@ -26,6 +27,7 @@ Avoid calling VF action upon page load as the action becomes vulnerable to CSRF.
     </rule>
 
     <rule name="VfUnescapeEl"
+          language="vf"
           since="5.6.0"
           message="Avoid unescaped user controlled content in EL"
           class="net.sourceforge.pmd.lang.vf.rule.security.VfUnescapeElRule"

--- a/pmd-vm/src/main/resources/category/vm/bestpractices.xml
+++ b/pmd-vm/src/main/resources/category/vm/bestpractices.xml
@@ -9,8 +9,8 @@
 Rules which enforce generally accepted best practices.
     </description>
 
-    <rule language="vm"
-          name="AvoidReassigningParameters"
+    <rule name="AvoidReassigningParameters"
+          language="vm"
           since="5.1"
           message="Avoid reassigning macro parameters such as ''{0}''"
           class="net.sourceforge.pmd.lang.vm.rule.bestpractices.AvoidReassigningParametersRule"
@@ -21,8 +21,8 @@ Reassigning values to incoming parameters is not recommended.  Use temporary loc
         <priority>2</priority>
     </rule>
 
-    <rule language="vm"
-          name="UnusedMacroParameter"
+    <rule name="UnusedMacroParameter"
+          language="vm"
           since="5.1"
           message="Avoid unused macro parameters such as ''{0}''"
           class="net.sourceforge.pmd.lang.vm.rule.bestpractices.UnusedMacroParameterRule"

--- a/pmd-vm/src/main/resources/category/vm/bestpractices.xml
+++ b/pmd-vm/src/main/resources/category/vm/bestpractices.xml
@@ -9,7 +9,8 @@
 Rules which enforce generally accepted best practices.
     </description>
 
-    <rule name="AvoidReassigningParameters"
+    <rule language="vm"
+          name="AvoidReassigningParameters"
           since="5.1"
           message="Avoid reassigning macro parameters such as ''{0}''"
           class="net.sourceforge.pmd.lang.vm.rule.bestpractices.AvoidReassigningParametersRule"
@@ -20,7 +21,8 @@ Reassigning values to incoming parameters is not recommended.  Use temporary loc
         <priority>2</priority>
     </rule>
 
-    <rule name="UnusedMacroParameter"
+    <rule language="vm"
+          name="UnusedMacroParameter"
           since="5.1"
           message="Avoid unused macro parameters such as ''{0}''"
           class="net.sourceforge.pmd.lang.vm.rule.bestpractices.UnusedMacroParameterRule"

--- a/pmd-vm/src/main/resources/category/vm/design.xml
+++ b/pmd-vm/src/main/resources/category/vm/design.xml
@@ -9,7 +9,8 @@
 Rules that help you discover design issues.
     </description>
 
-    <rule name="AvoidDeeplyNestedIfStmts"
+    <rule language="vm"
+          name="AvoidDeeplyNestedIfStmts"
           since="5.1"
           message="Deeply nested if..then statements are hard to read"
           class="net.sourceforge.pmd.lang.vm.rule.design.AvoidDeeplyNestedIfStmtsRule"
@@ -20,7 +21,8 @@ Avoid creating deeply nested if-then statements since they are harder to read an
         <priority>3</priority>
     </rule>
 
-    <rule name="CollapsibleIfStatements"
+    <rule language="vm"
+          name="CollapsibleIfStatements"
           since="5.1"
           message="These nested if statements could be combined"
           class="net.sourceforge.pmd.lang.vm.rule.design.CollapsibleIfStatementsRule"
@@ -31,7 +33,8 @@ Sometimes two consecutive 'if' statements can be consolidated by separating thei
         <priority>3</priority>
     </rule>
 
-    <rule name="ExcessiveTemplateLength"
+    <rule language="vm"
+          name="ExcessiveTemplateLength"
           since="5.1"
           message="Template is too long"
           class="net.sourceforge.pmd.lang.vm.rule.design.ExcessiveTemplateLengthRule"
@@ -45,7 +48,8 @@ The template is too long. It should be broken up into smaller pieces.
         </properties>
     </rule>
 
-    <rule name="NoInlineJavaScript"
+    <rule language="vm"
+          name="NoInlineJavaScript"
           since="5.1"
           message="Avoid inline JavaScript"
           class="net.sourceforge.pmd.lang.vm.rule.design.NoInlineJavaScriptRule"
@@ -56,10 +60,10 @@ Avoid inline JavaScript. Import .js files instead.
         <priority>2</priority>
     </rule>
 
-    <rule name="NoInlineStyles"
+    <rule language="vm"
+          name="NoInlineStyles"
           since="5.1"
           message="Avoid inline styles"
-          language="vm"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_vm_design.html#noinlinestyles">
         <description>

--- a/pmd-vm/src/main/resources/category/vm/design.xml
+++ b/pmd-vm/src/main/resources/category/vm/design.xml
@@ -9,8 +9,8 @@
 Rules that help you discover design issues.
     </description>
 
-    <rule language="vm"
-          name="AvoidDeeplyNestedIfStmts"
+    <rule name="AvoidDeeplyNestedIfStmts"
+          language="vm"
           since="5.1"
           message="Deeply nested if..then statements are hard to read"
           class="net.sourceforge.pmd.lang.vm.rule.design.AvoidDeeplyNestedIfStmtsRule"
@@ -21,8 +21,8 @@ Avoid creating deeply nested if-then statements since they are harder to read an
         <priority>3</priority>
     </rule>
 
-    <rule language="vm"
-          name="CollapsibleIfStatements"
+    <rule name="CollapsibleIfStatements"
+          language="vm"
           since="5.1"
           message="These nested if statements could be combined"
           class="net.sourceforge.pmd.lang.vm.rule.design.CollapsibleIfStatementsRule"
@@ -33,8 +33,8 @@ Sometimes two consecutive 'if' statements can be consolidated by separating thei
         <priority>3</priority>
     </rule>
 
-    <rule language="vm"
-          name="ExcessiveTemplateLength"
+    <rule name="ExcessiveTemplateLength"
+          language="vm"
           since="5.1"
           message="Template is too long"
           class="net.sourceforge.pmd.lang.vm.rule.design.ExcessiveTemplateLengthRule"
@@ -48,8 +48,8 @@ The template is too long. It should be broken up into smaller pieces.
         </properties>
     </rule>
 
-    <rule language="vm"
-          name="NoInlineJavaScript"
+    <rule name="NoInlineJavaScript"
+          language="vm"
           since="5.1"
           message="Avoid inline JavaScript"
           class="net.sourceforge.pmd.lang.vm.rule.design.NoInlineJavaScriptRule"
@@ -60,8 +60,8 @@ Avoid inline JavaScript. Import .js files instead.
         <priority>2</priority>
     </rule>
 
-    <rule language="vm"
-          name="NoInlineStyles"
+    <rule name="NoInlineStyles"
+          language="vm"
           since="5.1"
           message="Avoid inline styles"
           class="net.sourceforge.pmd.lang.rule.XPathRule"

--- a/pmd-vm/src/main/resources/category/vm/errorprone.xml
+++ b/pmd-vm/src/main/resources/category/vm/errorprone.xml
@@ -9,7 +9,8 @@
 Rules to detect constructs that are either broken, extremely confusing or prone to runtime errors.
     </description>
 
-    <rule name="EmptyForeachStmt"
+    <rule language="vm"
+          name="EmptyForeachStmt"
           since="5.1"
           message="Avoid empty foreach loops"
           class="net.sourceforge.pmd.lang.vm.rule.errorprone.EmptyForeachStmtRule"
@@ -20,7 +21,8 @@ Empty foreach statements should be deleted.
         <priority>2</priority>
     </rule>
 
-    <rule name="EmptyIfStmt"
+    <rule language="vm"
+          name="EmptyIfStmt"
           since="5.1"
           message="Avoid empty if statements"
           class="net.sourceforge.pmd.lang.vm.rule.errorprone.EmptyIfStmtRule"

--- a/pmd-vm/src/main/resources/category/vm/errorprone.xml
+++ b/pmd-vm/src/main/resources/category/vm/errorprone.xml
@@ -9,8 +9,8 @@
 Rules to detect constructs that are either broken, extremely confusing or prone to runtime errors.
     </description>
 
-    <rule language="vm"
-          name="EmptyForeachStmt"
+    <rule name="EmptyForeachStmt"
+          language="vm"
           since="5.1"
           message="Avoid empty foreach loops"
           class="net.sourceforge.pmd.lang.vm.rule.errorprone.EmptyForeachStmtRule"
@@ -21,8 +21,8 @@ Empty foreach statements should be deleted.
         <priority>2</priority>
     </rule>
 
-    <rule language="vm"
-          name="EmptyIfStmt"
+    <rule name="EmptyIfStmt"
+          language="vm"
           since="5.1"
           message="Avoid empty if statements"
           class="net.sourceforge.pmd.lang.vm.rule.errorprone.EmptyIfStmtRule"


### PR DESCRIPTION
## Describe the PR

Deprecate the practice of setting a rule's language in java rather than in the XML.

This also avoids parsing rulesets multiple times, otherwise the warning may be repeated. I do this simply by caching parsed rulesets in a RulesetFactory. Is this enough? I'm not sure 

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes item 1 of #2612 
- Fixes #724

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

