### PR TITLE
[java] UseCollectionIsEmpty can not detect the case this.foo.size()

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseCollectionIsEmptyRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseCollectionIsEmptyRule.java
@@ -4,18 +4,23 @@
 
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
-import java.util.Arrays;
+import static java.util.Arrays.asList;
+import static java.util.Collections.singletonList;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBody;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
 import net.sourceforge.pmd.lang.java.ast.ASTResultType;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
 import net.sourceforge.pmd.lang.java.rule.AbstractInefficientZeroCheck;
 import net.sourceforge.pmd.lang.java.symboltable.ClassScope;
 import net.sourceforge.pmd.lang.java.symboltable.JavaNameOccurrence;
@@ -45,41 +50,76 @@ public class UseCollectionIsEmptyRule extends AbstractInefficientZeroCheck {
      */
     @Override
     public boolean isTargetMethod(JavaNameOccurrence occ) {
-        if (occ.getNameForWhichThisIsAQualifier() != null) {
-            if (occ.getLocation().getImage().endsWith(".size")) {
-                return true;
-            }
-        }
-        return false;
+        return occ.getNameForWhichThisIsAQualifier() != null
+                && occ.getLocation().getImage().endsWith(".size");
     }
 
     @Override
     public Map<String, List<String>> getComparisonTargets() {
+        List<String> zeroAndOne = asList("0", "1");
+        List<String> zero = singletonList("0");
         Map<String, List<String>> rules = new HashMap<>();
-        rules.put("<", Arrays.asList("0", "1"));
-        rules.put(">", Arrays.asList("0"));
-        rules.put("==", Arrays.asList("0"));
-        rules.put("!=", Arrays.asList("0"));
-        rules.put(">=", Arrays.asList("0", "1"));
-        rules.put("<=", Arrays.asList("0"));
+        rules.put("<", zeroAndOne);
+        rules.put(">", zero);
+        rules.put("==", zero);
+        rules.put("!=", zero);
+        rules.put(">=", zeroAndOne);
+        rules.put("<=", zero);
         return rules;
     }
 
     @Override
     public Object visit(ASTPrimarySuffix node, Object data) {
-        if (node.getImage() != null && node.getImage().endsWith("size")) {
-
-            ASTClassOrInterfaceType type = getTypeOfPrimaryPrefix(node);
-            if (type == null) {
-                type = getTypeOfMethodCall(node);
-            }
-
-            if (type != null && CollectionUtil.isCollectionType(type.getType(), true)) {
-                Node expr = node.getParent().getParent();
-                checkNodeAndReport(data, node, expr);
-            }
+        if (isSizeMethodCall(node) && isCalledOnCollection(node)) {
+            Node expr = node.getParent().getParent();
+            checkNodeAndReport(data, node, expr);
         }
         return data;
+    }
+
+    private boolean isSizeMethodCall(ASTPrimarySuffix primarySuffix) {
+        String calledMethodName = primarySuffix.getImage();
+        return calledMethodName != null && calledMethodName.endsWith("size");
+    }
+
+    private boolean isCalledOnCollection(ASTPrimarySuffix primarySuffix) {
+        ASTClassOrInterfaceType calledOnType = getTypeOfVariable(primarySuffix);
+        if (calledOnType == null) {
+            calledOnType = getTypeOfMethodCall(primarySuffix);
+        }
+        return calledOnType != null
+                && CollectionUtil.isCollectionType(calledOnType.getType(), true);
+    }
+
+    private ASTClassOrInterfaceType getTypeOfVariable(ASTPrimarySuffix primarySuffix) {
+        ASTPrimaryExpression primaryExpression = primarySuffix.getFirstParentOfType(ASTPrimaryExpression.class);
+        ASTPrimaryPrefix varPrefix = primaryExpression.getFirstChildOfType(ASTPrimaryPrefix.class);
+        if (prefixWithNoModifiers(varPrefix)) {
+            return varPrefix.getFirstDescendantOfType(ASTClassOrInterfaceType.class);
+        }
+        String varName = getVariableNameBySuffix(primaryExpression);
+        return varName != null ? getTypeOfVariableByName(varName, primaryExpression) : null;
+    }
+
+    private boolean prefixWithNoModifiers(ASTPrimaryPrefix primaryPrefix) {
+        return !primaryPrefix.usesSuperModifier() && !primaryPrefix.usesThisModifier();
+    }
+
+    private String getVariableNameBySuffix(ASTPrimaryExpression primaryExpression) {
+        ASTPrimarySuffix varSuffix = primaryExpression
+                .getFirstChildOfType(ASTPrimarySuffix.class);
+        return varSuffix.getImage();
+    }
+
+    private ASTClassOrInterfaceType getTypeOfVariableByName(String varName, ASTPrimaryExpression expr) {
+        ASTClassOrInterfaceBody classBody = expr.getFirstParentOfType(ASTClassOrInterfaceBody.class);
+        List<ASTVariableDeclarator> varDeclarators = classBody.findDescendantsOfType(ASTVariableDeclarator.class);
+        for (ASTVariableDeclarator varDeclarator : varDeclarators) {
+            if (varDeclarator.getName().equals(varName)) {
+                return varDeclarator.getFirstDescendantOfType(ASTClassOrInterfaceType.class);
+            }
+        }
+        return null;
     }
 
     private ASTClassOrInterfaceType getTypeOfMethodCall(ASTPrimarySuffix node) {
@@ -99,10 +139,5 @@ public class UseCollectionIsEmptyRule extends AbstractInefficientZeroCheck {
             }
         }
         return type;
-    }
-
-    private ASTClassOrInterfaceType getTypeOfPrimaryPrefix(ASTPrimarySuffix node) {
-        return node.getParent().getFirstChildOfType(ASTPrimaryPrefix.class)
-                .getFirstDescendantOfType(ASTClassOrInterfaceType.class);
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UseCollectionIsEmpty.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UseCollectionIsEmpty.xml
@@ -314,4 +314,24 @@ public class PmdBugBait {
 }
         ]]></code>
     </test-code>
+    
+    <test-code>
+        <description>#2543 false negative on this.collection.size</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import java.util.List;
+import java.util.ArrayList;
+
+public class Foo {
+
+    private List<String> list = new ArrayList<>();
+
+    public void bar() {
+        if (this.list.size() == 0) {
+            throw new RuntimeException("Empty list");
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION

## Describe the PR

The UseCollectionIsEmptyRule class uses a primaryPrefix to get a type of a variable on which `size()` is called. But in case `this` or `super` is used, the actual object info is stored in the first primarySuffix and contains only variable name, so additional operations are required to get the actual type.

Also I have refactored some of class methods.
<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #2543 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

