### PR TITLE
[core] Update kotest to 4.3.1

### DIFF
--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/ReflectedFieldSymbolTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/ReflectedFieldSymbolTest.kt
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.java.symbols.internal
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.property.arbitrary.filterNot
 import javasymbols.testdata.impls.IdenticalToSomeFields
 import javasymbols.testdata.impls.SomeFields
 
@@ -34,8 +35,7 @@ class ReflectedFieldSymbolTest : WordSpec({
         }
 
         "reflect its modifiers properly" {
-            //TestClassesGen.filterNot { it.isArray }.forAllEqual {
-            TestClassesGen.filter_fixed { !it.isArray }.forAllEqual {
+            TestClassesGen.filterNot { it.isArray }.forAllEqual {
                 Pair(
                         classSym(it)!!.declaredFields.map { it.simpleName to it.modifiers },
                         it.declaredFields.map { it.name to it.modifiers }

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/Utils.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/Utils.kt
@@ -8,7 +8,6 @@ import io.kotest.assertions.withClue
 import io.kotest.matchers.collections.haveSize
 import io.kotest.matchers.should
 import io.kotest.property.*
-import io.kotest.property.arbitrary.filter
 import net.sourceforge.pmd.lang.java.symbols.JClassSymbol
 import net.sourceforge.pmd.lang.java.symbols.SymbolResolver
 import net.sourceforge.pmd.lang.java.types.testTypeSystem
@@ -44,13 +43,6 @@ suspend fun <T, R> Gen<T>.forAllEqual(test: (T) -> Pair<R, R>) {
 }
 
 /** Generator of test instances. */
-@Deprecated("can be removed once https://github.com/kotest/kotest/issues/1815 is released")
-fun <A> Arb<A>.filter_fixed(predicate: (A) -> Boolean) = object : Arb<A>() {
-    override fun edgecases(): List<A> = this@filter_fixed.edgecases().filter(predicate)
-    override fun values(rs: RandomSource): Sequence<Sample<A>> = this@filter_fixed.values(rs).filter { predicate(it.value) }
-    override fun sample(rs: RandomSource): Sample<A> = this@filter_fixed.samples(rs).filter { predicate(it.value) }.first()
-}
-
 object TestClassesGen : Arb<Class<*>>() {
     override fun edgecases(): List<Class<*>> =
             listOf(java.lang.Object::class.java,

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeOpsTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeOpsTest.kt
@@ -8,7 +8,6 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.property.Arb
-import io.kotest.property.arbitrary.arbitrary
 import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.shuffle
 import io.kotest.property.checkAll
@@ -25,11 +24,7 @@ class TypeOpsTest : FunSpec({
             // for any permutation of input, the output should be the same
             suspend fun checkMostSpecific(input: List<JTypeMirror>, output: List<JTypeMirror>) {
 
-                fun <A> shuffleOld(list: List<A>) = arbitrary {
-                    list.shuffled(it.random)
-                }
-
-                checkAll(shuffleOld(input)) { ts ->
+                checkAll(Arb.shuffle(input)) { ts ->
                     TypeOps.mostSpecific(ts).shouldContainExactlyInAnyOrder(output)
                 }
             }

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 
         <kotlin.compiler.jvmTarget>${maven.compiler.test.target}</kotlin.compiler.jvmTarget>
         <kotlin.version>1.4.10</kotlin.version>
-        <kotest.version>4.3.0</kotest.version>
+        <kotest.version>4.3.1</kotest.version>
         <dokka.version>1.4.10.2</dokka.version>
 
 


### PR DESCRIPTION
## Describe the PR

* Kotest 4.3.1 has been released -> https://github.com/kotest/kotest/releases/tag/v4.3.1
* This reverts the workaround that were necessary.

Note: This PR is draft, since the version change commit (the last one) should be done on master first.

## Related issues

- Relates #2870

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

