### PR TITLE
[java] Fix NoClassDefFoundErrors

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -27,6 +27,7 @@ This is a {{ site.pmd.release_type }} release.
     *   [#2653](https://github.com/pmd/pmd/issues/2653): \[lang-test] Upgrade kotlintest to Kotest
 *   java-bestpractices
     *   [#2471](https://github.com/pmd/pmd/issues/2471): \[java] New Rule: AvoidReassigningCatchVariables
+    *   [#2663](https://github.com/pmd/pmd/issues/2663): \[java] NoClassDefFoundError on upgrade from 6.25.0 to 6.26.0
     *   [#2668](https://github.com/pmd/pmd/issues/2668): \[java] UnusedAssignment false positives
 *   java-errorprone
     *   [#2431](https://github.com/pmd/pmd/issues/2431): \[java] InvalidLogMessageFormatRule throws IndexOutOfBoundsException when only logging exception message

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/ImportWrapper.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/ImportWrapper.java
@@ -39,15 +39,9 @@ public class ImportWrapper {
         this.node = node;
         this.isStaticDemand = isStaticDemand;
 
-        if (node != null && node.getType() != null) {
+        if (this.isStaticDemand && node != null && node.getType() != null) {
             Class<?> type = node.getType();
-            for (Method m : type.getMethods()) {
-                allDemands.add(m.getName());
-            }
-            for (Field f : type.getFields()) {
-                allDemands.add(f.getName());
-            }
-            // also consider static fields, that are not public
+            // consider static fields, public and non-public
             for (Field f : type.getDeclaredFields()) {
                 if (Modifier.isStatic(f.getModifiers())) {
                     allDemands.add(f.getName());

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/ImportWrapper.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/ImportWrapper.java
@@ -74,12 +74,10 @@ public class ImportWrapper {
             }
             return names;
         } catch (LinkageError e) {
-            String filename = ctx != null ? String.valueOf(ctx.getSourceCodeFile()) : "n/a";
-
             if (ctx != null) {
-                ctx.getReport().addError(new ProcessingError(e, filename));
+                ctx.getReport().addError(new ProcessingError(e, String.valueOf(ctx.getSourceCodeFile())));
             } else {
-                LOG.log(Level.WARNING, "Error while processing file " + filename, e);
+                LOG.log(Level.WARNING, "Error while processing imports", e);
             }
             return Collections.emptySet();
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/ImportWrapper.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/ImportWrapper.java
@@ -15,8 +15,6 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import net.sourceforge.pmd.Report.ProcessingError;
-import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
 
@@ -37,22 +35,22 @@ public class ImportWrapper {
     }
 
     public ImportWrapper(String fullname, String name, ASTImportDeclaration node) {
-        this(fullname, name, node, false, null);
+        this(fullname, name, node, false);
     }
 
-    public ImportWrapper(String fullname, String name, ASTImportDeclaration node, boolean isStaticDemand, RuleContext ctx) {
+    public ImportWrapper(String fullname, String name, ASTImportDeclaration node, boolean isStaticDemand) {
         this.fullname = fullname;
         this.name = name;
         this.node = node;
         this.isStaticDemand = isStaticDemand;
-        this.allStaticDemands = collectStaticFieldsAndMethods(node, ctx);
+        this.allStaticDemands = collectStaticFieldsAndMethods(node);
 
     }
 
     /**
      * @param node
      */
-    private Set<String> collectStaticFieldsAndMethods(ASTImportDeclaration node, RuleContext ctx) {
+    private Set<String> collectStaticFieldsAndMethods(ASTImportDeclaration node) {
         if (!this.isStaticDemand || node == null || node.getType() == null) {
             return Collections.emptySet();
         }
@@ -74,11 +72,8 @@ public class ImportWrapper {
             }
             return names;
         } catch (LinkageError e) {
-            if (ctx != null) {
-                ctx.getReport().addError(new ProcessingError(e, String.valueOf(ctx.getSourceCodeFile())));
-            } else {
-                LOG.log(Level.WARNING, "Error while processing imports", e);
-            }
+            // This is an incomplete classpath, report the missing class
+            LOG.log(Level.FINE, "Possible incomplete auxclasspath: Error while processing imports", e);
             return Collections.emptySet();
         }
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.Stack;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import net.sourceforge.pmd.lang.java.ast.ASTAllocationExpression;
@@ -131,7 +132,8 @@ public class MissingOverrideRule extends AbstractJavaRule {
 
             return new MethodLookup(result, overridden);
         } catch (final LinkageError e) {
-            // we may have an incomplete auxclasspath
+            // This is an incomplete classpath, report the missing class
+            LOG.log(Level.FINE, "Possible incomplete auxclasspath: Error while processing methods", e);
             return null;
         }
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
@@ -10,7 +10,6 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
@@ -118,7 +117,7 @@ public class UnusedImportsRule extends AbstractJavaRule {
     public Object visit(ASTImportDeclaration node, Object data) {
         if (node.isImportOnDemand()) {
             ASTName importedType = (ASTName) node.getChild(0);
-            imports.add(new ImportWrapper(importedType.getImage(), null, node, node.isStatic(), (RuleContext) data));
+            imports.add(new ImportWrapper(importedType.getImage(), null, node, node.isStatic()));
         } else {
             if (!node.isImportOnDemand()) {
                 ASTName importedType = (ASTName) node.getChild(0);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
@@ -117,7 +118,7 @@ public class UnusedImportsRule extends AbstractJavaRule {
     public Object visit(ASTImportDeclaration node, Object data) {
         if (node.isImportOnDemand()) {
             ASTName importedType = (ASTName) node.getChild(0);
-            imports.add(new ImportWrapper(importedType.getImage(), null, node, node.isStatic()));
+            imports.add(new ImportWrapper(importedType.getImage(), null, node, node.isStatic(), (RuleContext) data));
         } else {
             if (!node.isImportOnDemand()) {
                 ASTName importedType = (ASTName) node.getChild(0);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/DuplicateImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/DuplicateImportsRule.java
@@ -69,11 +69,15 @@ public class DuplicateImportsRule extends AbstractJavaRule {
                 } else {
                     Class<?> importClass = node.getClassTypeResolver().loadClassOrNull(thisImportOnDemand.getName());
                     if (importClass != null) {
-                        for (Method m : importClass.getMethods()) {
-                            if (Modifier.isStatic(m.getModifiers()) && m.getName().equals(singleTypeName)) {
-                                // static method in another imported class
-                                return true;
+                        try {
+                            for (Method m : importClass.getMethods()) {
+                                if (Modifier.isStatic(m.getModifiers()) && m.getName().equals(singleTypeName)) {
+                                    // static method in another imported class
+                                    return true;
+                                }
                             }
+                        } catch (LinkageError ignored) {
+                            // TODO : This is an incomplete classpath, report the missing class
                         }
                     }
                 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/DuplicateImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/DuplicateImportsRule.java
@@ -9,6 +9,7 @@ import java.lang.reflect.Modifier;
 import java.util.HashSet;
 import java.util.Set;
 
+import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
 import net.sourceforge.pmd.lang.java.ast.internal.ImportWrapper;
@@ -87,7 +88,7 @@ public class DuplicateImportsRule extends AbstractJavaRule {
     @Override
     public Object visit(ASTImportDeclaration node, Object data) {
         ImportWrapper wrapper = new ImportWrapper(node.getImportedName(), node.getImportedName(),
-                node, node.isStatic() && node.isImportOnDemand());
+                node, node.isStatic() && node.isImportOnDemand(), (RuleContext) data);
 
         // blahhhh... this really wants to be ASTImportDeclaration to be
         // polymorphic...

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/DuplicateImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/DuplicateImportsRule.java
@@ -8,14 +8,16 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
-import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
 import net.sourceforge.pmd.lang.java.ast.internal.ImportWrapper;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
 public class DuplicateImportsRule extends AbstractJavaRule {
+    private static final Logger LOG = Logger.getLogger(DuplicateImportsRule.class.getName());
 
     private Set<ImportWrapper> singleTypeImports;
     private Set<ImportWrapper> importOnDemandImports;
@@ -76,8 +78,9 @@ public class DuplicateImportsRule extends AbstractJavaRule {
                                     return true;
                                 }
                             }
-                        } catch (LinkageError ignored) {
-                            // TODO : This is an incomplete classpath, report the missing class
+                        } catch (LinkageError e) {
+                            // This is an incomplete classpath, report the missing class
+                            LOG.log(Level.FINE, "Possible incomplete auxclasspath: Error while processing methods", e);
                         }
                     }
                 }
@@ -92,7 +95,7 @@ public class DuplicateImportsRule extends AbstractJavaRule {
     @Override
     public Object visit(ASTImportDeclaration node, Object data) {
         ImportWrapper wrapper = new ImportWrapper(node.getImportedName(), node.getImportedName(),
-                node, node.isStatic() && node.isImportOnDemand(), (RuleContext) data);
+                node, node.isStatic() && node.isImportOnDemand());
 
         // blahhhh... this really wants to be ASTImportDeclaration to be
         // polymorphic...

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryFullyQualifiedNameRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryFullyQualifiedNameRule.java
@@ -335,10 +335,14 @@ public class UnnecessaryFullyQualifiedNameRule extends AbstractJavaRule {
                         // We need type resolution to make sure there is a
                         // conflicting method
                         if (importDeclaration.getType() != null) {
-                            for (final Method m : importDeclaration.getType().getMethods()) {
-                                if (m.getName().equals(methodCalled)) {
-                                    return true;
+                            try {
+                                for (final Method m : importDeclaration.getType().getMethods()) {
+                                    if (m.getName().equals(methodCalled)) {
+                                        return true;
+                                    }
                                 }
+                            } catch (LinkageError ignored) {
+                                // TODO : This is an incomplete classpath, report the missing class
                             }
                         }
                     } else if (importDeclaration.getImportedName().endsWith(methodCalled)) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryFullyQualifiedNameRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryFullyQualifiedNameRule.java
@@ -11,6 +11,8 @@ import java.util.List;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -32,6 +34,7 @@ import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
 import net.sourceforge.pmd.lang.symboltable.Scope;
 
 public class UnnecessaryFullyQualifiedNameRule extends AbstractJavaRule {
+    private static final Logger LOG = Logger.getLogger(UnnecessaryFullyQualifiedNameRule.class.getName());
 
     private List<ASTImportDeclaration> imports = new ArrayList<>();
     private String currentPackage;
@@ -341,8 +344,9 @@ public class UnnecessaryFullyQualifiedNameRule extends AbstractJavaRule {
                                         return true;
                                     }
                                 }
-                            } catch (LinkageError ignored) {
-                                // TODO : This is an incomplete classpath, report the missing class
+                            } catch (LinkageError e) {
+                                // This is an incomplete classpath, report the missing class
+                                LOG.log(Level.FINE, "Possible incomplete auxclasspath: Error while processing methods", e);
                             }
                         }
                     } else if (importDeclaration.getImportedName().endsWith(methodCalled)) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/MethodTypeResolution.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/MethodTypeResolution.java
@@ -475,8 +475,9 @@ public final class MethodTypeResolution {
                     result.add(getTypeDefOfMethod(context, method, typeArguments));
                 }
             }
-        } catch (final LinkageError ignored) {
-            // TODO : This is an incomplete classpath, report the missing class
+        } catch (final LinkageError e) {
+            // This is an incomplete classpath, report the missing class
+            LOG.log(Level.FINE, "Possible incomplete auxclasspath: Error while processing methods", e);
         }
 
         // search it's supertype


### PR DESCRIPTION
## Describe the PR

When determining methods/fields by reflection, we could run into situations, that the classes, that are referenced in the methods (e.g. parameter types, return types) are not on the auxclasspath. Then a LinkageError is thrown, which was not handled before.

The reason, why the types are missing on the auxclasspath is actually a valid case: As long as the methods are not used in the code, the referenced classes neither need to be on the compile classpath. And we use the compile classpath as our auxclasspath.

This can happen, if a project uses a provided dependency and this dependency has other transitive dependencies. These transitive dependencies are not on the compile classpath.

This PR fixes the problem in ImportWrapper as well as in two other cases, where we use reflection.

## Related issues

- Fixes #2663 

## Ready?

- [ ] Added unit tests for fixed bug/feature - I only tested it with the integration test from #2663 
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

