### PR TITLE
[java] ArrayIsStoredDirectly false positive with private constructor/…

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -14,10 +14,18 @@ This is a {{ site.pmd.release_type }} release.
 
 ### New and noteworthy
 
+#### Modified rules
+
+*   The Java rule {% rule "java/bestpractices/ArrayIsStoredDirectly" %} (`java-bestpractices`) now ignores
+    by default private methods and constructors. You can restore the old behavior by setting the new property
+    `allowPrivate` to "false".
+
 ### Fixed Issues
 
 *   apex-bestpractices
     *   [#2626](https://github.com/pmd/pmd/issues/2626): \[apex] UnusedLocalVariable - false positive on case insensitivity allowed in Apex
+*   java-bestpractices
+    *   [#2622](https://github.com/pmd/pmd/issues/2622): \[java] ArrayIsStoredDirectly false positive with private constructor/methods
 
 ### API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ArrayIsStoredDirectlyRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ArrayIsStoredDirectlyRule.java
@@ -22,6 +22,8 @@ import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
 import net.sourceforge.pmd.lang.java.ast.ASTStatementExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
 
 /**
  * If a method or constructor receives an array as an argument, the array should
@@ -32,6 +34,15 @@ import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
  * @author mgriffa
  */
 public class ArrayIsStoredDirectlyRule extends AbstractSunSecureRule {
+    private static final PropertyDescriptor<Boolean> ALLOW_PRIVATE =
+            PropertyFactory.booleanProperty("allowPrivate")
+                .defaultValue(true)
+                .desc("If true, allow private methods/constructors to store arrays directly")
+                .build();
+
+    public ArrayIsStoredDirectlyRule() {
+        definePropertyDescriptor(ALLOW_PRIVATE);
+    }
 
     @Override
     public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
@@ -43,6 +54,10 @@ public class ArrayIsStoredDirectlyRule extends AbstractSunSecureRule {
 
     @Override
     public Object visit(ASTConstructorDeclaration node, Object data) {
+        if (node.isPrivate() && getProperty(ALLOW_PRIVATE)) {
+            return data;
+        }
+
         ASTFormalParameter[] arrs = getArrays(node.getFormalParameters());
         // TODO check if one of these arrays is stored in a non local
         // variable
@@ -53,6 +68,10 @@ public class ArrayIsStoredDirectlyRule extends AbstractSunSecureRule {
 
     @Override
     public Object visit(ASTMethodDeclaration node, Object data) {
+        if (node.isPrivate() && getProperty(ALLOW_PRIVATE)) {
+            return data;
+        }
+
         final ASTFormalParameters params = node.getFirstDescendantOfType(ASTFormalParameters.class);
         ASTFormalParameter[] arrs = getArrays(params);
         checkAll(data, arrs, node.findDescendantsOfType(ASTBlockStatement.class));

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/ArrayIsStoredDirectly.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/ArrayIsStoredDirectly.xml
@@ -198,4 +198,44 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[java] ArrayIsStoredDirectly false positive with private constructor/methods #2622</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class AISD {
+    private final byte[] buf;
+    private AISD(final byte[] buf) {
+        this.buf = buf;  // this is not a violation!!
+    }
+    private void set(final byte[] buf) {
+        this.buf = buf;  // this is not a violation!!
+    }
+    public AISD of(final byte[] buf) {
+        return new AISD(buf.clone());
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>do not allow private methods</description>
+        <rule-property name="allowPrivate">false</rule-property>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,6</expected-linenumbers>
+        <code><![CDATA[
+public class AISD {
+    private final byte[] buf;
+    private AISD(final byte[] buf) {
+        this.buf = buf;
+    }
+    private void set(final byte[] buf) {
+        this.buf = buf;
+    }
+    public AISD of(final byte[] buf) {
+        return new AISD(buf.clone());
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
…methods

## Describe the PR

* Adds new property "allowPrivate"
* Changes the default behavior of the rule

## Related issues

- Fixes #2622

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

