### PR TITLE
[java] ExcessiveParameterListRule must ignore a private constructor

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveParameterListRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveParameterListRule.java
@@ -4,9 +4,10 @@
 
 package net.sourceforge.pmd.lang.java.rule.design;
 
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTFormalParameters;
-import net.sourceforge.pmd.util.NumericConstants;
 
 /**
  * This rule detects an abnormally long parameter list. Note: This counts Nodes,
@@ -14,14 +15,34 @@ import net.sourceforge.pmd.util.NumericConstants;
  * topcount and sigma should work.)
  */
 public class ExcessiveParameterListRule extends ExcessiveNodeCountRule {
+
+    private static final Integer COUNT = 1;
+    private static final Integer SKIP = 0;
+
     public ExcessiveParameterListRule() {
         super(ASTFormalParameters.class);
         setProperty(MINIMUM_DESCRIPTOR, 10d);
     }
 
-    // Count these nodes, but no others.
     @Override
-    public Object visit(ASTFormalParameter node, Object data) {
-        return NumericConstants.ONE;
+    public Object visit(ASTFormalParameters params, Object data) {
+        if (areParametersOfPrivateConstructor(params)) {
+            return SKIP;
+        }
+        return super.visit(params, data);
+    }
+
+    private boolean areParametersOfPrivateConstructor(ASTFormalParameters params) {
+        Node parent = params.getParent();
+        if (parent instanceof ASTConstructorDeclaration) {
+            ASTConstructorDeclaration constructor = (ASTConstructorDeclaration) parent;
+            return constructor.isPrivate();
+        }
+        return false;
+    }
+
+    @Override
+    public Object visit(ASTFormalParameter param, Object data) {
+        return COUNT;
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ExcessiveParameterList.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ExcessiveParameterList.xml
@@ -26,4 +26,31 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+    
+    <test-code>
+        <description>#2461 private constructor should be ignored</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    private Foo(int a, int b, int c, String abc, long d, double p,
+     String[] arr, int data, long in, float fl, String res) { } // 11 params
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>anonymous class in private constructor false-negative test</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    private Foo() {
+        Object obj = new Object() {
+            public void doWork(int a, int b, int c, String abc, long d, double p,
+                String[] arr, int data, long in, float fl, String res) {} // 11 params
+        };
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

I've added a visit to the ASTFormalParameters with a predicate in order to skip counting private constructor parameters.
<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #2461 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

