### PR TITLE
[core] Deprecations for ParametricRuleViolation and ParserOptions#suppressMarker

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -40,6 +40,7 @@ You can identify them with the `@InternalApi` annotation. You'll also get a depr
 *   {% jdoc !!javascript::lang.ecmascript.ast.EcmascriptParser#getSuppressMap() %}
 *   {% jdoc !!core::lang.rule.ParametricRuleViolation %}
 *   {% jdoc !!core::lang.ParserOptions#suppressMarker %}
+*   {% jdoc !!modelica::lang.modelica.rule.ModelicaRuleViolationFactory %}
 
 
 ### External Contributions

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -38,6 +38,8 @@ You can identify them with the `@InternalApi` annotation. You'll also get a depr
 *   {% jdoc !!javascript::lang.ecmascript.Ecmascript3Parser %}
 *   {% jdoc !!javascript::lang.ecmascript.ast.EcmascriptParser#parserOptions %}
 *   {% jdoc !!javascript::lang.ecmascript.ast.EcmascriptParser#getSuppressMap() %}
+*   {% jdoc !!core::lang.rule.ParametricRuleViolation %}
+*   {% jdoc !!core::lang.ParserOptions#suppressMarker %}
 
 
 ### External Contributions

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ParserOptions.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ParserOptions.java
@@ -11,6 +11,10 @@ package net.sourceforge.pmd.lang;
  * {@link Object#hashCode()}.
  */
 public class ParserOptions {
+    /**
+     * @deprecated Use {@link #getSuppressMarker()} instead.
+     */
+    @Deprecated
     protected String suppressMarker;
 
     public String getSuppressMarker() {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/ParametricRuleViolation.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/ParametricRuleViolation.java
@@ -10,10 +10,16 @@ import java.util.regex.Pattern;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.RuleViolation;
+import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.util.StringUtil;
 
+/**
+ * @deprecated This is internal. Clients should exclusively use {@link RuleViolation}.
+ */
+@Deprecated
+@InternalApi
 public class ParametricRuleViolation<T extends Node> implements RuleViolation {
 
     protected final Rule rule;

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/ModelicaRuleViolationFactory.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/ModelicaRuleViolationFactory.java
@@ -7,10 +7,17 @@ package net.sourceforge.pmd.lang.modelica.rule;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.RuleViolation;
+import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.rule.AbstractRuleViolationFactory;
 import net.sourceforge.pmd.lang.rule.ParametricRuleViolation;
+import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
 
+/**
+ * @deprecated See {@link RuleViolationFactory}
+ */
+@Deprecated
+@InternalApi
 public final class ModelicaRuleViolationFactory extends AbstractRuleViolationFactory {
     public static final ModelicaRuleViolationFactory INSTANCE = new ModelicaRuleViolationFactory();
 


### PR DESCRIPTION
## Describe the PR

* This adds deprecations introduced in #2807 
* Also adds missing internalization for ModelicaRuleViolationFactory

I've **not** internalized/deprecated `RuleViolationFactory`, since that is still public API and we don't have an alternative on master.


## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

