### PR TITLE
[core] Fix XMLRenderer with UTF-16

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -16,6 +16,9 @@ This is a {{ site.pmd.release_type }} release.
 
 ### Fixed Issues
 
+*   core
+    *   [#2874](https://github.com/pmd/pmd/pull/2874): \[core] Fix XMLRenderer with UTF-16
+
 ### API Changes
 
 ### External Contributions

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/XMLRendererTest.java
@@ -124,6 +124,12 @@ public class XMLRendererTest extends AbstractRendererTest {
     }
 
     @Test
+    public void testXMLEscapingWithUTF16() throws Exception {
+        Renderer renderer = getRenderer();
+        verifyXmlEscaping(renderer, "&#x1041c;", StandardCharsets.UTF_16);
+    }
+
+    @Test
     public void testXMLEscapingWithoutUTF8() throws Exception {
         Renderer renderer = getRenderer();
         verifyXmlEscaping(renderer, "&#x1041c;", StandardCharsets.ISO_8859_1);


### PR DESCRIPTION
## Describe the PR

When using UTF-16 as encoding, the XMLRenderer produced
invalid XML: When inserting the linebreak encoded with the
given encoding "UTF-16", a BOM was created. This inserted additional
characters U+FEFF in the middle of the file, which is not allowed.

A partial workaround for this issue would be, to use "UTF-16BE" as
encoding instead. This doesn't create a BOM. However, the resulting XML
file is then completely without a BOM.

## Related issues

- Relates #2831 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

