### PR TITLE
[java] Catch additional TypeNotPresentExceptions / LinkageErrors

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typedefinition/JavaTypeDefinitionSimple.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typedefinition/JavaTypeDefinitionSimple.java
@@ -349,13 +349,19 @@ import java.util.logging.Logger;
     protected Set<JavaTypeDefinition> getSuperTypeSet(Set<JavaTypeDefinition> destinationSet) {
         destinationSet.add(this);
 
-        if (this.clazz != Object.class) {
+        try {
+            if (this.clazz != Object.class) {
 
-            resolveTypeDefinition(clazz.getGenericSuperclass()).getSuperTypeSet(destinationSet);
+                resolveTypeDefinition(clazz.getGenericSuperclass()).getSuperTypeSet(destinationSet);
 
-            for (Type type : clazz.getGenericInterfaces()) {
-                resolveTypeDefinition(type).getSuperTypeSet(destinationSet);
+                for (Type type : clazz.getGenericInterfaces()) {
+                    resolveTypeDefinition(type).getSuperTypeSet(destinationSet);
+                }
             }
+        } catch (TypeNotPresentException | LinkageError e) {
+            // might be thrown by clazz.getGenericSuperclass(), clazz.getGenericInterfaces()
+            // This is an incomplete classpath, report the missing class
+            LOG.log(Level.FINE, "Possible incomplete auxclasspath: Error while processing methods", e);
         }
 
         return destinationSet;


### PR DESCRIPTION
## Describe the PR

These exceptions are indications of an incomplete auxclasspath but should not fail PMD entirely.

Incomplete auxclasspath can still result in invalid violations, either false positives or false negatives.

You can reproduce this easily by build PMD with the following command:

`./mvnw clean verify` followed by `./mvnw verify -Daggregate=true`

That results in the following build error:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-pmd-plugin:3.13.0:pmd (pmd) on project pmd:
Execution pmd of goal org.apache.maven.plugins:maven-pmd-plugin:3.13.0:pmd failed:
A required class was missing while executing org.apache.maven.plugins:maven-pmd-plugin:3.13.0:pmd:
apex/jorje/semantic/ast/AstNode
```

PMD doesn't catch the LinkageError and it falls through to maven which thinks, it's a classpath error on the maven side... (hence it prints out the plugin's classpath). We should catch these errors similar to the others, we already catch.

The auxclasspath here is incomplete is because of some strange structure we have: pmd-apex-jorje is a pom-module and the produced pmd-apex-jorje-lib.jar is not used (which can be considered a bug in m-pmd-p). We have a similar issue with pmd-core, where we shade in jaxen. the scala modules are also not straightforward (see #2763).

The aggreate-option has actually a slightly different, general problem, described in [MPMD-283](https://issues.apache.org/jira/browse/MPMD-283) - with aggregate m-pmd-p is run with the parent project already - before the modules are executed. You'll get a different result, if you start really fresh: first `./mvnw clean` and then `./mvnw verify -Daggregate=true` - there are no build results in "target/classes" yet, so at least the own project classes are missing on the auxclasspath.

In PMD, we also run into a different problem - processing errors: since we have a mix of java7 and java8.

## Related issues

- Similar to #2663 
- Addition to #2685 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

