### PR TITLE
[all] Fix rules to call super.visit or use rulechain

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexAssertionsShouldIncludeMessageRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexAssertionsShouldIncludeMessageRule.java
@@ -28,6 +28,6 @@ public class ApexAssertionsShouldIncludeMessageRule extends AbstractApexUnitTest
                     "''{0}'' should have 3 parameters.",
                     new Object[] { methodName });
         }
-        return data;
+        return super.visit(node, data);
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveAssertsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestClassShouldHaveAssertsRule.java
@@ -34,6 +34,8 @@ public class ApexUnitTestClassShouldHaveAssertsRule extends AbstractApexUnitTest
 
     @Override
     public Object visit(ASTMethod node, Object data) {
+        super.visit(node, data);
+
         if (!isTestMethodOrClass(node)) {
             return data;
         }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestMethodShouldHaveIsTestAnnotationRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestMethodShouldHaveIsTestAnnotationRule.java
@@ -24,6 +24,8 @@ public class ApexUnitTestMethodShouldHaveIsTestAnnotationRule extends AbstractAp
 
     @Override
     public Object visit(final ASTMethod node, final Object data) {
+        super.visit(node, data);
+
         // test methods should have @isTest annotation.
         if (isTestMethodOrClass(node)) {
             return data;

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestShouldNotUseSeeAllDataTrueRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestShouldNotUseSeeAllDataTrueRule.java
@@ -28,17 +28,21 @@ public class ApexUnitTestShouldNotUseSeeAllDataTrueRule extends AbstractApexUnit
 
     @Override
     public Object visit(final ASTUserClass node, final Object data) {
+        super.visit(node, data);
+
         // @isTest(seeAllData) was introduced in v24, and was set to false by default
         if (!isTestMethodOrClass(node) && node.getApexVersion() >= Version.V176.getExternal()) {
             return data;
         }
 
         checkForSeeAllData(node, data);
-        return super.visit(node, data);
+        return data;
     }
 
     @Override
     public Object visit(ASTMethod node, Object data) {
+        super.visit(node, data);
+
         if (!isTestMethodOrClass(node)) {
             return data;
         }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/AvoidGlobalModifierRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/AvoidGlobalModifierRule.java
@@ -14,6 +14,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTUserInterface;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 
+@SuppressWarnings("PMD.AlwaysCallSuperWhenNotUsingRuleChain")
 public class AvoidGlobalModifierRule extends AbstractApexRule {
 
     public AvoidGlobalModifierRule() {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/VariableNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/VariableNamingConventionsRule.java
@@ -138,6 +138,8 @@ public class VariableNamingConventionsRule extends AbstractApexRule {
 
     @Override
     public Object visit(ASTField node, Object data) {
+        super.visit(node, data);
+
         if (!checkMembers) {
             return data;
         }
@@ -150,6 +152,7 @@ public class VariableNamingConventionsRule extends AbstractApexRule {
 
     @Override
     public Object visit(ASTVariableDeclaration node, Object data) {
+        super.visit(node, data);
 
         if (!checkLocals) {
             return data;
@@ -161,6 +164,8 @@ public class VariableNamingConventionsRule extends AbstractApexRule {
 
     @Override
     public Object visit(ASTParameter node, Object data) {
+        super.visit(node, data);
+
         if (!checkParameters) {
             return data;
         }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/CognitiveComplexityRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/CognitiveComplexityRule.java
@@ -84,6 +84,7 @@ public class CognitiveComplexityRule extends AbstractApexRule {
 
     @Override
     public final Object visit(ASTMethod node, Object data) {
+        super.visit(node, data);
 
         if (ApexOperationMetricKey.COGNITIVE.supports(node)) {
             int cognitive = (int) MetricsUtil.computeMetric(ApexOperationMetricKey.COGNITIVE, node);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/CyclomaticComplexityRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/CyclomaticComplexityRule.java
@@ -89,6 +89,7 @@ public class CyclomaticComplexityRule extends AbstractApexRule {
 
     @Override
     public final Object visit(ASTMethod node, Object data) {
+        super.visit(node, data);
 
         if (ApexOperationMetricKey.CYCLO.supports(node)) {
             int cyclo = (int) MetricsUtil.computeMetric(ApexOperationMetricKey.CYCLO, node);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessiveLengthRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessiveLengthRule.java
@@ -25,6 +25,6 @@ public class ExcessiveLengthRule extends AbstractStatisticalApexRule {
             addDataPoint(point);
         }
 
-        return node.childrenAccept(this, data);
+        return super.visit(node, data);
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessiveNodeCountRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessiveNodeCountRule.java
@@ -26,7 +26,7 @@ import net.sourceforge.pmd.stat.DataPoint;
  * All others will return 0 (or the sum of counted nodes underneath.)
  * </p>
  */
-
+@SuppressWarnings("PMD.AlwaysCallSuperWhenNotUsingRuleChain")
 public class ExcessiveNodeCountRule extends AbstractStatisticalApexRule {
     private Class<?> nodeClass;
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessiveParameterListRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessiveParameterListRule.java
@@ -24,6 +24,7 @@ public class ExcessiveParameterListRule extends ExcessiveNodeCountRule {
 
     @Override
     public Object visit(ASTParameter node, Object data) {
+        super.visit(node, data);
         return NumericConstants.ONE;
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessivePublicCountRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessivePublicCountRule.java
@@ -35,6 +35,7 @@ public class ExcessivePublicCountRule extends ExcessiveNodeCountRule {
 
     @Override
     public Object visit(ASTMethod node, Object data) {
+        super.visit(node, data);
         if (node.getModifiers().isPublic() && !node.getImage().matches("<clinit>|<init>|clone")) {
             return NumericConstants.ONE;
         }
@@ -43,6 +44,7 @@ public class ExcessivePublicCountRule extends ExcessiveNodeCountRule {
 
     @Override
     public Object visit(ASTFieldDeclarationStatements node, Object data) {
+        super.visit(node, data);
         if (node.getModifiers().isPublic() && !node.getModifiers().isStatic()) {
             return NumericConstants.ONE;
         }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/NcssTypeCountRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/NcssTypeCountRule.java
@@ -17,6 +17,7 @@ import net.sourceforge.pmd.util.NumericConstants;
  *
  * @author ported from Java original of Jason Bennett
  */
+@SuppressWarnings("PMD.AlwaysCallSuperWhenNotUsingRuleChain")
 public class NcssTypeCountRule extends AbstractNcssCountRule {
 
     /**

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/StdCyclomaticComplexityRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/StdCyclomaticComplexityRule.java
@@ -9,7 +9,6 @@ import static net.sourceforge.pmd.properties.constraints.NumericConstraints.inRa
 
 import java.util.Stack;
 
-import net.sourceforge.pmd.lang.apex.ast.ASTBooleanExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTDoLoopStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTForEachStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTForLoopStatement;
@@ -18,8 +17,6 @@ import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
 import net.sourceforge.pmd.lang.apex.ast.ASTTernaryExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTTryCatchFinallyBlockStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
-import net.sourceforge.pmd.lang.apex.ast.ASTUserEnum;
-import net.sourceforge.pmd.lang.apex.ast.ASTUserInterface;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserTrigger;
 import net.sourceforge.pmd.lang.apex.ast.ASTWhileLoopStatement;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
@@ -123,18 +120,8 @@ public class StdCyclomaticComplexityRule extends AbstractApexRule {
     }
 
     @Override
-    public Object visit(ASTUserInterface node, Object data) {
-        return data;
-    }
-
-    @Override
-    public Object visit(ASTUserEnum node, Object data) {
-        return data;
-    }
-
-    @Override
     public Object visit(ASTMethod node, Object data) {
-        if (!node.getImage().matches("<clinit>|<init>|clone")) {
+        if (!entryStack.isEmpty() && !node.getImage().matches("<clinit>|<init>|clone")) {
             entryStack.push(new Entry());
             super.visit(node, data);
             Entry methodEntry = entryStack.pop();
@@ -202,11 +189,6 @@ public class StdCyclomaticComplexityRule extends AbstractApexRule {
     public Object visit(ASTTernaryExpression node, Object data) {
         entryStack.peek().bumpDecisionPoints();
         super.visit(node, data);
-        return data;
-    }
-
-    @Override
-    public Object visit(ASTBooleanExpression node, Object data) {
         return data;
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexCSRFRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/ApexCSRFRule.java
@@ -41,7 +41,7 @@ public class ApexCSRFRule extends AbstractApexRule {
         if (!Helper.isTestMethodOrClass(node)) {
             checkForCSRF(node, data);
         }
-        return data;
+        return super.visit(node, data);
     }
 
     @Override
@@ -49,7 +49,7 @@ public class ApexCSRFRule extends AbstractApexRule {
         if (node.getParent() instanceof ASTUserClass && Helper.foundAnyDML(node)) {
             addViolation(data, node);
         }
-        return data;
+        return super.visit(node, data);
     }
 
     private void checkForCSRF(ASTMethod node, Object data) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/performance/AvoidDmlStatementsInLoopsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/performance/AvoidDmlStatementsInLoopsRule.java
@@ -33,7 +33,7 @@ public class AvoidDmlStatementsInLoopsRule extends AbstractApexRule {
         if (insideLoop(node)) {
             addViolation(data, node);
         }
-        return data;
+        return super.visit(node, data);
     }
 
     @Override
@@ -41,7 +41,7 @@ public class AvoidDmlStatementsInLoopsRule extends AbstractApexRule {
         if (insideLoop(node)) {
             addViolation(data, node);
         }
-        return data;
+        return super.visit(node, data);
     }
 
     @Override
@@ -49,7 +49,7 @@ public class AvoidDmlStatementsInLoopsRule extends AbstractApexRule {
         if (insideLoop(node)) {
             addViolation(data, node);
         }
-        return data;
+        return super.visit(node, data);
     }
 
     @Override
@@ -57,7 +57,7 @@ public class AvoidDmlStatementsInLoopsRule extends AbstractApexRule {
         if (insideLoop(node)) {
             addViolation(data, node);
         }
-        return data;
+        return super.visit(node, data);
     }
 
     @Override
@@ -65,7 +65,7 @@ public class AvoidDmlStatementsInLoopsRule extends AbstractApexRule {
         if (insideLoop(node)) {
             addViolation(data, node);
         }
-        return data;
+        return super.visit(node, data);
     }
 
     @Override
@@ -73,7 +73,7 @@ public class AvoidDmlStatementsInLoopsRule extends AbstractApexRule {
         if (insideLoop(node)) {
             addViolation(data, node);
         }
-        return data;
+        return super.visit(node, data);
     }
 
     private boolean insideLoop(AbstractNode node) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/performance/AvoidSoqlInLoopsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/performance/AvoidSoqlInLoopsRule.java
@@ -17,6 +17,7 @@ import net.sourceforge.pmd.lang.ast.Node;
 public class AvoidSoqlInLoopsRule extends AbstractApexRule {
 
     public AvoidSoqlInLoopsRule() {
+        addRuleChainVisit(ASTSoqlExpression.class);
         setProperty(CODECLIMATE_CATEGORIES, "Performance");
         // Note: Often more complicated as just moving the SOQL a few lines.
         // Involves Maps...

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/performance/AvoidSoslInLoopsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/performance/AvoidSoslInLoopsRule.java
@@ -16,6 +16,7 @@ import net.sourceforge.pmd.lang.ast.Node;
 public class AvoidSoslInLoopsRule extends AbstractApexRule {
 
     public AvoidSoslInLoopsRule() {
+        addRuleChainVisit(ASTSoslExpression.class);
         setProperty(CODECLIMATE_CATEGORIES, "Performance");
         // Note: Often more complicated as just moving the SOSL a few lines.
         // Involves Maps...

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexBadCryptoRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexBadCryptoRule.java
@@ -38,6 +38,7 @@ public class ApexBadCryptoRule extends AbstractApexRule {
         setProperty(CODECLIMATE_CATEGORIES, "Security");
         setProperty(CODECLIMATE_REMEDIATION_MULTIPLIER, 100);
         setProperty(CODECLIMATE_BLOCK_HIGHLIGHTING, false);
+        addRuleChainVisit(ASTUserClass.class);
     }
 
     @Override

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
@@ -116,38 +116,38 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     @Override
     public Object visit(ASTMethodCallExpression node, Object data) {
         collectCRUDMethodLevelChecks(node);
-        return data;
+        return super.visit(node, data);
     }
 
     @Override
     public Object visit(ASTDmlInsertStatement node, Object data) {
         checkForCRUD(node, data, IS_CREATEABLE);
-        return data;
+        return super.visit(node, data);
     }
 
     @Override
     public Object visit(ASTDmlDeleteStatement node, Object data) {
         checkForCRUD(node, data, IS_DELETABLE);
-        return data;
+        return super.visit(node, data);
     }
 
     @Override
     public Object visit(ASTDmlUpdateStatement node, Object data) {
         checkForCRUD(node, data, IS_UPDATEABLE);
-        return data;
+        return super.visit(node, data);
     }
 
     @Override
     public Object visit(ASTDmlUpsertStatement node, Object data) {
         checkForCRUD(node, data, IS_CREATEABLE);
         checkForCRUD(node, data, IS_UPDATEABLE);
-        return data;
+        return super.visit(node, data);
     }
 
     @Override
     public Object visit(ASTDmlMergeStatement node, Object data) {
         checkForCRUD(node, data, IS_MERGEABLE);
-        return data;
+        return super.visit(node, data);
     }
 
     @Override
@@ -157,7 +157,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
             checkForAccessibility(soql, data);
         }
 
-        return data;
+        return super.visit(node, data);
     }
 
     @Override
@@ -170,8 +170,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
             checkForAccessibility(soql, data);
         }
 
-        return data;
-
+        return super.visit(node, data);
     }
 
     @Override
@@ -197,8 +196,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
             checkForAccessibility(soql, data);
         }
 
-        return data;
-
+        return super.visit(node, data);
     }
 
     @Override
@@ -208,7 +206,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
             checkForAccessibility(soql, data);
         }
 
-        return data;
+        return super.visit(node, data);
     }
 
     private void addVariableToMapping(final String variableName, final String type) {
@@ -242,8 +240,7 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
             addVariableToMapping(Helper.getFQVariableName(field), fieldType);
         }
 
-        return data;
-
+        return super.visit(node, data);
     }
 
     private void collectCRUDMethodLevelChecks(final ASTMethodCallExpression node) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexDangerousMethodsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexDangerousMethodsRule.java
@@ -40,7 +40,7 @@ public class ApexDangerousMethodsRule extends AbstractApexRule {
     private final Set<String> whiteListedVariables = new HashSet<>();
 
     public ApexDangerousMethodsRule() {
-        super.addRuleChainVisit(ASTUserClass.class);
+        addRuleChainVisit(ASTUserClass.class);
         setProperty(CODECLIMATE_CATEGORIES, "Security");
         setProperty(CODECLIMATE_REMEDIATION_MULTIPLIER, 100);
         setProperty(CODECLIMATE_BLOCK_HIGHLIGHTING, false);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexInsecureEndpointRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexInsecureEndpointRule.java
@@ -41,19 +41,19 @@ public class ApexInsecureEndpointRule extends AbstractApexRule {
     @Override
     public Object visit(ASTAssignmentExpression node, Object data) {
         findInsecureEndpoints(node);
-        return data;
+        return super.visit(node, data);
     }
 
     @Override
     public Object visit(ASTVariableDeclaration node, Object data) {
         findInsecureEndpoints(node);
-        return data;
+        return super.visit(node, data);
     }
 
     @Override
     public Object visit(ASTFieldDeclaration node, Object data) {
         findInsecureEndpoints(node);
-        return data;
+        return super.visit(node, data);
     }
 
     private void findInsecureEndpoints(ApexNode<?> node) {
@@ -83,7 +83,7 @@ public class ApexInsecureEndpointRule extends AbstractApexRule {
     @Override
     public Object visit(ASTMethodCallExpression node, Object data) {
         processInsecureEndpoint(node, data);
-        return data;
+        return super.visit(node, data);
     }
 
     private void processInsecureEndpoint(ASTMethodCallExpression node, Object data) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexOpenRedirectRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexOpenRedirectRule.java
@@ -31,7 +31,7 @@ public class ApexOpenRedirectRule extends AbstractApexRule {
     private final Set<String> listOfStringLiteralVariables = new HashSet<>();
 
     public ApexOpenRedirectRule() {
-        super.addRuleChainVisit(ASTUserClass.class);
+        addRuleChainVisit(ASTUserClass.class);
         setProperty(CODECLIMATE_CATEGORIES, "Security");
         setProperty(CODECLIMATE_REMEDIATION_MULTIPLIER, 100);
         setProperty(CODECLIMATE_BLOCK_HIGHLIGHTING, false);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
@@ -51,6 +51,7 @@ public class ApexSOQLInjectionRule extends AbstractApexRule {
     private final Map<String, Boolean> selectContainingVariables = new HashMap<>();
 
     public ApexSOQLInjectionRule() {
+        addRuleChainVisit(ASTUserClass.class);
         setProperty(CODECLIMATE_CATEGORIES, "Security");
         setProperty(CODECLIMATE_REMEDIATION_MULTIPLIER, 100);
         setProperty(CODECLIMATE_BLOCK_HIGHLIGHTING, false);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSharingViolationsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSharingViolationsRule.java
@@ -24,6 +24,7 @@ public class ApexSharingViolationsRule extends AbstractApexRule {
     private WeakHashMap<ApexNode<?>, Object> localCacheOfReportedNodes = new WeakHashMap<>();
 
     public ApexSharingViolationsRule() {
+        addRuleChainVisit(ASTUserClass.class);
         setProperty(CODECLIMATE_CATEGORIES, "Security");
         setProperty(CODECLIMATE_REMEDIATION_MULTIPLIER, 100);
         setProperty(CODECLIMATE_BLOCK_HIGHLIGHTING, false);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSuggestUsingNamedCredRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSuggestUsingNamedCredRule.java
@@ -34,7 +34,7 @@ public class ApexSuggestUsingNamedCredRule extends AbstractApexRule {
     private final Set<String> listOfAuthorizationVariables = new HashSet<>();
 
     public ApexSuggestUsingNamedCredRule() {
-        super.addRuleChainVisit(ASTUserClass.class);
+        addRuleChainVisit(ASTUserClass.class);
         setProperty(CODECLIMATE_CATEGORIES, "Security");
         setProperty(CODECLIMATE_REMEDIATION_MULTIPLIER, 100);
         setProperty(CODECLIMATE_BLOCK_HIGHLIGHTING, false);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromEscapeFalseRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromEscapeFalseRule.java
@@ -23,6 +23,7 @@ public class ApexXSSFromEscapeFalseRule extends AbstractApexRule {
     private static final String ADD_ERROR = "addError";
 
     public ApexXSSFromEscapeFalseRule() {
+        addRuleChainVisit(ASTUserClass.class);
         setProperty(CODECLIMATE_CATEGORIES, "Security");
         setProperty(CODECLIMATE_REMEDIATION_MULTIPLIER, 100);
         setProperty(CODECLIMATE_BLOCK_HIGHLIGHTING, false);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromURLParamRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexXSSFromURLParamRule.java
@@ -28,6 +28,7 @@ import net.sourceforge.pmd.lang.apex.rule.internal.Helper;
  * @author sergey.gorbaty
  *
  */
+@SuppressWarnings("PMD.AlwaysCallSuperWhenNotUsingRuleChain")
 public class ApexXSSFromURLParamRule extends AbstractApexRule {
     private static final String[] URL_PARAMETER_METHOD = new String[] { "ApexPages", "currentPage", "getParameters",
         "get", };

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexXSSFromURLParam.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexXSSFromURLParam.xml
@@ -147,6 +147,7 @@ public class Foo {
     <test-code>
         <description>URL parameter passed to a function without being escaped</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     public void test1() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractInefficientZeroCheck.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractInefficientZeroCheck.java
@@ -66,7 +66,7 @@ public abstract class AbstractInefficientZeroCheck extends AbstractJavaRule {
         if (nameNode == null || nameNode instanceof ASTPrimitiveType
                 || node.getNameDeclaration() == null
                 || !appliesToClassName(node.getNameDeclaration().getTypeImage())) {
-            return data;
+            return super.visit(node, data);
         }
 
         List<NameOccurrence> declars = node.getUsages();
@@ -78,7 +78,7 @@ public abstract class AbstractInefficientZeroCheck extends AbstractJavaRule {
             Node expr = jocc.getLocation().getParent().getParent().getParent();
             checkNodeAndReport(data, jocc.getLocation(), expr);
         }
-        return data;
+        return super.visit(node, data);
     }
 
     /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/GenericLiteralCheckerRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/GenericLiteralCheckerRule.java
@@ -30,6 +30,7 @@ public class GenericLiteralCheckerRule extends AbstractJavaRule {
 
     public GenericLiteralCheckerRule() {
         definePropertyDescriptor(REGEX_PROPERTY);
+        addRuleChainVisit(ASTLiteral.class);
     }
 
     private void init() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/StringConcatenationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/StringConcatenationRule.java
@@ -11,6 +11,10 @@ import net.sourceforge.pmd.lang.java.ast.ASTForStatement;
 //FUTURE This is not referenced by any RuleSet?
 public class StringConcatenationRule extends AbstractJavaRule {
 
+    public StringConcatenationRule() {
+        addRuleChainVisit(ASTForStatement.class);
+    }
+
     @Override
     public Object visit(ASTForStatement node, Object data) {
         Node forLoopStmt = null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/SymbolTableTestRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/SymbolTableTestRule.java
@@ -17,6 +17,10 @@ import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
 @Deprecated
 public class SymbolTableTestRule extends AbstractJavaRule {
 
+    public SymbolTableTestRule() {
+        addRuleChainVisit(ASTFieldDeclaration.class);
+    }
+
     @Override
     public Object visit(ASTFieldDeclaration node, Object data) {
         for (ASTVariableDeclaratorId declaration : node.findDescendantsOfType(ASTVariableDeclaratorId.class)) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/UselessAssignment.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/UselessAssignment.java
@@ -21,6 +21,10 @@ public class UselessAssignment extends AbstractJavaRule implements Executable {
 
     private RuleContext rc;
 
+    public UselessAssignment() {
+        addRuleChainVisit(ASTMethodDeclaration.class);
+    }
+
     @Override
     public Object visit(ASTMethodDeclaration node, Object data) {
         this.rc = (RuleContext) data;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AccessorMethodGenerationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AccessorMethodGenerationRule.java
@@ -33,6 +33,10 @@ public class AccessorMethodGenerationRule extends AbstractJavaRule {
 
     private List<String> cache = new ArrayList<>();
 
+    public AccessorMethodGenerationRule() {
+        addRuleChainVisit(ASTCompilationUnit.class);
+    }
+
     @Override
     public Object visit(final ASTCompilationUnit node, final Object data) {
         final SourceFileScope file = node.getScope().getEnclosingScope(SourceFileScope.class);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ArrayIsStoredDirectlyRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ArrayIsStoredDirectlyRule.java
@@ -47,7 +47,7 @@ public class ArrayIsStoredDirectlyRule extends AbstractSunSecureRule {
     @Override
     public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
         if (node.isInterface()) {
-            return data;
+            return super.visit(node, data);
         }
         return super.visit(node, data);
     }
@@ -55,7 +55,7 @@ public class ArrayIsStoredDirectlyRule extends AbstractSunSecureRule {
     @Override
     public Object visit(ASTConstructorDeclaration node, Object data) {
         if (node.isPrivate() && getProperty(ALLOW_PRIVATE)) {
-            return data;
+            return super.visit(node, data);
         }
 
         ASTFormalParameter[] arrs = getArrays(node.getFormalParameters());
@@ -63,19 +63,19 @@ public class ArrayIsStoredDirectlyRule extends AbstractSunSecureRule {
         // variable
         List<ASTBlockStatement> bs = node.findDescendantsOfType(ASTBlockStatement.class);
         checkAll(data, arrs, bs);
-        return data;
+        return super.visit(node, data);
     }
 
     @Override
     public Object visit(ASTMethodDeclaration node, Object data) {
         if (node.isPrivate() && getProperty(ALLOW_PRIVATE)) {
-            return data;
+            return super.visit(node, data);
         }
 
         final ASTFormalParameters params = node.getFirstDescendantOfType(ASTFormalParameters.class);
         ASTFormalParameter[] arrs = getArrays(params);
         checkAll(data, arrs, node.findDescendantsOfType(ASTBlockStatement.class));
-        return data;
+        return super.visit(node, data);
     }
 
     private void checkAll(Object context, ASTFormalParameter[] arrs, List<ASTBlockStatement> bs) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitTestsShouldIncludeAssertRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitTestsShouldIncludeAssertRule.java
@@ -33,7 +33,7 @@ public class JUnitTestsShouldIncludeAssertRule extends AbstractJUnitRule {
     @Override
     public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
         if (node.isInterface()) {
-            return data;
+            return super.visit(node, data);
         }
         return super.visit(node, data);
     }
@@ -52,7 +52,7 @@ public class JUnitTestsShouldIncludeAssertRule extends AbstractJUnitRule {
                 }
             }
         }
-        return data;
+        return super.visit(method, data);
     }
 
     private boolean containsExpectOrAssert(Node n,

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitUseExpectedRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitUseExpectedRule.java
@@ -59,7 +59,7 @@ public class JUnitUseExpectedRule extends AbstractJUnitRule {
                 boolean isJUnitMethod = isJUnitMethod((ASTMethodDeclaration) child, data);
                 if (inAnnotation || isJUnitMethod) {
                     List<Node> found = new ArrayList<>();
-                    found.addAll((List<Node>) visit((ASTMethodDeclaration) child, data));
+                    found.addAll(analyzeMethod((ASTMethodDeclaration) child));
                     for (Node name : found) {
                         addViolation(data, name);
                     }
@@ -71,8 +71,7 @@ public class JUnitUseExpectedRule extends AbstractJUnitRule {
         return super.visit(node, data);
     }
 
-    @Override
-    public Object visit(ASTMethodDeclaration node, Object data) {
+    private List<Node> analyzeMethod(ASTMethodDeclaration node) {
         List<ASTTryStatement> catches = node.findDescendantsOfType(ASTTryStatement.class);
         List<Node> found = new ArrayList<>();
         if (catches.isEmpty()) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LooseCouplingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LooseCouplingRule.java
@@ -29,6 +29,10 @@ public class LooseCouplingRule extends AbstractJavaRule {
     // "java.util.TreeMap", "java.util.Vector"
     // });
 
+    public LooseCouplingRule() {
+        addRuleChainVisit(ASTClassOrInterfaceType.class);
+    }
+
     @Override
     public Object visit(ASTClassOrInterfaceType node, Object data) {
         if (methodHasOverride(node)) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MethodReturnsInternalArrayRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MethodReturnsInternalArrayRule.java
@@ -35,7 +35,7 @@ public class MethodReturnsInternalArrayRule extends AbstractSunSecureRule {
     @Override
     public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
         if (node.isInterface()) {
-            return data;
+            return super.visit(node, data);
         }
         return super.visit(node, data);
     }
@@ -43,7 +43,7 @@ public class MethodReturnsInternalArrayRule extends AbstractSunSecureRule {
     @Override
     public Object visit(ASTMethodDeclaration method, Object data) {
         if (!method.getResultType().returnsArray() || method.isPrivate()) {
-            return data;
+            return super.visit(method, data);
         }
         List<ASTReturnStatement> returns = method.findDescendantsOfType(ASTReturnStatement.class);
         ASTAnyTypeDeclaration td = method.getFirstParentOfType(ASTAnyTypeDeclaration.class);
@@ -80,7 +80,7 @@ public class MethodReturnsInternalArrayRule extends AbstractSunSecureRule {
                 }
             }
         }
-        return data;
+        return super.visit(method, data);
     }
 
     private boolean hasClone(ASTReturnStatement ret, String varName) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedFormalParameterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedFormalParameterRule.java
@@ -41,18 +41,18 @@ public class UnusedFormalParameterRule extends AbstractJavaRule {
     @Override
     public Object visit(ASTConstructorDeclaration node, Object data) {
         check(node, data);
-        return data;
+        return super.visit(node, data);
     }
 
     @Override
     public Object visit(ASTMethodDeclaration node, Object data) {
         if (!node.isPrivate() && !getProperty(CHECKALL_DESCRIPTOR)) {
-            return data;
+            return super.visit(node, data);
         }
         if (!node.isNative() && !node.isAbstract() && !isSerializationMethod(node) && !hasOverrideAnnotation(node)) {
             check(node, data);
         }
-        return data;
+        return super.visit(node, data);
     }
 
     private boolean isSerializationMethod(ASTMethodDeclaration node) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
@@ -131,7 +131,7 @@ public class UnusedImportsRule extends AbstractJavaRule {
                 imports.add(new ImportWrapper(importedType.getImage(), className, node));
             }
         }
-        return data;
+        return super.visit(node, data);
     }
 
     @Override
@@ -143,11 +143,11 @@ public class UnusedImportsRule extends AbstractJavaRule {
     @Override
     public Object visit(ASTName node, Object data) {
         check(node);
-        return data;
+        return super.visit(node, data);
     }
 
     protected void check(Node node) {
-        if (imports.isEmpty()) {
+        if (imports.isEmpty() || node.getParent() instanceof ASTImportDeclaration) {
             return;
         }
         ImportWrapper candidate = getImportWrapper(node);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
@@ -48,7 +48,7 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
     @Override
     public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
         if (node.isInterface()) {
-            return data;
+            return super.visit(node, data);
         }
 
         Map<MethodNameDeclaration, List<NameOccurrence>> methods = node.getScope().getEnclosingScope(ClassScope.class)
@@ -67,7 +67,7 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
 
             }
         }
-        return data;
+        return super.visit(node, data);
     }
 
     private Set<MethodNameDeclaration> findUnique(Map<MethodNameDeclaration, List<NameOccurrence>> methods) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseCollectionIsEmptyRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseCollectionIsEmptyRule.java
@@ -74,7 +74,7 @@ public class UseCollectionIsEmptyRule extends AbstractInefficientZeroCheck {
             Node expr = node.getParent().getParent();
             checkNodeAndReport(data, node, expr);
         }
-        return data;
+        return super.visit(node, data);
     }
 
     private boolean isSizeMethodCall(ASTPrimarySuffix primarySuffix) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/DontImportJavaLangRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/DontImportJavaLangRule.java
@@ -10,9 +10,12 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 public class DontImportJavaLangRule extends AbstractJavaRule {
     private static final String IMPORT_JAVA_LANG = "java.lang";
 
+    public DontImportJavaLangRule() {
+        addRuleChainVisit(ASTImportDeclaration.class);
+    }
+
     @Override
     public Object visit(ASTImportDeclaration node, Object data) {
-
         if (node.isStatic()) {
             return data;
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/DuplicateImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/DuplicateImportsRule.java
@@ -104,7 +104,7 @@ public class DuplicateImportsRule extends AbstractJavaRule {
                 singleTypeImports.add(wrapper);
             }
         }
-        return data;
+        return super.visit(node, data);
     }
 
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldDeclarationsShouldBeAtStartOfClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldDeclarationsShouldBeAtStartOfClassRule.java
@@ -48,6 +48,7 @@ public class FieldDeclarationsShouldBeAtStartOfClassRule extends AbstractJavaRul
         definePropertyDescriptor(ignoreEnumDeclarations);
         definePropertyDescriptor(ignoreAnonymousClassDeclarations);
         definePropertyDescriptor(ignoreInterfaceDeclarations);
+        addRuleChainVisit(ASTFieldDeclaration.class);
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableCouldBeFinalRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableCouldBeFinalRule.java
@@ -29,10 +29,10 @@ public class LocalVariableCouldBeFinalRule extends AbstractOptimizationRule {
     @Override
     public Object visit(ASTLocalVariableDeclaration node, Object data) {
         if (node.isFinal()) {
-            return data;
+            return super.visit(node, data);
         }
         if (getProperty(IGNORE_FOR_EACH) && node.getParent() instanceof ASTForStatement) {
-            return data;
+            return super.visit(node, data);
         }
         Scope s = node.getScope();
         Map<VariableNameDeclaration, List<NameOccurrence>> decls = s.getDeclarations(VariableNameDeclaration.class);
@@ -45,7 +45,7 @@ public class LocalVariableCouldBeFinalRule extends AbstractOptimizationRule {
                 addViolation(data, var.getAccessNodeParent(), var.getImage());
             }
         }
-        return data;
+        return super.visit(node, data);
     }
 
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/OnlyOneReturnRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/OnlyOneReturnRule.java
@@ -8,19 +8,14 @@ import java.util.Iterator;
 import java.util.List;
 
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTReturnStatement;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
 public class OnlyOneReturnRule extends AbstractJavaRule {
 
-    @Override
-    public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
-        if (node.isInterface()) {
-            return data;
-        }
-        return super.visit(node, data);
+    public OnlyOneReturnRule() {
+        addRuleChainVisit(ASTMethodDeclaration.class);
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryFullyQualifiedNameRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryFullyQualifiedNameRule.java
@@ -37,10 +37,10 @@ public class UnnecessaryFullyQualifiedNameRule extends AbstractJavaRule {
     private String currentPackage;
 
     public UnnecessaryFullyQualifiedNameRule() {
-        super.addRuleChainVisit(ASTPackageDeclaration.class);
-        super.addRuleChainVisit(ASTImportDeclaration.class);
-        super.addRuleChainVisit(ASTClassOrInterfaceType.class);
-        super.addRuleChainVisit(ASTName.class);
+        addRuleChainVisit(ASTPackageDeclaration.class);
+        addRuleChainVisit(ASTImportDeclaration.class);
+        addRuleChainVisit(ASTClassOrInterfaceType.class);
+        addRuleChainVisit(ASTName.class);
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryLocalBeforeReturnRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryLocalBeforeReturnRule.java
@@ -14,7 +14,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTBlockStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTMemberSelector;
-import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
@@ -35,15 +34,7 @@ public class UnnecessaryLocalBeforeReturnRule extends AbstractJavaRule {
 
     public UnnecessaryLocalBeforeReturnRule() {
         definePropertyDescriptor(STATEMENT_ORDER_MATTERS);
-    }
-
-    @Override
-    public Object visit(ASTMethodDeclaration meth, Object data) {
-        // skip void/abstract/native method
-        if (meth.isVoid() || meth.isAbstract() || meth.isNative()) {
-            return data;
-        }
-        return super.visit(meth, data);
+        addRuleChainVisit(ASTReturnStatement.class);
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryReturnRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryReturnRule.java
@@ -13,22 +13,22 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
 public class UnnecessaryReturnRule extends AbstractJavaRule {
 
-    @Override
-    public Object visit(ASTMethodDeclaration node, Object data) {
-
-        if (node.getResultType().isVoid()) {
-            super.visit(node, data);
-        }
-        return data;
+    public UnnecessaryReturnRule() {
+        addRuleChainVisit(ASTReturnStatement.class);
     }
 
     @Override
     public Object visit(ASTReturnStatement node, Object data) {
-        if (node.getParent() instanceof ASTStatement && node.getNthParent(2) instanceof ASTBlockStatement
-                && node.getNthParent(3) instanceof ASTBlock && node.getNthParent(4) instanceof ASTMethodDeclaration) {
+        if (node.getNumChildren() == 0 && isDirectMethodStatement(node)) {
             addViolation(data, node);
         }
         return data;
     }
 
+    private boolean isDirectMethodStatement(ASTReturnStatement node) {
+        return node.getParent() instanceof ASTStatement
+                && node.getNthParent(2) instanceof ASTBlockStatement
+                && node.getNthParent(3) instanceof ASTBlock
+                && node.getNthParent(4) instanceof ASTMethodDeclaration;
+    }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/VariableNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/VariableNamingConventionsRule.java
@@ -112,7 +112,7 @@ public class VariableNamingConventionsRule extends AbstractJavaRule {
     @Override
     public Object visit(ASTFieldDeclaration node, Object data) {
         if (!checkMembers) {
-            return data;
+            return super.visit(node, data);
         }
         boolean isStatic = node.isStatic();
         boolean isFinal = node.isFinal();
@@ -125,26 +125,28 @@ public class VariableNamingConventionsRule extends AbstractJavaRule {
             isStatic = true;
             isFinal = true;
         }
-        return checkVariableDeclarators(node.isStatic() ? staticPrefixes : memberPrefixes,
+        checkVariableDeclarators(node.isStatic() ? staticPrefixes : memberPrefixes,
                 isStatic ? staticSuffixes : memberSuffixes, node, isStatic, isFinal, data);
+        return super.visit(node, data);
     }
 
     @Override
     public Object visit(ASTLocalVariableDeclaration node, Object data) {
         if (!checkLocals) {
-            return data;
+            return super.visit(node, data);
         }
-        return checkVariableDeclarators(localPrefixes, localSuffixes, node, false, node.isFinal(), data);
+        checkVariableDeclarators(localPrefixes, localSuffixes, node, false, node.isFinal(), data);
+        return super.visit(node, data);
     }
 
     @Override
     public Object visit(ASTFormalParameters node, Object data) {
         if (!checkParameters) {
-            return data;
+            return super.visit(node, data);
         }
         ASTMethodDeclaration methodDeclaration = node.getFirstParentOfType(ASTMethodDeclaration.class);
         if (!checkNativeMethodParameters && methodDeclaration.isNative()) {
-            return data;
+            return super.visit(node, data);
         }
 
         for (ASTFormalParameter formalParameter : node.findChildrenOfType(ASTFormalParameter.class)) {
@@ -154,10 +156,10 @@ public class VariableNamingConventionsRule extends AbstractJavaRule {
                         variableDeclaratorId, data);
             }
         }
-        return data;
+        return super.visit(node, data);
     }
 
-    private Object checkVariableDeclarators(List<String> prefixes, List<String> suffixes, Node root, boolean isStatic,
+    private void checkVariableDeclarators(List<String> prefixes, List<String> suffixes, Node root, boolean isStatic,
             boolean isFinal, Object data) {
         for (ASTVariableDeclarator variableDeclarator : root.findChildrenOfType(ASTVariableDeclarator.class)) {
             for (ASTVariableDeclaratorId variableDeclaratorId : variableDeclarator
@@ -165,10 +167,9 @@ public class VariableNamingConventionsRule extends AbstractJavaRule {
                 checkVariableDeclaratorId(prefixes, suffixes, isStatic, isFinal, variableDeclaratorId, data);
             }
         }
-        return data;
     }
 
-    private Object checkVariableDeclaratorId(List<String> prefixes, List<String> suffixes, boolean isStatic,
+    private void checkVariableDeclaratorId(List<String> prefixes, List<String> suffixes, boolean isStatic,
             boolean isFinal, ASTVariableDeclaratorId variableDeclaratorId, Object data) {
 
         // Get the variable name
@@ -176,7 +177,7 @@ public class VariableNamingConventionsRule extends AbstractJavaRule {
 
         // Skip serialVersionUID
         if ("serialVersionUID".equals(varName)) {
-            return data;
+            return;
         }
 
         // Static finals should be uppercase
@@ -186,7 +187,7 @@ public class VariableNamingConventionsRule extends AbstractJavaRule {
                         "Variables that are final and static should be all capitals, ''{0}'' is not all capitals.",
                         new Object[] { varName });
             }
-            return data;
+            return;
         } else if (!isFinal) {
             String normalizedVarName = normalizeVariableName(varName, prefixes, suffixes);
 
@@ -201,7 +202,6 @@ public class VariableNamingConventionsRule extends AbstractJavaRule {
                         new Object[] { varName });
             }
         }
-        return data;
     }
 
     private String normalizeVariableName(String varName, List<String> prefixes, List<String> suffixes) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CouplingBetweenObjectsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CouplingBetweenObjectsRule.java
@@ -54,7 +54,7 @@ public class CouplingBetweenObjectsRule extends AbstractJavaRule {
         typesFoundSoFar = new HashSet<>();
         couplingCount = 0;
 
-        Object returnObj = cu.childrenAccept(this, data);
+        Object returnObj = super.visit(cu, data);
 
         if (couplingCount > getProperty(THRESHOLD_DESCRIPTOR)) {
             addViolation(data, cu,
@@ -62,14 +62,6 @@ public class CouplingBetweenObjectsRule extends AbstractJavaRule {
         }
 
         return returnObj;
-    }
-
-    @Override
-    public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
-        if (node.isInterface()) {
-            return data;
-        }
-        return super.visit(node, data);
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CyclomaticComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CyclomaticComplexityRule.java
@@ -114,8 +114,7 @@ public class CyclomaticComplexityRule extends AbstractJavaMetricsRule {
         cycloOptions = MetricOptions.ofOptions(getProperty(CYCLO_OPTIONS_DESCRIPTOR));
 
 
-        super.visit(node, data);
-        return data;
+        return super.visit(node, data);
     }
 
 
@@ -165,7 +164,7 @@ public class CyclomaticComplexityRule extends AbstractJavaMetricsRule {
                                                        "" + cyclo, });
             }
         }
-        return data;
+        return super.visit(node, data);
     }
 
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExceptionAsFlowControlRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExceptionAsFlowControlRule.java
@@ -23,6 +23,10 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
  */
 public class ExceptionAsFlowControlRule extends AbstractJavaRule {
 
+    public ExceptionAsFlowControlRule() {
+        addRuleChainVisit(ASTThrowStatement.class);
+    }
+
     @Override
     public Object visit(ASTThrowStatement node, Object data) {
         ASTTryStatement parent = node.getFirstParentOfType(ASTTryStatement.class);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveImportsRule.java
@@ -33,6 +33,7 @@ public class ExcessiveImportsRule extends ExcessiveNodeCountRule {
      */
     @Override
     public Object visit(ASTImportDeclaration node, Object data) {
+        super.visit(node, data);
         return NumericConstants.ONE;
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveLengthRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveLengthRule.java
@@ -33,6 +33,6 @@ public class ExcessiveLengthRule extends AbstractStatisticalJavaRule {
             addDataPoint(point);
         }
 
-        return node.childrenAccept(this, data);
+        return super.visit(node, data);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveNodeCountRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveNodeCountRule.java
@@ -20,7 +20,7 @@ import net.sourceforge.pmd.stat.DataPoint;
  *
  * <p>All others will return 0 (or the sum of counted nodes underneath.)</p>
  */
-
+@SuppressWarnings("PMD.AlwaysCallSuperWhenNotUsingRuleChain")
 public class ExcessiveNodeCountRule extends AbstractStatisticalJavaRule {
     private Class<?> nodeClass;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveParameterListRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveParameterListRule.java
@@ -22,6 +22,7 @@ public class ExcessiveParameterListRule extends ExcessiveNodeCountRule {
     // Count these nodes, but no others.
     @Override
     public Object visit(ASTFormalParameter node, Object data) {
+        super.visit(node, data);
         return NumericConstants.ONE;
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessivePublicCountRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessivePublicCountRule.java
@@ -37,6 +37,7 @@ public class ExcessivePublicCountRule extends ExcessiveNodeCountRule {
      */
     @Override
     public Object visit(ASTMethodDeclarator node, Object data) {
+        super.visit(node, data);
         return this.getTallyOnAccessType((AccessNode) node.getParent());
     }
 
@@ -46,6 +47,7 @@ public class ExcessivePublicCountRule extends ExcessiveNodeCountRule {
      */
     @Override
     public Object visit(ASTFieldDeclaration node, Object data) {
+        super.visit(node, data);
         if (node.isFinal() && node.isStatic()) {
             return NumericConstants.ZERO;
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ModifiedCyclomaticComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ModifiedCyclomaticComplexityRule.java
@@ -23,7 +23,7 @@ public class ModifiedCyclomaticComplexityRule extends StdCyclomaticComplexityRul
     @Override
     public Object visit(ASTSwitchStatement node, Object data) {
         entryStack.peek().bumpDecisionPoints();
-        visit((JavaNode) node, data);
+        super.visit((JavaNode) node, data);
         return data;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NPathComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NPathComplexityRule.java
@@ -53,8 +53,7 @@ public class NPathComplexityRule extends AbstractJavaMetricsRule {
     public Object visit(ASTCompilationUnit node, Object data) {
         reportLevel = getReportLevel();
 
-        super.visit(node, data);
-        return data;
+        return super.visit(node, data);
     }
 
 
@@ -72,7 +71,7 @@ public class NPathComplexityRule extends AbstractJavaMetricsRule {
     @Override
     public final Object visit(ASTMethodOrConstructorDeclaration node, Object data) {
         if (!JavaOperationMetricKey.NPATH.supports(node)) {
-            return data;
+            return super.visit(node, data);
         }
 
         int npath = (int) MetricsUtil.computeMetric(JavaOperationMetricKey.NPATH, node);
@@ -83,7 +82,7 @@ public class NPathComplexityRule extends AbstractJavaMetricsRule {
                                                    String.valueOf(reportLevel)});
         }
 
-        return data;
+        return super.visit(node, data);
     }
 }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NcssConstructorCountRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NcssConstructorCountRule.java
@@ -27,6 +27,7 @@ public class NcssConstructorCountRule extends AbstractNcssCountRule {
 
     @Override
     public Object visit(ASTExplicitConstructorInvocation node, Object data) {
+        super.visit(node, data);
         return NumericConstants.ONE;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NcssCountRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NcssCountRule.java
@@ -82,8 +82,7 @@ public final class NcssCountRule extends AbstractJavaMetricsRule {
         classReportLevel = getProperty(CLASS_REPORT_LEVEL_DESCRIPTOR);
         ncssOptions = MetricOptions.ofOptions(getProperty(NCSS_OPTIONS_DESCRIPTOR));
 
-        super.visit(node, data);
-        return data;
+        return super.visit(node, data);
     }
 
 
@@ -110,6 +109,8 @@ public final class NcssCountRule extends AbstractJavaMetricsRule {
 
     @Override
     public Object visit(ASTMethodOrConstructorDeclaration node, Object data) {
+
+        super.visit(node, data);
 
         if (JavaOperationMetricKey.NCSS.supports((MethodLikeNode) node)) {
             int methodSize = (int) MetricsUtil.computeMetric(JavaOperationMetricKey.NCSS, node, ncssOptions);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NcssTypeCountRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NcssTypeCountRule.java
@@ -21,6 +21,7 @@ import net.sourceforge.pmd.util.NumericConstants;
  * @author Jason Bennett
  */
 @Deprecated
+@SuppressWarnings("PMD.AlwaysCallSuperWhenNotUsingRuleChain")
 public class NcssTypeCountRule extends AbstractNcssCountRule {
 
     /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/PositionalIteratorRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/PositionalIteratorRule.java
@@ -12,7 +12,12 @@ import net.sourceforge.pmd.lang.java.ast.ASTName;
 import net.sourceforge.pmd.lang.java.ast.ASTWhileStatement;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
+// TODO: This rule is not referenced in any category and is missing test cases
 public class PositionalIteratorRule extends AbstractJavaRule {
+
+    public PositionalIteratorRule() {
+        addRuleChainVisit(ASTWhileStatement.class);
+    }
 
     @Override
     public Object visit(ASTWhileStatement node, Object data) {
@@ -36,7 +41,7 @@ public class PositionalIteratorRule extends AbstractJavaRule {
 
             }
         }
-        return null;
+        return data;
     }
 
     private String getVariableName(String exprName) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SingularFieldRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SingularFieldRule.java
@@ -174,7 +174,7 @@ public class SingularFieldRule extends AbstractLombokAwareRule {
                 }
             }
         }
-        return data;
+        return super.visit(node, data);
     }
 
     private boolean isInAssignment(Node potentialStatement) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SwitchDensityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SwitchDensityRule.java
@@ -51,7 +51,6 @@ public class SwitchDensityRule extends AbstractStatisticalJavaRule {
     }
 
     public SwitchDensityRule() {
-        super();
         setProperty(MINIMUM_DESCRIPTOR, 10d);
     }
 
@@ -65,7 +64,7 @@ public class SwitchDensityRule extends AbstractStatisticalJavaRule {
 
         SwitchDensity density = new SwitchDensity();
 
-        node.childrenAccept(this, density);
+        super.visit(node, density);
 
         DataPoint point = new DataPoint();
         point.setNode(node);
@@ -86,9 +85,7 @@ public class SwitchDensityRule extends AbstractStatisticalJavaRule {
             ((SwitchDensity) data).addStatement();
         }
 
-        statement.childrenAccept(this, data);
-
-        return data;
+        return super.visit(statement, data);
     }
 
     @Override
@@ -97,7 +94,6 @@ public class SwitchDensityRule extends AbstractStatisticalJavaRule {
             ((SwitchDensity) data).addSwitchLabel();
         }
 
-        switchLabel.childrenAccept(this, data);
-        return data;
+        return super.visit(switchLabel, data);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDuplicateLiteralsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidDuplicateLiteralsRule.java
@@ -184,6 +184,8 @@ public class AvoidDuplicateLiteralsRule extends AbstractJavaRule {
 
     @Override
     public Object visit(ASTLiteral node, Object data) {
+        super.visit(node, data);
+
         if (!node.isStringLiteral()) {
             return data;
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidFieldNameMatchingTypeNameRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidFieldNameMatchingTypeNameRule.java
@@ -10,12 +10,8 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
 public class AvoidFieldNameMatchingTypeNameRule extends AbstractJavaRule {
 
-    @Override
-    public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
-        if (node.isInterface()) {
-            return data;
-        }
-        return super.visit(node, data);
+    public AvoidFieldNameMatchingTypeNameRule() {
+        addRuleChainVisit(ASTFieldDeclaration.class);
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidMultipleUnaryOperatorsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidMultipleUnaryOperatorsRule.java
@@ -15,8 +15,8 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 public class AvoidMultipleUnaryOperatorsRule extends AbstractJavaRule {
 
     public AvoidMultipleUnaryOperatorsRule() {
-        super.addRuleChainVisit(ASTUnaryExpression.class);
-        super.addRuleChainVisit(ASTUnaryExpressionNotPlusMinus.class);
+        addRuleChainVisit(ASTUnaryExpression.class);
+        addRuleChainVisit(ASTUnaryExpressionNotPlusMinus.class);
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidUsingOctalValuesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidUsingOctalValuesRule.java
@@ -27,6 +27,7 @@ public class AvoidUsingOctalValuesRule extends AbstractJavaRule {
 
     public AvoidUsingOctalValuesRule() {
         definePropertyDescriptor(STRICT_METHODS_DESCRIPTOR);
+        addRuleChainVisit(ASTLiteral.class);
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CheckSkipResultRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CheckSkipResultRule.java
@@ -20,6 +20,10 @@ import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
 
 public class CheckSkipResultRule extends AbstractJavaRule {
 
+    public CheckSkipResultRule() {
+        addRuleChainVisit(ASTVariableDeclaratorId.class);
+    }
+
     @Override
     public Object visit(ASTVariableDeclaratorId node, Object data) {
         ASTType typeNode = node.getTypeNode();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloneMethodMustImplementCloneableRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloneMethodMustImplementCloneableRule.java
@@ -83,6 +83,8 @@ public class CloneMethodMustImplementCloneableRule extends AbstractJavaRule {
 
     @Override
     public Object visit(final ASTMethodDeclaration node, final Object data) {
+        super.visit(node, data);
+
         // Is this a clone method?
         final ASTMethodDeclarator methodDeclarator = node.getFirstChildOfType(ASTMethodDeclarator.class);
         if (!isCloneMethod(methodDeclarator)) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CompareObjectsWithEqualsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CompareObjectsWithEqualsRule.java
@@ -17,6 +17,10 @@ import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
 
 public class CompareObjectsWithEqualsRule extends AbstractJavaRule {
 
+    public CompareObjectsWithEqualsRule() {
+        addRuleChainVisit(ASTEqualityExpression.class);
+    }
+
     private boolean hasName(Node n) {
         return n.getNumChildren() > 0 && n.getChild(0) instanceof ASTName;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/DontImportSunRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/DontImportSunRule.java
@@ -9,6 +9,10 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
 public class DontImportSunRule extends AbstractJavaRule {
 
+    public DontImportSunRule() {
+        addRuleChainVisit(ASTImportDeclaration.class);
+    }
+
     @Override
     public Object visit(ASTImportDeclaration node, Object data) {
         String img = node.getChild(0).getImage();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ImportFromSamePackageRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ImportFromSamePackageRule.java
@@ -12,6 +12,10 @@ import net.sourceforge.pmd.lang.java.symboltable.SourceFileScope;
 
 public class ImportFromSamePackageRule extends AbstractJavaRule {
 
+    public ImportFromSamePackageRule() {
+        addRuleChainVisit(ASTImportDeclaration.class);
+    }
+
     @Override
     public Object visit(ASTImportDeclaration importDecl, Object data) {
         String packageName = importDecl.getScope().getEnclosingScope(SourceFileScope.class).getPackageName();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/MoreThanOneLoggerRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/MoreThanOneLoggerRule.java
@@ -32,31 +32,38 @@ public class MoreThanOneLoggerRule extends AbstractJavaRule {
 
     @Override
     public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
-        return init(node, data);
+        preVisit();
+        super.visit(node, data);
+        postVisit(node, data);
+        return data;
     }
 
     @Override
     public Object visit(ASTEnumDeclaration node, Object data) {
-        return init(node, data);
+        preVisit();
+        super.visit(node, data);
+        postVisit(node, data);
+        return data;
     }
 
     @Override
     public Object visit(ASTAnnotationTypeDeclaration node, Object data) {
-        return init(node, data);
+        preVisit();
+        super.visit(node, data);
+        postVisit(node, data);
+        return data;
     }
 
-    private Object init(JavaNode node, Object data) {
+    private void preVisit() {
         stack.push(count);
         count = NumericConstants.ZERO;
+    }
 
-        node.childrenAccept(this, data);
-
+    private void postVisit(JavaNode node, Object data) {
         if (count > 1) {
             addViolation(data, node);
         }
         count = stack.pop();
-
-        return data;
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/TestClassWithoutTestCasesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/TestClassWithoutTestCasesRule.java
@@ -15,7 +15,7 @@ public class TestClassWithoutTestCasesRule extends AbstractJUnitRule {
     @Override
     public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
         if (node.isAbstract() || node.isInterface() || node.isNested()) {
-            return data;
+            return super.visit(node, data);
         }
 
         List<ASTMethodDeclaration> m = node.findDescendantsOfType(ASTMethodDeclaration.class);
@@ -34,6 +34,6 @@ public class TestClassWithoutTestCasesRule extends AbstractJUnitRule {
             addViolation(data, node);
         }
 
-        return data;
+        return super.visit(node, data);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnnecessaryCaseChangeRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UnnecessaryCaseChangeRule.java
@@ -13,6 +13,10 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
 public class UnnecessaryCaseChangeRule extends AbstractJavaRule {
 
+    public UnnecessaryCaseChangeRule() {
+        addRuleChainVisit(ASTPrimaryExpression.class);
+    }
+
     @Override
     public Object visit(ASTPrimaryExpression exp, Object data) {
         int n = exp.getNumChildren();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/AbstractOptimizationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/AbstractOptimizationRule.java
@@ -7,7 +7,6 @@ package net.sourceforge.pmd.lang.java.rule.performance;
 import java.util.List;
 
 import net.sourceforge.pmd.annotation.InternalApi;
-import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.symboltable.JavaNameOccurrence;
 import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
@@ -22,14 +21,6 @@ import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
 @Deprecated
 @InternalApi
 public class AbstractOptimizationRule extends AbstractJavaRule {
-
-    @Override
-    public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
-        if (node.isInterface()) {
-            return data;
-        }
-        return super.visit(node, data);
-    }
 
     protected boolean assigned(List<NameOccurrence> usages) {
         for (NameOccurrence occ : usages) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveLiteralAppendsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveLiteralAppendsRule.java
@@ -91,6 +91,7 @@ public class ConsecutiveLiteralAppendsRule extends AbstractJavaRule {
 
     public ConsecutiveLiteralAppendsRule() {
         definePropertyDescriptor(THRESHOLD_DESCRIPTOR);
+        addRuleChainVisit(ASTVariableDeclaratorId.class);
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientEmptyStringCheckRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientEmptyStringCheckRule.java
@@ -62,6 +62,7 @@ public class InefficientEmptyStringCheckRule extends AbstractInefficientZeroChec
 
     @Override
     public Object visit(ASTPrimaryExpression node, Object data) {
+        super.visit(node, data);
 
         if (node.getNumChildren() > 3) {
             // Check last suffix

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
@@ -53,6 +53,10 @@ public class InsufficientStringBufferDeclarationRule extends AbstractJavaRule {
     // as specified in StringBuffer and StringBuilder
     public static final int DEFAULT_BUFFER_SIZE = 16;
 
+    public InsufficientStringBufferDeclarationRule() {
+        addRuleChainVisit(ASTVariableDeclaratorId.class);
+    }
+
     @Override
     public Object visit(ASTVariableDeclaratorId node, Object data) {
         if (node.getNameDeclaration() == null

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/StringToStringRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/StringToStringRule.java
@@ -16,6 +16,10 @@ import net.sourceforge.pmd.lang.symboltable.ScopedNode;
 
 public class StringToStringRule extends AbstractJavaRule {
 
+    public StringToStringRule() {
+        addRuleChainVisit(ASTVariableDeclaratorId.class);
+    }
+
     @Override
     public Object visit(ASTVariableDeclaratorId node, Object data) {
         if (node.getNameDeclaration() == null

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/UseStringBufferLengthRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/UseStringBufferLengthRule.java
@@ -56,6 +56,8 @@ public class UseStringBufferLengthRule extends AbstractJavaRule {
 
     @Override
     public Object visit(ASTName decl, Object data) {
+        super.visit(decl, data);
+
         if (!decl.getImage().endsWith("toString")) {
             return data;
         }

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/CyclomaticComplexityRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/CyclomaticComplexityRule.java
@@ -13,7 +13,6 @@ import java.util.logging.Logger;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.plsql.ast.ASTCaseStatement;
 import net.sourceforge.pmd.lang.plsql.ast.ASTCaseWhenClause;
-import net.sourceforge.pmd.lang.plsql.ast.ASTConditionalOrExpression;
 import net.sourceforge.pmd.lang.plsql.ast.ASTElsifClause;
 import net.sourceforge.pmd.lang.plsql.ast.ASTExceptionHandler;
 import net.sourceforge.pmd.lang.plsql.ast.ASTExpression;
@@ -204,14 +203,10 @@ public class CyclomaticComplexityRule extends AbstractPLSQLRule {
     }
 
     @Override
-    public Object visit(ASTConditionalOrExpression node, Object data) {
-        return data;
-    }
-
-    @Override
     public Object visit(ASTPackageSpecification node, Object data) {
         LOGGER.entering(CLASS_NAME, "visit(ASTPackageSpecification)");
         // Treat Package Specification like an Interface
+        super.visit(node, data);
         LOGGER.exiting(CLASS_NAME, "visit(ASTPackageSpecification)");
         return data;
     }
@@ -220,6 +215,7 @@ public class CyclomaticComplexityRule extends AbstractPLSQLRule {
     public Object visit(ASTTypeSpecification node, Object data) {
         LOGGER.entering(CLASS_NAME, "visit(ASTTypeSpecification)");
         // Treat Type Specification like an Interface
+        super.visit(node, data);
         LOGGER.exiting(CLASS_NAME, "visit(ASTTypeSpecification)");
         return data;
     }

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessiveLengthRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessiveLengthRule.java
@@ -50,7 +50,7 @@ public class ExcessiveLengthRule extends AbstractStatisticalPLSQLRule {
             }
         }
 
-        return node.childrenAccept(this, data);
+        return super.visit(node, data);
     }
 
     @Override

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessiveNodeCountRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessiveNodeCountRule.java
@@ -20,7 +20,7 @@ import net.sourceforge.pmd.stat.DataPoint;
  *
  * <p>All others will return 0 (or the sum of counted nodes underneath.)</p>
  */
-
+@SuppressWarnings("PMD.AlwaysCallSuperWhenNotUsingRuleChain")
 public class ExcessiveNodeCountRule extends AbstractStatisticalPLSQLRule {
     private Class<?> nodeClass;
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessiveParameterListRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/ExcessiveParameterListRule.java
@@ -22,6 +22,7 @@ public class ExcessiveParameterListRule extends ExcessiveNodeCountRule {
     // Count these nodes, but no others.
     @Override
     public Object visit(ASTFormalParameter node, Object data) {
+        super.visit(node, data);
         return NumericConstants.ONE;
     }
 }

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/NPathComplexityRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/NPathComplexityRule.java
@@ -39,6 +39,7 @@ import net.sourceforge.pmd.util.NumericConstants;
  *
  * @author Jason Bennett
  */
+@SuppressWarnings("PMD.AlwaysCallSuperWhenNotUsingRuleChain")
 public class NPathComplexityRule extends AbstractStatisticalPLSQLRule {
     private static final String CLASS_NAME = NPathComplexityRule.class.getCanonicalName();
     private static final Logger LOGGER = Logger.getLogger(NPathComplexityRule.class.getName());

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/NcssObjectCountRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/NcssObjectCountRule.java
@@ -20,6 +20,7 @@ import net.sourceforge.pmd.util.NumericConstants;
  *
  * @author Stuart Turton
  */
+@SuppressWarnings("PMD.AlwaysCallSuperWhenNotUsingRuleChain")
 public class NcssObjectCountRule extends AbstractNcssCountRule {
     private static final String CLASS_NAME = NcssObjectCountRule.class.getName();
     private static final Logger LOGGER = Logger.getLogger(NcssObjectCountRule.class.getName());

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/TooManyFieldsRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/TooManyFieldsRule.java
@@ -65,7 +65,7 @@ public class TooManyFieldsRule extends AbstractPLSQLRule {
                 addViolation(data, n);
             }
         }
-        return data;
+        return super.visit(node, data);
     }
 
     @Override
@@ -85,7 +85,7 @@ public class TooManyFieldsRule extends AbstractPLSQLRule {
                 addViolation(data, n);
             }
         }
-        return data;
+        return super.visit(node, data);
     }
 
     private void bumpCounterFor(PLSQLNode clazz) {

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/rule/ScalaRule.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/rule/ScalaRule.java
@@ -166,6 +166,7 @@ import scala.meta.Type;
  * The default base implementation of a PMD Rule for Scala. Uses the Visitor
  * Pattern to traverse the AST.
  */
+@SuppressWarnings("PMD.AlwaysCallSuperWhenNotUsingRuleChain")
 public class ScalaRule extends AbstractRule implements ScalaParserVisitor<RuleContext, RuleContext> {
 
     /**

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/design/AvoidDeeplyNestedIfStmtsRule.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/design/AvoidDeeplyNestedIfStmtsRule.java
@@ -9,7 +9,7 @@ import static net.sourceforge.pmd.properties.constraints.NumericConstraints.posi
 import net.sourceforge.pmd.lang.vm.ast.ASTElseIfStatement;
 import net.sourceforge.pmd.lang.vm.ast.ASTIfStatement;
 import net.sourceforge.pmd.lang.vm.ast.ASTprocess;
-import net.sourceforge.pmd.lang.vm.ast.AbstractVmNode;
+import net.sourceforge.pmd.lang.vm.ast.VmNode;
 import net.sourceforge.pmd.lang.vm.rule.AbstractVmRule;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
@@ -38,22 +38,28 @@ public class AvoidDeeplyNestedIfStmtsRule extends AbstractVmRule {
 
     @Override
     public Object visit(ASTIfStatement node, Object data) {
-        return handleIf(node, data);
+        preVisit();
+        super.visit(node, data);
+        postVisit(node, data);
+        return data;
     }
 
     @Override
     public Object visit(ASTElseIfStatement node, Object data) {
-        return handleIf(node, data);
+        preVisit();
+        super.visit(node, data);
+        postVisit(node, data);
+        return data;
     }
 
-    private Object handleIf(AbstractVmNode node, Object data) {
+    private void preVisit() {
         depth++;
-        super.visit(node, data);
+    }
+
+    private void postVisit(VmNode node, Object data) {
         if (depth == depthLimit) {
             addViolation(data, node);
         }
         depth--;
-        return data;
     }
-
 }

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/design/ExcessiveTemplateLengthRule.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/design/ExcessiveTemplateLengthRule.java
@@ -17,6 +17,6 @@ public class ExcessiveTemplateLengthRule extends AbstractStatisticalVmRule {
         point.setScore(1.0 * (node.getEndLine() - node.getBeginLine()));
         point.setMessage(getMessage());
         addDataPoint(point);
-        return node.childrenAccept(this, data);
+        return super.visit(node, data);
     }
 }

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/AbstractDomXmlRule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/AbstractDomXmlRule.java
@@ -26,6 +26,7 @@ import net.sourceforge.pmd.lang.xml.ast.XmlNode;
  * using the DOM. Subclasses should override the DOM appropriate method and can
  * call <code>super</code> to visit children.
  */
+@SuppressWarnings("PMD.AlwaysCallSuperWhenNotUsingRuleChain")
 public class AbstractDomXmlRule extends AbstractXmlRule {
 
     @Override

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/AbstractXmlRule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/AbstractXmlRule.java
@@ -23,6 +23,7 @@ import net.sourceforge.pmd.properties.BooleanProperty;
  * {@link #visit(XmlNode, RuleContext)} and can call <code>super</code> to visit
  * children.
  */
+@SuppressWarnings("PMD.AlwaysCallSuperWhenNotUsingRuleChain")
 public class AbstractXmlRule extends AbstractRule implements ImmutableLanguage {
 
     public static final BooleanProperty COALESCING_DESCRIPTOR = XmlParserOptions.COALESCING_DESCRIPTOR;


### PR DESCRIPTION
## Describe the PR

* In the past, we had a couple of bugs, because super.visit wasn't called and part of the AST was not traversed (e.g. nested classes).
* In order to avoid this situation in the future, I've created a custom rule in build-tools: https://github.com/pmd/build-tools/pull/15
* This PR provides the fixes.

* I might have overdone this - so, maybe not all changes are good (the unit tests are running, but that doesn't proof the rules are still doing what they do). Let's see, what the regression tester does (at least for java).

* I agree, that there are some cases, where one explicitly doesn't want to go on traversing and stop traversal.
* But I think, these shouldn't be the normal cases. So, by default, the rule implementations should either traverse the whole tree or use the rule chain. If you have a good reason to do something else, you can suppress the violation.

* One take away: many rules only visited one node type and probably should have been rule chain rules anyway.

## Related issues

- None specific

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

