### PR TITLE
[ci] Fixes for pmdtester (baseline, danger)

### DIFF
--- a/.ci/inc/regression-tester.inc
+++ b/.ci/inc/regression-tester.inc
@@ -33,54 +33,31 @@ function regression_tester_setup_ci() {
 }
 
 #
-# Generate a new baseline and upload it to sourceforge
-#
-# Note: this function always succeeds, even if the upload fails.
-# In that case, just a error logging is provided.
+# Generate a new baseline and upload it to pmd-code.org
 #
 function regression_tester_uploadBaseline() {
     log_debug "$FUNCNAME branch=${PMD_CI_BRANCH}"
-    local targetUrl="https://sourceforge.net/projects/pmd/files/pmd-regression-tester/"
     local pmdcodeUrl="https://pmd-code.org/pmd-regression-tester/"
 
-    local errexitstate="$(shopt -po errexit)"
-    set +e # disable errexit
-    (
-        # This handler is called if any command fails
-        function upload_failed() {
-            log_error "Error while uploading ${BRANCH_FILENAME}-baseline.zip to pmd-code.org!"
-            log_error "Please upload manually: ${pmdcodeUrl}"
-            #log_error "Error while uploading ${BRANCH_FILENAME}-baseline.zip to sourceforge!"
-            #log_error "Please upload manually: ${targetUrl}"
-        }
-
-        # exit subshell after trap
-        set -e
-        trap upload_failed ERR
-
-        log_info "Generating and uploading baseline for pmdtester..."
-        cd ..
-        bundle config --local gemfile pmd/Gemfile
-        bundle config set --local path pmd/vendor/bundle
-        bundle exec pmdtester \
-            --mode single \
-            --local-git-repo ./pmd \
-            --patch-branch ${PMD_CI_BRANCH:-$PMD_CI_TAG} \
-            --patch-config ./pmd/.ci/files/all-java.xml \
-            --list-of-project ./pmd/.ci/files/project-list.xml --html-flag \
-            --error-recovery
-        cd target/reports
-        BRANCH_FILENAME="${PMD_CI_BRANCH:-$PMD_CI_TAG}"
-        BRANCH_FILENAME="${BRANCH_FILENAME/\//_}"
-        zip -q -r ${BRANCH_FILENAME}-baseline.zip ${BRANCH_FILENAME}/
-        # ssh-key for pmd-code.org is setup already by pmd_ci_setup_ssh
-        scp ${BRANCH_FILENAME}-baseline.zip pmd@pmd-code.org:/httpdocs/pmd-regression-tester/
-        log_success "Successfully uploaded ${BRANCH_FILENAME}-baseline.zip to ${pmdcodeUrl}"
-        #../../pmd/.ci/travis_wait "rsync -avh ${BRANCH_FILENAME}-baseline.zip ${PMD_SF_USER}@web.sourceforge.net:/home/frs/project/pmd/pmd-regression-tester/"
-        #log_success "Successfully uploaded ${BRANCH_FILENAME}-baseline.zip to ${targetUrl}"
-    )
-    # restore errexit state
-    eval "$errexitstate"
+    log_info "Generating and uploading baseline for pmdtester..."
+    pushd ..
+    bundle config --local gemfile pmd/Gemfile
+    bundle config set --local path pmd/vendor/bundle
+    bundle exec pmdtester \
+        --mode single \
+        --local-git-repo ./pmd \
+        --patch-branch ${PMD_CI_BRANCH:-$PMD_CI_TAG} \
+        --patch-config ./pmd/.ci/files/all-java.xml \
+        --list-of-project ./pmd/.ci/files/project-list.xml --html-flag \
+        --error-recovery
+    cd target/reports
+    BRANCH_FILENAME="${PMD_CI_BRANCH:-$PMD_CI_TAG}"
+    BRANCH_FILENAME="${BRANCH_FILENAME/\//_}"
+    zip -q -r ${BRANCH_FILENAME}-baseline.zip ${BRANCH_FILENAME}/
+    # ssh-key for pmd-code.org is setup already by pmd_ci_setup_ssh
+    scp ${BRANCH_FILENAME}-baseline.zip pmd@pmd-code.org:/httpdocs/pmd-regression-tester/
+    log_success "Successfully uploaded ${BRANCH_FILENAME}-baseline.zip to ${pmdcodeUrl}"
+    popd
 }
 
 #

--- a/.ci/inc/regression-tester.inc
+++ b/.ci/inc/regression-tester.inc
@@ -64,42 +64,24 @@ function regression_tester_uploadBaseline() {
 #
 # Execute danger, which executes pmd-regression-tester (via Dangerfile).
 #
-# Note: this function always succeeds, even if the danger fails.
-# In that case, just a error logging is provided.
-#
 function regression_tester_executeDanger() {
     log_debug "$FUNCNAME"
 
-    local errexitstate="$(shopt -po errexit)"
-    set +e # disable errexit
-    (
-        # This handler is called if any command fails
-        function danger_failed() {
-            log_error "Error while executing danger/pmd-regression-tester"
-        }
+    # Create a corresponding remote branch locally
+    if ! git show-ref --verify --quiet refs/heads/${PMD_CI_BRANCH}; then
+        git fetch --no-tags --depth=1 origin +refs/heads/${PMD_CI_BRANCH}:refs/remotes/origin/${PMD_CI_BRANCH}
+        git branch ${PMD_CI_BRANCH} origin/${PMD_CI_BRANCH}
+        log_debug "Created local branch ${PMD_CI_BRANCH}"
+    fi
+    # Fetch more commits of the PR for danger and regression tester
+    git fetch --no-tags --depth=50 origin +$(git rev-parse HEAD^2):
+    # Fetch more commits from master branch for regression tester
+    if [[ "${PMD_CI_BRANCH}" != "master" ]]; then
+        git fetch --no-tags --depth=50 origin +master:
+        git branch master origin/master
+    fi
 
-        # exit subshell after trap
-        set -e
-        trap danger_failed ERR
-
-        # Create a corresponding remote branch locally
-        if ! git show-ref --verify --quiet refs/heads/${PMD_CI_BRANCH}; then
-            git fetch --no-tags --depth=1 origin +refs/heads/${PMD_CI_BRANCH}:refs/remotes/origin/${PMD_CI_BRANCH}
-            git branch ${PMD_CI_BRANCH} origin/${PMD_CI_BRANCH}
-            log_debug "Created local branch ${PMD_CI_BRANCH}"
-        fi
-        # Fetch more commits of the PR for danger and regression tester
-        git fetch --no-tags --depth=50 origin +$(git rev-parse HEAD^2):
-        # Fetch more commits from master branch for regression tester
-        if [[ "${PMD_CI_BRANCH}" != "master" ]]; then
-            git fetch --no-tags --depth=50 origin +master:
-            git branch master origin/master
-        fi
-
-        log_info "Running danger on branch ${PMD_CI_BRANCH}"
-        bundle exec danger --verbose
-        log_success "Executing danger successfully"
-    )
-    # restore errexit state
-    eval "$errexitstate"
+    log_info "Running danger on branch ${PMD_CI_BRANCH}"
+    bundle exec danger --verbose
+    log_success "Executed danger successfully"
 }

--- a/.ci/inc/regression-tester.inc
+++ b/.ci/inc/regression-tester.inc
@@ -50,7 +50,8 @@ function regression_tester_uploadBaseline() {
         --patch-branch ${baseline_branch} \
         --patch-config ./pmd/.ci/files/all-java.xml \
         --list-of-project ./pmd/.ci/files/project-list.xml --html-flag \
-        --error-recovery
+        --error-recovery \
+        --debug
     pushd target/reports
     BRANCH_FILENAME="${baseline_branch/\//_}"
     zip -q -r ${BRANCH_FILENAME}-baseline.zip ${BRANCH_FILENAME}/

--- a/.ci/inc/regression-tester.inc
+++ b/.ci/inc/regression-tester.inc
@@ -36,27 +36,28 @@ function regression_tester_setup_ci() {
 # Generate a new baseline and upload it to pmd-code.org
 #
 function regression_tester_uploadBaseline() {
-    log_debug "$FUNCNAME branch=${PMD_CI_BRANCH}"
     local pmdcodeUrl="https://pmd-code.org/pmd-regression-tester/"
+    local baseline_branch="${PMD_CI_BRANCH:-$PMD_CI_TAG}"
+    log_debug "$FUNCNAME branch=${baseline_branch}"
 
-    log_info "Generating and uploading baseline for pmdtester..."
+    log_info "Generating and uploading baseline for pmdtester (${baseline_branch})..."
     pushd ..
-    bundle config --local gemfile pmd/Gemfile
-    bundle config set --local path pmd/vendor/bundle
+    rm -f .bundle/config
+    bundle config set --local gemfile pmd/Gemfile
     bundle exec pmdtester \
         --mode single \
         --local-git-repo ./pmd \
-        --patch-branch ${PMD_CI_BRANCH:-$PMD_CI_TAG} \
+        --patch-branch ${baseline_branch} \
         --patch-config ./pmd/.ci/files/all-java.xml \
         --list-of-project ./pmd/.ci/files/project-list.xml --html-flag \
         --error-recovery
-    cd target/reports
-    BRANCH_FILENAME="${PMD_CI_BRANCH:-$PMD_CI_TAG}"
-    BRANCH_FILENAME="${BRANCH_FILENAME/\//_}"
+    pushd target/reports
+    BRANCH_FILENAME="${baseline_branch/\//_}"
     zip -q -r ${BRANCH_FILENAME}-baseline.zip ${BRANCH_FILENAME}/
     # ssh-key for pmd-code.org is setup already by pmd_ci_setup_ssh
     scp ${BRANCH_FILENAME}-baseline.zip pmd@pmd-code.org:/httpdocs/pmd-regression-tester/
     log_success "Successfully uploaded ${BRANCH_FILENAME}-baseline.zip to ${pmdcodeUrl}"
+    popd
     popd
 }
 

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     continue-on-error: false
-    timeout-minutes: 30
+    timeout-minutes: 60
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]

--- a/Dangerfile
+++ b/Dangerfile
@@ -39,7 +39,7 @@ def upload_report
     `tar -cf #{tar_filename} diff/`
     report_url = `curl -u #{ENV['PMD_CI_CHUNK_TOKEN']} -T #{tar_filename} https://chunk.io`
     if $?.success?
-      @logger.info "Successfully uploaded #{tar_filename} to chunk.io"
+      @logger.info "Successfully uploaded #{tar_filename} to #{report_url}"
 
       # set value of sticky to true and the message is kept after new commits are submitted to the PR
       message("This changeset " \

--- a/Dangerfile
+++ b/Dangerfile
@@ -16,7 +16,7 @@ def run_pmdtester
             '--auto-gen-config',
             '--error-recovery',
             '--baseline-download-url', 'https://pmd-code.org/pmd-regression-tester/',
-            # '--debug',
+            '--debug',
             ]
     begin
       @summary = PmdTester::Runner.new(argv).run


### PR DESCRIPTION
## Describe the PR

This PR addresses some of the problems from the last builds:

### Missing baseline
The last baseline generated from master is from 2020-12-12 (see https://pmd-code.org/pmd-regression-tester/).
The [last build on master](https://github.com/pmd/pmd/runs/1664561802?check_suite_focus=true#step:6:48201) didn't run pmdtester successfully.

This PR hopefully fixes this problem (which can only be verified, after this PR has been merged). To see such problems earlier in the future, the build will fail now, when something doesn't work with the baseline.

### Unexpected diff report
The other problems from the [last build of PR 2983](https://github.com/pmd/pmd/pull/2983/checks#step:6:81765):
* a report has been generated, but the summary numbers are missing ("   new violations....")
* the report is very very big: 45mb... the PR only changed one rule and so only this rule has been used. But while comparing, the complete baseline has been used. This looks like a bug in pmdtester, where the baseline is not filtered anymore (option `--auto-gen-config`)

To further investigate these problems, debug logging is enabled now.

**Update:** This will be fixed with pmd/pmd-regression-tester#81 :heavy_check_mark: 
**Update:** Missing summary numbers will be fixed with pmd/pmd-regression-tester#82 :heavy_check_mark: 

### Build timeouts for PRs
PRs had a timeout of 30 minutes, which sometimes gets exceeded (e.g. https://github.com/pmd/pmd/actions/runs/461283976). The timeout will be increased to 60 minutes. Note: Push-Builds don't have such a timeout.

## Related issues

- Changes are related to #2967 but doesn't fix any of the tasks mentioned there.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

