### PR TITLE
[java] Fix method calls in type resolution

### DIFF
--- a/.ci/files/project-list.xml
+++ b/.ci/files/project-list.xml
@@ -86,7 +86,7 @@ export PATH=$JAVA_HOME/bin:$PATH
 EOF
 ) | patch
 
-./gradlew build -x javadoc -x dokka -x asciidoctor -x test -x testNG -x api -x distZip
+./gradlew build testClasses -x javadoc -x dokka -x asciidoctor -x test -x testNG -x api -x distZip
 ./gradlew createSquishClasspath -q > classpath.txt
 ]]></build-command>
     <auxclasspath-command>cat classpath.txt</auxclasspath-command>

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/AvoidInstantiatingObjectsInLoopsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/AvoidInstantiatingObjectsInLoopsRule.java
@@ -13,6 +13,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTBlock;
 import net.sourceforge.pmd.lang.java.ast.ASTBlockStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTBreakStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTDoStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTForInit;
 import net.sourceforge.pmd.lang.java.ast.ASTForStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
@@ -21,6 +22,8 @@ import net.sourceforge.pmd.lang.java.ast.ASTReturnStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTStatementExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTThrowStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTWhileStatement;
+import net.sourceforge.pmd.lang.java.ast.JavaNode;
+import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 
@@ -65,9 +68,25 @@ public class AvoidInstantiatingObjectsInLoopsRule extends AbstractJavaRule {
     private boolean notCollectionAccess(ASTAllocationExpression node) {
         if (node.getNthParent(4) instanceof ASTArgumentList && node.getNthParent(8) instanceof ASTStatementExpression) {
             ASTStatementExpression statement = (ASTStatementExpression) node.getNthParent(8);
-            return !TypeTestUtil.isA(Collection.class, statement);
+            return !isCallOnReceiverOfType(Collection.class, statement);
         }
         return true;
+    }
+
+    private static boolean isCallOnReceiverOfType(Class<?> receiverType, JavaNode expression) {
+        if ((expression instanceof ASTExpression || expression instanceof ASTStatementExpression)
+            && expression.getNumChildren() == 1) {
+            expression = expression.getChild(0);
+        }
+        int numChildren = expression.getNumChildren();
+        if (expression instanceof ASTPrimaryExpression && numChildren >= 2) {
+            JavaNode lastChild = expression.getChild(numChildren - 1);
+            if (lastChild instanceof ASTPrimarySuffix && ((ASTPrimarySuffix) lastChild).isArguments()) {
+                JavaNode receiverExpr = expression.getChild(numChildren - 2);
+                return receiverExpr instanceof TypeNode && TypeTestUtil.isA(receiverType, (TypeNode) receiverExpr);
+            }
+        }
+        return false;
     }
 
     private boolean notBreakFollowing(ASTAllocationExpression node) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -587,9 +587,6 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter implements Nulla
      */
     private JavaTypeDefinition getTypeDefinitionOfVariableFromScope(Scope scope, String image, Class<?>
             accessingClass) {
-        if (accessingClass == null) {
-            return null;
-        }
 
         for (/* empty */; scope != null; scope = scope.getParent()) {
             // search each enclosing scope one by one

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -1014,22 +1014,6 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter implements Nulla
                     primaryNodeType = currentChild.getTypeDefinition();
                 }
 
-                // if this expression is a method call, then make sure, PrimaryPrefix has the type
-                // on which the method is executed (type of the target reference)
-                if (currentChild.getFirstChildOfType(ASTArguments.class) != null && previousChild.getFirstChildOfType(ASTName.class) != null) {
-                    // restore type of the name and search again
-                    ASTName name = previousChild.getFirstChildOfType(ASTName.class);
-                    name.setTypeDefinition(null);
-                    searchNodeNameForClass(name, name.getImage().split("\\."));
-                    if (name.getTypeDefinition() != null) {
-                        // rollup from Name -> PrimaryPrefix
-                        previousChild.setTypeDefinition(name.getTypeDefinition());
-                    } else if (name.getTypeDefinition() == null) {
-                        // if there is no better type, use the type of the expression
-                        name.setTypeDefinition(primaryNodeType);
-                    }
-                }
-
                 // maybe array access?
                 if (primaryNodeType != null && primaryNodeType.isArrayType()) {
                     if (currentChild instanceof ASTPrimarySuffix && ((ASTPrimarySuffix) currentChild).isArrayDereference()) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/ClassTypeResolver.java
@@ -609,11 +609,7 @@ public class ClassTypeResolver extends JavaParserVisitorAdapter implements Nulla
                         return null;
                     }
 
-                    if (typeNode.getChild(0) instanceof ASTReferenceType) {
-                        return ((TypeNode) typeNode.getChild(0)).getTypeDefinition();
-                    } else { // primitive type
-                        return JavaTypeDefinition.forClass(typeNode.getType());
-                    }
+                    return entry.getKey().getDeclaratorId().getTypeDefinition();
                 }
             }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/MethodTypeResolution.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/MethodTypeResolution.java
@@ -565,7 +565,7 @@ public final class MethodTypeResolution {
      */
     public static boolean isMemberVisibleFromClass(Class<?> classWithMember, int modifiers, Class<?> accessingClass) {
         if (accessingClass == null) {
-            return false;
+            return true;
         }
 
         // public members

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typedefinition/JavaTypeDefinitionSimple.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/typedefinition/JavaTypeDefinitionSimple.java
@@ -209,8 +209,11 @@ import java.util.logging.Logger;
             }
         } else if (type instanceof GenericArrayType) {
             JavaTypeDefinition component = resolveTypeDefinition(((GenericArrayType) type).getGenericComponentType(), method, methodTypeArgs);
-            // TODO: retain the generic types of the array component...
-            return forClass(Array.newInstance(component.getType(), 0).getClass());
+            // only if we could determine the actual type
+            if (component != null) {
+                // TODO: retain the generic types of the array component...
+                return forClass(Array.newInstance(component.getType(), 0).getClass());
+            }
         }
 
         // TODO : Shall we throw here?

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
@@ -1402,7 +1402,7 @@ public class ClassTypeResolverTest {
 
         // Number e = field.noArguments();
         assertEquals(Number.class, expressions.get(index).getType());
-        assertEquals(Number.class, getChildType(expressions.get(index), 0));
+        assertEquals(MethodPotentialApplicability.class, getChildType(expressions.get(index), 0));
         assertEquals(Number.class, getChildType(expressions.get(index++), 1));
 
         // int f = this.vararg("");

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/ClassTypeResolverTest.java
@@ -1625,6 +1625,19 @@ public class ClassTypeResolverTest {
     }
 
     @Test
+    public void testGenericArrayUnresolved() {
+        // InnerClass cannot be resolved as no compiled code is available
+        // we should not throw a NPE when trying to parse/type resolve.
+        java11.parse("import java.util.*;"
+                + "class Foo {"
+                + "  private static class InnerClass {}"
+                + "  void useInnerClass(InnerClass... classes) {"
+                + "    List<InnerClass> result = new ArrayList<>(Arrays.<InnerClass>asList(classes));"
+                + "  }"
+                + "}");
+    }
+
+    @Test
     public void testMethodTypeInference() throws JaxenException {
         List<AbstractJavaTypeNode> expressions = selectNodes(GenericMethodsImplicit.class, AbstractJavaTypeNode.class, "//VariableInitializer/Expression/PrimaryExpression");
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
@@ -8,8 +8,11 @@
         <description>OK, guard is here - log4j</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
 public class Foo {
-    private static final Logger logger = Logger.getLogger(Foo.class);
+    private static final Logger logger = LogManager.getLogger(Foo.class);
 
     private void foo() {
         if ( logger.isDebugEnabled() )
@@ -23,6 +26,9 @@ public class Foo {
         <description>ok, no error expected - apache commons logging</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.logging.Log;
+
 public class Test {
     private static final Log __log = LogFactory.getLog(Test.class);
     public void test() {
@@ -39,6 +45,8 @@ public class Test {
         <description>Guarded call - OK - java util</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+import java.util.logging.Logger;
+
 public class Foo {
 
     private void foo(Logger logger) {
@@ -54,8 +62,11 @@ public class Foo {
         <description>KO, missing guard 1 - log4j</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
 public class Foo {
-    private static final Logger logger = Logger.getLogger(Foo.class);
+    private static final Logger logger = LogManager.getLogger(Foo.class);
 
     private void foo() {
         logger.debug("Debug statement" + "");
@@ -70,8 +81,11 @@ public class Foo {
         <rule-property name="guardsMethods">isDebugEnabled,isTraceEnabled</rule-property>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
 public class Foo {
-    private static final Logger logger = Logger.getLogger(Foo.class);
+    private static final Logger logger = LogManager.getLogger(Foo.class);
 
     private void foo() {
         logger.debug("Debug statement" + "");
@@ -88,6 +102,9 @@ public class Foo {
         <description>Complex logging without guard - apache commons logging</description>
         <expected-problems>2</expected-problems>
         <code><![CDATA[
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.logging.Log;
+
 public class Test {
     private static final Log __log = LogFactory.getLog(Test.class);
     public void test() {
@@ -111,6 +128,9 @@ public class Test {
         <description>Complex logging with misplaced guard - apache commons logging</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.loggong.Log;
+
 public class Test {
     private static final Log __log = LogFactory.getLog(Test.class);
     public void test() {
@@ -129,6 +149,8 @@ public class Test {
         <description>Unguarded call - KO - java util</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
+import java.util.logging.Logger;
+
 public class Foo {
 
     private void foo(Logger logger) {
@@ -142,8 +164,14 @@ public class Foo {
         <description>ok #1189 GuardLogStatementRule and GuardDebugLoggingRule broken for log4j2</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
+
 public class Test {
-    public void test() {
+    public void test(String mymarker) {
+        final Logger logger = LogManager.getLogger(Test.class);
         final Marker m = MarkerManager.getMarker(mymarker);
         if (logger.isDebugEnabled(m)) {
           logger.debug(m, message + "");
@@ -159,9 +187,16 @@ public class Test {
     <test-code>
         <description>violation - wrong guard #1189 GuardLogStatementRule and GuardDebugLoggingRule broken for log4j2</description>
         <expected-problems>2</expected-problems>
+        <expected-linenumbers>11,14</expected-linenumbers>
         <code><![CDATA[
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
+
 public class Test {
-    public void test() {
+    public void test(String mymarker) {
+        final Logger logger = LogManager.getLogger(Test.class);
         final Marker m = MarkerManager.getMarker(mymarker);
         if (logger.isTraceEnabled(m)) { // should have been isDebugEnabled
           logger.debug(m, message + "");
@@ -177,9 +212,16 @@ public class Test {
     <test-code>
         <description>violation - no if #1189 GuardLogStatementRule and GuardDebugLoggingRule broken for log4j2</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>11</expected-linenumbers>
         <code><![CDATA[
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
+
 public class Test {
-    public void test() {
+    public void test(String mymarker) {
+        final Logger logger = LogManager.getLogger(Test.class);
         final Marker m = MarkerManager.getMarker(mymarker);
         logger.isDebugEnabled(m); // must be within an if
         logger.debug(m, message + "");
@@ -192,6 +234,9 @@ public class Test {
         <description>#1224 GuardDebugLogging broken in 5.1.1 - missing additive statement check in log statement - apache commons logging</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+import org.apache.commons.logging.LogFactory;
+import org.apache.commons.logging.Log;
+
 public class Test {
     private static final Log __log = LogFactory.getLog(Test.class);
     public void test() {
@@ -214,7 +259,11 @@ public class Test {
         <description>#1341 pmd:GuardDebugLogging violates LOGGER.debug with format "{}" - slf4j</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class GuardDebugFalsePositive {
+    private static final Logger LOGGER = LoggerFactory.getLogger("GuardDebugFalsePositive");
     public void test() {
         String tempSelector = "a";
         LOGGER.debug("MessageSelector={}" , tempSelector);

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
@@ -1135,7 +1135,8 @@ public class CloseResourcePrintWriter {
         <expected-linenumbers>7,8,10</expected-linenumbers>
         <expected-messages>
             <message>Ensure that resources like this FileInputStream object are closed after use</message>
-            <message>Ensure that resources like this Scanner object are closed after use</message>
+            <!-- Note: it picks up on System.in -->
+            <message>Ensure that resources like this InputStream object are closed after use</message>
             <message>Ensure that resources like this FileInputStream object are closed after use</message>
         </expected-messages>
         <code><![CDATA[

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
@@ -1477,4 +1477,22 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>#2977 6.30.0 introduces new false positive in CloseResource rule</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.File;
+
+public class Foo {
+    void bar() {
+        File file = new File("name", "r");
+        try {
+            boolean isHundredBytes = file.length() == 100;
+        } finally {
+            file.close();
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CompareObjectsWithEquals.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CompareObjectsWithEquals.xml
@@ -317,4 +317,36 @@ public class ClassWithFields {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#2976 FP with array length</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class C0 {
+    public static byte[] myArrayFunc(byte[] a1, byte[] a2) {
+        if (a1.length != a2.length) {
+            throw new IllegalArgumentException();
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>#2976 FP with method call (unresolved class)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class C0 {
+    class Unresolved {
+        private final long val;
+        public long getVal() { return val; }
+    }
+
+    {
+        if (c1.getVal() != c2.getVal()) {  // <-- here
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UseEqualsToCompareStrings.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UseEqualsToCompareStrings.xml
@@ -129,4 +129,15 @@ public class ClassWithStringFields {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>#3004 UseEqualsToCompareStrings false positive with PMD 6.30.0</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class O {
+    boolean f(String s) {
+        return s.charAt(0) == s.charAt(1);
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UseEqualsToCompareStrings.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UseEqualsToCompareStrings.xml
@@ -140,4 +140,44 @@ public class O {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>#2979 UseEqualsToCompareStrings: FP with "var" variables</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class O {
+    boolean f(String s) {
+        final Matcher matcher = null;
+        if (matcher.matches()) {
+
+            final var firstString = matcher.group("a");
+            final var secondString = matcher.group("b");
+
+            if (firstString.isEmpty() != secondString.isEmpty()) { // <- violation
+                // ...
+            }
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>#2979 UseEqualsToCompareStrings: FP with "var" variables (control, types are explicit)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class O {
+    boolean f(String s) {
+        final Matcher matcher = null;
+        if (matcher.matches()) {
+
+            final String firstString = matcher.group("a");
+            final String secondString = matcher.group("b");
+
+            if (firstString.isEmpty() != secondString.isEmpty()) { // <- violation
+                // ...
+            }
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Fix a bug in type resolution, by which expressions like `a.m()` have type `a` and not whatever the return type of `m` is. The fixed issues are instances of this same problem. It was not introduced in type resolution by 6.30.0, only made discoverable because UseEqualsToCompareStrings was updated to use type resolution in #2934. 

This could be caused by unresolved local variables, though given how rotten the typeres code is I'm not sure. Other tests are failing now...

----
update

With these changes, in a call chain, the return type of method calls is now set on the PrimarySuffix that corresponds to the arguments. Previously, it was the PrimarySuffix for the method name, or the PrimaryPrefix, if the receiver is an ambiguous name (ASTName). This was inconsistent and hid the type of the receiver in that case.

Eg `str.contains("")` had the following type info (in the best case, whereas with the bug of #2976 the PrimaryExpression has the incorrect type string):
```java
+ PrimaryExpression (type =  boolean)
  + PrimaryPrefix
     + Name(image = "str.contains", type = boolean)
  + PrimarySuffix
     + Arguments
```
where nothing hints that the receiver is of type string. Now it's
```java
+ PrimaryExpression (type =  boolean)
  + PrimaryPrefix
     + Name(image = "str.contains", type = String)    <- this is the receiver type
  + PrimarySuffix (type = boolean)
     + Arguments
```

I think this is the best we can do on master. I don't want to add tests that will be thrown away when merging 7.0.x, I spent already too much time on this, so this only adds tests to the rules, not the typeres code.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #2976
- Fixes #2977
- Fixes #2979
- Fixes #3004

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

