### PR TITLE
[core] Use JUnit's TemporaryFolder rule

### DIFF
--- a/pmd-core/src/test/java/net/sourceforge/pmd/ConfigurationTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/ConfigurationTest.java
@@ -19,7 +19,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.Properties;
 
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import net.sourceforge.pmd.cache.FileAnalysisCache;
 import net.sourceforge.pmd.cache.NoopAnalysisCache;
@@ -28,6 +30,9 @@ import net.sourceforge.pmd.renderers.Renderer;
 import net.sourceforge.pmd.util.ClasspathClassLoader;
 
 public class ConfigurationTest {
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
 
     @Test
     public void testSuppressMarker() {
@@ -227,8 +232,7 @@ public class ConfigurationTest {
         configuration.setAnalysisCache(null);
         assertNotNull("Default cache was set to null", configuration.getAnalysisCache());
 
-        final File cacheFile = File.createTempFile("pmd-", ".cache");
-        cacheFile.deleteOnExit();
+        final File cacheFile = folder.newFile();
         final FileAnalysisCache analysisCache = new FileAnalysisCache(cacheFile);
         configuration.setAnalysisCache(analysisCache);
         assertSame("Configured cache not stored", analysisCache, configuration.getAnalysisCache());
@@ -254,8 +258,7 @@ public class ConfigurationTest {
         final PMDConfiguration configuration = new PMDConfiguration();
 
         // set dummy cache location
-        final File cacheFile = File.createTempFile("pmd-", ".cache");
-        cacheFile.deleteOnExit();
+        final File cacheFile = folder.newFile();
         final FileAnalysisCache analysisCache = new FileAnalysisCache(cacheFile);
         configuration.setAnalysisCache(analysisCache);
         assertNotNull("Null cache location accepted", configuration.getAnalysisCache());

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
@@ -10,8 +10,6 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import javax.xml.parsers.DocumentBuilderFactory;
 
 import org.apache.commons.io.IOUtils;
@@ -19,6 +17,7 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.rules.TemporaryFolder;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
@@ -38,6 +37,9 @@ import net.sourceforge.pmd.lang.rule.ParametricRuleViolation;
 public class XMLRendererTest extends AbstractRendererTest {
     @Rule // Restores system properties after test
     public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
 
     @Override
     public Renderer getRenderer() {
@@ -160,19 +162,16 @@ public class XMLRendererTest extends AbstractRendererTest {
     }
 
     private String renderTempFile(Renderer renderer, Report report, Charset expectedCharset) throws IOException {
-        Path tempFile = Files.createTempFile("pmd-report-test", null);
-        String absolutePath = tempFile.toAbsolutePath().toString();
+        File reportFile = folder.newFile();
 
-        renderer.setReportFile(absolutePath);
+        renderer.setReportFile(reportFile.getAbsolutePath());
         renderer.start();
         renderer.renderFileReport(report);
         renderer.end();
         renderer.flush();
 
-        try (FileInputStream input = new FileInputStream(absolutePath)) {
+        try (FileInputStream input = new FileInputStream(reportFile)) {
             return IOUtils.toString(input, expectedCharset);
-        } finally {
-            Files.delete(tempFile);
         }
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/YAHTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/YAHTMLRendererTest.java
@@ -15,9 +15,10 @@ import java.util.Arrays;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
-import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import net.sourceforge.pmd.FooRule;
 import net.sourceforge.pmd.PMD;
@@ -33,39 +34,14 @@ import net.sourceforge.pmd.lang.rule.ParametricRuleViolation;
 
 public class YAHTMLRendererTest extends AbstractRendererTest {
 
-    private String outputDir;
+    private File outputDir;
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
 
     @Before
     public void setUp() throws IOException {
-        outputDir = getTemporaryDirectory("pmdtest").getAbsolutePath();
-    }
-
-    @After
-    public void cleanUp() {
-        deleteDirectory(new File(outputDir));
-    }
-
-    private File getTemporaryDirectory(String prefix) throws IOException {
-        // TODO: move to util class?
-        File dir = File.createTempFile(prefix, "");
-        dir.delete();
-        dir.mkdir();
-        return dir;
-    }
-
-    private void deleteDirectory(File dir) {
-        // TODO: move to util class?
-        File[] a = dir.listFiles();
-        if (a != null) {
-            for (File f : a) {
-                if (f.isDirectory()) {
-                    deleteDirectory(f);
-                } else {
-                    f.delete();
-                }
-            }
-        }
-        dir.delete();
+        outputDir = folder.newFolder("pmdtest");
     }
 
     private RuleViolation newRuleViolation(int endColumn, final String packageNameArg, final String classNameArg) {
@@ -94,7 +70,7 @@ public class YAHTMLRendererTest extends AbstractRendererTest {
         String actual = ReportTest.render(getRenderer(), report);
         assertEquals(filter(getExpected()), filter(actual));
 
-        String[] htmlFiles = new File(outputDir).list();
+        String[] htmlFiles = outputDir.list();
         assertEquals(3, htmlFiles.length);
         Arrays.sort(htmlFiles);
         assertEquals("YAHTMLSampleClass1.html", htmlFiles[0]);
@@ -120,7 +96,7 @@ public class YAHTMLRendererTest extends AbstractRendererTest {
     @Override
     public Renderer getRenderer() {
         Renderer result = new YAHTMLRenderer();
-        result.setProperty(YAHTMLRenderer.OUTPUT_DIR, outputDir);
+        result.setProperty(YAHTMLRenderer.OUTPUT_DIR, outputDir.getAbsolutePath());
         return result;
     }
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/database/DBTypeTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/database/DBTypeTest.java
@@ -14,7 +14,9 @@ import java.util.ResourceBundle;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  *
@@ -27,6 +29,9 @@ public class DBTypeTest {
     private Properties testProperties;
     private Properties includeProperties;
 
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
     @Before
     public void setUp() throws Exception {
         testProperties = new Properties();
@@ -38,7 +43,7 @@ public class DBTypeTest {
         includeProperties.putAll(testProperties);
         includeProperties.put("prop3", "include3");
 
-        absoluteFile = File.createTempFile("dbtypetest", ".properties");
+        absoluteFile = folder.newFile();
         try (FileOutputStream fileOutputStream = new FileOutputStream(absoluteFile);
              PrintStream printStream = new PrintStream(fileOutputStream)) {
             for (Entry<?, ?> entry : testProperties.entrySet()) {
@@ -50,7 +55,6 @@ public class DBTypeTest {
     @After
     public void tearDown() throws Exception {
         testProperties = null;
-        absoluteFile.delete();
     }
 
     /**

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/AbstractBinaryDistributionTest.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/AbstractBinaryDistributionTest.java
@@ -5,13 +5,11 @@
 package net.sourceforge.pmd.it;
 
 import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 
-import org.apache.commons.io.FileUtils;
-import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.rules.TemporaryFolder;
 
 import net.sourceforge.pmd.PMDVersion;
 
@@ -21,6 +19,9 @@ public abstract class AbstractBinaryDistributionTest {
         return new File(".", "target/pmd-bin-" + PMDVersion.VERSION + ".zip");
     }
 
+    @ClassRule
+    public static TemporaryFolder folder = new TemporaryFolder();
+
     /**
      * The temporary directory, to which the binary distribution will be extracted.
      * It will be deleted again after the test.
@@ -29,16 +30,9 @@ public abstract class AbstractBinaryDistributionTest {
 
     @BeforeClass
     public static void setupTempDirectory() throws Exception {
-        tempDir = Files.createTempDirectory("pmd-it-test-");
+        tempDir = folder.newFolder().toPath();
         if (getBinaryDistribution().exists()) {
             ZipFileExtractor.extractZipFile(getBinaryDistribution().toPath(), tempDir);
-        }
-    }
-
-    @AfterClass
-    public static void cleanupTempDirectory() throws IOException {
-        if (tempDir != null && tempDir.toFile().exists()) {
-            FileUtils.forceDelete(tempDir.toFile());
         }
     }
 }

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/AllRulesIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/AllRulesIT.java
@@ -35,8 +35,8 @@ public class AllRulesIT extends AbstractBinaryDistributionTest {
     public void runRuleTests() throws Exception {
         String srcDir = new File(".", "src/test/resources/sample-source/" + language + "/").getAbsolutePath();
 
-        ExecutionResult result = PMDExecutor.runPMDRules(tempDir, srcDir, "src/test/resources/rulesets/all-"
-                + language + ".xml");
+        ExecutionResult result = PMDExecutor.runPMDRules(folder.newFile().toPath(), tempDir, srcDir,
+                "src/test/resources/rulesets/all-" + language + ".xml");
         assertDefaultExecutionResult(result);
     }
 

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistributionIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistributionIT.java
@@ -84,15 +84,15 @@ public class BinaryDistributionIT extends AbstractBinaryDistributionTest {
         result = PMDExecutor.runPMD(tempDir, "-h");
         result.assertExecutionResult(0, SUPPORTED_LANGUAGES_PMD);
 
-        result = PMDExecutor.runPMDRules(tempDir, srcDir, "src/test/resources/rulesets/sample-ruleset.xml");
+        result = PMDExecutor.runPMDRules(folder.newFile().toPath(), tempDir, srcDir, "src/test/resources/rulesets/sample-ruleset.xml");
         result.assertExecutionResult(4, "", "JumbledIncrementer.java:8:");
 
         // also test XML format
-        result = PMDExecutor.runPMDRules(tempDir, srcDir, "src/test/resources/rulesets/sample-ruleset.xml", "xml");
+        result = PMDExecutor.runPMDRules(folder.newFile().toPath(), tempDir, srcDir, "src/test/resources/rulesets/sample-ruleset.xml", "xml");
         result.assertExecutionResult(4, "", "JumbledIncrementer.java\">");
         result.assertExecutionResult(4, "", "<violation beginline=\"8\" endline=\"10\" begincolumn=\"13\" endcolumn=\"13\" rule=\"JumbledIncrementer\"");
 
-        result = PMDExecutor.runPMDRules(tempDir, srcDir, "rulesets/java/quickstart.xml");
+        result = PMDExecutor.runPMDRules(folder.newFile().toPath(), tempDir, srcDir, "rulesets/java/quickstart.xml");
         result.assertExecutionResult(4, "");
     }
 

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/PMDExecutor.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/PMDExecutor.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.it;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -97,20 +96,18 @@ public class PMDExecutor {
     /**
      * Executes the PMD found in tempDir against the given sourceDirectory path with the given ruleset.
      *
+     * @param reportFile the file to write the report to
      * @param tempDir the directory, to which the binary distribution has been extracted
      * @param sourceDirectory the source directory, that PMD should analyze
      * @param ruleset the ruleset, that PMD should execute
      * @return collected result of the execution
      * @throws Exception if the execution fails for any reason (executable not found, ...)
      */
-    public static ExecutionResult runPMDRules(Path tempDir, String sourceDirectory, String ruleset) throws Exception {
-        return runPMDRules(tempDir, sourceDirectory, ruleset, FORMATTER);
+    public static ExecutionResult runPMDRules(Path reportFile, Path tempDir, String sourceDirectory, String ruleset) throws Exception {
+        return runPMDRules(reportFile, tempDir, sourceDirectory, ruleset, FORMATTER);
     }
 
-    public static ExecutionResult runPMDRules(Path tempDir, String sourceDirectory, String ruleset, String formatter) throws Exception {
-        Path reportFile = Files.createTempFile("pmd-it-report", "txt");
-        reportFile.toFile().deleteOnExit();
-
+    public static ExecutionResult runPMDRules(Path reportFile, Path tempDir, String sourceDirectory, String ruleset, String formatter) throws Exception {
         if (SystemUtils.IS_OS_WINDOWS) {
             return runPMDWindows(tempDir, reportFile, SOURCE_DIRECTORY_FLAG, sourceDirectory, RULESET_FLAG, ruleset,
                     FORMAT_FLAG, formatter, REPORTFILE_FLAG, reportFile.toAbsolutePath().toString());

--- a/pmd-doc/src/test/java/net/sourceforge/pmd/docs/RuleDocGeneratorTest.java
+++ b/pmd-doc/src/test/java/net/sourceforge/pmd/docs/RuleDocGeneratorTest.java
@@ -9,19 +9,17 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
-import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import net.sourceforge.pmd.RuleSet;
 import net.sourceforge.pmd.RuleSetFactory;
@@ -34,11 +32,14 @@ public class RuleDocGeneratorTest {
     private MockedFileWriter writer = new MockedFileWriter();
     private Path root;
 
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
     @Before
     public void setup() throws IOException {
         writer.reset();
 
-        root = Files.createTempDirectory("pmd-ruledocgenerator-test");
+        root = folder.newFolder().toPath();
         Files.createDirectories(root.resolve("docs/_data/sidebars"));
         List<String> mockedSidebar = Arrays.asList(
                 "entries:",
@@ -49,23 +50,6 @@ public class RuleDocGeneratorTest {
                 "  - title: 3",
                 "  - title: Rules");
         Files.write(root.resolve("docs/_data/sidebars/pmd_sidebar.yml"), mockedSidebar);
-    }
-
-    @After
-    public void cleanup() throws IOException {
-        Files.walkFileTree(root, new SimpleFileVisitor<Path>() {
-            @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                Files.delete(file);
-                return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-                Files.delete(dir);
-                return FileVisitResult.CONTINUE;
-            }
-        });
     }
 
     private static String loadResource(String name) throws IOException {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/coverage/PMDCoverageTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/coverage/PMDCoverageTest.java
@@ -18,6 +18,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.StandardErrorStreamLog;
 import org.junit.contrib.java.lang.system.StandardOutputStreamLog;
+import org.junit.rules.TemporaryFolder;
 
 import net.sourceforge.pmd.PMD;
 
@@ -28,6 +29,9 @@ public class PMDCoverageTest {
 
     @Rule
     public StandardErrorStreamLog errorStream = new StandardErrorStreamLog();
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
 
     /**
      * Test some of the PMD command line options
@@ -46,9 +50,8 @@ public class PMDCoverageTest {
         String[] args;
         args = commandLine.split("\\s");
 
-        File f = null;
         try {
-            f = File.createTempFile("pmd", ".txt");
+            File f = folder.newFile();
             int n = args.length;
             String[] a = new String[n + 2 + 2];
             System.arraycopy(args, 0, a, 0, n);
@@ -74,10 +77,6 @@ public class PMDCoverageTest {
             assertEquals("No parsing error expected", 0, StringUtils.countMatches(report, "Error while parsing"));
         } catch (IOException ioe) {
             fail("Problem creating temporary file: " + ioe.getLocalizedMessage());
-        } finally {
-            if (f != null) {
-                f.delete();
-            }
         }
     }
 


### PR DESCRIPTION
Don't reinvent the wheel. TemporaryFolder already takes care of cleaning
up the created files.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

