### PR TITLE
[core] Bug with node stream drop 

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/IteratorBasedNStream.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/IteratorBasedNStream.java
@@ -104,6 +104,9 @@ abstract class IteratorBasedNStream<T extends Node> implements NodeStream<T> {
 
     @Override
     public @Nullable T get(int n) {
+        if (n == 0) {
+            return first();
+        }
         return IteratorUtil.getNth(iterator(), n);
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/StreamImpl.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/StreamImpl.java
@@ -142,12 +142,18 @@ public final class StreamImpl {
     static <T extends Node> NodeStream<T> ancestorsOrSelf(@Nullable Node node, Filtermap<Node, ? extends T> target) {
         if (node == null) {
             return empty();
-        } else if (node.getParent() == null) {
-            T apply = target.apply(node);
-            return apply != null ? singleton(apply) : empty();
         }
-        return target == Filtermap.NODE_IDENTITY ? (NodeStream<T>) new AncestorOrSelfStream(node)
-                                                 : new FilteredAncestorOrSelfStream<>(node, target);
+
+        if (target == Filtermap.NODE_IDENTITY) {
+            return (NodeStream<T>) new AncestorOrSelfStream(node);
+        }
+
+        T first = TraversalUtils.getFirstParentOrSelfMatching(node, target);
+        if (first == null) {
+            return empty();
+        }
+
+        return new FilteredAncestorOrSelfStream<>(first, target);
     }
 
     public static NodeStream<Node> ancestors(@NonNull Node node) {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/internal/NodeStreamBlanketTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/internal/NodeStreamBlanketTest.java
@@ -47,7 +47,9 @@ public class NodeStreamBlanketTest<T extends Node> {
                     node(
                         node(),
                         nodeB(
-                            node()
+                            node(
+                                nodeB()
+                            )
                         ),
                         node(),
                         nodeB()
@@ -132,7 +134,8 @@ public class NodeStreamBlanketTest<T extends Node> {
         assertImplication(
             stream,
             prop("count() > 1", it -> it.count() > 1),
-            prop("drop(2).toList() == toList().tail().tail()", it -> it.drop(2).toList().equals(tail(tail(it.toList()))))
+            prop("drop(2).toList() == toList().tail().tail()", it -> it.drop(2).toList().equals(tail(tail(it.toList())))),
+            prop("drop(1).drop(1) == drop(2)", it -> it.drop(1).drop(1).toList().equals(it.drop(2).toList()))
         );
     }
 


### PR DESCRIPTION
## Describe the PR

Fix a bug in ancestor node streams. 

If you have an ancestor path like `/B/B/A/A`, where the innermost (last) node is named `a`, then
`a.ancestors(B.class).drop(1)` was equivalent to `a.getParent().ancestors(B.class)`, which is wrong as it still contains both `B` nodes.

This also makes ancestor streams less lazy, so that they can be folded to empty streams more often.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

