### PR TITLE
Cleanup: replace StringBuffer with StringBuilder

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/HTMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/HTMLRenderer.java
@@ -173,7 +173,7 @@ public class HTMLRenderer extends AbstractIncrementingRenderer {
         writer.write("<table align=\"center\" cellspacing=\"0\" cellpadding=\"3\"><tr>" + PMD.EOL
                 + "<th>File</th><th>Problem</th></tr>" + PMD.EOL);
 
-        StringBuffer buf = new StringBuffer(500);
+        StringBuilder buf = new StringBuilder(500);
         boolean colorize = true;
         for (Report.ProcessingError pe : errors) {
             buf.setLength(0);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextPadRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextPadRenderer.java
@@ -50,7 +50,7 @@ public class TextPadRenderer extends AbstractIncrementingRenderer {
 
     @Override
     public void renderFileViolations(Iterator<RuleViolation> violations) throws IOException {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder buf = new StringBuilder();
         while (violations.hasNext()) {
             RuleViolation rv = violations.next();
             buf.setLength(0);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/designer/DFAPanel.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/designer/DFAPanel.java
@@ -66,7 +66,7 @@ public class DFAPanel extends JComponent implements ListSelectionListener {
                 return "";
             }
 
-            StringBuffer sb = new StringBuffer();
+            StringBuilder sb = new StringBuilder();
             sb.append(kids.get(0).getIndex());
 
             for (int j = 1; j < node.getChildren().size(); j++) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/designer/Designer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/designer/Designer.java
@@ -710,7 +710,7 @@ public class Designer implements ClipboardOwner {
             String text;
             if (value instanceof Node) {
                 Node node = (Node) value;
-                StringBuffer sb = new StringBuffer();
+                StringBuilder sb = new StringBuilder();
                 String name = node.getClass().getName().substring(node.getClass().getName().lastIndexOf('.') + 1);
                 if (Proxy.isProxyClass(value.getClass())) {
                     name = value.toString();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/gui/menu/SimpleNodeSubMenu.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/viewer/gui/menu/SimpleNodeSubMenu.java
@@ -38,7 +38,7 @@ public class SimpleNodeSubMenu extends JMenu {
     }
 
     private void init() {
-        StringBuffer buf = new StringBuffer(200);
+        StringBuilder buf = new StringBuilder(200);
         for (Node temp = node; temp != null; temp = temp.getParent()) {
             buf.insert(0, "/" + temp.toString());
         }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/FileReporterTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/FileReporterTest.java
@@ -57,7 +57,7 @@ public class FileReporterTest {
         BufferedReader reader = null;
         try {
             reader = new BufferedReader(new FileReader(file));
-            StringBuffer buffer = new StringBuffer();
+            StringBuilder buffer = new StringBuilder();
             String line = reader.readLine();
             while (line != null) {
                 buffer.append(line);

--- a/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
@@ -510,7 +510,7 @@ public abstract class RuleTst {
     }
 
     private static String parseTextNode(Node exampleNode) {
-        StringBuffer buffer = new StringBuffer();
+        StringBuilder buffer = new StringBuilder();
         for (int i = 0; i < exampleNode.getChildNodes().getLength(); i++) {
             Node node = exampleNode.getChildNodes().item(i);
             if (node.getNodeType() == Node.CDATA_SECTION_NODE || node.getNodeType() == Node.TEXT_NODE) {

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/ast/TemplateParseException.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/ast/TemplateParseException.java
@@ -162,7 +162,7 @@ public class TemplateParseException extends ParseException {
 
         int maxSize = 0;
 
-        final StringBuffer expected = new StringBuffer();
+        final StringBuilder expected = new StringBuilder();
 
         for (int i = 0; i < expectedTokenSequences.length; i++) {
             if (maxSize < expectedTokenSequences[i].length) {

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/ast/TokenMgrError.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/ast/TokenMgrError.java
@@ -67,7 +67,7 @@ public class TokenMgrError extends RuntimeException {
      * equivalents in the given string
      */
     protected static final String addEscapes(final String str) {
-        final StringBuffer retval = new StringBuffer();
+        final StringBuilder retval = new StringBuilder();
         char ch;
         for (int i = 0; i < str.length(); i++) {
             switch (str.charAt(i)) {


### PR DESCRIPTION
## change from StringBuffer to StringBuilder when possible

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

