### PR TITLE
[lang-test] Upgrade Kotlin, Dokka and Kotest

### DIFF
--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ParserTestSpec.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ParserTestSpec.kt
@@ -4,17 +4,17 @@
 
 package net.sourceforge.pmd.lang.java.ast
 
-import io.kotest.core.config.Project
-import io.kotest.core.spec.style.DslDrivenSpec
+import io.kotest.core.config.configuration
+import io.kotest.core.spec.DslDrivenSpec
 import io.kotest.core.spec.style.scopes.Lifecycle
 import io.kotest.core.spec.style.scopes.RootScope
 import io.kotest.core.spec.style.scopes.RootTestRegistration
 import io.kotest.core.test.TestCaseConfig
 import io.kotest.core.test.TestContext
-import io.kotest.core.test.TestName
 import io.kotest.core.test.TestType
-import io.kotest.runner.junit.platform.IntelliMarker
+import io.kotest.core.test.createTestName
 import net.sourceforge.pmd.lang.ast.test.Assertions
+import net.sourceforge.pmd.lang.ast.test.IntelliMarker
 import io.kotest.matchers.should as kotlintestShould
 
 /**
@@ -33,11 +33,15 @@ abstract class ParserTestSpec(body: ParserTestSpec.() -> Unit) : DslDrivenSpec()
 
     override fun lifecycle(): Lifecycle = Lifecycle.from(this)
     override fun defaultConfig(): TestCaseConfig = actualDefaultConfig()
+    override fun defaultTestCaseConfig(): TestCaseConfig? = defaultTestConfig
     override fun registration(): RootTestRegistration = RootTestRegistration.from(this)
+
+    private fun actualDefaultConfig() =
+            defaultTestConfig ?: defaultTestCaseConfig() ?: configuration.defaultTestConfig
 
     fun test(name: String, disabled: Boolean = false, test: suspend TestContext.() -> Unit) =
             registration().addTest(
-                    name = TestName(name),
+                    name = createTestName(name),
                     xdisabled = disabled,
                     test = test,
                     config = actualDefaultConfig()
@@ -63,7 +67,7 @@ abstract class ParserTestSpec(body: ParserTestSpec.() -> Unit) : DslDrivenSpec()
                         disabled: Boolean = false,
                         spec: suspend GroupTestCtx.() -> Unit) =
             registration().addContainerTest(
-                    name = TestName(name),
+                    name = createTestName(name),
                     test = { GroupTestCtx(this).spec() },
                     xdisabled = disabled
             )
@@ -119,16 +123,12 @@ abstract class ParserTestSpec(body: ParserTestSpec.() -> Unit) : DslDrivenSpec()
             assertions: ParserTestCtx.() -> Unit) {
 
         context.registerTestCase(
-                name = TestName(name),
+                name = createTestName(name),
                 test = { ParserTestCtx(javaVersion).assertions() },
                 config = actualDefaultConfig(),
                 type = TestType.Test
         )
     }
-
-    private fun actualDefaultConfig() =
-            defaultTestConfig ?: defaultTestCaseConfig()
-            ?: Project.testCaseConfig()
 
     inner class GroupTestCtx(private val context: TestContext) {
 
@@ -136,7 +136,7 @@ abstract class ParserTestSpec(body: ParserTestSpec.() -> Unit) : DslDrivenSpec()
             javaVersions.forEach { javaVersion ->
 
                 context.registerTestCase(
-                        name = TestName("Java ${javaVersion.pmdName}"),
+                        name = createTestName("Java ${javaVersion.pmdName}"),
                         test = { VersionedTestCtx(this, javaVersion).spec() },
                         config = actualDefaultConfig(),
                         type = TestType.Container

--- a/pmd-lang-test/pom.xml
+++ b/pmd-lang-test/pom.xml
@@ -13,7 +13,6 @@
         <groupId>net.sourceforge.pmd</groupId>
         <artifactId>pmd</artifactId>
         <version>6.30.0-SNAPSHOT</version>
-        <relativePath>../</relativePath>
     </parent>
 
     <build>
@@ -62,29 +61,8 @@
                     <execution>
                         <phase>package</phase>
                         <goals>
-                            <!--
-                              once https://github.com/Kotlin/dokka/issues/294 is fixed, use goal javadocJar instead
-                              and remove the additional jar plugin execution
-                             -->
-                            <goal>dokka</goal>
+                            <goal>javadocJar</goal>
                         </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>kotlin-javadoc</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                        <configuration>
-                            <classesDirectory>${project.build.directory}/dokka/pmd-lang-test</classesDirectory>
-                            <classifier>javadoc</classifier>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/IntelliMarker.kt
+++ b/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/IntelliMarker.kt
@@ -1,0 +1,21 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.ast.test
+
+
+import org.junit.jupiter.api.TestFactory
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+
+/**
+ * This is to trick Intellij into making subclasses executable (because of @TestFactory).
+ * But Junit does not use it because of the unsatisfiable condition. This comes from
+ * Kotest, but was removed in 4.2.0 without explanation.
+ */
+interface IntelliMarker {
+    @EnabledIfSystemProperty(named = "wibble", matches = "wobble")
+    @TestFactory
+    fun primer() {
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -85,9 +85,9 @@
 
 
         <kotlin.compiler.jvmTarget>${maven.compiler.test.target}</kotlin.compiler.jvmTarget>
-        <kotlin.version>1.3.72</kotlin.version>
-        <kotest.version>4.1.2</kotest.version>
-        <dokka.version>0.10.1</dokka.version>
+        <kotlin.version>1.4.10</kotlin.version>
+        <kotest.version>4.3.0</kotest.version>
+        <dokka.version>1.4.10.2</dokka.version>
 
 
         <javacc.version>5.0</javacc.version>


### PR DESCRIPTION

## Related issues

- Fixes #2762 
- Refs #2433: dokka now produces a normal javadoc jar, that is pushable to maven central

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

