### PR TITLE
[java] Add void type node to replace ResultType

### DIFF
--- a/pmd-java/etc/grammar/Java.jjt
+++ b/pmd-java/etc/grammar/Java.jjt
@@ -1443,10 +1443,11 @@ void PrimitiveType() :
 }
 
 
-void ResultType() :
+void ResultType() #void:
 {}
 {
-   "void" | AnnotatedType()
+   "void" #VoidType
+   | AnnotatedType()
 }
 
 
@@ -1734,7 +1735,7 @@ void PrimaryPrefix() #void :
 | "super"                                 #SuperExpression(true)
     ("." MemberSelector() | MethodReference())
 | UnqualifiedAllocationExpr()
-| ("void" "." "class")                    #ClassLiteral
+| ("void" #VoidType "." "class")          #ClassLiteral
 | LOOKAHEAD(1) // suppress the warning here.
   (PrimitiveType() [ Dims() ] )           #ArrayType(>1)
     (
@@ -2483,7 +2484,7 @@ void AnnotationTypeMemberDeclaration() #void:
 void AnnotationMethodDeclaration() #MethodDeclaration:
 {}
 {
-  Type() #ResultType
+  Type()
   <IDENTIFIER> { setLastTokenImage(jjtThis); }
   ("(" ")") #FormalParameters
   [ Dims() ]

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTClassLiteral.java
@@ -4,7 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * A class literal. Class literals are {@linkplain ASTPrimaryExpression primary expressions},
@@ -12,7 +12,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *
  * <pre class="grammar">
  *
- * ClassLiteral ::= ({@link ASTType Type} | "void") "." "class"
+ * ClassLiteral ::= {@link ASTType Type} "." "class"
  *
  * </pre>
  */
@@ -26,17 +26,10 @@ public final class ASTClassLiteral extends AbstractJavaExpr implements ASTPrimar
         return visitor.visit(this, data);
     }
 
-
-    public boolean isVoid() {
-        return getNumChildren() == 0;
-    }
-
-
     /**
-     * Returns the enclosed type node, or an empty optional if this is void.
+     * Returns the type node (this may be a {@link ASTVoidType}).
      */
-    @Nullable
-    public ASTType getTypeNode() {
-        return isVoid() ? null : (ASTType) getChild(0);
+    public @NonNull ASTType getTypeNode() {
+        return (ASTType) getChild(0);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodDeclaration.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.sourceforge.pmd.lang.ast.xpath.internal.DeprecatedAttribute;
@@ -27,7 +28,7 @@ import net.sourceforge.pmd.lang.java.symbols.JMethodSymbol;
  *
  * MethodDeclaration ::= {@link ASTModifierList ModifierList}
  *                       {@link ASTTypeParameters TypeParameters}?
- *                       {@link ASTResultType ResultType}
+ *                       {@link ASTType Type}
  *                       &lt;IDENTIFIER&gt;
  *                       {@link ASTFormalParameters FormalParameters}
  *                       {@link ASTArrayDimensions ArrayDimensions}?
@@ -87,11 +88,9 @@ public final class ASTMethodDeclaration extends AbstractMethodOrConstructorDecla
 
     /**
      * Returns true if the result type of this method is {@code void}.
-     *
-     * TODO remove, just as simple to write getResultType().isVoid()
      */
     public boolean isVoid() {
-        return getResultType().isVoid();
+        return getResultTypeNode().isVoid();
     }
 
 
@@ -106,9 +105,19 @@ public final class ASTMethodDeclaration extends AbstractMethodOrConstructorDecla
 
     /**
      * Returns the result type node of the method.
+     *
+     * @deprecated todo When removed from java-grammar, rename the other to this good name
      */
+    @Deprecated
     public ASTResultType getResultType() {
         return getFirstChildOfType(ASTResultType.class);
+    }
+
+    /**
+     * Returns the result type node of the method. This may be a {@link ASTVoidType}.
+     */
+    public @NonNull ASTType getResultTypeNode() {
+        return getFirstChildOfType(ASTType.class);
     }
 
     /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTResultType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTResultType.java
@@ -14,7 +14,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * ResultType ::= "void" | {@link ASTType Type}
  *
  * </pre>
+ *
+ * @deprecated This has been replaced by an unwrapped {@link ASTType},
+ *     "void" being represented by {@link ASTVoidType}.
  */
+@Deprecated
 public final class ASTResultType extends AbstractJavaNode {
 
     ASTResultType(int id) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTType.java
@@ -4,8 +4,6 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
-
 import net.sourceforge.pmd.annotation.Experimental;
 
 
@@ -45,24 +43,18 @@ public interface ASTType extends TypeNode, Annotatable, LeftRecursiveNode {
         return 0;
     }
 
-    @Nullable
-    default ASTPrimitiveType asPrimitiveType() {
-        return isPrimitiveType() ? (ASTPrimitiveType) this : null;
+
+    /**
+     * Returns true if this is the "void" pseudo-type, ie an {@link ASTVoidType}.
+     */
+    default boolean isVoid() {
+        return this instanceof ASTVoidType;
     }
 
-    @Nullable
-    default ASTReferenceType asReferenceType() {
-        return isReferenceType() ? (ASTReferenceType) this : null;
-    }
-
+    // TODO remove that, there's enough on JTypeMirror
 
     default boolean isPrimitiveType() {
         return this instanceof ASTPrimitiveType;
-    }
-
-
-    default boolean isReferenceType() {
-        return !isPrimitiveType();
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVoidType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVoidType.java
@@ -1,0 +1,34 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.ast;
+
+/**
+ * Type node to represent the void pseudo-type. This represents the
+ * absence of a type, not a type, but it's easier to process that way.
+ * Can only occur as return type of method declarations, and as the qualifier
+ * of a {@linkplain ASTClassLiteral class literal}.
+ *
+ * <pre class="grammar">
+ *
+ * VoidType ::= "void"
+ *
+ * </pre>
+ */
+public final class ASTVoidType extends AbstractJavaTypeNode implements ASTType {
+
+    ASTVoidType(int id) {
+        super(id);
+    }
+
+    @Override
+    protected <P, R> R acceptVisitor(JavaVisitor<? super P, ? extends R> visitor, P data) {
+        return visitor.visit(this, data);
+    }
+
+    @Override
+    public String getTypeImage() {
+        return "void";
+    }
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/multifile/signature/JavaOperationSignature.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/multifile/signature/JavaOperationSignature.java
@@ -15,7 +15,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodOrConstructorDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTResultType;
 
 /**
  * Signature for an operation.
@@ -128,7 +127,7 @@ public final class JavaOperationSignature extends JavaSignature<ASTMethodOrConst
         /** Attempts to determine if the method is a getter. */
         private static boolean isGetter(ASTMethodDeclaration node, Map<String, String> fieldNames) {
 
-            if (node.getArity() != 0 || node.getFirstDescendantOfType(ASTResultType.class).isVoid()) {
+            if (node.getArity() != 0 || node.isVoid()) {
                 return false;
             }
 
@@ -146,7 +145,7 @@ public final class JavaOperationSignature extends JavaSignature<ASTMethodOrConst
         /** Attempts to determine if the method is a setter. */
         private static boolean isSetter(ASTMethodDeclaration node, Map<String, String> fieldNames) {
 
-            if (node.getArity() != 1 || !node.getFirstDescendantOfType(ASTResultType.class).isVoid()) {
+            if (node.getArity() != 1 || !node.isVoid()) {
                 return false;
             }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJavaRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJavaRule.java
@@ -35,6 +35,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
 import net.sourceforge.pmd.lang.java.ast.ASTRelationalExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTResultType;
 import net.sourceforge.pmd.lang.java.ast.ASTShiftExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTStatementExpression;
@@ -221,6 +222,11 @@ public abstract class AbstractJavaRule extends AbstractRule implements JavaParse
 
     @Deprecated
     public Object visit(ASTMethodDeclarator node, Object data) {
+        return null;
+    }
+
+    @Deprecated
+    public Object visit(ASTResultType node, Object data) {
         return null;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LinguisticNamingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LinguisticNamingRule.java
@@ -18,7 +18,6 @@ import org.apache.commons.lang3.StringUtils;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTResultType;
 import net.sourceforge.pmd.lang.java.ast.ASTType;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
 import net.sourceforge.pmd.lang.java.rule.AbstractIgnoredAnnotationRule;
@@ -107,10 +106,9 @@ public class LinguisticNamingRule extends AbstractIgnoredAnnotationRule {
     }
 
     private void checkPrefixedTransformMethods(ASTMethodDeclaration node, Object data, String nameOfMethod) {
-        ASTResultType resultType = node.getResultType();
         List<String> prefixes = getProperty(TRANSFORM_METHOD_NAMES_PROPERTY);
         String[] splitMethodName = StringUtils.splitByCharacterTypeCamelCase(nameOfMethod);
-        if (resultType.isVoid() && splitMethodName.length > 0
+        if (node.isVoid() && splitMethodName.length > 0
                 && prefixes.contains(splitMethodName[0].toLowerCase(Locale.ROOT))) {
             // "To" or any other configured prefix found
             addViolationWithMessage(data, node, "Linguistics Antipattern - The transform method ''{0}'' should not return void linguistically",
@@ -119,10 +117,9 @@ public class LinguisticNamingRule extends AbstractIgnoredAnnotationRule {
     }
 
     private void checkTransformMethods(ASTMethodDeclaration node, Object data, String nameOfMethod) {
-        ASTResultType resultType = node.getResultType();
         List<String> infixes = getProperty(TRANSFORM_METHOD_NAMES_PROPERTY);
         for (String infix : infixes) {
-            if (resultType.isVoid() && containsWord(nameOfMethod, StringUtils.capitalize(infix))) {
+            if (node.isVoid() && containsWord(nameOfMethod, StringUtils.capitalize(infix))) {
                 // "To" or any other configured infix in the middle somewhere
                 addViolationWithMessage(data, node, "Linguistics Antipattern - The transform method ''{0}'' should not return void linguistically",
                         new Object[] { nameOfMethod });
@@ -133,16 +130,14 @@ public class LinguisticNamingRule extends AbstractIgnoredAnnotationRule {
     }
 
     private void checkGetters(ASTMethodDeclaration node, Object data, String nameOfMethod) {
-        ASTResultType resultType = node.getResultType();
-        if (hasPrefix(nameOfMethod, "get") && resultType.isVoid()) {
+        if (hasPrefix(nameOfMethod, "get") && node.isVoid()) {
             addViolationWithMessage(data, node, "Linguistics Antipattern - The getter ''{0}'' should not return void linguistically",
                     new Object[] { nameOfMethod });
         }
     }
 
     private void checkSetters(ASTMethodDeclaration node, Object data, String nameOfMethod) {
-        ASTResultType resultType = node.getResultType();
-        if (hasPrefix(nameOfMethod, "set") && !resultType.isVoid()) {
+        if (hasPrefix(nameOfMethod, "set") && !node.isVoid()) {
             addViolationWithMessage(data, node, "Linguistics Antipattern - The setter ''{0}'' should not return any type except void linguistically",
                     new Object[] { nameOfMethod });
         }
@@ -155,9 +150,8 @@ public class LinguisticNamingRule extends AbstractIgnoredAnnotationRule {
     }
 
     private void checkBooleanMethods(ASTMethodDeclaration node, Object data, String nameOfMethod) {
-        ASTResultType resultType = node.getResultType();
-        ASTType t = node.getResultType().getFirstChildOfType(ASTType.class);
-        if (!resultType.isVoid() && t != null) {
+        ASTType t = node.getResultTypeNode();
+        if (!t.isVoid()) {
             for (String prefix : getProperty(BOOLEAN_METHOD_PREFIXES_PROPERTY)) {
                 if (hasPrefix(nameOfMethod, prefix) && !isBooleanType(t)) {
                     addViolationWithMessage(data, node, "Linguistics Antipattern - The method ''{0}'' indicates linguistically it returns a boolean, but it returns ''{1}''",
@@ -187,7 +181,7 @@ public class LinguisticNamingRule extends AbstractIgnoredAnnotationRule {
 
     @Override
     public Object visit(ASTFieldDeclaration node, Object data) {
-        ASTType type = node.getFirstChildOfType(ASTType.class);
+        ASTType type = node.getTypeNode();
         if (type != null && getProperty(CHECK_FIELDS)) {
             List<ASTVariableDeclarator> fields = node.findChildrenOfType(ASTVariableDeclarator.class);
             for (ASTVariableDeclarator field : fields) {
@@ -199,7 +193,7 @@ public class LinguisticNamingRule extends AbstractIgnoredAnnotationRule {
 
     @Override
     public Object visit(ASTLocalVariableDeclaration node, Object data) {
-        ASTType type = node.getFirstChildOfType(ASTType.class);
+        ASTType type = node.getTypeNode();
         if (type != null && getProperty(CHECK_VARIABLES)) {
             List<ASTVariableDeclarator> variables = node.findChildrenOfType(ASTVariableDeclarator.class);
             for (ASTVariableDeclarator variable : variables) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryReturnRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryReturnRule.java
@@ -16,7 +16,7 @@ public class UnnecessaryReturnRule extends AbstractJavaRule {
     @Override
     public Object visit(ASTMethodDeclaration node, Object data) {
 
-        if (node.getResultType().isVoid()) {
+        if (node.isVoid()) {
             super.visit(node, data);
         }
         return data;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/SingletonClassReturningNewInstanceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/SingletonClassReturningNewInstanceRule.java
@@ -27,7 +27,7 @@ public class SingletonClassReturningNewInstanceRule extends AbstractJavaRule {
         String localVarName = null;
         String returnVariableName = null;
 
-        if (node.getResultType().isVoid()) {
+        if (node.isVoid()) {
             return super.visit(node, data);
         }
 

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTClassLiteralTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTClassLiteralTest.kt
@@ -19,7 +19,7 @@ class ASTClassLiteralTest : ParserTestSpec({
 
 
             "void.class" should parseAs {
-                classLiteral { null }
+                classLiteral { voidType() }
             }
 
 

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTMethodDeclarationTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTMethodDeclarationTest.kt
@@ -151,7 +151,7 @@ class ASTMethodDeclarationTest : ParserTestSpec({
 
                     it::getModifiers shouldBe modifiers { }
 
-                    it::getResultType shouldBe voidResult()
+                    it::getResultTypeNode shouldBe voidType()
 
 
                     it::getFormalParameters shouldBe formalsList(0)
@@ -178,7 +178,7 @@ class ASTMethodDeclarationTest : ParserTestSpec({
 
                     it::getModifiers shouldBe modifiers { }
 
-                    it::getResultType shouldBe voidResult()
+                    it::getResultTypeNode shouldBe voidType()
 
                     it::getFormalParameters shouldBe formalsList(0)
 
@@ -212,7 +212,7 @@ class ASTMethodDeclarationTest : ParserTestSpec({
 
                     it::getModifiers shouldBe modifiers { }
 
-                    it::getResultType shouldBe voidResult()
+                    it::getResultTypeNode shouldBe voidType()
 
                     it::getFormalParameters shouldBe formalsList(1) {
                         child<ASTFormalParameter> {
@@ -243,7 +243,7 @@ class ASTMethodDeclarationTest : ParserTestSpec({
 
                     it::getModifiers shouldBe modifiers { }
 
-                    it::getResultType shouldBe voidResult()
+                    it::getResultTypeNode shouldBe voidType()
 
                     it::getFormalParameters shouldBe formalsList(1) {
                         child<ASTFormalParameter> {
@@ -282,7 +282,7 @@ class ASTMethodDeclarationTest : ParserTestSpec({
 
                     it::getModifiers shouldBe modifiers { }
 
-                    it::getResultType shouldBe voidResult()
+                    it::getResultTypeNode shouldBe voidType()
 
                     it::getFormalParameters shouldBe formalsList(0)
 
@@ -313,9 +313,8 @@ class ASTMethodDeclarationTest : ParserTestSpec({
                 annotationMethod {
                     modifiers { }
 
-                    resultType {
-                        primitiveType(PrimitiveType.INT)
-                    }
+                    it::getResultTypeNode shouldBe primitiveType(PrimitiveType.INT)
+
                     formalsList(0)
                 }
             }
@@ -324,9 +323,8 @@ class ASTMethodDeclarationTest : ParserTestSpec({
                 annotationMethod {
                     it::getModifiers shouldBe modifiers { }
 
-                    it::getResultType shouldBe resultType {
-                        primitiveType(PrimitiveType.INT)
-                    }
+                    it::getResultTypeNode shouldBe primitiveType(PrimitiveType.INT)
+
                     it::getFormalParameters shouldBe formalsList(0)
 
                     it::getDefaultClause shouldBe defaultValue { int(2) }
@@ -336,9 +334,8 @@ class ASTMethodDeclarationTest : ParserTestSpec({
             "int bar() @NonZero [];" should parseAs {
                 annotationMethod {
                     it::getModifiers shouldBe modifiers { }
-                    it::getResultType shouldBe resultType {
-                        primitiveType(PrimitiveType.INT)
-                    }
+                    it::getResultTypeNode shouldBe primitiveType(PrimitiveType.INT)
+
                     it::getFormalParameters shouldBe formalsList(0)
 
                     it::getDefaultClause shouldBe null
@@ -353,9 +350,8 @@ class ASTMethodDeclarationTest : ParserTestSpec({
             "Override bar() default @Override;" should parseAs {
                 annotationMethod {
                     it::getModifiers shouldBe modifiers { }
-                    it::getResultType shouldBe resultType {
-                        classType("Override")
-                    }
+                    it::getResultTypeNode shouldBe classType("Override")
+
                     it::getFormalParameters shouldBe formalsList(0)
 
                     it::getDefaultClause shouldBe defaultValue { annotation("Override") }
@@ -365,9 +361,7 @@ class ASTMethodDeclarationTest : ParserTestSpec({
             "Override bar()[] default { @Override };" should parseAs {
                 annotationMethod {
                     it::getModifiers shouldBe modifiers { }
-                    it::getResultType shouldBe resultType {
-                        classType("Override")
-                    }
+                    it::getResultTypeNode shouldBe classType("Override")
                     it::getFormalParameters shouldBe formalsList(0)
 
                     it::getExtraDimensions shouldBe child {
@@ -401,7 +395,7 @@ class ASTMethodDeclarationTest : ParserTestSpec({
 
                     it::getModifiers shouldBe modifiers { }
 
-                    it::getResultType shouldBe voidResult()
+                    it::getResultTypeNode shouldBe voidType()
 
                     it::getFormalParameters shouldBe formalsList(0) {
                         it.toList() shouldBe emptyList()
@@ -429,7 +423,7 @@ class ASTMethodDeclarationTest : ParserTestSpec({
 
                     it::getModifiers shouldBe modifiers { }
 
-                    it::getResultType shouldBe voidResult()
+                    it::getResultTypeNode shouldBe voidType()
 
                     it::getFormalParameters shouldBe formalsList(1) {
 
@@ -473,11 +467,10 @@ class ASTMethodDeclarationTest : ParserTestSpec({
                         }
                     }
 
-                    it::getResultType shouldBe resultType {
-                        classType("Ret") {
-                            annotation("OnType")
-                        }
+                    it::getResultTypeNode shouldBe classType("Ret") {
+                        annotation("OnType")
                     }
+
 
                     formalsList(0)
                     block()

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/TestExtensions.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/TestExtensions.kt
@@ -225,18 +225,6 @@ fun TreeNodeWrapper<Node, *>.lambdaFormals(size: Int? = null, contents: NodeSpec
 fun TreeNodeWrapper<Node, *>.formalsList(arity: Int, contents: NodeSpec<ASTFormalParameters> = EmptyAssertions) =
         childW(listSpec(arity, contents))
 
-fun TreeNodeWrapper<Node, *>.voidResult() =
-        child<ASTResultType> {
-            it::getTypeNode shouldBe null
-            it::isVoid shouldBe true
-        }
-
-fun TreeNodeWrapper<Node, *>.resultType(contents: ValuedNodeSpec<ASTResultType, ASTType>) =
-        child<ASTResultType>(ignoreChildren = contents == EmptyAssertions) {
-            it::getTypeNode shouldBe contents()
-            it::isVoid shouldBe false
-        }
-
 fun TreeNodeWrapper<Node, *>.defaultValue(contents: ValuedNodeSpec<ASTDefaultValue, ASTMemberValue>) =
         child<ASTDefaultValue>(ignoreChildren = contents == EmptyAssertions) {
             it::getConstant shouldBe contents()
@@ -389,6 +377,8 @@ fun TreeNodeWrapper<Node, *>.unionType(contents: NodeSpec<ASTUnionType> = EmptyA
             contents()
         }
 
+fun TreeNodeWrapper<Node, *>.voidType() = child<ASTVoidType>() {}
+
 
 fun TreeNodeWrapper<Node, *>.typeExpr(contents: ValuedNodeSpec<ASTTypeExpression, ASTType>) =
         child<ASTTypeExpression>(ignoreChildren = contents == EmptyAssertions) {
@@ -453,10 +443,8 @@ fun TreeNodeWrapper<Node, *>.textBlock(contents: NodeSpec<ASTStringLiteral> = Em
             contents()
         }
 
-fun TreeNodeWrapper<Node, *>.classLiteral(contents: ValuedNodeSpec<ASTClassLiteral, ASTType?>) =
+fun TreeNodeWrapper<Node, *>.classLiteral(contents: ValuedNodeSpec<ASTClassLiteral, ASTType>) =
         child<ASTClassLiteral> {
-            val tn = it.typeNode
-            it::isVoid shouldBe (tn == null)
             it::getTypeNode shouldBe contents()
         }
 


### PR DESCRIPTION
## Describe the PR

Add a VoidType node to replace ResultType. This means we don't need the ResultType wrapper when the method is not void, and the result type node is never null:


<table>
<tr><th>Code</th><th>Old AST</th><th>New AST</th></tr>
<tr><td>

```java
void foo();
```

</td><td>

```
└─ MethodDeclaration
   └─ ResultType[@Void=true()]
   └─ MethodDeclarator
      └─ FormalParameters
```

</td><td>

```
└─ MethodDeclaration
   └─ ModifierList
   └─ VoidType
   └─ FormalParameters

```

</td></tr>
<tr><td>

```java
int foo();
```

</td><td>

```
└─ MethodDeclaration
   └─ ResultType[@Void=false()]
      └─ Type
         └─ PrimitiveType
   └─ MethodDeclarator
      └─ FormalParameters
```

</td><td>

```
└─ MethodDeclaration
   └─ ModifierList
   └─ PrimitiveType
   └─ FormalParameters

```

</td></tr>
</table>



This also makes the qualifier of a `ClassLiteral` non-null, which removes the inconsistency between `void.class` and `T.class`:

<table>
<tr><th>Code</th><th>Current java-grammar</th><th>After this PR</th></tr>
<tr><td>

```java
void.class
```

</td><td>

```
ClassLiteral[@Void=true()]
```

</td><td>

```
└─ ClassLiteral
   └─ VoidType
```

</td></tr>
<tr><td>

```java
int.class
```

</td><td>

```
└─ ClassLiteral
   └─ PrimitiveType
```

</td><td>

```
└─ ClassLiteral
   └─ PrimitiveType
```

</td></tr>
</table>


(this change description is relative to java-grammar as ASTClassLiteral does not exist on master, so we don't have to put it into the clean release notes).

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

