### PR TITLE
[java] Lambda parsing bug

### DIFF
--- a/pmd-java/etc/grammar/Java.jjt
+++ b/pmd-java/etc/grammar/Java.jjt
@@ -1754,9 +1754,21 @@ void UnaryExpressionNotPlusMinus() #UnaryExpressionNotPlusMinus((jjtn000.getImag
  * meaning we can't be explicit as to what can be casted depending on the cast type (primitive or otherwise)
 */
 | LOOKAHEAD("(" (Annotation())* PrimitiveType() ")") CastExpression()
-| LOOKAHEAD("(" (Annotation())* Type() ( "&" ReferenceType() )* ")" UnaryExpressionNotPlusMinus()) CastExpression()
-| PostfixExpression()
+| LOOKAHEAD("(" (Annotation())* Type() ( "&" ReferenceType() )* ")" UnaryExprNotPmStart()) CastExpression()
+| PostfixExpression() // this may be a parenthesized expr, which is why we have lookaheads
 | SwitchExpression()
+}
+
+
+private void UnaryExprNotPmStart() #void:
+{}
+{
+   //  Condensed FIRST set of UnaryExpressionNotPlusMinus
+   //  Avoid looking ahead for a whole UnaryExpressionNotPlusMinus, but just for a token
+
+   "~" | "!" | "(" | "switch" | "new" | "this" | "super" | Literal() | "@"
+   | <IDENTIFIER>
+   | "void" | PrimitiveType()
 }
 
 void PostfixExpression() #PostfixExpression((jjtn000.getImage() != null)):

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
@@ -178,6 +178,11 @@ public class ParserCornersTest {
     }
 
     @Test
+    public void testLambda2783() {
+        java8.parseResource("LambdaBug2783.java");
+    }
+
+    @Test
     public void testGitHubBug2767() {
         // PMD fails to parse an initializer block.
         // PMD 6.26.0 parses this code just fine.

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/LambdaBug2783.java
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/LambdaBug2783.java
@@ -1,0 +1,31 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+import java.util.List;
+
+public class LambdaBug2783 {
+    // https://github.com/pmd/pmd/issues/2783
+
+    public Spec<String> test() {
+        // cast, block body (the failing case)
+        Spec<String> result = (Spec<String>) (a, b) -> {
+            return a.toArray(String[]::new);
+        };
+        // no cast, block body
+        result = (a, b) -> {
+            return a.toArray(String[]::new);
+        };
+        // cast, expression body
+        result = (Spec<String>) (a, b) -> a.toArray(String[]::new);
+
+        // return position?
+        return (Spec<String>) (a, b) -> {
+            return a.toArray(String[]::new);
+        };
+    }
+
+    interface Spec<T> {
+        String[] process(List<T> var1, List<?> var2);
+    }
+}


### PR DESCRIPTION
## Describe the PR

There's a bug in the lookahead, I pulled out something from java-grammar to fix it

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #2783

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

