### PR TITLE
[java] add lombok.EqualsAndHashCode in AbstractLombokAwareRule

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractLombokAwareRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractLombokAwareRule.java
@@ -45,7 +45,6 @@ public class AbstractLombokAwareRule extends AbstractIgnoredAnnotationRule {
         LOMBOK_ANNOTATIONS.add("lombok.AllArgsConstructor");
         LOMBOK_ANNOTATIONS.add("lombok.NoArgsConstructor");
         LOMBOK_ANNOTATIONS.add("lombok.Builder");
-        LOMBOK_ANNOTATIONS.add("lombok.EqualsAndHashCode");
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractLombokAwareRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractLombokAwareRule.java
@@ -45,6 +45,7 @@ public class AbstractLombokAwareRule extends AbstractIgnoredAnnotationRule {
         LOMBOK_ANNOTATIONS.add("lombok.AllArgsConstructor");
         LOMBOK_ANNOTATIONS.add("lombok.NoArgsConstructor");
         LOMBOK_ANNOTATIONS.add("lombok.Builder");
+        LOMBOK_ANNOTATIONS.add("lombok.EqualsAndHashCode");
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateFieldRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateFieldRule.java
@@ -37,6 +37,7 @@ public class UnusedPrivateFieldRule extends AbstractLombokAwareRule {
         defaultValues.add("java.lang.Deprecated");
         defaultValues.add("javafx.fxml.FXML");
         defaultValues.add("lombok.experimental.Delegate");
+        defaultValues.add("lombok.EqualsAndHashCode");
         return defaultValues;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SingularFieldRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SingularFieldRule.java
@@ -62,6 +62,7 @@ public class SingularFieldRule extends AbstractLombokAwareRule {
         Collection<String> defaultValues = new ArrayList<>();
         defaultValues.addAll(super.defaultSuppressionAnnotations());
         defaultValues.add("lombok.experimental.Delegate");
+        defaultValues.add("lombok.EqualsAndHashCode");
         return defaultValues;
     }
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateField.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateField.xml
@@ -629,4 +629,16 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+    
+    <test-code>
+        <description>#2673 UnusedPrivateField false positive with lombok annotation EqualsAndHashCode</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import lombok.EqualsAndHashCode;
+@EqualsAndHashCode
+public class Foo {
+    private String bar;
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/SingularField.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/SingularField.xml
@@ -674,4 +674,17 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+    
+    <test-code>
+        <description>#2673 UnusedPrivateField false positive with lombok annotation EqualsAndHashCode</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode
+public class Foo {
+    private String bar;
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

Fix false positive with lombok annotation EqualsAndHashCode in UnusedPrivateField

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #2673

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

