### PR TITLE
[java] False negative: LiteralsFirstInComparisons for methods... (2569)

### DIFF
--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LiteralsFirstInComparisons.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LiteralsFirstInComparisons.xml
@@ -288,4 +288,17 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>ok, should be ignored in case both operands are string literals</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    boolean isFoo;
+    public void bar() {
+        this.isFoo = "Hello".equals("World");
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LiteralsFirstInComparisons.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LiteralsFirstInComparisons.xml
@@ -275,4 +275,17 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>bad, testing false negative at the end of a chain</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public boolean bar() {
+        File f;
+        return f.getFileType().equals("testStr");
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
returning Strings

## Describe the PR

I've changed the way we are getting operation name and primarySuffix in LiteralsFirstInComparisonsRule class, in order to fix false negative at methods chaining like this one:

    public void bar() {
        person.getName().equals("Hello, world!"); // <-- false negative here
    }

In case we have methods chaining like the one above, there are multiple primarySuffixes and comparison operation name is no longer in a primary prefix, it's in (n - 1)th primarySuffix. 

Also I've refactored some other methods of the class.
<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #2569 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

