### PR TITLE
[core] Fix XMLRenderer encoding issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org/'
 
 # bleeding edge from git
-#gem 'pmdtester', :git => 'https://github.com/pmd/pmd-regression-tester.git'
+gem 'pmdtester', :git => 'https://github.com/pmd/pmd-regression-tester.git'
 
-gem 'pmdtester', '~> 1.0'
+#gem 'pmdtester', '~> 1.0'
 gem 'danger', '~> 5.6', '>= 5.6'
 
 # This group is only needed for rendering release notes

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org/'
 
 # bleeding edge from git
-gem 'pmdtester', :git => 'https://github.com/pmd/pmd-regression-tester.git'
+#gem 'pmdtester', :git => 'https://github.com/pmd/pmd-regression-tester.git'
 
-#gem 'pmdtester', '~> 1.0'
+gem 'pmdtester', '~> 1.0'
 gem 'danger', '~> 5.6', '>= 5.6'
 
 # This group is only needed for rendering release notes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,13 +1,3 @@
-GIT
-  remote: https://github.com/pmd/pmd-regression-tester.git
-  revision: fa39704981b07ab732ce54ebc6a4578e1865399b
-  specs:
-    pmdtester (1.1.0.pre.SNAPSHOT)
-      differ (~> 0.1)
-      nokogiri (~> 1.8)
-      rufus-scheduler (~> 3.5)
-      slop (~> 4.6)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -58,6 +48,11 @@ GEM
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
+    pmdtester (1.0.1)
+      differ (~> 0.1)
+      nokogiri (~> 1.8)
+      rufus-scheduler (~> 3.5)
+      slop (~> 4.6)
     public_suffix (4.0.5)
     raabro (1.3.1)
     rchardet (1.8.0)
@@ -81,7 +76,7 @@ PLATFORMS
 DEPENDENCIES
   danger (~> 5.6, >= 5.6)
   liquid (>= 4.0.0)
-  pmdtester!
+  pmdtester (~> 1.0)
   rouge (>= 1.7, < 4)
   safe_yaml (>= 1.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,13 @@
+GIT
+  remote: https://github.com/pmd/pmd-regression-tester.git
+  revision: fa39704981b07ab732ce54ebc6a4578e1865399b
+  specs:
+    pmdtester (1.1.0.pre.SNAPSHOT)
+      differ (~> 0.1)
+      nokogiri (~> 1.8)
+      rufus-scheduler (~> 3.5)
+      slop (~> 4.6)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -31,9 +41,9 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (1.3.1)
       faraday (~> 0.8)
-    fugit (1.3.5)
+    fugit (1.3.6)
       et-orbi (~> 1.1, >= 1.1.8)
-      raabro (~> 1.1)
+      raabro (~> 1.3)
     git (1.7.0)
       rchardet (~> 1.8)
     kramdown (1.17.0)
@@ -42,21 +52,16 @@ GEM
     multipart-post (2.1.1)
     nap (1.1.0)
     no_proxy_fix (0.1.2)
-    nokogiri (1.10.9)
+    nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
-    pmdtester (1.0.0)
-      differ (~> 0.1)
-      nokogiri (~> 1.8)
-      rufus-scheduler (~> 3.5)
-      slop (~> 4.6)
     public_suffix (4.0.5)
     raabro (1.3.1)
     rchardet (1.8.0)
-    rouge (3.19.0)
+    rouge (3.20.0)
     rufus-scheduler (3.6.0)
       fugit (~> 1.1, >= 1.1.6)
     safe_yaml (1.0.5)
@@ -76,7 +81,7 @@ PLATFORMS
 DEPENDENCIES
   danger (~> 5.6, >= 5.6)
   liquid (>= 4.0.0)
-  pmdtester (~> 1.0)
+  pmdtester!
   rouge (>= 1.7, < 4)
   safe_yaml (>= 1.0)
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -18,6 +18,8 @@ This is a {{ site.pmd.release_type }} release.
 
 *   apex-bestpractices
     *   [#2626](https://github.com/pmd/pmd/issues/2626): \[apex] UnusedLocalVariable - false positive on case insensitivity allowed in Apex
+*   core
+    *   [#2615](https://github.com/pmd/pmd/issues/2615): \[core] PMD/CPD produces invalid XML (insufficient escaping/wrong encoding)
 
 ### API Changes
 

--- a/pmd-core/pom.xml
+++ b/pmd-core/pom.xml
@@ -135,6 +135,10 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
         </dependency>

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
@@ -217,8 +217,7 @@ public class PMD {
             try (TimedOperation to = TimeTracker.startOperation(TimedOperationCategory.REPORTING)) {
                 renderer = configuration.createRenderer();
                 renderers = Collections.singletonList(renderer);
-
-                renderer.setWriter(IOUtil.createWriter(configuration.getReportFile()));
+                renderer.setReportFile(configuration.getReportFile());
                 renderer.start();
             }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
@@ -19,7 +19,6 @@ import net.sourceforge.pmd.lang.LanguageVersionDiscoverer;
 import net.sourceforge.pmd.renderers.Renderer;
 import net.sourceforge.pmd.renderers.RendererFactory;
 import net.sourceforge.pmd.util.ClasspathClassLoader;
-import net.sourceforge.pmd.util.IOUtil;
 
 /**
  * This class contains the details for the runtime configuration of PMD. There
@@ -406,7 +405,7 @@ public class PMDConfiguration extends AbstractConfiguration {
             renderer.setUseShortNames(Arrays.asList(inputPaths.split(",")));
         }
         if (withReportWriter) {
-            renderer.setWriter(IOUtil.createWriter(reportFile));
+            renderer.setReportFile(reportFile);
         }
         return renderer;
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLRenderer.java
@@ -23,6 +23,7 @@ import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
 import net.sourceforge.pmd.cpd.renderer.CPDRenderer;
+import net.sourceforge.pmd.util.StringUtil;
 
 /**
  * @author Philippe T'Seyen - original implementation
@@ -121,14 +122,8 @@ public final class XMLRenderer implements Renderer, CPDRenderer {
             mark = iterator.next();
             final Element file = doc.createElement("file");
             file.setAttribute("line", String.valueOf(mark.getBeginLine()));
-            /*
-             * StringEscapeUtils escape basic chars like "<" and remove invalid chars like U+000C.
-             * But the DOM impl already escapes "<" by itself in attribute values, but doesn't remove
-             * invalid chars. In order to avoid double escaping, this escapes it once with StringEscapeUtils
-             * and unescapes it again - result is, that only invalid chars are removed (no escaping).
-             * Escaping is left to the DOM impl.
-             */
-            String filenameXml10 = StringEscapeUtils.unescapeXml(StringEscapeUtils.escapeXml10(mark.getFilename()));
+            // only remove invalid characters, escaping is done by the DOM impl.
+            String filenameXml10 = StringUtil.removedInvalidXml10Characters(mark.getFilename());
             file.setAttribute("path", filenameXml10);
             file.setAttribute("endline", String.valueOf(mark.getEndLine()));
             final int beginCol = mark.getBeginColumn();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLRenderer.java
@@ -121,6 +121,13 @@ public final class XMLRenderer implements Renderer, CPDRenderer {
             mark = iterator.next();
             final Element file = doc.createElement("file");
             file.setAttribute("line", String.valueOf(mark.getBeginLine()));
+            /*
+             * StringEscapeUtils escape basic chars like "<" and remove invalid chars like U+000C.
+             * But the DOM impl already escapes "<" by itself in attribute values, but doesn't remove
+             * invalid chars. In order to avoid double escaping, this escapes it once with StringEscapeUtils
+             * and unescapes it again - result is, that only invalid chars are removed (no escaping).
+             * Escaping is left to the DOM impl.
+             */
             String filenameXml10 = StringEscapeUtils.unescapeXml(StringEscapeUtils.escapeXml10(mark.getFilename()));
             file.setAttribute("path", filenameXml10);
             file.setAttribute("endline", String.valueOf(mark.getEndLine()));

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLRenderer.java
@@ -18,6 +18,7 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import org.apache.commons.text.StringEscapeUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -140,7 +141,7 @@ public final class XMLRenderer implements Renderer, CPDRenderer {
             // the code snippet has normalized line endings
             String platformSpecific = codeSnippet.replace("\n", System.lineSeparator());
             Element codefragment = doc.createElement("codefragment");
-            codefragment.appendChild(doc.createCDATASection(platformSpecific));
+            codefragment.appendChild(doc.createCDATASection(StringEscapeUtils.escapeXml10(platformSpecific)));
             duplication.appendChild(codefragment);
         }
         return duplication;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLRenderer.java
@@ -77,6 +77,7 @@ public final class XMLRenderer implements Renderer, CPDRenderer {
         try {
             TransformerFactory tf = TransformerFactory.newInstance();
             Transformer transformer = tf.newTransformer();
+            transformer.setOutputProperty(OutputKeys.VERSION, "1.0");
             transformer.setOutputProperty(OutputKeys.METHOD, "xml");
             transformer.setOutputProperty(OutputKeys.ENCODING, encoding);
             transformer.setOutputProperty(OutputKeys.INDENT, "yes");
@@ -120,7 +121,8 @@ public final class XMLRenderer implements Renderer, CPDRenderer {
             mark = iterator.next();
             final Element file = doc.createElement("file");
             file.setAttribute("line", String.valueOf(mark.getBeginLine()));
-            file.setAttribute("path", mark.getFilename());
+            String filenameXml10 = StringEscapeUtils.unescapeXml(StringEscapeUtils.escapeXml10(mark.getFilename()));
+            file.setAttribute("path", filenameXml10);
             file.setAttribute("endline", String.valueOf(mark.getEndLine()));
             final int beginCol = mark.getBeginColumn();
             final int endCol = mark.getEndColumn();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/AbstractRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/AbstractRenderer.java
@@ -12,9 +12,11 @@ import java.util.List;
 import org.apache.commons.io.IOUtils;
 
 import net.sourceforge.pmd.PMDConfiguration;
+import net.sourceforge.pmd.annotation.Experimental;
 import net.sourceforge.pmd.cli.PMDParameters;
 import net.sourceforge.pmd.internal.util.ShortFilenameUtil;
 import net.sourceforge.pmd.properties.AbstractPropertySource;
+import net.sourceforge.pmd.util.IOUtil;
 
 /**
  * Abstract base class for {@link Renderer} implementations.
@@ -108,5 +110,17 @@ public abstract class AbstractRenderer extends AbstractPropertySource implements
         } finally {
             IOUtils.closeQuietly(writer);
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This default implementation always uses the system default charset for the writer.
+     * Overwrite in specific renderers to support other charsets.
+     */
+    @Experimental
+    @Override
+    public void setReportFile(String reportFilename) {
+        this.setWriter(IOUtil.createWriter(reportFilename));
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/Renderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/Renderer.java
@@ -9,6 +9,7 @@ import java.io.Writer;
 import java.util.List;
 
 import net.sourceforge.pmd.Report;
+import net.sourceforge.pmd.annotation.Experimental;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertySource;
 import net.sourceforge.pmd.util.datasource.DataSource;
@@ -163,4 +164,17 @@ public interface Renderer extends PropertySource {
     void end() throws IOException;
 
     void flush() throws IOException;
+
+    /**
+     * Sets the filename where the report should be written to. If no filename is provided,
+     * the renderer should write to stdout.
+     *
+     * <p>Implementations must initialize the writer of the renderer.
+     *
+     * <p>See {@link AbstractRenderer#setReportFile(String)} for the default impl.
+     *
+     * @param reportFilename the filename (optional).
+     */
+    @Experimental
+    void setReportFile(String reportFilename);
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XMLRenderer.java
@@ -14,8 +14,6 @@ import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Iterator;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import javax.xml.XMLConstants;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
@@ -29,6 +27,7 @@ import net.sourceforge.pmd.PMDVersion;
 import net.sourceforge.pmd.Report;
 import net.sourceforge.pmd.RuleViolation;
 import net.sourceforge.pmd.properties.StringProperty;
+import net.sourceforge.pmd.util.StringUtil;
 
 /**
  * Renderer to XML format.
@@ -121,7 +120,7 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
                 maybeAdd("externalInfoUrl", rv.getRule().getExternalInfoUrl());
                 xmlWriter.writeAttribute("priority", String.valueOf(rv.getRule().getPriority().getPriority()));
                 xmlWriter.writeCharacters(PMD.EOL);
-                xmlWriter.writeCharacters(removeInvalidCharacters(rv.getDescription()));
+                xmlWriter.writeCharacters(StringUtil.removedInvalidXml10Characters(rv.getDescription()));
                 xmlWriter.writeCharacters(PMD.EOL);
                 xmlWriter.writeEndElement();
                 xmlWriter.writeCharacters(PMD.EOL);
@@ -199,26 +198,6 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
         } catch (IOException | XMLStreamException e) {
             throw new IllegalArgumentException(e);
         }
-    }
-
-    /**
-     * Remove characters, that are not allowed in XML 1.0 documents.
-     *
-     * <p>Allowed characters are:
-     * <blockquote>
-     * Char    ::=      #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
-     *  // any Unicode character, excluding the surrogate blocks, FFFE, and FFFF.
-     * </blockquote>
-     * (see <a href="https://www.w3.org/TR/xml/#charsets">Extensible Markup Language (XML) 1.0 (Fifth Edition)</a>).
-     */
-    private String removeInvalidCharacters(String text) {
-        Pattern pattern = Pattern.compile(
-                  "\\x00|\\x01|\\x02|\\x03|\\x04|\\x05|\\x06|\\x07|\\x08|"
-                + "\\x0b|\\x0c|\\x0e|\\x0f|"
-                + "\\x10|\\x11|\\x12|\\x13|\\x14|\\x15|\\x16|\\x17|\\x18|"
-                + "\\x19|\\x1a|\\x1b|\\x1c|\\x1d|\\x1e|\\x1f");
-        Matcher matcher = pattern.matcher(text);
-        return matcher.replaceAll("");
     }
 
     @Override

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XMLRenderer.java
@@ -6,16 +6,23 @@ package net.sourceforge.pmd.renderers;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.io.OutputStreamWriter;
-import java.nio.charset.Charset;
-import java.nio.charset.UnsupportedCharsetException;
+import java.io.UnsupportedEncodingException;
+import java.io.Writer;
 import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Iterator;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.xml.XMLConstants;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
 
+import org.apache.commons.io.output.WriterOutputStream;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.text.StringEscapeUtils;
 
 import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.PMDVersion;
@@ -33,6 +40,13 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
     // TODO 7.0.0 use PropertyDescriptor<String> or something more specialized
     public static final StringProperty ENCODING = new StringProperty("encoding",
             "XML encoding format, defaults to UTF-8.", "UTF-8", 0);
+
+    private static final String PMD_REPORT_NS_URI = "http://pmd.sourceforge.net/report/2.0.0";
+    private static final String PMD_REPORT_NS_LOCATION = "http://pmd.sourceforge.net/report_2_0_0.xsd";
+    private static final String XSI_NS_PREFIX = "xsi";
+
+    private XMLStreamWriter xmlWriter;
+    private OutputStream stream;
 
     public XMLRenderer() {
         super(NAME, "XML format.");
@@ -53,133 +67,121 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
     public void start() throws IOException {
         String encoding = getProperty(ENCODING);
 
-        StringBuilder buf = new StringBuilder(500);
-        buf.append("<?xml version=\"1.0\" encoding=\"" + encoding + "\"?>").append(PMD.EOL);
-        createVersionAttr(buf);
-        createTimestampAttr(buf);
-        // FIXME: elapsed time not available until the end of the processing
-        // buf.append(createTimeElapsedAttr(report));
-        buf.append('>').append(PMD.EOL);
-        writer.write(buf.toString());
+        try {
+            xmlWriter.writeStartDocument(encoding, "1.0");
+            xmlWriter.writeCharacters(PMD.EOL);
+            xmlWriter.setDefaultNamespace(PMD_REPORT_NS_URI);
+            xmlWriter.writeStartElement(PMD_REPORT_NS_URI, "pmd");
+            xmlWriter.writeDefaultNamespace(PMD_REPORT_NS_URI);
+            xmlWriter.writeNamespace(XSI_NS_PREFIX, XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI);
+            xmlWriter.writeAttribute(XSI_NS_PREFIX, XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI, "schemaLocation",
+                    PMD_REPORT_NS_URI + " " + PMD_REPORT_NS_LOCATION);
+            xmlWriter.writeAttribute("version", PMDVersion.VERSION);
+            xmlWriter.writeAttribute("timestamp", new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS").format(new Date()));
+            // FIXME: elapsed time not available until the end of the processing
+            // xmlWriter.writeAttribute("time_elapsed", ...);
+        } catch (XMLStreamException e) {
+            throw new IOException(e);
+        }
     }
 
     @Override
     public void renderFileViolations(Iterator<RuleViolation> violations) throws IOException {
-        StringBuilder buf = new StringBuilder(500);
         String filename = null;
 
-        // rule violations
-        while (violations.hasNext()) {
-            buf.setLength(0);
-            RuleViolation rv = violations.next();
-            String nextFilename = determineFileName(rv.getFilename());
-            if (!nextFilename.equals(filename)) {
-                // New File
-                if (filename != null) {
-                    // Not first file ?
-                    buf.append("</file>").append(PMD.EOL);
+        try {
+            // rule violations
+            while (violations.hasNext()) {
+                RuleViolation rv = violations.next();
+                String nextFilename = determineFileName(rv.getFilename());
+                if (!nextFilename.equals(filename)) {
+                    // New File
+                    if (filename != null) {
+                        // Not first file ?
+                        xmlWriter.writeEndElement();
+                    }
+                    filename = nextFilename;
+                    xmlWriter.writeCharacters(PMD.EOL);
+                    xmlWriter.writeStartElement("file");
+                    xmlWriter.writeAttribute("name", filename);
+                    xmlWriter.writeCharacters(PMD.EOL);
                 }
-                filename = nextFilename;
-                buf.append("<file name=\"");
-                buf.append(escape(filename));
-                buf.append("\">").append(PMD.EOL);
+
+                xmlWriter.writeStartElement("violation");
+                xmlWriter.writeAttribute("beginline", String.valueOf(rv.getBeginLine()));
+                xmlWriter.writeAttribute("endline", String.valueOf(rv.getEndLine()));
+                xmlWriter.writeAttribute("begincolumn", String.valueOf(rv.getBeginColumn()));
+                xmlWriter.writeAttribute("endcolumn", String.valueOf(rv.getEndColumn()));
+                xmlWriter.writeAttribute("rule", rv.getRule().getName());
+                xmlWriter.writeAttribute("ruleset", rv.getRule().getRuleSetName());
+                maybeAdd("package", rv.getPackageName());
+                maybeAdd("class", rv.getClassName());
+                maybeAdd("method", rv.getMethodName());
+                maybeAdd("variable", rv.getVariableName());
+                maybeAdd("externalInfoUrl", rv.getRule().getExternalInfoUrl());
+                xmlWriter.writeAttribute("priority", String.valueOf(rv.getRule().getPriority().getPriority()));
+                xmlWriter.writeCharacters(PMD.EOL);
+                xmlWriter.writeCharacters(removeInvalidCharacters(rv.getDescription()));
+                xmlWriter.writeCharacters(PMD.EOL);
+                xmlWriter.writeEndElement();
+                xmlWriter.writeCharacters(PMD.EOL);
             }
-
-            buf.append("<violation beginline=\"").append(rv.getBeginLine());
-            buf.append("\" endline=\"").append(rv.getEndLine());
-            buf.append("\" begincolumn=\"").append(rv.getBeginColumn());
-            buf.append("\" endcolumn=\"").append(rv.getEndColumn());
-            buf.append("\" rule=\"");
-            buf.append(escape(rv.getRule().getName()));
-            buf.append("\" ruleset=\"");
-            buf.append(escape(rv.getRule().getRuleSetName()));
-            buf.append('"');
-            maybeAdd("package", rv.getPackageName(), buf);
-            maybeAdd("class", rv.getClassName(), buf);
-            maybeAdd("method", rv.getMethodName(), buf);
-            maybeAdd("variable", rv.getVariableName(), buf);
-            maybeAdd("externalInfoUrl", rv.getRule().getExternalInfoUrl(), buf);
-            buf.append(" priority=\"");
-            buf.append(rv.getRule().getPriority().getPriority());
-            buf.append("\">").append(PMD.EOL);
-            buf.append(escape(rv.getDescription()));
-
-            buf.append(PMD.EOL);
-            buf.append("</violation>");
-            buf.append(PMD.EOL);
-            writer.write(buf.toString());
-        }
-        if (filename != null) { // Not first file ?
-            writer.write("</file>");
-            writer.write(PMD.EOL);
+            if (filename != null) { // Not first file ?
+                xmlWriter.writeEndElement();
+            }
+        } catch (XMLStreamException e) {
+            throw new IOException(e);
         }
     }
 
     @Override
     public void end() throws IOException {
-        StringBuilder buf = new StringBuilder(500);
-        // errors
-        for (Report.ProcessingError pe : errors) {
-            buf.setLength(0);
-            buf.append("<error ").append("filename=\"");
-            buf.append(escape(determineFileName(pe.getFile())));
-            buf.append("\" msg=\"");
-            buf.append(escape(pe.getMsg()));
-            buf.append("\">").append(PMD.EOL);
-            buf.append("<![CDATA[").append(pe.getDetail()).append("]]>").append(PMD.EOL);
-            buf.append("</error>").append(PMD.EOL);
-            writer.write(buf.toString());
-        }
-
-        // suppressed violations
-        if (showSuppressedViolations) {
-            for (Report.SuppressedViolation s : suppressed) {
-                buf.setLength(0);
-                buf.append("<suppressedviolation ").append("filename=\"");
-                buf.append(escape(determineFileName(s.getRuleViolation().getFilename())));
-                buf.append("\" suppressiontype=\"");
-                buf.append(escape(s.suppressedByNOPMD() ? "nopmd" : "annotation"));
-                buf.append("\" msg=\"");
-                buf.append(escape(s.getRuleViolation().getDescription()));
-                buf.append("\" usermsg=\"");
-                buf.append(escape(s.getUserMessage() == null ? "" : s.getUserMessage()));
-                buf.append("\"/>").append(PMD.EOL);
-                writer.write(buf.toString());
+        try {
+            // errors
+            for (Report.ProcessingError pe : errors) {
+                xmlWriter.writeCharacters(PMD.EOL);
+                xmlWriter.writeStartElement("error");
+                xmlWriter.writeAttribute("filename", determineFileName(pe.getFile()));
+                xmlWriter.writeAttribute("msg", pe.getMsg());
+                xmlWriter.writeCharacters(PMD.EOL);
+                xmlWriter.writeCData(pe.getDetail());
+                xmlWriter.writeCharacters(PMD.EOL);
+                xmlWriter.writeEndElement();
             }
-        }
 
-        // config errors
-        for (final Report.ConfigurationError ce : configErrors) {
-            buf.setLength(0);
-            buf.append("<configerror ").append("rule=\"");
-            buf.append(escape(ce.rule().getName()));
-            buf.append("\" msg=\"");
-            buf.append(escape(ce.issue()));
-            buf.append("\"/>").append(PMD.EOL);
-            writer.write(buf.toString());
-        }
+            // suppressed violations
+            if (showSuppressedViolations) {
+                for (Report.SuppressedViolation s : suppressed) {
+                    xmlWriter.writeCharacters(PMD.EOL);
+                    xmlWriter.writeStartElement("suppressedviolation");
+                    xmlWriter.writeAttribute("filename", determineFileName(s.getRuleViolation().getFilename()));
+                    xmlWriter.writeAttribute("suppressiontype", s.suppressedByNOPMD() ? "nopmd" : "annotation");
+                    xmlWriter.writeAttribute("msg", s.getRuleViolation().getDescription());
+                    xmlWriter.writeAttribute("usermsg", s.getUserMessage() == null ? "" : s.getUserMessage());
+                    xmlWriter.writeEndElement();
+                }
+            }
 
-        writer.write("</pmd>" + PMD.EOL);
+            // config errors
+            for (final Report.ConfigurationError ce : configErrors) {
+                xmlWriter.writeCharacters(PMD.EOL);
+                xmlWriter.writeEmptyElement("configerror");
+                xmlWriter.writeAttribute("rule", ce.rule().getName());
+                xmlWriter.writeAttribute("msg", ce.issue());
+            }
+            xmlWriter.writeCharacters(PMD.EOL);
+            xmlWriter.writeEndElement(); // </pmd>
+            xmlWriter.writeCharacters(PMD.EOL);
+            xmlWriter.flush();
+        } catch (XMLStreamException e) {
+            throw new IOException(e);
+        }
     }
 
-    private void maybeAdd(String attr, String value, StringBuilder buf) {
+    private void maybeAdd(String attr, String value) throws XMLStreamException {
         if (value != null && value.length() > 0) {
-            buf.append(' ').append(attr).append("=\"");
-            buf.append(escape(value));
-            buf.append('"');
+            xmlWriter.writeAttribute(attr, value);
         }
-    }
-
-    private void createVersionAttr(StringBuilder buffer) {
-        buffer.append("<pmd xmlns=\"http://pmd.sourceforge.net/report/2.0.0\"").append(PMD.EOL)
-            .append("    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"").append(PMD.EOL)
-            .append("    xsi:schemaLocation=\"http://pmd.sourceforge.net/report/2.0.0 http://pmd.sourceforge.net/report_2_0_0.xsd\"").append(PMD.EOL)
-            .append("    version=\"").append(PMDVersion.VERSION).append('"');
-    }
-
-    private void createTimestampAttr(StringBuilder buffer) {
-        buffer.append(" timestamp=\"").append(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS").format(new Date()))
-                .append('"');
     }
 
     @Override
@@ -187,36 +189,82 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
         String encoding = getProperty(ENCODING);
 
         try {
-            Charset charset = Charset.forName(encoding);
-            this.writer = StringUtils.isBlank(reportFilename) ? new OutputStreamWriter(System.out, charset)
-                    : Files.newBufferedWriter(new File(reportFilename).toPath(), charset);
-        } catch (IOException | UnsupportedCharsetException e) {
+            this.stream = StringUtils.isBlank(reportFilename)
+                    ? System.out : Files.newOutputStream(new File(reportFilename).toPath());
+
+            XMLOutputFactory outputFactory = XMLOutputFactory.newFactory();
+            this.xmlWriter = outputFactory.createXMLStreamWriter(this.stream, encoding);
+            // for backwards compatibility, also provide a writer. Note: xmlWriter won't use that.
+            this.writer = new WrappedOutputStreamWriter(xmlWriter, stream, encoding);
+        } catch (IOException | XMLStreamException e) {
             throw new IllegalArgumentException(e);
         }
     }
 
     /**
-     * Escape unicode characters for non UTF-8 encodings.
+     * Remove characters, that are not allowed in XML 1.0 documents.
+     *
+     * <p>Allowed characters are:
+     * <blockquote>
+     * Char    ::=      #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+     *  // any Unicode character, excluding the surrogate blocks, FFFE, and FFFF.
+     * </blockquote>
+     * (see <a href="https://www.w3.org/TR/xml/#charsets">Extensible Markup Language (XML) 1.0 (Fifth Edition)</a>).
      */
-    private String escape(String text) {
-        String result = StringEscapeUtils.escapeXml10(text);
+    private String removeInvalidCharacters(String text) {
+        Pattern pattern = Pattern.compile(
+                  "\\x00|\\x01|\\x02|\\x03|\\x04|\\x05|\\x06|\\x07|\\x08|"
+                + "\\x0b|\\x0c|\\x0e|\\x0f|"
+                + "\\x10|\\x11|\\x12|\\x13|\\x14|\\x15|\\x16|\\x17|\\x18|"
+                + "\\x19|\\x1a|\\x1b|\\x1c|\\x1d|\\x1e|\\x1f");
+        Matcher matcher = pattern.matcher(text);
+        return matcher.replaceAll("");
+    }
+
+    @Override
+    public void setWriter(final Writer writer) {
         String encoding = getProperty(ENCODING);
-        if (!"UTF-8".equalsIgnoreCase(encoding)) {
-            StringBuilder sb = new StringBuilder(result);
-            for (int i = 0; i < sb.length(); i++) {
-                char c = sb.charAt(i);
-                // surrogate characters are not allowed in XML
-                if (Character.isHighSurrogate(c)) {
-                    char low = sb.charAt(i + 1);
-                    int codepoint = Character.toCodePoint(c, low);
-                    sb.replace(i, i + 2, "&#x" + Integer.toHexString(codepoint) + ";");
-                } else if (c > 0xff) {
-                    sb.replace(i, i + 1, "&#x" + Integer.toHexString((int) c) + ";");
-                }
-            }
-            result = sb.toString();
+        // for backwards compatibility, create a OutputStream that writes to the writer.
+        this.stream = new WriterOutputStream(writer, encoding);
+
+        XMLOutputFactory outputFactory = XMLOutputFactory.newFactory();
+        try {
+            this.xmlWriter = outputFactory.createXMLStreamWriter(this.stream, encoding);
+            // for backwards compatibility, also provide a writer.
+            // Note: both XMLStreamWriter and this writer will write to this.stream
+            this.writer = new WrappedOutputStreamWriter(xmlWriter, stream, encoding);
+        } catch (XMLStreamException | UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
         }
-        return result;
+    }
+
+    private static class WrappedOutputStreamWriter extends OutputStreamWriter {
+        private final XMLStreamWriter xmlWriter;
+
+        WrappedOutputStreamWriter(XMLStreamWriter xmlWriter, OutputStream out, String charset) throws UnsupportedEncodingException {
+            super(out, charset);
+            this.xmlWriter = xmlWriter;
+        }
+
+        @Override
+        public void flush() throws IOException {
+            try {
+                xmlWriter.flush();
+            } catch (XMLStreamException e) {
+                throw new IOException(e);
+            }
+            super.flush();
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                xmlWriter.close();
+            } catch (XMLStreamException e) {
+                throw new IOException(e);
+            }
+            super.close();
+        }
     }
 
     // FIXME: elapsed time not available until the end of the processing

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XMLRenderer.java
@@ -4,17 +4,24 @@
 
 package net.sourceforge.pmd.renderers;
 
+import java.io.File;
 import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+import java.nio.charset.UnsupportedCharsetException;
+import java.nio.file.Files;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Iterator;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.PMDVersion;
 import net.sourceforge.pmd.Report;
 import net.sourceforge.pmd.RuleViolation;
 import net.sourceforge.pmd.properties.StringProperty;
-import net.sourceforge.pmd.util.StringUtil;
 
 /**
  * Renderer to XML format.
@@ -26,7 +33,6 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
     // TODO 7.0.0 use PropertyDescriptor<String> or something more specialized
     public static final StringProperty ENCODING = new StringProperty("encoding",
             "XML encoding format, defaults to UTF-8.", "UTF-8", 0);
-    private boolean useUTF8 = false;
 
     public XMLRenderer() {
         super(NAME, "XML format.");
@@ -46,9 +52,6 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
     @Override
     public void start() throws IOException {
         String encoding = getProperty(ENCODING);
-        if ("utf-8".equalsIgnoreCase(encoding)) {
-            useUTF8 = true;
-        }
 
         StringBuilder buf = new StringBuilder(500);
         buf.append("<?xml version=\"1.0\" encoding=\"" + encoding + "\"?>").append(PMD.EOL);
@@ -78,7 +81,7 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
                 }
                 filename = nextFilename;
                 buf.append("<file name=\"");
-                StringUtil.appendXmlEscaped(buf, filename, useUTF8);
+                buf.append(escape(filename));
                 buf.append("\">").append(PMD.EOL);
             }
 
@@ -87,9 +90,9 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
             buf.append("\" begincolumn=\"").append(rv.getBeginColumn());
             buf.append("\" endcolumn=\"").append(rv.getEndColumn());
             buf.append("\" rule=\"");
-            StringUtil.appendXmlEscaped(buf, rv.getRule().getName(), useUTF8);
+            buf.append(escape(rv.getRule().getName()));
             buf.append("\" ruleset=\"");
-            StringUtil.appendXmlEscaped(buf, rv.getRule().getRuleSetName(), useUTF8);
+            buf.append(escape(rv.getRule().getRuleSetName()));
             buf.append('"');
             maybeAdd("package", rv.getPackageName(), buf);
             maybeAdd("class", rv.getClassName(), buf);
@@ -99,7 +102,7 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
             buf.append(" priority=\"");
             buf.append(rv.getRule().getPriority().getPriority());
             buf.append("\">").append(PMD.EOL);
-            StringUtil.appendXmlEscaped(buf, rv.getDescription(), useUTF8);
+            buf.append(escape(rv.getDescription()));
 
             buf.append(PMD.EOL);
             buf.append("</violation>");
@@ -119,9 +122,9 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
         for (Report.ProcessingError pe : errors) {
             buf.setLength(0);
             buf.append("<error ").append("filename=\"");
-            StringUtil.appendXmlEscaped(buf, determineFileName(pe.getFile()), useUTF8);
+            buf.append(escape(determineFileName(pe.getFile())));
             buf.append("\" msg=\"");
-            StringUtil.appendXmlEscaped(buf, pe.getMsg(), useUTF8);
+            buf.append(escape(pe.getMsg()));
             buf.append("\">").append(PMD.EOL);
             buf.append("<![CDATA[").append(pe.getDetail()).append("]]>").append(PMD.EOL);
             buf.append("</error>").append(PMD.EOL);
@@ -133,13 +136,13 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
             for (Report.SuppressedViolation s : suppressed) {
                 buf.setLength(0);
                 buf.append("<suppressedviolation ").append("filename=\"");
-                StringUtil.appendXmlEscaped(buf, determineFileName(s.getRuleViolation().getFilename()), useUTF8);
+                buf.append(escape(determineFileName(s.getRuleViolation().getFilename())));
                 buf.append("\" suppressiontype=\"");
-                StringUtil.appendXmlEscaped(buf, s.suppressedByNOPMD() ? "nopmd" : "annotation", useUTF8);
+                buf.append(escape(s.suppressedByNOPMD() ? "nopmd" : "annotation"));
                 buf.append("\" msg=\"");
-                StringUtil.appendXmlEscaped(buf, s.getRuleViolation().getDescription(), useUTF8);
+                buf.append(escape(s.getRuleViolation().getDescription()));
                 buf.append("\" usermsg=\"");
-                StringUtil.appendXmlEscaped(buf, s.getUserMessage() == null ? "" : s.getUserMessage(), useUTF8);
+                buf.append(escape(s.getUserMessage() == null ? "" : s.getUserMessage()));
                 buf.append("\"/>").append(PMD.EOL);
                 writer.write(buf.toString());
             }
@@ -149,9 +152,9 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
         for (final Report.ConfigurationError ce : configErrors) {
             buf.setLength(0);
             buf.append("<configerror ").append("rule=\"");
-            StringUtil.appendXmlEscaped(buf, ce.rule().getName(), useUTF8);
+            buf.append(escape(ce.rule().getName()));
             buf.append("\" msg=\"");
-            StringUtil.appendXmlEscaped(buf, ce.issue(), useUTF8);
+            buf.append(escape(ce.issue()));
             buf.append("\"/>").append(PMD.EOL);
             writer.write(buf.toString());
         }
@@ -162,7 +165,7 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
     private void maybeAdd(String attr, String value, StringBuilder buf) {
         if (value != null && value.length() > 0) {
             buf.append(' ').append(attr).append("=\"");
-            StringUtil.appendXmlEscaped(buf, value, useUTF8);
+            buf.append(escape(value));
             buf.append('"');
         }
     }
@@ -177,6 +180,41 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
     private void createTimestampAttr(StringBuilder buffer) {
         buffer.append(" timestamp=\"").append(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS").format(new Date()))
                 .append('"');
+    }
+
+    @Override
+    public void setReportFile(String reportFilename) {
+        String encoding = getProperty(ENCODING);
+
+        try {
+            Charset charset = Charset.forName(encoding);
+            this.writer = StringUtils.isBlank(reportFilename) ? new OutputStreamWriter(System.out, charset)
+                    : Files.newBufferedWriter(new File(reportFilename).toPath(), charset);
+        } catch (IOException | UnsupportedCharsetException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    /**
+     * Escape unicode characters for non UTF-8 encodings.
+     */
+    private String escape(String text) {
+        String result = StringEscapeUtils.escapeXml10(text);
+        String encoding = getProperty(ENCODING);
+        if (!"UTF-8".equalsIgnoreCase(encoding)) {
+            StringBuilder sb = new StringBuilder(result);
+            for (int i = 0; i < sb.length(); i++) {
+                char c = sb.charAt(i);
+                // surrogate characters are not allowed in XML
+                if (Character.isHighSurrogate(c)) {
+                    char low = sb.charAt(i + 1);
+                    int codepoint = Character.toCodePoint(c, low);
+                    sb.replace(i, i + 2, "&#x" + Integer.toHexString(codepoint) + ";");
+                }
+            }
+            result = sb.toString();
+        }
+        return result;
     }
 
     // FIXME: elapsed time not available until the end of the processing

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XMLRenderer.java
@@ -210,6 +210,8 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
                     char low = sb.charAt(i + 1);
                     int codepoint = Character.toCodePoint(c, low);
                     sb.replace(i, i + 2, "&#x" + Integer.toHexString(codepoint) + ";");
+                } else if (c > 0xff) {
+                    sb.replace(i, i + 1, "&#x" + Integer.toHexString((int) c) + ";");
                 }
             }
             result = sb.toString();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XSLTRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XSLTRenderer.java
@@ -45,6 +45,7 @@ public class XSLTRenderer extends XMLRenderer {
     private Transformer transformer;
     private String xsltFilename = "/pmd-nicerhtml.xsl";
     private Writer outputWriter;
+    private StringWriter stringWriter;
 
     public XSLTRenderer() {
         super();
@@ -71,8 +72,8 @@ public class XSLTRenderer extends XMLRenderer {
         // We keep the inital writer to put the final html output
         this.outputWriter = getWriter();
         // We use a new one to store the XML...
-        Writer w = new StringWriter();
-        setWriter(w);
+        this.stringWriter = new StringWriter();
+        setWriter(stringWriter);
         // If don't find the xsl no need to bother doing the all report,
         // so we check this here...
         InputStream xslt = null;
@@ -100,16 +101,14 @@ public class XSLTRenderer extends XMLRenderer {
      *            The stylesheet provided as an InputStream
      */
     private void prepareTransformer(InputStream xslt) {
-        if (xslt != null) {
-            try {
-                // Get a TransformerFactory object
-                TransformerFactory factory = TransformerFactory.newInstance();
-                StreamSource src = new StreamSource(xslt);
-                // Get an XSL Transformer object
-                this.transformer = factory.newTransformer(src);
-            } catch (TransformerConfigurationException e) {
-                e.printStackTrace();
-            }
+        try {
+            // Get a TransformerFactory object
+            TransformerFactory factory = TransformerFactory.newInstance();
+            StreamSource src = new StreamSource(xslt);
+            // Get an XSL Transformer object
+            this.transformer = factory.newTransformer(src);
+        } catch (TransformerConfigurationException e) {
+            throw new RuntimeException(e);
         }
     }
 
@@ -118,25 +117,17 @@ public class XSLTRenderer extends XMLRenderer {
         // First we finish the XML report
         super.end();
         // Now we transform it using XSLT
-        if (writer instanceof StringWriter) {
-            StringWriter w = (StringWriter) writer;
-            Document doc = this.getDocument(w.toString());
-            this.transform(doc);
-        } else {
-            // Should not happen !
-            throw new RuntimeException("Wrong writer");
-        }
-
+        Document doc = this.getDocument(stringWriter.toString());
+        this.transform(doc);
     }
 
     private void transform(Document doc) {
         DOMSource source = new DOMSource(doc);
-        this.setWriter(new StringWriter());
         StreamResult result = new StreamResult(this.outputWriter);
         try {
             transformer.transform(source, result);
         } catch (TransformerException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
     }
 
@@ -145,8 +136,7 @@ public class XSLTRenderer extends XMLRenderer {
             DocumentBuilder parser = DocumentBuilderFactory.newInstance().newDocumentBuilder();
             return parser.parse(new InputSource(new StringReader(xml)));
         } catch (ParserConfigurationException | SAXException | IOException e) {
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
-        return null;
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/StringUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/StringUtil.java
@@ -9,8 +9,11 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 
 import net.sourceforge.pmd.annotation.InternalApi;
 
@@ -26,6 +29,12 @@ import net.sourceforge.pmd.annotation.InternalApi;
 public final class StringUtil {
 
     private static final String[] EMPTY_STRINGS = new String[0];
+
+    private static final Pattern XML_10_INVALID_CHARS = Pattern.compile(
+            "\\x00|\\x01|\\x02|\\x03|\\x04|\\x05|\\x06|\\x07|\\x08|"
+          + "\\x0b|\\x0c|\\x0e|\\x0f|"
+          + "\\x10|\\x11|\\x12|\\x13|\\x14|\\x15|\\x16|\\x17|\\x18|"
+          + "\\x19|\\x1a|\\x1b|\\x1c|\\x1d|\\x1e|\\x1f");
 
     private StringUtil() {
     }
@@ -211,8 +220,9 @@ public final class StringUtil {
      * @param src
      * @param supportUTF8 override the default setting, whether special characters should be replaced with entities (
      *                    <code>false</code>) or should be included as is ( <code>true</code>).
-     *
+     * @deprecated for removal. Use {@link StringEscapeUtils#escapeXml10(String)} instead.
      */
+    @Deprecated
     public static void appendXmlEscaped(StringBuilder buf, String src, boolean supportUTF8) {
         char c;
         int i = 0;
@@ -245,6 +255,20 @@ public final class StringUtil {
         }
     }
 
+    /**
+     * Remove characters, that are not allowed in XML 1.0 documents.
+     *
+     * <p>Allowed characters are:
+     * <blockquote>
+     * Char    ::=      #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+     *  // any Unicode character, excluding the surrogate blocks, FFFE, and FFFF.
+     * </blockquote>
+     * (see <a href="https://www.w3.org/TR/xml/#charsets">Extensible Markup Language (XML) 1.0 (Fifth Edition)</a>).
+     */
+    public static String removedInvalidXml10Characters(String text) {
+        Matcher matcher = XML_10_INVALID_CHARS.matcher(text);
+        return matcher.replaceAll("");
+    }
 
     /**
      * Replace some whitespace characters so they are visually apparent.

--- a/pmd-core/src/test/java/net/sourceforge/pmd/ReportTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/ReportTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -9,11 +9,16 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.StringWriter;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.Map;
 
+import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 
 import net.sourceforge.pmd.lang.ast.DummyNode;
@@ -195,5 +200,22 @@ public class ReportTest implements ThreadSafeReportListener {
         renderer.renderFileReport(report);
         renderer.end();
         return writer.toString();
+    }
+
+    public static String renderTempFile(Renderer renderer, Report report, Charset expectedCharset) throws IOException {
+        Path tempFile = Files.createTempFile("pmd-report-test", null);
+        String absolutePath = tempFile.toAbsolutePath().toString();
+
+        renderer.setReportFile(absolutePath);
+        renderer.start();
+        renderer.renderFileReport(report);
+        renderer.end();
+        renderer.flush();
+
+        try (FileInputStream input = new FileInputStream(absolutePath)) {
+            return IOUtils.toString(input, expectedCharset);
+        } finally {
+            Files.delete(tempFile);
+        }
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/XMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/XMLRendererTest.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.cpd;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -196,6 +197,23 @@ public class XMLRendererTest {
         assertTrue(report.contains(espaceChar));
     }
 
+    @Test
+    public void testRendererXMLEscaping() throws IOException {
+        String formfeed = "\u000C";
+        String codefragment = "code fragment" + formfeed + "\nline2\nline3";
+        CPDRenderer renderer = new XMLRenderer();
+        List<Match> list = new ArrayList<>();
+        Mark mark1 = createMark("public", "file1", 1, 2, codefragment);
+        Mark mark2 = createMark("public", "file2", 5, 2, codefragment);
+        Match match1 = new Match(75, mark1, mark2);
+        list.add(match1);
+
+        StringWriter sw = new StringWriter();
+        renderer.render(list.iterator(), sw);
+        String report = sw.toString();
+        assertFalse(report.contains(formfeed));
+    }
+
     private Mark createMark(String image, String tokenSrcID, int beginLine, int lineCount, String code) {
         Mark result = new Mark(new TokenEntry(image, tokenSrcID, beginLine));
 
@@ -213,9 +231,5 @@ public class XMLRendererTest {
         result.setEndToken(endToken);
         result.setSourceCode(new SourceCode(new SourceCode.StringCodeLoader(code)));
         return result;
-    }
-
-    public static junit.framework.Test suite() {
-        return new junit.framework.JUnit4TestAdapter(XMLRendererTest.class);
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
@@ -125,10 +125,10 @@ public class XMLRendererTest extends AbstractRendererTest {
 
     public String getHeader() {
         return "<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + PMD.EOL
-                + "<pmd xmlns=\"http://pmd.sourceforge.net/report/2.0.0\"" + PMD.EOL
-                + "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + PMD.EOL
-                + "    xsi:schemaLocation=\"http://pmd.sourceforge.net/report/2.0.0 http://pmd.sourceforge.net/report_2_0_0.xsd\"" + PMD.EOL
-                + "    version=\"" + PMDVersion.VERSION + "\" timestamp=\"2014-10-06T19:30:51.262\">" + PMD.EOL;
+                + "<pmd xmlns=\"http://pmd.sourceforge.net/report/2.0.0\""
+                + " xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\""
+                + " xsi:schemaLocation=\"http://pmd.sourceforge.net/report/2.0.0 http://pmd.sourceforge.net/report_2_0_0.xsd\""
+                + " version=\"" + PMDVersion.VERSION + "\" timestamp=\"2014-10-06T19:30:51.262\">" + PMD.EOL;
     }
 
     @Test

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
@@ -100,7 +100,7 @@ public class XMLRendererTest extends AbstractRendererTest {
         renderer.setProperty(XMLRenderer.ENCODING, charset.name());
         Report report = new Report();
         String surrogatePair = "\ud801\udc1c";
-        String msg = "The String literal \"Tokénizer " + surrogatePair + "\" appears...";
+        String msg = "The String 'literal' \"TokénizĀr " + surrogatePair + "\" appears...";
         report.addRuleViolation(createRuleViolation(msg));
         String actual = ReportTest.renderTempFile(renderer, report, charset);
         Assert.assertTrue(actual.contains(shouldContain));
@@ -139,12 +139,14 @@ public class XMLRendererTest extends AbstractRendererTest {
 
         Report report = new Report();
         String formFeed = "\u000C";
-        String specialChar = "é";
-        String originalChars = formFeed + specialChar; // u000C should be removed, é should be encoded correctly as UTF-8
+        // é = U+00E9 : can be represented in ISO-8859-1 as is
+        // Ā = U+0100 : cannot be represented in ISO-8859-1 -> would be a unmappable character, needs to be escaped
+        String specialChars = "éĀ";
+        String originalChars = formFeed + specialChars; // u000C should be removed, é should be encoded correctly as UTF-8
         String msg = "The String literal \"" + originalChars + "\" appears...";
         report.addRuleViolation(createRuleViolation(msg));
         String actual = ReportTest.renderTempFile(renderer, report, StandardCharsets.UTF_8);
-        Assert.assertTrue(actual.contains(specialChar));
+        Assert.assertTrue(actual.contains(specialChars));
         Assert.assertFalse(actual.contains(formFeed));
         Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder()
                 .parse(new InputSource(new StringReader(actual)));

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
@@ -6,10 +6,14 @@ package net.sourceforge.pmd.renderers;
 
 import java.io.File;
 import java.io.StringReader;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
@@ -28,6 +32,8 @@ import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.rule.ParametricRuleViolation;
 
 public class XMLRendererTest extends AbstractRendererTest {
+    @Rule // Restores system properties after test
+    public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
     @Override
     public Renderer getRenderer() {
@@ -90,12 +96,13 @@ public class XMLRendererTest extends AbstractRendererTest {
         return new ParametricRuleViolation<Node>(new FooRule(), ctx, node, description);
     }
 
-    private void verifyXmlEscaping(Renderer renderer, String shouldContain) throws Exception {
+    private void verifyXmlEscaping(Renderer renderer, String shouldContain, Charset charset) throws Exception {
+        renderer.setProperty(XMLRenderer.ENCODING, charset.name());
         Report report = new Report();
         String surrogatePair = "\ud801\udc1c";
-        String msg = "The String literal \"Tokenizer " + surrogatePair + "\" appears...";
+        String msg = "The String literal \"Tokénizer " + surrogatePair + "\" appears...";
         report.addRuleViolation(createRuleViolation(msg));
-        String actual = ReportTest.render(renderer, report);
+        String actual = ReportTest.renderTempFile(renderer, report, charset);
         Assert.assertTrue(actual.contains(shouldContain));
         Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder()
                 .parse(new InputSource(new StringReader(actual)));
@@ -107,15 +114,13 @@ public class XMLRendererTest extends AbstractRendererTest {
     @Test
     public void testXMLEscapingWithUTF8() throws Exception {
         Renderer renderer = getRenderer();
-        renderer.setProperty(XMLRenderer.ENCODING, "UTF-8");
-        verifyXmlEscaping(renderer, "\ud801\udc1c");
+        verifyXmlEscaping(renderer, "\ud801\udc1c", StandardCharsets.UTF_8);
     }
 
     @Test
     public void testXMLEscapingWithoutUTF8() throws Exception {
         Renderer renderer = getRenderer();
-        renderer.setProperty(XMLRenderer.ENCODING, "ISO-8859-1");
-        verifyXmlEscaping(renderer, "&#x1041c;");
+        verifyXmlEscaping(renderer, "&#x1041c;", StandardCharsets.ISO_8859_1);
     }
 
     public String getHeader() {
@@ -124,5 +129,27 @@ public class XMLRendererTest extends AbstractRendererTest {
                 + "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"" + PMD.EOL
                 + "    xsi:schemaLocation=\"http://pmd.sourceforge.net/report/2.0.0 http://pmd.sourceforge.net/report_2_0_0.xsd\"" + PMD.EOL
                 + "    version=\"" + PMDVersion.VERSION + "\" timestamp=\"2014-10-06T19:30:51.262\">" + PMD.EOL;
+    }
+
+    @Test
+    public void testCorrectCharset() throws Exception {
+        System.setProperty("file.encoding", StandardCharsets.ISO_8859_1.name());
+
+        Renderer renderer = getRenderer();
+
+        Report report = new Report();
+        String formFeed = "\u000C";
+        String specialChar = "é";
+        String originalChars = formFeed + specialChar; // u000C should be removed, é should be encoded correctly as UTF-8
+        String msg = "The String literal \"" + originalChars + "\" appears...";
+        report.addRuleViolation(createRuleViolation(msg));
+        String actual = ReportTest.renderTempFile(renderer, report, StandardCharsets.UTF_8);
+        Assert.assertTrue(actual.contains(specialChar));
+        Assert.assertFalse(actual.contains(formFeed));
+        Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+                .parse(new InputSource(new StringReader(actual)));
+        NodeList violations = doc.getElementsByTagName("violation");
+        Assert.assertEquals(1, violations.getLength());
+        Assert.assertEquals(msg.replaceAll(formFeed, ""), violations.item(0).getTextContent().trim());
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/StringUtilTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/StringUtilTest.java
@@ -36,14 +36,6 @@ public class StringUtilTest {
         assertEquals("replaceString didn't work with a char", "f", StringUtil.replaceString("foo", 'o', null));
     }
 
-    /**
-     * Usually you would set the system property
-     * "net.sourceforge.pmd.supportUTF8" to either "no" or "yes", to switch UTF8
-     * support.
-     *
-     * e.g.
-     * <code>System.setProperty("net.sourceforge.pmd.supportUTF8","yes");</code>
-     */
     @Test
     public void testUTF8NotSupported() {
         StringBuilder sb = new StringBuilder();
@@ -67,9 +59,5 @@ public class StringUtilTest {
         String test = "é";
         StringUtil.appendXmlEscaped(sb, test, true);
         assertEquals("é", sb.toString());
-    }
-
-    public static junit.framework.Test suite() {
-        return new junit.framework.JUnit4TestAdapter(StringUtilTest.class);
     }
 }

--- a/pmd-doc/pom.xml
+++ b/pmd-doc/pom.xml
@@ -95,7 +95,6 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.6</version>
         </dependency>
         <dependency>
             <groupId>org.yaml</groupId>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/ant/PMDTaskTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/ant/PMDTaskTest.java
@@ -8,10 +8,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.UnsupportedEncodingException;
-import java.lang.reflect.Field;
 import java.nio.charset.Charset;
 import java.util.Locale;
-import java.util.Objects;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
@@ -112,17 +110,8 @@ public class PMDTaskTest extends AbstractAntTestHelper {
         }
     };
 
-    // See http://stackoverflow.com/questions/361975/setting-the-default-java-character-encoding and http://stackoverflow.com/a/14987992/1169968
     private static void setDefaultCharset(String charsetName) {
-        try {
-            System.setProperty("file.encoding", charsetName);
-            Field charset = Charset.class.getDeclaredField("defaultCharset");
-            charset.setAccessible(true);
-            charset.set(null, null);
-            Objects.requireNonNull(Charset.defaultCharset());
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+        System.setProperty("file.encoding", charsetName);
     }
 
     @Rule

--- a/pmd-java/src/test/java/net/sourceforge/pmd/ant/PMDTaskTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/ant/PMDTaskTest.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.ant;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
 import java.nio.charset.Charset;
 import java.util.Locale;
@@ -149,14 +150,28 @@ public class PMDTaskTest extends AbstractAntTestHelper {
         assertTrue(report.contains("unusedVariableWithÜmlaut"));
     }
 
+    private static String convert(String report) {
+        // reinterpret output as cp1252 - ant BuildFileRule can only unicode
+        StringBuilder sb = new StringBuilder(report.length());
+        for (int i = 0; i < report.length(); i++) {
+            char c = report.charAt(i);
+            if (c > 0x7f) {
+                sb.append((char) (c & 0xff));
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+
     @Test
-    public void testFormatterEncodingWithXMLConsole() {
+    public void testFormatterEncodingWithXMLConsole() throws UnsupportedEncodingException {
         setDefaultCharset("cp1252");
 
         executeTarget("testFormatterEncodingWithXMLConsole");
-        String report = buildRule.getOutput();
+        String report = convert(buildRule.getOutput());
         assertTrue(report.startsWith("<?xml version=\"1.0\" encoding=\"windows-1252\"?>"));
-        assertTrue(report.contains("unusedVariableWith&#xdc;mlaut"));
+        assertTrue(report.contains("unusedVariableWithÜmlaut"));
     }
 
     @Test

--- a/pmd-java/src/test/java/net/sourceforge/pmd/cpd/CPDCommandLineInterfaceTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/cpd/CPDCommandLineInterfaceTest.java
@@ -77,7 +77,7 @@ public class CPDCommandLineInterfaceTest extends BaseCPDCLITest {
 
         String out = getOutput();
         Assert.assertTrue(out.startsWith("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
-        Assert.assertTrue(Pattern.compile("System\\.out\\.println\\([ij] \\+ \"ä\"\\);").matcher(out).find());
+        Assert.assertTrue(Pattern.compile("System\\.out\\.println\\([ij] \\+ &quot;ä&quot;\\);").matcher(out).find());
         Assert.assertEquals(4, Integer.parseInt(System.getProperty(CPDCommandLineInterface.STATUS_CODE_PROPERTY)));
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -670,6 +670,11 @@
                 <version>3.8.1</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-text</artifactId>
+                <version>1.6</version>
+            </dependency>
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>1.7.25</version>


### PR DESCRIPTION
## Describe the PR

This PR tries to fix #2615 . In order to use the correct encoding through the rendering process, the new API `Renderer::setReportFile` is added.

I'm not entirely sure about CPD renderer, whether we have a similar issue there. But as far as I can see, only the default platform encoding is used, there is no way to change the encoding. There is also no way to specify a output file as a command line option, so CPD renderers always render to Sysout and hence should use the default platform encoding.

## Related issues

- Fixes #2615 

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed).

