### PR TITLE
[core] Fix code climate severity strings

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/CodeClimateRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/CodeClimateRenderer.java
@@ -84,12 +84,16 @@ public class CodeClimateRenderer extends AbstractIncrementingRenderer {
 
         switch (rule.getPriority()) {
         case HIGH:
-            issue.severity = "critical";
+            issue.severity = "blocker";
             break;
         case MEDIUM_HIGH:
+            issue.severity = "critical";
+            break;
         case MEDIUM:
+            issue.severity = "major";
+            break;
         case MEDIUM_LOW:
-            issue.severity = "normal";
+            issue.severity = "minor";
             break;
         case LOW:
         default:


### PR DESCRIPTION
## Describe the PR

Code Climate issue severity are specified here
https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#issues
as `info`, `minor`, `major`, `critical`, or `blocker`. It was mapped to
a value `normal` that is not recognized by tools compatible with Code
Climate's format. I have mapped the five PMD priority values on the five Code Climate severity levels

## Related issues

I haven't open an issue

## Ready?

- [ ] Added unit tests for fixed bug/feature (it seems hard in the current context regarding the AbstractRendererTest architecture)
- [ ] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

