### PR TITLE
[core][java] Deprecate pmd-core::lang.rule.ImportWrapper

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -54,6 +54,7 @@ This is a {{ site.pmd.release_type }} release.
 * {% jdoc core::lang.rule.AbstractRuleChainVisitor %}
 * {% jdoc core::lang.Language#getRuleChainVisitorClass() %}
 * {% jdoc core::lang.BaseLanguageModule#<init>(java.lang.String,java.lang.String,java.lang.String,java.lang.Class,java.lang.String...) %}
+* {% jdoc core::lang.rule.ImportWrapper %}
 
 
 ### External Contributions

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
@@ -22,8 +22,8 @@ import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
 import net.sourceforge.pmd.lang.java.ast.Comment;
 import net.sourceforge.pmd.lang.java.ast.FormalComment;
 import net.sourceforge.pmd.lang.java.ast.TypeNode;
+import net.sourceforge.pmd.lang.java.ast.internal.ImportWrapper;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
-import net.sourceforge.pmd.lang.rule.ImportWrapper;
 
 public class UnusedImportsRule extends AbstractJavaRule {
 
@@ -117,7 +117,7 @@ public class UnusedImportsRule extends AbstractJavaRule {
     public Object visit(ASTImportDeclaration node, Object data) {
         if (node.isImportOnDemand()) {
             ASTName importedType = (ASTName) node.getChild(0);
-            imports.add(new ImportWrapper(importedType.getImage(), null, node, node.getType(), node.isStatic()));
+            imports.add(new ImportWrapper(importedType.getImage(), null, node, node.isStatic()));
         } else {
             if (!node.isImportOnDemand()) {
                 ASTName importedType = (ASTName) node.getChild(0);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/DuplicateImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/DuplicateImportsRule.java
@@ -11,8 +11,8 @@ import java.util.Set;
 
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
+import net.sourceforge.pmd.lang.java.ast.internal.ImportWrapper;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
-import net.sourceforge.pmd.lang.rule.ImportWrapper;
 
 public class DuplicateImportsRule extends AbstractJavaRule {
 


### PR DESCRIPTION
## Describe the PR

* Deprecates the class `ImportWrapper`, which is in pmd-core, but is Java specific.
* Copies this class to pmd-java into package `...lang.java.ast.internal`.
* Contains the fix from #2644

## Related issues

- Found while working on #2644

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

