### PR TITLE
[core] Deprecate RuleContext attributes

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -18,6 +18,12 @@ This is a {{ site.pmd.release_type }} release.
 
 ### API Changes
 
+#### Deprecated API
+
+- {% jdoc !!core::RuleContext#removeAttribute(java.lang.String) %}
+- {% jdoc !!core::RuleContext#getAttribute(java.lang.String) %}
+- {% jdoc !!core::RuleContext#setAttribute(java.lang.String, java.lang.Object) %}
+
 ### External Contributions
 
 {% endtocmaker %}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleContext.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleContext.java
@@ -167,7 +167,11 @@ public class RuleContext {
      *                <code>null</code>
      * @return <code>true</code> if the attribute was set, <code>false</code>
      *         otherwise.
+     *
+     * @deprecated Stateful methods of the rule context will be removed.
+     * Their interaction with incremental analysis are unspecified.
      */
+    @Deprecated
     public boolean setAttribute(String name, Object value) {
         if (name == null) {
             throw new IllegalArgumentException("Parameter 'name' cannot be null.");
@@ -194,7 +198,11 @@ public class RuleContext {
      *            The attribute name.
      * @return The current attribute value, or <code>null</code> if the
      *         attribute does not exist.
+     *
+     * @deprecated Stateful methods of the rule context will be removed.
+     * Their interaction with incremental analysis are unspecified.
      */
+    @Deprecated
     public Object getAttribute(String name) {
         return this.attributes.get(name);
     }
@@ -215,7 +223,11 @@ public class RuleContext {
      *            The attribute name.
      * @return The current attribute value, or <code>null</code> if the
      *         attribute does not exist.
+     *
+     * @deprecated Stateful methods of the rule context will be removed.
+     * Their interaction with incremental analysis are unspecified.
      */
+    @Deprecated
     public Object removeAttribute(String name) {
         return this.attributes.remove(name);
     }


### PR DESCRIPTION
## Describe the PR

Deprecate RuleContext attributes. They're apparently a way to share state between threads. This appears useless, and RuleContext could be a simpler object without them. Their interaction with incremental analysis is also unclear and overall they can't be relied upon.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

