### PR TITLE
Cleanup: use print instead of printf if no format exists

### DIFF
--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/database/DBMSMetadataTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/database/DBMSMetadataTest.java
@@ -279,7 +279,7 @@ public class DBMSMetadataTest {
                 "testURI=%s,\ngetSchemasList()=%s\n,getSourceCodeTypesList()=%s\n,getSourceCodeNmesList()=%s\n",
                 testURI, testURI.getSchemasList(), testURI.getSourceCodeTypesList(), testURI.getSourceCodeNamesList());
 
-        System.out.printf("sourceObjectList ...\n");
+        System.out.print("sourceObjectList ...\n");
         for (SourceObject sourceObject : sourceObjectList) {
             System.out.printf("sourceObject=%s\n", sourceObject);
             System.out.printf("sourceCode=[%s]\n", getStringFromReader(instance.getSourceCode(sourceObject)));


### PR DESCRIPTION
## use print instead of printf as no format exist.

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

