### PR TITLE
[apex] Analyze inner classes for sharing violations

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSharingViolationsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSharingViolationsRule.java
@@ -4,11 +4,20 @@
 
 package net.sourceforge.pmd.lang.apex.rule.security;
 
-import java.util.List;
+import java.util.Optional;
 import java.util.WeakHashMap;
 
+import net.sourceforge.pmd.RuleContext;
+import net.sourceforge.pmd.lang.apex.ast.ASTDmlDeleteStatement;
+import net.sourceforge.pmd.lang.apex.ast.ASTDmlInsertStatement;
+import net.sourceforge.pmd.lang.apex.ast.ASTDmlMergeStatement;
+import net.sourceforge.pmd.lang.apex.ast.ASTDmlUndeleteStatement;
+import net.sourceforge.pmd.lang.apex.ast.ASTDmlUpdateStatement;
+import net.sourceforge.pmd.lang.apex.ast.ASTDmlUpsertStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTModifierNode;
+import net.sourceforge.pmd.lang.apex.ast.ASTSoqlExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTSoslExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
@@ -21,45 +30,103 @@ import net.sourceforge.pmd.lang.apex.rule.internal.Helper;
  */
 public class ApexSharingViolationsRule extends AbstractApexRule {
 
+    /**
+     * Keep track of previously reported violations to avoid duplicates.
+     */
     private WeakHashMap<ApexNode<?>, Object> localCacheOfReportedNodes = new WeakHashMap<>();
 
     public ApexSharingViolationsRule() {
         setProperty(CODECLIMATE_CATEGORIES, "Security");
         setProperty(CODECLIMATE_REMEDIATION_MULTIPLIER, 100);
         setProperty(CODECLIMATE_BLOCK_HIGHLIGHTING, false);
+        addRuleChainVisit(ASTDmlDeleteStatement.class);
+        addRuleChainVisit(ASTDmlInsertStatement.class);
+        addRuleChainVisit(ASTDmlMergeStatement.class);
+        addRuleChainVisit(ASTDmlUndeleteStatement.class);
+        addRuleChainVisit(ASTDmlUpdateStatement.class);
+        addRuleChainVisit(ASTDmlUpsertStatement.class);
+        addRuleChainVisit(ASTMethodCallExpression.class);
+        addRuleChainVisit(ASTSoqlExpression.class);
+        addRuleChainVisit(ASTSoslExpression.class);
     }
 
     @Override
-    public Object visit(ASTUserClass node, Object data) {
-
-        if (Helper.isTestMethodOrClass(node) || Helper.isSystemLevelClass(node)) {
-            return data; // stops all the rules
-        }
-
-        if (!Helper.isTestMethodOrClass(node)) {
-            boolean sharingFound = isSharingPresent(node);
-            checkForSharingDeclaration(node, data, sharingFound);
-            checkForDatabaseMethods(node, data, sharingFound);
-        }
-
+    public void start(RuleContext ctx) {
+        super.start(ctx);
         localCacheOfReportedNodes.clear();
+    }
+
+    @Override
+    public Object visit(ASTSoqlExpression node, Object data) {
+        checkForViolation(node, data);
         return data;
     }
 
-    /**
-     * Check if class contains any Database.query / Database.insert [ Database.*
-     * ] methods
-     *
-     * @param node
-     * @param data
-     */
-    private void checkForDatabaseMethods(ASTUserClass node, Object data, boolean sharingFound) {
-        List<ASTMethodCallExpression> calls = node.findDescendantsOfType(ASTMethodCallExpression.class);
-        for (ASTMethodCallExpression call : calls) {
-            if (Helper.isMethodName(call, "Database", Helper.ANY_METHOD)) {
-                if (!sharingFound) {
-                    reportViolation(node, data);
-                }
+    @Override
+    public Object visit(ASTSoslExpression node, Object data) {
+        checkForViolation(node, data);
+        return data;
+    }
+
+    @Override
+    public Object visit(ASTDmlUpsertStatement node, Object data) {
+        checkForViolation(node, data);
+        return data;
+    }
+
+    @Override
+    public Object visit(ASTDmlUpdateStatement node, Object data) {
+        checkForViolation(node, data);
+        return data;
+    }
+
+    @Override
+    public Object visit(ASTDmlUndeleteStatement node, Object data) {
+        checkForViolation(node, data);
+        return data;
+    }
+
+    @Override
+    public Object visit(ASTDmlMergeStatement node, Object data) {
+        checkForViolation(node, data);
+        return data;
+    }
+
+    @Override
+    public Object visit(ASTDmlInsertStatement node, Object data) {
+        checkForViolation(node, data);
+        return data;
+    }
+
+    @Override
+    public Object visit(ASTDmlDeleteStatement node, Object data) {
+        checkForViolation(node, data);
+        return data;
+    }
+
+    @Override
+    public Object visit(ASTMethodCallExpression node, Object data) {
+        if (Helper.isMethodName(node, "Database", Helper.ANY_METHOD)) {
+            checkForViolation(node, data);
+        }
+
+        return data;
+    }
+
+    private void checkForViolation(ApexNode<?> node, Object data) {
+        // The closest ASTUserClass class in the tree hierarchy is the node that requires the sharing declaration
+        ASTUserClass sharingDeclarationClass = node.getFirstParentOfType(ASTUserClass.class);
+
+        // This is null in the case of triggers
+        if (sharingDeclarationClass != null) {
+            // Apex allows a single level of class nesting. Check to see if sharingDeclarationClass has an outer class
+            ASTUserClass outerClass = sharingDeclarationClass.getFirstParentOfType(ASTUserClass.class);
+            // The test annotation needs to be on the outermost class
+            ASTUserClass testAnnotationClass = Optional.ofNullable(outerClass).orElse(sharingDeclarationClass);
+
+            if (!Helper.isTestMethodOrClass(testAnnotationClass) && !Helper.isSystemLevelClass(sharingDeclarationClass) && !isSharingPresent(sharingDeclarationClass)) {
+                // The violation is reported on the class, not the node that performs data access
+                reportViolation(sharingDeclarationClass, data);
             }
         }
     }
@@ -74,19 +141,6 @@ public class ApexSharingViolationsRule extends AbstractApexRule {
             if (localCacheOfReportedNodes.put(node, data) == null) {
                 addViolation(data, node);
             }
-        }
-    }
-
-    /**
-     * Check if class has no sharing declared
-     *
-     * @param node
-     * @param data
-     */
-    private void checkForSharingDeclaration(ApexNode<?> node, Object data, boolean sharingFound) {
-        final boolean foundAnyDMLorSOQL = Helper.foundAnyDML(node) || Helper.foundAnySOQLorSOSL(node);
-        if (!sharingFound && !Helper.isTestMethodOrClass(node) && foundAnyDMLorSOQL) {
-            reportViolation(node, data);
         }
     }
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSharingViolationsNestedClassTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSharingViolationsNestedClassTest.java
@@ -1,0 +1,194 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.rule.security;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import net.sourceforge.pmd.Report;
+import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.RuleViolation;
+import net.sourceforge.pmd.lang.LanguageRegistry;
+import net.sourceforge.pmd.lang.apex.ApexLanguageModule;
+import net.sourceforge.pmd.testframework.RuleTst;
+
+/**
+ * <p>Sharing settings are not inherited by inner classes. Sharing settings need to be declared on the class that
+ * contains the Database method, DML, SOQL, or SOSL.</p>
+ *
+ * <p>This test runs against Apex code that has an Outer class and and Inner class. Different Apex code is generated
+ * based on the boolean permutations. Any classes that includes data access cod, but doesn't declare a sharing setting
+ * should trigger a violation.</p>
+ */
+@RunWith(Parameterized.class)
+public class ApexSharingViolationsNestedClassTest extends RuleTst {
+    /**
+     * Type of operation that may require a sharing declaration.
+     */
+    private enum Operation {
+        NONE(null),
+        DML_DELETE("Contact c = new Contact(); delete c;"),
+        DML_INSERT("Contact c = new Contact(); insert c;"),
+        DML_MERGE("Contact c1 = new Contact(); Contact c2 = new Contact(); merge c1 c2;"),
+        DML_UNDELETE("Contact c = new Contact(); undelete c;"),
+        DML_UPDATE("Contact c = new Contact(); update c;"),
+        DML_UPSERT("Contact c = new Contact(); upsert c;"),
+        METHOD_DATABASE("Database.query('Select Id from Contact LIMIT 100');"),
+        SOQL("[SELECT Name FROM Contact];"),
+        SOSL("[FIND 'Foo' IN ALL FIELDS RETURNING Account(Name)];");
+
+        final boolean requiresSharingDeclaration;
+        final String codeSnippet;
+
+        Operation(String codeSnippet) {
+            this.requiresSharingDeclaration = codeSnippet != null;
+            this.codeSnippet = codeSnippet;
+        }
+    }
+
+    /**
+     * The permutations used for class generation. See {@link #generateClass(boolean, Operation, boolean, Operation)}
+     */
+    private final boolean outerSharingDeclared;
+    private final Operation outerOperation;
+    private final boolean innerSharingDeclared;
+    private final Operation innerOperation;
+
+    /**
+     * Track the expected violations based on the permutations.
+     */
+    private final int expectedViolations;
+    private final List<Integer> expectedLineNumbers;
+
+    public ApexSharingViolationsNestedClassTest(boolean outerSharingDeclared, Operation outerOperation,
+                                                boolean innerSharingDeclared, Operation innerOperation,
+                                                int expectedViolations, List<Integer> expectedLineNumbers) {
+        this.outerSharingDeclared = outerSharingDeclared;
+        this.outerOperation = outerOperation;
+        this.innerSharingDeclared = innerSharingDeclared;
+        this.innerOperation = innerOperation;
+        this.expectedViolations = expectedViolations;
+        this.expectedLineNumbers = expectedLineNumbers;
+    }
+
+    @Test
+    public void testSharingPermutation() {
+        String apexClass = generateClass(outerSharingDeclared, outerOperation, innerSharingDeclared, innerOperation);
+        Report rpt = new Report();
+        runTestFromString(apexClass, new ApexSharingViolationsRule(), rpt,
+                LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
+        List<RuleViolation> violations = rpt.getViolations();
+        assertEquals("Unexpected Violation Size\n" + apexClass, expectedViolations, violations.size());
+        List<Integer> lineNumbers = violations.stream().map(v -> v.getBeginLine()).collect(Collectors.toList());
+        assertEquals("Unexpected Line Numbers\n" + apexClass, expectedLineNumbers, lineNumbers);
+    }
+
+    @Override
+    protected List<Rule> getRules() {
+        Rule rule = findRule("category/apex/security.xml", "ApexSharingViolations");
+        return Collections.singletonList(rule);
+    }
+
+    /**
+     * Parameter provider that covers are all permutations
+     */
+    @Parameterized.Parameters
+    public static Collection<?> data() {
+        List<Object[]> data = new ArrayList<>();
+
+        boolean[] boolPermutations = {false, true};
+
+        for (boolean outerSharingDeclared : boolPermutations) {
+            for (Operation outerOperation : Operation.values()) {
+                for (boolean innerSharingDeclared : boolPermutations) {
+                    for (Operation innerOperation : Operation.values()) {
+                        int expectedViolations = 0;
+                        List<Integer> expectedLineNumbers = new ArrayList<>();
+                        if (outerOperation.requiresSharingDeclaration && !outerSharingDeclared) {
+                            // The outer class contains SOQL but doesn't declare sharing
+                            expectedViolations++;
+                            expectedLineNumbers.add(1);
+                        }
+
+                        if (innerOperation.requiresSharingDeclaration && !innerSharingDeclared) {
+                            // The inner class contains SOQL but doesn't declare sharing
+                            expectedViolations++;
+                            // The location of the inner class declaration depends upon the content of the outer class
+                            expectedLineNumbers.add(outerOperation.requiresSharingDeclaration ? 3 : 2);
+                        }
+                        data.add(new Object[]{outerSharingDeclared, outerOperation, innerSharingDeclared, innerOperation,
+                                              expectedViolations, expectedLineNumbers});
+                    }
+                }
+            }
+        }
+
+        return data;
+    }
+
+    /**
+     * <p>Generate an Apex class with various Sharing/Database/DML/SOQL/SOSL permutations. An example of the class
+     * returned when invoked with generateClass(true, SOQL, true, SOQL).</p>
+     *
+     * <pre>
+     * public with sharing class Outer {
+     *    public void outerSOQL() {[SELECT Name FROM Contact];}
+     *    public with sharing class Inner {
+     *       public void innerSOQL() {[SELECT Name FROM Contact];}
+     *    }
+     * }
+     * </pre>
+     *
+     * @param outerSharing Add 'with sharing' to Outer class definition
+     * @param outerOperation Add a method to Outer class that performs the given operation
+     * @param innerSharing Add 'with sharing' to Inner class definition
+     * @param innerOperation Add a method to Inner class that performs the given operation
+     * @return String that represents Apex code
+     */
+    private static String generateClass(boolean outerSharing, Operation outerOperation, boolean innerSharing,
+                                        Operation innerOperation) {
+        StringBuilder sb = new StringBuilder();
+
+        sb.append("public ");
+        if (outerSharing) {
+            sb.append("with sharing ");
+        }
+        sb.append("class Outer {\n");
+        switch (outerOperation) {
+        case NONE:
+            // Do nothing
+            break;
+        default:
+            sb.append(String.format("\t\tpublic void outer%s(){ %s }\n", outerOperation.name(), outerOperation.codeSnippet));
+            break;
+        }
+        sb.append("\tpublic ");
+        if (innerSharing) {
+            sb.append("with sharing ");
+        }
+        sb.append("class Inner {\n");
+        switch (innerOperation) {
+        case NONE:
+            // DO Nothing
+            break;
+        default:
+            sb.append(String.format("\t\tpublic void inner%s(){ %s }\n", innerOperation.name(), innerOperation.codeSnippet));
+            break;
+        }
+        sb.append("\t}\n"); // Closes class Inner
+        sb.append("}\n"); // Closes class Outer
+
+        return sb.toString();
+    }
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSharingViolations.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSharingViolations.xml
@@ -159,4 +159,28 @@ trigger MyTrigger on Account(after insert, after update) {
 }
      ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Issue #2774(false positive). Sharing correctly declared on inner class.</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Outer {
+   public with sharing class Inner {
+      public List<Contact> getAllInnerSoqlSecrets() { return [SELECT Name FROM Contact]; }
+   }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Issue #2774(false negative). Sharing incorrectly declared on outer class.</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public with sharing class Outer {
+   public class Inner {
+      public List<Contact> getAllInnerSoqlSecrets() { return [SELECT Name FROM Contact]; }
+   }
+}
+     ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSharingViolations.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSharingViolations.xml
@@ -102,4 +102,61 @@ public inherited sharing class MyClass {
 }
      ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Apex test classes do not need a sharing declaration</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+@isTest public class MyClass {
+   public List<Contact> getAllTheSecrets() {
+       return [SELECT Name FROM Contact];
+   }
+}
+     ]]></code>
+    </test-code>
+
+    <!-- @isTest can only be declared on the outer class, it is inherited by the inner class-->
+    <test-code>
+        <description>Apex inner test classes do not need a sharing declaration</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+@isTest public class Outer {
+   public List<Contact> getAllTheOuterSecrets() {
+       return [SELECT Name FROM Contact];
+   }
+   public class Inner {
+       public List<Contact> getAllTheInnerSecrets() {
+           return [SELECT Name FROM Contact];
+       }
+   }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Nested method calls are detected</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Dao {
+  static Map<String, List<SObject>> recordsMap = new Map<String, List<SObject>>();
+
+  public List<SObject> getRecords(String query) {
+    if (!recordsMap.containsKey(query)) {
+      recordsMap.put(query, Database.query(query));
+    }
+    return recordsMap.get(query);
+  }
+}
+     ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Trigger does not require sharing</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+trigger MyTrigger on Account(after insert, after update) {
+    [SELECT Id,(SELECT Id FROM Opportunities) FROM Account WHERE Id IN :Trigger.New];
+}
+     ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Fixes https://github.com/pmd/pmd/issues/2774, false positives and false
negatives for [ApexSharingViolations](https://pmd.github.io/latest/pmd_rules_apex_security.html#apexsharingviolations).

Sharing settings are not inherited by inner classes. Sharing settings
need to be declared on the class that contains the Database method, DML,
SOQL, or SOSL.

The change inverts the direction from which nodes are found and
analyzed. The previous code visited the ASTUserClass and then searched
for descendant nodes that met a certain criteria. It did not visit inner
ASTUserClass nodes because it didn't use rule chains or call the super's
visit moethod for ASTUserClassi.

The new implementation visits all nodes that correspond to Database
method, DML, SOQL, or SOSL nodes and then finds the nearest ASTUserClass
parent node. This ASTUserClass is examined to determine if it has
declared a sharing setting as required.

## Related issues
https://github.com/pmd/pmd/issues/2774

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

