### PR TITLE
[core] Fix java7 compatibility

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -18,6 +18,24 @@ if travis_isLinux; then
     bundle config set --local path vendor/bundle
     bundle config set --local with release_notes_preprocessing
     bundle install
+
+    # install jdk7 for integration test
+    LOCAL_DIR=${HOME}/.cache/jdk7
+    TARGET_DIR=${HOME}/oraclejdk7
+    JDK7_ARCHIVE=jdk-7u80-linux-x64.tar.gz
+    DOWNLOAD_URL=https://pmd-code.org/oraclejdk/${JDK7_ARCHIVE}
+    mkdir -p ${LOCAL_DIR}
+    mkdir -p ${TARGET_DIR}
+    if [ ! -e ${LOCAL_DIR}/${JDK7_ARCHIVE} ]; then
+        log_info "Downloading from ${DOWNLOAD_URL} to ${LOCAL_DIR}"
+        wget --directory-prefix ${LOCAL_DIR} --timestamping --continue ${DOWNLOAD_URL}
+    else
+        log_info "Skipped download, file ${LOCAL_DIR}/${JDK7_ARCHIVE} already exists"
+    fi
+    log_info "Extracting to ${TARGET_DIR}"
+    tar --extract --file ${LOCAL_DIR}/${JDK7_ARCHIVE} -C ${TARGET_DIR} --strip-components=1
+    log_info "OracleJDK7 can be used via -Djava7.home=${TARGET_DIR}"
+
 else
     log_info "Not setting up ruby for ${TRAVIS_OS_NAME}."
     exit 0

--- a/.travis/build-deploy.sh
+++ b/.travis/build-deploy.sh
@@ -10,7 +10,11 @@ source .travis/regression-tester.sh
 VERSION=$(get_pom_version)
 log_info "Building PMD ${VERSION} on branch ${TRAVIS_BRANCH}"
 
-MVN_BUILD_FLAGS="-B -V"
+if travis_isLinux; then
+    MVN_BUILD_FLAGS="-B -V  -Djava7.home=${HOME}/oraclejdk7"
+else
+    MVN_BUILD_FLAGS="-B -V"
+fi
 
 if travis_isOSX; then
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -25,6 +25,7 @@ This is a {{ site.pmd.release_type }} release.
 *   core
     *   [#724](https://github.com/pmd/pmd/issues/724): \[core] Avoid parsing rulesets multiple times
     *   [#2653](https://github.com/pmd/pmd/issues/2653): \[lang-test] Upgrade kotlintest to Kotest
+    *   [#2690](https://github.com/pmd/pmd/pull/2690): \[core] Fix java7 compatibility
 *   java-bestpractices
     *   [#2471](https://github.com/pmd/pmd/issues/2471): \[java] New Rule: AvoidReassigningCatchVariables
     *   [#2668](https://github.com/pmd/pmd/issues/2668): \[java] UnusedAssignment false positives

--- a/pmd-core/pom.xml
+++ b/pmd-core/pom.xml
@@ -138,10 +138,6 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
         </dependency>

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/LanguageFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/LanguageFactory.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 
 public final class LanguageFactory {
@@ -40,7 +41,7 @@ public final class LanguageFactory {
             try {
                 Language language = iterator.next();
                 languagesList.add(language);
-            } catch (UnsupportedClassVersionError e) {
+            } catch (ServiceConfigurationError | UnsupportedClassVersionError e) {
                 // Some languages require java8 and are therefore only available
                 // if java8 or later is used as runtime.
                 System.err.println("Ignoring language for CPD: " + e.toString());

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLRenderer.java
@@ -18,7 +18,6 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
-import org.apache.commons.text.StringEscapeUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
@@ -145,7 +144,10 @@ public final class XMLRenderer implements Renderer, CPDRenderer {
             // the code snippet has normalized line endings
             String platformSpecific = codeSnippet.replace("\n", System.lineSeparator());
             Element codefragment = doc.createElement("codefragment");
-            codefragment.appendChild(doc.createCDATASection(StringEscapeUtils.escapeXml10(platformSpecific)));
+            // only remove invalid characters, escaping is not necessary in CDATA.
+            // if the string contains the end marker of a CDATA section, then the DOM impl will
+            // create two cdata sections automatically.
+            codefragment.appendChild(doc.createCDATASection(StringUtil.removedInvalidXml10Characters(platformSpecific)));
             duplication.appendChild(codefragment);
         }
         return duplication;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageRegistry.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageRegistry.java
@@ -12,6 +12,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 
 import org.apache.commons.lang3.StringUtils;
@@ -34,7 +35,7 @@ public final class LanguageRegistry {
             try {
                 Language language = iterator.next();
                 languagesList.add(language);
-            } catch (UnsupportedClassVersionError e) {
+            } catch (ServiceConfigurationError | UnsupportedClassVersionError e) {
                 // Some languages require java8 and are therefore only available
                 // if java8 or later is used as runtime.
                 System.err.println("Ignoring language for PMD: " + e.toString());

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/StringUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/StringUtil.java
@@ -13,7 +13,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.text.StringEscapeUtils;
 
 import net.sourceforge.pmd.annotation.InternalApi;
 
@@ -220,7 +219,9 @@ public final class StringUtil {
      * @param src
      * @param supportUTF8 override the default setting, whether special characters should be replaced with entities (
      *                    <code>false</code>) or should be included as is ( <code>true</code>).
-     * @deprecated for removal. Use {@link StringEscapeUtils#escapeXml10(String)} instead.
+     * @deprecated for removal. Use Java's XML implementations, that do the escaping,
+     *             use {@link #removedInvalidXml10Characters(String)} for fixing invalid characters in XML 1.0
+     *             documents or use {@code StringEscapeUtils#escapeXml10(String)} from apache commons-text instead.
      */
     @Deprecated
     public static void appendXmlEscaped(StringBuilder buf, String src, boolean supportUTF8) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeExportCli.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeExportCli.java
@@ -59,9 +59,8 @@ public class TreeExportCli {
 
     public static void main(String[] args) throws IOException {
         TreeExportCli cli = new TreeExportCli();
-        JCommander jcommander = JCommander.newBuilder()
-                                          .addObject(cli)
-                                          .build();
+        JCommander jcommander = new JCommander(cli);
+
         try {
             jcommander.parse(args);
         } catch (ParameterException e) {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/XMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/XMLRendererTest.java
@@ -204,11 +204,11 @@ public class XMLRendererTest {
 
     @Test
     public void testRendererXMLEscaping() throws IOException {
-        String codefragment = "code fragment" + FORM_FEED + "\nline2\nline3";
+        String codefragment = "code fragment" + FORM_FEED + "\nline2\nline3\nno & escaping necessary in CDATA\nx=\"]]>\";";
         CPDRenderer renderer = new XMLRenderer();
         List<Match> list = new ArrayList<>();
-        Mark mark1 = createMark("public", "file1", 1, 2, codefragment);
-        Mark mark2 = createMark("public", "file2", 5, 2, codefragment);
+        Mark mark1 = createMark("public", "file1", 1, 5, codefragment);
+        Mark mark2 = createMark("public", "file2", 5, 5, codefragment);
         Match match1 = new Match(75, mark1, mark2);
         list.add(match1);
 
@@ -217,6 +217,9 @@ public class XMLRendererTest {
         String report = sw.toString();
         assertFalse(report.contains(FORM_FEED));
         assertFalse(report.contains(FORM_FEED_ENTITY));
+        assertTrue(report.contains("no & escaping necessary in CDATA"));
+        assertFalse(report.contains("x=\"]]>\";")); // must be escaped
+        assertTrue(report.contains("x=\"]]]]><![CDATA[>\";"));
     }
 
     private Mark createMark(String image, String tokenSrcID, int beginLine, int lineCount, String code) {

--- a/pmd-dist/pom.xml
+++ b/pmd-dist/pom.xml
@@ -80,9 +80,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
                 <executions>
                     <execution>
+                        <id>failsafe-default</id>
                         <goals>
                             <goal>integration-test</goal>
                             <goal>verify</goal>
@@ -200,11 +200,6 @@
         </dependency>
         <dependency>
             <groupId>net.sourceforge.pmd</groupId>
-            <artifactId>pmd-scala_2.13</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-swift</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -261,10 +256,46 @@
                 </dependency>
                 <dependency>
                     <groupId>net.sourceforge.pmd</groupId>
+                    <artifactId>pmd-scala_2.13</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>net.sourceforge.pmd</groupId>
                     <artifactId>pmd-ui</artifactId>
                     <version>${pmd-designer.version}</version>
                 </dependency>
             </dependencies>
+        </profile>
+        <profile>
+            <id>jdk7-compat-it</id>
+            <activation>
+                <property>
+                    <name>java7.home</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>jdk7-compat-it</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <environmentVariables>
+                                        <JAVA_HOME>${java7.home}</JAVA_HOME>
+                                        <PATH>${java7.home}/bin:${env.PATH}</PATH>
+                                    </environmentVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 </project>

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/AllRulesIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/AllRulesIT.java
@@ -21,6 +21,11 @@ public class AllRulesIT extends AbstractBinaryDistributionTest {
 
     @Parameters
     public static Iterable<String> languagesToTest() {
+        if (PMDExecutor.isJava7Test()) {
+            // note: apex and scala require java8
+            return Arrays.asList("java", "javascript", "jsp", "modelica",
+                    "plsql", "pom", "visualforce", "velocitytemplate", "xml", "xsl");
+        }
         // note: scala and wsdl have no rules
         return Arrays.asList("java", "apex", "javascript", "jsp", "modelica",
                 "plsql", "pom", "visualforce", "velocitytemplate", "xml", "xsl");

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistributionIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistributionIT.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -21,7 +21,19 @@ import net.sourceforge.pmd.PMDVersion;
 
 public class BinaryDistributionIT extends AbstractBinaryDistributionTest {
 
-    private static final String SUPPORTED_LANGUAGES = "Supported languages: [apex, cpp, cs, dart, ecmascript, fortran, go, groovy, java, jsp, kotlin, lua, matlab, modelica, objectivec, perl, php, plsql, python, ruby, scala, swift, vf, xml]";
+    private static final String SUPPORTED_LANGUAGES_CPD;
+    private static final String SUPPORTED_LANGUAGES_PMD;
+
+    static {
+        // note: apex and scala require java8
+        if (PMDExecutor.isJava7Test()) {
+            SUPPORTED_LANGUAGES_CPD = "Supported languages: [cpp, cs, dart, ecmascript, fortran, go, groovy, java, jsp, kotlin, lua, matlab, modelica, objectivec, perl, php, plsql, python, ruby, swift, vf, xml]";
+            SUPPORTED_LANGUAGES_PMD = "ecmascript, java, jsp, modelica, plsql, pom, vf, vm, wsdl, xml, xsl";
+        } else {
+            SUPPORTED_LANGUAGES_CPD = "Supported languages: [apex, cpp, cs, dart, ecmascript, fortran, go, groovy, java, jsp, kotlin, lua, matlab, modelica, objectivec, perl, php, plsql, python, ruby, scala, swift, vf, xml]";
+            SUPPORTED_LANGUAGES_PMD = "apex, ecmascript, java, jsp, modelica, plsql, pom, scala, vf, vm, wsdl, xml, xsl";
+        }
+    }
 
     @Test
     public void testFileExistence() {
@@ -66,11 +78,19 @@ public class BinaryDistributionIT extends AbstractBinaryDistributionTest {
 
         ExecutionResult result;
 
+        result = PMDExecutor.runPMD(tempDir); // without any argument, display usage help and error
+        result.assertExecutionResult(1, SUPPORTED_LANGUAGES_PMD);
+
         result = PMDExecutor.runPMD(tempDir, "-h");
-        result.assertExecutionResult(0, "apex, ecmascript, java, jsp, modelica, plsql, pom, scala, vf, vm, wsdl, xml, xsl");
+        result.assertExecutionResult(0, SUPPORTED_LANGUAGES_PMD);
 
         result = PMDExecutor.runPMDRules(tempDir, srcDir, "src/test/resources/rulesets/sample-ruleset.xml");
         result.assertExecutionResult(4, "", "JumbledIncrementer.java:8:");
+
+        // also test XML format
+        result = PMDExecutor.runPMDRules(tempDir, srcDir, "src/test/resources/rulesets/sample-ruleset.xml", "xml");
+        result.assertExecutionResult(4, "", "JumbledIncrementer.java\">");
+        result.assertExecutionResult(4, "", "<violation beginline=\"8\" endline=\"10\" begincolumn=\"13\" endcolumn=\"13\" rule=\"JumbledIncrementer\"");
 
         result = PMDExecutor.runPMDRules(tempDir, srcDir, "rulesets/java/quickstart.xml");
         result.assertExecutionResult(4, "");
@@ -82,15 +102,23 @@ public class BinaryDistributionIT extends AbstractBinaryDistributionTest {
 
         ExecutionResult result;
 
+        result = CpdExecutor.runCpd(tempDir); // without any argument, display usage help and error
+        result.assertExecutionResult(1, SUPPORTED_LANGUAGES_CPD);
+
         result = CpdExecutor.runCpd(tempDir, "-h");
-        result.assertExecutionResult(0, SUPPORTED_LANGUAGES);
+        result.assertExecutionResult(0, SUPPORTED_LANGUAGES_CPD);
 
         result = CpdExecutor.runCpd(tempDir, "--minimum-tokens", "10", "--format", "text", "--files", srcDir);
         result.assertExecutionResult(4, "Found a 10 line (55 tokens) duplication in the following files:");
         result.assertExecutionResult(4, "Class1.java");
         result.assertExecutionResult(4, "Class2.java");
 
+        result = CpdExecutor.runCpd(tempDir, "--minimum-tokens", "10", "--format", "xml", "--files", srcDir);
+        result.assertExecutionResult(4, "<duplication lines=\"10\" tokens=\"55\">");
+        result.assertExecutionResult(4, "Class1.java\"/>");
+        result.assertExecutionResult(4, "Class2.java\"/>");
+
         result = CpdExecutor.runCpd(tempDir, "--minimum-tokens", "1000", "--format", "text", "--files", srcDir);
-        result.assertExecutionResult(0, "");
+        result.assertExecutionResult(0);
     }
 }

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/ExecutionResult.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/ExecutionResult.java
@@ -43,6 +43,15 @@ public class ExecutionResult {
     }
 
     /**
+     * Asserts that the command exited with the expected exit code. Any output is ignored.
+     *
+     * @param expectedExitCode the exit code, e.g. 0 if no rule violations are expected, or 4 if violations are found
+     */
+    public void assertExecutionResult(int expectedExitCode) {
+        assertExecutionResult(expectedExitCode, null);
+    }
+
+    /**
      * Asserts that the command exited with the expected exit code and that the given expected
      * output is contained in the actual command output.
      *
@@ -69,7 +78,7 @@ public class ExecutionResult {
             if (!output.contains(expectedOutput)) {
                 fail("Expected output '" + expectedOutput + "' not present.\nComplete result:\n\n" + this);
             }
-        } else {
+        } else if (expectedOutput != null && expectedOutput.isEmpty()) {
             assertTrue("The output should have been empty.\nComplete result:\n\n" + this, output.isEmpty());
         }
         if (expectedReport != null && !expectedReport.isEmpty()) {

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/PMDExecutor.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/PMDExecutor.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 
 import net.sourceforge.pmd.PMDVersion;
@@ -103,15 +104,19 @@ public class PMDExecutor {
      * @throws Exception if the execution fails for any reason (executable not found, ...)
      */
     public static ExecutionResult runPMDRules(Path tempDir, String sourceDirectory, String ruleset) throws Exception {
+        return runPMDRules(tempDir, sourceDirectory, ruleset, FORMATTER);
+    }
+
+    public static ExecutionResult runPMDRules(Path tempDir, String sourceDirectory, String ruleset, String formatter) throws Exception {
         Path reportFile = Files.createTempFile("pmd-it-report", "txt");
         reportFile.toFile().deleteOnExit();
 
         if (SystemUtils.IS_OS_WINDOWS) {
             return runPMDWindows(tempDir, reportFile, SOURCE_DIRECTORY_FLAG, sourceDirectory, RULESET_FLAG, ruleset,
-                    FORMAT_FLAG, FORMATTER, REPORTFILE_FLAG, reportFile.toAbsolutePath().toString());
+                    FORMAT_FLAG, formatter, REPORTFILE_FLAG, reportFile.toAbsolutePath().toString());
         } else {
             return runPMDUnix(tempDir, reportFile, SOURCE_DIRECTORY_FLAG, sourceDirectory, RULESET_FLAG, ruleset,
-                    FORMAT_FLAG, FORMATTER, REPORTFILE_FLAG, reportFile.toAbsolutePath().toString());
+                    FORMAT_FLAG, formatter, REPORTFILE_FLAG, reportFile.toAbsolutePath().toString());
         }
     }
 
@@ -128,5 +133,9 @@ public class PMDExecutor {
         } else {
             return runPMDUnix(tempDir, null, arguments);
         }
+    }
+
+    public static boolean isJava7Test() {
+        return StringUtils.equals(System.getenv("JAVA_HOME"), System.getProperty("java7.home"));
     }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/cpd/CPDCommandLineInterfaceTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/cpd/CPDCommandLineInterfaceTest.java
@@ -77,7 +77,7 @@ public class CPDCommandLineInterfaceTest extends BaseCPDCLITest {
 
         String out = getOutput();
         Assert.assertTrue(out.startsWith("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
-        Assert.assertTrue(Pattern.compile("System\\.out\\.println\\([ij] \\+ &quot;ä&quot;\\);").matcher(out).find());
+        Assert.assertTrue(Pattern.compile("System\\.out\\.println\\([ij] \\+ \"ä\"\\);").matcher(out).find());
         Assert.assertEquals(4, Integer.parseInt(System.getProperty(CPDCommandLineInterface.STATUS_CODE_PROPERTY)));
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -358,6 +358,11 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>2.19.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-pmd-plugin</artifactId>
                     <version>${pmd.plugin.version}</version>
                     <executions>
@@ -652,7 +657,7 @@
             <dependency>
                 <groupId>com.beust</groupId>
                 <artifactId>jcommander</artifactId>
-                <version>1.72</version>
+                <version>1.48</version> <!-- 1.48 is the latest version compatible with java7 -->
             </dependency>
             <dependency>
                 <groupId>org.ow2.asm</groupId>
@@ -699,7 +704,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-text</artifactId>
-                <version>1.6</version>
+                <version>1.3</version> <!-- 1.3 is still compatible with java7 -->
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
@@ -1064,10 +1069,6 @@
         <module>pmd-plsql</module>
         <module>pmd-python</module>
         <module>pmd-ruby</module>
-        <module>pmd-scala</module> <!-- deprecated -->
-        <module>pmd-scala-modules/pmd-scala-common</module>
-        <module>pmd-scala-modules/pmd-scala_2.13</module>
-        <module>pmd-scala-modules/pmd-scala_2.12</module>
         <module>pmd-swift</module>
         <module>pmd-test</module>
         <module>pmd-visualforce</module>
@@ -1080,5 +1081,9 @@
         <module>pmd-java8</module>
         <module>pmd-doc</module>
         <module>pmd-lang-test</module>
+        <module>pmd-scala</module> <!-- deprecated -->
+        <module>pmd-scala-modules/pmd-scala-common</module>
+        <module>pmd-scala-modules/pmd-scala_2.13</module>
+        <module>pmd-scala-modules/pmd-scala_2.12</module>
     </modules>
 </project>


### PR DESCRIPTION
## Describe the PR

Running PMD with Java7 does not work as promised. Main problems are with JCommander and commons-text.

* Downgrade JCommander for java7 compatibility
* Downgrade commons-text for java7 compatibility
* Scala also requires java8 and it failed indirectly via a ServiceConfigurationError while discovering the language.
  The Scala module itself doesn't need java8, but its dependencies require java8.
* Add integration test

## Related issues

- none

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

