### PR TITLE
Cleanup: change valueOf to parse when we need primitive return value.

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/BooleanProperty.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/BooleanProperty.java
@@ -33,7 +33,7 @@ public final class BooleanProperty extends AbstractSingleValueProperty<Boolean> 
      */
     @Deprecated
     public BooleanProperty(String theName, String theDescription, String defaultBoolStr, float theUIOrder) {
-        this(theName, theDescription, Boolean.valueOf(defaultBoolStr), theUIOrder, false);
+        this(theName, theDescription, Boolean.parseBoolean(defaultBoolStr), theUIOrder, false);
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/GenericClassCounterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/GenericClassCounterRule.java
@@ -93,7 +93,7 @@ public class GenericClassCounterRule extends AbstractJavaRule {
         this.operand = getProperty(OPERAND_DESCRIPTOR);
         this.typesMatch = RegexHelper.compilePatternsFromList(getProperty(TYPE_MATCH_DESCRIPTOR));
         String thresholdAsString = getProperty(THRESHOLD_DESCRIPTOR);
-        this.threshold = Integer.valueOf(thresholdAsString);
+        this.threshold = Integer.parseInt(thresholdAsString);
         // Initializing list of match
         this.matches = new ArrayList<>();
 


### PR DESCRIPTION
## change valueOf to parse when we need primitive return value.

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

