### PR TITLE
[java] LawOfDemeter: False positive with indexed array access

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -18,6 +18,8 @@ This is a {{ site.pmd.release_type }} release.
 
 *   apex-bestpractices
     *   [#2626](https://github.com/pmd/pmd/issues/2626): \[apex] UnusedLocalVariable - false positive on case insensitivity allowed in Apex
+*   java-design
+    *   [#2181](https://github.com/pmd/pmd/issues/2181): \[java] LawOfDemeter: False positive with indexed array access
 *   java-performance
     *   [#1736](https://github.com/pmd/pmd/issues/1736): \[java] UseStringBufferForStringAppends: False positive if only one concatenation
     *   [#2207](https://github.com/pmd/pmd/issues/2207): \[java] AvoidInstantiatingObjectsInLoops: False positive - should not flag objects when assigned to lists/arrays

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LawOfDemeterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LawOfDemeterRule.java
@@ -24,6 +24,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
+import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.symboltable.ClassScope;
 import net.sourceforge.pmd.lang.java.symboltable.LocalScope;
@@ -54,6 +55,10 @@ public class LawOfDemeterRule extends AbstractJavaRule {
     private static final String REASON_METHOD_CHAIN_CALLS = "method chain calls";
     private static final String REASON_OBJECT_NOT_CREATED_LOCALLY = "object not created locally";
     private static final String REASON_STATIC_ACCESS = "static property access";
+
+    public LawOfDemeterRule() {
+        addRuleChainVisit(ASTMethodDeclaration.class);
+    }
 
     /**
      * That's a new method. We are going to check each method call inside the
@@ -139,11 +144,17 @@ public class LawOfDemeterRule extends AbstractJavaRule {
             List<MethodCall> result = new ArrayList<>();
 
             if (isNotAConstructorCall(expression) && isNotLiteral(expression) && hasSuffixesWithArguments(expression)) {
-                ASTPrimaryPrefix prefixNode = expression.getFirstDescendantOfType(ASTPrimaryPrefix.class);
-                MethodCall firstMethodCallInChain = new MethodCall(expression, prefixNode);
-                result.add(firstMethodCallInChain);
+                ASTPrimaryPrefix prefixNode = expression.getFirstChildOfType(ASTPrimaryPrefix.class);
+                ASTPrimarySuffix followingSuffix = getFollowingSuffix(prefixNode);
+                boolean firstExpressionIsMethodCall = followingSuffix != null && followingSuffix.isArguments();
+                MethodCall firstMethodCallInChain = null;
 
-                if (firstMethodCallInChain.isNotBuilder()) {
+                if (firstExpressionIsMethodCall) {
+                    firstMethodCallInChain = new MethodCall(expression, prefixNode);
+                    result.add(firstMethodCallInChain);
+                }
+
+                if (firstMethodCallInChain == null || firstMethodCallInChain.isNotBuilder()) {
                     List<ASTPrimarySuffix> suffixes = findSuffixesWithoutArguments(expression);
                     for (ASTPrimarySuffix suffix : suffixes) {
                         result.add(new MethodCall(expression, suffix));
@@ -151,7 +162,26 @@ public class LawOfDemeterRule extends AbstractJavaRule {
                 }
             }
 
+            // when method chaining is detected, it must consist of multiple method calls
+            if (result.size() == 1) {
+                MethodCall m = result.get(0);
+                if (m.isViolation() && SCOPE_METHOD_CHAINING.equals(m.baseScope)) {
+                    result.clear();
+                }
+            }
+
             return result;
+        }
+
+        private static ASTPrimarySuffix getFollowingSuffix(JavaNode node) {
+            int current = node.getIndexInParent();
+            if (node.getParent().getNumChildren() > current + 1) {
+                JavaNode following = node.getParent().getChild(current + 1);
+                if (following instanceof ASTPrimarySuffix) {
+                    return (ASTPrimarySuffix) following;
+                }
+            }
+            return null;
         }
 
         private static boolean isNotAConstructorCall(ASTPrimaryExpression expression) {
@@ -177,7 +207,7 @@ public class LawOfDemeterRule extends AbstractJavaRule {
             if (hasRealPrefix(expr)) {
                 List<ASTPrimarySuffix> suffixes = expr.findDescendantsOfType(ASTPrimarySuffix.class);
                 for (ASTPrimarySuffix suffix : suffixes) {
-                    if (!suffix.isArguments()) {
+                    if (!suffix.isArguments() && !suffix.isArrayDereference()) {
                         result.add(suffix);
                     }
                 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/LawOfDemeter.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/LawOfDemeter.xml
@@ -291,4 +291,22 @@ public class Test {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[java] LawOfDemeter: False positive with indexed array access #2181</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public final class Util {
+    public static boolean check(String passwd, String hashed) {
+        try {
+            final String[] parts = hashed.split("\\$");
+
+            if (parts.length != 5 || !parts[1].equals("s0")) {      // wrong violation - method chain calls
+                throw new IllegalArgumentException("Invalid hashed value");
+            }
+        } catch (Exception e) { }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

The primary prefix might not always be a method call and array access is also not a method call.

## Related issues

- Fixes #2181
- Replaces #2561 

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

