### PR TITLE
[dart] [cpd] Improvements for Dart interpolated strings

### DIFF
--- a/pmd-dart/src/main/antlr4/net/sourceforge/pmd/lang/dart/antlr4/Dart2.g4
+++ b/pmd-dart/src/main/antlr4/net/sourceforge/pmd/lang/dart/antlr4/Dart2.g4
@@ -351,16 +351,16 @@ SingleLineString
 
 fragment
 StringContentDQ
-  : ~('\\' | '"' /*| '$'*/ | '\n' | '\r')
+  : ~('\\' | '"' | '$' | '\n' | '\r')
   | '\\' ~('\n' | '\r')
-  //| stringInterpolation
+  | StringInterpolation
   ;
 
 fragment
 StringContentSQ
-  : ~('\\' | '\'' /*| '$'*/ | '\n' | '\r')
+  : ~('\\' | '\'' | '$' | '\n' | '\r')
   | '\\' ~('\n' | '\r')
-  //| stringInterpolation
+  | StringInterpolation
   ;
 
 MultiLineString
@@ -372,15 +372,16 @@ MultiLineString
 
 fragment
 StringContentTDQ
-  : ~('\\' | '"' /*| '$'*/)
+  : ~('\\' | '"' | '$')
   | '"' ~'"' | '""' ~'"'
-  //| stringInterpolation
+  | StringInterpolation
   ;
 
-fragment StringContentTSQ
-  : ~('\\' | '\'' /*| '$'*/)
+fragment
+StringContentTSQ
+  : ~('\\' | '\'' | '$')
   | '\'' ~'\'' | '\'\'' ~'\''
-  //| stringInterpolation
+  | StringInterpolation
   ;
 
 NEWLINE
@@ -390,10 +391,17 @@ NEWLINE
   ;
 
 // 16.5.1 String Interpolation
-stringInterpolation
-//  : '$' IDENTIFIER_NO_DOLLAR
-  : '$' identifier// FIXME
-  | '${' expression '}'
+fragment
+StringInterpolation
+  : '$' IDENTIFIER_NO_DOLLAR
+  | '${' StringInterpolationContent* '}'
+  ;
+
+fragment
+StringInterpolationContent
+  : ~('$' | '{' | '}')
+  | '$' IDENTIFIER_NO_DOLLAR
+  | '${' StringInterpolationContent* '}'
   ;
 
 // 16.6 Symbols

--- a/pmd-dart/src/test/java/net/sourceforge/pmd/cpd/DartTokenizerTest.java
+++ b/pmd-dart/src/test/java/net/sourceforge/pmd/cpd/DartTokenizerTest.java
@@ -54,7 +54,10 @@ public class DartTokenizerTest extends CpdTextComparisonTest {
         doTest("imports");
     }
 
-
+    @Test
+    public void testStringInterpolation() {
+        doTest("string_interpolation");
+    }
 
     @Test
     public void testRegex() {

--- a/pmd-dart/src/test/resources/net/sourceforge/pmd/cpd/testdata/escape_sequences.dart
+++ b/pmd-dart/src/test/resources/net/sourceforge/pmd/cpd/testdata/escape_sequences.dart
@@ -1,3 +1,3 @@
 var newline = '\n';
-var dollar = '$';
+var dollar = '$newLine';
 var escaped_dollar = "\$";

--- a/pmd-dart/src/test/resources/net/sourceforge/pmd/cpd/testdata/escape_sequences.txt
+++ b/pmd-dart/src/test/resources/net/sourceforge/pmd/cpd/testdata/escape_sequences.txt
@@ -8,7 +8,7 @@ L2
     [var]                                   1         3
     [dollar]                                5         10
     [=]                                     12        12
-    ['$']                                   14        16
+    ['$newLine']                            14        23
 L3
     [var]                                   1         3
     [escaped_dollar]                        5         18

--- a/pmd-dart/src/test/resources/net/sourceforge/pmd/cpd/testdata/string_interpolation.dart
+++ b/pmd-dart/src/test/resources/net/sourceforge/pmd/cpd/testdata/string_interpolation.dart
@@ -1,0 +1,2 @@
+var stringInStringUnicode = "${"∆"}";
+var stringInStringNewline = "${"\n")}";

--- a/pmd-dart/src/test/resources/net/sourceforge/pmd/cpd/testdata/string_interpolation.txt
+++ b/pmd-dart/src/test/resources/net/sourceforge/pmd/cpd/testdata/string_interpolation.txt
@@ -1,0 +1,12 @@
+    [Image] or [Truncated image[            Bcol      Ecol
+L1
+    [var]                                   1         3
+    [stringInStringUnicode]                 5         25
+    [=]                                     27        27
+    ["${"∆"}"]                              29        36
+L2
+    [var]                                   1         3
+    [stringInStringNewline]                 5         25
+    [=]                                     27        27
+    ["${"\\n")}"]                           29        38
+EOF


### PR DESCRIPTION
## Describe the PR

The Dart tokenizer was incomplete, resulting in some strings that use
string interpolation not being parsed correctly. This has been worked
around by making sure that the contents of string interpolation are all
included in the same string token.

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

