### PR TITLE
[java] (doc) Update ExcessiveImports example code for clarity

### DIFF
--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -632,7 +632,7 @@ user-specified threshold.
 <![CDATA[
 import blah.blah.Baz;
 import blah.blah.Bif;
-// 18 others from the same package elided
+// 28 others from the same package elided
 public class Foo {
     public void doWork() {}
 }


### PR DESCRIPTION
## Describe the PR

[ExcessiveImports](https://pmd.github.io/latest/pmd_rules_java_design.html#excessiveimports):

Since the default minimum is 30, I believe it would make more sense if the comment said "28" instead of "18".