### PR TITLE
[core] Duplicate warning for missing language attribute

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactory.java
@@ -626,7 +626,7 @@ public class RuleSetFactory {
         Rule rule = new RuleFactory(resourceLoader).buildRule(ruleElement);
         rule.setRuleSetName(ruleSetBuilder.getName());
 
-        if (StringUtils.isBlank(ruleElement.getAttribute("language"))) {
+        if (warnDeprecated && StringUtils.isBlank(ruleElement.getAttribute("language"))) {
             LOG.warning("Rule " + ruleSetReferenceId.getRuleSetFileName() + "/" + rule.getName() + " does not mention attribute"
                             + " language='" + rule.getLanguage().getTerseName() + "',"
                             + " please mention it explicitly to be compatible with PMD 7");


### PR DESCRIPTION
## Describe the PR

I'm seeing duplicated warnings from #2617, I think that's caused by `warnDeprecated`. This is because we parse rulesets twice, once with warnings, a second time without....


## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

