### PR TITLE
[java] CloseResource - Fix #2764: False-negative when re-assigning variable

### DIFF
--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
@@ -1429,4 +1429,51 @@ public class CloseResourceWithVar {
 }
         ]]></code>
     </test-code>
+    
+    <test-code>
+        <description>#2764 false-negative when re-assigning connection</description>
+        <rule-property name="types">java.sql.Connection,java.sql.Statement,java.sql.ResultSet</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <expected-messages>
+            <message>'c' is reassigned, but the original instance is not closed</message>
+        </expected-messages>
+        <code><![CDATA[
+import java.sql.Connection;
+
+public class Foo {
+    void bar() {
+        Connection c = pool.getConnection();
+        try {
+          c = pool.getConnection();
+        } catch (Exception e) {
+        } finally {
+            c.close();
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#2764 false-negative when re-assigning connection - no problem when closed before</description>
+        <rule-property name="types">java.sql.Connection,java.sql.Statement,java.sql.ResultSet</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.sql.Connection;
+
+public class Foo {
+    void bar() {
+        Connection c = pool.getConnection();
+        try {
+          c.close();
+          c = pool.getConnection();
+        } catch (Exception e) {
+        } finally {
+            c.close();
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
This PR fixes a false-negative when re-assigning a variable without closing it before.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #2764 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

