### PR TITLE
[java] Improve DoNotCallSystemExit (Fixes #2157)

### DIFF
--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -1304,7 +1304,7 @@ public class GCCall {
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#donotcallsystemexit">
         <description>
 Web applications should not call System.exit(), since only the web container or the
-application server should stop the JVM. This rule also checks for the equivalent call Runtime.getRuntime().exit().
+application server should stop the JVM. This rule also checks for the equivalent calls Runtime.getRuntime().exit() and Runtime.getRuntime().halt().
         </description>
         <priority>3</priority>
         <properties>
@@ -1315,8 +1315,8 @@ application server should stop the JVM. This rule also checks for the equivalent
 //Name[
     starts-with(@Image,'System.exit')
     or
-    (starts-with(@Image,'Runtime.getRuntime') and ../../PrimarySuffix[ends-with(@Image,'exit')])
-]
+    (starts-with(@Image,'Runtime.getRuntime') and ../../PrimarySuffix[ends-with(@Image,'exit') or ends-with(@Image,'halt')])
+][not(ancestor::MethodDeclaration[1][@Name="main" and @Static = true()])]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/DoNotCallSystemExit.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/DoNotCallSystemExit.xml
@@ -6,9 +6,15 @@
 
     <test-code>
         <description>basic violations</description>
-        <expected-problems>1</expected-problems>
+        <expected-problems>2</expected-problems>
         <code><![CDATA[
 public class Bar {
+
+    static {
+        // NEVER DO THIS IN A APP SERVER !!!
+        System.exit(0);
+    }
+
     public void foo() {
         // NEVER DO THIS IN A APP SERVER !!!
         System.exit(0);
@@ -32,14 +38,46 @@ public class SystemCall {
 
     <test-code>
         <description>basic violations with Runtime</description>
-        <expected-problems>1</expected-problems>
+        <expected-problems>2</expected-problems>
         <code><![CDATA[
 public class Bar {
     public void foo() {
         // NEVER DO THIS IN A APP SERVER !!!
         Runtime.getRuntime().exit(0);
+        Runtime.getRuntime().halt(0);
     }
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>system exit in main</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class SystemCall {
+    public static void main(String[] args) {
+        // OK in main()
+        System.exit(0);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>system exit in anonymous class inside main</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class SystemCall {
+    public static void main(String[] args) {
+        new Runnable() {
+            public void run() {
+                // NEVER DO THIS IN A APP SERVER !!!
+                System.exit(0);
+            }
+        };
+    }
+}
+        ]]></code>
+    </test-code>
+
 </test-data>


### PR DESCRIPTION
## Describe the PR

System.exit() and its equivalents should be allowed in static main() methods, added check for Runtime.getRuntime().halt()

## Related issues

- Fixes #2157 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

