### PR TITLE
[java] InvalidLogMessageFormatRule throws IndexOutOfBoundsException when only logging exception message

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidLogMessageFormatRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidLogMessageFormatRule.java
@@ -89,9 +89,14 @@ public class InvalidLogMessageFormatRule extends AbstractJavaRule {
         final List<ASTExpression> argumentList = parentNode.getFirstChildOfType(ASTPrimarySuffix.class)
                 .getFirstDescendantOfType(ASTArgumentList.class).findChildrenOfType(ASTExpression.class);
 
-        // ignore the first argument if it is a known non-string value, e.g. a slf4j-Marker
         if (argumentList.get(0).getType() != null && !argumentList.get(0).getType().equals(String.class)) {
-            argumentList.remove(0);
+            if (argumentList.size() == 1) {
+                // no need to check for message params in case no string and no params found
+                return data;
+            } else {
+                // ignore the first argument if it is a known non-string value, e.g. a slf4j-Marker
+                argumentList.remove(0);
+            }
         }
 
         // remove the message parameter

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidLogMessageFormat.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidLogMessageFormat.xml
@@ -868,4 +868,23 @@ class InvalidLogMessageFormatTest {
 }
         ]]></code>
     </test-code>
+    
+    <test-code>
+        <description>#2431 IndexOutOfBoundsException when only logging exception message</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+public class Foo {
+    private static final Logger LOG = LoggerFactory.getLogger(Foo.class);
+    public void bar() {
+        try {
+            new File("/text.txt");
+        } catch (Exception e) {
+            LOG.warn(e.getMessage());
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION

## Describe the PR

Consider the following example:

     } catch(Exception e) {
        LOGGER.warn(e.getMessage());
     }

In the code below, an argument `e.getMessage()` will provide us with non null type returned from `argumentList.get(0).getType()` which is not String type, so the argument is removed. But as it is the only argument of a logger method call, `remove` statement at line 98 throws an exception. So I've added a separate check whether the argument is the only one.

https://github.com/pmd/pmd/blob/fe82f6a448205328ba95923dbb6b761881e1cd4f/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidLogMessageFormatRule.java#L93-L98

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #2431 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

