### PR TITLE
[java] UnnecessaryCaseChange can not detect the case like: foo.equals(bar.toLowerCase())

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnnecessaryCaseChangeRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnnecessaryCaseChangeRule.java
@@ -83,15 +83,21 @@ public class UnnecessaryCaseChangeRule extends AbstractJavaRule {
     }
 
     private boolean isArgumentOfEqualsMethodCall(ASTPrimaryExpression expr) {
-        JavaNode parent = expr.getParent().getParent();
-        if (parent instanceof ASTArgumentList) {
-            ASTPrimarySuffix parentMethodCallArgs = parent.getFirstParentOfType(ASTPrimarySuffix.class);
+        ASTPrimarySuffix parentMethodCallArgs = getParentMethodCallArgsSuffix(expr);
+        if (parentMethodCallArgs != null) {
             List<JavaNode> parentNodes = parentMethodCallArgs.getParent().findChildrenOfType(JavaNode.class);
             int parentMethodCallIndex = parentNodes.indexOf(parentMethodCallArgs) - 1;
             JavaNode parentMethodCall = parentNodes.get(parentMethodCallIndex);
             return isEqualsMethodCall(parentMethodCall, parentMethodCallArgs);
         }
         return false;
+    }
+
+    private ASTPrimarySuffix getParentMethodCallArgsSuffix(ASTPrimaryExpression expr) {
+        JavaNode parent = expr.getParent().getParent(); // ASTArgumentList/ASTExpression/ASTPrimaryExpression
+        return parent instanceof ASTArgumentList
+                ? parent.getFirstParentOfType(ASTPrimarySuffix.class)
+                : null;
     }
 
     private boolean isEqualsMethodCall(JavaNode methodCall, JavaNode methodCallArgs) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnnecessaryCaseChangeRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnnecessaryCaseChangeRule.java
@@ -4,83 +4,105 @@
 
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 
-import net.sourceforge.pmd.lang.ast.Node;
+import static java.util.Arrays.asList;
+
+import java.util.List;
+
+import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
+import net.sourceforge.pmd.lang.java.ast.ASTArguments;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
+import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
 public class UnnecessaryCaseChangeRule extends AbstractJavaRule {
 
+    private static final List<String> CASE_CHANGING_METHODS = asList("toLowerCase", "toUpperCase");
+    private static final List<String> EQUALITY_METHODS = asList("equals", "equalsIgnoreCase");
+
     @Override
-    public Object visit(ASTPrimaryExpression exp, Object data) {
-        int n = exp.getNumChildren();
-        if (n < 4) {
-            return data;
+    public Object visit(ASTPrimaryExpression expr, Object data) {
+        int caseChangingCallIndex = getCaseChangingMethodCallIndex(expr);
+        if (caseChangingCallIndex != -1) {
+            int chainedMethodCallIndex = caseChangingCallIndex + 2;
+            if (hasEqualsMethodCallChainedAtPosition(expr, chainedMethodCallIndex)
+                    || isArgumentOfEqualsMethodCall(expr)) {
+                addViolation(data, expr);
+            }
         }
-
-        int first = getBadPrefixOrNull(exp, n);
-        if (first == -1) {
-            return data;
-        }
-
-        String second = getBadSuffixOrNull(exp, first + 2);
-        if (second == null) {
-            return data;
-        }
-
-        if (!(exp.getChild(first + 1) instanceof ASTPrimarySuffix)) {
-            return data;
-        }
-        ASTPrimarySuffix methodCall = (ASTPrimarySuffix) exp.getChild(first + 1);
-        if (!methodCall.isArguments() || methodCall.getArgumentCount() > 0) {
-            return data;
-        }
-
-        addViolation(data, exp);
-        return data;
+        return super.visit(expr, data);
     }
 
-    private int getBadPrefixOrNull(ASTPrimaryExpression exp, int childrenCount) {
-        // verify PrimaryPrefix/Name[ends-with(@Image, 'toUpperCase']
-        for (int i = 0; i < childrenCount - 3; i++) {
-            Node child = exp.getChild(i);
-            String image;
-            if (child instanceof ASTPrimaryPrefix) {
-                if (child.getNumChildren() != 1 || !(child.getChild(0) instanceof ASTName)) {
-                    continue;
-                }
-
-                ASTName name = (ASTName) child.getChild(0);
-                image = name.getImage();
-            } else if (child instanceof ASTPrimarySuffix) {
-                image = ((ASTPrimarySuffix) child).getImage();
-            } else {
-                continue;
-            }
-
-            if (image == null || !(image.endsWith("toUpperCase") || image.endsWith("toLowerCase"))) {
-                continue;
-            } else {
-                return i;
+    private int getCaseChangingMethodCallIndex(ASTPrimaryExpression expr) {
+        List<JavaNode> exprNodes = expr.findChildrenOfType(JavaNode.class);
+        for (int callArgsIndex = 1; callArgsIndex < exprNodes.size(); callArgsIndex++) {
+            int callIndex = callArgsIndex - 1;
+            if (isCaseChangingMethodCall(exprNodes.get(callIndex), exprNodes.get(callArgsIndex))) {
+                return callIndex;
             }
         }
         return -1;
     }
 
-    private String getBadSuffixOrNull(ASTPrimaryExpression exp, int equalsPosition) {
-        // verify PrimarySuffix[@Image='equals']
-        if (!(exp.getChild(equalsPosition) instanceof ASTPrimarySuffix)) {
-            return null;
-        }
-
-        ASTPrimarySuffix suffix = (ASTPrimarySuffix) exp.getChild(equalsPosition);
-        if (suffix.getImage() == null
-                || !(suffix.hasImageEqualTo("equals") || suffix.hasImageEqualTo("equalsIgnoreCase"))) {
-            return null;
-        }
-        return suffix.getImage();
+    private boolean isCaseChangingMethodCall(JavaNode methodCall, JavaNode methodCallArgs) {
+        String methodName = getCalledMethodName(methodCall);
+        int methodArgsCount = getCalledMethodArgsCount(methodCallArgs);
+        return methodName != null
+                && isNameOfCaseChangingMethod(methodName) && methodArgsCount == 0;
     }
 
+    private String getCalledMethodName(JavaNode methodCall) {
+        if (methodCall instanceof ASTPrimaryPrefix) {
+            ASTName methodName = methodCall.getFirstDescendantOfType(ASTName.class);
+            return methodName != null ? methodName.getImage() : null;
+        }
+        return methodCall.getImage();
+    }
+
+    private boolean isNameOfCaseChangingMethod(String methodName) {
+        for (String caseChangingMethod : CASE_CHANGING_METHODS) {
+            if (methodName.endsWith(caseChangingMethod)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean hasEqualsMethodCallChainedAtPosition(ASTPrimaryExpression expr, int pos) {
+        int argsPos = pos + 1;
+        if (hasNodeAtPosition(expr, argsPos)) {
+            return isEqualsMethodCall(expr.getChild(pos), expr.getChild(argsPos));
+        }
+        return false;
+    }
+
+    private boolean hasNodeAtPosition(ASTPrimaryExpression expr, int pos) {
+        return pos < expr.getNumChildren();
+    }
+
+    private boolean isArgumentOfEqualsMethodCall(ASTPrimaryExpression expr) {
+        JavaNode parent = expr.getParent().getParent();
+        if (parent instanceof ASTArgumentList) {
+            ASTPrimarySuffix parentMethodCallArgs = parent.getFirstParentOfType(ASTPrimarySuffix.class);
+            List<JavaNode> parentNodes = parentMethodCallArgs.getParent().findChildrenOfType(JavaNode.class);
+            int parentMethodCallIndex = parentNodes.indexOf(parentMethodCallArgs) - 1;
+            JavaNode parentMethodCall = parentNodes.get(parentMethodCallIndex);
+            return isEqualsMethodCall(parentMethodCall, parentMethodCallArgs);
+        }
+        return false;
+    }
+
+    private boolean isEqualsMethodCall(JavaNode methodCall, JavaNode methodCallArgs) {
+        String methodName = methodCall.getImage();
+        int methodArgsCount = getCalledMethodArgsCount(methodCallArgs);
+        return methodName != null
+                && EQUALITY_METHODS.contains(methodName) && methodArgsCount == 1;
+    }
+
+    private int getCalledMethodArgsCount(JavaNode methodCall) {
+        ASTArguments args = methodCall.getFirstDescendantOfType(ASTArguments.class);
+        return args != null ? args.size() : -1;
+    }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnnecessaryCaseChangeRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnnecessaryCaseChangeRule.java
@@ -8,12 +8,9 @@ import static java.util.Arrays.asList;
 
 import java.util.List;
 
-import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTArguments;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
-import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
@@ -24,48 +21,81 @@ public class UnnecessaryCaseChangeRule extends AbstractJavaRule {
 
     @Override
     public Object visit(ASTPrimaryExpression expr, Object data) {
-        int caseChangingCallIndex = getCaseChangingMethodCallIndex(expr);
-        if (caseChangingCallIndex != -1) {
-            int chainedMethodCallIndex = caseChangingCallIndex + 2;
-            if (hasEqualsMethodCallChainedAtPosition(expr, chainedMethodCallIndex)
-                    || isArgumentOfEqualsMethodCall(expr)) {
-                addViolation(data, expr);
-                return data;
-            }
+        if (hasUnnecessaryCaseChange(expr)) {
+            addViolation(data, expr);
         }
         return super.visit(expr, data);
     }
 
-    private int getCaseChangingMethodCallIndex(ASTPrimaryExpression expr) {
-        for (int callArgsIndex = 1; callArgsIndex < expr.getNumChildren(); callArgsIndex++) {
-            JavaNode methodCallArgs = expr.getChild(callArgsIndex);
-            int callIndex = callArgsIndex - 1;
+    private boolean hasUnnecessaryCaseChange(ASTPrimaryExpression expr) {
+        int equalsMethodCallIndex = getEqualsMethodCallIndex(expr);
+        if (equalsMethodCallIndex != -1) {
+            int equalsMethodCallArgsIndex = equalsMethodCallIndex + 1;
+            ASTPrimaryExpression equalsCallArgs = getMethodCallArgsAtPosition(expr, equalsMethodCallArgsIndex);
+            return anyHasCaseChangingMethodCall(expr, equalsCallArgs);
+        }
+        return false;
+    }
+
+    private int getEqualsMethodCallIndex(ASTPrimaryExpression expr) {
+        for (int callIndex = 0; callIndex < expr.getNumChildren(); callIndex++) {
             JavaNode methodCall = expr.getChild(callIndex);
-            if (isCaseChangingMethodCall(methodCall, methodCallArgs)) {
+            if (isEqualsMethodCall(methodCall)) {
                 return callIndex;
             }
         }
         return -1;
     }
 
-    private boolean isCaseChangingMethodCall(JavaNode methodCall, JavaNode methodCallArgs) {
-        String methodName = getCalledMethodName(methodCall);
-        int methodArgsCount = getCalledMethodArgsCount(methodCallArgs);
-        return isNameOfCaseChangingMethod(methodName) && methodArgsCount == 0;
+    private boolean isEqualsMethodCall(JavaNode methodCall) {
+        return calledMethodHasNameFromList(methodCall, EQUALITY_METHODS);
     }
 
-    private String getCalledMethodName(JavaNode methodCall) {
-        if (methodCall instanceof ASTPrimaryPrefix) {
-            ASTName methodName = methodCall.getFirstDescendantOfType(ASTName.class);
-            return methodName != null ? methodName.getImage() : null;
+    private ASTPrimaryExpression getMethodCallArgsAtPosition(ASTPrimaryExpression expr, int argsPos) {
+        if (hasChildAtPosition(expr, argsPos)) {
+            JavaNode methodCallArgs = expr.getChild(argsPos);
+            return methodCallArgs.getFirstDescendantOfType(ASTPrimaryExpression.class);
         }
-        return methodCall.getImage();
+        return null;
     }
 
-    private boolean isNameOfCaseChangingMethod(String methodName) {
+    private boolean hasChildAtPosition(ASTPrimaryExpression expr, int pos) {
+        return expr.getNumChildren() > pos;
+    }
+
+    private boolean anyHasCaseChangingMethodCall(ASTPrimaryExpression ... exprs) {
+        for (ASTPrimaryExpression expr : exprs) {
+            if (expr != null && hasCaseChangingMethodCall(expr)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean hasCaseChangingMethodCall(ASTPrimaryExpression expr) {
+        for (int callArgsIndex = 1; callArgsIndex < expr.getNumChildren(); callArgsIndex++) {
+            JavaNode methodCall = expr.getChild(callArgsIndex - 1);
+            JavaNode methodCallArgs = expr.getChild(callArgsIndex);
+            if (isCaseChangingMethodCall(methodCall, methodCallArgs)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isCaseChangingMethodCall(JavaNode methodCall, JavaNode methodCallArgs) {
+        if (calledMethodHasNameFromList(methodCall, CASE_CHANGING_METHODS)) {
+            ASTArguments args = methodCallArgs.getFirstDescendantOfType(ASTArguments.class);
+            return args != null && args.size() == 0;
+        }
+        return false;
+    }
+
+    private boolean calledMethodHasNameFromList(JavaNode methodCall, List<String> nameList) {
+        String methodName = getCalledMethodName(methodCall);
         if (methodName != null) {
-            for (String caseChangingMethod : CASE_CHANGING_METHODS) {
-                if (methodName.endsWith(caseChangingMethod)) {
+            for (String nameFromList : nameList) {
+                if (methodName.endsWith(nameFromList)) {
                     return true;
                 }
             }
@@ -73,45 +103,20 @@ public class UnnecessaryCaseChangeRule extends AbstractJavaRule {
         return false;
     }
 
-    private boolean hasEqualsMethodCallChainedAtPosition(ASTPrimaryExpression expr, int pos) {
-        int argsPos = pos + 1;
-        if (hasNodeAtPosition(expr, argsPos)) {
-            JavaNode chainedMethodCall = expr.getChild(pos);
-            JavaNode chainedMethodCallArgs = expr.getChild(argsPos);
-            return isEqualsMethodCall(chainedMethodCall, chainedMethodCallArgs);
+    private String getCalledMethodName(JavaNode methodCall) {
+        String methodName = methodCall.getImage();
+        if (methodName == null) {
+            ASTName name = methodCall.getFirstDescendantOfType(ASTName.class);
+            return name != null ? methodNameFromCallImage(name.getImage()) : null;
         }
-        return false;
+        return methodName;
     }
 
-    private boolean hasNodeAtPosition(ASTPrimaryExpression expr, int pos) {
-        return pos < expr.getNumChildren();
-    }
-
-    private boolean isArgumentOfEqualsMethodCall(ASTPrimaryExpression expr) {
-        ASTPrimarySuffix parentMethodCallArgs = getParentMethodCallArgsSuffix(expr);
-        if (parentMethodCallArgs != null) {
-            List<JavaNode> parentNodes = parentMethodCallArgs.getParent().findChildrenOfType(JavaNode.class);
-            int parentMethodCallIndex = parentNodes.indexOf(parentMethodCallArgs) - 1;
-            JavaNode parentMethodCall = parentNodes.get(parentMethodCallIndex);
-            return isEqualsMethodCall(parentMethodCall, parentMethodCallArgs);
+    private String methodNameFromCallImage(String methodCallImage) {
+        if (methodCallImage.contains(".")) {
+            String[] callParts = methodCallImage.split("\\.");
+            return callParts[1];
         }
-        return false;
-    }
-
-    private ASTPrimarySuffix getParentMethodCallArgsSuffix(ASTPrimaryExpression expr) {
-        JavaNode parent = expr.getParent().getParent(); // ASTArgumentList/ASTExpression/ASTPrimaryExpression
-        return parent instanceof ASTArgumentList
-                ? parent.getFirstParentOfType(ASTPrimarySuffix.class)
-                : null;
-    }
-
-    private boolean isEqualsMethodCall(JavaNode methodCall, JavaNode methodCallArgs) {
-        int methodArgsCount = getCalledMethodArgsCount(methodCallArgs);
-        return EQUALITY_METHODS.contains(methodCall.getImage()) && methodArgsCount == 1;
-    }
-
-    private int getCalledMethodArgsCount(JavaNode methodCallArgs) {
-        ASTArguments args = methodCallArgs.getFirstDescendantOfType(ASTArguments.class);
-        return args != null ? args.size() : -1;
+        return methodCallImage;
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnnecessaryCaseChange.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnnecessaryCaseChange.xml
@@ -81,5 +81,18 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>NullPointerException if in constructor test</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void bar(String s) {
+        Person p = new Person(s.toUpperCase());
+        p.printData();
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnnecessaryCaseChange.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnnecessaryCaseChange.xml
@@ -54,7 +54,7 @@ public class Foo {
 
     <test-code>
         <description>failure case with toLowerCase().equals()</description>
-        <expected-problems>2</expected-problems>
+        <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Foo {
     public Object visit(ASTFieldDeclaration node, Object data) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnnecessaryCaseChange.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UnnecessaryCaseChange.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <test-data
-    xmlns="http://pmd.sourceforge.net/rule-tests"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
 
     <test-code>
         <description>failure case with toUpperCase().equals()</description>
@@ -54,7 +54,7 @@ public class Foo {
 
     <test-code>
         <description>failure case with toLowerCase().equals()</description>
-        <expected-problems>1</expected-problems>
+        <expected-problems>2</expected-problems>
         <code><![CDATA[
 public class Foo {
     public Object visit(ASTFieldDeclaration node, Object data) {
@@ -67,4 +67,19 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#2531 foo.equals(bar.toLowerCase()) false negative</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void bar(String s) {
+        if ("test".equals(s.toLowerCase())) {
+            System.out.println("Done");
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>
+


### PR DESCRIPTION

## Describe the PR

A check whether `toLowerCase()` or `toUpperCase()` method is called in arguments of an equals method has been added.
Also I've refactored some other methods of the class.
<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #2531 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

