### PR TITLE
[java] Fix UnusedAssignment FP with methods throwing exceptions

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -36,6 +36,7 @@ This is a {{ site.pmd.release_type }} release.
 *   java-bestpractices
     *   [#2471](https://github.com/pmd/pmd/issues/2471): \[java] New Rule: AvoidReassigningCatchVariables
     *   [#2668](https://github.com/pmd/pmd/issues/2668): \[java] UnusedAssignment false positives
+    *   [#2684](https://github.com/pmd/pmd/issues/2684): \[java] UnusedAssignment FP in try/catch
 *   java-errorprone
     *   [#2431](https://github.com/pmd/pmd/issues/2431): \[java] InvalidLogMessageFormatRule throws IndexOutOfBoundsException when only logging exception message
     *   [#2439](https://github.com/pmd/pmd/issues/2439): \[java] AvoidCatchingThrowable can not detect the case: catch (java.lang.Throwable t)

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedAssignmentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedAssignmentRule.java
@@ -1312,11 +1312,7 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
         }
 
         private SpanInfo doFork(/*nullable*/ SpanInfo parent, Map<ASTVariableDeclaratorId, VarLocalInfo> reaching) {
-            SpanInfo forked = new SpanInfo(parent, this.global, reaching);
-            if (parent != null && !parent.myCatches.isEmpty()) {
-                forked.myCatches = new ArrayList<>(parent.myCatches);
-            }
-            return forked;
+            return new SpanInfo(parent, this.global, reaching);
         }
 
         /** Abrupt completion for return, continue, break. */

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedAssignmentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedAssignmentRule.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.java.ast.ASTAllocationExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeBodyDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignmentOperator;
@@ -536,14 +537,28 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
                 before.myFinally = before.forkEmpty();
             }
 
+            final List<ASTCatchStatement> catchClauses = node.getCatchClauses();
+            final List<SpanInfo> catchSpans = catchClauses.isEmpty() ? Collections.<SpanInfo>emptyList()
+                                                                     : new ArrayList<SpanInfo>();
+
+            // pre-fill catch spans
+            for (int i = 0; i < catchClauses.size(); i++) {
+                catchSpans.add(before.forkEmpty());
+            }
+
             ASTResourceSpecification resources = node.getFirstChildOfType(ASTResourceSpecification.class);
 
-            SpanInfo bodyState = acceptOpt(resources, before.fork());
+            SpanInfo bodyState = before.fork();
+            bodyState = bodyState.withCatchBlocks(catchSpans);
+            bodyState = acceptOpt(resources, bodyState);
             bodyState = acceptOpt(node.getBody(), bodyState);
+            bodyState = bodyState.withCatchBlocks(Collections.<SpanInfo>emptyList());
 
             SpanInfo exceptionalState = null;
-            for (ASTCatchStatement catchClause : node.getCatchClauses()) {
-                SpanInfo current = acceptOpt(catchClause, before.fork().absorb(bodyState));
+            for (int i = 0; i < catchClauses.size(); i++) {
+                ASTCatchStatement catchClause = catchClauses.get(i);
+
+                SpanInfo current = acceptOpt(catchClause, catchSpans.get(i));
                 exceptionalState = current.absorb(exceptionalState);
             }
 
@@ -556,6 +571,7 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
                 SpanInfo abruptFinally = before.myFinally.absorb(before);
                 acceptOpt(finallyClause, abruptFinally);
                 before.myFinally = null;
+                abruptFinally.abruptCompletionByThrow(false); // propagate to enclosing catch/finallies
 
                 // this is the normal finally
                 finalState = acceptOpt(finallyClause, finalState);
@@ -756,7 +772,7 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
         @Override
         public Object visit(ASTThrowStatement node, Object data) {
             super.visit(node, data);
-            return ((SpanInfo) data).abruptCompletion(null);
+            return ((SpanInfo) data).abruptCompletionByThrow(false);
         }
 
         @Override
@@ -863,7 +879,35 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
             if (var != null) {
                 state.use(var);
             }
+
+            maybeThrowUncheckedExceptions(node, state);
+
             return state;
+        }
+
+        private void maybeThrowUncheckedExceptions(ASTPrimaryExpression e, SpanInfo state) {
+            // Note that this doesn't really respect the order of evaluation of subexpressions
+            // This can be easily fixed in the 7.0 tree, but this is rare enough to not deserve
+            // the effort on master.
+
+            // For the record this has problems with call chains with side effects, like
+            //  a.foo(a = 2).bar(a = 3);
+
+            if (!state.isInTryBlock()) {
+                return;
+            }
+            // otherwise any method/ctor call may throw
+
+            // In 7.0, with the precise type/overload resolution, we
+            // could only target methods that throw checked exceptions
+            // (unless some catch block catches an unchecked exceptions)
+            for (JavaNode child : e.children()) {
+                if (child instanceof ASTPrimarySuffix && ((ASTPrimarySuffix) child).isArguments()
+                    || child instanceof ASTPrimarySuffix && child.getNumChildren() > 0 && child.getChild(0) instanceof ASTAllocationExpression
+                    || child instanceof ASTPrimaryPrefix && child.getNumChildren() > 0 && child.getChild(0) instanceof ASTAllocationExpression) {
+                    state.abruptCompletionByThrow(true);
+                }
+            }
         }
 
         /**
@@ -1147,6 +1191,14 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
         // needs to go through the finally span (the finally must absorb it)
         SpanInfo myFinally = null;
 
+
+        /**
+         * Inside a try block, we assume that any method/ctor call may
+         * throw, which means, any assignment reaching such a method call
+         * may reach the catch blocks if there are any.
+         */
+        List<SpanInfo> myCatches;
+
         final GlobalAlgoState global;
 
         final Map<ASTVariableDeclaratorId, VarLocalInfo> symtable;
@@ -1161,6 +1213,7 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
             this.parent = parent;
             this.global = global;
             this.symtable = symtable;
+            this.myCatches = Collections.emptyList();
         }
 
         boolean hasVar(ASTVariableDeclaratorId var) {
@@ -1258,16 +1311,24 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
             return copy;
         }
 
-        private SpanInfo doFork(SpanInfo parent, Map<ASTVariableDeclaratorId, VarLocalInfo> reaching) {
-            return new SpanInfo(parent, this.global, reaching);
+        private SpanInfo doFork(/*nullable*/ SpanInfo parent, Map<ASTVariableDeclaratorId, VarLocalInfo> reaching) {
+            SpanInfo forked = new SpanInfo(parent, this.global, reaching);
+            if (parent != null && !parent.myCatches.isEmpty()) {
+                forked.myCatches = new ArrayList<>(parent.myCatches);
+            }
+            return forked;
         }
 
+        /** Abrupt completion for return, continue, break. */
         SpanInfo abruptCompletion(SpanInfo target) {
             // if target == null then this will unwind all the parents
             SpanInfo parent = this;
             while (parent != target && parent != null) { // NOPMD CompareObjectsWithEqual this is what we want
                 if (parent.myFinally != null) {
                     parent.myFinally.absorb(this);
+                    // stop on the first finally, its own end state will
+                    // be merged into the nearest enclosing finally
+                    return this;
                 }
                 parent = parent.parent;
             }
@@ -1276,6 +1337,57 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
             return this;
         }
 
+
+        /**
+         * Record an abrupt completion occurring because of a thrown
+         * exception.
+         *
+         * @param byMethodCall If true, a method/ctor call threw the exception
+         *                     (we conservatively consider they do inside try blocks).
+         *                     Otherwise, a throw statement threw.
+         */
+        SpanInfo abruptCompletionByThrow(boolean byMethodCall) {
+            // Find the first block that has a finally
+            // Be absorbed into every catch block on the way.
+
+            // In 7.0, with the precise type/overload resolution, we
+            // can target the specific catch block that would catch the
+            // exception.
+
+            SpanInfo parent = this;
+            while (parent != null) {
+
+                if (!parent.myCatches.isEmpty()) {
+                    for (SpanInfo c : parent.myCatches) {
+                        c.absorb(this);
+                    }
+                }
+
+                if (parent.myFinally != null) {
+                    // stop on the first finally, its own end state will
+                    // be merged into the nearest enclosing finally
+                    parent.myFinally.absorb(this);
+                    return this;
+                }
+                parent = parent.parent;
+            }
+
+            if (!byMethodCall) {
+                this.symtable.clear(); // following is dead code
+            }
+            return this;
+        }
+
+        SpanInfo withCatchBlocks(List<SpanInfo> catchStmts) {
+            assert myCatches.isEmpty() || catchStmts.isEmpty() : "Cannot set catch blocks twice";
+            myCatches = Collections.unmodifiableList(catchStmts); // we own the list now, to avoid copying
+            return this;
+        }
+
+        private boolean isInTryBlock() {
+            // ignore resources, once they're initialized everything's fine in the block
+            return !myCatches.isEmpty() || myFinally != null;
+        }
 
         SpanInfo absorb(SpanInfo other) {
             // Merge reaching defs of the other scope into this

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -1367,6 +1367,16 @@ class Foo{
             out by default, in case you already have enabled those rules, but may be enabled with the property
             `reportUnusedVariables`. Variables whose name starts with `ignored` are filtered out, as
             is standard practice for exceptions.
+
+            Limitations:
+            * The rule currently cannot know which method calls throw exceptions, or which exceptions they throw.
+            In the body of a try block, every method or constructor call is assumed to throw.  This may cause false-negatives.
+            The only other language construct that is assumed to throw is the `throw` statement, in particular,
+            things like `assert` statements, or NullPointerExceptions on dereference are ignored.
+            * The rule cannot resolve assignments across constructors, when they're called with the special
+            `this(...)` syntax. This may cause false-negatives.
+
+            Both of those limitations may be partly relaxed in PMD 7.
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
@@ -1176,8 +1176,13 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>Definitions in try block reach catch blocks</description>
-        <expected-problems>0</expected-problems>
+        <description>Definitions in try block reach catch blocks through method calls</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>4,7</expected-linenumbers>
+        <expected-messages>
+            <message>The initializer for variable 'halfway' is never used (overwritten on line 7)</message>
+            <message>The value assigned to variable 'halfway' is never used</message>
+        </expected-messages>
         <code><![CDATA[
 public class Foo {
 
@@ -1185,6 +1190,57 @@ public class Foo {
         boolean halfway = false;
 
         try {
+            halfway = true; // this may not fail so the catch block is unreachable
+        } catch(Exception e) {
+            System.out.println(halfway);
+        }
+    }
+}
+
+
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Definitions in try block reach catch blocks through method calls 2</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>The initializer for variable 'halfway' is never used (overwritten on line 7)</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+
+    void method() {
+        boolean halfway = false;
+
+        try {
+            halfway = true;
+            trySomethingWhichFails(); // catch may be reached if this throws
+        } catch(Exception e) {
+            System.out.println(halfway);
+        }
+    }
+}
+
+
+]]></code>
+    </test-code>
+    <test-code>
+        <description>Definitions in try block reach catch blocks through method calls 3</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>8</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'halfway' is never used</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+
+    void method() {
+        boolean halfway = false;
+
+        try {
+            trySomethingWhichFails(); // catch may be reached if this throws (initializer would be used)
             halfway = true;
         } catch(Exception e) {
             System.out.println(halfway);
@@ -1203,7 +1259,7 @@ public class Foo {
 public class Foo {
 
     public int foo() {
-        int a = 0;
+        int a = 0; // used in catch
         try (Reader r = new StringReader("")) {
             a = r.read();  // used in finally
         } catch (IOException e) {
@@ -1229,9 +1285,9 @@ public class Foo {
     public int foo() {
         int a = 0;
         try (Reader r = new StringReader("")) {
-            a = r.read();  // used in finally
+            a = r.read();  // used in return
         } catch (IOException e) {
-            a = -1; // used in finally
+            a = -1; // used in return
         } finally {
             // don't use a
         }
@@ -1239,6 +1295,68 @@ public class Foo {
     }
 
 }        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Try/catch finally 4</description>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>4,6,8</expected-linenumbers>
+        <expected-messages>
+            <message>The initializer for variable 'a' is never used (overwritten on lines 6, 8 and 10)</message>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 10)</message>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 10)</message>
+        </expected-messages>
+        <code><![CDATA[
+public class Foo {
+
+    public int foo() {
+        int a = 0; // overwritten in try body & catch
+        try (Reader r = new StringReader("")) {
+            a = r.read();  // overwritten in finally
+        } catch (IOException e) {
+            a = -1; // overwritten in finally
+        } finally {
+            a = 0;
+        }
+        return a;
+    }
+
+}        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Nested finally</description>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>8,11,13,16</expected-linenumbers>
+        <expected-messages>
+            <message>The initializer for variable 'a' is never used (overwritten on lines 11, 13, 16 and 18)</message>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 13)</message>
+            <message>The value assigned to variable 'a' is never used (overwritten on lines 16 and 18)</message>
+            <message>The value assigned to variable 'a' is never used (overwritten on line 18)</message>
+        </expected-messages>
+        <code><![CDATA[
+            import java.io.IOException;
+            import java.io.Reader;
+            import java.io.StringReader;
+
+            public class Foo {
+
+                public int foo() {
+                    int a = 0;
+                    try (Reader r = new StringReader("")) {
+                        try (Reader r = new StringReader("")) {
+                            a = r.read();       // overwritten in finally
+                        } finally {
+                            a = 0; // overwritten in enclosing catch, if `read()` threw, otherwise in enclosing finally
+                        }
+                    } catch (IOException e) {
+                        a = -1; // overwritten in finally
+                    } finally {
+                        a = 1;
+                    }
+                    return a;
+                }
+
+            }
+        ]]></code>
     </test-code>
     <test-code>
         <description>Try/catch finally in loop</description>
@@ -2922,6 +3040,59 @@ class Foo {
                 A(int k) {
                     Worker.show(this); // observes `ignore = true`
                 }
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Try stmt FP in try when method can throw #2684</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            import java.io.Reader;
+            import java.io.StringReader;
+            import java.io.IOException;
+
+            public class Foo {
+
+                public int foo() {
+                    int a = 0;
+                    try (Reader r = new StringReader("")) {
+                        a = r.read(); // might assign or fail
+                        a = r.read(); // might assign or fail
+                    } catch (IOException e) {
+                    }
+                    return a;
+                }
+
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Try stmt FP in try when method can throw (2) #2684</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>10</expected-linenumbers>
+        <expected-messages>
+            <message>The value assigned to variable 'a' is never used (overwritten on lines 11 and 13)</message>
+        </expected-messages>
+        <code><![CDATA[
+            import java.io.IOException;
+            import java.io.Reader;
+            import java.io.StringReader;
+
+            class Foo {
+
+                public int foo() {
+                    int a;
+                    try (Reader r = new StringReader("")) {
+                        a = r.read(); // really unused: overwritten with r.read() and 0;
+                        a = r.read(); // might assign or fail
+                    } catch (IOException e) {
+                        a = 0;
+                    }
+                    return a;
+                }
+
             }
             ]]></code>
     </test-code>


### PR DESCRIPTION
## Describe the PR

Fixes #2684. We conservatively assume that any method/ctor call may throw within a try block. There are several improvements we can do to this in PMD 7, with #2689: the overload resolution allows us to find out which methods throw checked exceptions and associate them to the actual catch block they would be dispatched to.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #2684

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

