### PR TITLE
[java] UnusedAssignment false positive with leaking this in constructor

### DIFF
--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
@@ -2784,10 +2784,11 @@ class Foo {
 
     <test-code>
         <description>This reference leak #2668</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>19</expected-linenumbers>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>19,26</expected-linenumbers>
         <expected-messages>
             <message>The value assigned to field 'ignore' is never used (overwritten on line 20)</message>
+            <message>The value assigned to field 'ignore' is never used (overwritten on line 28)</message>
         </expected-messages>
         <code><![CDATA[
 
@@ -2810,10 +2811,15 @@ class Foo {
 
                 A() {
                     ignore = false; // actually unused
-                    ignore = true;
-                    worker = new Worker(this); // leak (`ignore = true` may be used)
-                    ignore = false; // since the this reference has leaked, this may be observed by another thread
+                    ignore = true;  // may be observed by the leak
+                    worker = new Worker(this); // leak
+
+                    // This could technically be observed by another thread (not sure, maybe the field needs to be volatile too)
+                    // This looks like a very rare circumstance though.
+                    // So we say it's unused
                     ignore = false;
+
+                    ignore = false; // this exits the ctor so may be used later
                 }
 
                 void doWork() { worker.work(); }
@@ -2851,10 +2857,11 @@ class Foo {
 
     <test-code>
         <description>This reference leak in conditional #2668</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>4</expected-linenumbers>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>4,13</expected-linenumbers>
         <expected-messages>
             <message>The field initializer for 'ignore' is never used (overwritten on line 7)</message>
+            <message>The value assigned to field 'ignore' is never used (overwritten on line 15)</message>
         </expected-messages>
         <code><![CDATA[
             import somewhere.Worker;
@@ -2864,13 +2871,14 @@ class Foo {
 
                 A() {
                     ignore = false; // may be used by leak
+
                     if (Worker.something()) {
-                        worker = new Worker(this.foo());
+                        worker = new Worker(this.foo()); // marks the reaching defs as used bc of leak
                     } else {
                         worker = null;
-                        ignore = true; // false negative? there is no leak in this branch
+                        ignore = true; // there is no leak in this branch
                     }
-                    ignore = true; // but there is in the merged state
+                    ignore = true;
                 }
             }
             ]]></code>
@@ -2878,15 +2886,19 @@ class Foo {
 
     <test-code>
         <description>This reference leak with super call #2668</description>
-        <expected-problems>0</expected-problems>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>The field initializer for 'ignore' is never used (overwritten on line 8)</message>
+        </expected-messages>
         <code><![CDATA[
             import somewhere.Worker;
 
             class A extends Worker { // extends some unknown class
-                private boolean ignore = true;  // may be used by virtual method in super call
+                private boolean ignore = true;  // unused
 
                 A() {
-                    // implicit super call
+                    // implicit super call, which may observe the default value of ignore
                     ignore = false; // may be used by leak
                 }
             }
@@ -2894,21 +2906,21 @@ class Foo {
     </test-code>
 
     <test-code>
-        <description>This reference leak in conditional 2 #2668</description>
+        <description>This reference leak with explicit this ctor #2668</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
             import somewhere.Worker;
 
             class A {
-                private boolean ignore = true;  // may be used by leak
+                private boolean ignore = true;
 
                 A() {
-                    this(2); // this is opaque and we must assume that the ref is leaked
+                    this(2); // this may observe `ignore = true`
                     ignore = false; // may be used by leak
                 }
 
                 A(int k) {
-                    // actually doesn't leak the this..
+                    Worker.show(this); // observes `ignore = true`
                 }
             }
             ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
@@ -2782,5 +2782,136 @@ class Foo {
         ]]></code>
     </test-code>
 
+    <test-code>
+        <description>This reference leak #2668</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>19</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to field 'ignore' is never used (overwritten on line 20)</message>
+        </expected-messages>
+        <code><![CDATA[
+
+            class Worker {
+                private final Worker.Listener listener;
+
+                Worker(Listener listener) {
+                    this.listener = listener;
+                    work();
+                }
+
+                void work() {listener.onWork();}
+
+                interface Listener { void onWork(); }
+            }
+
+            class A implements Worker.Listener {
+                private boolean ignore;
+                private Worker worker;
+
+                A() {
+                    ignore = false; // actually unused
+                    ignore = true;
+                    worker = new Worker(this); // leak (`ignore = true` may be used)
+                    ignore = false; // since the this reference has leaked, this may be observed by another thread
+                    ignore = false;
+                }
+
+                void doWork() { worker.work(); }
+
+                public void onWork() {
+                    if (ignore) {
+                        return;
+                    }
+                    System.out.println("onWork");
+                }
+            }
+
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>This reference leak in field initializers #2668</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            import somewhere.Worker;
+
+            class A {
+                private boolean ignore = true;  // used
+
+                A() {
+                    ignore = false; // used
+                }
+
+                private Worker worker = new Worker(this.foo()); // there is a leak here
+
+                A foo() { return null; } // is virtual
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>This reference leak in conditional #2668</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>The field initializer for 'ignore' is never used (overwritten on line 7)</message>
+        </expected-messages>
+        <code><![CDATA[
+            import somewhere.Worker;
+
+            class A {
+                private boolean ignore = true;  // unused
+
+                A() {
+                    ignore = false; // may be used by leak
+                    if (Worker.something()) {
+                        worker = new Worker(this.foo());
+                    } else {
+                        worker = null;
+                        ignore = true; // false negative? there is no leak in this branch
+                    }
+                    ignore = true; // but there is in the merged state
+                }
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>This reference leak with super call #2668</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            import somewhere.Worker;
+
+            class A extends Worker { // extends some unknown class
+                private boolean ignore = true;  // may be used by virtual method in super call
+
+                A() {
+                    // implicit super call
+                    ignore = false; // may be used by leak
+                }
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>This reference leak in conditional 2 #2668</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            import somewhere.Worker;
+
+            class A {
+                private boolean ignore = true;  // may be used by leak
+
+                A() {
+                    this(2); // this is opaque and we must assume that the ref is leaked
+                    ignore = false; // may be used by leak
+                }
+
+                A(int k) {
+                    // actually doesn't leak the this..
+                }
+            }
+            ]]></code>
+    </test-code>
 
 </test-data>


### PR DESCRIPTION
## Describe the PR

Mark field assignments as used, if they may be observed by an external method/constructor call. This may occur if a constructor calls "leaks" a `this` reference by passing it as a parameter, or calls its own methods.

## Related issues


- Fixes #2668 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

