### PR TITLE
[java] LiteralsFirstInComparisons should consider constant fields

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
@@ -136,14 +136,14 @@ public class LiteralsFirstInComparisonsRule extends AbstractJavaRule {
     }
 
     private JavaNode getFirstLiteralArgument(ASTPrimarySuffix primarySuffix) {
-        return getArgumentPrimaryPrefixFromSuffix(primarySuffix).getFirstChildOfType(ASTLiteral.class);
+        return getArgumentPrimaryPrefix(primarySuffix).getFirstChildOfType(ASTLiteral.class);
     }
 
     private JavaNode getFirstNameArgument(ASTPrimarySuffix primarySuffix) {
-        return getArgumentPrimaryPrefixFromSuffix(primarySuffix).getFirstChildOfType(ASTName.class);
+        return getArgumentPrimaryPrefix(primarySuffix).getFirstChildOfType(ASTName.class);
     }
 
-    private JavaNode getArgumentPrimaryPrefixFromSuffix(ASTPrimarySuffix primarySuffix) {
+    private JavaNode getArgumentPrimaryPrefix(ASTPrimarySuffix primarySuffix) {
         ASTArguments arguments = primarySuffix.getFirstChildOfType(ASTArguments.class);
         ASTArgumentList argumentList = arguments.getFirstChildOfType(ASTArgumentList.class);
         ASTExpression expression = argumentList.getFirstChildOfType(ASTExpression.class);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
@@ -8,21 +8,21 @@ import java.util.List;
 
 import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTArguments;
+import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBody;
+import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBodyDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTConditionalAndExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTConditionalOrExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTEqualityExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTLiteral;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
 import net.sourceforge.pmd.lang.java.ast.ASTNullLiteral;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
-import net.sourceforge.pmd.lang.java.ast.JavaNode;
-import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBodyDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBody;
-import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
+import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
 public class LiteralsFirstInComparisonsRule extends AbstractJavaRule {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
@@ -136,21 +136,19 @@ public class LiteralsFirstInComparisonsRule extends AbstractJavaRule {
     }
 
     private JavaNode getFirstLiteralArgument(ASTPrimarySuffix primarySuffix) {
-        ASTArguments arguments = primarySuffix.getFirstChildOfType(ASTArguments.class);
-        ASTArgumentList argumentList = arguments.getFirstChildOfType(ASTArgumentList.class);
-        ASTExpression expression = argumentList.getFirstChildOfType(ASTExpression.class);
-        ASTPrimaryExpression primaryExpression = expression.getFirstChildOfType(ASTPrimaryExpression.class);
-        ASTPrimaryPrefix primaryPrefix = primaryExpression.getFirstChildOfType(ASTPrimaryPrefix.class);
-        return primaryPrefix.getFirstChildOfType(ASTLiteral.class);
+        return getArgumentPrimaryPrefixFromSuffix(primarySuffix).getFirstChildOfType(ASTLiteral.class);
     }
 
     private JavaNode getFirstNameArgument(ASTPrimarySuffix primarySuffix) {
+        return getArgumentPrimaryPrefixFromSuffix(primarySuffix).getFirstChildOfType(ASTName.class);
+    }
+
+    private JavaNode getArgumentPrimaryPrefixFromSuffix(ASTPrimarySuffix primarySuffix) {
         ASTArguments arguments = primarySuffix.getFirstChildOfType(ASTArguments.class);
         ASTArgumentList argumentList = arguments.getFirstChildOfType(ASTArgumentList.class);
         ASTExpression expression = argumentList.getFirstChildOfType(ASTExpression.class);
         ASTPrimaryExpression primaryExpression = expression.getFirstChildOfType(ASTPrimaryExpression.class);
-        ASTPrimaryPrefix primaryPrefix = primaryExpression.getFirstChildOfType(ASTPrimaryPrefix.class);
-        return primaryPrefix.getFirstChildOfType(ASTName.class);
+        return primaryExpression.getFirstChildOfType(ASTPrimaryPrefix.class);
     }
 
     private boolean isStringLiteral(JavaNode node) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LiteralsFirstInComparisons.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LiteralsFirstInComparisons.xml
@@ -357,4 +357,17 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#575 PositionLiteralsFirstInComparisons must not trigger if the constant field is not a String</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    private final Integer TEST_CONSTANT = 5;
+    public boolean test(String someString) {
+        return someString.equals(TEST_CONSTANT);
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LiteralsFirstInComparisons.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LiteralsFirstInComparisons.xml
@@ -318,4 +318,43 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#575 PositionLiteralsFirstInComparisons to consider constant fields, i.e. static final Strings</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    private static final String TEST_CONSTANT = "Test-Constant";
+    public boolean test(String someString) {
+        return someString.equals(TEST_CONSTANT);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#575 PositionLiteralsFirstInComparisons must not trigger if the field is not final</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    private static String TEST_CONSTANT = "Test-Constant";
+    public boolean test(String someString) {
+        return someString.equals(TEST_CONSTANT);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#575 PositionLiteralsFirstInComparisons must not trigger if the field is not static</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    private final String TEST_CONSTANT = "Test-Constant";
+    public boolean test(String someString) {
+        return someString.equals(TEST_CONSTANT);
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

The [issue](https://github.com/pmd/pmd/issues/575) is about a false negative: The PositionLiteralsFirstInComparisons rule in Java should consider constant fields as string literals and raise a warning to position these as the first argument in comparisons.

The warning is only to be triggered, if the field is:
a. static,
b. final, and
c. a String

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #575

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests (tested via maven test lifecycle in the PMD Java project)
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

