### PR TITLE
[java] Remove usages of DummyJavaNode

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -20,7 +20,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
 import net.sourceforge.pmd.lang.java.ast.Comment;
-import net.sourceforge.pmd.lang.java.ast.DummyJavaNode;
 import net.sourceforge.pmd.lang.java.ast.FormalComment;
 import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
@@ -83,16 +82,16 @@ public class UnusedImportsRule extends AbstractJavaRule {
             for (Pattern p : PATTERNS) {
                 Matcher m = p.matcher(comment.getImage());
                 while (m.find()) {
-                    String s = m.group(1);
+                    String fullname = m.group(1);
 
-                    if (s != null) { // may be null for "@see #" and "@link #"
-                        imports.remove(new ImportWrapper(s, s, new DummyJavaNode(-1)));
+                    if (fullname != null) { // may be null for "@see #" and "@link #"
+                        imports.remove(new ImportWrapper(fullname, fullname));
                     }
 
                     if (m.groupCount() > 1) {
-                        s = m.group(2);
-                        if (s != null) {
-                            String[] params = s.split("\\s*,\\s*");
+                        fullname = m.group(2);
+                        if (fullname != null) {
+                            String[] params = fullname.split("\\s*,\\s*");
                             for (String param : params) {
                                 final int firstDot = param.indexOf('.');
                                 final String expectedImportName;
@@ -101,7 +100,7 @@ public class UnusedImportsRule extends AbstractJavaRule {
                                 } else {
                                     expectedImportName = param.substring(0, firstDot);
                                 }
-                                imports.remove(new ImportWrapper(param, expectedImportName, new DummyJavaNode(-1)));
+                                imports.remove(new ImportWrapper(param, expectedImportName));
                             }
                         }
                     }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symboltable/ClassScopeTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symboltable/ClassScopeTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -19,8 +19,9 @@ import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTName;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
-import net.sourceforge.pmd.lang.java.ast.DummyJavaNode;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.symboltable.testdata.InnerClass;
 import net.sourceforge.pmd.lang.java.symboltable.testdata.InnerClass.TheInnerClass;
@@ -69,23 +70,23 @@ public class ClassScopeTest extends BaseNonParserTest {
 
     @Test
     public void testCantContainsSuperToString() {
-        ClassNameDeclaration classDeclaration = new ClassNameDeclaration(null);
+        ASTCompilationUnit cu = java.parse("class Foo { public String toString() { return super.toString(); } }");
+        ClassNameDeclaration classDeclaration = new ClassNameDeclaration(cu.getFirstDescendantOfType(ASTClassOrInterfaceDeclaration.class));
         ClassScope s = new ClassScope("Foo", classDeclaration);
-        JavaNode node = new DummyJavaNode(1);
-        node.setImage("super.toString");
-        assertFalse(s.contains(new JavaNameOccurrence(node, node.getImage())));
+        JavaNode node = cu.getFirstDescendantOfType(ASTPrimaryExpression.class); // "super.toString();"
+        assertFalse(s.contains(new JavaNameOccurrence(node, "super.toString")));
     }
 
     @Test
     public void testContainsStaticVariablePrefixedWithClassName() {
-        ClassNameDeclaration classDeclaration = new ClassNameDeclaration(null);
+        ASTCompilationUnit cu = java.parse("class Foo { static int X; public int bar() { return Foo.X; } }");
+
+        ClassNameDeclaration classDeclaration = new ClassNameDeclaration(cu.getFirstDescendantOfType(ASTClassOrInterfaceDeclaration.class));
         ClassScope s = new ClassScope("Foo", classDeclaration);
-        ASTVariableDeclaratorId node = new ASTVariableDeclaratorId(1);
-        node.setImage("X");
+        ASTVariableDeclaratorId node = cu.getFirstDescendantOfType(ASTVariableDeclaratorId.class);
         s.addDeclaration(new VariableNameDeclaration(node));
 
-        JavaNode node2 = new DummyJavaNode(2);
-        node2.setImage("Foo.X");
+        JavaNode node2 = cu.getFirstDescendantOfType(ASTName.class);
         assertTrue(s.contains(new JavaNameOccurrence(node2, node2.getImage())));
     }
 


### PR DESCRIPTION
## Describe the PR

Removes any remaining usages of DummyJavaNode - which accidentaly got added to the main source.
We could then simply delete this class in PMD 7 and forget about it.

This changes one rule: UnusedImports.

## Related issues

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

