### PR TITLE
[apex] New Rule: override equals and hashcode rule

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/OverrideBothEqualsAndHashcodeRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/OverrideBothEqualsAndHashcodeRule.java
@@ -1,0 +1,66 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.rule.errorprone;
+
+import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
+import net.sourceforge.pmd.lang.apex.ast.ASTParameter;
+import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
+import net.sourceforge.pmd.lang.apex.ast.ApexNode;
+import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+
+public class OverrideBothEqualsAndHashcodeRule extends AbstractApexRule {
+
+    @Override
+    public Object visit(ASTUserClass node, Object data) {
+        super.visit(node, data);
+
+        ApexNode<?> equalsNode = null;
+        ApexNode<?> hashNode = null;
+        for (ASTMethod method : node.findChildrenOfType(ASTMethod.class)) {
+            if (equalsNode == null && isEquals(method)) {
+                equalsNode = method;
+            }
+            if (hashNode == null && isHashCode(method)) {
+                hashNode = method;
+            }
+            if (hashNode != null && equalsNode != null) {
+                break;
+            }
+        }
+
+        if (equalsNode != null && hashNode == null) {
+            addViolation(data, equalsNode);
+        } else if (hashNode != null && equalsNode == null) {
+            addViolation(data, hashNode);
+        }
+
+        return data;
+    }
+
+    private Boolean isEquals(ASTMethod node) {
+        int numParams = 0;
+        String paramType = null;
+        for (int ix = 0; ix < node.getNumChildren(); ix++) {
+            ApexNode<?> sn = node.getChild(ix);
+            if (sn instanceof ASTParameter) {
+                numParams++;
+                paramType = ((ASTParameter) sn).getType();
+            }
+        }
+        return numParams == 1 && node.hasImageEqualTo("equals") && "Object".equalsIgnoreCase(paramType);
+    }
+
+    private Boolean isHashCode(ASTMethod node) {
+        int numParams = 0;
+        for (int ix = 0; ix < node.getNumChildren(); ix++) {
+            ApexNode<?> sn = node.getChild(ix);
+            if (sn instanceof ASTParameter) {
+                numParams++;
+            }
+        }
+
+        return numParams == 0 && node.hasImageEqualTo("hashCode");
+    }
+}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/OverrideBothEqualsAndHashcodeRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/OverrideBothEqualsAndHashcodeRule.java
@@ -41,7 +41,7 @@ public class OverrideBothEqualsAndHashcodeRule extends AbstractApexRule {
         return data;
     }
 
-    private Boolean isEquals(ASTMethod node) {
+    private boolean isEquals(ASTMethod node) {
         int numParams = 0;
         String paramType = null;
         for (int ix = 0; ix < node.getNumChildren(); ix++) {
@@ -54,7 +54,7 @@ public class OverrideBothEqualsAndHashcodeRule extends AbstractApexRule {
         return numParams == 1 && node.hasImageEqualTo("equals") && "Object".equalsIgnoreCase(paramType);
     }
 
-    private Boolean isHashCode(ASTMethod node) {
+    private boolean isHashCode(ASTMethod node) {
         int numParams = 0;
         for (int ix = 0; ix < node.getNumChildren(); ix++) {
             ApexNode<?> sn = node.getChild(ix);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/OverrideBothEqualsAndHashcodeRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/OverrideBothEqualsAndHashcodeRule.java
@@ -12,10 +12,12 @@ import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 
 public class OverrideBothEqualsAndHashcodeRule extends AbstractApexRule {
 
+    public OverrideBothEqualsAndHashcodeRule() {
+        addRuleChainVisit(ASTUserClass.class);
+    }
+
     @Override
     public Object visit(ASTUserClass node, Object data) {
-        super.visit(node, data);
-
         ApexNode<?> equalsNode = null;
         ApexNode<?> hashNode = null;
         for (ASTMethod method : node.findChildrenOfType(ASTMethod.class)) {

--- a/pmd-apex/src/main/resources/category/apex/errorprone.xml
+++ b/pmd-apex/src/main/resources/category/apex/errorprone.xml
@@ -295,6 +295,40 @@ public void bar(Integer a, Integer b) {
         </example>
     </rule>
 
+        <rule name="OverrideBothEqualsAndHashcode"
+          language="apex"
+          since="6.31.0"
+          message="Ensure you override both equals() and hashCode()"
+          class="net.sourceforge.pmd.lang.apex.rule.errorprone.OverrideBothEqualsAndHashcodeRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#overridebothequalsandhashcode">
+        <description>
+Override both public boolean Object.equals(Object other), and public int Object.hashCode(), or override neither.  Even if you are inheriting a hashCode() from a parent class, consider implementing hashCode and explicitly delegating to your superclass.
+        </description>
+        <priority>3</priority>
+        <example>
+<![CDATA[
+public class Bar {        // poor, missing a hashcode() method
+    public Boolean equals(Object o) {
+      // do some comparison
+    }
+}
+public class Baz {        // poor, missing an equals() method
+    public Integer hashCode() {
+      // return some hash value
+    }
+}
+public class Foo {        // perfect, both methods provided
+    public Boolean equals(Object other) {
+      // do some comparison
+    }
+    public Integer hashCode() {
+      // return some hash value
+    }
+}
+]]>
+        </example>
+    </rule>
+
     <rule name="MethodWithSameNameAsEnclosingClass"
           language="apex"
           since="5.5.0"

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/OverrideBothEqualsAndHashcodeTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/OverrideBothEqualsAndHashcodeTest.java
@@ -1,0 +1,11 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.rule.errorprone;
+
+import net.sourceforge.pmd.testframework.PmdRuleTst;
+
+public class OverrideBothEqualsAndHashcodeTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/xml/OverrideBothEqualsAndHashcode.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/xml/OverrideBothEqualsAndHashcode.xml
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+    <test-code>
+        <description>hash code only</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public Integer hashCode() {}
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>nested hash code only</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public class Bar {
+        public Integer hashCode() {}
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>equals only</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public boolean equals(Object other) {}
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>nested equals only</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public class Bar {
+        public Integer equals(Object other) {}
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>overrides both</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public boolean equals(Object other) {}
+    public Integer hashCode() {}
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>nested overrides both</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public class Bar {
+        public boolean equals(Object other) {}
+        public Integer hashCode() {}
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>overrides neither</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>equals sig uses String, not Object</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public boolean equals(String o) {
+        return true;
+    }
+    public Integer hashCode() {
+        return 0;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>interface</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public interface Foo {
+    boolean equals(Object o);
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>implements equals but with 2 args</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public boolean equals(java.lang.Object o1, java.lang.Object o2) {
+        return true;
+    }
+    public Integer hashCode(java.lang.Object o) {
+        return 0;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>overloaded hashCode</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo  {
+    public Integer hashCode(Object o1) { return false; }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>overloaded both</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo  {
+    public boolean equals(Object o1, Object o2) { return false; }
+    public Integer hashCode(Object o1) { return false; }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>overloaded hashCode, should fail on equals</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo  {
+    public boolean equals(Object o1) { return false; }
+    public Integer hashCode(Object o1) { return false; }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>implements hashCode but with args</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public Integer hashCode(List<Decimal> a) {
+        return 0;
+    }
+}
+        ]]></code>
+    </test-code>
+</test-data>


### PR DESCRIPTION
## Describe the PR

Copied the Java override equals and hashcode rule into Apex. Only difference I intend between the two implementations are that the Apex implementation does not contain an exception for classes that implement the Comparable interface. I couldn't find a good reason for making that exclusion. 

For reference: Java's [OverrideBothEqualsAndHashcode](https://pmd.github.io/latest/pmd_rules_java_errorprone.html#overridebothequalsandhashcode)

## Related issues

n/a

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [X] Added (in-code) documentation (if needed)

