### PR TITLE
[ci] Use auxclasspath with regression-tester

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -32,6 +32,7 @@ function install_jdk() {
 }
 
 if travis_isLinux; then
+    change_ruby_version
     gem install bundler
     bundle config set --local path vendor/bundle
     bundle config set --local with release_notes_preprocessing

--- a/.travis/common-functions.sh
+++ b/.travis/common-functions.sh
@@ -57,3 +57,8 @@ function travis_isWindows() {
 function get_pom_version() {
     echo $(./mvnw -q -Dexec.executable="echo" -Dexec.args='${project.version}' --non-recursive org.codehaus.mojo:exec-maven-plugin:3.0.0:exec)
 }
+
+function change_ruby_version() {
+    source "$HOME/.rvm/scripts/rvm"
+    rvm use ruby-2.7
+}

--- a/.travis/project-list.xml
+++ b/.travis/project-list.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <projectlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-xsi:noNamespaceSchemaLocation="projectlist_1_0_0.xsd">
+xsi:noNamespaceSchemaLocation="projectlist_1_1_0.xsd">
   <description>Standard Projects</description>
 
   <project>
@@ -9,6 +9,19 @@ xsi:noNamespaceSchemaLocation="projectlist_1_0_0.xsd">
     <type>git</type>
     <connection>https://github.com/checkstyle/checkstyle</connection>
     <tag>checkstyle-8.10</tag>
+
+    <exclude-pattern>.*/target/test-classes/com/puppycrawl/tools/checkstyle/.*</exclude-pattern>
+    <exclude-pattern>.*/target/generated-sources/.*</exclude-pattern>
+
+    <build-command><![CDATA[#!/usr/bin/env bash
+if test -e classpath.txt; then
+  exit
+fi
+
+mvn test-compile
+mvn dependency:build-classpath -DincludeScope=test -Dmdep.outputFile=classpath.txt
+]]></build-command>
+    <auxclasspath-command>echo -n "$(pwd)/target/classes:$(pwd)/target/test-classes:"; cat classpath.txt</auxclasspath-command>
   </project>
 
   <project>
@@ -16,6 +29,39 @@ xsi:noNamespaceSchemaLocation="projectlist_1_0_0.xsd">
     <type>git</type>
     <connection>https://github.com/spring-projects/spring-framework</connection>
     <tag>v5.0.6.RELEASE</tag>
+
+    <build-command><![CDATA[#!/usr/bin/env bash
+if test -e classpath.txt; then
+  exit
+fi
+
+# Note: openjdk8 will be installed by "before_install.sh"
+JAVA_HOME=${HOME}/openjdk8
+PATH=$JAVA_HOME/bin:$PATH
+
+./gradlew build -x javadoc -x dokka -x asciidoctor -x test -x testNG -x api -x distZip
+cat >> build.gradle <<EOF
+task createSquishClasspath {
+  doLast {
+    def dependencies = new HashSet()
+    dependencies.addAll(subprojects.configurations.compile.resolvedConfiguration.resolvedArtifacts.file.flatten())
+    dependencies.addAll(subprojects.configurations.optional.resolvedConfiguration.resolvedArtifacts.file.flatten())
+    dependencies.addAll(subprojects.configurations.testCompile.resolvedConfiguration.resolvedArtifacts.file.flatten())
+    dependencies.addAll(subprojects.configurations.testRuntime.resolvedConfiguration.resolvedArtifacts.file.flatten())
+
+    def paths = new ArrayList()
+    paths.addAll(subprojects.jar.outputs.files.asPath)
+    paths.addAll(subprojects.sourceSets.test.output.resourcesDir)
+    paths.addAll(subprojects.sourceSets.test.output.classesDirs.files.flatten())
+    paths.addAll(dependencies)
+    println paths.join(File.pathSeparator)
+  }
+}
+EOF
+
+./gradlew createSquishClasspath -q > classpath.txt
+]]></build-command>
+    <auxclasspath-command>cat classpath.txt</auxclasspath-command>
   </project>
 
   <!---<project>

--- a/.travis/regression-tester.sh
+++ b/.travis/regression-tester.sh
@@ -1,6 +1,7 @@
 #
 # The functions here require the following scripts:
 # .travis/logger.sh
+# .travis/common-functions.sh
 #
 # The functions here require the following environment variables:
 # PMD_SF_USER
@@ -12,6 +13,7 @@
 # In that case, just a error logging is provided.
 #
 function regression-tester_uploadBaseline() {
+    change_ruby_version
     log_debug "$FUNCNAME branch=${TRAVIS_BRANCH}"
     local targetUrl="https://sourceforge.net/projects/pmd/files/pmd-regression-tester/"
 
@@ -49,6 +51,7 @@ function regression-tester_uploadBaseline() {
 # In that case, just a error logging is provided.
 #
 function regression-tester_executeDanger() {
+    change_ruby_version
     log_debug "$FUNCNAME"
 
     local errexitstate="$(shopt -po errexit)"

--- a/Dangerfile
+++ b/Dangerfile
@@ -7,6 +7,7 @@ require 'logger'
 def run_pmdtester
   Dir.chdir('..') do
     argv = ['--local-git-repo', './pmd',
+            '--list-of-project', './pmd/.travis/project-list.xml',
             '--base-branch', "#{ENV['TRAVIS_BRANCH']}",
             '--patch-branch', 'HEAD',
             '--patch-config', './pmd/.travis/all-java.xml',

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,7 @@
 source 'https://rubygems.org/'
 
 # bleeding edge from git
-#gem 'pmdtester', :git => 'https://github.com/pmd/pmd-regression-tester.git'
-gem 'pmdtester', :git => 'https://github.com/adangel/pmd-regression-tester.git', :branch => 'auxclasspath'
+gem 'pmdtester', :git => 'https://github.com/pmd/pmd-regression-tester.git'
 
 #gem 'pmdtester', '~> 1.0'
 gem 'danger', '~> 5.6', '>= 5.6'

--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,9 @@ source 'https://rubygems.org/'
 
 # bleeding edge from git
 #gem 'pmdtester', :git => 'https://github.com/pmd/pmd-regression-tester.git'
+gem 'pmdtester', :git => 'https://github.com/adangel/pmd-regression-tester.git', :branch => 'auxclasspath'
 
-gem 'pmdtester', '~> 1.0'
+#gem 'pmdtester', '~> 1.0'
 gem 'danger', '~> 5.6', '>= 5.6'
 
 # This group is only needed for rendering release notes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GIT
-  remote: https://github.com/adangel/pmd-regression-tester.git
-  revision: b30efaea1c77bd0f914309562538b9eed4fa47f4
-  branch: auxclasspath
+  remote: https://github.com/pmd/pmd-regression-tester.git
+  revision: 6875868e8be772807498ab46411e44d163633d64
   specs:
     pmdtester (1.1.0.pre.SNAPSHOT)
       differ (~> 0.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,14 @@
+GIT
+  remote: https://github.com/adangel/pmd-regression-tester.git
+  revision: b30efaea1c77bd0f914309562538b9eed4fa47f4
+  branch: auxclasspath
+  specs:
+    pmdtester (1.1.0.pre.SNAPSHOT)
+      differ (~> 0.1)
+      nokogiri (~> 1.8)
+      rufus-scheduler (~> 3.5)
+      slop (~> 4.6)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -31,9 +42,9 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (1.3.1)
       faraday (~> 0.8)
-    fugit (1.3.8)
+    fugit (1.4.0)
       et-orbi (~> 1.1, >= 1.1.8)
-      raabro (~> 1.3)
+      raabro (~> 1.4)
     git (1.7.0)
       rchardet (~> 1.8)
     kramdown (1.17.0)
@@ -44,19 +55,14 @@ GEM
     no_proxy_fix (0.1.2)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
-    octokit (4.18.0)
+    octokit (4.19.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
-    pmdtester (1.0.1)
-      differ (~> 0.1)
-      nokogiri (~> 1.8)
-      rufus-scheduler (~> 3.5)
-      slop (~> 4.6)
-    public_suffix (4.0.5)
-    raabro (1.3.1)
+    public_suffix (4.0.6)
+    raabro (1.4.0)
     rchardet (1.8.0)
-    rouge (3.22.0)
+    rouge (3.24.0)
     rufus-scheduler (3.6.0)
       fugit (~> 1.1, >= 1.1.6)
     safe_yaml (1.0.5)
@@ -76,7 +82,7 @@ PLATFORMS
 DEPENDENCIES
   danger (~> 5.6, >= 5.6)
   liquid (>= 4.0.0)
-  pmdtester (~> 1.0)
+  pmdtester!
   rouge (>= 1.7, < 4)
   safe_yaml (>= 1.0)
 


### PR DESCRIPTION
## Describe the PR

* For testing, this will use the pmd-regression-tester from PR-branch pmd/pmd-regression-tester#72 . If it works, we can merge that regression-tester-pr and point to the master branch
* ~This additionally - a bit unrelated - changes, how we download openjdk11. We now use a fixed URL, so that we don't need to update the version in the script anymore.~ I've cherry-picked these already on master
* Finally, updates the `project-list.xml` configuration to include build-command and auxclasspath-command for both checkstyle and spring-framework. This enables auxclasspath usage. We hopefully see the different between no-typeresolution (current master baseline) and typeresolution (this PR).

Note: the project-list has a minimal set of exclude-patterns (for checkstyle). For PMD7, there are more needed (refs #2808). The complete set is documented in pmd/pmd-regression-tester#72

## Related issues

- Depends on pmd/pmd-regression-tester#48

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

