### PR TITLE
[java] StringToString can not detect the case: getStringMethod().toString()

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/StringToStringRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/StringToStringRule.java
@@ -321,7 +321,10 @@ public class StringToStringRule extends AbstractJavaRule {
 
     private String getReturnTypeName(ASTMethodDeclaration method) {
         ASTType returnType = method.getResultType().getFirstDescendantOfType(ASTType.class);
-        Class<?> type = returnType.getType();
-        return type != null ? type.getSimpleName() : returnType.getTypeImage();
+        if (returnType != null) {
+            Class<?> type = returnType.getType();
+            return type != null ? type.getSimpleName() : returnType.getTypeImage();
+        }
+        return null;
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/StringToStringRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/StringToStringRule.java
@@ -285,8 +285,7 @@ public class StringToStringRule extends AbstractJavaRule {
     private Class<?> getMethodReturnType(ASTMethodDeclaration method) {
         ASTType returnType = method != null ? method.getResultType().getFirstDescendantOfType(ASTType.class) : null;
         if (returnType != null) {
-            Class<?> type = returnType.getType();
-            return type;
+            return returnType.getType();
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/StringToStringRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/StringToStringRule.java
@@ -4,9 +4,9 @@
 
 package net.sourceforge.pmd.lang.java.rule.performance;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -14,19 +14,17 @@ import java.util.Set;
 import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTArguments;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBody;
-import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
+import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
 import net.sourceforge.pmd.lang.java.ast.ASTFormalParameters;
-import net.sourceforge.pmd.lang.java.ast.ASTLiteral;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodReference;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
-import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
 import net.sourceforge.pmd.lang.java.ast.ASTType;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
+import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.symboltable.JavaNameOccurrence;
 import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
@@ -34,39 +32,95 @@ import net.sourceforge.pmd.lang.java.typeresolution.TypeHelper;
 import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
 import net.sourceforge.pmd.lang.symboltable.ScopedNode;
 
+/**
+ *  Finds toString() call on String object.
+ *
+ *  <b>Note:</b> due to an issue with type resolution, this implementation doesn't detect cases when toString()
+ *  call is chained to a method returning String which is not declared in the class having the call or the call
+ *  arguments are not of the exact same type as method parameters are, excluding the case when method name and
+ *  number of it's parameters is enough to identify the method. Example:
+ *    <pre>{@code
+ *    class A {
+ *         public String str() {
+ *            return "exampleStr";
+ *         }
+ *    }
+ *    class B {
+ *        public void foo() {
+ *            String s = new A().str().toString(); // not detected because str() is from another class
+ *            s = getString().toString(); // detected
+ *            s = getData(new FileInputStream()).toString(); // not detected because of argument type
+ *            s = getData(new Integer(4), new Integer(5)).toString(); // detected because of unique args count
+ *        }
+ *        public String getString() {
+ *            return "exampleStr";
+ *        }
+ *        public String getData(InputStream is) {
+ *            return "argsResolutionIssueExample";
+ *        }
+ *        public int getData(String s) {
+ *            return 0;
+ *        }
+ *        public String getData(Number a, Number b) {
+ *            return "uniqueArgsCountExample";
+ *        }
+ *    }
+ *    }</pre>
+ */
 public class StringToStringRule extends AbstractJavaRule {
 
-    private final Map<String, Class<?>> declaredVariables = new HashMap<>();
-    private final Set<ASTMethodDeclaration> methodsReturningString = new HashSet<>();
+    private static final Map<String, String> PRIMITIVE_TO_WRAPPER_MAP;
 
-    @Override
-    public Object visit(ASTVariableDeclarator node, Object data) {
-        declaredVariables.put(node.getName(), node.getType());
-        return super.visit(node, data);
+    private final Set<ASTMethodDeclaration> declaredMethods = new HashSet<>();
+    private final Map<String, String> declaredVariables = new HashMap<>();
+
+    static {
+        Map<String, String> primitiveToWrapper = new HashMap<>();
+        primitiveToWrapper.put("byte", "Byte");
+        primitiveToWrapper.put("short", "Short");
+        primitiveToWrapper.put("char", "Character");
+        primitiveToWrapper.put("int", "Integer");
+        primitiveToWrapper.put("long", "Long");
+        primitiveToWrapper.put("float", "Float");
+        primitiveToWrapper.put("double", "Double");
+        primitiveToWrapper.put("boolean", "Boolean");
+        PRIMITIVE_TO_WRAPPER_MAP = primitiveToWrapper;
     }
 
     @Override
     public Object visit(ASTClassOrInterfaceBody body, Object data) {
+        clearStateIfNewClass(body);
         List<ASTMethodDeclaration> methodDeclarations = body.findDescendantsOfType(ASTMethodDeclaration.class);
-        for (ASTMethodDeclaration methodDeclaration : methodDeclarations) {
-            if (methodReturnsString(methodDeclaration)) {
-                methodsReturningString.add(methodDeclaration);
-            }
-        }
+        declaredMethods.addAll(methodDeclarations);
         return super.visit(body, data);
     }
 
-    private boolean methodReturnsString(ASTMethodDeclaration methodDeclaration) {
-        ASTType returnType = methodDeclaration.getResultType().getFirstChildOfType(ASTType.class);
-        return returnType != null && String.class.equals(returnType.getType());
+    private void clearStateIfNewClass(ASTClassOrInterfaceBody body) {
+        if (isBodyOfOuterClass(body)) {
+            declaredMethods.clear();
+            declaredVariables.clear();
+        }
+    }
+
+    private boolean isBodyOfOuterClass(ASTClassOrInterfaceBody body) {
+        return body.getFirstParentOfType(ASTClassOrInterfaceBody.class) == null;
     }
 
     @Override
-    public Object visit(ASTVariableDeclaratorId node, Object data) {
-        if (isStringVariableDeclarator(node)) {
-            for (NameOccurrence varUsage : node.getUsages()) {
+    public Object visit(ASTVariableDeclarator var, Object data) {
+        String varTypeName = getSimpleNameOfType(var);
+        if (varTypeName != null) {
+            declaredVariables.put(var.getName(), varTypeName);
+        }
+        return super.visit(var, data);
+    }
+
+    @Override
+    public Object visit(ASTVariableDeclaratorId varId, Object data) {
+        if (isStringVariableDeclarator(varId)) {
+            for (NameOccurrence varUsage : varId.getUsages()) {
                 NameOccurrence qualifier = getVarUsageQualifier(varUsage);
-                if (isToStringOnStringCall(node, qualifier)) {
+                if (isToStringOnStringCall(varId, qualifier)) {
                     addViolation(data, varUsage.getLocation());
                 }
             }
@@ -112,94 +166,162 @@ public class StringToStringRule extends AbstractJavaRule {
 
     @Override
     public Object visit(ASTPrimaryExpression primaryExpr, Object data) {
-        if (callsToStringOnMethodReturningString(primaryExpr)) {
-            addViolation(data, primaryExpr);
+        if (hasChainedMethods(primaryExpr)) {
+            for (int callIndex = 2; callIndex < primaryExpr.getNumChildren(); callIndex++) {
+                JavaNode methodCall = primaryExpr.getChild(callIndex);
+                if (isToStringMethodCall(methodCall)) {
+                    JavaNode prevMethodCall = primaryExpr.getChild(callIndex - 2);
+                    JavaNode prevMethodCallArgs = primaryExpr.getChild(callIndex - 1);
+                    if (calledMethodReturnsString(prevMethodCall, prevMethodCallArgs)) {
+                        addViolation(data, methodCall);
+                    }
+                }
+            }
         }
         return super.visit(primaryExpr, data);
     }
 
-    private boolean callsToStringOnMethodReturningString(ASTPrimaryExpression primaryExpr) {
-        return doesSrcMethodReturnString(primaryExpr) && hasToStringCall(primaryExpr);
+    private boolean hasChainedMethods(ASTPrimaryExpression primaryExpr) {
+        return primaryExpr.getNumChildren() >= 4;
     }
 
-    private boolean doesSrcMethodReturnString(ASTPrimaryExpression primaryExpr) {
-        String srcMethodName = getSrcMethodName(primaryExpr);
-        ASTArguments srcMethodArgs = primaryExpr.getFirstDescendantOfType(ASTArguments.class);
-        if (srcMethodArgs != null) {
-            for (ASTMethodDeclaration methodReturningString : methodsReturningString) {
-                if (methodReturningString.getName().equals(srcMethodName)
-                        && areArgsValidForMethod(srcMethodArgs, methodReturningString)) {
-                    return true;
+    private boolean isToStringMethodCall(JavaNode methodCall) {
+        String methodName = getCalledMethodName(methodCall);
+        return isToString(methodName);
+    }
+
+    private boolean isToString(String methodName) {
+        return "toString".equals(methodName);
+    }
+
+    private boolean calledMethodReturnsString(JavaNode methodCall, JavaNode methodCallArgs) {
+        String returnTypeName = getCalledMethodReturnTypeName(methodCall, methodCallArgs);
+        return "String".equals(returnTypeName);
+    }
+
+    private String getCalledMethodReturnTypeName(JavaNode methodCall, JavaNode methodCallArgs) {
+        String calledMethodName = getCalledMethodName(methodCall);
+        ASTArguments arguments = methodCallArgs.getFirstDescendantOfType(ASTArguments.class);
+        return calledMethodName != null && arguments != null
+                ? findMethodReturnTypeName(calledMethodName, arguments)
+                : null;
+    }
+
+    private String getCalledMethodName(JavaNode methodCall) {
+        ASTName name = methodCall.getFirstDescendantOfType(ASTName.class);
+        return name != null ? name.getImage() : methodCall.getImage();
+    }
+
+    private String findMethodReturnTypeName(String methodName, ASTArguments args) {
+        List<ASTMethodDeclaration> candidateMethods = getMethodsByNameAndArgsCount(methodName, args.size());
+        if (candidateMethods.size() > 1) {
+            ASTArgumentList argsList = args.getFirstChildOfType(ASTArgumentList.class);
+            for (ASTMethodDeclaration candidateMethod : candidateMethods) {
+                ASTFormalParameters methodParams = candidateMethod.getFormalParameters();
+                if (argsMatchMethodParamsByType(argsList, methodParams)) {
+                    return getReturnTypeName(candidateMethod);
                 }
             }
         }
-        return false;
+        return getFirstMethodReturnTypeNameIfPresent(candidateMethods);
     }
 
-    private String getSrcMethodName(ASTPrimaryExpression primaryExpr) {
-        ASTPrimaryPrefix primaryPrefix = primaryExpr.getFirstDescendantOfType(ASTPrimaryPrefix.class);
-        if (hasNoModifiers(primaryPrefix)) {
-            ASTName name = primaryPrefix.getFirstDescendantOfType(ASTName.class);
-            return name != null ? name.getImage() : null;
+    private List<ASTMethodDeclaration> getMethodsByNameAndArgsCount(String name, int argsCount) {
+        List<ASTMethodDeclaration> matchingMethods = new ArrayList<>();
+        for (ASTMethodDeclaration method : declaredMethods) {
+            if (name.equals(method.getName()) && method.getArity() == argsCount) {
+                matchingMethods.add(method);
+            }
         }
-        ASTPrimarySuffix primarySuffix = primaryExpr.getFirstDescendantOfType(ASTPrimarySuffix.class);
-        return primarySuffix != null ? primarySuffix.getImage() : null;
+        return matchingMethods;
     }
 
-    private boolean hasNoModifiers(ASTPrimaryPrefix primaryPrefix) {
-        return !primaryPrefix.usesThisModifier() && !primaryPrefix.usesSuperModifier();
-    }
-
-    private boolean areArgsValidForMethod(ASTArguments args, ASTMethodDeclaration methodDeclaration) {
-        if (args.size() == methodDeclaration.getArity()) {
-            ASTArgumentList argsList = args.getFirstChildOfType(ASTArgumentList.class);
-            return argsList == null || argsMatchMethodParams(argsList, methodDeclaration);
-        }
-        return false;
-    }
-
-    private boolean argsMatchMethodParams(ASTArgumentList argsList, ASTMethodDeclaration methodDeclaration) {
-        Iterator<? extends JavaNode> argsIterator = argsList.children().iterator();
-        ASTFormalParameters methodParams = methodDeclaration.getFormalParameters();
-        for (ASTFormalParameter methodParam : methodParams) {
-            if (argNotMatchesMethodParam(argsIterator.next(), methodParam)) {
+    private boolean argsMatchMethodParamsByType(ASTArgumentList argsList, ASTFormalParameters methodParams) {
+        for (int paramIndex = 0; paramIndex < methodParams.size(); paramIndex++) {
+            JavaNode methodParam = methodParams.getChild(paramIndex);
+            String methodParamTypeName = typeNameOfNode(methodParam);
+            JavaNode arg = argsList.getChild(paramIndex);
+            String argTypeName = getArgumentTypeName(arg);
+            if (simpleNamesAreNotOfSameType(methodParamTypeName, argTypeName)) {
                 return false;
             }
         }
         return true;
     }
 
-    private boolean argNotMatchesMethodParam(JavaNode arg, ASTFormalParameter methodParam) {
-        return !argMatchesMethodParam(arg, methodParam);
-    }
-
-    private boolean argMatchesMethodParam(JavaNode arg, ASTFormalParameter methodParam) {
-        Class<?> argType = getArgumentType(arg);
-        Class<?> paramType = methodParam.getType();
-        return argType != null && paramType.isAssignableFrom(argType);
-    }
-
-    private Class<?> getArgumentType(JavaNode arg) {
-        ASTLiteral literalArg = arg.getFirstDescendantOfType(ASTLiteral.class);
-        if (literalArg == null) {
-            ASTName varName = arg.getFirstDescendantOfType(ASTName.class);
-            return varName != null ? declaredVariables.get(varName.getImage()) : null;
+    private String getArgumentTypeName(JavaNode arg) {
+        String argTypeName = typeNameOfNode(arg);
+        if (argTypeName == null) {
+            argTypeName = typeNameOfCalledVariable(arg);
+            return argTypeName != null ? argTypeName
+                    : typeNameOfCalledMethod(arg);
         }
-        return literalArg.getType();
+        return argTypeName;
     }
 
-    private boolean hasToStringCall(ASTPrimaryExpression primaryExpr) {
-        List<ASTPrimarySuffix> methodCalls = primaryExpr.findDescendantsOfType(ASTPrimarySuffix.class);
-        for (ASTPrimarySuffix methodCall : methodCalls) {
-            String methodName = methodCall.getImage();
-            if (isToString(methodName)) {
-                return true;
-            }
+    private String typeNameOfNode(JavaNode node) {
+        TypeNode typeNode = (TypeNode) node;
+        return getSimpleNameOfType(typeNode);
+    }
+
+    private String getSimpleNameOfType(TypeNode typeNode) {
+        Class<?> type = typeNode.getType();
+        if (type == null) {
+            ASTClassOrInterfaceType cioType = typeNode.getFirstDescendantOfType(ASTClassOrInterfaceType.class);
+            return cioType != null ? cioType.getImage() : null;
+        }
+        return type.getSimpleName();
+    }
+
+    private String typeNameOfCalledVariable(JavaNode varCall) {
+        ASTName calledVarName = varCall.getFirstDescendantOfType(ASTName.class);
+        return calledVarName != null ? declaredVariables.get(calledVarName.getImage()) : null;
+    }
+
+    private String typeNameOfCalledMethod(JavaNode methodCallExpr) {
+        ASTPrimaryExpression primaryExpr = methodCallExpr.getFirstDescendantOfType(ASTPrimaryExpression.class);
+        if (isMethodCall(primaryExpr)) {
+            JavaNode methodCall = primaryExpr.getChild(0);
+            JavaNode methodCallArgs = primaryExpr.getChild(1);
+            return getCalledMethodReturnTypeName(methodCall, methodCallArgs);
+        }
+        return null;
+    }
+
+    private boolean isMethodCall(ASTPrimaryExpression primaryExpression) {
+        return primaryExpression != null && primaryExpression.getNumChildren() == 2;
+    }
+
+    private boolean simpleNamesAreNotOfSameType(String sn0, String sn1) {
+        return !simpleNamesAreOfSameType(sn0, sn1);
+    }
+
+    private boolean simpleNamesAreOfSameType(String sn0, String sn1) {
+        if (sn0 != null && sn1 != null) {
+            String wrappedSN0 = toWrapperNameIfPrimitive(sn0);
+            String wrappedSN1 = toWrapperNameIfPrimitive(sn1);
+            return wrappedSN0.equals(wrappedSN1);
         }
         return false;
     }
 
-    private boolean isToString(String methodName) {
-        return "toString".equals(methodName);
+    private String toWrapperNameIfPrimitive(String simpleName) {
+        return PRIMITIVE_TO_WRAPPER_MAP.containsKey(simpleName)
+                ? PRIMITIVE_TO_WRAPPER_MAP.get(simpleName)
+                : simpleName;
+    }
+
+    private String getFirstMethodReturnTypeNameIfPresent(List<ASTMethodDeclaration> methods) {
+        if (!methods.isEmpty()) {
+            ASTMethodDeclaration firstMethod = methods.get(0);
+            return getReturnTypeName(firstMethod);
+        }
+        return null;
+    }
+
+    private String getReturnTypeName(ASTMethodDeclaration method) {
+        ASTType returnType = method.getResultType().getFirstDescendantOfType(ASTType.class);
+        Class<?> type = returnType.getType();
+        return type != null ? type.getSimpleName() : returnType.getTypeImage();
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/StringToStringRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/StringToStringRule.java
@@ -4,38 +4,97 @@
 
 package net.sourceforge.pmd.lang.java.rule.performance;
 
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
+import net.sourceforge.pmd.lang.java.ast.ASTArguments;
+import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBody;
+import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
+import net.sourceforge.pmd.lang.java.ast.ASTFormalParameters;
+import net.sourceforge.pmd.lang.java.ast.ASTLiteral;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodReference;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
+import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
+import net.sourceforge.pmd.lang.java.ast.ASTType;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
-import net.sourceforge.pmd.lang.java.ast.AbstractJavaNode;
+import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.symboltable.JavaNameOccurrence;
+import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
 import net.sourceforge.pmd.lang.java.typeresolution.TypeHelper;
 import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
 import net.sourceforge.pmd.lang.symboltable.ScopedNode;
 
 public class StringToStringRule extends AbstractJavaRule {
 
+    private final Map<String, Class<?>> declaredVariables = new HashMap<>();
+    private final Set<ASTMethodDeclaration> methodsReturningString = new HashSet<>();
+
+    @Override
+    public Object visit(ASTVariableDeclarator node, Object data) {
+        declaredVariables.put(node.getName(), node.getType());
+        return super.visit(node, data);
+    }
+
+    @Override
+    public Object visit(ASTClassOrInterfaceBody body, Object data) {
+        List<ASTMethodDeclaration> methodDeclarations = body.findDescendantsOfType(ASTMethodDeclaration.class);
+        for (ASTMethodDeclaration methodDeclaration : methodDeclarations) {
+            if (methodReturnsString(methodDeclaration)) {
+                methodsReturningString.add(methodDeclaration);
+            }
+        }
+        return super.visit(body, data);
+    }
+
+    private boolean methodReturnsString(ASTMethodDeclaration methodDeclaration) {
+        ASTType returnType = methodDeclaration.getResultType().getFirstChildOfType(ASTType.class);
+        return returnType != null && String.class.equals(returnType.getType());
+    }
+
     @Override
     public Object visit(ASTVariableDeclaratorId node, Object data) {
-        if (node.getNameDeclaration() == null
-            || !TypeHelper.isExactlyAny(node.getNameDeclaration(), String.class)
-                && !TypeHelper.isExactlyAny(node.getNameDeclaration(), String[].class)) {
-            return data;
-        }
-        boolean isArray = node.isArray();
-        for (NameOccurrence occ : node.getUsages()) {
-            JavaNameOccurrence jocc = (JavaNameOccurrence) occ;
-            NameOccurrence qualifier = jocc.getNameForWhichThisIsAQualifier();
-            if (qualifier != null) {
-                if (!isArray && isNotAMethodReference(qualifier) && qualifier.getImage().indexOf("toString") != -1) {
-                    addViolation(data, jocc.getLocation());
-                } else if (isArray && isNotAName(qualifier) && "toString".equals(qualifier.getImage())) {
-                    addViolation(data, jocc.getLocation());
+        if (isStringVariableDeclarator(node)) {
+            for (NameOccurrence varUsage : node.getUsages()) {
+                NameOccurrence qualifier = getVarUsageQualifier(varUsage);
+                if (isToStringOnStringCall(node, qualifier)) {
+                    addViolation(data, varUsage.getLocation());
                 }
             }
         }
         return data;
+    }
+
+    private boolean isStringVariableDeclarator(ASTVariableDeclaratorId varDeclaratorId) {
+        VariableNameDeclaration varNameDeclaration = varDeclaratorId.getNameDeclaration();
+        return varNameDeclaration != null
+                && TypeHelper.isExactlyAny(varNameDeclaration, String.class, String[].class);
+    }
+
+    private NameOccurrence getVarUsageQualifier(NameOccurrence varUsage) {
+        JavaNameOccurrence jVarUsage = (JavaNameOccurrence) varUsage;
+        return jVarUsage.getNameForWhichThisIsAQualifier();
+    }
+
+    private boolean isToStringOnStringCall(ASTVariableDeclaratorId varDeclaratorId, NameOccurrence qualifier) {
+        if (qualifier != null) {
+            return isNotAMethodReference(qualifier) && isNotAnArrayField(varDeclaratorId, qualifier)
+                    && isToString(qualifier.getImage());
+        }
+        return false;
+    }
+
+    private boolean isNotAnArrayField(ASTVariableDeclaratorId varDeclaratorId, NameOccurrence qualifier) {
+        return !varDeclaratorId.hasArrayType() || isNotAName(qualifier);
     }
 
     private boolean isNotAMethodReference(NameOccurrence qualifier) {
@@ -46,8 +105,101 @@ public class StringToStringRule extends AbstractJavaRule {
         return isNotA(qualifier, ASTName.class);
     }
 
-    private boolean isNotA(NameOccurrence qualifier, Class<? extends AbstractJavaNode> type) {
+    private boolean isNotA(NameOccurrence qualifier, Class<? extends JavaNode> type) {
         ScopedNode location = qualifier.getLocation();
-        return location == null || !(type.isAssignableFrom(location.getClass()));
+        return location == null || !type.isAssignableFrom(location.getClass());
+    }
+
+    @Override
+    public Object visit(ASTPrimaryExpression primaryExpr, Object data) {
+        if (callsToStringOnMethodReturningString(primaryExpr)) {
+            addViolation(data, primaryExpr);
+        }
+        return super.visit(primaryExpr, data);
+    }
+
+    private boolean callsToStringOnMethodReturningString(ASTPrimaryExpression primaryExpr) {
+        return doesSrcMethodReturnString(primaryExpr) && hasToStringCall(primaryExpr);
+    }
+
+    private boolean doesSrcMethodReturnString(ASTPrimaryExpression primaryExpr) {
+        String srcMethodName = getSrcMethodName(primaryExpr);
+        ASTArguments srcMethodArgs = primaryExpr.getFirstDescendantOfType(ASTArguments.class);
+        if (srcMethodArgs != null) {
+            for (ASTMethodDeclaration methodReturningString : methodsReturningString) {
+                if (methodReturningString.getName().equals(srcMethodName)
+                        && areArgsValidForMethod(srcMethodArgs, methodReturningString)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private String getSrcMethodName(ASTPrimaryExpression primaryExpr) {
+        ASTPrimaryPrefix primaryPrefix = primaryExpr.getFirstDescendantOfType(ASTPrimaryPrefix.class);
+        if (hasNoModifiers(primaryPrefix)) {
+            ASTName name = primaryPrefix.getFirstDescendantOfType(ASTName.class);
+            return name != null ? name.getImage() : null;
+        }
+        ASTPrimarySuffix primarySuffix = primaryExpr.getFirstDescendantOfType(ASTPrimarySuffix.class);
+        return primarySuffix != null ? primarySuffix.getImage() : null;
+    }
+
+    private boolean hasNoModifiers(ASTPrimaryPrefix primaryPrefix) {
+        return !primaryPrefix.usesThisModifier() && !primaryPrefix.usesSuperModifier();
+    }
+
+    private boolean areArgsValidForMethod(ASTArguments args, ASTMethodDeclaration methodDeclaration) {
+        if (args.size() == methodDeclaration.getArity()) {
+            ASTArgumentList argsList = args.getFirstChildOfType(ASTArgumentList.class);
+            return argsList == null || argsMatchMethodParams(argsList, methodDeclaration);
+        }
+        return false;
+    }
+
+    private boolean argsMatchMethodParams(ASTArgumentList argsList, ASTMethodDeclaration methodDeclaration) {
+        Iterator<? extends JavaNode> argsIterator = argsList.children().iterator();
+        ASTFormalParameters methodParams = methodDeclaration.getFormalParameters();
+        for (ASTFormalParameter methodParam : methodParams) {
+            if (argNotMatchesMethodParam(argsIterator.next(), methodParam)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean argNotMatchesMethodParam(JavaNode arg, ASTFormalParameter methodParam) {
+        return !argMatchesMethodParam(arg, methodParam);
+    }
+
+    private boolean argMatchesMethodParam(JavaNode arg, ASTFormalParameter methodParam) {
+        Class<?> argType = getArgumentType(arg);
+        Class<?> paramType = methodParam.getType();
+        return argType != null && paramType.isAssignableFrom(argType);
+    }
+
+    private Class<?> getArgumentType(JavaNode arg) {
+        ASTLiteral literalArg = arg.getFirstDescendantOfType(ASTLiteral.class);
+        if (literalArg == null) {
+            ASTName varName = arg.getFirstDescendantOfType(ASTName.class);
+            return varName != null ? declaredVariables.get(varName.getImage()) : null;
+        }
+        return literalArg.getType();
+    }
+
+    private boolean hasToStringCall(ASTPrimaryExpression primaryExpr) {
+        List<ASTPrimarySuffix> methodCalls = primaryExpr.findDescendantsOfType(ASTPrimarySuffix.class);
+        for (ASTPrimarySuffix methodCall : methodCalls) {
+            String methodName = methodCall.getImage();
+            if (isToString(methodName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isToString(String methodName) {
+        return "toString".equals(methodName);
     }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/stringtostring/Car.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/stringtostring/Car.java
@@ -1,0 +1,9 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.performance.stringtostring;
+
+public class Car {
+
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/stringtostring/User.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/stringtostring/User.java
@@ -1,0 +1,9 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.performance.stringtostring;
+
+public class User {
+
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/StringToString.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/StringToString.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <test-data
-    xmlns="http://pmd.sourceforge.net/rule-tests"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
 
     <test-code>
         <description>local var</description>
@@ -138,6 +138,85 @@ public class Foo {
         String abc = "abc";
         log(abc::toString); // fails rule
         log(() -> abc); // passes rule
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#2530 toString on String value returned from a method should be detected</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public String foo() {
+        return "Test String";
+    }
+
+    public int bar() {
+        String test = this.foo().toString();
+        return test.length();
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>getString().toString(), anonymous class method false-positive test</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public Integer value() {
+        return 0;
+    }
+
+    public String bar() {
+        Object obj = new Object() {
+            public String value() {
+                return "0";
+            }
+        };
+        return value().toString();
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>getString().toString(), method overloading false-positive test</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public String value(String str) {
+        return str.trim();
+    }
+
+    public Integer value(Integer num) {
+        return num + 1;
+    }
+
+    public void bar() {
+        String str = value(5).toString();
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>getString().toString(), object false-positive test</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public String value() {
+        return "test";
+    }
+
+    public void bar() {
+        Person p = new Person();
+        int val = p.value();
+        if (val == 0) {
+            throw new RuntimeException();
+        }
     }
 }
         ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/StringToString.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/StringToString.xml
@@ -239,4 +239,33 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Limitations</description>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>5,6,7</expected-linenumbers>
+        <code><![CDATA[
+import java.io.*;
+class B {
+    public void foo() {
+        String s = new A().str().toString(); // not detected because str() is from another class
+        s = getString().toString(); // detected
+        s = getData(new FileInputStream()).toString(); // detected because of argument (sub) type
+        s = getData(new Integer(4), new Integer(5)).toString(); // detected because of unique args count
+    }
+    public String getString() {
+        return "exampleStr";
+    }
+    public String getData(InputStream is) {
+        return "argsResolutionIssueExample";
+    }
+    public int getData(String s) {
+        return 0;
+    }
+    public String getData(Number a, Number b) {
+        return "uniqueArgsCountExample";
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/StringToString.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/StringToString.xml
@@ -221,4 +221,22 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>external class as a method parameter NullPointerException test</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>8</expected-linenumbers>
+        <code><![CDATA[
+import org.springframework.context.MessageSourceResolvable;
+public class Foo {
+    public String getData(MessageSourceResolvable msr) {
+        return "MSR: " + msr.toString();
+    }
+
+    public void bar() {
+        String s = getData(new MessageSourceResolvable()).toString();
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/StringToString.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/StringToString.xml
@@ -223,18 +223,20 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>external class as a method parameter NullPointerException test</description>
+        <description>external class as a method parameter</description>
         <expected-problems>1</expected-problems>
-        <expected-linenumbers>8</expected-linenumbers>
+        <expected-linenumbers>10</expected-linenumbers>
         <code><![CDATA[
-import org.springframework.context.MessageSourceResolvable;
+import java.util.Properties;
 public class Foo {
-    public String getData(MessageSourceResolvable msr) {
-        return "MSR: " + msr.toString();
+    public Long getData(User usr) {
+        return usr.getId();
     }
-
+    public String getData(Properties props) {
+        return "Props: " + props.toString();
+    }
     public void bar() {
-        String s = getData(new MessageSourceResolvable()).toString();
+        String s = getData(new Properties()).toString();
     }
 }
         ]]></code>
@@ -264,6 +266,49 @@ class B {
     }
     public String getData(Number a, Number b) {
         return "uniqueArgsCountExample";
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>variable as method call argument</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+package net.sourceforge.pmd.lang.java.rule.performance.stringtostring;
+public class Foo {
+    public void bar() {
+        User user = new User();
+        String s = getId(user).toString();
+    }
+    public int getId(Car car) {
+        return 0;
+    }
+    public String getId(User user) {
+        return "";
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>method call as method call argument</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public void bar() {
+        String s = getData(getLong()).toString();
+    }
+    public long getLong() {
+        return 0;
+    }
+    public long getData(String d) {
+        return 0;
+    }
+    public String getData(long d) {
+        return "";
     }
 }
         ]]></code>


### PR DESCRIPTION
## Describe the PR

I've added a visit to the ASTPrimaryExpression node checking whether call to a method returning String is followed by `toString()`. Method call arguments are checked in order to get the actual method's return type and avoid false positives like in the example below:

    public String getId(String name) {...}

    public Integer getId(int position) {...}

    public void foo() {
      String a = getId(0).toString(); // <-- avoiding false-positive here
    }

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #2530 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

