### PR TITLE
[java] Improve example for AvoidSynchronizedAtMethodLevel

### DIFF
--- a/pmd-java/src/main/resources/category/java/multithreading.xml
+++ b/pmd-java/src/main/resources/category/java/multithreading.xml
@@ -24,30 +24,50 @@ gets it.
         <properties>
             <property name="version" value="2.0"/>
             <property name="xpath">
-                <value>//MethodDeclaration[@Synchronized= true()]</value>
+                <value>//MethodDeclaration[@Synchronized = true()]</value>
             </property>
         </properties>
         <example>
 <![CDATA[
 public class Foo {
-  // Try to avoid this:
-  synchronized void foo() {
-  }
-  // Prefer this:
-  void bar() {
-    synchronized(this) {
+    // Try to avoid this:
+    synchronized void foo() {
+        // code, that doesn't need synchronization
+        // ...
+        // code, that requires synchronization
+        if (!sharedData.has("bar")) {
+            sharedData.add("bar");
+        }
+        // more code, that doesn't need synchronization
+        // ...
     }
-  }
-
-  // Try to avoid this for static methods:
-  static synchronized void fooStatic() {
-  }
-
-  // Prefer this:
-  static void barStatic() {
-    synchronized(Foo.class) {
+    // Prefer this:
+    void bar() {
+        // code, that doesn't need synchronization
+        // ...
+        synchronized(this) {
+            if (!sharedData.has("bar")) {
+                sharedData.add("bar");
+            }
+        }
+        // more code, that doesn't need synchronization
+        // ...
     }
-  }
+
+    // Try to avoid this for static methods:
+    static synchronized void fooStatic() {
+    }
+
+    // Prefer this:
+    static void barStatic() {
+        // code, that doesn't need synchronization
+        // ...
+        synchronized(Foo.class) {
+            // code, that requires synchronization
+        }
+        // more code, that doesn't need synchronization
+        // ...
+    }
 }
 ]]>
         </example>


### PR DESCRIPTION
## Describe the PR

Improve the example for rule [AvoidSynchronizedAtMethodLevel](https://pmd.github.io/latest/pmd_rules_java_multithreading.html#avoidsynchronizedatmethodlevel) to make
it clear, that this rule is about code, that doesn't need to be syncronized.

See https://stackoverflow.com/questions/63132263/avoid-synchronized-at-method-level

## Related issues

- None

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

