### PR TITLE
[java] Fix TypeTestUtil for arrays

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeTestUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeTestUtil.java
@@ -41,10 +41,10 @@ public final class TypeTestUtil {
      * if the type of the node is parameterized. Examples:
      *
      * <pre>{@code
-     * isA(<new ArrayList<String>()>, List.class)      = true
-     * isA(<new ArrayList<String>()>, ArrayList.class) = true
-     * isA(<new int[0]>, int[].class)                  = true
-     * isA(<new String[0]>, Object[].class)            = true
+     * isA(List.class, <new ArrayList<String>()>)      = true
+     * isA(ArrayList.class, <new ArrayList<String>()>) = true
+     * isA(int[].class, <new int[0]>)                  = true
+     * isA(Object[].class, <new String[0]>)            = true
      * isA(_, null) = false
      * isA(null, _) = NullPointerException
      * }</pre>
@@ -78,10 +78,10 @@ public final class TypeTestUtil {
      * if the type of the node is parameterized. Examples:
      *
      * <pre>{@code
-     * isA(<new ArrayList<String>()>, "java.util.List")      = true
-     * isA(<new ArrayList<String>()>, "java.util.ArrayList") = true
-     * isA(<new int[0]>, "int[]")                            = true
-     * isA(<new String[0]>, "java.lang.Object[]")            = true
+     * isA("java.util.List", <new ArrayList<String>()>)      = true
+     * isA("java.util.ArrayList", <new ArrayList<String>()>) = true
+     * isA("int[]", <new int[0]>)                            = true
+     * isA("java.lang.Object[]", <new String[0]>)            = true
      * isA(_, null) = false
      * isA(null, _) = NullPointerException
      * }</pre>
@@ -158,10 +158,10 @@ public final class TypeTestUtil {
      * if the type of the node is parameterized.
      *
      * <pre>{@code
-     * isExactlyA(<new ArrayList<String>()>, List.class)      = false
-     * isExactlyA(<new ArrayList<String>()>, ArrayList.class) = true
-     * isExactlyA(<new int[0]>, int[].class)                  = true
-     * isExactlyA(<new String[0]>, Object[].class)            = false
+     * isExactlyA(List.class, <new ArrayList<String>()>)      = false
+     * isExactlyA(ArrayList.class, <new ArrayList<String>()>) = true
+     * isExactlyA(int[].class, <new int[0]>)                  = true
+     * isExactlyA(Object[].class, <new String[0]>)            = false
      * isExactlyA(_, null) = false
      * isExactlyA(null, _) = NullPointerException
      * }</pre>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/TypeTestUtilTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/TypeTestUtilTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.types;
 
+import java.io.ObjectStreamField;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
 import java.util.concurrent.Callable;
@@ -20,6 +21,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTEnumDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMarkerAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
+import net.sourceforge.pmd.lang.java.ast.ASTType;
 import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.symboltable.BaseNonParserTest;
 import net.sourceforge.pmd.lang.java.types.testdata.SomeClassWithAnon;
@@ -56,11 +58,59 @@ public class TypeTestUtilTest extends BaseNonParserTest {
 
         Assert.assertNull(klass.getType());
         Assert.assertTrue(TypeTestUtil.isA("org.FooBar", klass));
-        assertIsA(klass, Iterable.class);
-        assertIsA(klass, Enum.class);
-        assertIsA(klass, Serializable.class);
-        assertIsA(klass, Object.class);
+        assertIsStrictSubtype(klass, Iterable.class);
+        assertIsStrictSubtype(klass, Enum.class);
+        assertIsStrictSubtype(klass, Serializable.class);
+        assertIsStrictSubtype(klass, Object.class);
     }
+
+
+    @Test
+    public void testIsAnArrayClass() {
+
+        ASTType arrayT =
+            java.parse("import java.io.ObjectStreamField; "
+                           + "class Foo { private static final ObjectStreamField[] serialPersistentFields; }")
+                .getFirstDescendantOfType(ASTType.class);
+
+
+        assertIsExactlyA(arrayT, ObjectStreamField[].class);
+        assertIsStrictSubtype(arrayT, Object[].class);
+        assertIsStrictSubtype(arrayT, Serializable.class);
+        assertIsNot(arrayT, Serializable[].class);
+        assertIsStrictSubtype(arrayT, Object.class);
+    }
+
+    @Test
+    public void testIsAnAnnotationClass() {
+
+        ASTType arrayT =
+            java.parse("class Foo { org.junit.Test field; }")
+                .getFirstDescendantOfType(ASTType.class);
+
+
+        assertIsExactlyA(arrayT, Test.class);
+        assertIsStrictSubtype(arrayT, Annotation.class);
+        assertIsStrictSubtype(arrayT, Object.class);
+    }
+
+    @Test
+    public void testIsAPrimitiveArrayClass() {
+
+        ASTType arrayT =
+            java.parse("import java.io.ObjectStreamField; "
+                           + "class Foo { private static final int[] serialPersistentFields; }")
+                .getFirstDescendantOfType(ASTType.class);
+
+
+        assertIsExactlyA(arrayT, int[].class);
+        assertIsNot(arrayT, long[].class);
+        assertIsNot(arrayT, Object[].class);
+
+        assertIsStrictSubtype(arrayT, Serializable.class);
+        assertIsStrictSubtype(arrayT, Object.class);
+    }
+
 
     @Test
     public void testIsAFallbackAnnotation() {
@@ -161,10 +211,38 @@ public class TypeTestUtilTest extends BaseNonParserTest {
     }
 
     private void assertIsA(TypeNode node, Class<?> type) {
-        Assert.assertTrue("TypeTestUtil::isA with class arg: " + type.getCanonicalName(),
-                          TypeTestUtil.isA(type, node));
-        Assert.assertTrue("TypeTestUtil::isA with string arg: " + type.getCanonicalName(),
-                          TypeTestUtil.isA(type.getCanonicalName(), node));
+        assertIsA(node, type, false, true);
     }
+
+    private void assertIsExactlyA(TypeNode node, Class<?> type) {
+        assertIsA(node, type, true, true);
+        assertIsA(node, type, false, true);
+    }
+
+    private void assertIsNot(TypeNode node, Class<?> type) {
+        assertIsA(node, type, true, false);
+        assertIsA(node, type, false, false);
+    }
+
+    private void assertIsNotExactly(TypeNode node, Class<?> type) {
+        assertIsA(node, type, true, false);
+    }
+
+    private void assertIsStrictSubtype(TypeNode node, Class<?> type) {
+        assertIsNotExactly(node, type);
+        assertIsA(node, type);
+    }
+
+    private void assertIsA(TypeNode node, Class<?> type, boolean exactly, boolean expectTrue) {
+        Assert.assertEquals("TypeTestUtil::isA with class arg: " + type.getCanonicalName(),
+                            expectTrue,
+                            exactly ? TypeTestUtil.isExactlyA(type, node)
+                                    : TypeTestUtil.isA(type, node));
+        Assert.assertEquals("TypeTestUtil::isA with string arg: " + type.getCanonicalName(),
+                            expectTrue,
+                            exactly ? TypeTestUtil.isExactlyA(type.getCanonicalName(), node)
+                                    : TypeTestUtil.isA(type.getCanonicalName(), node));
+    }
+
 
 }


### PR DESCRIPTION
## Describe the PR

* Fix a bug, whereby array types were not supported by `TypeTestUtil.isA`. The reason is, we use `getName` on the Class instance, but this method returns a type descriptor for array types, not a canonical name (eg `[Ljava.lang.Object;` instead of `java.lang.Object[]`). So parsing the descriptor to load the class failed, because the other overload requires a canonical name
* Array covariance was not really tested
* The examples in the documentation had the arguments the wrong way around

## Related issues

 * This PR can be mentioned in the release notes as an issue

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

