### PR TITLE
[java] AvoidCatchingThrowable can not detect the case: catch (java.lang.Throwable t)

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidCatchingThrowableRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidCatchingThrowableRule.java
@@ -5,8 +5,6 @@
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 
 import net.sourceforge.pmd.lang.java.ast.ASTCatchStatement;
-import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
-import net.sourceforge.pmd.lang.java.ast.ASTType;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
 /**
@@ -18,12 +16,12 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 public class AvoidCatchingThrowableRule extends AbstractJavaRule {
 
     @Override
-    public Object visit(ASTCatchStatement node, Object data) {
-        ASTType type = node.getFirstDescendantOfType(ASTType.class);
-        ASTClassOrInterfaceType name = type.getFirstDescendantOfType(ASTClassOrInterfaceType.class);
-        if (name.hasImageEqualTo("Throwable")) {
-            addViolation(data, name);
+    public Object visit(ASTCatchStatement catchStatement, Object data) {
+        for (Class<? extends Exception> caughtException : catchStatement.getCaughtExceptionTypes()) {
+            if (Throwable.class.equals(caughtException)) {
+                addViolation(data, catchStatement);
+            }
         }
-        return super.visit(node, data);
+        return super.visit(catchStatement, data);
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidCatchingThrowable.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidCatchingThrowable.xml
@@ -27,4 +27,21 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>full class name false-negative test</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public void bar() {
+        try {
+            Foo.class.isAssignableFrom(null);
+        } catch(java.lang.Throwable e) {
+            e.printStackTrace();
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION

## Describe the PR

The predicate checking whether thrown type is Throwable has been changed to `Throwable.class.equals` to avoid false-negatives at `catch (java.lang.Throwable t)`.
<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #2439 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

