### PR TITLE
[java] issue-2738: Adding null check to avoid npe when switch case is default

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchStatement.java
@@ -86,7 +86,10 @@ public class ASTSwitchStatement extends AbstractJavaNode implements Iterable<AST
                 // since this is an enum switch, the labels are necessarily
                 // the simple name of some enum constant.
 
-                constantNames.remove(label.getFirstDescendantOfType(ASTName.class).getImage());
+                // descendant can be null for default case
+                if (label.getFirstDescendantOfType(ASTName.class) != null) {
+                    constantNames.remove(label.getFirstDescendantOfType(ASTName.class).getImage());
+                }
 
             }
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchStatementTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchStatementTest.java
@@ -1,0 +1,21 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.ast;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ASTSwitchStatementTest extends BaseParserTest {
+
+    @Test
+    public void exhaustiveEnumSwitchWithDefault() {
+        ASTSwitchStatement switchStatement = getNodes(ASTSwitchStatement.class,
+                "import java.nio.file.AccessMode; class Foo { void bar(AccessMode m) {"
+                + "switch (m) { case READ: break; default: break; } } }")
+                .get(0);
+        Assert.assertFalse(switchStatement.isExhaustiveEnumSwitch()); // this should not throw a NPE...
+        Assert.assertTrue(switchStatement.hasDefaultCase());
+    }
+}


### PR DESCRIPTION
## Describe the PR

For isExhaustiveEnumSwitch method, the first descendant can be null for the default switch case hence adding null check.

Tried adding new unit tests for this but, I was not able to get it to work. Somehow expression type was coming out to null for switch on enums.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #2738 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature 
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)
