### PR TITLE
[java] NullPointerException in rule ProperCloneImplementation

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ProperCloneImplementationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ProperCloneImplementationRule.java
@@ -25,17 +25,17 @@ public class ProperCloneImplementationRule extends AbstractJavaRule {
         if (!"clone".equals(node.getName()) || node.getArity() > 0) {
             return data;
         }
-        
+
         ASTBlock block = node.getFirstChildOfType(ASTBlock.class);
         if (block == null) {
             return data;
         }
-        
+
         String enclosingClassName = node.getFirstParentOfType(ASTClassOrInterfaceDeclaration.class).getSimpleName();
         if (blockHasAllocations(block, enclosingClassName)) {
             addViolation(data, node);
         }
-        
+
         return data;
     }
 
@@ -43,10 +43,14 @@ public class ProperCloneImplementationRule extends AbstractJavaRule {
         List<ASTAllocationExpression> allocations = block.findDescendantsOfType(ASTAllocationExpression.class);
         for (ASTAllocationExpression alloc : allocations) {
             ASTClassOrInterfaceType type = alloc.getFirstChildOfType(ASTClassOrInterfaceType.class);
-            if (type.hasImageEqualTo(enclosingClassName)) {
+            if (typeHasImage(type, enclosingClassName)) {
                 return true;
             }
         }
         return false;
+    }
+
+    private boolean typeHasImage(ASTClassOrInterfaceType type, String image) {
+        return type != null && type.hasImageEqualTo(image);
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ProperCloneImplementation.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ProperCloneImplementation.xml
@@ -53,4 +53,17 @@ public class Bar {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>ok, should not throw NullPointerException while processing primitive array allocation</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void clone() {
+        super.clone();
+        byte[] array = new byte[6];
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

The method checking whether allocations of class are present in it's clone() method fails in case of non ASTClassOrInterfaceType allocation. But as we are interested in ASTClassOrInterfaceType allocations only, in my opinion, it's enough to check if allocated type is null.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #2634

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

