### PR TITLE
[core] Fix XMLRenderer newlines when running under IBM Java

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -23,6 +23,8 @@ This is a {{ site.pmd.release_type }} release.
 
 ### Fixed Issues
 
+* core
+    * [#2831](https://github.com/pmd/pmd/pull/2831): \[core] Fix XMLRenderer newlines when running under IBM Java
 * java-errorprone
     * [#2157](https://github.com/pmd/pmd/issues/2157): \[java] Improve DoNotCallSystemExit: permit call in main(), flag System.halt
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XMLRenderer.java
@@ -46,6 +46,7 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
 
     private XMLStreamWriter xmlWriter;
     private OutputStream stream;
+    private byte[] lineSeparator = new byte[0];
 
     public XMLRenderer() {
         super(NAME, "XML format.");
@@ -65,10 +66,11 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
     @Override
     public void start() throws IOException {
         String encoding = getProperty(ENCODING);
+        lineSeparator = PMD.EOL.getBytes(encoding);
 
         try {
             xmlWriter.writeStartDocument(encoding, "1.0");
-            xmlWriter.writeCharacters(PMD.EOL);
+            writeNewLine();
             xmlWriter.setDefaultNamespace(PMD_REPORT_NS_URI);
             xmlWriter.writeStartElement(PMD_REPORT_NS_URI, "pmd");
             xmlWriter.writeDefaultNamespace(PMD_REPORT_NS_URI);
@@ -82,6 +84,33 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
         } catch (XMLStreamException e) {
             throw new IOException(e);
         }
+    }
+
+    /**
+     * Outputs a platform dependent line separator.
+     *
+     * @throws XMLStreamException if XMLStreamWriter couldn't be flushed.
+     * @throws IOException if an I/O error occurs.
+     */
+    private void writeNewLine() throws XMLStreamException, IOException {
+        /*
+         * Note: we are not using xmlWriter.writeCharacters(PMD.EOL), because some
+         * XMLStreamWriter implementations might do extra encoding for \r and/or \n.
+         * Notably IBM's Java 8 will escape "\r" with "&#xD;" which will render an
+         * invalid XML document. IBM's Java 8 would also output a platform dependent
+         * line separator when writing "\n" which results under Windows, that "\r"
+         * actually is written twice (once escaped, once raw).
+         *
+         * Note2: Before writing the raw bytes to the underlying stream, we need
+         * to flush XMLStreamWriter. Notably IBM's Java 8 might still need to output
+         * data.
+         *
+         * Note3: Before writing the raw bytes, we issue a empty writeCharacters,
+         * so that any open tags are closed and we are ready for writing raw bytes.
+         */
+        xmlWriter.writeCharacters("");
+        xmlWriter.flush();
+        stream.write(lineSeparator);
     }
 
     @Override
@@ -100,10 +129,10 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
                         xmlWriter.writeEndElement();
                     }
                     filename = nextFilename;
-                    xmlWriter.writeCharacters(PMD.EOL);
+                    writeNewLine();
                     xmlWriter.writeStartElement("file");
                     xmlWriter.writeAttribute("name", filename);
-                    xmlWriter.writeCharacters(PMD.EOL);
+                    writeNewLine();
                 }
 
                 xmlWriter.writeStartElement("violation");
@@ -119,11 +148,11 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
                 maybeAdd("variable", rv.getVariableName());
                 maybeAdd("externalInfoUrl", rv.getRule().getExternalInfoUrl());
                 xmlWriter.writeAttribute("priority", String.valueOf(rv.getRule().getPriority().getPriority()));
-                xmlWriter.writeCharacters(PMD.EOL);
+                writeNewLine();
                 xmlWriter.writeCharacters(StringUtil.removedInvalidXml10Characters(rv.getDescription()));
-                xmlWriter.writeCharacters(PMD.EOL);
+                writeNewLine();
                 xmlWriter.writeEndElement();
-                xmlWriter.writeCharacters(PMD.EOL);
+                writeNewLine();
             }
             if (filename != null) { // Not first file ?
                 xmlWriter.writeEndElement();
@@ -138,20 +167,20 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
         try {
             // errors
             for (Report.ProcessingError pe : errors) {
-                xmlWriter.writeCharacters(PMD.EOL);
+                writeNewLine();
                 xmlWriter.writeStartElement("error");
                 xmlWriter.writeAttribute("filename", determineFileName(pe.getFile()));
                 xmlWriter.writeAttribute("msg", pe.getMsg());
-                xmlWriter.writeCharacters(PMD.EOL);
+                writeNewLine();
                 xmlWriter.writeCData(pe.getDetail());
-                xmlWriter.writeCharacters(PMD.EOL);
+                writeNewLine();
                 xmlWriter.writeEndElement();
             }
 
             // suppressed violations
             if (showSuppressedViolations) {
                 for (Report.SuppressedViolation s : suppressed) {
-                    xmlWriter.writeCharacters(PMD.EOL);
+                    writeNewLine();
                     xmlWriter.writeStartElement("suppressedviolation");
                     xmlWriter.writeAttribute("filename", determineFileName(s.getRuleViolation().getFilename()));
                     xmlWriter.writeAttribute("suppressiontype", s.suppressedByNOPMD() ? "nopmd" : "annotation");
@@ -163,14 +192,15 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
 
             // config errors
             for (final Report.ConfigurationError ce : configErrors) {
-                xmlWriter.writeCharacters(PMD.EOL);
+                writeNewLine();
                 xmlWriter.writeEmptyElement("configerror");
                 xmlWriter.writeAttribute("rule", ce.rule().getName());
                 xmlWriter.writeAttribute("msg", ce.issue());
             }
-            xmlWriter.writeCharacters(PMD.EOL);
+            writeNewLine();
             xmlWriter.writeEndElement(); // </pmd>
-            xmlWriter.writeCharacters(PMD.EOL);
+            writeNewLine();
+            xmlWriter.writeEndDocument();
             xmlWriter.flush();
         } catch (XMLStreamException e) {
             throw new IOException(e);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XMLRenderer.java
@@ -46,7 +46,7 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
 
     private XMLStreamWriter xmlWriter;
     private OutputStream stream;
-    private byte[] lineSeparator = new byte[0];
+    private byte[] lineSeparator;
 
     public XMLRenderer() {
         super(NAME, "XML format.");


### PR DESCRIPTION
## Describe the PR

When running PMD under Windows with [IBM's Java](https://www.ibm.com/support/pages/java-sdk-downloads-version-80), then the produced XML report looks like this:

```xml
<?xml version="1.0" encoding="UTF-8"?>&#xD;
<pmd xmlns="http://pmd.sourceforge.net/report/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pmd.sourceforge.net/report/2.0.0 http://pmd.sourceforge.net/report_2_0_0.xsd" version="6.28.0" timestamp="2020-10-15T10:24:55.318">&#xD;
</pmd>&#xD;
```

IBM's Java obviously uses an interesting implementation for XMLStreamWriter. The produced XML is invalid, e.g. xmllint says this:

```
$ xmllint out.xml
out.xml:1: parser error : Start tag expected, '<' not found
<?xml version="1.0" encoding="UTF-8"?>&#xD;
```

This problem exists since I've refactored XMLRenderer to use XMLStreamWriter with PMD 6.26.0 (see #2633).

Testing is a bit complicated, but possible under Linux (originally, this problem appears only under Windows, due to different default line separators). In order to test it, you'll need

1. IBM's Java 8 SDK -> https://www.ibm.com/support/pages/java-sdk-downloads-version-80
2. The following start script for PMD for some bash magic...

```bash
#!/bin/bash

PMD_DIR=~/PMD/pmd-bin-6.28.0
#PMD_DIR=~/PMD/pmd-bin-6.29.0-SNAPSHOT

PMD_JAVA_OPTS=-Dline.separator=$'\r\n'
LIB_DIR=$PMD_DIR/lib

# need to source run.sh, otherwise subshell is used and IFS is not inherited and contains $'\n'
# which will destroy line.separator property (PMD_JAVA_OPTS is word split at the newline char)
IFS=' '
source $PMD_DIR/bin/run.sh pmd -f xml -d . -R rulesets/java/quickstart.xml -no-cache
```

### Other changes

This PR also adds the missing call to "writeEndDocument()".

## Related issues

- #2633
- #2615
- See also https://stackoverflow.com/questions/29675481/xmlstreamwriter-java-8-writecharacters-xd

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

