### PR TITLE
[java] New rule: UnusedAssignment

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotation.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotation.java
@@ -26,7 +26,7 @@ import net.sourceforge.pmd.annotation.InternalApi;
 public class ASTAnnotation extends AbstractJavaTypeNode {
 
     private static final List<String> UNUSED_RULES
-        = Arrays.asList("UnusedPrivateField", "UnusedLocalVariable", "UnusedPrivateMethod", "UnusedFormalParameter");
+        = Arrays.asList("UnusedPrivateField", "UnusedLocalVariable", "UnusedPrivateMethod", "UnusedFormalParameter", "UnusedAssignment");
 
     private static final List<String> SERIAL_RULES = Arrays.asList("BeanMembersShouldSerialize", "MissingSerialVersionUID");
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTConditionalExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTConditionalExpression.java
@@ -74,7 +74,7 @@ public class ASTConditionalExpression extends AbstractJavaTypeNode {
      * Returns the node that represents the guard of this conditional.
      * That is the expression before the '?'.
      */
-    public Node getCondition() {
+    public JavaNode getCondition() {
         return getChild(0);
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTryStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTryStatement.java
@@ -49,7 +49,7 @@ public class ASTTryStatement extends AbstractJavaNode {
      * Returns the body of this try statement.
      */
     public ASTBlock getBody() {
-        return (ASTBlock) getChild(1);
+        return (ASTBlock) getFirstChildOfType(ASTBlock.class);
     }
 
     /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedAssignmentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedAssignmentRule.java
@@ -1,0 +1,235 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone;
+
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import net.sourceforge.pmd.lang.java.ast.ASTAssignmentOperator;
+import net.sourceforge.pmd.lang.java.ast.ASTBlock;
+import net.sourceforge.pmd.lang.java.ast.ASTExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTName;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
+import net.sourceforge.pmd.lang.java.ast.ASTStatementExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableInitializer;
+import net.sourceforge.pmd.lang.java.ast.JavaNode;
+import net.sourceforge.pmd.lang.java.ast.JavaParserVisitorAdapter;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
+import net.sourceforge.pmd.lang.java.rule.errorprone.UnusedAssignmentRule.LivenessVisitor.ScopeData;
+import net.sourceforge.pmd.lang.java.rule.errorprone.UnusedAssignmentRule.LivenessVisitor.ScopeData.AssignmentEntry;
+import net.sourceforge.pmd.lang.java.symboltable.ClassScope;
+import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
+import net.sourceforge.pmd.lang.symboltable.Scope;
+
+public class UnusedAssignmentRule extends AbstractJavaRule {
+
+
+    @Override
+    public Object visit(ASTMethodDeclaration node, Object data) {
+
+        ScopeData bodyData = new ScopeData();
+
+        //        for (ASTFormalParameter param : node.getFormalParameters()) {
+        //            bodyData.varsThatMustBeUsed.add(param.getVariableDeclaratorId().getNameDeclaration());
+        //        }
+
+        ScopeData endData = (ScopeData) node.getBody().jjtAccept(new LivenessVisitor(), bodyData);
+
+        if (endData.usedAssignments.size() < endData.allAssignments.size()) {
+            HashSet<AssignmentEntry> unused = new HashSet<>(endData.allAssignments);
+            unused.removeAll(endData.usedAssignments);
+            // allAssignments is the unused assignments now
+
+            for (AssignmentEntry entry : unused) {
+                addViolationWithMessage(data, entry.rhs, "The value assigned to variable ''{0}'' is never used", new Object[] {entry.var.getImage()});
+            }
+        }
+        //        if (!endData.varsThatMustBeUsed.isEmpty()) {
+        //            HashSet<VariableNameDeclaration> assignedVars = new HashSet<>();
+        //            for (AssignmentEntry assignment : endData.allAssignments) {
+        //                assignedVars.add(assignment.var);
+        //            }
+
+        //            for (VariableNameDeclaration var : endData.varsThatMustBeUsed) {
+        //                if (assignedVars.contains(var)) {
+        //                    addViolationWithMessage(data, var.getNode(), "The variable ''{0}'' is assigned, but never accessed", new Object[] {var.getImage()});
+        //                } else {
+        //                    addViolationWithMessage(data, var.getNode(), "The variable ''{0}'' is never used", new Object[] {var.getImage()});
+        //                }
+        //            }
+        //        }
+
+        return super.visit(node, data);
+    }
+
+    static class LivenessVisitor extends JavaParserVisitorAdapter {
+
+        void bar(int i) {
+            int j = 0;
+            int z = 0;
+            if (i < 10) {
+                j = i;
+            }
+        }
+
+        static class ScopeData {
+
+            final Set<VariableNameDeclaration> varsThatMustBeUsed = new HashSet<>();
+
+            final Set<AssignmentEntry> allAssignments = new HashSet<>();
+            final Set<AssignmentEntry> usedAssignments = new HashSet<>();
+
+            final Map<VariableNameDeclaration, List<AssignmentEntry>> liveAssignments = new HashMap<>();
+
+            static class AssignmentEntry {
+
+                final VariableNameDeclaration var;
+                final JavaNode rhs;
+
+                AssignmentEntry(VariableNameDeclaration var, JavaNode rhs) {
+                    this.var = var;
+                    this.rhs = rhs;
+                }
+            }
+
+            public void assign(VariableNameDeclaration var, JavaNode rhs) {
+                AssignmentEntry entry = new AssignmentEntry(var, rhs);
+                liveAssignments.put(var, Collections.singletonList(entry)); // kills the previous value
+                allAssignments.add(entry);
+            }
+
+            public void use(VariableNameDeclaration var) {
+                List<AssignmentEntry> live = liveAssignments.get(var);
+                // may be null for implicit assignments, like method parameter
+                if (live != null) {
+                    usedAssignments.addAll(live);
+                }
+            }
+        }
+
+
+        @Override
+        public Object visit(ASTBlock node, Object data) {
+
+            for (JavaNode child : node.children()) {
+                // each statement's output is passed as input to the next
+                data = child.jjtAccept(this, data);
+            }
+
+            return data;
+        }
+
+        @Override
+        public Object visit(ASTVariableDeclarator node, Object data) {
+            VariableNameDeclaration var = node.getVariableId().getNameDeclaration();
+            ASTVariableInitializer rhs = node.getInitializer();
+            if (rhs != null) {
+                rhs.jjtAccept(this, data);
+                ((ScopeData) data).assign(var, rhs);
+            }
+            return data;
+        }
+
+        @Override
+        public Object visit(ASTExpression node, Object data) {
+            return checkAssignment(node, data);
+        }
+
+        @Override
+        public Object visit(ASTStatementExpression node, Object data) {
+            return checkAssignment(node, data);
+        }
+
+        public Object checkAssignment(JavaNode node, Object data) {
+            if (node.getNumChildren() == 3) {
+                // assignment
+                assert node.getChild(1) instanceof ASTAssignmentOperator;
+
+                // visit the rhs as it is evaluated before
+                ASTExpression rhs = (ASTExpression) node.getChild(2);
+                rhs.jjtAccept(this, data);
+
+                VariableNameDeclaration lhsVar = getLhsVar(node.getChild(0), true);
+                if (lhsVar != null) {
+                    ((ScopeData) data).assign(lhsVar, rhs);
+                } else {
+                    node.getChild(0).jjtAccept(this, data);
+                }
+                return data;
+            } else {
+                return super.visit(node, data);
+            }
+        }
+
+        @Override
+        public Object visit(ASTPrimaryExpression node, Object data) {
+            super.visit(node, data); // visit subexpressions
+
+            VariableNameDeclaration var = getLhsVar(node, false);
+            if (var != null) {
+                ((ScopeData) data).use(var);
+            }
+            return data;
+        }
+
+        private VariableNameDeclaration getLhsVar(JavaNode primary, boolean inLhs) {
+            if (primary instanceof ASTPrimaryExpression) {
+                ASTPrimaryPrefix prefix = (ASTPrimaryPrefix) primary.getChild(0);
+
+                if (prefix.usesThisModifier()) {
+                    if (primary.getNumChildren() != 2 && inLhs) {
+                        return null;
+                    }
+                    ASTPrimarySuffix suffix = (ASTPrimarySuffix) primary.getChild(1);
+                    if (suffix.isArguments() || suffix.isArrayDereference()) {
+                        return null;
+                    }
+                    return findVar(primary.getScope(), true, suffix.getImage());
+                } else {
+                    if (inLhs && primary.getNumChildren() > 1) {
+                        return null;
+                    }
+
+                    if (prefix.getChild(0) instanceof ASTName) {
+                        return findVar(prefix.getScope(), false, prefix.getChild(0).getImage());
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private VariableNameDeclaration findVar(Scope scope, boolean isThis, String name) {
+            if (name == null) {
+                return null;
+            }
+            if (isThis) {
+                scope = scope.getEnclosingScope(ClassScope.class);
+            }
+
+            while (scope != null) {
+                for (VariableNameDeclaration decl : scope.getDeclarations(VariableNameDeclaration.class).keySet()) {
+                    if (decl.getImage().equals(name)) {
+                        return decl;
+                    }
+                }
+
+                scope = scope.getParent();
+            }
+
+            return null;
+        }
+    }
+
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedAssignmentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedAssignmentRule.java
@@ -81,7 +81,7 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
            * labels on arbitrary statements
            * foreach var should be reassigned from one iter to another
            * test local class/anonymous class
-           * test this.field in ctors
+           * explicit ctor call (hard to impossible without type res)
 
         DONE
            * conditionals
@@ -92,6 +92,7 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
            * lambdas
            * constructors + initializers
            * anon class
+           * test this.field in ctors
 
 
      */
@@ -320,6 +321,12 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
                 // this is the normal finally
                 finalState = acceptOpt(finallyClause, finalState);
             }
+
+            // In the 7.0 grammar, the resources should be explicitly
+            // used here. For now they don't trigger anything as their
+            // node is not a VariableDeclaratorId. There's a test to
+            // check that.
+
             return finalState;
         }
 
@@ -964,6 +971,9 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
     static class AssignmentEntry {
 
         final VariableNameDeclaration var;
+
+        // this is not necessarily an expression, it may be also the
+        // variable declarator of a foreach loop
         final JavaNode rhs;
 
         AssignmentEntry(VariableNameDeclaration var, JavaNode rhs) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedAssignmentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedAssignmentRule.java
@@ -15,6 +15,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import net.sourceforge.pmd.lang.java.ast.ASTAssignmentOperator;
+import net.sourceforge.pmd.lang.java.ast.ASTBreakStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
@@ -128,6 +129,12 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
         }
 
         @Override
+        public Object visit(ASTBreakStatement node, Object data) {
+            data = super.visit(node, data);
+            return ((ScopeData) data).abruptCompletion();
+        }
+
+        @Override
         public Object visit(ASTReturnStatement node, Object data) {
             data = super.visit(node, data);
             return ((ScopeData) data).abruptCompletion();
@@ -169,6 +176,11 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
 
                 VariableNameDeclaration lhsVar = getLhsVar(node.getChild(0), true);
                 if (lhsVar != null) {
+                    if (node.getChild(1).getImage().length() >= 2) {
+                        // compound assignment, to use BEFORE assigning
+                        ((ScopeData) data).use(lhsVar);
+                    }
+
                     ((ScopeData) data).assign(lhsVar, rhs);
                 } else {
                     node.getChild(0).jjtAccept(this, data);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedAssignmentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedAssignmentRule.java
@@ -63,12 +63,10 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
 
     @Override
     public Object visit(ASTMethodDeclaration node, Object data) {
+        // This analysis can be used to check for unused variables easily
+        // See reverted commit somewhere in the PR
 
         ScopeData bodyData = new ScopeData();
-
-        //        for (ASTFormalParameter param : node.getFormalParameters()) {
-        //            bodyData.varsThatMustBeUsed.add(param.getVariableDeclaratorId().getNameDeclaration());
-        //        }
 
         ScopeData endData = (ScopeData) node.getBody().jjtAccept(new LivenessVisitor(), bodyData);
 
@@ -81,20 +79,6 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
                 addViolationWithMessage(data, entry.rhs, "The value assigned to variable ''{0}'' is never used", new Object[] {entry.var.getImage()});
             }
         }
-        //        if (!endData.varsThatMustBeUsed.isEmpty()) {
-        //            HashSet<VariableNameDeclaration> assignedVars = new HashSet<>();
-        //            for (AssignmentEntry assignment : endData.allAssignments) {
-        //                assignedVars.add(assignment.var);
-        //            }
-
-        //            for (VariableNameDeclaration var : endData.varsThatMustBeUsed) {
-        //                if (assignedVars.contains(var)) {
-        //                    addViolationWithMessage(data, var.getNode(), "The variable ''{0}'' is assigned, but never accessed", new Object[] {var.getImage()});
-        //                } else {
-        //                    addViolationWithMessage(data, var.getNode(), "The variable ''{0}'' is never used", new Object[] {var.getImage()});
-        //                }
-        //            }
-        //        }
 
         return super.visit(node, data);
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedAssignmentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedAssignmentRule.java
@@ -74,6 +74,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTYieldStatement;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.ast.JavaParserVisitorAdapter;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
+import net.sourceforge.pmd.lang.java.rule.codestyle.ConfusingTernaryRule;
 import net.sourceforge.pmd.lang.java.symboltable.ClassScope;
 import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
 import net.sourceforge.pmd.lang.symboltable.Scope;
@@ -104,7 +105,6 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
            * explicit ctor call (hard to impossible without type res,
              or at least proper graph algorithms like toposort)
                 -> this is pretty invisible as it causes false negatives, not FPs
-           * shortcut conditionals have their own control-flow
            * test ternary expr
 
         DONE
@@ -119,6 +119,8 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
            * test this.field in ctors
            * foreach var should be reassigned from one iter to another
            * test local class/anonymous class
+           * shortcut conditionals have their own control-flow
+           * parenthesized expressions
 
      */
 
@@ -352,6 +354,8 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
         }
 
         private AlgoState linkConditional(AlgoState before, JavaNode condition, AlgoState thenState, AlgoState elseState, boolean isTopLevel) {
+            condition = ConfusingTernaryRule.unwrapParentheses(condition);
+
             if (condition instanceof ASTConditionalOrExpression) {
                 return visitShortcutOrExpr(condition, before, thenState, elseState);
             } else if (condition instanceof ASTConditionalAndExpression) {
@@ -368,7 +372,6 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
                 }
                 return state;
             }
-            // TODO parenthesized expression
         }
 
         AlgoState visitShortcutOrExpr(JavaNode orExpr,

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedAssignmentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedAssignmentRule.java
@@ -127,6 +127,7 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
                         // assignments to fields don't really go out of scope
                         continue;
                     }
+                    // This is a "DU" anomaly, the others are "DD"
                     addViolation(ruleCtx, entry.rhs, new Object[] {entry.var.getImage(), "goes out of scope"});
                 } else if (killers.size() == 1) {
                     AssignmentEntry k = killers.iterator().next();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/VariableNameDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/VariableNameDeclaration.java
@@ -141,12 +141,12 @@ public class VariableNameDeclaration extends AbstractNameDeclaration implements 
             return false;
         }
         VariableNameDeclaration n = (VariableNameDeclaration) o;
-        return n.node.getImage().equals(node.getImage());
+        return n.node.equals(this.node);
     }
 
     @Override
     public int hashCode() {
-        return node.getImage().hashCode();
+        return node.hashCode();
     }
 
     @Override

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -3280,17 +3280,79 @@ public String convert(int x) {
     <rule name="UnusedAssignment"
           language="java"
           since="6.26.0"
-          message="The value assigned to variable ''{0}'' is never used ({1})"
+          message="The value assigned to this variable is never used or always overwritten"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.UnusedAssignmentRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#unusedassignment">
         <description>
-            TODO
+            Reports assignments to variables that are never used before the variable is overwritten,
+            or goes out of scope. Unused assignments are those for which
+            1. The variable is never read after the assignment, or
+            2. The assigned value is always overwritten by other assignments before the next read of
+            the variable.
+
+            The rule doesn't consider assignments to fields except for those of `this` in a constructor,
+            or static fields of the current class in static initializers.
+
+            The rule may be suppressed with the standard `@SuppressWarnings("unused")` tag.
         </description>
         <priority>3</priority>
         <example>
         <![CDATA[
-            // TODO
+            class A {
+                // this field initializer is redundant,
+                // it is always overwritten in the constructor
+                int f = 1;
+
+                A(int f) {
+                    this.f = f;
+                }
+            }
         ]]>
+        </example>
+        <example><![CDATA[
+class B {
+
+    int method(int i, int j) {
+        // this initializer is redundant,
+        // it is overwritten in all branches of the `if`
+        int k = 0;
+
+        // Both the assignments to k are unused, because k is
+        // not read after the if/else
+        // This may hide a bug: the programmer probably wanted to return k
+        if (i < j)
+            k = i;
+        else
+            k = j;
+
+        return j;
+    }
+
+}
+        ]]>
+
+        </example>
+        <example><![CDATA[
+class C {
+
+    int method() {
+        int i = 0;
+
+        checkSomething(++i);
+        checkSomething(++i);
+        checkSomething(++i);
+        checkSomething(++i);
+
+        // That last increment is not reported unless
+        // the property `checkUnusedPrefixIncrement` is
+        // set to `true`
+        // Technically it could be written (i+1), but it
+        // is not very important
+    }
+
+}
+        ]]>
+
         </example>
     </rule>
 

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -3280,7 +3280,7 @@ public String convert(int x) {
     <rule name="UnusedAssignment"
           language="java"
           since="6.26.0"
-          message="The value assigned to variable ''{0}'' is never used"
+          message="The value assigned to variable ''{0}'' is never used ({1})"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.UnusedAssignmentRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#unusedassignment">
         <description>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -3276,6 +3276,25 @@ public String convert(int x) {
         </example>
     </rule>
 
+
+    <rule name="UnusedAssignment"
+          language="java"
+          since="6.26.0"
+          message="The value assigned to variable ''{0}'' is never used"
+          class="net.sourceforge.pmd.lang.java.rule.errorprone.UnusedAssignmentRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#unusedassignment">
+        <description>
+            TODO
+        </description>
+        <priority>3</priority>
+        <example>
+        <![CDATA[
+            // TODO
+        ]]>
+        </example>
+    </rule>
+
+
     <rule name="UnusedNullCheckInEquals"
           language="java"
           since="3.5"

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedAssignmentTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnusedAssignmentTest.java
@@ -1,0 +1,11 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone;
+
+import net.sourceforge.pmd.testframework.PmdRuleTst;
+
+public class UnusedAssignmentTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -2220,5 +2220,226 @@ class Foo {
         ]]></code>
     </test-code>
 
+    <test-code>
+        <description>DU anomaly false positive? #1304</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            import static org.apache.commons.lang3.StringUtils.trimToNull;
+
+            public class DummyService {
+
+                public boolean dummyMethod(final String stringValue, final Set<String> dummySet) {
+                    final String trimmedValue = trimToNull(stringValue);
+                    return dummySet.stream()
+                                   .noneMatch(value -> value.equalsIgnoreCase(trimmedValue));
+                }
+
+            }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>DataflowAnomalyAnalysis DU false positive #399</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class Test {
+                public int indexOf(Object obj) {
+                    // throws ClassCastException
+                    Integer dig = (Integer)obj;
+                    if (dig != 0 && dig != 1) {
+                        return -1;
+                    }
+                    // throws IllegalArgumentException and NullPointerException
+                    boolean cand = int2bool(dig);//<cand
+                    for(int i = 0; i < this.size; i++) {
+                        if (cand == this.digits[i]) {
+                            return i;
+                        }
+                    }
+                    return -1;
+                }
+            }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>DataflowAnomalyAnalysis: DD false positive #400</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class Test {
+                public T addS(List<T> args) {
+                    T res = zeroS();//<res
+                    for (T arg : args) {
+                        res = res.add(arg);
+                    }
+
+                    return res;
+                }
+            }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>DU Anomaly #1107</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class Sample {
+
+                private static final LocalTime ONE_PAST_MIDNIGHT = MIDNIGHT.plusMinutes(1);
+
+                public ZonedDateTime sample(final String date, final ZonedDateTime paymentTimeStamp) {
+                    final ZonedDateTime startOfDayOnInceptionDate = zonedDateTimeAtOnePastMidnight(date, paymentTimeStamp.getZone());
+                    final ZonedDateTime startOfDayOnPaymentDate = zonedDateTimeAtOnePastMidnight(paymentTimeStamp.toLocalDate(), paymentTimeStamp.getZone());
+                    if (startOfDayOnInceptionDate.isAfter(paymentTimeStamp)) {
+                        return startOfDayOnInceptionDate;
+                    } else if (paymentTimeStamp.isAfter(startOfDayOnPaymentDate)) {
+                        return paymentTimeStamp;
+                    } else {
+                        return startOfDayOnPaymentDate;
+                    }
+                }
+
+                public ZonedDateTime zonedDateTimeAtOnePastMidnight(final String date, final ZoneId zoneId) {
+                    return zonedDateTimeAtOnePastMidnight(parseStringWithIsoDateFormat(date), zoneId);
+                }
+
+                private ZonedDateTime zonedDateTimeAtOnePastMidnight(final LocalDate localDate, final ZoneId zoneId) {
+                    return ZonedDateTime.of(localDate, ONE_PAST_MIDNIGHT, zoneId);
+                }
+            }
+
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>DataflowAnomalyAnalysis: DD false positive for arrays #1251</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class Test {
+                public void test() {
+                    final BigInteger[] msg2 = new BigInteger[11];
+                    msg2[0] = G1.modPow(x2, OtrCryptoEngine.MODULUS);
+                    BigInteger[] res = proofKnowLog(x2, 3);
+                    msg2[1] = res[0];
+                    msg2[2] = res[1];
+                    // etc.
+                }
+            }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>DU false positive in DataflowAnomalyAnalysis #1606</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public final class Fib {
+                /** utility class */
+                private Fib() {}
+
+                public static int fib(final int n) {
+                    Preconditions.checkArgument(n >= 0);
+
+                    if (n < 2) {
+                        return n;
+                    } else {
+                        int a = 0;
+                        int b = 1;
+                        final int m = n - 1;
+
+                        for (int i = 0; i < m; i++) {
+                            final int c = a;
+                            a = b;
+                            b = c + b;
+                        }
+
+                        return b;
+                    }
+                }
+            }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>false-positive in DD-part of DataflowAnomalyAnalysis #1675</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class Test {
+                public void test() {
+                    Formatter formatter = null;
+                    if (formatterClassName != null) {
+                        try {
+                            Class<? extends Formatter> formatterClass = findClass(formatterClassName);
+                            formatter = formatterClass.getDeclaredConstructor().newInstance();
+                        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InstantiationException | InvocationTargetException ignored) {
+                        }
+                    }
+                    setFormatter((formatter == null) ? new SimpleFormatter() : formatter);
+                }
+            }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>DU false positive in DataflowAnomalyAnalysis #1682</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class Test {
+                public void append(LogEvent event) {
+                    String logMessage = wrapIn.wrap(new String(getLayout().toByteArray(event), getLayout().getCharset()));
+                    DiscordManager discordManager = findDiscordManager();
+                    if (discordManager == null) {
+                        bufferMessage(logMessage, event.getTimeMillis());
+                    } else {
+                        bufferedMessagesByAppenderName.computeIfPresent(getName(), (name, bufferedMessages) -> {
+                            bufferedMessages.forEach(bufferedMessage -> sendMessage(discordManager, bufferedMessage));
+                            return null;
+                        });
+                        sendMessage(discordManager, logMessage);
+                    }
+                }
+            }
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>DataflowAnomalyAnalysis has false positive for object initialised outside loop. #2131</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            package pmdtests;
+
+            import java.util.ArrayList;
+            import java.util.List;
+            import java.util.stream.Collectors;
+            import java.util.stream.IntStream;
+
+            public class TestDu {
+
+                private List<String> list = new ArrayList<>();
+
+                public void run() {
+                    String str = Thread.currentThread().getName() + " Element : %d";
+                    for (int i = 0; i < 10_000; i++) {
+                        list.add(String.format(str, i));
+                    }
+                }
+
+                public void runAgain() {
+                    String str = Thread.currentThread().getName() + " Element : %d";
+                    for (int i = 0; i < 10_000; i++)
+                        list.add(String.format(str, i));
+                }
+
+                public void runOnceMore() {
+                    String str = Thread.currentThread().getName() + " Element : %d";
+                    list =  IntStream.range(0, 10_000)
+                                     .mapToObj(i -> String.format(str, i))
+                                     .collect(Collectors.toList());
+                }
+            }
+        ]]></code>
+    </test-code>
+
 
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -1099,11 +1099,7 @@ public class Foo {
 
     <test-code>
         <description>Try/catch finally</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>4</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'a' is never used (overwritten on lines 6 and 8)</message>
-        </expected-messages>
+        <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
 
@@ -1170,6 +1166,41 @@ class Foo {
         return a;
     }
 
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Abstract method NPE</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+
+abstract class Foo {
+
+    public abstract int foo();
+
+    interface Bar {
+        int bar();
+    }
+
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>FP in finally</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+
+class Foo {
+    public Object intercept(Object proxy) throws Throwable {
+        Object oldProxy = null; // FP here
+        try {
+            oldProxy = new Object[] { proxy };
+            return null;
+        }
+        finally {
+            System.out.println(oldProxy);
+        }
+    }
 }
         ]]></code>
     </test-code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -2124,23 +2124,48 @@ class Foo {
             <message>The initializer for variable 'i' is never used (overwritten on line 7)</message>
         </expected-messages>
         <code><![CDATA[
-class Foo {
+            class Foo {
 
-  void main(int[] bufline, int start, int bufsize) {
+              void main(int[] bufline, int start, int bufsize) {
 
-    int i = 0, j, k = 0;
+                int i = 0, j, k = 0;
 
-    if (  (i = 2) < (j = i)
-       && (j = k) == i       ) {
+                if (  (i = 2) < (j = i)
+                   && (j = k) == i       ) {
 
-        // reaching: i = 2, j = k  (not j = i)
-    } else {
-        // reaching: i = 2, j = k, j = i
-        log(j);
-    }
-  }
-}
+                    // reaching: i = 2, j = k  (not j = i)
+                } else {
+                    // reaching: i = 2, j = k, j = i
+                    log(j);
+                }
+              }
+            }
 
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>FP with argument</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>The initializer for variable 'i' is never used (overwritten on line 7)</message>
+        </expected-messages>
+        <code><![CDATA[
+            class Foo {
+
+                static String replaceBackslash(String str) {
+                    int i = 0, len = str.length();
+                    char c;
+                    StringBuffer b = new StringBuffer();
+                    for (i = 0; i < len; i++)
+                        if ((c = str.charAt(i)) == '\\')
+                            b.append("\\\\");
+                        else
+                            b.append(c);
+
+                    return b.toString();
+                }
+            }
         ]]></code>
     </test-code>
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -1794,4 +1794,83 @@ public class Foo {
     </test-code>
 
 
+    <test-code>
+        <description>Post-increment behavior</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'i' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        int i=0;
+        i++;
+        i++;
+    }
+}
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Post-increment behavior 2</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'i' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        int i=0;
+        i++;
+        i++;
+        foo(i++);
+    }
+}
+        ]]></code>
+    </test-code>
+
+
+
+    <test-code>
+        <description>Pre-increment behavior</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'i' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        int i=0;
+        ++i;
+        ++i;
+    }
+}
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Pre-increment behavior 2</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'i' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        int i=0;
+        ++i;
+        ++i;
+        foo(++i);
+    }
+}
+        ]]></code>
+    </test-code>
+
+
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -324,13 +324,9 @@ class Test{
         ]]></code>
     </test-code>
 
-    <test-code regressionTest="false">
-        <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 3. DU-Anomaly(a)</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>5</expected-linenumbers>
-        <expected-messages>
-            <message>Found 'DU'-anomaly for variable 'a' (lines '5'-'7').</message>
-        </expected-messages>
+    <test-code>
+        <description>Foreach</description>
+        <expected-problems>0</expected-problems>
         <code><![CDATA[
 class Test{
     public static void main(String[] args){
@@ -459,6 +455,72 @@ class Test{
         ]]></code>
     </test-code>
 
+
+    <test-code>
+        <description>While loop with continue</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0;
+        int i = 0;
+        while (true) {
+            if (a >= 30) {
+                i = a + 1; // used by below
+                continue;
+            }
+            a = a + 3;
+            i = i + 1; // used by itself
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>While loop with continue 2</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0;
+        int i = 0;
+        while (a < 50) {
+            if (i >= 30) {
+                a = i + 1; // used by loop condition
+                continue;
+            }
+            i++; // used by itself
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>While loop with break (control for continue test above)</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'a' is never used</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0;
+        int i = 0;
+        while (a < 50) {
+            if (i >= 30) {
+                a = i + 1; // unused
+                break;
+            }
+            i++; // used by itself
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
     <test-code>
         <description>Do while 0</description>
         <expected-problems>0</expected-problems>
@@ -515,6 +577,29 @@ class Test{
                 i = 4;
                 a *= 5;
                 break;
+            }
+
+            a = i + 3;
+            i += 3;
+        } while (i < 30);
+   }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Do while with continue</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0;
+        int i = 0;
+        do {
+            if (a >= 20) {
+                i = 4;  // used by condition
+                a *= 5;
+                continue;
             }
 
             a = i + 3;

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -21,6 +21,10 @@
     <test-code>
         <description>DD anomaly</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'i' is never used</message>
+        </expected-messages>
         <code><![CDATA[
 public class Foo {
     void bar() {
@@ -58,8 +62,14 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>more komplex anomalysis</description>
-        <expected-problems>4</expected-problems>
+        <description>Conditional flow 0</description>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>3,4,6</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'j' is never used</message>
+            <message>The value assigned to variable 'z' is never used</message>
+            <message>The value assigned to variable 'j' is never used</message>
+        </expected-messages>
         <code><![CDATA[
 public class Foo {
     void bar(int i) {
@@ -68,6 +78,100 @@ public class Foo {
         if (i < 10) {
             j = i;
         }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Conditional flow 1</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'z' is never used</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    void bar(int i) {
+        int j = 0;
+        int z = 0; // unused
+        if (i < 10) {
+            j = i;
+        }
+        System.out.println(j);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Conditional flow 2</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'j' is never used</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    void bar(int i) {
+        int j = 0; // unused
+        int z = 0;
+        if (i < 10) {
+            j = i;
+        } else {
+            j = z;
+        }
+        System.out.println(j);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Conditional flow with abrupt throw</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,6</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'j' is never used</message>
+            <message>The value assigned to variable 'j' is never used</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    void bar(int i) {
+        int j = 0; // unused
+        int z = 0;
+        if (i < 10) {
+            j = i; // unused
+            throw new Exception();
+        } else {
+            j = z;
+        }
+        System.out.println(j);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Conditional flow with abrupt return</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,6</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'j' is never used</message>
+            <message>The value assigned to variable 'j' is never used</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    void bar(int i) {
+        int j = 0;  // unused
+        int z = 0;
+        if (i < 10) {
+            j = i;  // unused
+            return;
+        } else {
+            j = z;
+        }
+        System.out.println(j);
     }
 }
         ]]></code>
@@ -136,7 +240,7 @@ public class AssertTest {
         <expected-problems>1</expected-problems>
         <expected-linenumbers>6</expected-linenumbers>
         <expected-messages>
-            <message>Found 'DU'-anomaly for variable 'b' (lines '6'-'7').</message>
+            <message>The value assigned to variable 'b' is never used</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -152,11 +256,10 @@ class Test{
 
     <test-code>
         <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 2. DU-Anomaly(a)</description>
-        <expected-problems>2</expected-problems>
-        <expected-linenumbers>3,5</expected-linenumbers>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
         <expected-messages>
-            <message>Found 'DU'-anomaly for variable 'a' (lines '3'-'7').</message>
-            <message>Found 'DU'-anomaly for variable 'a' (lines '5'-'7').</message>
+            <message>The value assigned to variable 'a' is never used</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -191,11 +294,10 @@ class Test{
 
     <test-code>
         <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 4. DU-Anomaly(a)</description>
-        <expected-problems>2</expected-problems>
-        <expected-linenumbers>3,6</expected-linenumbers>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
         <expected-messages>
-            <message>Found 'DU'-anomaly for variable 'a' (lines '3'-'9').</message>
-            <message>Found 'DU'-anomaly for variable 'a' (lines '6'-'9').</message>
+            <message>The value assigned to variable 'a' is never used</message>
         </expected-messages>
         <code><![CDATA[
 class Test{

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -293,7 +293,7 @@ class Test{
     </test-code>
 
     <test-code>
-        <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 4. DU-Anomaly(a)</description>
+        <description>While loop 1</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 class Test{
@@ -304,6 +304,105 @@ class Test{
             a = a+3;
             i += 3;
         }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>While loop 2</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>4,7</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'i' is never used</message>
+            <message>The value assigned to variable 'i' is never used</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0;
+        int i = 0; // unused
+        while(a < 30){
+            a = a + 3;
+            i = 5; // unused (kills itself)
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>While loop with break</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'i' is never used</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0;
+        int i = 0;
+        while (true) {
+            if (a >= 30) {
+                i = a + 1; // unused
+                break;
+            }
+            a = a + 3;
+            i = i + 1; // used by itself
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>While loop without break (control case)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0;
+        int i = 0;
+        while (true) {
+            if (a >= 30) {
+                i = a + 1; // used by below
+                // break;  // no break here
+            }
+            a = a + 3;
+            i = i + 1; // used by itself
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>While loop with break 2</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>12</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'i' is never used</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0;
+        int i = 0; // used now
+
+        outer:
+        while (true) {
+            a += 2;
+
+            while (true) {
+                if (a >= 30) {
+                    i = i + 1; // used now
+                    break outer;
+                }
+                a = a + 3;
+                i = i + 2; // unused (kills itself)
+            }
+        }
+
+        System.out.println(i); // uses i = i + 1
     }
 }
         ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -4,19 +4,19 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
 
-<!--    <test-code>-->
-<!--        <description>ok</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--public class Foo {-->
-<!--    void bar(int b) {-->
-<!--        for (int i = 0; i < 10; i++) {-->
-<!--            throw new Exception();-->
-<!--        }-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
+    <test-code>
+        <description>ok</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void bar(int b) {
+        for (int i = 0; i < 10; i++) {
+            throw new Exception();
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 
     <test-code>
         <description>DD anomaly</description>
@@ -526,14 +526,14 @@ class Test{
     </test-code>
 
     <test-code>
-        <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 6. DU-Anomaly(a)</description>
+        <description>Switch statement 0</description>
         <expected-problems>4</expected-problems>
         <expected-linenumbers>6,8,10,12</expected-linenumbers>
         <expected-messages>
-            <message>Found 'DU'-anomaly for variable 'a' (lines '6'-'14').</message>
-            <message>Found 'DU'-anomaly for variable 'a' (lines '8'-'14').</message>
-            <message>Found 'DU'-anomaly for variable 'a' (lines '10'-'14').</message>
-            <message>Found 'DU'-anomaly for variable 'a' (lines '12'-'14').</message>
+            <message>The value assigned to variable 'a' is never used</message>
+            <message>The value assigned to variable 'a' is never used</message>
+            <message>The value assigned to variable 'a' is never used</message>
+            <message>The value assigned to variable 'a' is never used</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -547,7 +547,7 @@ class Test{
             break;
             case 3 : a = a+3;
             break;
-            default : a = a + 0;
+            default : a = a + 1;
         }
     }
 }
@@ -555,11 +555,85 @@ class Test{
     </test-code>
 
     <test-code>
-        <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 7. DU-Anomaly(a)</description>
+        <description>Switch statement 1</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        int i = 0 ;
+        switch(i){
+            case 1 : a = 1;
+            break;
+            case 2 : a = 2;
+            break;
+            case 3 : a = 3;
+            break;
+            default : a = a + 1;
+        }
+
+        System.out.println(a);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Switch statement 2</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        int i = 0 ;
+        switch(i){
+            case 1 : a = 1;
+                     if (args.length > 0) break; // else fallthrough
+            case 2 : a = 2; break;
+            case 3 : a = 3; break;
+            default : a = a + 1;
+        }
+
+        System.out.println(a);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Switch fallthrough</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'a' is never used</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        int i = 0 ;
+        switch(i){
+            case 1 : a = 1; // unused
+            // break; // no break
+            case 2 : a = 2;
+            break;
+            case 3 : a = 3;
+            break;
+            default : a = a + 1;
+        }
+
+        System.out.println(a);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Switch fallthrough 2</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>9</expected-linenumbers>
         <expected-messages>
-            <message>Found 'DU'-anomaly for variable 'a' (lines '9'-'11').</message>
+            <message>The value assigned to variable 'a' is never used</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -570,8 +644,56 @@ class Test{
             case 1 : a = a+1;
             case 2 : a = a+2;
             case 3 : a = a+3;
-            default : a = a + 0;
+            default : a = a + 0; // this one
         }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Switch non-fallthrough</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        int i = 0 ;
+        switch(i) {
+            case 1 -> a = 1;
+            case 2 -> a = 2;
+            case 3 -> a = 3;
+            default -> a = a + 1;
+        }
+        System.out.println(a);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Switch expr non-fallthrough</description>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>6,7,8,9</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'a' is never used</message>
+            <message>The value assigned to variable 'a' is never used</message>
+            <message>The value assigned to variable 'a' is never used</message>
+            <message>The value assigned to variable 'a' is never used</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        a = switch(i) { // this is used
+            // all those are unused
+            case 1 -> a = 1;
+            case 2 -> a = 2;
+            case 3 -> a = 3;
+            default -> a = a + 1;
+        };
+
+        System.out.println(a);
     }
 }
         ]]></code>
@@ -681,9 +803,6 @@ public class Test {
     public void test(){
         int a = 0;
         a = a + 3;
-
-        int i = 0;
-        i += 3; // same with compound
     }
 }
         ]]></code>
@@ -706,7 +825,7 @@ public class Test {
     </test-code>
     <test-code>
         <description>Another case</description>
-        <expected-problems>1</expected-problems>
+        <expected-problems>2</expected-problems>
         <expected-linenumbers>3,5</expected-linenumbers>
         <expected-messages>
             <message>The value assigned to variable 'iter' is never used</message>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -294,16 +294,12 @@ class Test{
 
     <test-code>
         <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 4. DU-Anomaly(a)</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>6</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'a' is never used</message>
-        </expected-messages>
+        <expected-problems>0</expected-problems>
         <code><![CDATA[
 class Test{
     public static void main(String[] args){
-        int a = 0 ;
-        int i = 0 ;
+        int a = 0;
+        int i = 0;
         while(i < 30){
             a = a+3;
             i += 3;

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -757,6 +757,36 @@ class Test{
     </test-code>
 
     <test-code>
+        <description>Switch non-fallthrough blocks</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>9</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'i' is never used</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        int i = 0 ;
+        switch(i) {
+            case 1 -> a = 1;
+            case 2 -> {
+                if (args.length > 0) {
+                    i = 4;
+                    break;
+                }
+                a = 2;
+            }
+            case 3 -> a = 3;
+            default -> a = a + 1;
+        }
+        System.out.println(a);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>Switch expr non-fallthrough</description>
         <expected-problems>4</expected-problems>
         <expected-linenumbers>6,7,8,9</expected-linenumbers>
@@ -774,6 +804,39 @@ class Test{
             // all those are unused
             case 1 -> a = 1;
             case 2 -> a = 2;
+            case 3 -> a = 3;
+            default -> a = a + 1;
+        };
+
+        System.out.println(a);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Switch expr with yield</description>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>6,9,13,14</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'a' is never used</message>
+            <message>The value assigned to variable 'a' is never used</message>
+            <message>The value assigned to variable 'a' is never used</message>
+            <message>The value assigned to variable 'a' is never used</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        a = switch(i) { // this is used
+            // all those are unused
+            case 1 -> a = 1;
+            case 2 -> {
+                if (a > 0) {
+                    yield a++;
+                }
+                yield 4;
+            }
             case 3 -> a = 3;
             default -> a = a + 1;
         };

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -894,7 +894,7 @@ class Test{
         <expected-linenumbers>6,9,13,14</expected-linenumbers>
         <expected-messages>
             <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
-            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
+            <message>The updated value of variable 'a' is never used (overwritten on line 4)</message>
             <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
             <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
         </expected-messages>
@@ -1799,7 +1799,7 @@ public class Foo {
         <expected-problems>1</expected-problems>
         <expected-linenumbers>5</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'i' is never used (goes out of scope)</message>
+            <message>The updated value of variable 'i' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
 public class Foo {
@@ -1818,7 +1818,7 @@ public class Foo {
         <expected-problems>1</expected-problems>
         <expected-linenumbers>6</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'i' is never used (goes out of scope)</message>
+            <message>The updated value of variable 'i' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
 public class Foo {
@@ -1839,7 +1839,26 @@ public class Foo {
         <expected-problems>1</expected-problems>
         <expected-linenumbers>5</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'i' is never used (goes out of scope)</message>
+            <message>The updated value of variable 'i' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        int i=0;
+        ++i;
+        ++i;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Pre-increment behavior</description>
+        <rule-property name="checkUnusedPrefixIncrement">true</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <expected-messages>
+            <message>The updated value of variable 'i' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
 public class Foo {
@@ -1855,10 +1874,27 @@ public class Foo {
 
     <test-code>
         <description>Pre-increment behavior 2</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        int i=0;
+        ++i;
+        ++i;
+        foo(++i);
+    }
+}
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Pre-increment behavior 2</description>
+        <rule-property name="checkUnusedPrefixIncrement">true</rule-property>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>6</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'i' is never used (goes out of scope)</message>
+            <message>The updated value of variable 'i' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
 public class Foo {
@@ -1867,6 +1903,26 @@ public class Foo {
         ++i;
         ++i;
         foo(++i);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Pre-increment behavior 2</description>
+        <rule-property name="checkUnusedPrefixIncrement">true</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <expected-messages>
+            <message>The updated value of variable 'i' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        int i=0;
+        --i;
+        --i;
+        foo(--i);
     }
 }
         ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -1929,4 +1929,54 @@ public class Foo {
     </test-code>
 
 
+    <test-code>
+        <description>Test local class</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>4,6</expected-linenumbers>
+        <expected-messages>
+            <message>The initializer for variable 'shadowed' is never used (goes out of scope)</message>
+            <message>The field initializer for 'f' is never used (overwritten on line 8)</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        int captured = 0;
+        int shadowed = 2;
+        class Local {
+            int f = captured;
+            Local(int shadowed) {
+                f = shadowed;
+            }
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Test anonymous class</description>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>4,5,6</expected-linenumbers>
+        <expected-messages>
+            <message>The initializer for variable 'shadowed' is never used (overwritten on line 5)</message>
+            <message>The value assigned to variable 'shadowed' is never used (goes out of scope)</message>
+            <message>The field initializer for 'f' is never used (overwritten on line 8)</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        int captured = 0;
+        int shadowed = 2;
+        new Foo(shadowed = 4) {
+            int f = captured;
+            {
+                f = 2;
+            }
+        };
+    }
+}
+        ]]></code>
+    </test-code>
+
+
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -4,1344 +4,1408 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
 
-    <test-code>
-        <description>ok</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-public class Foo {
-    void bar(int b) {
-        for (int i = 0; i < 10; i++) {
-            throw new Exception();
-        }
-    }
-}
-        ]]></code>
-    </test-code>
+<!--    <test-code>-->
+<!--        <description>ok</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--public class Foo {-->
+<!--    void bar(int b) {-->
+<!--        for (int i = 0; i < 10; i++) {-->
+<!--            throw new Exception();-->
+<!--        }-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>DD anomaly</description>-->
+<!--        <expected-problems>1</expected-problems>-->
+<!--        <expected-linenumbers>3</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'i' is never used (overwritten on line 4)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--public class Foo {-->
+<!--    void bar() {-->
+<!--        int i=0;-->
+<!--        i=1;-->
+<!--        if (i==2) {}-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>DU anomaly</description>-->
+<!--        <expected-problems>1</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--public class Foo {-->
+<!--    void bar() {-->
+<!--        int i=0;-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>UR anomaly</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--public class Foo {-->
+<!--    void bar() {-->
+<!--        int i;-->
+<!--        if (i == 0) {}-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Conditional flow 0</description>-->
+<!--        <expected-problems>3</expected-problems>-->
+<!--        <expected-linenumbers>3,4,6</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'j' is never used (overwritten on line 6)</message>-->
+<!--            <message>The value assigned to variable 'z' is never used (goes out of scope)</message>-->
+<!--            <message>The value assigned to variable 'j' is never used (goes out of scope)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--public class Foo {-->
+<!--    void bar(int i) {-->
+<!--        int j = 0;-->
+<!--        int z = 0;-->
+<!--        if (i < 10) {-->
+<!--            j = i;-->
+<!--        }-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Conditional flow 1</description>-->
+<!--        <expected-problems>1</expected-problems>-->
+<!--        <expected-linenumbers>4</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'z' is never used (goes out of scope)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--public class Foo {-->
+<!--    void bar(int i) {-->
+<!--        int j = 0;-->
+<!--        int z = 0; // unused-->
+<!--        if (i < 10) {-->
+<!--            j = i;-->
+<!--        }-->
+<!--        System.out.println(j);-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Conditional flow 2</description>-->
+<!--        <expected-problems>1</expected-problems>-->
+<!--        <expected-linenumbers>3</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'j' is never used (overwritten on lines 6 and 8)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--public class Foo {-->
+<!--    void bar(int i) {-->
+<!--        int j = 0; // unused-->
+<!--        int z = 0;-->
+<!--        if (i < 10) {-->
+<!--            j = i;-->
+<!--        } else {-->
+<!--            j = z;-->
+<!--        }-->
+<!--        System.out.println(j);-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Conditional flow with abrupt throw</description>-->
+<!--        <expected-problems>2</expected-problems>-->
+<!--        <expected-linenumbers>3,6</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'j' is never used (overwritten on lines 6 and 9)</message>-->
+<!--            <message>The value assigned to variable 'j' is never used (goes out of scope)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--public class Foo {-->
+<!--    void bar(int i) {-->
+<!--        int j = 0; // unused-->
+<!--        int z = 0;-->
+<!--        if (i < 10) {-->
+<!--            j = i; // unused-->
+<!--            throw new Exception();-->
+<!--        } else {-->
+<!--            j = z;-->
+<!--        }-->
+<!--        System.out.println(j);-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Conditional flow with abrupt return</description>-->
+<!--        <expected-problems>2</expected-problems>-->
+<!--        <expected-linenumbers>3,6</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'j' is never used (overwritten on lines 6 and 9)</message>-->
+<!--            <message>The value assigned to variable 'j' is never used (goes out of scope)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--public class Foo {-->
+<!--    void bar(int i) {-->
+<!--        int j = 0;  // unused-->
+<!--        int z = 0;-->
+<!--        if (i < 10) {-->
+<!--            j = i;  // unused-->
+<!--            return;-->
+<!--        } else {-->
+<!--            j = z;-->
+<!--        }-->
+<!--        System.out.println(j);-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Local variable in loop</description>-->
+<!--        <expected-problems>2</expected-problems>-->
+<!--        <expected-linenumbers>10,19</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'fail' is never used (overwritten on line 19)</message>-->
+<!--            <message>The value assigned to variable 'fail' is never used (overwritten on line 19)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--public class LoopTest {-->
+<!--    public static void main(String[] args) {-->
+<!--        int[] a = {1,2,3};-->
+<!--        int[] b = {4,5,6};-->
+<!--        int[] c = {7,8,9};-->
+<!--        for (int i : a) {-->
+<!--            if (i == 0) {-->
+<!--                break;-->
+<!--            } else {-->
+<!--                boolean fail = false;-->
+<!--                for (int j : b) {-->
+<!--                    boolean match = false;-->
+<!--                    for (int k : c) {-->
+<!--                        if (k == 42) {-->
+<!--                            match = true;-->
+<!--                        }-->
+<!--                    }-->
+<!--                    if (!match) {-->
+<!--                        fail = true;-->
+<!--                    }-->
+<!--                }-->
+<!--            }-->
+<!--        }-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>#408 Assert statements causing </description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--public class AssertTest {-->
+<!--    public void test() {-->
+<!--        final String s = "";-->
+<!--        assert(s != null);-->
+
+<!--        System.out.println(s);-->
+
+<!--        final Double d = 9;-->
+<!--        assert(d != null);-->
+
+<!--        System.out.println(d);-->
+
+<!--        final String k = "k";-->
+<!--        assert(k != null);-->
+
+<!--        System.out.println(k);-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 1. DU-Anomaly(b)</description>-->
+<!--        <expected-problems>1</expected-problems>-->
+<!--        <expected-linenumbers>6</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'b' is never used (goes out of scope)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0 ;-->
+<!--        int b = 0 ;-->
+<!--        a = a + b ;-->
+<!--        b = a + b ;-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>For loop</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0 ;-->
+<!--        for(int i = 0 ; i <= 10; i ++){-->
+<!--            a = a+3;-->
+<!--        }-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>For loop 2</description>-->
+<!--        <expected-problems>2</expected-problems>-->
+<!--        <expected-linenumbers>3,5</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'a' is never used (overwritten on line 5)</message>-->
+<!--            &lt;!&ndash; Overwrites itself &ndash;&gt;-->
+<!--            <message>The value assigned to variable 'a' is never used (overwritten on line 5)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0 ;-->
+<!--        for(int i = 0 ; i <= 10; i ++){-->
+<!--            a = i * 3;-->
+<!--        }-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>For loop 3</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0 ;-->
+<!--        for(int i = 0 ; i <= 10; i ++){-->
+<!--            a = i * 3;-->
+<!--        }-->
+<!--        System.out.println(a);-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>For loop 4</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0 ;-->
+<!--        for(int i = 0 ; (i + a) <= 10; i ++){-->
+<!--            a = i * 3;-->
+<!--        }-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Foreach</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int[] b = new int[10];-->
+<!--        for(int a : b){-->
+<!--            a = a+3;-->
+<!--        }-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>While loop 1</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0;-->
+<!--        int i = 0;-->
+<!--        while (i < 30) {-->
+<!--            a = a + 3;-->
+<!--            i += 3;-->
+<!--        }-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>While loop 2</description>-->
+<!--        <expected-problems>2</expected-problems>-->
+<!--        <expected-linenumbers>4,7</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'i' is never used (overwritten on line 7)</message>-->
+<!--            <message>The value assigned to variable 'i' is never used (overwritten on line 7)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0;-->
+<!--        int i = 0; // unused-->
+<!--        while (a < 30) {-->
+<!--            a = a + 3;-->
+<!--            i = 5; // unused (kills itself)-->
+<!--        }-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+<!--    <test-code>-->
+<!--        <description>While loop with break</description>-->
+<!--        <expected-problems>1</expected-problems>-->
+<!--        <expected-linenumbers>7</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'i' is never used (goes out of scope)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0;-->
+<!--        int i = 0;-->
+<!--        while (true) {-->
+<!--            if (a >= 30) {-->
+<!--                i = a + 1; // unused-->
+<!--                break;-->
+<!--            }-->
+<!--            a = a + 3;-->
+<!--            i = i + 1; // used by itself-->
+<!--        }-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>While loop without break (control case)</description>-->
+<!--        <expected-problems>1</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0; // used by compound below-->
+<!--        int i = 0;-->
+<!--        while (true) {-->
+<!--            if (a >= 30) {-->
+<!--                i += a + 1; // unused by below-->
+<!--                // break;  // no break here-->
+<!--            }-->
+<!--            a = a + 3;-->
+<!--            i = a + 2; // used by above-->
+<!--        }-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>While loop without break 2 (control case)</description>-->
+<!--        <expected-problems>1</expected-problems>-->
+<!--        <expected-linenumbers>12</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'i' is never used (overwritten on line 16)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0;-->
+<!--        int i = 0; // unused now-->
+
+<!--        outer:-->
+<!--        while (true) {-->
+<!--            a += 2;-->
+
+<!--            while (true) {-->
+<!--                if (a >= 30) {-->
+<!--                    i += a + 1; // unused because of i = a + 2-->
+<!--                    // break outer;-->
+<!--                }-->
+<!--                a = a + 3;-->
+<!--                i = a + 2;  // killed by below-->
+<!--            }-->
+
+<!--            i = 2; // used by print-->
+<!--        }-->
+
+<!--        System.out.println(i); // uses i = i + 1-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>While loop without break 2 (control case)</description>-->
+<!--        <expected-problems>1</expected-problems>-->
+<!--        <expected-linenumbers>12</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'i' is never used (overwritten on line 19)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0;-->
+<!--        int i = 0; // unused now-->
+
+<!--        outer:-->
+<!--        while (true) {-->
+<!--            a += 2;-->
+
+<!--            while (true) {-->
+<!--                if (a >= 30) {-->
+<!--                    i += a + 1; // unused because of i = 2-->
+<!--                    break;-->
+<!--                }-->
+<!--                a = a + 3;-->
+<!--                i = a + 2;  // used by i += a + 1-->
+<!--            }-->
+
+<!--            i = 2; // used by print-->
+<!--        }-->
+
+<!--        System.out.println(i); // uses i = i + 1-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>While loop with named break 2</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0;-->
+<!--        int i = 0; // unused now-->
+
+<!--        outer:-->
+<!--        while (true) {-->
+<!--            a += 2;-->
+
+<!--            while (true) {-->
+<!--                if (a >= 30) {-->
+<!--                    i += a + 1; // used by print-->
+<!--                    break outer;-->
+<!--                }-->
+<!--                a = a + 3;-->
+<!--                i = a + 2;  // used by i += a + 1-->
+<!--            }-->
+
+<!--            i = 2; // used by print-->
+<!--        }-->
+
+<!--        System.out.println(i); // uses i = i + 1-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+
+<!--    <test-code>-->
+<!--        <description>While loop with continue</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0;-->
+<!--        int i = 0;-->
+<!--        while (true) {-->
+<!--            if (a >= 30) {-->
+<!--                i = a + 1; // used by below-->
+<!--                continue;-->
+<!--            }-->
+<!--            a = a + 3;-->
+<!--            i = i + 1; // used by itself-->
+<!--        }-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>While loop with continue 2</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0;-->
+<!--        int i = 0;-->
+<!--        while (a < 50) {-->
+<!--            if (i >= 30) {-->
+<!--                a = i + 1; // used by loop condition-->
+<!--                continue;-->
+<!--            }-->
+<!--            i++; // used by itself-->
+<!--        }-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>While loop with break (control for continue test above)</description>-->
+<!--        <expected-problems>1</expected-problems>-->
+<!--        <expected-linenumbers>7</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0;-->
+<!--        int i = 0;-->
+<!--        while (a < 50) {-->
+<!--            if (i >= 30) {-->
+<!--                a = i + 1; // unused-->
+<!--                break;-->
+<!--            }-->
+<!--            i++; // used by itself-->
+<!--        }-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Do while 0</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0 ;-->
+<!--        int i = 0 ;-->
+<!--        do {-->
+<!--            a = a+3;-->
+<!--            i += 3;-->
+<!--        } while (i < 30);-->
+<!--   }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Do while 1</description>-->
+<!--        <expected-problems>1</expected-problems>-->
+<!--        <expected-linenumbers>3</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'a' is never used (overwritten on line 6)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0;-->
+<!--        int i = 0;-->
+<!--        do {-->
+<!--            a = i+3;-->
+<!--            i += 3;-->
+<!--        } while ((a+i) < 30);-->
+<!--   }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Do while with break</description>-->
+<!--        <expected-problems>2</expected-problems>-->
+<!--        <expected-linenumbers>7,8</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'i' is never used (goes out of scope)</message>-->
+<!--            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0;-->
+<!--        int i = 0;-->
+<!--        do {-->
+<!--            if (a >= 20) {-->
+<!--                i = 4;-->
+<!--                a *= 5;-->
+<!--                break;-->
+<!--            }-->
+
+<!--            a = i + 3;-->
+<!--            i += 3;-->
+<!--        } while (i < 30);-->
+<!--   }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Do while with continue</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0;-->
+<!--        int i = 0;-->
+<!--        do {-->
+<!--            if (a >= 20) {-->
+<!--                i = 4;  // used by condition-->
+<!--                a *= 5;-->
+<!--                continue;-->
+<!--            }-->
+
+<!--            a = i + 3;-->
+<!--            i += 3;-->
+<!--        } while (i < 30);-->
+<!--   }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Switch statement 0</description>-->
+<!--        <expected-problems>4</expected-problems>-->
+<!--        <expected-linenumbers>6,8,10,12</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>-->
+<!--            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>-->
+<!--            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>-->
+<!--            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0 ;-->
+<!--        int i = 0 ;-->
+<!--        switch(i){-->
+<!--            case 1 : a = a+1;-->
+<!--            break;-->
+<!--            case 2 : a = a+2;-->
+<!--            break;-->
+<!--            case 3 : a = a+3;-->
+<!--            break;-->
+<!--            default : a = a + 1;-->
+<!--        }-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Switch statement 1</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0 ;-->
+<!--        int i = 0 ;-->
+<!--        switch(i){-->
+<!--            case 1 : a = 1;-->
+<!--            break;-->
+<!--            case 2 : a = 2;-->
+<!--            break;-->
+<!--            case 3 : a = 3;-->
+<!--            break;-->
+<!--            default : a = a + 1;-->
+<!--        }-->
+
+<!--        System.out.println(a);-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Switch statement 2</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0 ;-->
+<!--        int i = 0 ;-->
+<!--        switch(i){-->
+<!--            case 1 : a = 1;-->
+<!--                     if (args.length > 0) break; // else fallthrough-->
+<!--            case 2 : a = 2; break;-->
+<!--            case 3 : a = 3; break;-->
+<!--            default : a = a + 1;-->
+<!--        }-->
+
+<!--        System.out.println(a);-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Switch fallthrough</description>-->
+<!--        <expected-problems>1</expected-problems>-->
+<!--        <expected-linenumbers>6</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'a' is never used (overwritten on line 8)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0 ;-->
+<!--        int i = 0 ;-->
+<!--        switch(i){-->
+<!--            case 1 : a = 1; // unused-->
+<!--            // break; // no break-->
+<!--            case 2 : a = 2;-->
+<!--            break;-->
+<!--            case 3 : a = 3;-->
+<!--            break;-->
+<!--            default : a = a + 1;-->
+<!--        }-->
+
+<!--        System.out.println(a);-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Switch fallthrough 2</description>-->
+<!--        <expected-problems>1</expected-problems>-->
+<!--        <expected-linenumbers>9</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0 ;-->
+<!--        int i = 0 ;-->
+<!--        switch(i){-->
+<!--            case 1 : a = a+1;-->
+<!--            case 2 : a = a+2;-->
+<!--            case 3 : a = a+3;-->
+<!--            default : a = a + 0; // this one-->
+<!--        }-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Switch non-fallthrough</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0 ;-->
+<!--        int i = 0 ;-->
+<!--        switch(i) {-->
+<!--            case 1 -> a = 1;-->
+<!--            case 2 -> a = 2;-->
+<!--            case 3 -> a = 3;-->
+<!--            default -> a = a + 1;-->
+<!--        }-->
+<!--        System.out.println(a);-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Switch non-fallthrough blocks</description>-->
+<!--        <expected-problems>1</expected-problems>-->
+<!--        <expected-linenumbers>9</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'i' is never used (goes out of scope)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0 ;-->
+<!--        int i = 0 ;-->
+<!--        switch(i) {-->
+<!--            case 1 -> a = 1;-->
+<!--            case 2 -> {-->
+<!--                if (args.length > 0) {-->
+<!--                    i = 4;-->
+<!--                    break;-->
+<!--                }-->
+<!--                a = 2;-->
+<!--            }-->
+<!--            case 3 -> a = 3;-->
+<!--            default -> a = a + 1;-->
+<!--        }-->
+<!--        System.out.println(a);-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Switch expr non-fallthrough</description>-->
+<!--        <expected-problems>4</expected-problems>-->
+<!--        <expected-linenumbers>6,7,8,9</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>-->
+<!--            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>-->
+<!--            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>-->
+<!--            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0 ;-->
+<!--        a = switch(i) { // this is used-->
+<!--            // all those are unused-->
+<!--            case 1 -> a = 1;-->
+<!--            case 2 -> a = 2;-->
+<!--            case 3 -> a = 3;-->
+<!--            default -> a = a + 1;-->
+<!--        };-->
+
+<!--        System.out.println(a);-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Switch expr with yield</description>-->
+<!--        <expected-problems>4</expected-problems>-->
+<!--        <expected-linenumbers>6,9,13,14</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>-->
+<!--            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>-->
+<!--            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>-->
+<!--            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int a = 0 ;-->
+<!--        a = switch(i) { // this is used-->
+<!--            // all those are unused-->
+<!--            case 1 -> a = 1;-->
+<!--            case 2 -> {-->
+<!--                if (a > 0) {-->
+<!--                    yield a++;-->
+<!--                }-->
+<!--                yield 4;-->
+<!--            }-->
+<!--            case 3 -> a = 3;-->
+<!--            default -> a = a + 1;-->
+<!--        };-->
+
+<!--        System.out.println(a);-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Usage as LHS of method</description>-->
+<!--        <expected-problems>1</expected-problems>-->
+<!--        <expected-linenumbers>5</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 't1' is never used (goes out of scope)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int t1 = 0 ;-->
+<!--        Test2 test = new Test2() ;-->
+<!--        t1 = test.simpleTest(t1) ;-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Assignment in operand</description>-->
+<!--        <expected-problems>1</expected-problems>-->
+<!--        <expected-linenumbers>6</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 't1' is never used (goes out of scope)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int t1 = 0 ;-->
+<!--        int t2 = 0 ;-->
+<!--        Test2 test = new Test2();-->
+<!--        if((t1 = test.simpleTest(t1)) == t2);-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Assignment in operand 2</description>-->
+<!--        <expected-problems>1</expected-problems>-->
+<!--        <expected-linenumbers>7</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 't1' is never used (goes out of scope)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int t1 = 0 ;-->
+<!--        int t2 = 0 ;-->
+<!--        // the left assignment reaches the right of the ==-->
+<!--        if (   (t1 = t1 + t2)-->
+<!--            == (t1 = t2 * t1) ); // only this assignment is unused-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Assignment in operand 3</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int t1 = 0 ;-->
+
+<!--        Test2 test = new Test2();-->
+<!--        if( (t1 = test.simpleTest(t1)) == t1);-->
+<!--   }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Assignment in operand 4</description>-->
+<!--        <expected-problems>2</expected-problems>-->
+<!--        <expected-linenumbers>4,6</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 't2' is never used (goes out of scope)</message>-->
+<!--            <message>The value assigned to variable 't1' is never used (goes out of scope)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--class Test{-->
+<!--    public static void main(String[] args){-->
+<!--        int t1 = 0;-->
+<!--        int t2 = 0;-->
+<!--        Test2 test = new Test2() ;-->
+<!--        if( t1 == (t1 = test.simpleTest(t1))) ;-->
+<!--   }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>#1749 DD False Positive in DataflowAnomalyAnalysis</description>-->
+<!--        <expected-problems>1</expected-problems>-->
+<!--        <expected-linenumbers>4</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--public class Test {-->
+<!--    public void test(){-->
+<!--        int a = 0;-->
+<!--        a = a + 3;-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+<!--    <test-code>-->
+<!--        <description>Compound assignment</description>-->
+<!--        <expected-problems>1</expected-problems>-->
+<!--        <expected-linenumbers>4</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--public class Test {-->
+<!--    public void test(){-->
+<!--        int a = 0;-->
+<!--        a += 3; // same with compound-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+<!--    <test-code>-->
+<!--        <description>Another case</description>-->
+<!--        <expected-problems>2</expected-problems>-->
+<!--        <expected-linenumbers>3,5</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'iter' is never used (overwritten on line 4)</message>-->
+<!--            <message>The value assigned to variable 'iter' is never used (goes out of scope)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--public class Test {-->
+<!--    public void test(){-->
+<!--       ScopeData iter = acceptOpt(node.getBody(), before.fork()); // this assignment is unused-->
+<!--       iter = acceptOpt(node.getCondition(), before.fork());-->
+<!--       iter = acceptOpt(node.getBody(), iter);-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Var usage in lambda (#1304)</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--public class Foo {-->
+
+<!--    public boolean dummyMethod(final String captured, final Set<String> dummySet) {-->
+<!--        captured = captured.trim();-->
+<!--        return dummySet.stream().noneMatch(value -> value.equalsIgnoreCase(captured));-->
+<!--    }-->
+
+<!--}        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Try/catch</description>-->
+<!--        <expected-problems>1</expected-problems>-->
+<!--        <expected-linenumbers>4</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'a' is never used (overwritten on lines 6 and 8)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--public class Foo {-->
+
+<!--    public int foo() {-->
+<!--        int a = 0;-->
+<!--        try (Reader r = new StringReader("")) {-->
+<!--            a = r.read();-->
+<!--        } catch (IOException e) {-->
+<!--            a = -1;-->
+<!--        }-->
+<!--        return a;-->
+<!--    }-->
+
+<!--}        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Try with several catches</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--public class Foo {-->
+
+<!--    public int foo() {-->
+<!--        int a;-->
+<!--        try (Reader r = new StringReader("")) {-->
+<!--            a = r.read();-->
+<!--        } catch (IOException e) {-->
+<!--            a = -1;-->
+<!--        } catch (IllegalArgumentException e) {-->
+<!--            a = 2;-->
+<!--        }-->
+<!--        return a;-->
+<!--    }-->
+
+<!--}        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Definitions in try block reach catch blocks</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--public class Foo {-->
+
+<!--    void method() {-->
+<!--        boolean halfway = false;-->
+
+<!--        try {-->
+<!--            halfway = true;-->
+<!--        } catch(Exception e) {-->
+<!--            System.out.println(halfway);-->
+<!--        }-->
+<!--    }-->
+<!--}-->
+
+
+<!--]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Try/catch finally</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--public class Foo {-->
+
+<!--    public int foo() {-->
+<!--        int a = 0;-->
+<!--        try (Reader r = new StringReader("")) {-->
+<!--            a = r.read();  // used in finally-->
+<!--        } catch (IOException e) {-->
+<!--            a = -1; // used in finally-->
+<!--        } finally {-->
+<!--            print(a);-->
+<!--        }-->
+<!--        return 0;-->
+<!--    }-->
+
+<!--}        ]]></code>-->
+<!--    </test-code>-->
+<!--    <test-code>-->
+<!--        <description>Try/catch finally 3</description>-->
+<!--        <expected-problems>1</expected-problems>-->
+<!--        <expected-linenumbers>4</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'a' is never used (overwritten on lines 6 and 8)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--public class Foo {-->
+
+<!--    public int foo() {-->
+<!--        int a = 0;-->
+<!--        try (Reader r = new StringReader("")) {-->
+<!--            a = r.read();  // used in finally-->
+<!--        } catch (IOException e) {-->
+<!--            a = -1; // used in finally-->
+<!--        } finally {-->
+<!--            // don't use a-->
+<!--        }-->
+<!--        return a;-->
+<!--    }-->
+
+<!--}        ]]></code>-->
+<!--    </test-code>-->
+<!--    <test-code>-->
+<!--        <description>Try/catch finally in loop</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--import java.io.IOException;-->
+<!--import java.io.Reader;-->
+<!--import java.io.StringReader;-->
+
+<!--class Foo {-->
+
+<!--    public int foo() {-->
+<!--        int a = 0;-->
+<!--        while (a > 10) {-->
+<!--            try (Reader r = new StringReader("")) {-->
+<!--                r.read();-->
+<!--            } catch (IOException e) {-->
+<!--                a = -1; // used in finally even if break-->
+<!--                break;-->
+<!--            } finally {-->
+<!--                a++;-->
+<!--            }-->
+<!--        }-->
+<!--        return a;-->
+<!--    }-->
+
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+<!--    <test-code>-->
+<!--        <description>Abstract method NPE</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+
+<!--abstract class Foo {-->
+
+<!--    public abstract int foo();-->
+
+<!--    interface Bar {-->
+<!--        int bar();-->
+<!--    }-->
+
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+<!--    <test-code>-->
+<!--        <description>FP in finally</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+
+<!--class Foo {-->
+<!--    public Object intercept(Object proxy) throws Throwable {-->
+<!--        Object oldProxy = null; // FP here-->
+<!--        try {-->
+<!--            oldProxy = new Object[] { proxy };-->
+<!--            return null;-->
+<!--        }-->
+<!--        finally {-->
+<!--            System.out.println(oldProxy);-->
+<!--        }-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Lambda captured var use</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--class Foo {-->
+
+<!--  public Flux<Object> decode() {-->
+<!--    Flux<List<XMLEvent>> splitEvents = splitEvts();-->
+
+<!--    return map(events -> {-->
+<!--      return unmarshal(events.append(splitEvents));-->
+<!--    });-->
+<!--  }-->
+
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+<!--    <test-code>-->
+<!--        <description>Lambda assignment</description>-->
+<!--        <expected-problems>2</expected-problems>-->
+<!--        <expected-linenumbers>5,6</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'k' is never used (overwritten on line 6)</message>-->
+<!--            <message>The value assigned to variable 'k' is never used (goes out of scope)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--class Foo {-->
+
+<!--  public void decode() {-->
+<!--    doSomething(events -> {-->
+<!--      int k = 0;-->
+<!--      return k = 2;-->
+<!--    });-->
+<!--  }-->
+
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+<!--    <test-code>-->
+<!--        <description>Lambda returns 2</description>-->
+<!--        <expected-problems>2</expected-problems>-->
+<!--        <expected-linenumbers>4,7</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'splitEvents' is never used (goes out of scope)</message>-->
+<!--            <message>The value assigned to variable 'events' is never used (goes out of scope)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--class Foo {-->
+
+<!--  public Flux<Object> decode() {-->
+<!--    Flux<List<XMLEvent>> splitEvents = splitEvts();-->
+
+<!--    return map(events -> {-->
+<!--      events = events.normalize();-->
+<!--      return dontUseEvents();-->
+<!--    });-->
+<!--  }-->
+
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+<!--    <test-code>-->
+<!--        <description>FP in try</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--package foo;-->
+<!--class Foo {-->
+
+<!--    public Object getSubject() {-->
+<!--      try {-->
+<!--        Object subject = Other.currentUserMethod.invoke();-->
+<!--        if (subject == null) {-->
+<!--          subject = Other.anonymousSubjectMethod.invoke(0);-->
+<!--        }-->
+<!--        return subject;-->
+<!--      } catch (Exception ex) {-->
+<!--        throw new RuntimeException("Failed to obtain SubjectHandle", ex);-->
+<!--      }-->
+<!--    }-->
+
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Field initializers 0</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--class Foo {-->
+
+<!--    int f1 = 0;-->
+<!--    int f2 = f1++;-->
+
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Field initializers 1</description>-->
+<!--        <expected-problems>1</expected-problems>-->
+<!--        <expected-linenumbers>3</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'f1' is never used (overwritten on line 4)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--class Foo {-->
+
+<!--    int f1 = 0;-->
+<!--    int f2 = f1 = 1, f3 = f2;-->
+
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Field initializers 1</description>-->
+<!--        <expected-problems>1</expected-problems>-->
+<!--        <expected-linenumbers>3</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'f1' is never used (overwritten on line 4)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--class Foo {-->
+
+<!--    int f1 = 0;-->
+<!--    int f2 = this.f1 = 1, f3 = f2;-->
+
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Field initializers and ctor</description>-->
+<!--        <expected-problems>1</expected-problems>-->
+<!--        <expected-linenumbers>3</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The value assigned to variable 'f1' is never used (overwritten on lines 7 and 11)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--class Foo {-->
+
+<!--    int f1 = 0;-->
+<!--    int f2 = 0;-->
+
+<!--    Foo(int f, int g) {-->
+<!--        f1 = f;-->
+<!--    }-->
+
+<!--    Foo(int f, int g) {-->
+<!--        f1 = f;-->
+<!--        f2 = f + g;-->
+<!--    }-->
+
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
 
     <test-code>
-        <description>DD anomaly</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>3</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'i' is never used (overwritten on line 4)</message>
-        </expected-messages>
-        <code><![CDATA[
-public class Foo {
-    void bar() {
-        int i=0;
-        i=1;
-        if (i==2) {}
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>DU anomaly</description>
-        <expected-problems>1</expected-problems>
-        <code><![CDATA[
-public class Foo {
-    void bar() {
-        int i=0;
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>UR anomaly</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-public class Foo {
-    void bar() {
-        int i;
-        if (i == 0) {}
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Conditional flow 0</description>
-        <expected-problems>3</expected-problems>
-        <expected-linenumbers>3,4,6</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'j' is never used (overwritten on line 6)</message>
-            <message>The value assigned to variable 'z' is never used (goes out of scope)</message>
-            <message>The value assigned to variable 'j' is never used (goes out of scope)</message>
-        </expected-messages>
-        <code><![CDATA[
-public class Foo {
-    void bar(int i) {
-        int j = 0;
-        int z = 0;
-        if (i < 10) {
-            j = i;
-        }
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Conditional flow 1</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>4</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'z' is never used (goes out of scope)</message>
-        </expected-messages>
-        <code><![CDATA[
-public class Foo {
-    void bar(int i) {
-        int j = 0;
-        int z = 0; // unused
-        if (i < 10) {
-            j = i;
-        }
-        System.out.println(j);
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Conditional flow 2</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>3</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'j' is never used (overwritten on lines 6 and 8)</message>
-        </expected-messages>
-        <code><![CDATA[
-public class Foo {
-    void bar(int i) {
-        int j = 0; // unused
-        int z = 0;
-        if (i < 10) {
-            j = i;
-        } else {
-            j = z;
-        }
-        System.out.println(j);
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Conditional flow with abrupt throw</description>
-        <expected-problems>2</expected-problems>
-        <expected-linenumbers>3,6</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'j' is never used (overwritten on lines 6 and 9)</message>
-            <message>The value assigned to variable 'j' is never used (goes out of scope)</message>
-        </expected-messages>
-        <code><![CDATA[
-public class Foo {
-    void bar(int i) {
-        int j = 0; // unused
-        int z = 0;
-        if (i < 10) {
-            j = i; // unused
-            throw new Exception();
-        } else {
-            j = z;
-        }
-        System.out.println(j);
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Conditional flow with abrupt return</description>
-        <expected-problems>2</expected-problems>
-        <expected-linenumbers>3,6</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'j' is never used (overwritten on lines 6 and 9)</message>
-            <message>The value assigned to variable 'j' is never used (goes out of scope)</message>
-        </expected-messages>
-        <code><![CDATA[
-public class Foo {
-    void bar(int i) {
-        int j = 0;  // unused
-        int z = 0;
-        if (i < 10) {
-            j = i;  // unused
-            return;
-        } else {
-            j = z;
-        }
-        System.out.println(j);
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Local variable in loop</description>
-        <expected-problems>2</expected-problems>
-        <expected-linenumbers>10,19</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'fail' is never used (overwritten on line 19)</message>
-            <message>The value assigned to variable 'fail' is never used (overwritten on line 19)</message>
-        </expected-messages>
-        <code><![CDATA[
-public class LoopTest {
-    public static void main(String[] args) {
-        int[] a = {1,2,3};
-        int[] b = {4,5,6};
-        int[] c = {7,8,9};
-        for (int i : a) {
-            if (i == 0) {
-                break;
-            } else {
-                boolean fail = false;
-                for (int j : b) {
-                    boolean match = false;
-                    for (int k : c) {
-                        if (k == 42) {
-                            match = true;
-                        }
-                    }
-                    if (!match) {
-                        fail = true;
-                    }
-                }
-            }
-        }
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>#408 Assert statements causing </description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-public class AssertTest {
-    public void test() {
-        final String s = "";
-        assert(s != null);
-
-        System.out.println(s);
-
-        final Double d = 9;
-        assert(d != null);
-
-        System.out.println(d);
-
-        final String k = "k";
-        assert(k != null);
-
-        System.out.println(k);
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 1. DU-Anomaly(b)</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>6</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'b' is never used (goes out of scope)</message>
-        </expected-messages>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0 ;
-        int b = 0 ;
-        a = a + b ;
-        b = a + b ;
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>For loop</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0 ;
-        for(int i = 0 ; i <= 10; i ++){
-            a = a+3;
-        }
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>For loop 2</description>
-        <expected-problems>2</expected-problems>
-        <expected-linenumbers>3,5</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'a' is never used (overwritten on line 5)</message>
-            <!-- Overwrites itself -->
-            <message>The value assigned to variable 'a' is never used (overwritten on line 5)</message>
-        </expected-messages>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0 ;
-        for(int i = 0 ; i <= 10; i ++){
-            a = i * 3;
-        }
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>For loop 3</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0 ;
-        for(int i = 0 ; i <= 10; i ++){
-            a = i * 3;
-        }
-        System.out.println(a);
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>For loop 4</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0 ;
-        for(int i = 0 ; (i + a) <= 10; i ++){
-            a = i * 3;
-        }
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Foreach</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int[] b = new int[10];
-        for(int a : b){
-            a = a+3;
-        }
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>While loop 1</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0;
-        int i = 0;
-        while (i < 30) {
-            a = a + 3;
-            i += 3;
-        }
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>While loop 2</description>
-        <expected-problems>2</expected-problems>
-        <expected-linenumbers>4,7</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'i' is never used (overwritten on line 7)</message>
-            <message>The value assigned to variable 'i' is never used (overwritten on line 7)</message>
-        </expected-messages>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0;
-        int i = 0; // unused
-        while (a < 30) {
-            a = a + 3;
-            i = 5; // unused (kills itself)
-        }
-    }
-}
-        ]]></code>
-    </test-code>
-    <test-code>
-        <description>While loop with break</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>7</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'i' is never used (goes out of scope)</message>
-        </expected-messages>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0;
-        int i = 0;
-        while (true) {
-            if (a >= 30) {
-                i = a + 1; // unused
-                break;
-            }
-            a = a + 3;
-            i = i + 1; // used by itself
-        }
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>While loop without break (control case)</description>
-        <expected-problems>1</expected-problems>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0; // used by compound below
-        int i = 0;
-        while (true) {
-            if (a >= 30) {
-                i += a + 1; // unused by below
-                // break;  // no break here
-            }
-            a = a + 3;
-            i = a + 2; // used by above
-        }
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>While loop without break 2 (control case)</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>12</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'i' is never used (overwritten on line 16)</message>
-        </expected-messages>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0;
-        int i = 0; // unused now
-
-        outer:
-        while (true) {
-            a += 2;
-
-            while (true) {
-                if (a >= 30) {
-                    i += a + 1; // unused because of i = a + 2
-                    // break outer;
-                }
-                a = a + 3;
-                i = a + 2;  // killed by below
-            }
-
-            i = 2; // used by print
-        }
-
-        System.out.println(i); // uses i = i + 1
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>While loop without break 2 (control case)</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>12</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'i' is never used (overwritten on line 19)</message>
-        </expected-messages>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0;
-        int i = 0; // unused now
-
-        outer:
-        while (true) {
-            a += 2;
-
-            while (true) {
-                if (a >= 30) {
-                    i += a + 1; // unused because of i = 2
-                    break;
-                }
-                a = a + 3;
-                i = a + 2;  // used by i += a + 1
-            }
-
-            i = 2; // used by print
-        }
-
-        System.out.println(i); // uses i = i + 1
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>While loop with named break 2</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0;
-        int i = 0; // unused now
-
-        outer:
-        while (true) {
-            a += 2;
-
-            while (true) {
-                if (a >= 30) {
-                    i += a + 1; // used by print
-                    break outer;
-                }
-                a = a + 3;
-                i = a + 2;  // used by i += a + 1
-            }
-
-            i = 2; // used by print
-        }
-
-        System.out.println(i); // uses i = i + 1
-    }
-}
-        ]]></code>
-    </test-code>
-
-
-    <test-code>
-        <description>While loop with continue</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0;
-        int i = 0;
-        while (true) {
-            if (a >= 30) {
-                i = a + 1; // used by below
-                continue;
-            }
-            a = a + 3;
-            i = i + 1; // used by itself
-        }
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>While loop with continue 2</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0;
-        int i = 0;
-        while (a < 50) {
-            if (i >= 30) {
-                a = i + 1; // used by loop condition
-                continue;
-            }
-            i++; // used by itself
-        }
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>While loop with break (control for continue test above)</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>7</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
-        </expected-messages>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0;
-        int i = 0;
-        while (a < 50) {
-            if (i >= 30) {
-                a = i + 1; // unused
-                break;
-            }
-            i++; // used by itself
-        }
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Do while 0</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0 ;
-        int i = 0 ;
-        do {
-            a = a+3;
-            i += 3;
-        } while (i < 30);
-   }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Do while 1</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>3</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'a' is never used (overwritten on line 6)</message>
-        </expected-messages>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0;
-        int i = 0;
-        do {
-            a = i+3;
-            i += 3;
-        } while ((a+i) < 30);
-   }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Do while with break</description>
-        <expected-problems>2</expected-problems>
-        <expected-linenumbers>7,8</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'i' is never used (goes out of scope)</message>
-            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
-        </expected-messages>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0;
-        int i = 0;
-        do {
-            if (a >= 20) {
-                i = 4;
-                a *= 5;
-                break;
-            }
-
-            a = i + 3;
-            i += 3;
-        } while (i < 30);
-   }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Do while with continue</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0;
-        int i = 0;
-        do {
-            if (a >= 20) {
-                i = 4;  // used by condition
-                a *= 5;
-                continue;
-            }
-
-            a = i + 3;
-            i += 3;
-        } while (i < 30);
-   }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Switch statement 0</description>
-        <expected-problems>4</expected-problems>
-        <expected-linenumbers>6,8,10,12</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
-            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
-            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
-            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
-        </expected-messages>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0 ;
-        int i = 0 ;
-        switch(i){
-            case 1 : a = a+1;
-            break;
-            case 2 : a = a+2;
-            break;
-            case 3 : a = a+3;
-            break;
-            default : a = a + 1;
-        }
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Switch statement 1</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0 ;
-        int i = 0 ;
-        switch(i){
-            case 1 : a = 1;
-            break;
-            case 2 : a = 2;
-            break;
-            case 3 : a = 3;
-            break;
-            default : a = a + 1;
-        }
-
-        System.out.println(a);
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Switch statement 2</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0 ;
-        int i = 0 ;
-        switch(i){
-            case 1 : a = 1;
-                     if (args.length > 0) break; // else fallthrough
-            case 2 : a = 2; break;
-            case 3 : a = 3; break;
-            default : a = a + 1;
-        }
-
-        System.out.println(a);
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Switch fallthrough</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>6</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'a' is never used (overwritten on line 8)</message>
-        </expected-messages>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0 ;
-        int i = 0 ;
-        switch(i){
-            case 1 : a = 1; // unused
-            // break; // no break
-            case 2 : a = 2;
-            break;
-            case 3 : a = 3;
-            break;
-            default : a = a + 1;
-        }
-
-        System.out.println(a);
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Switch fallthrough 2</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>9</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
-        </expected-messages>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0 ;
-        int i = 0 ;
-        switch(i){
-            case 1 : a = a+1;
-            case 2 : a = a+2;
-            case 3 : a = a+3;
-            default : a = a + 0; // this one
-        }
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Switch non-fallthrough</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0 ;
-        int i = 0 ;
-        switch(i) {
-            case 1 -> a = 1;
-            case 2 -> a = 2;
-            case 3 -> a = 3;
-            default -> a = a + 1;
-        }
-        System.out.println(a);
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Switch non-fallthrough blocks</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>9</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'i' is never used (goes out of scope)</message>
-        </expected-messages>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0 ;
-        int i = 0 ;
-        switch(i) {
-            case 1 -> a = 1;
-            case 2 -> {
-                if (args.length > 0) {
-                    i = 4;
-                    break;
-                }
-                a = 2;
-            }
-            case 3 -> a = 3;
-            default -> a = a + 1;
-        }
-        System.out.println(a);
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Switch expr non-fallthrough</description>
-        <expected-problems>4</expected-problems>
-        <expected-linenumbers>6,7,8,9</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
-            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
-            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
-            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
-        </expected-messages>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0 ;
-        a = switch(i) { // this is used
-            // all those are unused
-            case 1 -> a = 1;
-            case 2 -> a = 2;
-            case 3 -> a = 3;
-            default -> a = a + 1;
-        };
-
-        System.out.println(a);
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Switch expr with yield</description>
-        <expected-problems>4</expected-problems>
-        <expected-linenumbers>6,9,13,14</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
-            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
-            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
-            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
-        </expected-messages>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int a = 0 ;
-        a = switch(i) { // this is used
-            // all those are unused
-            case 1 -> a = 1;
-            case 2 -> {
-                if (a > 0) {
-                    yield a++;
-                }
-                yield 4;
-            }
-            case 3 -> a = 3;
-            default -> a = a + 1;
-        };
-
-        System.out.println(a);
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Usage as LHS of method</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>5</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 't1' is never used (goes out of scope)</message>
-        </expected-messages>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int t1 = 0 ;
-        Test2 test = new Test2() ;
-        t1 = test.simpleTest(t1) ;
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Assignment in operand</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>6</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 't1' is never used (goes out of scope)</message>
-        </expected-messages>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int t1 = 0 ;
-        int t2 = 0 ;
-        Test2 test = new Test2();
-        if((t1 = test.simpleTest(t1)) == t2);
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Assignment in operand 2</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>7</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 't1' is never used (goes out of scope)</message>
-        </expected-messages>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int t1 = 0 ;
-        int t2 = 0 ;
-        // the left assignment reaches the right of the ==
-        if (   (t1 = t1 + t2)
-            == (t1 = t2 * t1) ); // only this assignment is unused
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Assignment in operand 3</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int t1 = 0 ;
-
-        Test2 test = new Test2();
-        if( (t1 = test.simpleTest(t1)) == t1);
-   }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Assignment in operand 4</description>
-        <expected-problems>2</expected-problems>
-        <expected-linenumbers>4,6</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 't2' is never used (goes out of scope)</message>
-            <message>The value assigned to variable 't1' is never used (goes out of scope)</message>
-        </expected-messages>
-        <code><![CDATA[
-class Test{
-    public static void main(String[] args){
-        int t1 = 0;
-        int t2 = 0;
-        Test2 test = new Test2() ;
-        if( t1 == (t1 = test.simpleTest(t1))) ;
-   }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>#1749 DD False Positive in DataflowAnomalyAnalysis</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>4</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
-        </expected-messages>
-        <code><![CDATA[
-public class Test {
-    public void test(){
-        int a = 0;
-        a = a + 3;
-    }
-}
-        ]]></code>
-    </test-code>
-    <test-code>
-        <description>Compound assignment</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>4</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
-        </expected-messages>
-        <code><![CDATA[
-public class Test {
-    public void test(){
-        int a = 0;
-        a += 3; // same with compound
-    }
-}
-        ]]></code>
-    </test-code>
-    <test-code>
-        <description>Another case</description>
-        <expected-problems>2</expected-problems>
-        <expected-linenumbers>3,5</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'iter' is never used (overwritten on line 4)</message>
-            <message>The value assigned to variable 'iter' is never used (goes out of scope)</message>
-        </expected-messages>
-        <code><![CDATA[
-public class Test {
-    public void test(){
-       ScopeData iter = acceptOpt(node.getBody(), before.fork()); // this assignment is unused
-       iter = acceptOpt(node.getCondition(), before.fork());
-       iter = acceptOpt(node.getBody(), iter);
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Var usage in lambda (#1304)</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-public class Foo {
-
-    public boolean dummyMethod(final String captured, final Set<String> dummySet) {
-        captured = captured.trim();
-        return dummySet.stream().noneMatch(value -> value.equalsIgnoreCase(captured));
-    }
-
-}        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Try/catch</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>4</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'a' is never used (overwritten on lines 6 and 8)</message>
-        </expected-messages>
-        <code><![CDATA[
-public class Foo {
-
-    public int foo() {
-        int a = 0;
-        try (Reader r = new StringReader("")) {
-            a = r.read();
-        } catch (IOException e) {
-            a = -1;
-        }
-        return a;
-    }
-
-}        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Try with several catches</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-public class Foo {
-
-    public int foo() {
-        int a;
-        try (Reader r = new StringReader("")) {
-            a = r.read();
-        } catch (IOException e) {
-            a = -1;
-        } catch (IllegalArgumentException e) {
-            a = 2;
-        }
-        return a;
-    }
-
-}        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Try/catch finally</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-public class Foo {
-
-    public int foo() {
-        int a = 0;
-        try (Reader r = new StringReader("")) {
-            a = r.read();  // used in finally
-        } catch (IOException e) {
-            a = -1; // used in finally
-        } finally {
-            print(a);
-        }
-        return 0;
-    }
-
-}        ]]></code>
-    </test-code>
-    <test-code>
-        <description>Try/catch finally 3</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>4</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'a' is never used (overwritten on lines 6 and 8)</message>
-        </expected-messages>
-        <code><![CDATA[
-public class Foo {
-
-    public int foo() {
-        int a = 0;
-        try (Reader r = new StringReader("")) {
-            a = r.read();  // used in finally
-        } catch (IOException e) {
-            a = -1; // used in finally
-        } finally {
-            // don't use a
-        }
-        return a;
-    }
-
-}        ]]></code>
-    </test-code>
-    <test-code>
-        <description>Try/catch finally in loop</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-import java.io.IOException;
-import java.io.Reader;
-import java.io.StringReader;
-
-class Foo {
-
-    public int foo() {
-        int a = 0;
-        while (a > 10) {
-            try (Reader r = new StringReader("")) {
-                r.read();
-            } catch (IOException e) {
-                a = -1; // used in finally even if break
-                break;
-            } finally {
-                a++;
-            }
-        }
-        return a;
-    }
-
-}
-        ]]></code>
-    </test-code>
-    <test-code>
-        <description>Abstract method NPE</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-
-abstract class Foo {
-
-    public abstract int foo();
-
-    interface Bar {
-        int bar();
-    }
-
-}
-        ]]></code>
-    </test-code>
-    <test-code>
-        <description>FP in finally</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-
-class Foo {
-    public Object intercept(Object proxy) throws Throwable {
-        Object oldProxy = null; // FP here
-        try {
-            oldProxy = new Object[] { proxy };
-            return null;
-        }
-        finally {
-            System.out.println(oldProxy);
-        }
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Lambda captured var use</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-class Foo {
-
-  public Flux<Object> decode() {
-    Flux<List<XMLEvent>> splitEvents = splitEvts();
-
-    return map(events -> {
-      return unmarshal(events.append(splitEvents));
-    });
-  }
-
-}
-        ]]></code>
-    </test-code>
-    <test-code>
-        <description>Lambda assignment</description>
-        <expected-problems>2</expected-problems>
-        <expected-linenumbers>5,6</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'k' is never used (overwritten on line 6)</message>
-            <message>The value assigned to variable 'k' is never used (goes out of scope)</message>
-        </expected-messages>
-        <code><![CDATA[
-class Foo {
-
-  public void decode() {
-    doSomething(events -> {
-      int k = 0;
-      return k = 2;
-    });
-  }
-
-}
-        ]]></code>
-    </test-code>
-    <test-code>
-        <description>Lambda returns 2</description>
-        <expected-problems>2</expected-problems>
-        <expected-linenumbers>4,7</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'splitEvents' is never used (goes out of scope)</message>
-            <message>The value assigned to variable 'events' is never used (goes out of scope)</message>
-        </expected-messages>
-        <code><![CDATA[
-class Foo {
-
-  public Flux<Object> decode() {
-    Flux<List<XMLEvent>> splitEvents = splitEvts();
-
-    return map(events -> {
-      events = events.normalize();
-      return dontUseEvents();
-    });
-  }
-
-}
-        ]]></code>
-    </test-code>
-    <test-code>
-        <description>FP in try</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-package foo;
-class Foo {
-
-    public Object getSubject() {
-      try {
-        Object subject = Other.currentUserMethod.invoke();
-        if (subject == null) {
-          subject = Other.anonymousSubjectMethod.invoke(0);
-        }
-        return subject;
-      } catch (Exception ex) {
-        throw new RuntimeException("Failed to obtain SubjectHandle", ex);
-      }
-    }
-
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Field initializers 0</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-class Foo {
-
-    int f1 = 0;
-    int f2 = f1++;
-
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Field initializers 1</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>3</expected-linenumbers>
-        <expected-messages>
-            <message>The value assigned to variable 'f1' is never used (overwritten on line 4)</message>
-        </expected-messages>
-        <code><![CDATA[
-class Foo {
-
-    int f1 = 0;
-    int f2 = f1 = 1, f3 = f2;
-
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Field initializers and ctor</description>
+        <description>Field initializers and ctor with this, shadowing</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>3</expected-linenumbers>
         <expected-messages>
@@ -1353,13 +1417,35 @@ class Foo {
     int f1 = 0;
     int f2 = 0;
 
-    Foo(int f, int g) {
-        f1 = f;
+    Foo(int f1, int g) {
+        this.f1 = f1;
     }
 
-    Foo(int f, int g) {
-        f1 = f;
-        f2 = f + g;
+    Foo(int f1, int g) {
+        this.f1 = f1;
+        this.f2 = f1 + g;
+    }
+
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Field initializers and ctor with this, field access</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Foo {
+
+    Bar f1 = 0;
+    Bar f2 = 0;
+
+    Foo(Bar f1, Bar g) {
+        this.f1.field = f1;
+    }
+
+    Foo(Bar f1, Bar g) {
+        this.f1 = f1;
+        this.f2 = f1 + g;
     }
 
 }
@@ -1397,5 +1483,213 @@ class Foo {
         ]]></code>
     </test-code>
 
+    <test-code>
+        <description>Static initializer</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Foo {
+	private static Class<? extends Annotation> ejbRefClass;
+
+	private static Class<? extends Annotation> webServiceRefClass;
+
+	static {
+		try {
+			Class<? extends Annotation> clazz = (Class<? extends Annotation>)					Class.forName("javax.xml.ws.WebServiceRef");
+			webServiceRefClass = clazz;
+		} catch (ClassNotFoundException ex) {
+			webServiceRefClass = null;
+		}
+
+		try {
+			Class<? extends Annotation> clazz = Class.forName("javax.ejb.EJB");
+			ejbRefClass = clazz;
+		} catch (ClassNotFoundException ex) {
+			ejbRefClass = null;
+		}
+	}
+
+
+	private static Class<? extends Annotation> other = webServiceRefClass;
+
+}
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>FP with anonymous classes on the way</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Foo {
+    private static final Method privateLookupInMethod;
+
+    private static final Method lookupDefineClassMethod;
+
+    private static final Method classLoaderDefineClassMethod;
+
+    private static final ProtectionDomain PROTECTION_DOMAIN;
+
+    private static final Throwable THROWABLE;
+
+    private static final List<Method> OBJECT_METHODS = new ArrayList<Method>();
+
+    static {
+        Method privateLookupIn;
+        Method lookupDefineClass;
+        Method classLoaderDefineClass;
+        ProtectionDomain protectionDomain;
+        Throwable throwable = null;
+        try {
+            privateLookupIn = (Method) AccessController.doPrivileged(new PrivilegedExceptionAction() {
+                public Object run() throws Exception {
+                    try {
+                        return MethodHandles.class.getMethod("privateLookupIn", Class.class, MethodHandles.Lookup.class);
+                    }
+                    catch (NoSuchMethodException ex) {
+                        return null;
+                    }
+                }
+            });
+            lookupDefineClass = (Method) AccessController.doPrivileged(new PrivilegedExceptionAction() {
+                public Object run() throws Exception {
+                    try {
+                        return MethodHandles.Lookup.class.getMethod("defineClass", byte[].class);
+                    }
+                    catch (NoSuchMethodException ex) {
+                        return null;
+                    }
+                }
+            });
+            classLoaderDefineClass = (Method) AccessController.doPrivileged(new PrivilegedExceptionAction() {
+                public Object run() throws Exception {
+                    return ClassLoader.class.getDeclaredMethod("defineClass",
+                                                               String.class, byte[].class, Integer.TYPE, Integer.TYPE, ProtectionDomain.class);
+                }
+            });
+            protectionDomain = getProtectionDomain(ReflectUtils.class);
+            AccessController.doPrivileged(new PrivilegedExceptionAction() {
+                public Object run() throws Exception {
+                    Method[] methods = Object.class.getDeclaredMethods();
+                    for (Method method : methods) {
+                        if ("finalize".equals(method.getName())
+                            || (method.getModifiers() & (Modifier.FINAL | Modifier.STATIC)) > 0) {
+                            continue;
+                        }
+                        OBJECT_METHODS.add(method);
+                    }
+                    return null;
+                }
+            });
+        }
+        catch (Throwable t) {
+            privateLookupIn = null;
+            lookupDefineClass = null;
+            classLoaderDefineClass = null;
+            protectionDomain = null;
+            throwable = t;
+        }
+        privateLookupInMethod = privateLookupIn;
+        lookupDefineClassMethod = lookupDefineClass;
+        classLoaderDefineClassMethod = classLoaderDefineClass;
+        PROTECTION_DOMAIN = protectionDomain;
+        THROWABLE = throwable;
+    }
+
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>FP with array access</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.Map;
+
+class Foo {
+    void foo(Map<String, String> map, String name, int[] arr) {
+        Integer index = map.get(name);
+        arr[index] = 4;
+    }
+
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>FP with array access</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+
+class Foo {
+    int foo(int index, int[] arr) {
+        arr = new int[4];
+        index = arr[index];
+        return index;
+    }
+
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>FP with long field access</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+
+class Foo {
+    int foo(int index, int[] arr) {
+        index.method().field = 4; // not an assignment to index
+    }
+
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>FP with long access 2</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+
+class Foo {
+    int foo(int index, String[] arr) {
+        arr = new String[] { "1" };
+        arr[0].trim(); // this is a usage of arr
+    }
+
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>FP with long access 2</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+
+class Foo {
+    int foo(int index, String[] arr) {
+        arr = new String[] { "1" };
+        arr.clone().clone(); // this is a usage of arr
+    }
+
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>FN with casts</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+
+class Foo {
+
+	public void test() {
+		// Two calls
+		OptionalCollectionResourceInjectionBean bean = (OptionalCollectionResourceInjectionBean) bf.getBean("annotatedBean");
+		bean = (OptionalCollectionResourceInjectionBean) bf.getBean("annotatedBean");
+		assertSame(tb, bean.getTestBean());
+		assertSame(tb, bean.getTestBean2());
+	}
+}
+        ]]></code>
+    </test-code>
 
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -327,7 +327,11 @@ class Test{
 
     <test-code>
         <description>Foreach</description>
-        <expected-problems>0</expected-problems>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
+        </expected-messages>
         <code><![CDATA[
 class Test{
     public static void main(String[] args){

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -1737,4 +1737,61 @@ class Foo {
         ]]></code>
     </test-code>
 
+
+    <test-code>
+        <description>SuppressWarnings test (local)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void bar(int i) {
+        int j = 0;
+        @SuppressWarnings("unused")
+        int z = 0; // unused
+        if (i < 10) {
+            j = i;
+        }
+        System.out.println(j);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>SuppressWarnings test (method)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @SuppressWarnings("unused")
+    void bar(int i) {
+        int j = 0;
+        int z = 0; // unused
+        if (i < 10) {
+            j = i;
+        }
+        System.out.println(j);
+    }
+}
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>SuppressWarnings test (class)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+@SuppressWarnings("unused")
+public class Foo {
+    void bar(int i) {
+        int j = 0;
+        int z = 0; // unused
+        if (i < 10) {
+            j = i;
+        }
+        System.out.println(j);
+    }
+}
+        ]]></code>
+    </test-code>
+
+
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -1310,4 +1310,92 @@ class Foo {
         ]]></code>
     </test-code>
 
+    <test-code>
+        <description>Field initializers 0</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Foo {
+
+    int f1 = 0;
+    int f2 = f1++;
+
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Field initializers 1</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'f1' is never used (overwritten on line 4)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Foo {
+
+    int f1 = 0;
+    int f2 = f1 = 1, f3 = f2;
+
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Field initializers and ctor</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'f1' is never used (overwritten on lines 7 and 11)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Foo {
+
+    int f1 = 0;
+    int f2 = 0;
+
+    Foo(int f, int g) {
+        f1 = f;
+    }
+
+    Foo(int f, int g) {
+        f1 = f;
+        f2 = f + g;
+    }
+
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Field initializers and ctor</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,11</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'f1' is never used (overwritten on line 11)</message>
+            <message>The value assigned to variable 'f1' is never used (overwritten on lines 7 and 15)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Foo {
+
+    int f1 = 0;
+    int f3 = 0;
+
+    Foo(int f, int g) {
+        f1 = f;
+    }
+
+    {
+        f1 = 1;
+    }
+
+    Foo(int f, int g) {
+        f1 = f;
+        f2 = f + g;
+    }
+
+}
+        ]]></code>
+    </test-code>
+
+
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -4,1405 +4,1446 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
 
-<!--    <test-code>-->
-<!--        <description>ok</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--public class Foo {-->
-<!--    void bar(int b) {-->
-<!--        for (int i = 0; i < 10; i++) {-->
-<!--            throw new Exception();-->
-<!--        }-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>DD anomaly</description>-->
-<!--        <expected-problems>1</expected-problems>-->
-<!--        <expected-linenumbers>3</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'i' is never used (overwritten on line 4)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--public class Foo {-->
-<!--    void bar() {-->
-<!--        int i=0;-->
-<!--        i=1;-->
-<!--        if (i==2) {}-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>DU anomaly</description>-->
-<!--        <expected-problems>1</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--public class Foo {-->
-<!--    void bar() {-->
-<!--        int i=0;-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>UR anomaly</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--public class Foo {-->
-<!--    void bar() {-->
-<!--        int i;-->
-<!--        if (i == 0) {}-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Conditional flow 0</description>-->
-<!--        <expected-problems>3</expected-problems>-->
-<!--        <expected-linenumbers>3,4,6</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'j' is never used (overwritten on line 6)</message>-->
-<!--            <message>The value assigned to variable 'z' is never used (goes out of scope)</message>-->
-<!--            <message>The value assigned to variable 'j' is never used (goes out of scope)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--public class Foo {-->
-<!--    void bar(int i) {-->
-<!--        int j = 0;-->
-<!--        int z = 0;-->
-<!--        if (i < 10) {-->
-<!--            j = i;-->
-<!--        }-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Conditional flow 1</description>-->
-<!--        <expected-problems>1</expected-problems>-->
-<!--        <expected-linenumbers>4</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'z' is never used (goes out of scope)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--public class Foo {-->
-<!--    void bar(int i) {-->
-<!--        int j = 0;-->
-<!--        int z = 0; // unused-->
-<!--        if (i < 10) {-->
-<!--            j = i;-->
-<!--        }-->
-<!--        System.out.println(j);-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Conditional flow 2</description>-->
-<!--        <expected-problems>1</expected-problems>-->
-<!--        <expected-linenumbers>3</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'j' is never used (overwritten on lines 6 and 8)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--public class Foo {-->
-<!--    void bar(int i) {-->
-<!--        int j = 0; // unused-->
-<!--        int z = 0;-->
-<!--        if (i < 10) {-->
-<!--            j = i;-->
-<!--        } else {-->
-<!--            j = z;-->
-<!--        }-->
-<!--        System.out.println(j);-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Conditional flow with abrupt throw</description>-->
-<!--        <expected-problems>2</expected-problems>-->
-<!--        <expected-linenumbers>3,6</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'j' is never used (overwritten on lines 6 and 9)</message>-->
-<!--            <message>The value assigned to variable 'j' is never used (goes out of scope)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--public class Foo {-->
-<!--    void bar(int i) {-->
-<!--        int j = 0; // unused-->
-<!--        int z = 0;-->
-<!--        if (i < 10) {-->
-<!--            j = i; // unused-->
-<!--            throw new Exception();-->
-<!--        } else {-->
-<!--            j = z;-->
-<!--        }-->
-<!--        System.out.println(j);-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Conditional flow with abrupt return</description>-->
-<!--        <expected-problems>2</expected-problems>-->
-<!--        <expected-linenumbers>3,6</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'j' is never used (overwritten on lines 6 and 9)</message>-->
-<!--            <message>The value assigned to variable 'j' is never used (goes out of scope)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--public class Foo {-->
-<!--    void bar(int i) {-->
-<!--        int j = 0;  // unused-->
-<!--        int z = 0;-->
-<!--        if (i < 10) {-->
-<!--            j = i;  // unused-->
-<!--            return;-->
-<!--        } else {-->
-<!--            j = z;-->
-<!--        }-->
-<!--        System.out.println(j);-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Local variable in loop</description>-->
-<!--        <expected-problems>2</expected-problems>-->
-<!--        <expected-linenumbers>10,19</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'fail' is never used (overwritten on line 19)</message>-->
-<!--            <message>The value assigned to variable 'fail' is never used (overwritten on line 19)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--public class LoopTest {-->
-<!--    public static void main(String[] args) {-->
-<!--        int[] a = {1,2,3};-->
-<!--        int[] b = {4,5,6};-->
-<!--        int[] c = {7,8,9};-->
-<!--        for (int i : a) {-->
-<!--            if (i == 0) {-->
-<!--                break;-->
-<!--            } else {-->
-<!--                boolean fail = false;-->
-<!--                for (int j : b) {-->
-<!--                    boolean match = false;-->
-<!--                    for (int k : c) {-->
-<!--                        if (k == 42) {-->
-<!--                            match = true;-->
-<!--                        }-->
-<!--                    }-->
-<!--                    if (!match) {-->
-<!--                        fail = true;-->
-<!--                    }-->
-<!--                }-->
-<!--            }-->
-<!--        }-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>#408 Assert statements causing </description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--public class AssertTest {-->
-<!--    public void test() {-->
-<!--        final String s = "";-->
-<!--        assert(s != null);-->
-
-<!--        System.out.println(s);-->
-
-<!--        final Double d = 9;-->
-<!--        assert(d != null);-->
-
-<!--        System.out.println(d);-->
-
-<!--        final String k = "k";-->
-<!--        assert(k != null);-->
-
-<!--        System.out.println(k);-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 1. DU-Anomaly(b)</description>-->
-<!--        <expected-problems>1</expected-problems>-->
-<!--        <expected-linenumbers>6</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'b' is never used (goes out of scope)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0 ;-->
-<!--        int b = 0 ;-->
-<!--        a = a + b ;-->
-<!--        b = a + b ;-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>For loop</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0 ;-->
-<!--        for(int i = 0 ; i <= 10; i ++){-->
-<!--            a = a+3;-->
-<!--        }-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>For loop 2</description>-->
-<!--        <expected-problems>2</expected-problems>-->
-<!--        <expected-linenumbers>3,5</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'a' is never used (overwritten on line 5)</message>-->
-<!--            &lt;!&ndash; Overwrites itself &ndash;&gt;-->
-<!--            <message>The value assigned to variable 'a' is never used (overwritten on line 5)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0 ;-->
-<!--        for(int i = 0 ; i <= 10; i ++){-->
-<!--            a = i * 3;-->
-<!--        }-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>For loop 3</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0 ;-->
-<!--        for(int i = 0 ; i <= 10; i ++){-->
-<!--            a = i * 3;-->
-<!--        }-->
-<!--        System.out.println(a);-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>For loop 4</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0 ;-->
-<!--        for(int i = 0 ; (i + a) <= 10; i ++){-->
-<!--            a = i * 3;-->
-<!--        }-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Foreach</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int[] b = new int[10];-->
-<!--        for(int a : b){-->
-<!--            a = a+3;-->
-<!--        }-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>While loop 1</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0;-->
-<!--        int i = 0;-->
-<!--        while (i < 30) {-->
-<!--            a = a + 3;-->
-<!--            i += 3;-->
-<!--        }-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>While loop 2</description>-->
-<!--        <expected-problems>2</expected-problems>-->
-<!--        <expected-linenumbers>4,7</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'i' is never used (overwritten on line 7)</message>-->
-<!--            <message>The value assigned to variable 'i' is never used (overwritten on line 7)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0;-->
-<!--        int i = 0; // unused-->
-<!--        while (a < 30) {-->
-<!--            a = a + 3;-->
-<!--            i = 5; // unused (kills itself)-->
-<!--        }-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-<!--    <test-code>-->
-<!--        <description>While loop with break</description>-->
-<!--        <expected-problems>1</expected-problems>-->
-<!--        <expected-linenumbers>7</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'i' is never used (goes out of scope)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0;-->
-<!--        int i = 0;-->
-<!--        while (true) {-->
-<!--            if (a >= 30) {-->
-<!--                i = a + 1; // unused-->
-<!--                break;-->
-<!--            }-->
-<!--            a = a + 3;-->
-<!--            i = i + 1; // used by itself-->
-<!--        }-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>While loop without break (control case)</description>-->
-<!--        <expected-problems>1</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0; // used by compound below-->
-<!--        int i = 0;-->
-<!--        while (true) {-->
-<!--            if (a >= 30) {-->
-<!--                i += a + 1; // unused by below-->
-<!--                // break;  // no break here-->
-<!--            }-->
-<!--            a = a + 3;-->
-<!--            i = a + 2; // used by above-->
-<!--        }-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>While loop without break 2 (control case)</description>-->
-<!--        <expected-problems>1</expected-problems>-->
-<!--        <expected-linenumbers>12</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'i' is never used (overwritten on line 16)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0;-->
-<!--        int i = 0; // unused now-->
-
-<!--        outer:-->
-<!--        while (true) {-->
-<!--            a += 2;-->
-
-<!--            while (true) {-->
-<!--                if (a >= 30) {-->
-<!--                    i += a + 1; // unused because of i = a + 2-->
-<!--                    // break outer;-->
-<!--                }-->
-<!--                a = a + 3;-->
-<!--                i = a + 2;  // killed by below-->
-<!--            }-->
-
-<!--            i = 2; // used by print-->
-<!--        }-->
-
-<!--        System.out.println(i); // uses i = i + 1-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>While loop without break 2 (control case)</description>-->
-<!--        <expected-problems>1</expected-problems>-->
-<!--        <expected-linenumbers>12</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'i' is never used (overwritten on line 19)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0;-->
-<!--        int i = 0; // unused now-->
-
-<!--        outer:-->
-<!--        while (true) {-->
-<!--            a += 2;-->
-
-<!--            while (true) {-->
-<!--                if (a >= 30) {-->
-<!--                    i += a + 1; // unused because of i = 2-->
-<!--                    break;-->
-<!--                }-->
-<!--                a = a + 3;-->
-<!--                i = a + 2;  // used by i += a + 1-->
-<!--            }-->
-
-<!--            i = 2; // used by print-->
-<!--        }-->
-
-<!--        System.out.println(i); // uses i = i + 1-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>While loop with named break 2</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0;-->
-<!--        int i = 0; // unused now-->
-
-<!--        outer:-->
-<!--        while (true) {-->
-<!--            a += 2;-->
-
-<!--            while (true) {-->
-<!--                if (a >= 30) {-->
-<!--                    i += a + 1; // used by print-->
-<!--                    break outer;-->
-<!--                }-->
-<!--                a = a + 3;-->
-<!--                i = a + 2;  // used by i += a + 1-->
-<!--            }-->
-
-<!--            i = 2; // used by print-->
-<!--        }-->
-
-<!--        System.out.println(i); // uses i = i + 1-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-
-<!--    <test-code>-->
-<!--        <description>While loop with continue</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0;-->
-<!--        int i = 0;-->
-<!--        while (true) {-->
-<!--            if (a >= 30) {-->
-<!--                i = a + 1; // used by below-->
-<!--                continue;-->
-<!--            }-->
-<!--            a = a + 3;-->
-<!--            i = i + 1; // used by itself-->
-<!--        }-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>While loop with continue 2</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0;-->
-<!--        int i = 0;-->
-<!--        while (a < 50) {-->
-<!--            if (i >= 30) {-->
-<!--                a = i + 1; // used by loop condition-->
-<!--                continue;-->
-<!--            }-->
-<!--            i++; // used by itself-->
-<!--        }-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>While loop with break (control for continue test above)</description>-->
-<!--        <expected-problems>1</expected-problems>-->
-<!--        <expected-linenumbers>7</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0;-->
-<!--        int i = 0;-->
-<!--        while (a < 50) {-->
-<!--            if (i >= 30) {-->
-<!--                a = i + 1; // unused-->
-<!--                break;-->
-<!--            }-->
-<!--            i++; // used by itself-->
-<!--        }-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Do while 0</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0 ;-->
-<!--        int i = 0 ;-->
-<!--        do {-->
-<!--            a = a+3;-->
-<!--            i += 3;-->
-<!--        } while (i < 30);-->
-<!--   }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Do while 1</description>-->
-<!--        <expected-problems>1</expected-problems>-->
-<!--        <expected-linenumbers>3</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'a' is never used (overwritten on line 6)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0;-->
-<!--        int i = 0;-->
-<!--        do {-->
-<!--            a = i+3;-->
-<!--            i += 3;-->
-<!--        } while ((a+i) < 30);-->
-<!--   }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Do while with break</description>-->
-<!--        <expected-problems>2</expected-problems>-->
-<!--        <expected-linenumbers>7,8</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'i' is never used (goes out of scope)</message>-->
-<!--            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0;-->
-<!--        int i = 0;-->
-<!--        do {-->
-<!--            if (a >= 20) {-->
-<!--                i = 4;-->
-<!--                a *= 5;-->
-<!--                break;-->
-<!--            }-->
-
-<!--            a = i + 3;-->
-<!--            i += 3;-->
-<!--        } while (i < 30);-->
-<!--   }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Do while with continue</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0;-->
-<!--        int i = 0;-->
-<!--        do {-->
-<!--            if (a >= 20) {-->
-<!--                i = 4;  // used by condition-->
-<!--                a *= 5;-->
-<!--                continue;-->
-<!--            }-->
-
-<!--            a = i + 3;-->
-<!--            i += 3;-->
-<!--        } while (i < 30);-->
-<!--   }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Switch statement 0</description>-->
-<!--        <expected-problems>4</expected-problems>-->
-<!--        <expected-linenumbers>6,8,10,12</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>-->
-<!--            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>-->
-<!--            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>-->
-<!--            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0 ;-->
-<!--        int i = 0 ;-->
-<!--        switch(i){-->
-<!--            case 1 : a = a+1;-->
-<!--            break;-->
-<!--            case 2 : a = a+2;-->
-<!--            break;-->
-<!--            case 3 : a = a+3;-->
-<!--            break;-->
-<!--            default : a = a + 1;-->
-<!--        }-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Switch statement 1</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0 ;-->
-<!--        int i = 0 ;-->
-<!--        switch(i){-->
-<!--            case 1 : a = 1;-->
-<!--            break;-->
-<!--            case 2 : a = 2;-->
-<!--            break;-->
-<!--            case 3 : a = 3;-->
-<!--            break;-->
-<!--            default : a = a + 1;-->
-<!--        }-->
-
-<!--        System.out.println(a);-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Switch statement 2</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0 ;-->
-<!--        int i = 0 ;-->
-<!--        switch(i){-->
-<!--            case 1 : a = 1;-->
-<!--                     if (args.length > 0) break; // else fallthrough-->
-<!--            case 2 : a = 2; break;-->
-<!--            case 3 : a = 3; break;-->
-<!--            default : a = a + 1;-->
-<!--        }-->
-
-<!--        System.out.println(a);-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Switch fallthrough</description>-->
-<!--        <expected-problems>1</expected-problems>-->
-<!--        <expected-linenumbers>6</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'a' is never used (overwritten on line 8)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0 ;-->
-<!--        int i = 0 ;-->
-<!--        switch(i){-->
-<!--            case 1 : a = 1; // unused-->
-<!--            // break; // no break-->
-<!--            case 2 : a = 2;-->
-<!--            break;-->
-<!--            case 3 : a = 3;-->
-<!--            break;-->
-<!--            default : a = a + 1;-->
-<!--        }-->
-
-<!--        System.out.println(a);-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Switch fallthrough 2</description>-->
-<!--        <expected-problems>1</expected-problems>-->
-<!--        <expected-linenumbers>9</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0 ;-->
-<!--        int i = 0 ;-->
-<!--        switch(i){-->
-<!--            case 1 : a = a+1;-->
-<!--            case 2 : a = a+2;-->
-<!--            case 3 : a = a+3;-->
-<!--            default : a = a + 0; // this one-->
-<!--        }-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Switch non-fallthrough</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0 ;-->
-<!--        int i = 0 ;-->
-<!--        switch(i) {-->
-<!--            case 1 -> a = 1;-->
-<!--            case 2 -> a = 2;-->
-<!--            case 3 -> a = 3;-->
-<!--            default -> a = a + 1;-->
-<!--        }-->
-<!--        System.out.println(a);-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Switch non-fallthrough blocks</description>-->
-<!--        <expected-problems>1</expected-problems>-->
-<!--        <expected-linenumbers>9</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'i' is never used (goes out of scope)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0 ;-->
-<!--        int i = 0 ;-->
-<!--        switch(i) {-->
-<!--            case 1 -> a = 1;-->
-<!--            case 2 -> {-->
-<!--                if (args.length > 0) {-->
-<!--                    i = 4;-->
-<!--                    break;-->
-<!--                }-->
-<!--                a = 2;-->
-<!--            }-->
-<!--            case 3 -> a = 3;-->
-<!--            default -> a = a + 1;-->
-<!--        }-->
-<!--        System.out.println(a);-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Switch expr non-fallthrough</description>-->
-<!--        <expected-problems>4</expected-problems>-->
-<!--        <expected-linenumbers>6,7,8,9</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>-->
-<!--            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>-->
-<!--            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>-->
-<!--            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0 ;-->
-<!--        a = switch(i) { // this is used-->
-<!--            // all those are unused-->
-<!--            case 1 -> a = 1;-->
-<!--            case 2 -> a = 2;-->
-<!--            case 3 -> a = 3;-->
-<!--            default -> a = a + 1;-->
-<!--        };-->
-
-<!--        System.out.println(a);-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Switch expr with yield</description>-->
-<!--        <expected-problems>4</expected-problems>-->
-<!--        <expected-linenumbers>6,9,13,14</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>-->
-<!--            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>-->
-<!--            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>-->
-<!--            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int a = 0 ;-->
-<!--        a = switch(i) { // this is used-->
-<!--            // all those are unused-->
-<!--            case 1 -> a = 1;-->
-<!--            case 2 -> {-->
-<!--                if (a > 0) {-->
-<!--                    yield a++;-->
-<!--                }-->
-<!--                yield 4;-->
-<!--            }-->
-<!--            case 3 -> a = 3;-->
-<!--            default -> a = a + 1;-->
-<!--        };-->
-
-<!--        System.out.println(a);-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Usage as LHS of method</description>-->
-<!--        <expected-problems>1</expected-problems>-->
-<!--        <expected-linenumbers>5</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 't1' is never used (goes out of scope)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int t1 = 0 ;-->
-<!--        Test2 test = new Test2() ;-->
-<!--        t1 = test.simpleTest(t1) ;-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Assignment in operand</description>-->
-<!--        <expected-problems>1</expected-problems>-->
-<!--        <expected-linenumbers>6</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 't1' is never used (goes out of scope)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int t1 = 0 ;-->
-<!--        int t2 = 0 ;-->
-<!--        Test2 test = new Test2();-->
-<!--        if((t1 = test.simpleTest(t1)) == t2);-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Assignment in operand 2</description>-->
-<!--        <expected-problems>1</expected-problems>-->
-<!--        <expected-linenumbers>7</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 't1' is never used (goes out of scope)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int t1 = 0 ;-->
-<!--        int t2 = 0 ;-->
-<!--        // the left assignment reaches the right of the ==-->
-<!--        if (   (t1 = t1 + t2)-->
-<!--            == (t1 = t2 * t1) ); // only this assignment is unused-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Assignment in operand 3</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int t1 = 0 ;-->
-
-<!--        Test2 test = new Test2();-->
-<!--        if( (t1 = test.simpleTest(t1)) == t1);-->
-<!--   }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Assignment in operand 4</description>-->
-<!--        <expected-problems>2</expected-problems>-->
-<!--        <expected-linenumbers>4,6</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 't2' is never used (goes out of scope)</message>-->
-<!--            <message>The value assigned to variable 't1' is never used (goes out of scope)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--class Test{-->
-<!--    public static void main(String[] args){-->
-<!--        int t1 = 0;-->
-<!--        int t2 = 0;-->
-<!--        Test2 test = new Test2() ;-->
-<!--        if( t1 == (t1 = test.simpleTest(t1))) ;-->
-<!--   }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>#1749 DD False Positive in DataflowAnomalyAnalysis</description>-->
-<!--        <expected-problems>1</expected-problems>-->
-<!--        <expected-linenumbers>4</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--public class Test {-->
-<!--    public void test(){-->
-<!--        int a = 0;-->
-<!--        a = a + 3;-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-<!--    <test-code>-->
-<!--        <description>Compound assignment</description>-->
-<!--        <expected-problems>1</expected-problems>-->
-<!--        <expected-linenumbers>4</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--public class Test {-->
-<!--    public void test(){-->
-<!--        int a = 0;-->
-<!--        a += 3; // same with compound-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-<!--    <test-code>-->
-<!--        <description>Another case</description>-->
-<!--        <expected-problems>2</expected-problems>-->
-<!--        <expected-linenumbers>3,5</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'iter' is never used (overwritten on line 4)</message>-->
-<!--            <message>The value assigned to variable 'iter' is never used (goes out of scope)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--public class Test {-->
-<!--    public void test(){-->
-<!--       ScopeData iter = acceptOpt(node.getBody(), before.fork()); // this assignment is unused-->
-<!--       iter = acceptOpt(node.getCondition(), before.fork());-->
-<!--       iter = acceptOpt(node.getBody(), iter);-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Var usage in lambda (#1304)</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--public class Foo {-->
-
-<!--    public boolean dummyMethod(final String captured, final Set<String> dummySet) {-->
-<!--        captured = captured.trim();-->
-<!--        return dummySet.stream().noneMatch(value -> value.equalsIgnoreCase(captured));-->
-<!--    }-->
-
-<!--}        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Try/catch</description>-->
-<!--        <expected-problems>1</expected-problems>-->
-<!--        <expected-linenumbers>4</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'a' is never used (overwritten on lines 6 and 8)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--public class Foo {-->
-
-<!--    public int foo() {-->
-<!--        int a = 0;-->
-<!--        try (Reader r = new StringReader("")) {-->
-<!--            a = r.read();-->
-<!--        } catch (IOException e) {-->
-<!--            a = -1;-->
-<!--        }-->
-<!--        return a;-->
-<!--    }-->
-
-<!--}        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Try with several catches</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--public class Foo {-->
-
-<!--    public int foo() {-->
-<!--        int a;-->
-<!--        try (Reader r = new StringReader("")) {-->
-<!--            a = r.read();-->
-<!--        } catch (IOException e) {-->
-<!--            a = -1;-->
-<!--        } catch (IllegalArgumentException e) {-->
-<!--            a = 2;-->
-<!--        }-->
-<!--        return a;-->
-<!--    }-->
-
-<!--}        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Definitions in try block reach catch blocks</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--public class Foo {-->
-
-<!--    void method() {-->
-<!--        boolean halfway = false;-->
-
-<!--        try {-->
-<!--            halfway = true;-->
-<!--        } catch(Exception e) {-->
-<!--            System.out.println(halfway);-->
-<!--        }-->
-<!--    }-->
-<!--}-->
-
-
-<!--]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Try/catch finally</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--public class Foo {-->
-
-<!--    public int foo() {-->
-<!--        int a = 0;-->
-<!--        try (Reader r = new StringReader("")) {-->
-<!--            a = r.read();  // used in finally-->
-<!--        } catch (IOException e) {-->
-<!--            a = -1; // used in finally-->
-<!--        } finally {-->
-<!--            print(a);-->
-<!--        }-->
-<!--        return 0;-->
-<!--    }-->
-
-<!--}        ]]></code>-->
-<!--    </test-code>-->
-<!--    <test-code>-->
-<!--        <description>Try/catch finally 3</description>-->
-<!--        <expected-problems>1</expected-problems>-->
-<!--        <expected-linenumbers>4</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'a' is never used (overwritten on lines 6 and 8)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--public class Foo {-->
-
-<!--    public int foo() {-->
-<!--        int a = 0;-->
-<!--        try (Reader r = new StringReader("")) {-->
-<!--            a = r.read();  // used in finally-->
-<!--        } catch (IOException e) {-->
-<!--            a = -1; // used in finally-->
-<!--        } finally {-->
-<!--            // don't use a-->
-<!--        }-->
-<!--        return a;-->
-<!--    }-->
-
-<!--}        ]]></code>-->
-<!--    </test-code>-->
-<!--    <test-code>-->
-<!--        <description>Try/catch finally in loop</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--import java.io.IOException;-->
-<!--import java.io.Reader;-->
-<!--import java.io.StringReader;-->
-
-<!--class Foo {-->
-
-<!--    public int foo() {-->
-<!--        int a = 0;-->
-<!--        while (a > 10) {-->
-<!--            try (Reader r = new StringReader("")) {-->
-<!--                r.read();-->
-<!--            } catch (IOException e) {-->
-<!--                a = -1; // used in finally even if break-->
-<!--                break;-->
-<!--            } finally {-->
-<!--                a++;-->
-<!--            }-->
-<!--        }-->
-<!--        return a;-->
-<!--    }-->
-
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-<!--    <test-code>-->
-<!--        <description>Abstract method NPE</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-
-<!--abstract class Foo {-->
-
-<!--    public abstract int foo();-->
-
-<!--    interface Bar {-->
-<!--        int bar();-->
-<!--    }-->
-
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-<!--    <test-code>-->
-<!--        <description>FP in finally</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-
-<!--class Foo {-->
-<!--    public Object intercept(Object proxy) throws Throwable {-->
-<!--        Object oldProxy = null; // FP here-->
-<!--        try {-->
-<!--            oldProxy = new Object[] { proxy };-->
-<!--            return null;-->
-<!--        }-->
-<!--        finally {-->
-<!--            System.out.println(oldProxy);-->
-<!--        }-->
-<!--    }-->
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Lambda captured var use</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--class Foo {-->
-
-<!--  public Flux<Object> decode() {-->
-<!--    Flux<List<XMLEvent>> splitEvents = splitEvts();-->
-
-<!--    return map(events -> {-->
-<!--      return unmarshal(events.append(splitEvents));-->
-<!--    });-->
-<!--  }-->
-
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-<!--    <test-code>-->
-<!--        <description>Lambda assignment</description>-->
-<!--        <expected-problems>2</expected-problems>-->
-<!--        <expected-linenumbers>5,6</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'k' is never used (overwritten on line 6)</message>-->
-<!--            <message>The value assigned to variable 'k' is never used (goes out of scope)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--class Foo {-->
-
-<!--  public void decode() {-->
-<!--    doSomething(events -> {-->
-<!--      int k = 0;-->
-<!--      return k = 2;-->
-<!--    });-->
-<!--  }-->
-
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-<!--    <test-code>-->
-<!--        <description>Lambda returns 2</description>-->
-<!--        <expected-problems>2</expected-problems>-->
-<!--        <expected-linenumbers>4,7</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'splitEvents' is never used (goes out of scope)</message>-->
-<!--            <message>The value assigned to variable 'events' is never used (goes out of scope)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--class Foo {-->
-
-<!--  public Flux<Object> decode() {-->
-<!--    Flux<List<XMLEvent>> splitEvents = splitEvts();-->
-
-<!--    return map(events -> {-->
-<!--      events = events.normalize();-->
-<!--      return dontUseEvents();-->
-<!--    });-->
-<!--  }-->
-
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-<!--    <test-code>-->
-<!--        <description>FP in try</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--package foo;-->
-<!--class Foo {-->
-
-<!--    public Object getSubject() {-->
-<!--      try {-->
-<!--        Object subject = Other.currentUserMethod.invoke();-->
-<!--        if (subject == null) {-->
-<!--          subject = Other.anonymousSubjectMethod.invoke(0);-->
-<!--        }-->
-<!--        return subject;-->
-<!--      } catch (Exception ex) {-->
-<!--        throw new RuntimeException("Failed to obtain SubjectHandle", ex);-->
-<!--      }-->
-<!--    }-->
-
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Field initializers 0</description>-->
-<!--        <expected-problems>0</expected-problems>-->
-<!--        <code><![CDATA[-->
-<!--class Foo {-->
-
-<!--    int f1 = 0;-->
-<!--    int f2 = f1++;-->
-
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Field initializers 1</description>-->
-<!--        <expected-problems>1</expected-problems>-->
-<!--        <expected-linenumbers>3</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'f1' is never used (overwritten on line 4)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--class Foo {-->
-
-<!--    int f1 = 0;-->
-<!--    int f2 = f1 = 1, f3 = f2;-->
-
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Field initializers 1</description>-->
-<!--        <expected-problems>1</expected-problems>-->
-<!--        <expected-linenumbers>3</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'f1' is never used (overwritten on line 4)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--class Foo {-->
-
-<!--    int f1 = 0;-->
-<!--    int f2 = this.f1 = 1, f3 = f2;-->
-
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
-
-<!--    <test-code>-->
-<!--        <description>Field initializers and ctor</description>-->
-<!--        <expected-problems>1</expected-problems>-->
-<!--        <expected-linenumbers>3</expected-linenumbers>-->
-<!--        <expected-messages>-->
-<!--            <message>The value assigned to variable 'f1' is never used (overwritten on lines 7 and 11)</message>-->
-<!--        </expected-messages>-->
-<!--        <code><![CDATA[-->
-<!--class Foo {-->
-
-<!--    int f1 = 0;-->
-<!--    int f2 = 0;-->
-
-<!--    Foo(int f, int g) {-->
-<!--        f1 = f;-->
-<!--    }-->
-
-<!--    Foo(int f, int g) {-->
-<!--        f1 = f;-->
-<!--        f2 = f + g;-->
-<!--    }-->
-
-<!--}-->
-<!--        ]]></code>-->
-<!--    </test-code>-->
+    <test-code>
+        <description>ok</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void bar(int b) {
+        for (int i = 0; i < 10; i++) {
+            throw new Exception();
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>DD anomaly</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'i' is never used (overwritten on line 4)</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        int i=0;
+        i=1;
+        if (i==2) {}
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>DU anomaly</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        int i=0;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>UR anomaly</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        int i;
+        if (i == 0) {}
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Conditional flow 0</description>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>3,4,6</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'j' is never used (overwritten on line 6)</message>
+            <message>The value assigned to variable 'z' is never used (goes out of scope)</message>
+            <message>The value assigned to variable 'j' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    void bar(int i) {
+        int j = 0;
+        int z = 0;
+        if (i < 10) {
+            j = i;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Conditional flow 1</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'z' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    void bar(int i) {
+        int j = 0;
+        int z = 0; // unused
+        if (i < 10) {
+            j = i;
+        }
+        System.out.println(j);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Conditional flow 2</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'j' is never used (overwritten on lines 6 and 8)</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    void bar(int i) {
+        int j = 0; // unused
+        int z = 0;
+        if (i < 10) {
+            j = i;
+        } else {
+            j = z;
+        }
+        System.out.println(j);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Conditional flow with abrupt throw</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,6</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'j' is never used (overwritten on lines 6 and 9)</message>
+            <message>The value assigned to variable 'j' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    void bar(int i) {
+        int j = 0; // unused
+        int z = 0;
+        if (i < 10) {
+            j = i; // unused
+            throw new Exception();
+        } else {
+            j = z;
+        }
+        System.out.println(j);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Conditional flow with abrupt return</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,6</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'j' is never used (overwritten on lines 6 and 9)</message>
+            <message>The value assigned to variable 'j' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+    void bar(int i) {
+        int j = 0;  // unused
+        int z = 0;
+        if (i < 10) {
+            j = i;  // unused
+            return;
+        } else {
+            j = z;
+        }
+        System.out.println(j);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Local variable in loop</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>10,19</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'fail' is never used (overwritten on line 19)</message>
+            <message>The value assigned to variable 'fail' is never used (overwritten on line 19)</message>
+        </expected-messages>
+        <code><![CDATA[
+public class LoopTest {
+    public static void main(String[] args) {
+        int[] a = {1,2,3};
+        int[] b = {4,5,6};
+        int[] c = {7,8,9};
+        for (int i : a) {
+            if (i == 0) {
+                break;
+            } else {
+                boolean fail = false;
+                for (int j : b) {
+                    boolean match = false;
+                    for (int k : c) {
+                        if (k == 42) {
+                            match = true;
+                        }
+                    }
+                    if (!match) {
+                        fail = true;
+                    }
+                }
+            }
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#408 Assert statements causing </description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class AssertTest {
+    public void test() {
+        final String s = "";
+        assert(s != null);
+
+        System.out.println(s);
+
+        final Double d = 9;
+        assert(d != null);
+
+        System.out.println(d);
+
+        final String k = "k";
+        assert(k != null);
+
+        System.out.println(k);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 1. DU-Anomaly(b)</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'b' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        int b = 0 ;
+        a = a + b ;
+        b = a + b ;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>For loop</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        for(int i = 0 ; i <= 10; i ++){
+            a = a+3;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>For loop 2</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,5</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 5)</message>
+            <!-- Overwrites itself -->
+            <message>The value assigned to variable 'a' is never used (overwritten on line 5)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        for(int i = 0 ; i <= 10; i ++){
+            a = i * 3;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>For loop 3</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        for(int i = 0 ; i <= 10; i ++){
+            a = i * 3;
+        }
+        System.out.println(a);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>For loop 4</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        for(int i = 0 ; (i + a) <= 10; i ++){
+            a = i * 3;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Foreach</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int[] b = new int[10];
+        for(int a : b){
+            a = a+3;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>While loop 1</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0;
+        int i = 0;
+        while (i < 30) {
+            a = a + 3;
+            i += 3;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>While loop 2</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>4,7</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'i' is never used (overwritten on line 7)</message>
+            <message>The value assigned to variable 'i' is never used (overwritten on line 7)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0;
+        int i = 0; // unused
+        while (a < 30) {
+            a = a + 3;
+            i = 5; // unused (kills itself)
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>While loop with break</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'i' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0;
+        int i = 0;
+        while (true) {
+            if (a >= 30) {
+                i = a + 1; // unused
+                break;
+            }
+            a = a + 3;
+            i = i + 1; // used by itself
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>While loop without break (control case)</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0; // used by compound below
+        int i = 0;
+        while (true) {
+            if (a >= 30) {
+                i += a + 1; // unused by below
+                // break;  // no break here
+            }
+            a = a + 3;
+            i = a + 2; // used by above
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>While loop without break 2 (control case)</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>12</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'i' is never used (overwritten on line 16)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0;
+        int i = 0; // unused now
+
+        outer:
+        while (true) {
+            a += 2;
+
+            while (true) {
+                if (a >= 30) {
+                    i += a + 1; // unused because of i = a + 2
+                    // break outer;
+                }
+                a = a + 3;
+                i = a + 2;  // killed by below
+            }
+
+            i = 2; // used by print
+        }
+
+        System.out.println(i); // uses i = i + 1
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>While loop without break 2 (control case)</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>12</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'i' is never used (overwritten on line 19)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0;
+        int i = 0; // unused now
+
+        outer:
+        while (true) {
+            a += 2;
+
+            while (true) {
+                if (a >= 30) {
+                    i += a + 1; // unused because of i = 2
+                    break;
+                }
+                a = a + 3;
+                i = a + 2;  // used by i += a + 1
+            }
+
+            i = 2; // used by print
+        }
+
+        System.out.println(i); // uses i = i + 1
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>While loop with named break 2</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0;
+        int i = 0; // unused now
+
+        outer:
+        while (true) {
+            a += 2;
+
+            while (true) {
+                if (a >= 30) {
+                    i += a + 1; // used by print
+                    break outer;
+                }
+                a = a + 3;
+                i = a + 2;  // used by i += a + 1
+            }
+
+            i = 2; // used by print
+        }
+
+        System.out.println(i); // uses i = i + 1
+    }
+}
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>While loop with continue</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0;
+        int i = 0;
+        while (true) {
+            if (a >= 30) {
+                i = a + 1; // used by below
+                continue;
+            }
+            a = a + 3;
+            i = i + 1; // used by itself
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>While loop with continue 2</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0;
+        int i = 0;
+        while (a < 50) {
+            if (i >= 30) {
+                a = i + 1; // used by loop condition
+                continue;
+            }
+            i++; // used by itself
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>While loop with break (control for continue test above)</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0;
+        int i = 0;
+        while (a < 50) {
+            if (i >= 30) {
+                a = i + 1; // unused
+                break;
+            }
+            i++; // used by itself
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Do while 0</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        int i = 0 ;
+        do {
+            a = a+3;
+            i += 3;
+        } while (i < 30);
+   }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Do while 1</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 6)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0;
+        int i = 0;
+        do {
+            a = i+3;
+            i += 3;
+        } while ((a+i) < 30);
+   }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Do while with break</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>7,8</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'i' is never used (goes out of scope)</message>
+            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0;
+        int i = 0;
+        do {
+            if (a >= 20) {
+                i = 4;
+                a *= 5;
+                break;
+            }
+
+            a = i + 3;
+            i += 3;
+        } while (i < 30);
+   }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Do while with continue</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0;
+        int i = 0;
+        do {
+            if (a >= 20) {
+                i = 4;  // used by condition
+                a *= 5;
+                continue;
+            }
+
+            a = i + 3;
+            i += 3;
+        } while (i < 30);
+   }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Switch statement 0</description>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>6,8,10,12</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
+            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
+            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
+            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        int i = 0 ;
+        switch(i){
+            case 1 : a = a+1;
+            break;
+            case 2 : a = a+2;
+            break;
+            case 3 : a = a+3;
+            break;
+            default : a = a + 1;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Switch statement 1</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        int i = 0 ;
+        switch(i){
+            case 1 : a = 1;
+            break;
+            case 2 : a = 2;
+            break;
+            case 3 : a = 3;
+            break;
+            default : a = a + 1;
+        }
+
+        System.out.println(a);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Switch statement 2</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        int i = 0 ;
+        switch(i){
+            case 1 : a = 1;
+                     if (args.length > 0) break; // else fallthrough
+            case 2 : a = 2; break;
+            case 3 : a = 3; break;
+            default : a = a + 1;
+        }
+
+        System.out.println(a);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Switch fallthrough</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 8)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        int i = 0 ;
+        switch(i){
+            case 1 : a = 1; // unused
+            // break; // no break
+            case 2 : a = 2;
+            break;
+            case 3 : a = 3;
+            break;
+            default : a = a + 1;
+        }
+
+        System.out.println(a);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Switch fallthrough 2</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>9</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        int i = 0 ;
+        switch(i){
+            case 1 : a = a+1;
+            case 2 : a = a+2;
+            case 3 : a = a+3;
+            default : a = a + 0; // this one
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Switch non-fallthrough</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        int i = 0 ;
+        switch(i) {
+            case 1 -> a = 1;
+            case 2 -> a = 2;
+            case 3 -> a = 3;
+            default -> a = a + 1;
+        }
+        System.out.println(a);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Switch non-fallthrough blocks</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>9</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'i' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        int i = 0 ;
+        switch(i) {
+            case 1 -> a = 1;
+            case 2 -> {
+                if (args.length > 0) {
+                    i = 4;
+                    break;
+                }
+                a = 2;
+            }
+            case 3 -> a = 3;
+            default -> a = a + 1;
+        }
+        System.out.println(a);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Switch expr non-fallthrough</description>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>6,7,8,9</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        a = switch(i) { // this is used
+            // all those are unused
+            case 1 -> a = 1;
+            case 2 -> a = 2;
+            case 3 -> a = 3;
+            default -> a = a + 1;
+        };
+
+        System.out.println(a);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Switch expr with yield</description>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>6,9,13,14</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        a = switch(i) { // this is used
+            // all those are unused
+            case 1 -> a = 1;
+            case 2 -> {
+                if (a > 0) {
+                    yield a++;
+                }
+                yield 4;
+            }
+            case 3 -> a = 3;
+            default -> a = a + 1;
+        };
+
+        System.out.println(a);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Usage as LHS of method</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 't1' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int t1 = 0 ;
+        Test2 test = new Test2() ;
+        t1 = test.simpleTest(t1) ;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Assignment in operand</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 't1' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int t1 = 0 ;
+        int t2 = 0 ;
+        Test2 test = new Test2();
+        if((t1 = test.simpleTest(t1)) == t2);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Assignment in operand 2</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 't1' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int t1 = 0 ;
+        int t2 = 0 ;
+        // the left assignment reaches the right of the ==
+        if (   (t1 = t1 + t2)
+            == (t1 = t2 * t1) ); // only this assignment is unused
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Assignment in operand 3</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int t1 = 0 ;
+
+        Test2 test = new Test2();
+        if( (t1 = test.simpleTest(t1)) == t1);
+   }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Assignment in operand 4</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>4,6</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 't2' is never used (goes out of scope)</message>
+            <message>The value assigned to variable 't1' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int t1 = 0;
+        int t2 = 0;
+        Test2 test = new Test2() ;
+        if( t1 == (t1 = test.simpleTest(t1))) ;
+   }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#1749 DD False Positive in DataflowAnomalyAnalysis</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Test {
+    public void test(){
+        int a = 0;
+        a = a + 3;
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Compound assignment</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Test {
+    public void test(){
+        int a = 0;
+        a += 3; // same with compound
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Another case</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,5</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'iter' is never used (overwritten on line 4)</message>
+            <message>The value assigned to variable 'iter' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Test {
+    public void test(){
+       ScopeData iter = acceptOpt(node.getBody(), before.fork()); // this assignment is unused
+       iter = acceptOpt(node.getCondition(), before.fork());
+       iter = acceptOpt(node.getBody(), iter);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Var usage in lambda (#1304)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+
+    public boolean dummyMethod(final String captured, final Set<String> dummySet) {
+        captured = captured.trim();
+        return dummySet.stream().noneMatch(value -> value.equalsIgnoreCase(captured));
+    }
+
+}        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Try/catch</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'a' is never used (overwritten on lines 6 and 8)</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+
+    public int foo() {
+        int a = 0;
+        try (Reader r = new StringReader("")) {
+            a = r.read();
+        } catch (IOException e) {
+            a = -1;
+        }
+        return a;
+    }
+
+}        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Try with several catches</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+
+    public int foo() {
+        int a;
+        try (Reader r = new StringReader("")) {
+            a = r.read();
+        } catch (IOException e) {
+            a = -1;
+        } catch (IllegalArgumentException e) {
+            a = 2;
+        }
+        return a;
+    }
+
+}        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Try with resources: resources should be used</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+
+    public void foo() {
+        try (Reader r = new StringReader("")) {
+
+        }
+    }
+
+}        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Definitions in try block reach catch blocks</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+
+    void method() {
+        boolean halfway = false;
+
+        try {
+            halfway = true;
+        } catch(Exception e) {
+            System.out.println(halfway);
+        }
+    }
+}
+
+
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Try/catch finally</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+
+    public int foo() {
+        int a = 0;
+        try (Reader r = new StringReader("")) {
+            a = r.read();  // used in finally
+        } catch (IOException e) {
+            a = -1; // used in finally
+        } finally {
+            print(a);
+        }
+        return 0;
+    }
+
+}        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Try/catch finally 3</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'a' is never used (overwritten on lines 6 and 8)</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+
+    public int foo() {
+        int a = 0;
+        try (Reader r = new StringReader("")) {
+            a = r.read();  // used in finally
+        } catch (IOException e) {
+            a = -1; // used in finally
+        } finally {
+            // don't use a
+        }
+        return a;
+    }
+
+}        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Try/catch finally in loop</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+
+class Foo {
+
+    public int foo() {
+        int a = 0;
+        while (a > 10) {
+            try (Reader r = new StringReader("")) {
+                r.read();
+            } catch (IOException e) {
+                a = -1; // used in finally even if break
+                break;
+            } finally {
+                a++;
+            }
+        }
+        return a;
+    }
+
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Abstract method NPE</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+
+abstract class Foo {
+
+    public abstract int foo();
+
+    interface Bar {
+        int bar();
+    }
+
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>FP in finally</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+
+class Foo {
+    public Object intercept(Object proxy) throws Throwable {
+        Object oldProxy = null; // FP here
+        try {
+            oldProxy = new Object[] { proxy };
+            return null;
+        }
+        finally {
+            System.out.println(oldProxy);
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Lambda captured var use</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Foo {
+
+  public Flux<Object> decode() {
+    Flux<List<XMLEvent>> splitEvents = splitEvts();
+
+    return map(events -> {
+      return unmarshal(events.append(splitEvents));
+    });
+  }
+
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Lambda assignment</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>5,6</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'k' is never used (overwritten on line 6)</message>
+            <message>The value assigned to variable 'k' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Foo {
+
+  public void decode() {
+    doSomething(events -> {
+      int k = 0;
+      return k = 2;
+    });
+  }
+
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Lambda returns 2</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>4,7</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'splitEvents' is never used (goes out of scope)</message>
+            <message>The value assigned to variable 'events' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Foo {
+
+  public Flux<Object> decode() {
+    Flux<List<XMLEvent>> splitEvents = splitEvts();
+
+    return map(events -> {
+      events = events.normalize();
+      return dontUseEvents();
+    });
+  }
+
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>FP in try</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+package foo;
+class Foo {
+
+    public Object getSubject() {
+      try {
+        Object subject = Other.currentUserMethod.invoke();
+        if (subject == null) {
+          subject = Other.anonymousSubjectMethod.invoke(0);
+        }
+        return subject;
+      } catch (Exception ex) {
+        throw new RuntimeException("Failed to obtain SubjectHandle", ex);
+      }
+    }
+
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Field initializers 0</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Foo {
+
+    int f1 = 0;
+    int f2 = f1++;
+
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Field initializers 1</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'f1' is never used (overwritten on line 4)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Foo {
+
+    int f1 = 0;
+    int f2 = f1 = 1, f3 = f2;
+
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Field initializers 1</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'f1' is never used (overwritten on line 4)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Foo {
+
+    int f1 = 0;
+    int f2 = this.f1 = 1, f3 = f2;
+
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Field initializers and ctor</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'f1' is never used (overwritten on lines 7 and 11)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Foo {
+
+    int f1 = 0;
+    int f2 = 0;
+
+    Foo(int f) {
+        f1 = f;
+    }
+
+    Foo(int f, int g) {
+        f1 = f;
+        f2 = f + g;
+    }
+
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Field initializers and ctor with this</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'f1' is never used (overwritten on lines 7 and 11)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Foo {
+
+    int f1 = 0;
+    int f2 = 0;
+
+    Foo(int f) {
+        this.f1 = f;
+    }
+
+    Foo(int f, int g) {
+        this.f1 = f;
+        this.f2 = f + g;
+    }
+
+}
+        ]]></code>
+    </test-code>
 
     <test-code>
         <description>Field initializers and ctor with this, shadowing</description>
@@ -1417,7 +1458,7 @@ class Foo {
     int f1 = 0;
     int f2 = 0;
 
-    Foo(int f1, int g) {
+    Foo(int f1) {
         this.f1 = f1;
     }
 
@@ -1439,7 +1480,7 @@ class Foo {
     Bar f1 = 0;
     Bar f2 = 0;
 
-    Foo(Bar f1, Bar g) {
+    Foo(Bar f1) {
         this.f1.field = f1;
     }
 
@@ -1466,7 +1507,7 @@ class Foo {
     int f1 = 0;
     int f3 = 0;
 
-    Foo(int f, int g) {
+    Foo(int f) {
         f1 = f;
     }
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -2145,6 +2145,57 @@ class Foo {
     </test-code>
 
     <test-code>
+        <description>Nested boolean logic 1</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>The value assigned to variable 'i' is never used (overwritten on line 7)</message>
+        </expected-messages>
+        <code><![CDATA[
+            class Foo {
+
+              void main(int[] bufline, int start, int bufsize) {
+
+                int i = 0, j, k = 0;
+
+                if ( (i = 1) > 0 || ((i = 2) < (j = i) && (j = k) == i) ) {
+                    // reaching: i = 1, i = 2, j = k  (not j = i)
+                } else {
+                    // reaching: i = 2, j = k, j = i  (not i = 1)
+                    log(j);
+                    log(i);
+                }
+              }
+            }
+
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Nested boolean logic 2</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>The value assigned to variable 'i' is never used (overwritten on line 7)</message>
+        </expected-messages>
+        <code><![CDATA[
+            class Foo {
+
+              void main(int[] bufline, int start, int bufsize) {
+
+                int i = 0, j, k = 0;
+
+                if ( (i = 1) > 0 && ((i = 2) < (j = i) || (j = k) == i) ) {
+                    // reaching: i = 2, j = i, j = k  (not i = 1)
+                    log(i);
+                } else {
+                    // reaching: i = 1, i = 2, j = k, j = i
+                    log(j);
+                }
+              }
+            }
+
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>FP with argument</description>
         <expected-problems>1</expected-problems>
         <expected-messages>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -1978,5 +1978,171 @@ public class Foo {
         ]]></code>
     </test-code>
 
+<!--    <test-code>-->
+<!--        <description>Test shortcut AND</description>-->
+<!--        <expected-problems>1</expected-problems>-->
+<!--        <expected-linenumbers>5</expected-linenumbers>-->
+<!--        <expected-messages>-->
+<!--            <message>The initializer for variable 'k' is never used (overwritten on line 5)</message>-->
+<!--        </expected-messages>-->
+<!--        <code><![CDATA[-->
+<!--class Foo {-->
+
+<!--  void main(int[] bufline, int start, int bufsize) {-->
+
+<!--    int i = 0, j, k = 0;-->
+
+<!--    while (i < bufline.length-->
+<!--        // this is AND-->
+<!--        && bufline[j = start % bufsize] == bufline[k = ++start % bufsize]) {-->
+
+<!--      bufline[j] = bufline[k];-->
+<!--      i++;-->
+<!--    }-->
+<!--  }-->
+<!--}-->
+
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+<!--    <test-code>-->
+<!--        <description>Test shortcut OR</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--class Foo {-->
+
+<!--  void main(int[] bufline, int start, int bufsize) {-->
+
+<!--    int i = 0, j, k = 0;-->
+
+<!--    while (i < bufline.length-->
+<!--        // this is OR-->
+<!--        || bufline[j = start % bufsize] == bufline[k = ++start % bufsize]) {-->
+
+<!--      // here j, k might be their initializers-->
+<!--      bufline[j] = bufline[k];-->
+<!--      i++;-->
+<!--    }-->
+<!--  }-->
+<!--}-->
+
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+    <test-code>
+        <description>Test shortcut OR</description>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>5,7,8</expected-linenumbers>
+        <expected-messages>
+            <message>The initializer for variable 'i' is never used (overwritten on line 7)</message>
+            <message>The value assigned to variable 'j' is never used (overwritten on line 8)</message>
+            <message>The value assigned to variable 'j' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Foo {
+
+  void main(int[] bufline, int start, int bufsize) {
+
+    int i = 0, j, k = 0;
+
+    if (  (i = 2) < (j = i)
+     ||   (j = k) == i       ) {
+
+        // reaching: i = 2, j = i, j = k
+
+    } else {
+        // reaching: i = 2, j = k  (not j = i)
+    }
+  }
+}
+
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Test shortcut OR 2</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>The initializer for variable 'i' is never used (overwritten on line 7)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Foo {
+
+  void main(int[] bufline, int start, int bufsize) {
+
+    int i = 0, j, k = 0;
+
+    if (  (i = 2) < (j = i)
+     ||   (j = k) == i       ) {
+
+        // reaching: i = 2, j = i, j = k
+        log(j);
+    } else {
+        // reaching: i = 2, j = k  (not j = i)
+    }
+  }
+}
+
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Test shortcut AND</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>5,7</expected-linenumbers>
+        <expected-messages>
+            <message>The initializer for variable 'i' is never used (overwritten on line 7)</message>
+            <message>The value assigned to variable 'j' is never used (overwritten on line 8)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Foo {
+
+  void main(int[] bufline, int start, int bufsize) {
+
+    int i = 0, j, k = 0;
+
+    if (  (i = 2) < (j = i)
+       && (j = k) == i       ) {
+
+        // reaching: i = 2, j = k  (not j = i)
+        log(j);
+    } else {
+        // reaching: i = 2, j = k, j = i
+    }
+  }
+}
+
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Test shortcut AND 2</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>The initializer for variable 'i' is never used (overwritten on line 7)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Foo {
+
+  void main(int[] bufline, int start, int bufsize) {
+
+    int i = 0, j, k = 0;
+
+    if (  (i = 2) < (j = i)
+       && (j = k) == i       ) {
+
+        // reaching: i = 2, j = k  (not j = i)
+    } else {
+        // reaching: i = 2, j = k, j = i
+        log(j);
+    }
+  }
+}
+
+        ]]></code>
+    </test-code>
+
 
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -348,8 +348,8 @@ class Test{
     public static void main(String[] args){
         int a = 0;
         int i = 0;
-        while(i < 30){
-            a = a+3;
+        while (i < 30) {
+            a = a + 3;
             i += 3;
         }
     }
@@ -370,7 +370,7 @@ class Test{
     public static void main(String[] args){
         int a = 0;
         int i = 0; // unused
-        while(a < 30){
+        while (a < 30) {
             a = a + 3;
             i = 5; // unused (kills itself)
         }
@@ -1201,6 +1201,68 @@ class Foo {
             System.out.println(oldProxy);
         }
     }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Lambda captured var use</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Foo {
+
+	public Flux<Object> decode() {
+		Flux<List<XMLEvent>> splitEvents = splitEvts();
+
+		return map(events -> {
+			return unmarshal(events.append(splitEvents));
+		});
+	}
+
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Lambda assignment</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>5,6</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'k' is never used (overwritten on line 6)</message>
+            <message>The value assigned to variable 'k' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Foo {
+
+	public void decode() {
+    doSomething(events -> {
+      int k = 0;
+      return k = 2;
+    });
+	}
+
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Lambda returns 2</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>4,7</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'splitEvents' is never used (goes out of scope)</message>
+            <message>The value assigned to variable 'events' is never used (goes out of scope)</message>
+        </expected-messages>
+        <code><![CDATA[
+class Foo {
+
+	public Flux<Object> decode() {
+		Flux<List<XMLEvent>> splitEvents = splitEvts();
+
+		return map(events -> {
+		  events = events.normalize();
+			return dontUseEvents();
+		});
+	}
+
 }
         ]]></code>
     </test-code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -23,7 +23,7 @@ public class Foo {
         <expected-problems>1</expected-problems>
         <expected-linenumbers>3</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'i' is never used (overwritten on line 4)</message>
+            <message>The initializer for variable 'i' is never used (overwritten on line 4)</message>
         </expected-messages>
         <code><![CDATA[
 public class Foo {
@@ -66,8 +66,8 @@ public class Foo {
         <expected-problems>3</expected-problems>
         <expected-linenumbers>3,4,6</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'j' is never used (overwritten on line 6)</message>
-            <message>The value assigned to variable 'z' is never used (goes out of scope)</message>
+            <message>The initializer for variable 'j' is never used (overwritten on line 6)</message>
+            <message>The initializer for variable 'z' is never used (goes out of scope)</message>
             <message>The value assigned to variable 'j' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
@@ -88,7 +88,7 @@ public class Foo {
         <expected-problems>1</expected-problems>
         <expected-linenumbers>4</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'z' is never used (goes out of scope)</message>
+            <message>The initializer for variable 'z' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
 public class Foo {
@@ -109,7 +109,7 @@ public class Foo {
         <expected-problems>1</expected-problems>
         <expected-linenumbers>3</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'j' is never used (overwritten on lines 6 and 8)</message>
+            <message>The initializer for variable 'j' is never used (overwritten on lines 6 and 8)</message>
         </expected-messages>
         <code><![CDATA[
 public class Foo {
@@ -132,7 +132,7 @@ public class Foo {
         <expected-problems>2</expected-problems>
         <expected-linenumbers>3,6</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'j' is never used (overwritten on lines 6 and 9)</message>
+            <message>The initializer for variable 'j' is never used (overwritten on lines 6 and 9)</message>
             <message>The value assigned to variable 'j' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
@@ -157,7 +157,7 @@ public class Foo {
         <expected-problems>2</expected-problems>
         <expected-linenumbers>3,6</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'j' is never used (overwritten on lines 6 and 9)</message>
+            <message>The initializer for variable 'j' is never used (overwritten on lines 6 and 9)</message>
             <message>The value assigned to variable 'j' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
@@ -182,7 +182,7 @@ public class Foo {
         <expected-problems>2</expected-problems>
         <expected-linenumbers>10,19</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'fail' is never used (overwritten on line 19)</message>
+            <message>The initializer for variable 'fail' is never used (overwritten on line 19)</message>
             <message>The value assigned to variable 'fail' is never used (overwritten on line 19)</message>
         </expected-messages>
         <code><![CDATA[
@@ -278,7 +278,7 @@ class Test{
         <expected-problems>2</expected-problems>
         <expected-linenumbers>3,5</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'a' is never used (overwritten on line 5)</message>
+            <message>The initializer for variable 'a' is never used (overwritten on line 5)</message>
             <!-- Overwrites itself -->
             <message>The value assigned to variable 'a' is never used (overwritten on line 5)</message>
         </expected-messages>
@@ -366,7 +366,7 @@ class Test{
         <expected-problems>2</expected-problems>
         <expected-linenumbers>4,7</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'i' is never used (overwritten on line 7)</message>
+            <message>The initializer for variable 'i' is never used (overwritten on line 7)</message>
             <message>The value assigned to variable 'i' is never used (overwritten on line 7)</message>
         </expected-messages>
         <code><![CDATA[
@@ -617,7 +617,7 @@ class Test{
         <expected-problems>1</expected-problems>
         <expected-linenumbers>3</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'a' is never used (overwritten on line 6)</message>
+            <message>The initializer for variable 'a' is never used (overwritten on line 6)</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -998,7 +998,7 @@ class Test{
         <expected-problems>2</expected-problems>
         <expected-linenumbers>4,6</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 't2' is never used (goes out of scope)</message>
+            <message>The initializer for variable 't2' is never used (goes out of scope)</message>
             <message>The value assigned to variable 't1' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
@@ -1050,7 +1050,7 @@ public class Test {
         <expected-problems>2</expected-problems>
         <expected-linenumbers>3,5</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'iter' is never used (overwritten on line 4)</message>
+            <message>The initializer for variable 'iter' is never used (overwritten on line 4)</message>
             <message>The value assigned to variable 'iter' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
@@ -1083,7 +1083,7 @@ public class Foo {
         <expected-problems>1</expected-problems>
         <expected-linenumbers>4</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'a' is never used (overwritten on lines 6 and 8)</message>
+            <message>The initializer for variable 'a' is never used (overwritten on lines 6 and 8)</message>
         </expected-messages>
         <code><![CDATA[
 public class Foo {
@@ -1183,7 +1183,7 @@ public class Foo {
         <expected-problems>1</expected-problems>
         <expected-linenumbers>4</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'a' is never used (overwritten on lines 6 and 8)</message>
+            <message>The initializer for variable 'a' is never used (overwritten on lines 6 and 8)</message>
         </expected-messages>
         <code><![CDATA[
 public class Foo {
@@ -1288,7 +1288,7 @@ class Foo {
         <expected-problems>2</expected-problems>
         <expected-linenumbers>5,6</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'k' is never used (overwritten on line 6)</message>
+            <message>The initializer for variable 'k' is never used (overwritten on line 6)</message>
             <message>The value assigned to variable 'k' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
@@ -1309,7 +1309,7 @@ class Foo {
         <expected-problems>2</expected-problems>
         <expected-linenumbers>4,7</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'splitEvents' is never used (goes out of scope)</message>
+            <message>The initializer for variable 'splitEvents' is never used (goes out of scope)</message>
             <message>The value assigned to variable 'events' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
@@ -1368,7 +1368,7 @@ class Foo {
         <expected-problems>1</expected-problems>
         <expected-linenumbers>3</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'f1' is never used (overwritten on line 4)</message>
+            <message>The field initializer for 'f1' is never used (overwritten on line 4)</message>
         </expected-messages>
         <code><![CDATA[
 class Foo {
@@ -1385,7 +1385,7 @@ class Foo {
         <expected-problems>1</expected-problems>
         <expected-linenumbers>3</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'f1' is never used (overwritten on line 4)</message>
+            <message>The field initializer for 'f1' is never used (overwritten on line 4)</message>
         </expected-messages>
         <code><![CDATA[
 class Foo {
@@ -1402,7 +1402,7 @@ class Foo {
         <expected-problems>1</expected-problems>
         <expected-linenumbers>3</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'f1' is never used (overwritten on lines 7 and 11)</message>
+            <message>The field initializer for 'f1' is never used (overwritten on lines 7 and 11)</message>
         </expected-messages>
         <code><![CDATA[
 class Foo {
@@ -1428,7 +1428,7 @@ class Foo {
         <expected-problems>1</expected-problems>
         <expected-linenumbers>3</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'f1' is never used (overwritten on lines 7 and 11)</message>
+            <message>The field initializer for 'f1' is never used (overwritten on lines 7 and 11)</message>
         </expected-messages>
         <code><![CDATA[
 class Foo {
@@ -1454,7 +1454,7 @@ class Foo {
         <expected-problems>1</expected-problems>
         <expected-linenumbers>3</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'f1' is never used (overwritten on lines 7 and 11)</message>
+            <message>The field initializer for 'f1' is never used (overwritten on lines 7 and 11)</message>
         </expected-messages>
         <code><![CDATA[
 class Foo {
@@ -1502,8 +1502,8 @@ class Foo {
         <expected-problems>2</expected-problems>
         <expected-linenumbers>3,11</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'f1' is never used (overwritten on line 11)</message>
-            <message>The value assigned to variable 'f1' is never used (overwritten on lines 7 and 15)</message>
+            <message>The field initializer for 'f1' is never used (overwritten on line 11)</message>
+            <message>The value assigned to field 'f1' is never used (overwritten on lines 7 and 15)</message>
         </expected-messages>
         <code><![CDATA[
 class Foo {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -1073,4 +1073,104 @@ public class Foo {
 
 }        ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Try/catch</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'a' is never used (overwritten on lines 6 and 8)</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+
+    public int foo() {
+        int a = 0;
+        try (Reader r = new StringReader("")) {
+            a = r.read();
+        } catch (IOException e) {
+            a = -1;
+        }
+        return a;
+    }
+
+}        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Try/catch finally</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'a' is never used (overwritten on lines 6 and 8)</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+
+    public int foo() {
+        int a = 0;
+        try (Reader r = new StringReader("")) {
+            a = r.read();  // used in finally
+        } catch (IOException e) {
+            a = -1; // used in finally
+        } finally {
+            print(a);
+        }
+        return 0;
+    }
+
+}        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Try/catch finally 3</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'a' is never used (overwritten on lines 6 and 8)</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+
+    public int foo() {
+        int a = 0;
+        try (Reader r = new StringReader("")) {
+            a = r.read();  // used in finally
+        } catch (IOException e) {
+            a = -1; // used in finally
+        } finally {
+            // don't use a
+        }
+        return a;
+    }
+
+}        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Try/catch finally in loop</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringReader;
+
+class Foo {
+
+    public int foo() {
+        int a = 0;
+        while (a > 10) {
+            try (Reader r = new StringReader("")) {
+                r.read();
+            } catch (IOException e) {
+                a = -1; // used in finally even if break
+                break;
+            } finally {
+                a++;
+            }
+        }
+        return a;
+    }
+
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -179,8 +179,12 @@ public class Foo {
 
     <test-code>
         <description>#1393 PMD hanging during DataflowAnomalyAnalysis</description>
-        <!-- Note: due to https://sourceforge.net/p/pmd/bugs/1383/ the 3 problems are false positives!  -->
-        <expected-problems>3</expected-problems>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>10,19</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'fail' is never used</message>
+            <message>The value assigned to variable 'fail' is never used</message>
+        </expected-messages>
         <code><![CDATA[
 public class LoopTest {
     public static void main(String[] args) {
@@ -255,10 +259,26 @@ class Test{
     </test-code>
 
     <test-code>
-        <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 2. DU-Anomaly(a)</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>5</expected-linenumbers>
+        <description>For loop</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        for(int i = 0 ; i <= 10; i ++){
+            a = a+3;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>For loop 2</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,5</expected-linenumbers>
         <expected-messages>
+            <message>The value assigned to variable 'a' is never used</message>
             <message>The value assigned to variable 'a' is never used</message>
         </expected-messages>
         <code><![CDATA[
@@ -266,7 +286,38 @@ class Test{
     public static void main(String[] args){
         int a = 0 ;
         for(int i = 0 ; i <= 10; i ++){
-            a = a+3;
+            a = i * 3;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>For loop 3</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        for(int i = 0 ; i <= 10; i ++){
+            a = i * 3;
+        }
+        System.out.println(a);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>For loop 4</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        for(int i = 0 ; (i + a) <= 10; i ++){
+            a = i * 3;
         }
     }
 }
@@ -409,12 +460,8 @@ class Test{
     </test-code>
 
     <test-code>
-        <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 5. DU-Anomaly(a)</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>6</expected-linenumbers>
-        <expected-messages>
-            <message>Found 'DU'-anomaly for variable 'a' (lines '6'-'9').</message>
-        </expected-messages>
+        <description>Do while 0</description>
+        <expected-problems>0</expected-problems>
         <code><![CDATA[
 class Test{
     public static void main(String[] args){
@@ -422,6 +469,55 @@ class Test{
         int i = 0 ;
         do {
             a = a+3;
+            i += 3;
+        } while (i < 30);
+   }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Do while 1</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'a' is never used</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0;
+        int i = 0;
+        do {
+            a = i+3;
+            i += 3;
+        } while ((a+i) < 30);
+   }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Do while with break</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>7,8</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'i' is never used</message>
+            <message>The value assigned to variable 'a' is never used</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0;
+        int i = 0;
+        do {
+            if (a >= 20) {
+                i = 4;
+                a *= 5;
+                break;
+            }
+
+            a = i + 3;
             i += 3;
         } while (i < 30);
    }
@@ -482,11 +578,11 @@ class Test{
     </test-code>
 
     <test-code>
-        <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 9. DU-Anomaly(t1)</description>
+        <description>Usage as LHS of method</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>5</expected-linenumbers>
         <expected-messages>
-            <message>Found 'DU'-anomaly for variable 't1' (lines '5'-'6').</message>
+            <message>The value assigned to variable 't1' is never used</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -500,11 +596,11 @@ class Test{
     </test-code>
 
     <test-code>
-        <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 12. DU-Anomaly(t1)</description>
+        <description>Assignment in operand</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>6</expected-linenumbers>
         <expected-messages>
-            <message>Found 'DU'-anomaly for variable 't1' (lines '6'-'7').</message>
+            <message>The value assigned to variable 't1' is never used</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -519,7 +615,27 @@ class Test{
     </test-code>
 
     <test-code>
-        <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 13</description>
+        <description>Assignment in operand 2</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 't1' is never used</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int t1 = 0 ;
+        int t2 = 0 ;
+        // the left assignment reaches the right of the ==
+        if (   (t1 = t1 + t2)
+            == (t1 = t2 * t1) ); // only this assignment is unused
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Assignment in operand 3</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 class Test{
@@ -534,12 +650,12 @@ class Test{
     </test-code>
 
     <test-code>
-        <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 14. DU-Anomaly(t1, t2)</description>
+        <description>Assignment in operand 4</description>
         <expected-problems>2</expected-problems>
         <expected-linenumbers>4,6</expected-linenumbers>
         <expected-messages>
-            <message>Found 'DU'-anomaly for variable 't2' (lines '4'-'7').</message>
-            <message>Found 'DU'-anomaly for variable 't1' (lines '6'-'7').</message>
+            <message>The value assigned to variable 't2' is never used</message>
+            <message>The value assigned to variable 't1' is never used</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -558,13 +674,50 @@ class Test{
         <expected-problems>1</expected-problems>
         <expected-linenumbers>4</expected-linenumbers>
         <expected-messages>
-            <message>Found 'DU'-anomaly for variable 'a' (lines '4'-'5').</message>
+            <message>The value assigned to variable 'a' is never used</message>
         </expected-messages>
         <code><![CDATA[
 public class Test {
     public void test(){
         int a = 0;
         a = a + 3;
+
+        int i = 0;
+        i += 3; // same with compound
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Compound assignment</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'a' is never used</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Test {
+    public void test(){
+        int a = 0;
+        a += 3; // same with compound
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Another case</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3,5</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'iter' is never used</message>
+            <message>The value assigned to variable 'iter' is never used</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Test {
+    public void test(){
+       ScopeData iter = acceptOpt(node.getBody(), before.fork()); // this assignment is unused
+       iter = acceptOpt(node.getCondition(), before.fork());
+       iter = acceptOpt(node.getBody(), iter);
     }
 }
         ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -401,21 +401,22 @@ class Test{
 }
         ]]></code>
     </test-code>
+
     <test-code>
         <description>While loop without break (control case)</description>
-        <expected-problems>0</expected-problems>
+        <expected-problems>1</expected-problems>
         <code><![CDATA[
 class Test{
     public static void main(String[] args){
-        int a = 0;
+        int a = 0; // used by compound below
         int i = 0;
         while (true) {
             if (a >= 30) {
-                i = a + 1; // used by below
+                i += a + 1; // unused by below
                 // break;  // no break here
             }
             a = a + 3;
-            i = i + 1; // used by itself
+            i = a + 2; // used by above
         }
     }
 }
@@ -423,7 +424,7 @@ class Test{
     </test-code>
 
     <test-code>
-        <description>While loop with break 2</description>
+        <description>While loop without break 2 (control case)</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>12</expected-linenumbers>
         <expected-messages>
@@ -433,7 +434,7 @@ class Test{
 class Test{
     public static void main(String[] args){
         int a = 0;
-        int i = 0; // used now
+        int i = 0; // unused now
 
         outer:
         while (true) {
@@ -441,12 +442,80 @@ class Test{
 
             while (true) {
                 if (a >= 30) {
-                    i = i + 1; // used now
+                    i += a + 1; // unused because of i = a + 2
+                    // break outer;
+                }
+                a = a + 3;
+                i = a + 2;  // killed by below
+            }
+
+            i = 2; // used by print
+        }
+
+        System.out.println(i); // uses i = i + 1
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>While loop without break 2 (control case)</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>12</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'i' is never used</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0;
+        int i = 0; // unused now
+
+        outer:
+        while (true) {
+            a += 2;
+
+            while (true) {
+                if (a >= 30) {
+                    i += a + 1; // unused because of i = 2
+                    break;
+                }
+                a = a + 3;
+                i = a + 2;  // used by i += a + 1
+            }
+
+            i = 2; // used by print
+        }
+
+        System.out.println(i); // uses i = i + 1
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>While loop with named break 2</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0;
+        int i = 0; // unused now
+
+        outer:
+        while (true) {
+            a += 2;
+
+            while (true) {
+                if (a >= 30) {
+                    i += a + 1; // used by print
                     break outer;
                 }
                 a = a + 3;
-                i = i + 2; // unused (kills itself)
+                i = a + 2;  // used by i += a + 1
             }
+
+            i = 2; // used by print
         }
 
         System.out.println(i); // uses i = i + 1
@@ -988,5 +1057,19 @@ public class Test {
     }
 }
         ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Var usage in lambda (#1304)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+
+    public boolean dummyMethod(final String captured, final Set<String> dummySet) {
+        captured = captured.trim();
+        return dummySet.stream().noneMatch(value -> value.equalsIgnoreCase(captured));
+    }
+
+}        ]]></code>
     </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -1098,6 +1098,27 @@ public class Foo {
     </test-code>
 
     <test-code>
+        <description>Try with several catches</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+
+    public int foo() {
+        int a;
+        try (Reader r = new StringReader("")) {
+            a = r.read();
+        } catch (IOException e) {
+            a = -1;
+        } catch (IllegalArgumentException e) {
+            a = 2;
+        }
+        return a;
+    }
+
+}        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>Try/catch finally</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
@@ -1211,13 +1232,13 @@ class Foo {
         <code><![CDATA[
 class Foo {
 
-	public Flux<Object> decode() {
-		Flux<List<XMLEvent>> splitEvents = splitEvts();
+  public Flux<Object> decode() {
+    Flux<List<XMLEvent>> splitEvents = splitEvts();
 
-		return map(events -> {
-			return unmarshal(events.append(splitEvents));
-		});
-	}
+    return map(events -> {
+      return unmarshal(events.append(splitEvents));
+    });
+  }
 
 }
         ]]></code>
@@ -1233,12 +1254,12 @@ class Foo {
         <code><![CDATA[
 class Foo {
 
-	public void decode() {
+  public void decode() {
     doSomething(events -> {
       int k = 0;
       return k = 2;
     });
-	}
+  }
 
 }
         ]]></code>
@@ -1254,16 +1275,39 @@ class Foo {
         <code><![CDATA[
 class Foo {
 
-	public Flux<Object> decode() {
-		Flux<List<XMLEvent>> splitEvents = splitEvts();
+  public Flux<Object> decode() {
+    Flux<List<XMLEvent>> splitEvents = splitEvts();
 
-		return map(events -> {
-		  events = events.normalize();
-			return dontUseEvents();
-		});
-	}
+    return map(events -> {
+      events = events.normalize();
+      return dontUseEvents();
+    });
+  }
 
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>FP in try</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+package foo;
+class Foo {
+
+    public Object getSubject() {
+      try {
+        Object subject = Other.currentUserMethod.invoke();
+        if (subject == null) {
+          subject = Other.anonymousSubjectMethod.invoke(0);
+        }
+        return subject;
+      } catch (Exception ex) {
+        throw new RuntimeException("Failed to obtain SubjectHandle", ex);
+      }
+    }
+
+}
+        ]]></code>
+    </test-code>
+
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -23,7 +23,7 @@ public class Foo {
         <expected-problems>1</expected-problems>
         <expected-linenumbers>3</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'i' is never used</message>
+            <message>The value assigned to variable 'i' is never used (overwritten on line 4)</message>
         </expected-messages>
         <code><![CDATA[
 public class Foo {
@@ -66,9 +66,9 @@ public class Foo {
         <expected-problems>3</expected-problems>
         <expected-linenumbers>3,4,6</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'j' is never used</message>
-            <message>The value assigned to variable 'z' is never used</message>
-            <message>The value assigned to variable 'j' is never used</message>
+            <message>The value assigned to variable 'j' is never used (overwritten on line 6)</message>
+            <message>The value assigned to variable 'z' is never used (goes out of scope)</message>
+            <message>The value assigned to variable 'j' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
 public class Foo {
@@ -88,7 +88,7 @@ public class Foo {
         <expected-problems>1</expected-problems>
         <expected-linenumbers>4</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'z' is never used</message>
+            <message>The value assigned to variable 'z' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
 public class Foo {
@@ -109,7 +109,7 @@ public class Foo {
         <expected-problems>1</expected-problems>
         <expected-linenumbers>3</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'j' is never used</message>
+            <message>The value assigned to variable 'j' is never used (overwritten on lines 6 and 8)</message>
         </expected-messages>
         <code><![CDATA[
 public class Foo {
@@ -132,8 +132,8 @@ public class Foo {
         <expected-problems>2</expected-problems>
         <expected-linenumbers>3,6</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'j' is never used</message>
-            <message>The value assigned to variable 'j' is never used</message>
+            <message>The value assigned to variable 'j' is never used (overwritten on lines 6 and 9)</message>
+            <message>The value assigned to variable 'j' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
 public class Foo {
@@ -157,8 +157,8 @@ public class Foo {
         <expected-problems>2</expected-problems>
         <expected-linenumbers>3,6</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'j' is never used</message>
-            <message>The value assigned to variable 'j' is never used</message>
+            <message>The value assigned to variable 'j' is never used (overwritten on lines 6 and 9)</message>
+            <message>The value assigned to variable 'j' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
 public class Foo {
@@ -178,12 +178,12 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>#1393 PMD hanging during DataflowAnomalyAnalysis</description>
+        <description>Local variable in loop</description>
         <expected-problems>2</expected-problems>
         <expected-linenumbers>10,19</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'fail' is never used</message>
-            <message>The value assigned to variable 'fail' is never used</message>
+            <message>The value assigned to variable 'fail' is never used (overwritten on line 19)</message>
+            <message>The value assigned to variable 'fail' is never used (overwritten on line 19)</message>
         </expected-messages>
         <code><![CDATA[
 public class LoopTest {
@@ -244,7 +244,7 @@ public class AssertTest {
         <expected-problems>1</expected-problems>
         <expected-linenumbers>6</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'b' is never used</message>
+            <message>The value assigned to variable 'b' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -278,8 +278,9 @@ class Test{
         <expected-problems>2</expected-problems>
         <expected-linenumbers>3,5</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'a' is never used</message>
-            <message>The value assigned to variable 'a' is never used</message>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 5)</message>
+            <!-- Overwrites itself -->
+            <message>The value assigned to variable 'a' is never used (overwritten on line 5)</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -361,8 +362,8 @@ class Test{
         <expected-problems>2</expected-problems>
         <expected-linenumbers>4,7</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'i' is never used</message>
-            <message>The value assigned to variable 'i' is never used</message>
+            <message>The value assigned to variable 'i' is never used (overwritten on line 7)</message>
+            <message>The value assigned to variable 'i' is never used (overwritten on line 7)</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -382,7 +383,7 @@ class Test{
         <expected-problems>1</expected-problems>
         <expected-linenumbers>7</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'i' is never used</message>
+            <message>The value assigned to variable 'i' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -428,7 +429,7 @@ class Test{
         <expected-problems>1</expected-problems>
         <expected-linenumbers>12</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'i' is never used</message>
+            <message>The value assigned to variable 'i' is never used (overwritten on line 16)</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -463,7 +464,7 @@ class Test{
         <expected-problems>1</expected-problems>
         <expected-linenumbers>12</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'i' is never used</message>
+            <message>The value assigned to variable 'i' is never used (overwritten on line 19)</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -571,7 +572,7 @@ class Test{
         <expected-problems>1</expected-problems>
         <expected-linenumbers>7</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'a' is never used</message>
+            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -612,7 +613,7 @@ class Test{
         <expected-problems>1</expected-problems>
         <expected-linenumbers>3</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'a' is never used</message>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 6)</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -633,8 +634,8 @@ class Test{
         <expected-problems>2</expected-problems>
         <expected-linenumbers>7,8</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'i' is never used</message>
-            <message>The value assigned to variable 'a' is never used</message>
+            <message>The value assigned to variable 'i' is never used (goes out of scope)</message>
+            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -684,10 +685,10 @@ class Test{
         <expected-problems>4</expected-problems>
         <expected-linenumbers>6,8,10,12</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'a' is never used</message>
-            <message>The value assigned to variable 'a' is never used</message>
-            <message>The value assigned to variable 'a' is never used</message>
-            <message>The value assigned to variable 'a' is never used</message>
+            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
+            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
+            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
+            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -759,7 +760,7 @@ class Test{
         <expected-problems>1</expected-problems>
         <expected-linenumbers>6</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'a' is never used</message>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 8)</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -787,7 +788,7 @@ class Test{
         <expected-problems>1</expected-problems>
         <expected-linenumbers>9</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'a' is never used</message>
+            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -830,7 +831,7 @@ class Test{
         <expected-problems>1</expected-problems>
         <expected-linenumbers>9</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'i' is never used</message>
+            <message>The value assigned to variable 'i' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -860,10 +861,10 @@ class Test{
         <expected-problems>4</expected-problems>
         <expected-linenumbers>6,7,8,9</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'a' is never used</message>
-            <message>The value assigned to variable 'a' is never used</message>
-            <message>The value assigned to variable 'a' is never used</message>
-            <message>The value assigned to variable 'a' is never used</message>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -888,10 +889,10 @@ class Test{
         <expected-problems>4</expected-problems>
         <expected-linenumbers>6,9,13,14</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'a' is never used</message>
-            <message>The value assigned to variable 'a' is never used</message>
-            <message>The value assigned to variable 'a' is never used</message>
-            <message>The value assigned to variable 'a' is never used</message>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 4)</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -921,7 +922,7 @@ class Test{
         <expected-problems>1</expected-problems>
         <expected-linenumbers>5</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 't1' is never used</message>
+            <message>The value assigned to variable 't1' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -939,7 +940,7 @@ class Test{
         <expected-problems>1</expected-problems>
         <expected-linenumbers>6</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 't1' is never used</message>
+            <message>The value assigned to variable 't1' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -958,7 +959,7 @@ class Test{
         <expected-problems>1</expected-problems>
         <expected-linenumbers>7</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 't1' is never used</message>
+            <message>The value assigned to variable 't1' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -993,8 +994,8 @@ class Test{
         <expected-problems>2</expected-problems>
         <expected-linenumbers>4,6</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 't2' is never used</message>
-            <message>The value assigned to variable 't1' is never used</message>
+            <message>The value assigned to variable 't2' is never used (goes out of scope)</message>
+            <message>The value assigned to variable 't1' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
 class Test{
@@ -1013,7 +1014,7 @@ class Test{
         <expected-problems>1</expected-problems>
         <expected-linenumbers>4</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'a' is never used</message>
+            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
 public class Test {
@@ -1029,7 +1030,7 @@ public class Test {
         <expected-problems>1</expected-problems>
         <expected-linenumbers>4</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'a' is never used</message>
+            <message>The value assigned to variable 'a' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
 public class Test {
@@ -1045,8 +1046,8 @@ public class Test {
         <expected-problems>2</expected-problems>
         <expected-linenumbers>3,5</expected-linenumbers>
         <expected-messages>
-            <message>The value assigned to variable 'iter' is never used</message>
-            <message>The value assigned to variable 'iter' is never used</message>
+            <message>The value assigned to variable 'iter' is never used (overwritten on line 4)</message>
+            <message>The value assigned to variable 'iter' is never used (goes out of scope)</message>
         </expected-messages>
         <code><![CDATA[
 public class Test {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnusedAssignment.xml
@@ -1,0 +1,375 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+<!--    <test-code>-->
+<!--        <description>ok</description>-->
+<!--        <expected-problems>0</expected-problems>-->
+<!--        <code><![CDATA[-->
+<!--public class Foo {-->
+<!--    void bar(int b) {-->
+<!--        for (int i = 0; i < 10; i++) {-->
+<!--            throw new Exception();-->
+<!--        }-->
+<!--    }-->
+<!--}-->
+<!--        ]]></code>-->
+<!--    </test-code>-->
+
+    <test-code>
+        <description>DD anomaly</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        int i=0;
+        i=1;
+        if (i==2) {}
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>DU anomaly</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        int i=0;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>UR anomaly</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        int i;
+        if (i == 0) {}
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>more komplex anomalysis</description>
+        <expected-problems>4</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void bar(int i) {
+        int j = 0;
+        int z = 0;
+        if (i < 10) {
+            j = i;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#1393 PMD hanging during DataflowAnomalyAnalysis</description>
+        <!-- Note: due to https://sourceforge.net/p/pmd/bugs/1383/ the 3 problems are false positives!  -->
+        <expected-problems>3</expected-problems>
+        <code><![CDATA[
+public class LoopTest {
+    public static void main(String[] args) {
+        int[] a = {1,2,3};
+        int[] b = {4,5,6};
+        int[] c = {7,8,9};
+        for (int i : a) {
+            if (i == 0) {
+                break;
+            } else {
+                boolean fail = false;
+                for (int j : b) {
+                    boolean match = false;
+                    for (int k : c) {
+                        if (k == 42) {
+                            match = true;
+                        }
+                    }
+                    if (!match) {
+                        fail = true;
+                    }
+                }
+            }
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#408 Assert statements causing </description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class AssertTest {
+    public void test() {
+        final String s = "";
+        assert(s != null);
+
+        System.out.println(s);
+
+        final Double d = 9;
+        assert(d != null);
+
+        System.out.println(d);
+
+        final String k = "k";
+        assert(k != null);
+
+        System.out.println(k);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 1. DU-Anomaly(b)</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <expected-messages>
+            <message>Found 'DU'-anomaly for variable 'b' (lines '6'-'7').</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        int b = 0 ;
+        a = a + b ;
+        b = a + b ;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 2. DU-Anomaly(a)</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,5</expected-linenumbers>
+        <expected-messages>
+            <message>Found 'DU'-anomaly for variable 'a' (lines '3'-'7').</message>
+            <message>Found 'DU'-anomaly for variable 'a' (lines '5'-'7').</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        for(int i = 0 ; i <= 10; i ++){
+            a = a+3;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code regressionTest="false">
+        <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 3. DU-Anomaly(a)</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <expected-messages>
+            <message>Found 'DU'-anomaly for variable 'a' (lines '5'-'7').</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int[] b = new int[10];
+        for(int a : b){
+            a = a+3;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 4. DU-Anomaly(a)</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,6</expected-linenumbers>
+        <expected-messages>
+            <message>Found 'DU'-anomaly for variable 'a' (lines '3'-'9').</message>
+            <message>Found 'DU'-anomaly for variable 'a' (lines '6'-'9').</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        int i = 0 ;
+        while(i < 30){
+            a = a+3;
+            i += 3;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 5. DU-Anomaly(a)</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <expected-messages>
+            <message>Found 'DU'-anomaly for variable 'a' (lines '6'-'9').</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        int i = 0 ;
+        do {
+            a = a+3;
+            i += 3;
+        } while (i < 30);
+   }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 6. DU-Anomaly(a)</description>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>6,8,10,12</expected-linenumbers>
+        <expected-messages>
+            <message>Found 'DU'-anomaly for variable 'a' (lines '6'-'14').</message>
+            <message>Found 'DU'-anomaly for variable 'a' (lines '8'-'14').</message>
+            <message>Found 'DU'-anomaly for variable 'a' (lines '10'-'14').</message>
+            <message>Found 'DU'-anomaly for variable 'a' (lines '12'-'14').</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        int i = 0 ;
+        switch(i){
+            case 1 : a = a+1;
+            break;
+            case 2 : a = a+2;
+            break;
+            case 3 : a = a+3;
+            break;
+            default : a = a + 0;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 7. DU-Anomaly(a)</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>9</expected-linenumbers>
+        <expected-messages>
+            <message>Found 'DU'-anomaly for variable 'a' (lines '9'-'11').</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int a = 0 ;
+        int i = 0 ;
+        switch(i){
+            case 1 : a = a+1;
+            case 2 : a = a+2;
+            case 3 : a = a+3;
+            default : a = a + 0;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 9. DU-Anomaly(t1)</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <expected-messages>
+            <message>Found 'DU'-anomaly for variable 't1' (lines '5'-'6').</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int t1 = 0 ;
+        Test2 test = new Test2() ;
+        t1 = test.simpleTest(t1) ;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 12. DU-Anomaly(t1)</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <expected-messages>
+            <message>Found 'DU'-anomaly for variable 't1' (lines '6'-'7').</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int t1 = 0 ;
+        int t2 = 0 ;
+        Test2 test = new Test2();
+        if((t1 = test.simpleTest(t1)) == t2);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 13</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int t1 = 0 ;
+
+        Test2 test = new Test2();
+        if( (t1 = test.simpleTest(t1)) == t1);
+   }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#1905 [java] DataflowAnomalyAnalysis Rule in right order : Case 14. DU-Anomaly(t1, t2)</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>4,6</expected-linenumbers>
+        <expected-messages>
+            <message>Found 'DU'-anomaly for variable 't2' (lines '4'-'7').</message>
+            <message>Found 'DU'-anomaly for variable 't1' (lines '6'-'7').</message>
+        </expected-messages>
+        <code><![CDATA[
+class Test{
+    public static void main(String[] args){
+        int t1 = 0;
+        int t2 = 0;
+        Test2 test = new Test2() ;
+        if( t1 == (t1 = test.simpleTest(t1))) ;
+   }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#1749 DD False Positive in DataflowAnomalyAnalysis</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>Found 'DU'-anomaly for variable 'a' (lines '4'-'5').</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Test {
+    public void test(){
+        int a = 0;
+        a = a + 3;
+    }
+}
+        ]]></code>
+    </test-code>
+</test-data>


### PR DESCRIPTION
## Describe the PR

Add the rule UnusedAssignment. This reports the same thing as DataflowAnomalyAnalysisRule, but doesn't use the current data flow framework. Improvements over DFAAR:
* It handles assignments in field initializers, including static initializers
   * The only thing it doesn't do is explicit `this(...)` constructor call, because our overload resolution doesn't resolve them afaik. This can be solved easily in the 7.0 framework.
* It handles control flow caused by shortcut boolean expressions
* It supports properly all features of Java 5+ (lambdas, foreach, try-with-resources, etc)
* The code is manageable and can be updated for new language features. The current DFA framework is impossible to navigate and to change.
* It never hangs or fail with obscure messages (#873)
* It's nearly 4 times faster, if you factor in that DFAAR needs a preprocessing step of the tree that builds "DataflowNodes"
* Messages are readable (ref #2129). Compare:
   > Found 'DU'-anomaly for variable 'z' (lines '4'-'9').

   to 

  > The initializer for variable 'z' is never used (goes out of scope)

* It's very precise, in principle it makes exactly the same assumptions as the ones a java compiler takes to determine definite assigned-ness. This means it reports less things than DFAAR, but every violation is actually a violation. We can let the regression tester be the judge of that though



The rule supports `@SuppressWarnings("unused")`


---

This rule is meant to replace DFAAR. That way, we remove the last dependency we have on our horrible data flow codebase, and can remove it in PMD 7. I think it would be more interesting to integrate a state-of-the-art data flow solver into pmd in the future, than try to reinvent the wheel (I don't plan to work on this for 7.0).


## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

* https://github.com/pmd/pmd/labels/in%3Adata-flow
  * All the false positives were added as test cases of the new rule
  * We could close all those as wont-fix, if we deprecate DFAAR

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->
- [ ] Move to bestpractices.xml maybe? It's not really "error prone"

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

