### PR TITLE
[java] AvoidCallingFinalize detects some false positives (2578)

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidCallingFinalizeRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidCallingFinalizeRule.java
@@ -4,11 +4,9 @@
 
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import net.sourceforge.pmd.lang.java.ast.ASTBlock;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
@@ -21,55 +19,29 @@ public class AvoidCallingFinalizeRule extends AbstractJavaRule {
     private static final Pattern FINALIZE_METHOD_PATTERN = Pattern.compile("^(.+\\.)?finalize$");
 
     @Override
-    public Object visit(ASTBlock block, Object data) {
-        List<ASTPrimaryExpression> finalizeMethodCalls = getIncorrectFinalizeMethodCalls(block);
-        for (ASTPrimaryExpression finalizeMethodCall : finalizeMethodCalls) {
-            addViolation(data, finalizeMethodCall);
+    public Object visit(ASTPrimaryExpression primaryExpression, Object data) {
+        if (isIncorrectFinalizeMethodCall(primaryExpression)) {
+            addViolation(data, primaryExpression);
         }
         return data;
     }
 
-    private List<ASTPrimaryExpression> getIncorrectFinalizeMethodCalls(ASTBlock block) {
-        if (isFinalizeMethodBlock(block)) {
-            return getNotSuperFinalizeMethodCalls(block);
-        }
-        return getFinalizeMethodCalls(block);
+    private boolean isIncorrectFinalizeMethodCall(ASTPrimaryExpression primaryExpression) {
+        return isFinalizeMethodCall(primaryExpression)
+                && (isNotInFinalizeMethod(primaryExpression) || isNotSuperMethodCall(primaryExpression));
     }
 
-    private boolean isFinalizeMethodBlock(ASTBlock block) {
-        ASTMethodDeclaration methodDeclaration = block.getFirstParentOfType(ASTMethodDeclaration.class);
-        return methodDeclaration != null && isFinalizeMethodDeclaration(methodDeclaration);
+    private boolean isNotInFinalizeMethod(ASTPrimaryExpression primaryExpression) {
+        ASTMethodDeclaration methodDeclaration = primaryExpression.getFirstParentOfType(ASTMethodDeclaration.class);
+        return methodDeclaration == null || isNotFinalizeMethodDeclaration(methodDeclaration);
+    }
+
+    private boolean isNotFinalizeMethodDeclaration(ASTMethodDeclaration methodDeclaration) {
+        return !isFinalizeMethodDeclaration(methodDeclaration);
     }
 
     private boolean isFinalizeMethodDeclaration(ASTMethodDeclaration methodDeclaration) {
         return "finalize".equals(methodDeclaration.getName()) && methodDeclaration.getArity() == 0;
-    }
-
-    private List<ASTPrimaryExpression> getNotSuperFinalizeMethodCalls(ASTBlock block) {
-        List<ASTPrimaryExpression> finalizeMethodCalls = getFinalizeMethodCalls(block);
-        List<ASTPrimaryExpression> notSuperCalls = new ArrayList<>();
-        for (ASTPrimaryExpression finalizeMethodCall : finalizeMethodCalls) {
-            if (isNotSuperMethodCall(finalizeMethodCall)) {
-                notSuperCalls.add(finalizeMethodCall);
-            }
-        }
-        return notSuperCalls;
-    }
-
-    private boolean isNotSuperMethodCall(ASTPrimaryExpression primaryExpression) {
-        ASTPrimaryPrefix primaryPrefix = primaryExpression.getFirstChildOfType(ASTPrimaryPrefix.class);
-        return primaryPrefix == null || !primaryPrefix.usesSuperModifier();
-    }
-
-    private List<ASTPrimaryExpression> getFinalizeMethodCalls(ASTBlock block) {
-        List<ASTPrimaryExpression> primaryExpressions = block.findDescendantsOfType(ASTPrimaryExpression.class);
-        List<ASTPrimaryExpression> finalizeMethodCalls = new ArrayList<>();
-        for (ASTPrimaryExpression primaryExpression : primaryExpressions) {
-            if (isFinalizeMethodCall(primaryExpression)) {
-                finalizeMethodCalls.add(primaryExpression);
-            }
-        }
-        return finalizeMethodCalls;
     }
 
     private boolean isFinalizeMethodCall(ASTPrimaryExpression primaryExpression) {
@@ -97,5 +69,10 @@ public class AvoidCallingFinalizeRule extends AbstractJavaRule {
             return primarySuffixes.get(lastSuffixIndex).getArgumentCount();
         }
         return -1;
+    }
+
+    private boolean isNotSuperMethodCall(ASTPrimaryExpression primaryExpression) {
+        ASTPrimaryPrefix primaryPrefix = primaryExpression.getFirstChildOfType(ASTPrimaryPrefix.class);
+        return primaryPrefix == null || !primaryPrefix.usesSuperModifier();
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidCallingFinalize.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidCallingFinalize.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <test-data
-    xmlns="http://pmd.sourceforge.net/rule-tests"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
 
     <test-code>
         <description>simple failure case</description>
@@ -87,6 +87,35 @@ public class Foo {
 public class InputFinalize {
     {
         super.finalize();
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>overloaded finalize is ok</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void foo() {
+        finalize("hello", "world");
+    }
+
+    public void finalize(String ... args) {}
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>variable name false-positive test</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    private int finalize;
+
+    public void bar() {
+        finalize++;
+        return finalize;
     }
 }
         ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidCallingFinalize.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidCallingFinalize.xml
@@ -124,6 +124,7 @@ public class Foo {
     <test-code>
         <description>super.finalize in constructor false-negative test</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     public Foo() throws Throwable {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidCallingFinalize.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidCallingFinalize.xml
@@ -120,4 +120,17 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>super.finalize in constructor false-negative test</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public Foo() throws Throwable {
+        super.equals(new String());
+        super.finalize();
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

I have modified the AvoidCallingFinalizeRule class to fix false positives when variables with name 'finalize' and finalize methods with args are detected as a problem. Also I've added 2 tests validating that the false positive bugs were fixed.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #2578 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

