### PR TITLE
[java] NPE in UseCollectionIsEmptyRule with enums #2833

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseCollectionIsEmptyRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseCollectionIsEmptyRule.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBody;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
+import net.sourceforge.pmd.lang.java.ast.ASTEnumBody;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
@@ -112,11 +113,14 @@ public class UseCollectionIsEmptyRule extends AbstractInefficientZeroCheck {
     }
 
     private ASTClassOrInterfaceType getTypeOfVariableByName(String varName, ASTPrimaryExpression expr) {
-        ASTClassOrInterfaceBody classBody = expr.getFirstParentOfType(ASTClassOrInterfaceBody.class);
-        List<ASTVariableDeclarator> varDeclarators = classBody.findDescendantsOfType(ASTVariableDeclarator.class);
+        Node classOrEnumBody = expr.getFirstParentOfType(ASTClassOrInterfaceBody.class);
+        if (classOrEnumBody == null) {
+            classOrEnumBody = expr.getFirstParentOfType(ASTEnumBody.class);
+        }                 
+        List<ASTVariableDeclarator> varDeclarators = classOrEnumBody.findDescendantsOfType(ASTVariableDeclarator.class);
         for (ASTVariableDeclarator varDeclarator : varDeclarators) {
             if (varDeclarator.getName().equals(varName)) {
-                return varDeclarator.getFirstDescendantOfType(ASTClassOrInterfaceType.class);
+                return varDeclarator.getParent().getFirstDescendantOfType(ASTClassOrInterfaceType.class);
             }
         }
         return null;

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UseCollectionIsEmpty.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UseCollectionIsEmpty.xml
@@ -163,8 +163,8 @@ public class Foo {
 
     <test-code>
         <description>#1214 UseCollectionIsEmpty misses some usage</description>
-        <expected-problems>5</expected-problems>
-        <expected-linenumbers>25,28,31,34,37</expected-linenumbers>
+        <expected-problems>10</expected-problems>
+        <expected-linenumbers>8,11,14,17,20,23,26,29,32,35</expected-linenumbers>
         <code><![CDATA[
 import java.util.ArrayList;
 
@@ -172,24 +172,22 @@ public class TestIsEmpty {
     public static void main(String args[]) {
         ArrayList<String> testObject = new ArrayList<String>();
 
-        // These ones are flagged
-//      if (testObject.size() == 0) {
-//          System.out.println("List is empty");
-//      }
-//      if (testObject.size() != 0) {
-//          System.out.println("List is empty");
-//      }
-//      if (0 == testObject.size()) {
-//          System.out.println("List is empty");
-//      }
-//      if (0 != testObject.size()) {
-//          System.out.println("List is empty");
-//      }
-//      if (testObject.size() > 0) {
-//          System.out.println("List is empty");
-//      }
-
-        // These ones are not flagged, but should be flagged
+        // These should be flagged
+        if (testObject.size() == 0) {
+            System.out.println("List is empty");
+        }
+        if (testObject.size() != 0) {
+            System.out.println("List is empty");
+        }
+        if (0 == testObject.size()) {
+            System.out.println("List is empty");
+        }
+        if (0 != testObject.size()) {
+            System.out.println("List is empty");
+        }
+        if (testObject.size() > 0) {
+            System.out.println("List is empty");
+        }
         if (testObject.size() < 1) {
             System.out.println("List is empty");
         }
@@ -232,7 +230,7 @@ public class IsEmptyTest {
     public static void main(String args[]) {
         ArrayList<String> testObject = new ArrayList<String>();
 
-        // these should be flagged (as they are equivalent to == 0) and are
+        // These should be flagged
         if (testObject.size() < 1) { // line 8
             System.out.println("List is empty");
         }
@@ -240,7 +238,7 @@ public class IsEmptyTest {
             System.out.println("List is empty");
         }
 
-        // these should not be flagged, and are not
+        // These should not be flagged
         if (testObject.size() <= 1) { // line 16
             System.out.println("List may or may not be empty");
         }
@@ -248,7 +246,7 @@ public class IsEmptyTest {
             System.out.println("List may or may not be empty");
         }
 
-        // these should be flagged (as they are equivalent to != 0) and are not
+        // These should be flagged (as they are equivalent to != 0) and are not
         if (testObject.size() >= 1) { // line 24
             System.out.println("List is not empty");
         }
@@ -256,7 +254,7 @@ public class IsEmptyTest {
             System.out.println("List is not empty");
         }
 
-        // these should not be flagged, yet are
+        // These should not be flagged
         if (testObject.size() > 1) { // line 32
             System.out.println("List is not empty, but not all non-empty lists will trigger this");
         }
@@ -348,4 +346,63 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    
+	<test-code>
+        <description>#2833 NPE in UseCollectionIsEmptyRule with enums</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public enum ComponentSize {
+
+    S("s"),
+    M("m"),
+    L("l"),
+    XL("xl");
+
+
+    private String size;
+
+    ComponentSize(String size) {
+        this.size = size;
+    }
+
+    @Override
+    public String toString() {
+        return size;
+    }
+
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>##2833 NPE in UseCollectionIsEmptyRule with enums (sanity check)</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>12</expected-linenumbers>
+        <code><![CDATA[
+public enum ComponentSize {
+
+    S("s"),
+    M("m"),
+    L("l"),
+    XL("xl");
+
+    private List<String> list;
+    private String size;
+
+    ComponentSize(String size) {
+        if (list.size() == 0) {
+            this.size = size;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return size;
+    }
+
+}
+        ]]></code>
+    </test-code>
+
 </test-data>


### PR DESCRIPTION
## Describe the PR

The UseCollectionIsEmptyRule requires finding the first parent of the class `ASTClassOrInterfaceBody` when searching for the type of a variable by name. In the case of an enum, the call to fetch the parent returns null, resulting in a NPE. This was fixed by checking for null and finding a parent of type `ASTEnumBody` instead.

I also refactored, cleared-up, and formatted a few test cases.

## Related issues

- Fixes #2833

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

