### PR TITLE
[doc] [java] SuspiciousEqualsMethodName: update description, fixes #2264

### DIFF
--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -3052,8 +3052,12 @@ StringBuilder sb4 = new StringBuilder("c");
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#suspiciousequalsmethodname">
         <description>
-The method name and parameter number are suspiciously close to equals(Object), which can denote an
-intention to override the equals(Object) method.
+The method name and parameter number are suspiciously close to Object.equals, which can denote an
+intention to override it. However, the method does not override Object.equals, but overloads it instead.
+Overloading Object.equals method is confusing for other programmers, error-prone and hard to main,
+especially when using inheritance, because @Override annotations used in subclasses can provide a false
+sense of security. For more information on Object.equals method, see Effective Java, 3rd Edition,
+Item 10: Obey the general contract when overriding equals.
         </description>
         <priority>2</priority>
         <properties>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -3054,7 +3054,7 @@ StringBuilder sb4 = new StringBuilder("c");
         <description>
 The method name and parameter number are suspiciously close to Object.equals, which can denote an
 intention to override it. However, the method does not override Object.equals, but overloads it instead.
-Overloading Object.equals method is confusing for other programmers, error-prone and hard to main,
+Overloading Object.equals method is confusing for other programmers, error-prone and hard to maintain,
 especially when using inheritance, because @Override annotations used in subclasses can provide a false
 sense of security. For more information on Object.equals method, see Effective Java, 3rd Edition,
 Item 10: Obey the general contract when overriding equals.


### PR DESCRIPTION
## Describe the PR

Extends Java SuspiciousEqualsMethodName rule description

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #2264

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

