### PR TITLE
[java] AvoidThrowingNullPointerException marks all NullPointerException…

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AvoidThrowingNullPointerExceptionRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AvoidThrowingNullPointerExceptionRule.java
@@ -66,10 +66,6 @@ public class AvoidThrowingNullPointerExceptionRule extends AbstractJavaRule {
         return assignedValueType != null ? assignedValueType.getType() : null;
     }
 
-    private boolean isNullPointerException(Class<?> clazz) {
-        return NullPointerException.class.equals(clazz);
-    }
-
     @Override
     public Object visit(ASTThrowStatement throwStatement, Object data) {
         if (throwsNullPointerException(throwStatement)) {
@@ -87,9 +83,13 @@ public class AvoidThrowingNullPointerExceptionRule extends AbstractJavaRule {
         ASTClassOrInterfaceType thrownType = throwStatement.getFirstDescendantOfType(ASTClassOrInterfaceType.class);
         if (thrownType != null) {
             Class<?> thrownException = thrownType.getType();
-            return NullPointerException.class.equals(thrownException);
+            return isNullPointerException(thrownException);
         }
         return false;
+    }
+
+    private boolean isNullPointerException(Class<?> clazz) {
+        return NullPointerException.class.equals(clazz);
     }
 
     private boolean throwsNullPointerExceptionVariable(ASTThrowStatement throwStatement) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AvoidThrowingNullPointerExceptionRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AvoidThrowingNullPointerExceptionRule.java
@@ -1,0 +1,77 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.design;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import net.sourceforge.pmd.lang.java.ast.ASTAllocationExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBody;
+import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
+import net.sourceforge.pmd.lang.java.ast.ASTThrowStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
+
+/**
+ * Finds <code>throw</code> statements containing <code>NullPointerException</code>
+ * instances as thrown values
+ *
+ * @author <a href="mailto:michaeller.2012@gmail.com">Mykhailo Palahuta</a>
+ */
+public class AvoidThrowingNullPointerExceptionRule extends AbstractJavaRule {
+
+    @Override
+    public Object visit(ASTClassOrInterfaceBody node, Object data) {
+        if (bodyHasThrowNullPointerExceptionStatement(node)) {
+            addViolation(data, node);
+        }
+        return super.visit(node, data);
+    }
+
+    private boolean bodyHasThrowNullPointerExceptionStatement(ASTClassOrInterfaceBody body) {
+        List<ASTThrowStatement> throwStatements = body.findDescendantsOfType(ASTThrowStatement.class);
+        List<String> npeInstances = getNullPointerExceptionInstances(body);
+        for (ASTThrowStatement throwStatement : throwStatements) {
+            if (throwsNullPointerException(throwStatement, npeInstances)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private List<String> getNullPointerExceptionInstances(ASTClassOrInterfaceBody body) {
+        List<ASTAllocationExpression> allocations = body.findDescendantsOfType(ASTAllocationExpression.class);
+        List<String> npeInstances = new ArrayList<>();
+        for (ASTAllocationExpression allocation : allocations) {
+            if (allocatesNullPointerException(allocation)) {
+                String assignedVarName = getNameOfAssignedVariable(allocation);
+                npeInstances.add(assignedVarName);
+            }
+        }
+        return npeInstances;
+    }
+
+    private boolean allocatesNullPointerException(ASTAllocationExpression allocation) {
+        Class<?> allocatedType = getAllocatedInstanceType(allocation);
+        return allocatedType != null && NullPointerException.class.isAssignableFrom(allocatedType);
+    }
+
+    private Class<?> getAllocatedInstanceType(ASTAllocationExpression allocation) {
+        List<ASTClassOrInterfaceType> allocatedTypes = allocation
+                .findDescendantsOfType(ASTClassOrInterfaceType.class);
+        return allocatedTypes.isEmpty() ? null : allocatedTypes.get(0).getType();
+    }
+
+    private String getNameOfAssignedVariable(ASTAllocationExpression allocation) {
+        List<ASTVariableDeclarator> variableDeclarators = allocation.getParent()
+                .findDescendantsOfType(ASTVariableDeclarator.class);
+        return variableDeclarators.isEmpty() ? null : variableDeclarators.get(0).getName();
+    }
+
+    private boolean throwsNullPointerException(ASTThrowStatement throwStatement, List<String> npeInstances) {
+        String thrownImage = throwStatement.getFirstClassOrInterfaceTypeImage();
+        return "NullPointerException".equals(thrownImage) || npeInstances.contains(thrownImage);
+    }
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AvoidThrowingNullPointerExceptionRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/AvoidThrowingNullPointerExceptionRule.java
@@ -23,22 +23,24 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 public class AvoidThrowingNullPointerExceptionRule extends AbstractJavaRule {
 
     @Override
-    public Object visit(ASTClassOrInterfaceBody node, Object data) {
-        if (bodyHasThrowNullPointerExceptionStatement(node)) {
-            addViolation(data, node);
+    public Object visit(ASTClassOrInterfaceBody body, Object data) {
+        List<ASTThrowStatement> throwNPEs = getThrowNullPointerExceptionStatements(body);
+        for (ASTThrowStatement throwNPE : throwNPEs) {
+            addViolation(data, throwNPE);
         }
-        return super.visit(node, data);
+        return data;
     }
 
-    private boolean bodyHasThrowNullPointerExceptionStatement(ASTClassOrInterfaceBody body) {
+    private List<ASTThrowStatement> getThrowNullPointerExceptionStatements(ASTClassOrInterfaceBody body) {
         List<ASTThrowStatement> throwStatements = body.findDescendantsOfType(ASTThrowStatement.class);
         List<String> npeInstances = getNullPointerExceptionInstances(body);
+        List<ASTThrowStatement> throwNPEStatements = new ArrayList<>();
         for (ASTThrowStatement throwStatement : throwStatements) {
             if (throwsNullPointerException(throwStatement, npeInstances)) {
-                return true;
+                throwNPEStatements.add(throwStatement);
             }
         }
-        return false;
+        return throwNPEStatements;
     }
 
     private List<String> getNullPointerExceptionInstances(ASTClassOrInterfaceBody body) {

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -200,7 +200,7 @@ public void bar() {
           language="java"
           since="1.8"
           message="Avoid throwing null pointer exceptions."
-          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          class="net.sourceforge.pmd.lang.java.rule.design.AvoidThrowingNullPointerExceptionRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#avoidthrowingnullpointerexception">
         <description>
 <![CDATA[
@@ -234,16 +234,6 @@ public class Foo {
 ]]>
         </description>
         <priority>1</priority>
-        <properties>
-            <property name="version" value="2.0"/>
-            <property name="xpath">
-                <value>
-<![CDATA[
-//AllocationExpression/ClassOrInterfaceType[@Image='NullPointerException']
-]]>
-                </value>
-            </property>
-        </properties>
         <example>
 <![CDATA[
 public class Foo {

--- a/pmd-java/src/main/resources/rulesets/java/quickstart.xml
+++ b/pmd-java/src/main/resources/rulesets/java/quickstart.xml
@@ -121,7 +121,7 @@
     <!-- <rule ref="category/java/design.xml/AvoidDeeplyNestedIfStmts" /> -->
     <!-- <rule ref="category/java/design.xml/AvoidRethrowingException" /> -->
     <!-- <rule ref="category/java/design.xml/AvoidThrowingNewInstanceOfSameException" /> -->
-    <!-- <rule ref="category/java/design.xml/AvoidThrowingNullPointerException" /> -->
+    <!--<rule ref="category/java/design.xml/AvoidThrowingNullPointerException" />-->
     <!-- <rule ref="category/java/design.xml/AvoidThrowingRawExceptionTypes" /> -->
     <!-- <rule ref="category/java/design.xml/AvoidUncheckedExceptionsInSignatures" /> -->
     <rule ref="category/java/design.xml/ClassWithOnlyPrivateConstructorsShouldBeFinal"/>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidThrowingNullPointerException.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidThrowingNullPointerException.xml
@@ -41,4 +41,66 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+    
+    <test-code>
+        <description>variables with same name false positive test</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void foo() {
+        Exception e = new NullPointerException();
+        e.printStackTrace();
+    }
+
+    void bar() {
+        Exception e = new RuntimeException();
+        throw e;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>ok, variable has been reassigned to RuntimeException before thrown</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        Exception e = new NullPointerException();
+        e = new RuntimeException();
+        throw e;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>ok, variable is reassigned with NullPointerException after thrown</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void bar(String s) {
+        Exception e = new RuntimeException();
+        if (s.equals("throw")) {
+            throw e;
+        }
+        e = new NullPointerException();
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>bad, variable had been reassigned with NullPointerException before thrown</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        Exception e = new RuntimeException();
+        e = new NullPointerException();
+        throw e;
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidThrowingNullPointerException.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AvoidThrowingNullPointerException.xml
@@ -15,4 +15,30 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>no problems if NullPointerException is only instantiated but not thrown</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        Exception e = new NullPointerException("Test message");
+        String msg = e.getMessage();
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>problem should be detected even if NullPointerException is stored in some intermediate variable</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        Exception e = new NullPointerException();
+        throw e;
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
… objects as wrong, whether or not thrown

## Describe the PR

Separate java class has been added for the rule AvoidThrowingNullPointerException. In this implementation NPEs are marked as wrong only in case they are thrown. NPE allocations are tracked and rule violation is detected even if intermediate variable has been used.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #2580 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

