### PR TITLE
[java] Fix #2767, PMD cannot parse a local var with final in instance initializer

### DIFF
--- a/pmd-java/etc/grammar/Java.jjt
+++ b/pmd-java/etc/grammar/Java.jjt
@@ -1997,8 +1997,10 @@ void BlockStatement():
         |
         {
             List<Node> annotationsAndChildren = new ArrayList<Node>();
-            while (jjtree.peekNode() instanceof ASTAnnotation) {
-              annotationsAndChildren.add(jjtree.popNode());
+            if (jjtree.nodeArity() > 0) { // peekNode would throw if the stack is empty
+                while (jjtree.peekNode() instanceof ASTAnnotation) {
+                  annotationsAndChildren.add(jjtree.popNode());
+                }
             }
         }
         LocalVariableDeclaration()

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
@@ -178,6 +178,16 @@ public class ParserCornersTest {
     }
 
     @Test
+    public void testGitHubBug2767() {
+        // PMD fails to parse an initializer block.
+        // PMD 6.26.0 parses this code just fine.
+        java.withDefaultVersion("15-preview")
+            .parse("class Foo {\n"
+                       + "    {final int I;}\n"
+                       + "}\n");
+    }
+
+    @Test
     public void testBug206() {
         java8.parse("public @interface Foo {" + "\n"
                         + "static final ThreadLocal<Interner<Integer>> interner =" + "\n"


### PR DESCRIPTION

## Describe the PR

The problem was, the stack is empty if the local var declaration is the first node of the compilation unit to be pushed.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #2767

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

