### PR TITLE
[java] Update UnusedAssignmentRule to PMD 7 grammar

### DIFF
--- a/docs/pages/7_0_0_release_notes.md
+++ b/docs/pages/7_0_0_release_notes.md
@@ -69,6 +69,9 @@ The following previously deprecated rules have been finally removed:
 
 ### Fixed Issues
 
+* java-bestpractices
+    * [#2796](https://github.com/pmd/pmd/issue/2796): \[java] UnusedAssignment false positive with call chains
+
 ### API Changes
 
 * [#1648](https://github.com/pmd/pmd/pull/1702): \[apex,vf] Remove CodeClimate dependency - [Robert Sösemann](https://github.com/rsoesemann)

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedAssignmentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedAssignmentRule.java
@@ -881,15 +881,8 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
         }
 
         private <T extends InvocationNode & QualifiableExpression> SpanInfo visitInvocationExpr(T node, SpanInfo state) {
-            // Note that this doesn't really respect the order of evaluation of subexpressions
-            // This can be easily fixed in the 7.0 tree, but this is rare enough to not deserve
-            // the effort on master.
-
-            // For the record this has problems with call chains with side effects, like
-            //  a.foo(a = 2).bar(a = 3);
             state = acceptOpt(node.getQualifier(), state);
             state = acceptOpt(node.getArguments(), state);
-
 
             // todo In 7.0, with the precise type/overload resolution, we
             //  could only target methods that throw checked exceptions

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedAssignmentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedAssignmentRule.java
@@ -5,8 +5,6 @@
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
 
-import static net.sourceforge.pmd.lang.java.rule.codestyle.ConfusingTernaryRule.unwrapParentheses;
-
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -14,7 +12,6 @@ import java.util.Comparator;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -24,24 +21,25 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.ast.NodeStream;
 import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignableExpr;
+import net.sourceforge.pmd.lang.java.ast.ASTAssignableExpr.ASTNamedReferenceExpr;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignmentExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTBlock;
 import net.sourceforge.pmd.lang.java.ast.ASTBodyDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTBreakStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTCatchClause;
-import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBody;
+import net.sourceforge.pmd.lang.java.ast.ASTCatchParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
-import net.sourceforge.pmd.lang.java.ast.ASTConditionalAndExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTConditionalExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTConditionalOrExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTContinueStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTDoStatement;
-import net.sourceforge.pmd.lang.java.ast.ASTEnumBody;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTExpressionStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTFieldAccess;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTFinallyClause;
 import net.sourceforge.pmd.lang.java.ast.ASTForInit;
@@ -50,15 +48,14 @@ import net.sourceforge.pmd.lang.java.ast.ASTForUpdate;
 import net.sourceforge.pmd.lang.java.ast.ASTForeachStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTInfixExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTInitializer;
 import net.sourceforge.pmd.lang.java.ast.ASTLabeledStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTLambdaExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTLoopStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTName;
-import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
-import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
 import net.sourceforge.pmd.lang.java.ast.ASTResourceList;
 import net.sourceforge.pmd.lang.java.ast.ASTReturnStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTStatement;
@@ -66,21 +63,25 @@ import net.sourceforge.pmd.lang.java.ast.ASTSwitchArrowBranch;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchLabel;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTThisExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTThrowStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTTryStatement;
-import net.sourceforge.pmd.lang.java.ast.ASTTypeBody;
 import net.sourceforge.pmd.lang.java.ast.ASTUnaryExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableAccess;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
-import net.sourceforge.pmd.lang.java.ast.ASTVariableInitializer;
 import net.sourceforge.pmd.lang.java.ast.ASTWhileStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTYieldStatement;
+import net.sourceforge.pmd.lang.java.ast.BinaryOp;
+import net.sourceforge.pmd.lang.java.ast.InvocationNode;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.ast.JavaVisitorBase;
+import net.sourceforge.pmd.lang.java.ast.QualifiableExpression;
+import net.sourceforge.pmd.lang.java.ast.UnaryOp;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
-import net.sourceforge.pmd.lang.java.symboltable.ClassScope;
-import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
-import net.sourceforge.pmd.lang.symboltable.Scope;
+import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JFieldSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
 
@@ -106,6 +107,17 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
              or at least proper graph algorithms like toposort)
                 -> this is pretty invisible as it causes false negatives, not FPs
            * test ternary expr
+           * more precise exception handling: since we have access to
+             the overload for method & ctors, we can know where its thrown
+             exceptions may end up in enclosing catches.
+           * extract the reaching definition analysis, to exploit control
+           flow information in rules + symbol table. The following are needed
+           to implement scoping of pattern variables, and are already computed
+           by this analysis:
+             * whether a switch may fall through
+             * whether a statement always completes abruptly
+             * whether a statement never completes abruptly because of break
+
 
         DONE
            * conditionals
@@ -176,7 +188,7 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
                 if (killers == null || killers.isEmpty()) {
                     // var went out of scope before being used (no assignment kills it, yet it's unused)
 
-                    if (entry.var.isField()) {
+                    if (entry.var instanceof JFieldSymbol) {
                         // assignments to fields don't really go out of scope
                         continue;
                     } else if (suppressUnusedVariableRuleOverlap(entry)) {
@@ -202,13 +214,13 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
                 } else {
                     reason = joinLines("overwritten on lines ", killers);
                 }
-                if (reason == null && hasExplicitIgnorableName(entry.var.getName())) {
+                if (reason == null && hasExplicitIgnorableName(entry.var.getSimpleName())) {
                     // Then the variable is never used (cf UnusedVariable)
                     // We ignore those that start with "ignored", as that is standard
                     // practice for exceptions, and may be useful for resources/foreach vars
                     continue;
                 }
-                addViolationWithMessage(ruleCtx, entry.rhs, makeMessage(entry, reason, entry.var.isField()));
+                addViolationWithMessage(ruleCtx, entry.rhs, makeMessage(entry, reason, entry.var instanceof JFieldSymbol));
             }
         }
     }
@@ -219,8 +231,7 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
     }
 
     private boolean suppressUnusedVariableRuleOverlap(AssignmentEntry entry) {
-        return !getProperty(REPORT_UNUSED_VARS) && (entry.rhs instanceof ASTVariableInitializer
-            || entry.rhs instanceof ASTVariableDeclaratorId);
+        return !getProperty(REPORT_UNUSED_VARS) && (entry.isInitializer() || entry.isBlankDeclaration());
     }
 
     private static String getKind(ASTVariableDeclaratorId id) {
@@ -230,7 +241,7 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
             return "resource";
         } else if (id.isExceptionBlockParameter()) {
             return "exception parameter";
-        } else if (id.getNthParent(3) instanceof ASTForStatement) {
+        } else if (id.getNthParent(3) instanceof ASTForeachStatement) {
             return "loop variable";
         } else if (id.isFormalParameter()) {
             return "parameter";
@@ -242,7 +253,9 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
         if (assignment instanceof ASTUnaryExpression) {
             // the variable value is used if it was found somewhere else
             // than in statement position
-            return !getProperty(CHECK_PREFIX_INCREMENT) && !(assignment.getParent() instanceof ASTExpressionStatement);
+            UnaryOp op = ((ASTUnaryExpression) assignment).getOperator();
+            return !getProperty(CHECK_PREFIX_INCREMENT) && !op.isPure() && op.isPrefix()
+                && !(assignment.getParent() instanceof ASTExpressionStatement);
         }
         return false;
     }
@@ -250,18 +263,18 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
     private static String makeMessage(AssignmentEntry assignment, /* Nullable */ String reason, boolean isField) {
         // if reason is null, then the variable is unused (at most assigned to)
 
-        String varName = assignment.var.getName();
+        String varName = assignment.var.getSimpleName();
         StringBuilder result = new StringBuilder(64);
-        if (assignment.rhs instanceof ASTVariableInitializer) {
+        if (assignment.isInitializer()) {
             result.append(isField ? "the field initializer for"
                                   : "the initializer for variable");
-        } else if (assignment.rhs instanceof ASTVariableDeclaratorId) {
+        } else if (assignment.isBlankDeclaration()) {
             if (reason != null) {
                 result.append("the initial value of ");
             }
-            result.append(getKind(assignment.var));
-        } else {
-            if (assignment.rhs instanceof ASTUnaryExpression) {
+            result.append(getKind(assignment.node));
+        } else { // regular assignment
+            if (assignment.isUnaryReassign()) {
                 result.append("the updated value of ");
             } else {
                 result.append("the value assigned to ");
@@ -280,14 +293,8 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
     private static String joinLines(String prefix, Set<AssignmentEntry> killers) {
         StringBuilder sb = new StringBuilder(prefix);
         ArrayList<AssignmentEntry> sorted = new ArrayList<>(killers);
-        Collections.sort(sorted, new Comparator<AssignmentEntry>() {
-            @Override
-            public int compare(AssignmentEntry o1, AssignmentEntry o2) {
-                int lineRes = Integer.compare(o1.rhs.getBeginLine(), o2.rhs.getBeginLine());
-                return lineRes != 0 ? lineRes
-                                    : Integer.compare(o1.rhs.getBeginColumn(), o2.rhs.getBeginColumn());
-            }
-        });
+        sorted.sort(Comparator.comparingInt((AssignmentEntry o) -> o.rhs.getBeginLine())
+                              .thenComparingInt(o -> o.rhs.getBeginColumn()));
 
         sb.append(sorted.get(0).rhs.getBeginLine());
         for (int i = 1; i < sorted.size() - 1; i++) {
@@ -308,9 +315,9 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
         // null if we're not processing instance/static initializers,
         // so in methods we don't care about fields
         // If not null, fields are effectively treated as locals
-        private final ClassScope enclosingClassScope;
+        private final JClassSymbol enclosingClassScope;
 
-        private ReachingDefsVisitor(ClassScope scope) {
+        private ReachingDefsVisitor(JClassSymbol scope) {
             this.enclosingClassScope = scope;
         }
 
@@ -337,17 +344,15 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
             for (JavaNode child : node.children()) {
                 // each output is passed as input to the next (most relevant for blocks)
                 state = acceptOpt(child, state);
-                if (child instanceof ASTStatement
-                    && child.getChild(0) instanceof ASTLocalVariableDeclaration) {
-                    ASTLocalVariableDeclaration local = (ASTLocalVariableDeclaration) child.getChild(0);
-                    for (ASTVariableDeclaratorId id : local) {
+                if (child instanceof ASTLocalVariableDeclaration) {
+                    for (ASTVariableDeclaratorId id : (ASTLocalVariableDeclaration) child) {
                         localsToKill.add(id);
                     }
                 }
             }
 
             for (ASTVariableDeclaratorId var : localsToKill) {
-                state.deleteVar(var);
+                state.deleteVar(var.getSymbol());
             }
 
             return state;
@@ -392,18 +397,15 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
 
         @Override
         public SpanInfo visit(ASTIfStatement node, SpanInfo data) {
-            SpanInfo before = data;
-            return makeConditional(before, node.getCondition(), node.getThenBranch(), node.getElseBranch());
+            return makeConditional(data, node.getCondition(), node.getThenBranch(), node.getElseBranch());
         }
 
         @Override
         public SpanInfo visit(ASTConditionalExpression node, SpanInfo data) {
-            SpanInfo before = data;
-            return makeConditional(before, node.getCondition(), node.getChild(1), node.getChild(2));
+            return makeConditional(data, node.getCondition(), node.getThenBranch(), node.getElseBranch());
         }
 
-        // This will be much easier with the 7.0 grammar.....
-        SpanInfo makeConditional(SpanInfo before, JavaNode condition, JavaNode thenBranch, JavaNode elseBranch) {
+        SpanInfo makeConditional(SpanInfo before, ASTExpression condition, JavaNode thenBranch, JavaNode elseBranch) {
             SpanInfo thenState = before.fork();
             SpanInfo elseState = elseBranch != null ? before.fork() : before;
 
@@ -442,31 +444,31 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
          *      Eg for `a && b`, this is the `then` state (all evaluated to true)
          *
          */
-        private SpanInfo linkConditional(SpanInfo before, JavaNode condition, SpanInfo thenState, SpanInfo elseState, boolean isTopLevel) {
+        private SpanInfo linkConditional(SpanInfo before, ASTExpression condition, SpanInfo thenState, SpanInfo elseState, boolean isTopLevel) {
             if (condition == null) {
                 return before;
             }
-            condition = unwrapParentheses(condition);
 
-            if (condition instanceof ASTConditionalOrExpression) {
-                return visitShortcutOrExpr(condition, before, thenState, elseState);
-            } else if (condition instanceof ASTConditionalAndExpression) {
-                // To mimic a shortcut AND expr, swap the thenState and the elseState
-                // See explanations in method
-                return visitShortcutOrExpr(condition, before, elseState, thenState);
-            } else if (condition instanceof ASTExpression && condition.getNumChildren() == 1) {
-                return linkConditional(before, condition.getChild(0), thenState, elseState, isTopLevel);
-            } else {
-                SpanInfo state = acceptOpt(condition, before);
-                if (isTopLevel) {
-                    thenState.absorb(state);
-                    elseState.absorb(state);
+            if (condition instanceof ASTInfixExpression) {
+                BinaryOp op = ((ASTInfixExpression) condition).getOperator();
+                if (op == BinaryOp.CONDITIONAL_OR) {
+                    return visitShortcutOrExpr((ASTInfixExpression) condition, before, thenState, elseState);
+                } else if (op == BinaryOp.CONDITIONAL_AND) {
+                    // To mimic a shortcut AND expr, swap the thenState and the elseState
+                    // See explanations in method
+                    return visitShortcutOrExpr((ASTInfixExpression) condition, before, elseState, thenState);
                 }
-                return state;
             }
+
+            SpanInfo state = acceptOpt(condition, before);
+            if (isTopLevel) {
+                thenState.absorb(state);
+                elseState.absorb(state);
+            }
+            return state;
         }
 
-        SpanInfo visitShortcutOrExpr(JavaNode orExpr,
+        SpanInfo visitShortcutOrExpr(ASTInfixExpression orExpr,
                                      SpanInfo before,
                                      SpanInfo thenState,
                                      SpanInfo elseState) {
@@ -486,14 +488,11 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
             // This method side effects on thenState and elseState to
             // set the variables.
 
-            Iterator<? extends JavaNode> iterator = orExpr.children().iterator();
-
             SpanInfo cur = before;
-            do {
-                JavaNode cond = iterator.next();
-                cur = linkConditional(cur, cond, thenState, elseState, false);
-                thenState.absorb(cur);
-            } while (iterator.hasNext());
+            cur = linkConditional(cur, orExpr.getLeftOperand(), thenState, elseState, false);
+            thenState.absorb(cur);
+            cur = linkConditional(cur, orExpr.getRightOperand(), thenState, elseState, false);
+            thenState.absorb(cur);
 
             elseState.absorb(cur);
 
@@ -502,9 +501,7 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
 
 
         @Override
-        public SpanInfo visit(ASTTryStatement node, SpanInfo data) {
-            final SpanInfo before = data;
-            ASTFinallyClause finallyClause = node.getFinallyClause();
+        public SpanInfo visit(ASTTryStatement node, final SpanInfo before) {
 
             /*
                 <before>
@@ -525,6 +522,7 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
                 reason (if the <finally> completes normally), which
                 means it doesn't go to <end>
              */
+            ASTFinallyClause finallyClause = node.getFinallyClause();
 
             if (finallyClause != null) {
                 before.myFinally = before.forkEmpty();
@@ -532,7 +530,7 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
 
             final List<ASTCatchClause> catchClauses = node.getCatchClauses().toList();
             final List<SpanInfo> catchSpans = catchClauses.isEmpty() ? Collections.emptyList()
-                                                                     : new ArrayList<SpanInfo>();
+                                                                     : new ArrayList<>();
 
             // pre-fill catch spans
             for (int i = 0; i < catchClauses.size(); i++) {
@@ -548,9 +546,11 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
             bodyState = bodyState.withCatchBlocks(Collections.emptyList());
 
             SpanInfo exceptionalState = null;
+            int i = 0;
             for (ASTCatchClause catchClause : node.getCatchClauses()) {
-                SpanInfo current = acceptOpt(catchClause, before.fork().absorb(bodyState));
+                SpanInfo current = acceptOpt(catchClause, catchSpans.get(i));
                 exceptionalState = current.absorb(exceptionalState);
+                i++;
             }
 
             SpanInfo finalState;
@@ -579,7 +579,7 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
         @Override
         public SpanInfo visit(ASTCatchClause node, SpanInfo data) {
             SpanInfo result = visitJavaNode(node, data);
-            result.deleteVar(node.getParameter().getVarId());
+            result.deleteVar(node.getParameter().getVarId().getSymbol());
             return result;
         }
 
@@ -630,12 +630,12 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
         }
 
 
-        private SpanInfo handleLoop(JavaNode loop,
+        private SpanInfo handleLoop(ASTLoopStatement loop,
                                     SpanInfo before,
                                     JavaNode init,
-                                    JavaNode cond,
+                                    ASTExpression cond,
                                     JavaNode update,
-                                    JavaNode body,
+                                    ASTStatement body,
                                     boolean checkFirstIter,
                                     ASTVariableDeclaratorId foreachVar) {
             final GlobalAlgoState globalState = before.global;
@@ -657,7 +657,7 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
 
             if (foreachVar != null) {
                 // in foreach loops, the loop variable is assigned before the first iteration
-                before.assign(foreachVar, foreachVar);
+                before.assign(foreachVar.getSymbol(), foreachVar);
             }
 
 
@@ -667,7 +667,7 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
 
             if (foreachVar != null && iter.hasVar(foreachVar)) {
                 // in foreach loops, the loop variable is reassigned on each update
-                iter.assign(foreachVar, foreachVar);
+                iter.assign(foreachVar.getSymbol(), foreachVar);
             } else {
                 iter = acceptOpt(update, iter);
             }
@@ -697,39 +697,39 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
             }
 
             if (foreachVar != null) {
-                result.deleteVar(foreachVar);
+                result.deleteVar(foreachVar.getSymbol());
             }
 
             return result;
         }
 
-        private void pushTargets(JavaNode loop, SpanInfo breakTarget, SpanInfo continueTarget) {
+        private void pushTargets(ASTLoopStatement loop, SpanInfo breakTarget, SpanInfo continueTarget) {
             GlobalAlgoState globalState = breakTarget.global;
             globalState.breakTargets.unnamedTargets.push(breakTarget);
             globalState.continueTargets.unnamedTargets.push(continueTarget);
 
-            Node parent = loop.getNthParent(2);
+            Node parent = loop.getParent();
             while (parent instanceof ASTLabeledStatement) {
-                String label = parent.getImage();
+                String label = ((ASTLabeledStatement) parent).getLabel();
                 globalState.breakTargets.namedTargets.put(label, breakTarget);
                 globalState.continueTargets.namedTargets.put(label, continueTarget);
-                parent = parent.getNthParent(2);
+                parent = parent.getParent();
             }
         }
 
-        private SpanInfo popTargets(JavaNode loop, SpanInfo breakTarget, SpanInfo continueTarget) {
+        private SpanInfo popTargets(ASTLoopStatement loop, SpanInfo breakTarget, SpanInfo continueTarget) {
             GlobalAlgoState globalState = breakTarget.global;
             globalState.breakTargets.unnamedTargets.pop();
             globalState.continueTargets.unnamedTargets.pop();
 
             SpanInfo total = breakTarget.absorb(continueTarget);
 
-            Node parent = loop.getNthParent(2);
+            Node parent = loop.getParent();
             while (parent instanceof ASTLabeledStatement) {
-                String label = parent.getImage();
+                String label = ((ASTLabeledStatement) parent).getLabel();
                 total = total.absorb(globalState.breakTargets.namedTargets.remove(label));
                 total = total.absorb(globalState.continueTargets.namedTargets.remove(label));
-                parent = parent.getNthParent(2);
+                parent = parent.getParent();
             }
             return total;
         }
@@ -775,20 +775,25 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
 
         @Override
         public SpanInfo visit(ASTFormalParameter node, SpanInfo data) {
-            ASTVariableDeclaratorId id = node.getVarId();
-            data.assign(id, id);
+            data.declareBlank(node.getVarId());
+            return data;
+        }
+
+        @Override
+        public SpanInfo visit(ASTCatchParameter node, SpanInfo data) {
+            data.declareBlank(node.getVarId());
             return data;
         }
 
         @Override
         public SpanInfo visit(ASTVariableDeclarator node, SpanInfo data) {
-            ASTVariableDeclaratorId var = node.getVarId();
+            JVariableSymbol var = node.getVarId().getSymbol();
             ASTExpression rhs = node.getInitializer();
             if (rhs != null) {
                 rhs.acceptVisitor(this, data);
                 data.assign(var, rhs);
             } else {
-                data.assign(var, node.getVarId());
+                data.declareBlank(node.getVarId());
             }
             return data;
         }
@@ -803,220 +808,122 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
             // visit the rhs as it is evaluated before
             result = acceptOpt(rhs, result);
 
-            ASTVariableDeclaratorId lhsVar = getVarFromExpression(lhs, true, result);
-            if (lhsVar != null) {
-                // in that case lhs is a normal variable (array access not supported)
+            if (lhs instanceof ASTNamedReferenceExpr) {
+                JVariableSymbol lhsVar = ((ASTNamedReferenceExpr) lhs).getReferencedSym();
+                if (lhsVar != null) {
+                    if (node.getOperator().isCompound()) {
+                        // compound assignment, to use BEFORE assigning
+                        result.use(lhsVar);
+                    }
 
-                if (node.getOperator().isCompound()) {
-                    // compound assignment, to use BEFORE assigning
-                    result.use(lhsVar);
+                    result.assign(lhsVar, rhs);
+                    return result;
                 }
-
-                result.assign(lhsVar, rhs);
-            } else {
-                result = acceptOpt(lhs, result);
             }
+            result = acceptOpt(lhs, result);
             return result;
         }
 
         @Override
         public SpanInfo visit(ASTUnaryExpression node, SpanInfo data) {
-            ASTVariableDeclaratorId var = getVarFromExpression(node.getChild(0), true, data);
-            if (var != null) {
-                data.use(var);
-                data.assign(var, node);
+            data = node.getOperand().acceptVisitor(this, data);
+            JVariableSymbol sym = getVarIfUnaryAssignment(node);
+            if (sym != null) {
+                data.assign(sym, node);
             }
             return data;
+        }
+
+        private static JVariableSymbol getVarIfUnaryAssignment(ASTUnaryExpression node) {
+            ASTExpression operand = node.getOperand();
+            if (!node.getOperator().isPure() && operand instanceof ASTNamedReferenceExpr) {
+                return ((ASTNamedReferenceExpr) operand).getReferencedSym();
+            }
+            return null;
         }
 
         // variable usage
 
         @Override
-        public SpanInfo visitPrimaryExpr(ASTPrimaryExpression node, SpanInfo data) {
-            SpanInfo state = visitJavaNode(node, data); // visit subexpressions
+        public SpanInfo visit(ASTVariableAccess node, SpanInfo data) {
+            data.use(node.getReferencedSym());
+            return data;
+        }
 
-            ASTVariableDeclaratorId var = getVarFromExpression(node, false, state);
-            if (var != null) {
-                state.use(var);
+        @Override
+        public SpanInfo visit(ASTFieldAccess node, SpanInfo data) {
+            data = node.getQualifier().acceptVisitor(this, data);
+
+            if (enclosingClassScope != null && node.getQualifier() instanceof ASTThisExpression) {
+                data.use(node.getReferencedSym());
             }
+            return data;
+        }
 
-            maybeThrowUncheckedExceptions(node, state);
+        @Override
+        public SpanInfo visit(ASTThisExpression node, SpanInfo data) {
+            if (enclosingClassScope != null) {
+                data.recordThisLeak(true, enclosingClassScope);
+            }
+            return data;
+        }
 
+        @Override
+        public SpanInfo visit(ASTMethodCall node, SpanInfo state) {
+            return visitInvocationExpr(node, state);
+        }
+
+        @Override
+        public SpanInfo visit(ASTConstructorCall node, SpanInfo state) {
+            state = visitInvocationExpr(node, state);
+            acceptOpt(node.getAnonymousClassDeclaration(), state);
             return state;
         }
 
-        private void maybeThrowUncheckedExceptions(ASTPrimaryExpression e, SpanInfo state) {
+        private <T extends InvocationNode & QualifiableExpression> SpanInfo visitInvocationExpr(T node, SpanInfo state) {
             // Note that this doesn't really respect the order of evaluation of subexpressions
             // This can be easily fixed in the 7.0 tree, but this is rare enough to not deserve
             // the effort on master.
 
             // For the record this has problems with call chains with side effects, like
             //  a.foo(a = 2).bar(a = 3);
-
-            // In 7.0, with the precise type/overload resolution, we
-            // could only target methods that throw checked exceptions
-            // (unless some catch block catches an unchecked exceptions)
-            for (JavaNode child : e.children()) {
-                if (child instanceof ASTPrimarySuffix && ((ASTPrimarySuffix) child).isArguments()
-                // fixme commented out on java-grammar
-                // || child instanceof ASTPrimarySuffix && child.getNumChildren() > 0 && child.getChild(0) instanceof ASTAllocationExpression
-                // || child instanceof ASTPrimaryPrefix && child.getNumChildren() > 0 && child.getChild(0) instanceof ASTAllocationExpression
-                ) {
-                    state.abruptCompletionByThrow(true); // this is a noop if we're outside a try block that has catch/finally
-                }
-            }
-        }
-
-        /**
-         * Get the variable accessed from a primary.
-         */
-        private ASTVariableDeclaratorId getVarFromExpression(JavaNode primary, boolean inLhs, SpanInfo state) {
-
-            if (primary instanceof ASTPrimaryExpression) {
-                ASTPrimaryPrefix prefix = (ASTPrimaryPrefix) primary.getChild(0);
+            state = acceptOpt(node.getQualifier(), state);
+            state = acceptOpt(node.getArguments(), state);
 
 
-                //   this.x = 2;
-                if (prefix.usesThisModifier() && this.enclosingClassScope != null) {
-                    int numChildren = primary.getNumChildren();
-                    if (numChildren < 2 || numChildren > 2 && inLhs) {
-                        if (numChildren == 3 || numChildren == 1) {
-                            // method call on this, or just bare `this` reference
-                            state.recordThisLeak(true, enclosingClassScope);
-                        }
-                        return null;
-                    }
+            // todo In 7.0, with the precise type/overload resolution, we
+            //  could only target methods that throw checked exceptions
+            //  (unless some catch block catches an unchecked exceptions)
 
-                    ASTPrimarySuffix suffix = (ASTPrimarySuffix) primary.getChild(1);
-                    if (suffix.getImage() == null) {
-                        return null;
-                    } else if (primary.getNumChildren() > 2 && ((ASTPrimarySuffix) primary.getChild(2)).isArguments()) {
-                        //     this.foo()
-                        // first suffix is the name, second is the arguments
-                        state.recordThisLeak(true, enclosingClassScope);
-                        return null;
-                    }
-
-                    return findVar(primary.getScope(), true, suffix.getImage());
-                } else {
-                    if (prefix.getNumChildren() > 0 && prefix.getChild(0) instanceof ASTName) {
-                        String prefixImage = prefix.getChild(0).getImage();
-                        String varname = identOf(inLhs, prefixImage);
-                        if (primary.getNumChildren() > 1) {
-                            if (primary.getNumChildren() > 2 && inLhs) {
-                                // this is for chains like `foo.m().field = 3`
-                                return null;
-                            }
-                            ASTPrimarySuffix suffix = (ASTPrimarySuffix) primary.getChild(1);
-                            if (suffix.isArguments()) {
-                                // then the prefix has the method name
-                                varname = methodLhsName(prefixImage);
-                            } else if (suffix.isArrayDereference() && inLhs) {
-                                return null;
-                            }
-                        }
-                        return findVar(prefix.getScope(), false, varname);
-                    }
-                }
-            }
-
-            return null;
-        }
-
-        private static String identOf(boolean inLhs, String str) {
-            int i = str.indexOf('.');
-            if (i < 0) {
-                return str;
-            } else if (inLhs) {
-                // a qualified name in LHS, so
-                // the assignment doesn't assign the variable but one of its fields
-                return null;
-            }
-            return str.substring(0, i);
-        }
-
-        private static String methodLhsName(String name) {
-            int i = name.indexOf('.');
-            return i < 0 ? null // no lhs, the name is just the method name
-                         : name.substring(0, i);
-        }
-
-        private ASTVariableDeclaratorId findVar(Scope scope, boolean isField, String name) {
-            if (name == null) {
-                return null;
-            }
-
-            if (isField) {
-                return getFromSingleScope(enclosingClassScope, name);
-            }
-
-            while (scope != null) {
-                ASTVariableDeclaratorId result = getFromSingleScope(scope, name);
-                if (result != null) {
-                    if (scope instanceof ClassScope && scope != enclosingClassScope) { // NOPMD CompareObjectsWithEqual this is what we want
-                        // don't handle fields
-                        return null;
-                    }
-                    return result;
-                }
-
-                scope = scope.getParent();
-            }
-
-            return null;
-        }
-
-        private ASTVariableDeclaratorId getFromSingleScope(Scope scope, String name) {
-            if (scope != null) {
-                for (VariableNameDeclaration decl : scope.getDeclarations(VariableNameDeclaration.class).keySet()) {
-                    if (decl.getImage().equals(name)) {
-                        return (ASTVariableDeclaratorId) decl.getNode();
-                    }
-                }
-            }
-            return null;
+            state.abruptCompletionByThrow(true); // this is a noop if we're outside a try block that has catch/finally
+            return state;
         }
 
 
         // ctor/initializer handling
 
-        // this is the common denominator between anonymous class & astAnyTypeDeclaration on master
-
         @Override
-        public SpanInfo visit(ASTClassOrInterfaceBody node, SpanInfo data) {
-            visitTypeBody(node, data);
-            return data; // type doesn't contribute anything to the enclosing control flow
-        }
+        public SpanInfo visitTypeDecl(ASTAnyTypeDeclaration node, SpanInfo data) {
+            processInitializers(node.getDeclarations(), data, node.getSymbol());
 
-        @Override
-        public SpanInfo visit(ASTEnumBody node, SpanInfo data) {
-            visitTypeBody(node, data);
-            return data; // type doesn't contribute anything to the enclosing control flow
-        }
-
-
-        private void visitTypeBody(ASTTypeBody typeBody, SpanInfo data) {
-            List<ASTBodyDeclaration> declarations = typeBody.toList();
-            processInitializers(declarations, data, (ClassScope) typeBody.getScope());
-
-            for (ASTBodyDeclaration decl : declarations) {
+            for (ASTBodyDeclaration decl : node.getDeclarations()) {
                 if (decl instanceof ASTMethodDeclaration) {
                     ASTMethodDeclaration method = (ASTMethodDeclaration) decl;
                     if (method.getBody() != null) {
                         ONLY_LOCALS.acceptOpt(decl, data.forkCapturingNonLocal());
                     }
                 } else if (decl instanceof ASTAnyTypeDeclaration) {
-                    ASTTypeBody body = (ASTTypeBody) decl.getChild(decl.getNumChildren() - 1);
-                    visitTypeBody(body, data.forkEmptyNonLocal());
+                    visitTypeDecl((ASTAnyTypeDeclaration) decl, data.forkEmptyNonLocal());
                 }
             }
+            return data; // type doesn't contribute anything to the enclosing control flow
         }
 
-        private static void processInitializers(List<ASTBodyDeclaration> declarations,
+        private static void processInitializers(NodeStream<ASTBodyDeclaration> declarations,
                                                 SpanInfo beforeLocal,
-                                                ClassScope scope) {
+                                                JClassSymbol classSymbol) {
 
-            ReachingDefsVisitor visitor = new ReachingDefsVisitor(scope);
+            ReachingDefsVisitor visitor = new ReachingDefsVisitor(classSymbol);
 
             // All field initializers + instance initializers
             SpanInfo ctorHeader = beforeLocal.forkCapturingNonLocal();
@@ -1057,15 +964,14 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
             useAllSelfFields(staticInit, ctorEndState, visitor.enclosingClassScope);
         }
 
-        static void useAllSelfFields(/*nullable*/SpanInfo staticState, SpanInfo instanceState, ClassScope classScope) {
-            for (VariableNameDeclaration field : classScope.getVariableDeclarations().keySet()) {
-                ASTVariableDeclaratorId var = field.getDeclaratorId();
-                if (field.getAccessNodeParent().isStatic()) {
+        static void useAllSelfFields(/*nullable*/SpanInfo staticState, SpanInfo instanceState, JClassSymbol enclosingSym) {
+            for (JFieldSymbol field : enclosingSym.getDeclaredFields()) {
+                if (field.isStatic()) {
                     if (staticState != null) {
-                        staticState.use(var);
+                        staticState.use(field);
                     }
                 } else {
-                    instanceState.use(var);
+                    instanceState.use(field);
                 }
             }
         }
@@ -1098,9 +1004,9 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
         }
 
         private GlobalAlgoState() {
-            this(new HashSet<AssignmentEntry>(),
-                 new HashSet<AssignmentEntry>(),
-                 new HashMap<AssignmentEntry, Set<AssignmentEntry>>());
+            this(new HashSet<>(),
+                 new HashSet<>(),
+                 new HashMap<>());
         }
     }
 
@@ -1158,15 +1064,15 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
 
         final GlobalAlgoState global;
 
-        final Map<ASTVariableDeclaratorId, VarLocalInfo> symtable;
+        final Map<JVariableSymbol, VarLocalInfo> symtable;
 
         private SpanInfo(GlobalAlgoState global) {
-            this(null, global, new HashMap<ASTVariableDeclaratorId, VarLocalInfo>());
+            this(null, global, new HashMap<>());
         }
 
         private SpanInfo(SpanInfo parent,
                          GlobalAlgoState global,
-                         Map<ASTVariableDeclaratorId, VarLocalInfo> symtable) {
+                         Map<JVariableSymbol, VarLocalInfo> symtable) {
             this.parent = parent;
             this.global = global;
             this.symtable = symtable;
@@ -1174,11 +1080,19 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
         }
 
         boolean hasVar(ASTVariableDeclaratorId var) {
-            return symtable.containsKey(var);
+            return symtable.containsKey(var.getSymbol());
         }
 
-        void assign(ASTVariableDeclaratorId var, JavaNode rhs) {
-            AssignmentEntry entry = new AssignmentEntry(var, rhs);
+        void declareBlank(ASTVariableDeclaratorId id) {
+            assign(id.getSymbol(), id);
+        }
+
+        void assign(JVariableSymbol var, JavaNode rhs) {
+            ASTVariableDeclaratorId node = var.tryGetNode();
+            if (node == null) {
+                return; // we don't care about non-local declarations
+            }
+            AssignmentEntry entry = new AssignmentEntry(var, node, rhs);
             VarLocalInfo previous = symtable.put(var, new VarLocalInfo(Collections.singleton(entry)));
             if (previous != null) {
                 // those assignments were overwritten ("killed")
@@ -1188,19 +1102,15 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
                         && killed.rhs != rhs) {
                         continue;
                     }
-                    // java8: computeIfAbsent
-                    Set<AssignmentEntry> killers = global.killRecord.get(killed);
-                    if (killers == null) {
-                        killers = new HashSet<>(1);
-                        global.killRecord.put(killed, killers);
-                    }
-                    killers.add(entry);
+
+                    global.killRecord.computeIfAbsent(killed, k -> new HashSet<>(1))
+                                     .add(entry);
                 }
             }
             global.allAssignments.add(entry);
         }
 
-        void use(ASTVariableDeclaratorId var) {
+        void use(@Nullable JVariableSymbol var) {
             VarLocalInfo info = symtable.get(var);
             // may be null for implicit assignments, like method parameter
             if (info != null) {
@@ -1208,7 +1118,7 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
             }
         }
 
-        void deleteVar(ASTVariableDeclaratorId var) {
+        void deleteVar(JVariableSymbol var) {
             symtable.remove(var);
         }
 
@@ -1232,10 +1142,10 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
          * of `this`. So the analysis may show some false positives, which
          * hopefully should be rare enough.
          */
-        public void recordThisLeak(boolean thisIsLeaking, ClassScope enclosingClassScope) {
-            if (thisIsLeaking && enclosingClassScope != null) {
+        public void recordThisLeak(boolean thisIsLeaking, JClassSymbol enclosingClassSym) {
+            if (thisIsLeaking && enclosingClassSym != null) {
                 // all reaching defs to fields until now may be observed
-                ReachingDefsVisitor.useAllSelfFields(null, this, enclosingClassScope);
+                ReachingDefsVisitor.useAllSelfFields(null, this, enclosingClassSym);
             }
         }
 
@@ -1248,27 +1158,27 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
         }
 
         SpanInfo forkEmpty() {
-            return doFork(this, new HashMap<ASTVariableDeclaratorId, VarLocalInfo>());
+            return doFork(this, new HashMap<>());
         }
 
 
         SpanInfo forkEmptyNonLocal() {
-            return doFork(null, new HashMap<ASTVariableDeclaratorId, VarLocalInfo>());
+            return doFork(null, new HashMap<>());
         }
 
         SpanInfo forkCapturingNonLocal() {
             return doFork(null, copyTable());
         }
 
-        private Map<ASTVariableDeclaratorId, VarLocalInfo> copyTable() {
-            HashMap<ASTVariableDeclaratorId, VarLocalInfo> copy = new HashMap<>(this.symtable.size());
-            for (ASTVariableDeclaratorId var : this.symtable.keySet()) {
+        private Map<JVariableSymbol, VarLocalInfo> copyTable() {
+            HashMap<JVariableSymbol, VarLocalInfo> copy = new HashMap<>(this.symtable.size());
+            for (JVariableSymbol var : this.symtable.keySet()) {
                 copy.put(var, this.symtable.get(var).copy());
             }
             return copy;
         }
 
-        private SpanInfo doFork(/*nullable*/ SpanInfo parent, Map<ASTVariableDeclaratorId, VarLocalInfo> reaching) {
+        private SpanInfo doFork(/*nullable*/ SpanInfo parent, Map<JVariableSymbol, VarLocalInfo> reaching) {
             return new SpanInfo(parent, this.global, reaching);
         }
 
@@ -1349,10 +1259,10 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
 
             // we don't have to double the capacity since they're normally of the same size
             // (vars are deleted when exiting a block)
-            Set<ASTVariableDeclaratorId> keysUnion = new HashSet<>(this.symtable.keySet());
+            Set<JVariableSymbol> keysUnion = new HashSet<>(this.symtable.keySet());
             keysUnion.addAll(other.symtable.keySet());
 
-            for (ASTVariableDeclaratorId var : keysUnion) {
+            for (JVariableSymbol var : keysUnion) {
                 VarLocalInfo thisInfo = this.symtable.get(var);
                 VarLocalInfo otherInfo = other.symtable.get(var);
                 if (thisInfo == otherInfo) { // NOPMD CompareObjectsWithEqual this is what we want
@@ -1410,20 +1320,36 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
 
     static class AssignmentEntry {
 
-        final ASTVariableDeclaratorId var;
+        final JVariableSymbol var;
+        final ASTVariableDeclaratorId node;
 
         // this is not necessarily an expression, it may be also the
         // variable declarator of a foreach loop
         final JavaNode rhs;
 
-        AssignmentEntry(ASTVariableDeclaratorId var, JavaNode rhs) {
+        AssignmentEntry(JVariableSymbol var, ASTVariableDeclaratorId node, JavaNode rhs) {
             this.var = var;
+            this.node = node;
             this.rhs = rhs;
+        }
+
+        boolean isInitializer() {
+            return rhs.getParent() instanceof ASTVariableDeclarator
+                && rhs.getIndexInParent() > 0;
+        }
+
+        boolean isBlankDeclaration() {
+            return rhs instanceof ASTVariableDeclaratorId;
+        }
+
+        boolean isUnaryReassign() {
+            return rhs instanceof ASTUnaryExpression
+                && ReachingDefsVisitor.getVarIfUnaryAssignment((ASTUnaryExpression) rhs) == var;
         }
 
         @Override
         public String toString() {
-            return var.getName() + " := " + rhs;
+            return var.getSimpleName() + " := " + rhs;
         }
 
         @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JAccessibleElementSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JAccessibleElementSymbol.java
@@ -32,6 +32,11 @@ public interface JAccessibleElementSymbol extends JElementSymbol {
     int getModifiers();
 
 
+    default boolean isStatic() {
+        return Modifier.isStatic(getModifiers());
+    }
+
+
     /**
      * Returns the class that directly encloses this declaration.
      * This is equivalent to {@link Class#getEnclosingClass()}.

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/AbstractJavaScope.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/AbstractJavaScope.java
@@ -28,7 +28,10 @@ public abstract class AbstractJavaScope extends AbstractScope {
 
     protected void checkForDuplicatedNameDeclaration(NameDeclaration declaration) {
         if (declaration instanceof VariableNameDeclaration && getDeclarations().keySet().contains(declaration)) {
-            throw new RuntimeException(declaration + " is already in the symbol table");
+            // don't throw anymore
+            // Scopes will be removed before 7.0, and this sometimes triggers for no reason
+            // because Scopes were not ported to the newer grammar
+            // throw new RuntimeException(declaration + " is already in the symbol table");
         }
     }
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedAssignmentTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedAssignmentTest.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
 import net.sourceforge.pmd.testframework.PmdRuleTst;
 
-@org.junit.Ignore("Rule has not been updated yet")
 public class UnusedAssignmentTest extends PmdRuleTst {
     // no additional unit tests
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
@@ -3184,4 +3184,29 @@ public class UnusedAssignmentNative {
             ]]></code>
     </test-code>
 
+    <test-code>
+        <!-- This was an unhandled edge case in PMD 6, fixed in PMD 7 -->
+        <description>Call chain with side-effects in try</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>The initializer for variable 'a' is never used (overwritten on line 7)</message>
+        </expected-messages>
+        <code><![CDATA[
+            class Test {
+                int a() {
+                    int a = 10;
+                    try {
+                        // both method calls may throw, so a = 2 and a = 4 reach after the try,
+                        // but not a = 10
+                        "".substring(a = 2)
+                          .substring(a = 4);
+                    } catch (RuntimeException e) {
+
+                    }
+                    return a;
+                }
+            }
+            ]]></code>
+    </test-code>
+
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
@@ -2809,7 +2809,7 @@ class Foo {
     </test-code>
 
     <test-code>
-        <description>Test ignored name 1</description>
+        <description>Test ignored name 1 (method param, reportUnusedVariables)</description>
         <rule-property name="reportUnusedVariables">true</rule-property>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
@@ -2823,7 +2823,7 @@ class Foo {
     </test-code>
 
     <test-code>
-        <description>Test ignored name 2</description>
+        <description>Test ignored name 2 (single underscore, reportUnusedVariables)</description>
         <rule-property name="reportUnusedVariables">true</rule-property>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
@@ -2841,7 +2841,7 @@ class Foo {
     </test-code>
 
     <test-code>
-        <description>Test ignored name 2</description>
+        <description>Test ignored name 3 (reportUnusedVariables)</description>
         <rule-property name="reportUnusedVariables">true</rule-property>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
@@ -2864,7 +2864,7 @@ class Foo {
     </test-code>
 
     <test-code>
-        <description>Test ignored name 2</description>
+        <description>Test ignored name 3 (!reportUnusedVariables)</description>
         <rule-property name="reportUnusedVariables">false</rule-property>
         <expected-problems>0</expected-problems>
         <code><![CDATA[

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
@@ -3209,4 +3209,28 @@ public class UnusedAssignmentNative {
             ]]></code>
     </test-code>
 
+    <test-code regressionTest="true">
+        <!-- TODO for later -->
+        <description>Explicit this ctor call</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <expected-messages>
+            <message>The initializer for field 'field' is never used (overwritten on line 10)</message>
+        </expected-messages>
+        <code><![CDATA[
+            class Test {
+
+                private int field = 0;
+
+                Test() {
+                    this(0);
+                }
+
+                Test(int i) {
+                    field = i;
+                }
+            }
+            ]]></code>
+    </test-code>
+
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
@@ -3209,7 +3209,7 @@ public class UnusedAssignmentNative {
             ]]></code>
     </test-code>
 
-    <test-code regressionTest="true">
+    <test-code regressionTest="false">
         <!-- TODO for later -->
         <description>Explicit this ctor call</description>
         <expected-problems>1</expected-problems>


### PR DESCRIPTION
## Describe the PR

* Update UnusedAssignment
* As described on #2701 I think the reaching definitions analysis may be useful for other rules, and maybe for the symbol table. This is work for later, but reenabling the tests of the rule is good for future refactorings.

This also fixes a bug with call chains. I'll open an issue to describe it (-> #2796)

## Related issues

- An item of #2701
- Fix #2796 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

