### PR TITLE
[core] Add error recovery mode

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/SourceCodeProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/SourceCodeProcessor.java
@@ -14,6 +14,7 @@ import net.sourceforge.pmd.benchmark.TimeTracker;
 import net.sourceforge.pmd.benchmark.TimedOperation;
 import net.sourceforge.pmd.benchmark.TimedOperationCategory;
 import net.sourceforge.pmd.internal.RulesetStageDependencyHelper;
+import net.sourceforge.pmd.internal.SystemProps;
 import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.lang.Parser;
 import net.sourceforge.pmd.lang.ast.Node;
@@ -105,9 +106,15 @@ public class SourceCodeProcessor {
         } catch (ParseException pe) {
             configuration.getAnalysisCache().analysisFailed(ctx.getSourceCodeFile());
             throw new PMDException("Error while parsing " + ctx.getSourceCodeFile(), pe);
-        } catch (Exception | StackOverflowError | AssertionError e) {
+        } catch (Exception e) {
             configuration.getAnalysisCache().analysisFailed(ctx.getSourceCodeFile());
             throw new PMDException("Error while processing " + ctx.getSourceCodeFile(), e);
+        } catch (StackOverflowError | AssertionError e) {
+            if (SystemProps.isErrorRecoveryMode()) {
+                configuration.getAnalysisCache().analysisFailed(ctx.getSourceCodeFile());
+                throw new PMDException("Error while processing " + ctx.getSourceCodeFile(), e);
+            }
+            throw e;
         } finally {
             ruleSets.end(ctx);
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/internal/SystemProps.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/internal/SystemProps.java
@@ -1,0 +1,28 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.internal;
+
+public final class SystemProps {
+
+    public static final String PMD_ERROR_RECOVERY = "pmd.error_recovery";
+
+    private SystemProps() {
+    }
+
+    /**
+     * In error recovery mode errors like StackOverflowError or AssetionErrors are logged
+     * and the execution continues.
+     * These exceptions mean, that something went really wrong while executing and
+     * depending on where the error occurred, the internal state might be corrupted
+     * or not. Hence, it might work to continue and "ignore" (just log) the error
+     * or we'll see more problems when continuing. That's why error recovery mode
+     * is not enabled by default.
+     * <p>
+     * The System Property is called {@code pmd.error_recovery}.
+     */
+    public static boolean isErrorRecoveryMode() {
+        return System.getProperty(PMD_ERROR_RECOVERY) != null;
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/internal/SystemProps.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/internal/SystemProps.java
@@ -12,7 +12,7 @@ public final class SystemProps {
     }
 
     /**
-     * In error recovery mode errors like StackOverflowError or AssetionErrors are logged
+     * In error recovery mode errors like StackOverflowError or AssertionErrors are logged
      * and the execution continues.
      * These exceptions mean, that something went really wrong while executing and
      * depending on where the error occurred, the internal state might be corrupted

--- a/pmd-core/src/test/java/net/sourceforge/pmd/SourceCodeProcessorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/SourceCodeProcessorTest.java
@@ -1,0 +1,104 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd;
+
+import java.io.StringReader;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.rules.TestRule;
+
+import net.sourceforge.pmd.internal.SystemProps;
+import net.sourceforge.pmd.lang.DummyLanguageModule;
+import net.sourceforge.pmd.lang.Language;
+import net.sourceforge.pmd.lang.LanguageRegistry;
+import net.sourceforge.pmd.lang.LanguageVersion;
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.rule.AbstractRule;
+
+public class SourceCodeProcessorTest {
+
+    @org.junit.Rule
+    public TestRule restoreSystemProperties = new RestoreSystemProperties();
+
+    private SourceCodeProcessor processor;
+    private StringReader sourceCode;
+    private RuleContext ctx;
+    private List<RuleSet> rulesets;
+    private LanguageVersion dummyThrows;
+    private LanguageVersion dummyDefault;
+
+    @Before
+    public void prepare() {
+        Language dummyLanguage = LanguageRegistry.findLanguageByTerseName(DummyLanguageModule.TERSE_NAME);
+        dummyDefault = dummyLanguage.getDefaultVersion();
+        dummyThrows = dummyLanguage.getVersion("1.9-throws");
+
+        processor = new SourceCodeProcessor(new PMDConfiguration());
+        sourceCode = new StringReader("test");
+        Rule rule = new RuleThatThrows();
+        rulesets = Arrays.asList(RulesetsFactoryUtils.defaultFactory().createSingleRuleRuleSet(rule));
+
+        ctx = new RuleContext();
+    }
+
+    @Test
+    public void inErrorRecoveryModeErrorsShouldBeLoggedByParser() {
+        System.setProperty(SystemProps.PMD_ERROR_RECOVERY, "");
+        ctx.setLanguageVersion(dummyThrows);
+
+        Assert.assertThrows(PMDException.class, () -> {
+            processor.processSourceCode(sourceCode, new RuleSets(rulesets), ctx);
+        });
+        // the error is actually logged by PmdRunnable
+    }
+
+    @Test
+    public void inErrorRecoveryModeErrorsShouldBeLoggedByRule() throws Exception {
+        System.setProperty(SystemProps.PMD_ERROR_RECOVERY, "");
+        ctx.setLanguageVersion(dummyDefault);
+
+        processor.processSourceCode(sourceCode, new RuleSets(rulesets), ctx);
+        Assert.assertEquals(1, ctx.getReport().getProcessingErrors().size());
+        Assert.assertSame(AssertionError.class, ctx.getReport().getProcessingErrors().get(0).getError().getClass());
+    }
+
+    @Test
+    public void withoutErrorRecoveryModeProcessingShouldBeAbortedByParser() {
+        Assert.assertNull(System.getProperty(SystemProps.PMD_ERROR_RECOVERY));
+        ctx.setLanguageVersion(dummyThrows);
+
+        Assert.assertThrows(AssertionError.class, () -> {
+            processor.processSourceCode(sourceCode, new RuleSets(rulesets), ctx);
+        });
+    }
+
+    @Test
+    public void withoutErrorRecoveryModeProcessingShouldBeAbortedByRule() {
+        Assert.assertNull(System.getProperty(SystemProps.PMD_ERROR_RECOVERY));
+        ctx.setLanguageVersion(dummyDefault);
+
+        Assert.assertThrows(AssertionError.class, () -> {
+            processor.processSourceCode(sourceCode, new RuleSets(rulesets), ctx);
+        });
+    }
+
+    private static class RuleThatThrows extends AbstractRule {
+
+        RuleThatThrows() {
+            Language dummyLanguage = LanguageRegistry.findLanguageByTerseName(DummyLanguageModule.TERSE_NAME);
+            setLanguage(dummyLanguage);
+        }
+
+        @Override
+        public void apply(Node target, RuleContext ctx) {
+            throw new AssertionError("test");
+        }
+    }
+}

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageModule.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageModule.java
@@ -14,6 +14,7 @@ import net.sourceforge.pmd.lang.ast.DummyAstStages;
 import net.sourceforge.pmd.lang.ast.DummyRoot;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.ast.ParseException;
+import net.sourceforge.pmd.lang.ast.RootNode;
 import net.sourceforge.pmd.lang.rule.ParametricRuleViolation;
 import net.sourceforge.pmd.lang.rule.impl.DefaultRuleViolationFactory;
 
@@ -36,6 +37,7 @@ public class DummyLanguageModule extends BaseLanguageModule {
         addVersion("1.6", new Handler(), "6");
         addDefaultVersion("1.7", new Handler(), "7");
         addVersion("1.8", new Handler(), "8");
+        addVersion("1.9-throws", new HandlerWithParserThatThrows());
     }
 
     public static class Handler extends AbstractPmdLanguageVersionHandler {
@@ -60,6 +62,18 @@ public class DummyLanguageModule extends BaseLanguageModule {
                     return node;
                 }
 
+            };
+        }
+    }
+
+    public static class HandlerWithParserThatThrows extends Handler {
+        @Override
+        public Parser getParser(ParserOptions parserOptions) {
+            return new AbstractParser(parserOptions) {
+                @Override
+                public RootNode parse(String fileName, Reader source) throws ParseException {
+                    throw new AssertionError("test error while parsing");
+                }
             };
         }
     }


### PR DESCRIPTION
This can be enabled by setting system property "pmd.error_recovery"
to an arbitrary value, e.g. "-Dpmd.error_recovery".

Next step is, to add enable this in our regression tester by default (setting both "-Dpmd.error_recovery" and "-ea" for assertions).

## Related issues

- Fixes #2885

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

