### PR TITLE
[core] Include rule name in text renderer

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextRenderer.java
@@ -16,6 +16,10 @@ import net.sourceforge.pmd.RuleViolation;
  */
 public class TextRenderer extends AbstractIncrementingRenderer {
 
+    private static final Character SMALL_SEPERATOR = ':';
+    private static final String MEDIUM_SEPERATOR = ":\t";
+    private static final String LARGE_SEPERATOR = "\t-\t";
+
     public static final String NAME = "text";
 
     public TextRenderer() {
@@ -35,9 +39,9 @@ public class TextRenderer extends AbstractIncrementingRenderer {
             buf.setLength(0);
             RuleViolation rv = violations.next();
             buf.append(determineFileName(rv.getFilename()));
-            buf.append(':').append(rv.getBeginLine());
-            buf.append(":\t").append(rv.getDescription());
-            buf.append(":\t").append(rv.getRule().getName()).append(PMD.EOL);
+            buf.append(SMALL_SEPERATOR).append(rv.getBeginLine());
+            buf.append(MEDIUM_SEPERATOR).append(rv.getDescription());
+            buf.append(MEDIUM_SEPERATOR).append(rv.getRule().getName()).append(PMD.EOL);
             writer.write(buf.toString());
         }
     }
@@ -49,7 +53,7 @@ public class TextRenderer extends AbstractIncrementingRenderer {
         for (Report.ProcessingError error : errors) {
             buf.setLength(0);
             buf.append(determineFileName(error.getFile()));
-            buf.append("\t-\t").append(error.getMsg()).append(PMD.EOL);
+            buf.append(LARGE_SEPERATOR).append(error.getMsg()).append(PMD.EOL);
             writer.write(buf.toString());
         }
 
@@ -65,7 +69,7 @@ public class TextRenderer extends AbstractIncrementingRenderer {
         for (Report.ConfigurationError error : configErrors) {
             buf.setLength(0);
             buf.append(error.rule().getName());
-            buf.append("\t-\t").append(error.issue()).append(PMD.EOL);
+            buf.append(LARGE_SEPERATOR).append(error.issue()).append(PMD.EOL);
             writer.write(buf.toString());
         }
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextRenderer.java
@@ -35,7 +35,7 @@ public class TextRenderer extends AbstractIncrementingRenderer {
             buf.setLength(0);
             RuleViolation rv = violations.next();
             buf.append(determineFileName(rv.getFilename()));
-            buf.append(':').append(Integer.toString(rv.getBeginLine()));
+            buf.append(':').append(rv.getBeginLine());
             buf.append(":\t").append(rv.getDescription());
             buf.append(":\t").append(rv.getRule().getName()).append(PMD.EOL);
             writer.write(buf.toString());

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextRenderer.java
@@ -40,8 +40,8 @@ public class TextRenderer extends AbstractIncrementingRenderer {
             RuleViolation rv = violations.next();
             buf.append(determineFileName(rv.getFilename()));
             buf.append(SMALL_SEPARATOR).append(rv.getBeginLine());
-            buf.append(MEDIUM_SEPARATOR).append(rv.getDescription());
-            buf.append(MEDIUM_SEPARATOR).append(rv.getRule().getName()).append(PMD.EOL);
+            buf.append(MEDIUM_SEPARATOR).append(rv.getRule().getName());
+            buf.append(MEDIUM_SEPARATOR).append(rv.getDescription()).append(PMD.EOL);
             writer.write(buf.toString());
         }
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextRenderer.java
@@ -36,7 +36,8 @@ public class TextRenderer extends AbstractIncrementingRenderer {
             RuleViolation rv = violations.next();
             buf.append(determineFileName(rv.getFilename()));
             buf.append(':').append(Integer.toString(rv.getBeginLine()));
-            buf.append(":\t").append(rv.getDescription()).append(PMD.EOL);
+            buf.append(":\t").append(rv.getDescription());
+            buf.append(":\t").append(rv.getRule().getName()).append(PMD.EOL);
             writer.write(buf.toString());
         }
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextRenderer.java
@@ -16,7 +16,7 @@ import net.sourceforge.pmd.RuleViolation;
  */
 public class TextRenderer extends AbstractIncrementingRenderer {
 
-    private static final Character SMALL_SEPARATOR = ':';
+    private static final char SMALL_SEPARATOR = ':';
     private static final String MEDIUM_SEPARATOR = ":\t";
     private static final String LARGE_SEPARATOR = "\t-\t";
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/TextRenderer.java
@@ -16,9 +16,9 @@ import net.sourceforge.pmd.RuleViolation;
  */
 public class TextRenderer extends AbstractIncrementingRenderer {
 
-    private static final Character SMALL_SEPERATOR = ':';
-    private static final String MEDIUM_SEPERATOR = ":\t";
-    private static final String LARGE_SEPERATOR = "\t-\t";
+    private static final Character SMALL_SEPARATOR = ':';
+    private static final String MEDIUM_SEPARATOR = ":\t";
+    private static final String LARGE_SEPARATOR = "\t-\t";
 
     public static final String NAME = "text";
 
@@ -39,9 +39,9 @@ public class TextRenderer extends AbstractIncrementingRenderer {
             buf.setLength(0);
             RuleViolation rv = violations.next();
             buf.append(determineFileName(rv.getFilename()));
-            buf.append(SMALL_SEPERATOR).append(rv.getBeginLine());
-            buf.append(MEDIUM_SEPERATOR).append(rv.getDescription());
-            buf.append(MEDIUM_SEPERATOR).append(rv.getRule().getName()).append(PMD.EOL);
+            buf.append(SMALL_SEPARATOR).append(rv.getBeginLine());
+            buf.append(MEDIUM_SEPARATOR).append(rv.getDescription());
+            buf.append(MEDIUM_SEPARATOR).append(rv.getRule().getName()).append(PMD.EOL);
             writer.write(buf.toString());
         }
     }
@@ -53,7 +53,7 @@ public class TextRenderer extends AbstractIncrementingRenderer {
         for (Report.ProcessingError error : errors) {
             buf.setLength(0);
             buf.append(determineFileName(error.getFile()));
-            buf.append(LARGE_SEPERATOR).append(error.getMsg()).append(PMD.EOL);
+            buf.append(LARGE_SEPARATOR).append(error.getMsg()).append(PMD.EOL);
             writer.write(buf.toString());
         }
 
@@ -69,7 +69,7 @@ public class TextRenderer extends AbstractIncrementingRenderer {
         for (Report.ConfigurationError error : configErrors) {
             buf.setLength(0);
             buf.append(error.rule().getName());
-            buf.append(LARGE_SEPERATOR).append(error.issue()).append(PMD.EOL);
+            buf.append(LARGE_SEPARATOR).append(error.issue()).append(PMD.EOL);
             writer.write(buf.toString());
         }
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/ant/PMDTaskTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/ant/PMDTaskTest.java
@@ -78,7 +78,7 @@ public class PMDTaskTest {
             String actual = IOUtils.toString(in, StandardCharsets.UTF_8);
             // remove any trailing newline
             actual = actual.replaceAll("\n|\r", "");
-            Assert.assertEquals("sample.dummy:0:\tTest Rule 2", actual);
+            Assert.assertEquals("sample.dummy:0:\tTest Rule 2:\tSampleXPathRule", actual);
         }
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/ant/PMDTaskTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/ant/PMDTaskTest.java
@@ -78,7 +78,7 @@ public class PMDTaskTest {
             String actual = IOUtils.toString(in, StandardCharsets.UTF_8);
             // remove any trailing newline
             actual = actual.replaceAll("\n|\r", "");
-            Assert.assertEquals("sample.dummy:0:\tTest Rule 2:\tSampleXPathRule", actual);
+            Assert.assertEquals("sample.dummy:0:\tSampleXPathRule:\tTest Rule 2", actual);
         }
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/TextRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/TextRendererTest.java
@@ -17,7 +17,7 @@ public class TextRendererTest extends AbstractRendererTest {
 
     @Override
     public String getExpected() {
-        return getSourceCodeFilename() + ":1:\tblah:\tFoo" + PMD.EOL;
+        return getSourceCodeFilename() + ":1:\tFoo:\tblah" + PMD.EOL;
     }
 
     @Override
@@ -27,8 +27,8 @@ public class TextRendererTest extends AbstractRendererTest {
 
     @Override
     public String getExpectedMultiple() {
-        return getSourceCodeFilename() + ":1:\tblah:\tFoo" + PMD.EOL
-                + getSourceCodeFilename() + ":1:\tblah:\tFoo" + PMD.EOL;
+        return getSourceCodeFilename() + ":1:\tFoo:\tblah" + PMD.EOL
+                + getSourceCodeFilename() + ":1:\tFoo:\tblah" + PMD.EOL;
     }
 
     @Override

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/TextRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/TextRendererTest.java
@@ -17,7 +17,7 @@ public class TextRendererTest extends AbstractRendererTest {
 
     @Override
     public String getExpected() {
-        return getSourceCodeFilename() + ":1:\tblah" + PMD.EOL;
+        return getSourceCodeFilename() + ":1:\tblah:\tFoo" + PMD.EOL;
     }
 
     @Override
@@ -27,8 +27,8 @@ public class TextRendererTest extends AbstractRendererTest {
 
     @Override
     public String getExpectedMultiple() {
-        return getSourceCodeFilename() + ":1:\tblah" + PMD.EOL
-                + getSourceCodeFilename() + ":1:\tblah" + PMD.EOL;
+        return getSourceCodeFilename() + ":1:\tblah:\tFoo" + PMD.EOL
+                + getSourceCodeFilename() + ":1:\tblah:\tFoo" + PMD.EOL;
     }
 
     @Override


### PR DESCRIPTION
## Describe the PR

This PR adds the RuleName of the violating rule at the end of the output line generated by the TextRenderer.

Before this was for each violating rule: ```SourceCodeFileName:LineNumber:<TAB>RuleDescription```
Now this is for each violating rule: ```SourceCodeFileName:LineNumber:<TAB>RuleName:<TAB>RuleDescription```

## Related issues

- Fixes https://github.com/pmd/pmd/issues/1961

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

