### PR TITLE
[cs] CPD: fix issue where ignoring using directives could not be disabled

### DIFF
--- a/pmd-cs/src/main/java/net/sourceforge/pmd/cpd/CsTokenizer.java
+++ b/pmd-cs/src/main/java/net/sourceforge/pmd/cpd/CsTokenizer.java
@@ -21,9 +21,7 @@ public class CsTokenizer extends AntlrTokenizer {
     private boolean ignoreUsings = false;
 
     public void setProperties(Properties properties) {
-        if (properties.containsKey(IGNORE_USINGS)) {
-            ignoreUsings = Boolean.parseBoolean(properties.getProperty(IGNORE_USINGS, "false"));
-        }
+        ignoreUsings = Boolean.parseBoolean(properties.getProperty(IGNORE_USINGS, "false"));
     }
 
     public void setIgnoreUsings(boolean ignoreUsings) {


### PR DESCRIPTION
## Describe the PR

CPD has an option to filter out using directives for C# code. When using the GUI to do this, enabling the option prevents it from being disabled again afterwards. The only way to work around this is to restart the application.

In order to reproduce:
1. Create a C# file with lots of identical using statements:
```
using System;
using System;
...
using System;
```
2. Start the CPD GUI, select C# as language and click "Go". This will result in many instances of code duplication being shown.
3. Click the "Ignore usings?" checkbox and click "Go" again. No duplicates will be found now.
4. Uncheck the "Ignore usings?" checkbox and click "Go" again. You'd expect to get the original results, but there are still no duplicates.

This is caused by the internal property only being updated when it has been set. If it's not set, it also won't be changed. This PR fixes that.

## Related issues

No known issues that I could find.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

