### PR TITLE
[java] Remove weird trailing characters

### DIFF
--- a/pmd-java/etc/grammar/Java.jjt
+++ b/pmd-java/etc/grammar/Java.jjt
@@ -923,8 +923,6 @@ ASTCompilationUnit CompilationUnit() :
   // a module (most common case)
   [ LOOKAHEAD(ModuleDeclLahead()) ModuleDeclaration() ( EmptyDeclaration() )* ]
   ( TypeDeclaration() ( EmptyDeclaration() )* )*
-  ( < "\u001a" > )?
-  ( < "~[]" > )? // what's this for? Do you mean ( < ~[] > )*, i.e. "any character"?
   <EOF>
   {
      jjtThis.setComments(token_source.comments);


### PR DESCRIPTION
## Describe the PR

The grammar had two strange string literals, which allowed ending a file with
* u001a (a SUBSTITUTE control char), or
*  the string `~[]`, which was probably a typo, meant to allow any number of trailing chars. 

A file with only those would also have been valid. I think it's safe to remove those

Edit: this also showed up in parse error messages:
```java
Was expecting one of:
    <EOF> 
    "import" ...
    "\u001a" ...
    "~[]" ...
```


## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

