### PR TITLE
[java] Fix threading issue in MethodNamingConventionsRule

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -20,6 +20,8 @@ This is a {{ site.pmd.release_type }} release.
     *   [#2994](https://github.com/pmd/pmd/pull/2994): \[core] Fix code climate severity strings
 *   java-bestpractices
     *   [#575](https://github.com/pmd/pmd/issues/575): \[java] LiteralsFirstInComparisons should consider constant fields
+*   java-codestyle
+    *   [#2960](https://github.com/pmd/pmd/issues/2960): \[java] Thread issue in MethodNamingConventionsRule
 
 ### API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/MethodNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/MethodNamingConventionsRule.java
@@ -22,7 +22,7 @@ import net.sourceforge.pmd.properties.PropertyDescriptor;
 
 public class MethodNamingConventionsRule extends AbstractNamingConventionRule<ASTMethodDeclaration> {
 
-    private static final Map<String, String> DESCRIPTOR_TO_DISPLAY_NAME = new HashMap<>();
+    private final Map<String, String> descriptorToDisplayName = new HashMap<>();
 
     @Deprecated
     private static final BooleanProperty CHECK_NATIVE_METHODS_DESCRIPTOR = new BooleanProperty("checkNativeMethods",
@@ -118,7 +118,7 @@ public class MethodNamingConventionsRule extends AbstractNamingConventionRule<AS
         String display = (displayName + " method").trim();
         RegexPropertyBuilder prop = super.defaultProp(name.isEmpty() ? "method" : name, display);
 
-        DESCRIPTOR_TO_DISPLAY_NAME.put(prop.getName(), display);
+        descriptorToDisplayName.put(prop.getName(), display);
 
         return prop;
     }
@@ -126,6 +126,6 @@ public class MethodNamingConventionsRule extends AbstractNamingConventionRule<AS
 
     @Override
     String kindDisplayName(ASTMethodDeclaration node, PropertyDescriptor<Pattern> descriptor) {
-        return DESCRIPTOR_TO_DISPLAY_NAME.get(descriptor.name());
+        return descriptorToDisplayName.get(descriptor.name());
     }
 }


### PR DESCRIPTION
## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #2960

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] ~Added unit tests for fixed bug/feature~ i don't think we can write a test for this. The bug was also discovered by an automated verification tool, and not by actual faulty behavior  
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

