### PR TITLE
Cleanup: use StandardCharsets instead of Charset.forName

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactoryCompatibility.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactoryCompatibility.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactoryCompatibility.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetFactoryCompatibility.java
@@ -9,6 +9,7 @@ import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Level;
@@ -138,9 +139,9 @@ public class RuleSetFactoryCompatibility {
      */
     String determineEncoding(byte[] bytes) {
         String firstBytes = new String(bytes, 0, bytes.length > 1024 ? 1024 : bytes.length,
-                Charset.forName("ISO-8859-1"));
+                StandardCharsets.ISO_8859_1);
         Matcher matcher = ENCODING_PATTERN.matcher(firstBytes);
-        String encoding = Charset.forName("UTF-8").name();
+        String encoding = StandardCharsets.UTF_8.name();
         if (matcher.find()) {
             encoding = matcher.group(1);
         }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryCompatibilityTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryCompatibilityTest.java
@@ -7,8 +7,8 @@ package net.sourceforge.pmd;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.Reader;
-import java.nio.charset.Charset;
 
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Test;
@@ -16,8 +16,6 @@ import org.junit.Test;
 import net.sourceforge.pmd.util.ResourceLoader;
 
 public class RuleSetFactoryCompatibilityTest {
-    private static final Charset ISO_8859_1 = Charset.forName("ISO-8859-1");
-    private static final Charset UTF_8 = Charset.forName("UTF-8");
 
     @Test
     public void testCorrectOldReference() throws Exception {
@@ -48,7 +46,7 @@ public class RuleSetFactoryCompatibilityTest {
         rsfc.addFilterRuleMoved("dummy", "notexisting", "basic", "OldDummyBasicMockRule");
         rsfc.addFilterRuleRenamed("dummy", "basic", "OldDummyBasicMockRule", "NewNameForDummyBasicMockRule");
 
-        InputStream stream = new ByteArrayInputStream(ruleset.getBytes(ISO_8859_1));
+        InputStream stream = new ByteArrayInputStream(ruleset.getBytes(StandardCharsets.ISO_8859_1));
         Reader filtered = rsfc.filterRuleSetFile(stream);
         String out = IOUtils.toString(filtered);
 
@@ -90,7 +88,7 @@ public class RuleSetFactoryCompatibilityTest {
         RuleSetFactoryCompatibility rsfc = new RuleSetFactoryCompatibility();
         rsfc.addFilterRuleMovedAndRenamed("dummy", "oldbasic", "OldDummyBasicMockRule", "basic", "NewNameForDummyBasicMockRule");
 
-        InputStream stream = new ByteArrayInputStream(ruleset.getBytes(ISO_8859_1));
+        InputStream stream = new ByteArrayInputStream(ruleset.getBytes(StandardCharsets.ISO_8859_1));
         Reader filtered = rsfc.filterRuleSetFile(stream);
         String out = IOUtils.toString(filtered);
 
@@ -112,7 +110,7 @@ public class RuleSetFactoryCompatibilityTest {
                 + " <rule ref=\"rulesets/dummy/notexisting.xml/DummyBasicMockRule\" />\n"
                 + " <rule ref=\"rulesets/dummy/basic.xml/DeletedRule\" />\n"
                 + " <rule ref=\"rulesets/dummy/basic.xml/OldNameOfBasicMockRule\" />\n" + "</ruleset>\n";
-        InputStream stream = new ByteArrayInputStream(in.getBytes(ISO_8859_1));
+        InputStream stream = new ByteArrayInputStream(in.getBytes(StandardCharsets.ISO_8859_1));
         Reader filtered = rsfc.filterRuleSetFile(stream);
         String out = IOUtils.toString(filtered);
 
@@ -136,7 +134,7 @@ public class RuleSetFactoryCompatibilityTest {
                 + "    xsi:schemaLocation=\"http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd\">\n"
                 + "  <description>Test</description>\n" + "\n" + " <rule ref=\"rulesets/dummy/basic.xml\">\n"
                 + "   <exclude name=\"AnotherOldNameOfBasicMockRule\"/>\n" + " </rule>\n" + "</ruleset>\n";
-        InputStream stream = new ByteArrayInputStream(in.getBytes(ISO_8859_1));
+        InputStream stream = new ByteArrayInputStream(in.getBytes(StandardCharsets.ISO_8859_1));
         Reader filtered = rsfc.filterRuleSetFile(stream);
         String out = IOUtils.toString(filtered);
 
@@ -150,10 +148,10 @@ public class RuleSetFactoryCompatibilityTest {
         String testString;
 
         testString = "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?><x></x>";
-        Assert.assertEquals("ISO-8859-1", rsfc.determineEncoding(testString.getBytes(ISO_8859_1)));
+        Assert.assertEquals("ISO-8859-1", rsfc.determineEncoding(testString.getBytes(StandardCharsets.ISO_8859_1)));
 
         testString = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><x></x>";
-        Assert.assertEquals("UTF-8", rsfc.determineEncoding(testString.getBytes(ISO_8859_1)));
+        Assert.assertEquals("UTF-8", rsfc.determineEncoding(testString.getBytes(StandardCharsets.ISO_8859_1)));
     }
 
     private RuleSet createRulesetFromString(final String ruleset, RuleSetFactory factory)
@@ -161,7 +159,7 @@ public class RuleSetFactoryCompatibilityTest {
         return factory.createRuleSet(new RuleSetReferenceId(null) {
             @Override
             public InputStream getInputStream(ResourceLoader resourceLoader) throws RuleSetNotFoundException {
-                return new ByteArrayInputStream(ruleset.getBytes(UTF_8));
+                return new ByteArrayInputStream(ruleset.getBytes(StandardCharsets.UTF_8));
             }
         });
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryCompatibilityTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryCompatibilityTest.java
@@ -7,8 +7,8 @@ package net.sourceforge.pmd;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.io.Reader;
-
 import java.nio.charset.StandardCharsets;
+
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Test;

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryTest.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -1269,11 +1269,7 @@ public class RuleSetFactoryTest {
         return new RuleSetReferenceId(null) {
             @Override
             public InputStream getInputStream(ResourceLoader resourceLoader) throws RuleSetNotFoundException {
-                try {
-                    return new ByteArrayInputStream(ruleSetXml.getBytes("UTF-8"));
-                } catch (UnsupportedEncodingException e) {
-                    return null;
-                }
+                return new ByteArrayInputStream(ruleSetXml.getBytes(StandardCharsets.UTF_8));
             }
         };
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/processor/MultiThreadProcessorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/processor/MultiThreadProcessorTest.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.processor;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -98,7 +99,7 @@ public class MultiThreadProcessorTest {
 
         @Override
         public InputStream getInputStream() throws IOException {
-            return new ByteArrayInputStream(data.getBytes("UTF-8"));
+            return new ByteArrayInputStream(data.getBytes(StandardCharsets.UTF_8));
         }
 
         @Override

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/docs/DeadLinksChecker.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/docs/DeadLinksChecker.java
@@ -8,7 +8,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -297,7 +297,7 @@ public class DeadLinksChecker {
 
     private String fileToString(Path mdFile) {
         try (InputStream inputStream = Files.newInputStream(mdFile)) {
-            return IOUtils.toString(inputStream, Charset.forName("UTF-8"));
+            return IOUtils.toString(inputStream, StandardCharsets.UTF_8);
         } catch (IOException ex) {
             throw new RuntimeException("error reading " + mdFile, ex);
         }

--- a/pmd-test/src/main/java/net/sourceforge/pmd/AbstractRuleSetFactoryTest.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/AbstractRuleSetFactoryTest.java
@@ -15,7 +15,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -483,11 +483,7 @@ public abstract class AbstractRuleSetFactoryTest {
         return new RuleSetReferenceId(null) {
             @Override
             public InputStream getInputStream(ResourceLoader resourceLoader) throws RuleSetNotFoundException {
-                try {
-                    return new ByteArrayInputStream(ruleSetXml.getBytes("UTF-8"));
-                } catch (UnsupportedEncodingException e) {
-                    return null;
-                }
+                return new ByteArrayInputStream(ruleSetXml.getBytes(StandardCharsets.UTF_8));
             }
         };
     }


### PR DESCRIPTION
## use StandardCharsets

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

