### PR TITLE
[ci] Do not merge - pmdtester integration test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,9 @@
 source 'https://rubygems.org/'
 
 # bleeding edge from git
-#gem 'pmdtester', :git => 'https://github.com/pmd/pmd-regression-tester.git'
+gem 'pmdtester', :git => 'https://github.com/pmd/pmd-regression-tester.git'
 
-gem 'pmdtester', '~> 1.1'
+#gem 'pmdtester', '~> 1.1'
 gem 'danger', '~> 5.6', '>= 5.6'
 
 # This group is only needed for rendering release notes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,15 @@
+GIT
+  remote: https://github.com/pmd/pmd-regression-tester.git
+  revision: d9756a1fbfbae5869d618fda94b6af2509bce612
+  specs:
+    pmdtester (1.1.1.pre.SNAPSHOT)
+      differ (~> 0.1)
+      liquid (>= 4.0)
+      logger-colors (~> 1.0)
+      nokogiri (>= 1.11.0.rc4)
+      rufus-scheduler (~> 3.5)
+      slop (~> 4.6)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -31,7 +43,7 @@ GEM
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (1.3.1)
       faraday (~> 0.8)
-    fugit (1.4.1)
+    fugit (1.4.2)
       et-orbi (~> 1.1, >= 1.1.8)
       raabro (~> 1.4)
     git (1.8.1)
@@ -50,13 +62,6 @@ GEM
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
-    pmdtester (1.1.0)
-      differ (~> 0.1)
-      liquid (>= 4.0)
-      logger-colors (~> 1.0)
-      nokogiri (~> 1.8)
-      rufus-scheduler (~> 3.5)
-      slop (~> 4.6)
     public_suffix (4.0.6)
     raabro (1.4.0)
     racc (1.5.2)
@@ -81,7 +86,7 @@ PLATFORMS
 DEPENDENCIES
   danger (~> 5.6, >= 5.6)
   liquid (>= 4.0.0)
-  pmdtester (~> 1.1)
+  pmdtester!
   rouge (>= 1.7, < 4)
   safe_yaml (>= 1.0)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/pmd/pmd-regression-tester.git
-  revision: d9756a1fbfbae5869d618fda94b6af2509bce612
+  revision: 156097deb90ed03bbfdecbe7d2aeab55251824b3
   specs:
     pmdtester (1.1.1.pre.SNAPSHOT)
       differ (~> 0.1)

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AbstractClassWithoutAbstractMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AbstractClassWithoutAbstractMethodRule.java
@@ -35,7 +35,7 @@ public class AbstractClassWithoutAbstractMethodRule extends AbstractJavaRule {
             }
         }
         if (countOfAbstractMethods == 0) {
-            addViolation(data, node);
+            //addViolation(data, node);
         }
         return data;
     }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AbstractClassWithoutAbstractMethodTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AbstractClassWithoutAbstractMethodTest.java
@@ -4,8 +4,11 @@
 
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
+import org.junit.Ignore;
+
 import net.sourceforge.pmd.testframework.PmdRuleTst;
 
+@Ignore
 public class AbstractClassWithoutAbstractMethodTest extends PmdRuleTst {
     // no additional unit tests
 }


### PR DESCRIPTION
## Describe the PR

:warning: Do not merge this PR

This PR is testing, that pmdtester generates a correct diff report.
It serves as a late integration test.

The PR basically disables the Java rule AbstractClassWithoutAbstractMethods. No violations will be reported
for this rule. This results in false negatives when compared to the baseline.

The generated diff report should only report false negatives of this rule, but no other rules,
since the results should be filtered.

Note: since the baseline for master is old, ~we also see new violations for LiteralsFirstInComparison and CloseResource...~ After #3000, these should be gone. **Update:** Not for this test case - here we filter down to a single rule, so all other rules are not shown. But this would appear if a xpath rule is changed and we reevaluate a complete ruleset.

## Related issues

- see also #3000 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

