### PR TITLE
[core] Compatibility measures for rulechain simplification

### DIFF
--- a/docs/_plugins/javadoc_tag.rb
+++ b/docs/_plugins/javadoc_tag.rb
@@ -36,6 +36,7 @@ require_relative 'jdoc_namespace_tag'
 #   * The (erased) types of method arguments must be fully qualified. This is the same
 #     convention as in javadoc {@link} tags, so you can use you're IDE's javadoc auto-
 #     complete and copy-paste. Namespaces also can be used for method arguments if they're from PMD.
+#   * Use the name <init> to reference a constructor
 #
 #
 # * Defining custom namespaces
@@ -90,13 +91,15 @@ require_relative 'jdoc_namespace_tag'
 #   - Include spaces in any part of the reference
 #   - Use double or single quotes around the arguments
 #   - Use the "#" suffix to reference a nested type, instead, use a dot "." and reference it like a normal type name
+#   - Use `[]` instead of `...` for vararg parameters
+#   - Use the type name instead of `<init>` for a constructor
 #
 #
 class JavadocTag < Liquid::Tag
 
   QNAME_NO_NAMESPACE_REGEX = /((?:\w+\.)*\w+)/
 
-  ARG_REGEX = Regexp.new(Regexp.union(JDocNamespaceDeclaration::NAMESPACED_FQCN_REGEX, QNAME_NO_NAMESPACE_REGEX).source + '(\[\])*')
+  ARG_REGEX = Regexp.new(Regexp.union(JDocNamespaceDeclaration::NAMESPACED_FQCN_REGEX, QNAME_NO_NAMESPACE_REGEX).source + '(\[\])*(...)?')
   ARGUMENTS_REGEX = Regexp.new('\(\)|\((' + ARG_REGEX.source + "(?:,(?:" + ARG_REGEX.source + "))*" + ')\)')
 
 
@@ -174,7 +177,7 @@ class JavadocTag < Liquid::Tag
   def self.get_visible_name(opts, type_fqcn, member_suffix, is_package_ref, resolved_type)
 
     # method or field
-    if member_suffix && Regexp.new('(\w+)(' + ARGUMENTS_REGEX.source + ")?") =~ member_suffix
+    if member_suffix && Regexp.new('(\w+|<init>)(' + ARGUMENTS_REGEX.source + ")?") =~ member_suffix
 
       suffix = $1 # method or field name
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -18,6 +18,16 @@ This is a {{ site.pmd.release_type }} release.
 
 ### API Changes
 
+#### Deprecated API
+
+##### For removal
+
+* {% jdoc core::lang.rule.RuleChainVisitor %} and all implementations in language modules
+* {% jdoc core::lang.rule.AbstractRuleChainVisitor %}
+* {% jdoc core::lang.Language#getRuleChainVisitorClass() %}
+* {% jdoc core::lang.BaseLanguageModule#<init>(java.lang.String,java.lang.String,java.lang.String,java.lang.Class,java.lang.String...) %}
+
+
 ### External Contributions
 
 {% endtocmaker %}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ApexLanguageModule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ApexLanguageModule.java
@@ -5,7 +5,6 @@
 package net.sourceforge.pmd.lang.apex;
 
 import net.sourceforge.pmd.lang.BaseLanguageModule;
-import net.sourceforge.pmd.lang.apex.rule.ApexRuleChainVisitor;
 
 import apex.jorje.services.Version;
 
@@ -16,7 +15,7 @@ public class ApexLanguageModule extends BaseLanguageModule {
     public static final String[] EXTENSIONS = { "cls", "trigger" };
 
     public ApexLanguageModule() {
-        super(NAME, null, TERSE_NAME, ApexRuleChainVisitor.class, EXTENSIONS);
+        super(NAME, null, TERSE_NAME, "cls", "trigger");
         addVersion(String.valueOf((int) Version.CURRENT.getExternal()), new ApexHandler(), true);
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexRule.java
@@ -137,12 +137,8 @@ public abstract class AbstractApexRule extends AbstractRule
 
     protected void visitAll(List<? extends Node> nodes, RuleContext ctx) {
         for (Object element : nodes) {
-            if (element instanceof ASTUserClass) {
-                visit((ASTUserClass) element, ctx);
-            } else if (element instanceof ASTUserInterface) {
-                visit((ASTUserInterface) element, ctx);
-            } else if (element instanceof ASTUserTrigger) {
-                visit((ASTUserTrigger) element, ctx);
+            if (element instanceof ApexNode<?>) {
+                ((ApexNode<?>) element).jjtAccept(this, ctx);
             }
         }
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/ApexRuleChainVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/ApexRuleChainVisitor.java
@@ -16,6 +16,7 @@ import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.rule.AbstractRuleChainVisitor;
 import net.sourceforge.pmd.lang.rule.XPathRule;
 
+@Deprecated
 public class ApexRuleChainVisitor extends AbstractRuleChainVisitor {
 
     @Override

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/BaseLanguageModule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/BaseLanguageModule.java
@@ -11,10 +11,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import net.sourceforge.pmd.Rule;
-import net.sourceforge.pmd.RuleContext;
-import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.rule.AbstractRuleChainVisitor;
+import net.sourceforge.pmd.lang.internal.DefaultRulechainVisitor;
 import net.sourceforge.pmd.util.CollectionUtil;
 
 /**
@@ -202,28 +199,5 @@ public abstract class BaseLanguageModule implements Language {
         return getName().compareTo(o.getName());
     }
 
-
-
-    private static class DefaultRulechainVisitor extends AbstractRuleChainVisitor {
-
-        @Override
-        protected void visit(Rule rule, Node node, RuleContext ctx) {
-            rule.apply(Collections.singletonList(node), ctx);
-        }
-
-        @Override
-        protected void indexNodes(List<Node> nodes, RuleContext ctx) {
-            for (Node node : nodes) {
-                indexNodeRec(node);
-            }
-        }
-
-        protected void indexNodeRec(Node top) {
-            indexNode(top);
-            for (Node child : top.children()) {
-                indexNodeRec(child);
-            }
-        }
-    }
 
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/BaseLanguageModule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/BaseLanguageModule.java
@@ -15,6 +15,7 @@ import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.rule.AbstractRuleChainVisitor;
+import net.sourceforge.pmd.util.CollectionUtil;
 
 /**
  * Created by christoferdutz on 21.09.14.
@@ -30,6 +31,12 @@ public abstract class BaseLanguageModule implements Language {
     protected Map<String, LanguageVersion> versions;
     protected LanguageVersion defaultVersion;
 
+    /**
+     * @deprecated Use the other constructor. It doesn't require a
+     *     rulechain visitor class, but forces you to mention at least
+     *     one file extension.
+     */
+    @Deprecated
     public BaseLanguageModule(String name, String shortName, String terseName, Class<?> ruleChainVisitorClass,
             String... extensions) {
         this.name = name;
@@ -37,6 +44,18 @@ public abstract class BaseLanguageModule implements Language {
         this.terseName = terseName;
         this.ruleChainVisitorClass = ruleChainVisitorClass;
         this.extensions = Arrays.asList(extensions);
+    }
+
+    public BaseLanguageModule(String name,
+                              String shortName,
+                              String terseName,
+                              String firstExtension,
+                              String... otherExtensions) {
+        this.name = name;
+        this.shortName = shortName;
+        this.terseName = terseName;
+        this.ruleChainVisitorClass = DefaultRulechainVisitor.class;
+        this.extensions = CollectionUtil.listOf(firstExtension, otherExtensions);
     }
 
     private void addVersion(String version, LanguageVersionHandler languageVersionHandler, boolean isDefault, String... versionAliases) {
@@ -194,7 +213,16 @@ public abstract class BaseLanguageModule implements Language {
 
         @Override
         protected void indexNodes(List<Node> nodes, RuleContext ctx) {
+            for (Node node : nodes) {
+                indexNodeRec(node);
+            }
+        }
 
+        protected void indexNodeRec(Node top) {
+            indexNode(top);
+            for (Node child : top.children()) {
+                indexNodeRec(child);
+            }
         }
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/BaseLanguageModule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/BaseLanguageModule.java
@@ -11,6 +11,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.RuleContext;
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.rule.AbstractRuleChainVisitor;
+
 /**
  * Created by christoferdutz on 21.09.14.
  */
@@ -177,4 +182,20 @@ public abstract class BaseLanguageModule implements Language {
     public int compareTo(Language o) {
         return getName().compareTo(o.getName());
     }
+
+
+
+    private static class DefaultRulechainVisitor extends AbstractRuleChainVisitor {
+
+        @Override
+        protected void visit(Rule rule, Node node, RuleContext ctx) {
+            rule.apply(Collections.singletonList(node), ctx);
+        }
+
+        @Override
+        protected void indexNodes(List<Node> nodes, RuleContext ctx) {
+
+        }
+    }
+
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/Language.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/Language.java
@@ -77,7 +77,10 @@ public interface Language extends Comparable<Language> {
      *
      * @return The RuleChainVisitor class.
      * @see net.sourceforge.pmd.lang.rule.RuleChainVisitor
+     *
+     * @deprecated Will be removed in PMD 7, avoid using this
      */
+    @Deprecated
     Class<?> getRuleChainVisitorClass();
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/internal/DefaultRulechainVisitor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/internal/DefaultRulechainVisitor.java
@@ -1,0 +1,40 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.internal;
+
+import java.util.Collections;
+import java.util.List;
+
+import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.RuleContext;
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.rule.AbstractRuleChainVisitor;
+import net.sourceforge.pmd.lang.rule.RuleChainVisitor;
+
+/**
+ * @deprecated See {@link RuleChainVisitor}
+ */
+@Deprecated
+public class DefaultRulechainVisitor extends AbstractRuleChainVisitor {
+
+    @Override
+    protected void visit(Rule rule, Node node, RuleContext ctx) {
+        rule.apply(Collections.singletonList(node), ctx);
+    }
+
+    @Override
+    protected void indexNodes(List<Node> nodes, RuleContext ctx) {
+        for (Node node : nodes) {
+            indexNodeRec(node);
+        }
+    }
+
+    protected void indexNodeRec(Node top) {
+        indexNode(top);
+        for (Node child : top.children()) {
+            indexNodeRec(child);
+        }
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRuleChainVisitor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRuleChainVisitor.java
@@ -28,7 +28,10 @@ import net.sourceforge.pmd.lang.ast.Node;
  * This is a base class for RuleChainVisitor implementations which extracts
  * interesting nodes from an AST, and lets each Rule visit the nodes it has
  * expressed interest in.
+ *
+ * @deprecated See {@link RuleChainVisitor}
  */
+@Deprecated
 public abstract class AbstractRuleChainVisitor implements RuleChainVisitor {
     private static final Logger LOG = Logger.getLogger(AbstractRuleChainVisitor.class.getName());
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleChainVisitor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleChainVisitor.java
@@ -9,12 +9,18 @@ import java.util.List;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.RuleSet;
+import net.sourceforge.pmd.lang.BaseLanguageModule;
 import net.sourceforge.pmd.lang.ast.Node;
 
 /**
  * The RuleChainVisitor understands how to visit an AST for a particular
  * Language.
+ *
+ * @deprecated This interface will be removed. It's only used in internal
+ *      code. Language implementors no longer need to register a rulechain
+ *      visitor implementation in the {@link BaseLanguageModule} constructor.
  */
+@Deprecated
 public interface RuleChainVisitor {
     /**
      * Add the given rule to the visitor.

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/CollectionUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/CollectionUtil.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -185,6 +186,15 @@ public final class CollectionUtil {
             list.add(it.next());
         }
         return list;
+    }
+
+    @SafeVarargs
+    public static <T> List<T> listOf(T first, T... rest) {
+        // note: 7.0.x already has a better version of that
+        ArrayList<T> result = new ArrayList<>(rest.length + 1);
+        result.add(first);
+        Collections.addAll(result, rest);
+        return result;
     }
 
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/Dummy2LanguageModule.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/Dummy2LanguageModule.java
@@ -13,7 +13,7 @@ public class Dummy2LanguageModule extends BaseLanguageModule {
     public static final String TERSE_NAME = "dummy2";
 
     public Dummy2LanguageModule() {
-        super(NAME, null, TERSE_NAME, null, "dummy2");
+        super(NAME, null, TERSE_NAME, "dummy2");
         addVersion("1.0", new DummyLanguageModule.Handler(), true);
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageModule.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageModule.java
@@ -37,7 +37,7 @@ public class DummyLanguageModule extends BaseLanguageModule {
     public static final String TERSE_NAME = "dummy";
 
     public DummyLanguageModule() {
-        super(NAME, null, TERSE_NAME, DummyRuleChainVisitor.class, "dummy");
+        super(NAME, null, TERSE_NAME, "dummy");
         addVersion("1.0", new Handler());
         addVersion("1.1", new Handler());
         addVersion("1.2", new Handler());

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/JavaLanguageModule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/JavaLanguageModule.java
@@ -5,7 +5,6 @@
 package net.sourceforge.pmd.lang.java;
 
 import net.sourceforge.pmd.lang.BaseLanguageModule;
-import net.sourceforge.pmd.lang.java.rule.JavaRuleChainVisitor;
 
 /**
  * Created by christoferdutz on 20.09.14.
@@ -16,7 +15,7 @@ public class JavaLanguageModule extends BaseLanguageModule {
     public static final String TERSE_NAME = "java";
 
     public JavaLanguageModule() {
-        super(NAME, null, TERSE_NAME, JavaRuleChainVisitor.class, "java");
+        super(NAME, null, TERSE_NAME, "java");
         addVersion("1.3", new JavaLanguageHandler(3));
         addVersion("1.4", new JavaLanguageHandler(4));
         addVersion("1.5", new JavaLanguageHandler(5), "5");

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJavaRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJavaRule.java
@@ -158,14 +158,8 @@ public abstract class AbstractJavaRule extends AbstractRule implements JavaParse
 
     protected void visitAll(List<? extends Node> nodes, RuleContext ctx) {
         for (Object element : nodes) {
-            /*
-                It is important to note that we are assuming that all nodes here are of type Compilation Unit,
-                but our caller method may be called with any type of node, and that's why we need to check the kind
-                of instance of each element
-            */
-            if (element instanceof ASTCompilationUnit) {
-                ASTCompilationUnit node = (ASTCompilationUnit) element;
-                visit(node, ctx);
+            if (element instanceof JavaNode) {
+                ((JavaNode) element).jjtAccept(this, ctx);
             }
         }
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/JavaRuleChainVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/JavaRuleChainVisitor.java
@@ -16,6 +16,7 @@ import net.sourceforge.pmd.lang.java.ast.JavaParserVisitorAdapter;
 import net.sourceforge.pmd.lang.rule.AbstractRuleChainVisitor;
 import net.sourceforge.pmd.lang.rule.XPathRule;
 
+@Deprecated
 public class JavaRuleChainVisitor extends AbstractRuleChainVisitor {
 
     @Override

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/EcmascriptLanguageModule.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/EcmascriptLanguageModule.java
@@ -5,7 +5,6 @@
 package net.sourceforge.pmd.lang.ecmascript;
 
 import net.sourceforge.pmd.lang.BaseLanguageModule;
-import net.sourceforge.pmd.lang.ecmascript.rule.EcmascriptRuleChainVisitor;
 
 /**
  * Created by christoferdutz on 20.09.14.
@@ -16,7 +15,7 @@ public class EcmascriptLanguageModule extends BaseLanguageModule {
     public static final String TERSE_NAME = "ecmascript";
 
     public EcmascriptLanguageModule() {
-        super(NAME, null, TERSE_NAME, EcmascriptRuleChainVisitor.class, "js");
+        super(NAME, null, TERSE_NAME,"js");
         addVersion("3", new Ecmascript3Handler(), true);
     }
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/rule/AbstractEcmascriptRule.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/rule/AbstractEcmascriptRule.java
@@ -96,8 +96,9 @@ public abstract class AbstractEcmascriptRule extends AbstractRule
 
     protected void visitAll(List<? extends Node> nodes, RuleContext ctx) {
         for (Object element : nodes) {
-            ASTAstRoot node = (ASTAstRoot) element;
-            visit(node, ctx);
+            if (element instanceof EcmascriptNode<?>) {
+                ((EcmascriptNode<?>) element).jjtAccept(this, ctx);
+            }
         }
     }
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/rule/EcmascriptRuleChainVisitor.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/rule/EcmascriptRuleChainVisitor.java
@@ -16,6 +16,7 @@ import net.sourceforge.pmd.lang.ecmascript.ast.EcmascriptParserVisitor;
 import net.sourceforge.pmd.lang.rule.AbstractRuleChainVisitor;
 import net.sourceforge.pmd.lang.rule.XPathRule;
 
+@Deprecated
 public class EcmascriptRuleChainVisitor extends AbstractRuleChainVisitor {
 
     @Override

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/JspLanguageModule.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/JspLanguageModule.java
@@ -5,7 +5,6 @@
 package net.sourceforge.pmd.lang.jsp;
 
 import net.sourceforge.pmd.lang.BaseLanguageModule;
-import net.sourceforge.pmd.lang.jsp.rule.JspRuleChainVisitor;
 
 /**
  * Created by christoferdutz on 20.09.14.
@@ -16,7 +15,7 @@ public class JspLanguageModule extends BaseLanguageModule {
     public static final String TERSE_NAME = "jsp";
 
     public JspLanguageModule() {
-        super(NAME, "JSP", TERSE_NAME, JspRuleChainVisitor.class, "jsp", "jspx", "jspf", "tag");
+        super(NAME, "JSP", TERSE_NAME, "jsp", "jspx", "jspf", "tag");
         addVersion("", new JspHandler(), true);
     }
 }

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/AbstractJspRule.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/AbstractJspRule.java
@@ -55,8 +55,9 @@ public abstract class AbstractJspRule extends AbstractRule implements JspParserV
 
     protected void visitAll(List<? extends Node> nodes, RuleContext ctx) {
         for (Object element : nodes) {
-            JspNode node = (JspNode) element;
-            visit(node, ctx);
+            if (element instanceof JspNode) {
+                ((JspNode) element).jjtAccept(this, ctx);
+            }
         }
     }
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/JspRuleChainVisitor.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/JspRuleChainVisitor.java
@@ -16,6 +16,7 @@ import net.sourceforge.pmd.lang.jsp.ast.JspParserVisitorAdapter;
 import net.sourceforge.pmd.lang.rule.AbstractRuleChainVisitor;
 import net.sourceforge.pmd.lang.rule.XPathRule;
 
+@Deprecated
 public class JspRuleChainVisitor extends AbstractRuleChainVisitor {
 
     @Override

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ModelicaLanguageModule.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ModelicaLanguageModule.java
@@ -5,14 +5,13 @@
 package net.sourceforge.pmd.lang.modelica;
 
 import net.sourceforge.pmd.lang.BaseLanguageModule;
-import net.sourceforge.pmd.lang.modelica.rule.ModelicaRuleChainVisitor;
 
 public class ModelicaLanguageModule extends BaseLanguageModule {
     public static final String NAME = "Modelica";
     public static final String TERSE_NAME = "modelica";
 
     public ModelicaLanguageModule() {
-        super(NAME, null, TERSE_NAME, ModelicaRuleChainVisitor.class, "mo");
+        super(NAME, null, TERSE_NAME, "mo");
         addVersion("", new ModelicaHandler(), true);
     }
 }

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/AbstractModelicaRule.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/AbstractModelicaRule.java
@@ -172,8 +172,9 @@ public abstract class AbstractModelicaRule extends AbstractRule implements Model
 
     protected void visitAll(final List<? extends Node> nodes, final RuleContext ctx) {
         for (final Object element : nodes) {
-            final ASTStoredDefinition node = (ASTStoredDefinition) element;
-            visit(node, ctx);
+            if (element instanceof ModelicaNode) {
+                ((ModelicaNode) element).jjtAccept(this, ctx);
+            }
         }
     }
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/ModelicaRuleChainVisitor.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/ModelicaRuleChainVisitor.java
@@ -16,6 +16,7 @@ import net.sourceforge.pmd.lang.modelica.ast.ModelicaParserVisitorAdapter;
 import net.sourceforge.pmd.lang.rule.AbstractRuleChainVisitor;
 import net.sourceforge.pmd.lang.rule.XPathRule;
 
+@Deprecated
 public class ModelicaRuleChainVisitor extends AbstractRuleChainVisitor {
     @Override
     protected void visit(Rule rule, Node node, RuleContext ctx) {

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/PLSQLLanguageModule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/PLSQLLanguageModule.java
@@ -5,7 +5,6 @@
 package net.sourceforge.pmd.lang.plsql;
 
 import net.sourceforge.pmd.lang.BaseLanguageModule;
-import net.sourceforge.pmd.lang.plsql.rule.PLSQLRuleChainVisitor;
 
 /**
  * Created by christoferdutz on 20.09.14.
@@ -16,7 +15,7 @@ public class PLSQLLanguageModule extends BaseLanguageModule {
     public static final String TERSE_NAME = "plsql";
 
     public PLSQLLanguageModule() {
-        super(NAME, null, TERSE_NAME, PLSQLRuleChainVisitor.class,
+        super(NAME, null, TERSE_NAME,
                 "sql",
                 "trg",  // Triggers
                 "prc", "fnc", // Standalone Procedures and Functions

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractPLSQLRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractPLSQLRule.java
@@ -256,8 +256,9 @@ public abstract class AbstractPLSQLRule extends AbstractRule implements PLSQLPar
     protected void visitAll(List<? extends Node> nodes, RuleContext ctx) {
         LOGGER.entering(CLASS_NAME, "visitAll");
         for (Object element : nodes) {
-            ASTInput node = (ASTInput) element;
-            visit(node, ctx);
+            if (element instanceof PLSQLNode) {
+                ((PLSQLNode) element).jjtAccept(this, ctx);
+            }
         }
         LOGGER.exiting(CLASS_NAME, "visitAll");
     }

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/PLSQLRuleChainVisitor.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/PLSQLRuleChainVisitor.java
@@ -18,6 +18,7 @@ import net.sourceforge.pmd.lang.plsql.ast.PLSQLParserVisitorAdapter;
 import net.sourceforge.pmd.lang.rule.AbstractRuleChainVisitor;
 import net.sourceforge.pmd.lang.rule.XPathRule;
 
+@Deprecated
 public class PLSQLRuleChainVisitor extends AbstractRuleChainVisitor {
     private static final Logger LOGGER = Logger.getLogger(PLSQLRuleChainVisitor.class.getName());
     private static final String CLASS_NAME = PLSQLRuleChainVisitor.class.getName();

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ScalaLanguageModule.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ScalaLanguageModule.java
@@ -5,7 +5,6 @@
 package net.sourceforge.pmd.lang.scala;
 
 import net.sourceforge.pmd.lang.BaseLanguageModule;
-import net.sourceforge.pmd.lang.scala.rule.ScalaRuleChainVisitor;
 
 /**
  * Language Module for Scala.
@@ -22,7 +21,7 @@ public class ScalaLanguageModule extends BaseLanguageModule {
      * Create a new instance of Scala Language Module.
      */
     public ScalaLanguageModule() {
-        super(NAME, null, TERSE_NAME, ScalaRuleChainVisitor.class, "scala");
+        super(NAME, null, TERSE_NAME, "scala");
         addVersion("2.13", new ScalaLanguageHandler(scala.meta.dialects.package$.MODULE$.Scala213()), true);
         addVersion("2.12", new ScalaLanguageHandler(scala.meta.dialects.package$.MODULE$.Scala212()), false);
         addVersion("2.11", new ScalaLanguageHandler(scala.meta.dialects.package$.MODULE$.Scala211()), false);

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/rule/ScalaRule.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/rule/ScalaRule.java
@@ -178,8 +178,8 @@ public class ScalaRule extends AbstractRule implements ScalaParserVisitor<RuleCo
     @Override
     public void apply(List<? extends Node> nodes, RuleContext ctx) {
         for (Node node : nodes) {
-            if (node instanceof ASTSource) {
-                visit((ASTSource) node, ctx);
+            if (node instanceof ScalaNode) {
+                ((ScalaNode<?>) node).accept(this, ctx);
             }
         }
     }

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/rule/ScalaRuleChainVisitor.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/rule/ScalaRuleChainVisitor.java
@@ -19,6 +19,7 @@ import net.sourceforge.pmd.lang.scala.ast.ScalaParserVisitorAdapter;
 /**
  * A Rule Chain visitor for Scala.
  */
+@Deprecated
 public class ScalaRuleChainVisitor extends AbstractRuleChainVisitor {
 
     @SuppressWarnings("unchecked")

--- a/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/DummyLanguageModule.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/DummyLanguageModule.java
@@ -48,6 +48,7 @@ public class DummyLanguageModule extends BaseLanguageModule {
         addVersion("1.8", new Handler(), false);
     }
 
+    @Deprecated
     public static class DummyRuleChainVisitor extends AbstractRuleChainVisitor {
         @Override
         protected void visit(Rule rule, Node node, RuleContext ctx) {

--- a/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/DummyLanguageModule.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/DummyLanguageModule.java
@@ -36,7 +36,7 @@ public class DummyLanguageModule extends BaseLanguageModule {
     public static final String TERSE_NAME = "dummy";
 
     public DummyLanguageModule() {
-        super(NAME, null, TERSE_NAME, DummyRuleChainVisitor.class, "dummy");
+        super(NAME, null, TERSE_NAME, "dummy");
         addVersion("1.0", new Handler(), false);
         addVersion("1.1", new Handler(), false);
         addVersion("1.2", new Handler(), false);

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/VfLanguageModule.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/VfLanguageModule.java
@@ -5,7 +5,6 @@
 package net.sourceforge.pmd.lang.vf;
 
 import net.sourceforge.pmd.lang.BaseLanguageModule;
-import net.sourceforge.pmd.lang.vf.rule.VfRuleChainVisitor;
 
 
 /**
@@ -18,7 +17,7 @@ public class VfLanguageModule extends BaseLanguageModule {
     public static final String TERSE_NAME = "vf";
 
     public VfLanguageModule() {
-        super(NAME, "VisualForce", TERSE_NAME, VfRuleChainVisitor.class, "page", "component");
+        super(NAME, "VisualForce", TERSE_NAME, "page", "component");
         addVersion("", new VfHandler(), true);
     }
 }

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/rule/AbstractVfRule.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/rule/AbstractVfRule.java
@@ -46,12 +46,8 @@ public abstract class AbstractVfRule extends AbstractRule implements VfParserVis
 
     protected void visitAll(List<? extends Node> nodes, RuleContext ctx) {
         for (Object element : nodes) {
-            if (element instanceof ASTCompilationUnit) {
-                ASTCompilationUnit node = (ASTCompilationUnit) element;
-                visit(node, ctx);
-            } else {
-                VfNode node = (VfNode) element;
-                visit(node, ctx);
+            if (element instanceof VfNode) {
+                ((VfNode) element).jjtAccept(this, ctx);
             }
         }
     }

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/rule/VfRuleChainVisitor.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/rule/VfRuleChainVisitor.java
@@ -16,6 +16,7 @@ import net.sourceforge.pmd.lang.vf.ast.VfNode;
 import net.sourceforge.pmd.lang.vf.ast.VfParserVisitor;
 import net.sourceforge.pmd.lang.vf.ast.VfParserVisitorAdapter;
 
+@Deprecated
 public class VfRuleChainVisitor extends AbstractRuleChainVisitor {
 
     @Override

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/VmLanguageModule.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/VmLanguageModule.java
@@ -5,7 +5,6 @@
 package net.sourceforge.pmd.lang.vm;
 
 import net.sourceforge.pmd.lang.BaseLanguageModule;
-import net.sourceforge.pmd.lang.vm.rule.VmRuleChainVisitor;
 
 /**
  * Created by christoferdutz on 20.09.14.
@@ -16,7 +15,7 @@ public class VmLanguageModule extends BaseLanguageModule {
     public static final String TERSE_NAME = "vm";
 
     public VmLanguageModule() {
-        super(NAME, null, TERSE_NAME, VmRuleChainVisitor.class, "vm");
+        super(NAME, null, TERSE_NAME, "vm");
         addVersion("", new VmHandler(), true);
     }
 

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/AbstractVmRule.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/AbstractVmRule.java
@@ -75,8 +75,9 @@ public abstract class AbstractVmRule extends AbstractRule implements VmParserVis
 
     protected void visitAll(final List<? extends Node> nodes, final RuleContext ctx) {
         for (final Object element : nodes) {
-            final ASTprocess node = (ASTprocess) element;
-            visit(node, ctx);
+            if (element instanceof VmNode) {
+                ((VmNode) element).jjtAccept(this, ctx);
+            }
         }
     }
 

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/VmRuleChainVisitor.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/VmRuleChainVisitor.java
@@ -17,6 +17,7 @@ import net.sourceforge.pmd.lang.vm.ast.VmNode;
 import net.sourceforge.pmd.lang.vm.ast.VmParserVisitor;
 import net.sourceforge.pmd.lang.vm.ast.VmParserVisitorAdapter;
 
+@Deprecated
 public class VmRuleChainVisitor extends AbstractRuleChainVisitor {
 
     @Override

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/pom/PomLanguageModule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/pom/PomLanguageModule.java
@@ -6,14 +6,13 @@ package net.sourceforge.pmd.lang.pom;
 
 import net.sourceforge.pmd.lang.BaseLanguageModule;
 import net.sourceforge.pmd.lang.xml.XmlHandler;
-import net.sourceforge.pmd.lang.xml.rule.XmlRuleChainVisitor;
 
 public class PomLanguageModule extends BaseLanguageModule {
     public static final String NAME = "Maven POM";
     public static final String TERSE_NAME = "pom";
 
     public PomLanguageModule() {
-        super(NAME, null, TERSE_NAME, XmlRuleChainVisitor.class, "pom");
+        super(NAME, null, TERSE_NAME, "pom");
         addVersion("", new XmlHandler(), true);
     }
 }

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/wsdl/WsdlLanguageModule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/wsdl/WsdlLanguageModule.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.lang.wsdl;
 
 import net.sourceforge.pmd.lang.BaseLanguageModule;
 import net.sourceforge.pmd.lang.xml.XmlHandler;
-import net.sourceforge.pmd.lang.xml.rule.XmlRuleChainVisitor;
 
 /**
  * Created by bernardo-macedo on 24.06.15.
@@ -16,7 +15,7 @@ public class WsdlLanguageModule extends BaseLanguageModule {
     public static final String TERSE_NAME = "wsdl";
 
     public WsdlLanguageModule() {
-        super(NAME, null, TERSE_NAME, XmlRuleChainVisitor.class, "wsdl");
+        super(NAME, null, TERSE_NAME, "wsdl");
         addVersion("", new XmlHandler(), true);
     }
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/XmlLanguageModule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/XmlLanguageModule.java
@@ -5,7 +5,6 @@
 package net.sourceforge.pmd.lang.xml;
 
 import net.sourceforge.pmd.lang.BaseLanguageModule;
-import net.sourceforge.pmd.lang.xml.rule.XmlRuleChainVisitor;
 
 /**
  * Created by christoferdutz on 20.09.14.
@@ -16,7 +15,7 @@ public class XmlLanguageModule extends BaseLanguageModule {
     public static final String TERSE_NAME = "xml";
 
     public XmlLanguageModule() {
-        super(NAME, null, TERSE_NAME, XmlRuleChainVisitor.class, "xml");
+        super(NAME, null, TERSE_NAME, "xml");
         addVersion("", new XmlHandler(), true);
     }
 }

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/AbstractXmlRule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/AbstractXmlRule.java
@@ -65,8 +65,9 @@ public class AbstractXmlRule extends AbstractRule implements ImmutableLanguage {
 
     protected void visitAll(List<? extends Node> nodes, RuleContext ctx) {
         for (Object element : nodes) {
-            XmlNode node = (XmlNode) element;
-            visit(node, ctx);
+            if (element instanceof XmlNode) {
+                visit((XmlNode) element, ctx);
+            }
         }
     }
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/XmlRuleChainVisitor.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/XmlRuleChainVisitor.java
@@ -14,6 +14,7 @@ import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.rule.AbstractRuleChainVisitor;
 import net.sourceforge.pmd.lang.rule.XPathRule;
 
+@Deprecated
 public class XmlRuleChainVisitor extends AbstractRuleChainVisitor {
 
     @Override

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xsl/XslLanguageModule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xsl/XslLanguageModule.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.lang.xsl;
 
 import net.sourceforge.pmd.lang.BaseLanguageModule;
 import net.sourceforge.pmd.lang.xml.XmlHandler;
-import net.sourceforge.pmd.lang.xml.rule.XmlRuleChainVisitor;
 
 /**
  * Created by christoferdutz on 20.09.14.
@@ -17,7 +16,7 @@ public class XslLanguageModule extends BaseLanguageModule {
     public static final String TERSE_NAME = "xsl";
 
     public XslLanguageModule() {
-        super(NAME, null, TERSE_NAME, XmlRuleChainVisitor.class, "xsl", "xslt");
+        super(NAME, null, TERSE_NAME, "xsl", "xslt");
         addVersion("", new XmlHandler(), true);
     }
 }


### PR DESCRIPTION
## Describe the PR

Update master to be forward compatible with #2490, deprecate rulechain visitors. Add a rulechain visitor that is language-independent for now.

The new constructor for BaseLanguageModule takes file extensions as varargs+1. At least one extension is required, and this is also the case currently (but not explained anywhere). When making the PlainTextLanguage for the designer this was a hard to see issue.

## Related issues

- Refs #2490

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

