### PR TITLE
[java] Fix #2756, NPE in TypeTestUtil

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeTestUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeTestUtil.java
@@ -106,7 +106,11 @@ public final class TypeTestUtil {
 
         final Class<?> clazz = loadClassWithNodeClassloader(node, canonicalName);
 
+
         if (clazz != null) {
+            if (clazz.getCanonicalName() == null) {
+                return false; // no canonical name, give up: we shouldn't be able to access them
+            }
             return clazz.isAssignableFrom(nodeType);
         } else {
             return fallbackIsA(node, canonicalName, true);
@@ -174,8 +178,16 @@ public final class TypeTestUtil {
         }
 
 
-        return node.getType() == null ? fallbackIsA(node, canonicalName, false)
-                                      : node.getType().getCanonicalName().equals(canonicalName);
+        if (node.getType() == null) {
+            return fallbackIsA(node, canonicalName, false);
+        }
+
+        String canoname = node.getType().getCanonicalName();
+        if (canoname == null) {
+            // anonymous/local class, or class nested within one of those
+            return false;
+        }
+        return canoname.equals(canonicalName);
     }
 
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/TypeTestUtilTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/TypeTestUtilTest.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.java.types;
 
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
+import java.util.concurrent.Callable;
 
 import org.junit.Assert;
 import org.junit.Rule;
@@ -13,6 +14,7 @@ import org.junit.Test;
 import org.junit.function.ThrowingRunnable;
 import org.junit.rules.ExpectedException;
 
+import net.sourceforge.pmd.lang.java.ast.ASTAllocationExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotationTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTEnumDeclaration;
@@ -20,6 +22,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTMarkerAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
 import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.symboltable.BaseNonParserTest;
+import net.sourceforge.pmd.lang.java.types.testdata.SomeClassWithAnon;
 
 public class TypeTestUtilTest extends BaseNonParserTest {
 
@@ -72,6 +75,31 @@ public class TypeTestUtilTest extends BaseNonParserTest {
         Assert.assertTrue(TypeTestUtil.isA("org.FooBar", klass));
         assertIsA(klass, Annotation.class);
         assertIsA(klass, Object.class);
+    }
+
+    @Test
+    public void testAnonClassTypeNPE() {
+        // #2756
+
+        ASTAllocationExpression anon =
+            java.parseClass(SomeClassWithAnon.class)
+                .getFirstDescendantOfType(ASTAllocationExpression.class);
+
+
+        Assert.assertNotNull("Type should be resolved", anon.getType());
+        Assert.assertTrue("Anon class", anon.isAnonymousClass());
+        Assert.assertTrue("Anon class", anon.getType().isAnonymousClass());
+        Assert.assertTrue("Should be a Runnable", TypeTestUtil.isA(Runnable.class, anon));
+
+        // This is not a canonical name, so we give up early
+        Assert.assertFalse(TypeTestUtil.isA(SomeClassWithAnon.class.getName() + "$1", anon));
+        Assert.assertFalse(TypeTestUtil.isExactlyA(SomeClassWithAnon.class.getName() + "$1", anon));
+
+        // this is the failure case: if the binary name doesn't match, we test the canoname, which was null
+        Assert.assertFalse(TypeTestUtil.isA(Callable.class, anon));
+        Assert.assertFalse(TypeTestUtil.isA(Callable.class.getCanonicalName(), anon));
+        Assert.assertFalse(TypeTestUtil.isExactlyA(Callable.class, anon));
+        Assert.assertFalse(TypeTestUtil.isExactlyA(Callable.class.getCanonicalName(), anon));
     }
 
     /**

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/testdata/SomeClassWithAnon.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/testdata/SomeClassWithAnon.java
@@ -1,0 +1,25 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.types.testdata;
+
+/**
+ * #2756
+ */
+public class SomeClassWithAnon {
+
+    {
+        new Runnable() {
+
+            @Override
+            public void run() {
+
+            }
+        };
+
+
+    }
+
+
+}


### PR DESCRIPTION
## Describe the PR

* Fix the NPE
* Forbid testing types against anonymous/ local classes. The parameter must be a canonical name, and those don't have one. This means you can't write eg `TypeTestUtil.isA("java.util.Collections$1", node)` anymore, which anyway would be practically useless (eg can only match within this particular class). This simplifies the contract of SymbolResolver in PMD 7, in #2689 it is restricted to resolving only classes that have a canonical name, ie resolving anonymous or local classes is undefined behavior. Instead those are solely represented by AST symbols.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #2756

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

