### PR TITLE
[java] CloseResource: Fix NPE in case of "var"

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -32,6 +32,7 @@ AbstractTokenizer and the custom tokenizers of Fortran, Perl and Ruby are deprec
 * pmd-java
     * [#2708](https://github.com/pmd/pmd/issues/2708): \[java] False positive FinalFieldCouldBeStatic when using lombok Builder.Default
     * [#2738](https://github.com/pmd/pmd/issues/2738): \[java] Custom rule with @ExhaustiveEnumSwitch throws NPE
+    * [#2755](https://github.com/pmd/pmd/issues/2755): \[java] \[6.27.0] Exception applying rule CloseResource on file ... java.lang.NullPointerException
     * [#2756](https://github.com/pmd/pmd/issues/2756): \[java] TypeTestUtil fails with NPE for anonymous class
     * [#2759](https://github.com/pmd/pmd/issues/2759): \[java] False positive in UnusedAssignment
     * [#2767](https://github.com/pmd/pmd/issues/2767): \[java] IndexOutOfBoundsException when parsing an initializer BlockStatement

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
@@ -175,7 +175,7 @@ public class CloseResourceRule extends AbstractJavaRule {
         Map<ASTVariableDeclarator, TypeNode> resVars = new HashMap<>();
         for (ASTVariableDeclarator var : vars) {
             TypeNode varType = getTypeOfVariable(var);
-            if (isResourceTypeOrSubtype(varType)) {
+            if (varType != null && isResourceTypeOrSubtype(varType)) {
                 resVars.put(var, wrappedResourceTypeOrReturn(var, varType));
             }
         }
@@ -189,7 +189,7 @@ public class CloseResourceRule extends AbstractJavaRule {
 
     private TypeNode getDeclaredTypeOfVariable(ASTVariableDeclarator var) {
         ASTLocalVariableDeclaration localVar = (ASTLocalVariableDeclaration) var.getParent();
-        return localVar.getTypeNode();
+        return localVar.getTypeNode(); // note: can be null, if type is inferred (var)
     }
 
     private TypeNode getRuntimeTypeOfVariable(ASTVariableDeclarator var) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
@@ -1388,4 +1388,25 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[java] [6.27.0] Exception applying rule CloseResource on file ... java.lang.NullPointerException #2755</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.*;
+
+public class Foo {
+    public int bar() {
+        var inputStream = getInputStreamFromSomewhere();
+        if (inputStream != null) {
+            try (InputStreamReader reader = new InputStreamReader(inputStream, "UTF-8")) {
+                char c = reader.read();
+                return c;
+            }
+        }
+        return -1;
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
@@ -999,6 +999,8 @@ public class Foo {
         }
         return -1;
     }
+
+    InputStream getInputStreamFromSomewhere() { return null; }
 }
         ]]></code>
     </test-code>
@@ -1406,6 +1408,8 @@ public class Foo {
         }
         return -1;
     }
+
+    InputStream getInputStreamFromSomewhere() { return null; }
 }
         ]]></code>
     </test-code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
@@ -1413,4 +1413,20 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>CloseResource with var</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <code><![CDATA[
+import java.io.*;
+public class CloseResourceWithVar {
+    public int bar() throws IOException {
+        var inputStream = new FileInputStream("bar.txt");
+        int c = inputStream.read();
+        return c;
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Fixes the NPE when trying to determine the type. The type might be null.

## Related issues

- Fixes #2755 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

