### PR TITLE
[lang-test] Upgrade kotlintest to Kotest

### DIFF
--- a/pmd-java/pom.xml
+++ b/pmd-java/pom.xml
@@ -177,6 +177,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <!-- Contains stuff like FunSpec, etc -->
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-runner-junit5-jvm</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <scope>test</scope>
@@ -188,7 +194,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test</artifactId>
+            <artifactId>kotlin-test-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pmd-java/pom.xml
+++ b/pmd-java/pom.xml
@@ -172,13 +172,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.kotlintest</groupId>
-            <artifactId>kotlintest-assertions</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.kotlintest</groupId>
-            <artifactId>kotlintest-core</artifactId>
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-assertions-core-jvm</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTCatchStatementTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTCatchStatementTest.kt
@@ -1,8 +1,8 @@
 package net.sourceforge.pmd.lang.java.ast
 
-import io.kotlintest.matchers.collections.shouldContainExactly
-import io.kotlintest.should
-import io.kotlintest.shouldBe
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
 import net.sourceforge.pmd.lang.java.ast.JavaVersion.*
 import net.sourceforge.pmd.lang.java.ast.JavaVersion.Companion.Earliest
 import net.sourceforge.pmd.lang.java.ast.JavaVersion.Companion.Latest

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/Java11Test.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/Java11Test.kt
@@ -1,5 +1,5 @@
 
-import io.kotlintest.shouldBe
+import io.kotest.matchers.shouldBe
 import net.sourceforge.pmd.lang.java.ast.*
 import net.sourceforge.pmd.lang.java.ast.JavaVersion.*
 import net.sourceforge.pmd.lang.java.ast.JavaVersion.Companion.Latest

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/KotlinTestingDsl.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/KotlinTestingDsl.kt
@@ -1,7 +1,7 @@
 package net.sourceforge.pmd.lang.java.ast
 
-import io.kotlintest.matchers.string.shouldContain
-import io.kotlintest.shouldThrow
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.string.shouldContain
 import net.sourceforge.pmd.lang.ast.Node
 import net.sourceforge.pmd.lang.ast.test.Assertions
 import net.sourceforge.pmd.lang.ast.test.NodeSpec
@@ -56,7 +56,7 @@ enum class JavaVersion : Comparable<JavaVersion> {
  *
  * These are implicitly used by [matchExpr] and [matchStmt], which specify a matcher directly
  * on the strings, using their type parameter and the info in this test context to parse, find
- * the node, and execute the matcher in a single call. These may be used by [io.kotlintest.should],
+ * the node, and execute the matcher in a single call. These may be used by [io.kotest.matchers.should],
  * e.g.
  *
  *      parserTest("Test ShiftExpression operator") {
@@ -69,7 +69,7 @@ enum class JavaVersion : Comparable<JavaVersion> {
  * Import statements in the parsing contexts can be configured by adding types to [importedTypes],
  * or strings to [otherImports].
  *
- * Technically the utilities provided by this class may be used outside of [io.kotlintest.specs.FunSpec]s,
+ * Technically the utilities provided by this class may be used outside of [io.kotest.specs.FunSpec]s,
  * e.g. in regular JUnit tests, but I think we should strive to uniformize our testing style,
  * especially since KotlinTest defines so many.
  *

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ParserTestSpec.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ParserTestSpec.kt
@@ -1,10 +1,12 @@
 package net.sourceforge.pmd.lang.java.ast
 
-import io.kotlintest.AbstractSpec
-import io.kotlintest.TestContext
-import io.kotlintest.TestType
+import io.kotest.core.config.Project
+import io.kotest.core.spec.style.DslDrivenSpec
+import io.kotest.core.test.TestContext
+import io.kotest.core.test.TestName
+import io.kotest.core.test.TestType
 import net.sourceforge.pmd.lang.ast.test.Assertions
-import io.kotlintest.should as kotlintestShould
+import io.kotest.matchers.should as kotlintestShould
 
 /**
  * Base class for grammar tests that use the DSL. Tests are layered into

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/SwitchExpressionTests.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/SwitchExpressionTests.kt
@@ -4,7 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.ast
 
-import io.kotlintest.shouldBe
+import io.kotest.matchers.shouldBe
 
 /**
  * @author Clément Fournier

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/WildcardBoundsTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/WildcardBoundsTest.kt
@@ -1,6 +1,6 @@
 package net.sourceforge.pmd.lang.java.ast
 
-import io.kotlintest.shouldBe
+import io.kotest.matchers.shouldBe
 
 class WildcardBoundsTest : ParserTestSpec({
 

--- a/pmd-lang-test/pom.xml
+++ b/pmd-lang-test/pom.xml
@@ -105,8 +105,14 @@
              of the pmd-lang-test module
         -->
         <dependency>
-            <groupId>io.kotlintest</groupId>
-            <artifactId>kotlintest-assertions</artifactId>
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-assertions-core-jvm</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <!-- Contains stuff like FunSpec, etc -->
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-runner-junit5-jvm</artifactId>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/pmd-lang-test/pom.xml
+++ b/pmd-lang-test/pom.xml
@@ -115,11 +115,6 @@
             <artifactId>kotest-runner-junit5-jvm</artifactId>
             <scope>compile</scope>
         </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test</artifactId>
-            <scope>compile</scope>
-        </dependency>
 
         <dependency>
             <groupId>org.jetbrains</groupId>

--- a/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/cpd/test/CpdTextComparisonTest.kt
+++ b/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/cpd/test/CpdTextComparisonTest.kt
@@ -4,7 +4,7 @@
 
 package net.sourceforge.pmd.cpd.test
 
-import io.kotlintest.shouldThrow
+import io.kotest.assertions.throwables.shouldThrow
 import net.sourceforge.pmd.cpd.SourceCode
 import net.sourceforge.pmd.cpd.TokenEntry
 import net.sourceforge.pmd.cpd.Tokenizer

--- a/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/AstMatcherDslAdapter.kt
+++ b/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/AstMatcherDslAdapter.kt
@@ -26,7 +26,7 @@ object NodeTreeLikeAdapter : DoublyLinkedTreeLikeAdapter<Node> {
 /** A subtree matcher written in the DSL documented on [TreeNodeWrapper]. */
 typealias NodeSpec<N> = TreeNodeWrapper<Node, N>.() -> Unit
 
-/** A function feedable to [io.kotlintest.should], which fails the test if an [AssertionError] is thrown. */
+/** A function feedable to [io.kotest.matchers.should], which fails the test if an [AssertionError] is thrown. */
 typealias Assertions<M> = (M) -> Unit
 
 /** A shorthand for [baseShouldMatchSubtree] providing the [NodeTreeLikeAdapter]. */
@@ -37,7 +37,7 @@ inline fun <reified N : Node> Node?.shouldMatchNode(ignoreChildren: Boolean = fa
 /**
  * Returns [an assertion function][Assertions] asserting that its parameter conforms to the given [NodeSpec].
  *
- * Use it with [io.kotlintest.should], e.g. `node should matchNode<ASTExpression> {}`.
+ * Use it with [io.kotest.matchers.should], e.g. `node should matchNode<ASTExpression> {}`.
  *
  * See also the samples on [TreeNodeWrapper].
  *
@@ -50,7 +50,7 @@ inline fun <reified N : Node> Node?.shouldMatchNode(ignoreChildren: Boolean = fa
  *                 Assertions may consist of [NWrapper.child] calls, which perform the same type of node
  *                 matching on a child of the tested node.
  *
- * @return A matcher for AST nodes, suitable for use by [io.kotlintest.should].
+ * @return A matcher for AST nodes, suitable for use by [io.kotest.matchers.should].
  */
 inline fun <reified N : Node> matchNode(ignoreChildren: Boolean = false, noinline nodeSpec: NodeSpec<N>)
         : Assertions<Node?> = { it.shouldMatchNode(ignoreChildren, nodeSpec) }

--- a/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/TestUtils.kt
+++ b/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/TestUtils.kt
@@ -4,10 +4,10 @@
 
 package net.sourceforge.pmd.lang.ast.test
 
-import io.kotlintest.should
+import io.kotest.matchers.should
 import kotlin.reflect.KCallable
 import kotlin.reflect.jvm.isAccessible
-import io.kotlintest.shouldBe as ktShouldBe
+import io.kotest.matchers.shouldBe as ktShouldBe
 
 /**
  * Extension to add the name of a property to error messages.
@@ -48,7 +48,7 @@ private fun <N, V> assertWrapper(callable: KCallable<N>, right: V, asserter: (N,
  * have to use the name of the getter instead of that of the generated
  * property (with the get prefix).
  *
- * If this conflicts with [io.kotlintest.shouldBe], use the equivalent [shouldEqual]
+ * If this conflicts with [io.kotest.matchers.shouldBe], use the equivalent [shouldEqual]
  *
  */
 infix fun <N, V : N> KCallable<N>.shouldBe(expected: V?) = this.shouldEqual(expected)

--- a/pmd-modelica/pom.xml
+++ b/pmd-modelica/pom.xml
@@ -120,13 +120,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.kotlintest</groupId>
-            <artifactId>kotlintest-assertions</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.kotlintest</groupId>
-            <artifactId>kotlintest-core</artifactId>
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-assertions-core-jvm</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pmd-modelica/pom.xml
+++ b/pmd-modelica/pom.xml
@@ -111,7 +111,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test</artifactId>
+            <artifactId>kotlin-test-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pmd-modelica/src/test/kotlin/net/sourceforge/pmd/lang/modelica/ast/ModelicaCoordsTest.kt
+++ b/pmd-modelica/src/test/kotlin/net/sourceforge/pmd/lang/modelica/ast/ModelicaCoordsTest.kt
@@ -4,9 +4,9 @@
 
 package net.sourceforge.pmd.lang.modelica.ast
 
-import io.kotlintest.should
-import io.kotlintest.shouldBe
-import io.kotlintest.specs.AbstractFunSpec
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.specs.AbstractFunSpec
 import net.sourceforge.pmd.lang.LanguageRegistry
 import net.sourceforge.pmd.lang.ast.Node
 import net.sourceforge.pmd.lang.ast.test.matchNode

--- a/pmd-modelica/src/test/kotlin/net/sourceforge/pmd/lang/modelica/ast/ModelicaCoordsTest.kt
+++ b/pmd-modelica/src/test/kotlin/net/sourceforge/pmd/lang/modelica/ast/ModelicaCoordsTest.kt
@@ -4,16 +4,16 @@
 
 package net.sourceforge.pmd.lang.modelica.ast
 
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
-import io.kotest.specs.AbstractFunSpec
 import net.sourceforge.pmd.lang.LanguageRegistry
 import net.sourceforge.pmd.lang.ast.Node
 import net.sourceforge.pmd.lang.ast.test.matchNode
 import net.sourceforge.pmd.lang.ast.test.shouldBe
 import java.io.StringReader
 
-class ModelicaCoordsTest : AbstractFunSpec({
+class ModelicaCoordsTest : FunSpec({
 
 
     test("Test line/column numbers for implicit nodes") {

--- a/pmd-scala-modules/pmd-scala-common/pom.xml
+++ b/pmd-scala-modules/pmd-scala-common/pom.xml
@@ -140,13 +140,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.kotlintest</groupId>
-            <artifactId>kotlintest-assertions</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>io.kotlintest</groupId>
-            <artifactId>kotlintest-core</artifactId>
+            <groupId>io.kotest</groupId>
+            <artifactId>kotest-assertions-core-jvm</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pmd-scala-modules/pmd-scala-common/pom.xml
+++ b/pmd-scala-modules/pmd-scala-common/pom.xml
@@ -151,7 +151,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test</artifactId>
+            <artifactId>kotlin-test-junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pmd-scala-modules/pmd-scala-common/src/test/kotlin/net/sourceforge/pmd/lang/scala/ast/ScalaTreeTests.kt
+++ b/pmd-scala-modules/pmd-scala-common/src/test/kotlin/net/sourceforge/pmd/lang/scala/ast/ScalaTreeTests.kt
@@ -4,15 +4,15 @@
 
 package net.sourceforge.pmd.lang.scala.ast
 
+import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.should
-import io.kotest.specs.AbstractFunSpec
 import net.sourceforge.pmd.lang.LanguageRegistry
 import net.sourceforge.pmd.lang.ast.Node
 import net.sourceforge.pmd.lang.ast.test.matchNode
 import net.sourceforge.pmd.lang.ast.test.shouldBe
 import java.io.StringReader
 
-class ScalaTreeTests : AbstractFunSpec({
+class ScalaTreeTests : FunSpec({
 
 
     test("Test line/column numbers") {

--- a/pmd-scala-modules/pmd-scala-common/src/test/kotlin/net/sourceforge/pmd/lang/scala/ast/ScalaTreeTests.kt
+++ b/pmd-scala-modules/pmd-scala-common/src/test/kotlin/net/sourceforge/pmd/lang/scala/ast/ScalaTreeTests.kt
@@ -4,8 +4,8 @@
 
 package net.sourceforge.pmd.lang.scala.ast
 
-import io.kotlintest.should
-import io.kotlintest.specs.AbstractFunSpec
+import io.kotest.matchers.should
+import io.kotest.specs.AbstractFunSpec
 import net.sourceforge.pmd.lang.LanguageRegistry
 import net.sourceforge.pmd.lang.ast.Node
 import net.sourceforge.pmd.lang.ast.test.matchNode

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 
 
         <kotlin.compiler.jvmTarget>${maven.compiler.test.target}</kotlin.compiler.jvmTarget>
-        <kotlin.version>1.3.0</kotlin.version>
+        <kotlin.version>1.3.72</kotlin.version>
         <kotest.version>4.1.2</kotest.version>
         <dokka.version>0.10.1</dokka.version>
 
@@ -817,12 +817,6 @@
             <dependency>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-test-junit</artifactId>
-                <version>${kotlin.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-test</artifactId>
                 <version>${kotlin.version}</version>
                 <scope>test</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 
         <kotlin.compiler.jvmTarget>${maven.compiler.test.target}</kotlin.compiler.jvmTarget>
         <kotlin.version>1.3.0</kotlin.version>
-        <kotlintest.version>3.1.8</kotlintest.version>
+        <kotest.version>4.1.2</kotest.version>
         <dokka.version>0.10.1</dokka.version>
 
 
@@ -269,9 +269,9 @@
                         </dependency>
                         <!-- Junit5 Platform Engine for Kotlin Tests -->
                         <dependency>
-                            <groupId>io.kotlintest</groupId>
-                            <artifactId>kotlintest-runner-junit5</artifactId>
-                            <version>${kotlintest.version}</version>
+                            <groupId>io.kotest</groupId>
+                            <artifactId>kotest-runner-junit5-jvm</artifactId>
+                            <version>${kotest.version}</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -826,17 +826,22 @@
                 <version>${kotlin.version}</version>
                 <scope>test</scope>
             </dependency>
-
             <dependency>
-                <groupId>io.kotlintest</groupId>
-                <artifactId>kotlintest-assertions</artifactId>
-                <version>${kotlintest.version}</version>
+                <groupId>io.kotest</groupId>
+                <artifactId>kotest-runner-junit5-jvm</artifactId>
+                <version>${kotest.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>io.kotlintest</groupId>
-                <artifactId>kotlintest-core</artifactId>
-                <version>${kotlintest.version}</version>
+                <groupId>io.kotest</groupId>
+                <artifactId>kotest-assertions-core-jvm</artifactId>
+                <version>${kotest.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.kotest</groupId>
+                <artifactId>kotest-property-jvm</artifactId>
+                <version>${kotest.version}</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
## Describe the PR

Upgrade kotlintest to Kotest. Also updates the kotlin version to the latest stable

This is depended on by type resolution

@adangel FunSpec is contained in the kotest core module, but I still added the dependency on the kotest junit runner for pmd-java. This allows usage of the marker interface IntelliMarker, which for makes the tests written with the custom parser spec runnable from intellij. Surefire still mentions the runner as a plugin dependency

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #2653 

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

