### PR TITLE
[java] Fix problem with whitespace in properties

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/internal/util/AssertionUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/internal/util/AssertionUtil.java
@@ -1,0 +1,58 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.internal.util;
+
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ *
+ */
+public final class AssertionUtil {
+
+    private static final Pattern PACKAGE_PATTERN = Pattern.compile("[\\w$]+(\\.[\\w$]+)*|");
+    private static final Pattern BINARY_NAME_PATTERN = Pattern.compile("[\\w$]+(?:\\.[\\w$]+)*(?:\\[])*");
+
+    private AssertionUtil() {
+        // utility class
+    }
+
+    public static boolean isValidJavaPackageName(CharSequence name) {
+        requireParamNotNull("name", name);
+        return PACKAGE_PATTERN.matcher(name).matches();
+    }
+
+    /**
+     * @throws IllegalArgumentException if the name is not a binary name
+     */
+    public static void assertValidJavaBinaryName(CharSequence name) {
+        if (!isJavaBinaryName(name)) {
+            throw new IllegalArgumentException("Not a Java binary name '" + name + "'");
+        }
+    }
+
+    public static boolean isJavaBinaryName(CharSequence name) {
+        return BINARY_NAME_PATTERN.matcher(name).matches();
+    }
+
+
+    public static <T> T requireParamNotNull(String paramName, T obj) {
+        if (obj == null) {
+            throw new NullPointerException("Parameter " + paramName + " is null");
+        }
+
+        return obj;
+    }
+
+    public static AssertionError shouldNotReachHere(String message) {
+        String prefix = "This should be unreachable";
+        message = StringUtils.isBlank(message) ? prefix
+                                               : prefix + ": " + message;
+        return new AssertionError(message);
+    }
+
+
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractJavaAnnotatableNode.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractJavaAnnotatableNode.java
@@ -7,6 +7,8 @@ package net.sourceforge.pmd.lang.java.ast;
 import java.util.Collection;
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
+
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 
 // package private
@@ -26,11 +28,12 @@ abstract class AbstractJavaAnnotatableNode extends AbstractJavaNode implements A
     }
 
     @Override
-    public ASTAnnotation getAnnotation(String annotQualifiedName) {
+    public ASTAnnotation getAnnotation(String binaryName) {
+        binaryName = StringUtils.deleteWhitespace(binaryName);
         List<ASTAnnotation> annotations = getDeclaredAnnotations();
         for (ASTAnnotation annotation : annotations) {
             ASTName name = annotation.getFirstDescendantOfType(ASTName.class);
-            if (TypeTestUtil.isA(annotQualifiedName, name)) {
+            if (TypeTestUtil.isA(binaryName, name)) {
                 return annotation;
             }
         }
@@ -38,13 +41,13 @@ abstract class AbstractJavaAnnotatableNode extends AbstractJavaNode implements A
     }
 
     @Override
-    public boolean isAnnotationPresent(String annotQualifiedName) {
-        return getAnnotation(annotQualifiedName) != null;
+    public boolean isAnnotationPresent(String binaryName) {
+        return getAnnotation(binaryName) != null;
     }
 
     @Override
-    public boolean isAnyAnnotationPresent(Collection<String> annotQualifiedNames) {
-        for (String annotQualifiedName : annotQualifiedNames) {
+    public boolean isAnyAnnotationPresent(Collection<String> binaryNames) {
+        for (String annotQualifiedName : binaryNames) {
             if (isAnnotationPresent(annotQualifiedName)) {
                 return true;
             }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/Annotatable.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/Annotatable.java
@@ -20,29 +20,31 @@ public interface Annotatable extends JavaNode {
     List<ASTAnnotation> getDeclaredAnnotations();
 
     /**
-     * Get specific annotaion on this node.
+     * Returns a specific annotation on this node, or null if absent.
      *
-     * @param annotQualifiedName
-     *            qulified name of the annotation.
-     * @return <code>ASTAnnotaion</code> node if the annotation is present on this node, else <code>null</code>
+     * @param binaryName
+     *            Binary name of the annotation type.
+     *            Note: for now, canonical names are tolerated, this may be changed in PMD 7.
      */
-    ASTAnnotation getAnnotation(String annotQualifiedName);
+    ASTAnnotation getAnnotation(String binaryName);
 
     /**
      * Checks whether any annotation is present on this node.
      *
-     * @param annotQualifiedNames
-     *            collection that cotains qulified name of annotations.
+     * @param binaryNames
+     *            Collection that contains binary names of annotations.
+     *            Note: for now, canonical names are tolerated, this may be changed in PMD 7.
      * @return <code>true</code> if any annotation is present on this node, else <code>false</code>
      */
-    boolean isAnyAnnotationPresent(Collection<String> annotQualifiedNames);
+    boolean isAnyAnnotationPresent(Collection<String> binaryNames);
 
     /**
      * Checks whether the annotation is present on this node.
      *
-     * @param annotQualifiedName
-     *            qulified name of the annotation.
+     * @param binaryName
+     *            Binary name of the annotation type.
+     *            Note: for now, canonical names are tolerated, this may be changed in PMD 7.
      * @return <code>true</code> if the annotation is present on this node, else <code>false</code>
      */
-    boolean isAnnotationPresent(String annotQualifiedName);
+    boolean isAnnotationPresent(String binaryName);
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelper.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/TypeHelper.java
@@ -6,6 +6,8 @@ package net.sourceforge.pmd.lang.java.typeresolution;
 
 import java.util.Objects;
 
+import org.apache.commons.lang3.StringUtils;
+
 import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.symboltable.TypedNameDeclaration;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
@@ -37,7 +39,7 @@ public final class TypeHelper {
     @Deprecated
     public static boolean isA(final TypeNode n, final String clazzName) {
         Objects.requireNonNull(n);
-        return clazzName != null && TypeTestUtil.isA(clazzName, n);
+        return clazzName != null && TypeTestUtil.isA(StringUtils.deleteWhitespace(clazzName), n);
     }
 
     /**
@@ -52,7 +54,7 @@ public final class TypeHelper {
     @Deprecated
     public static boolean isExactlyA(final TypeNode n, final String clazzName) {
         Objects.requireNonNull(n);
-        return clazzName != null && TypeTestUtil.isExactlyA(clazzName, n);
+        return clazzName != null && TypeTestUtil.isExactlyA(StringUtils.deleteWhitespace(clazzName), n);
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeTestUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeTestUtil.java
@@ -60,7 +60,7 @@ public final class TypeTestUtil {
      * @throws NullPointerException if the class parameter is null
      */
     public static boolean isA(/*@NonNull*/ Class<?> clazz, /*@Nullable*/ TypeNode node) {
-        AssertionUtil.requireParamNotNull("class",  clazz);
+        AssertionUtil.requireParamNotNull("class", clazz);
         if (node == null) {
             return false;
         } else if (node.getType() == clazz) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeTestUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeTestUtil.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.java.types;
 import java.lang.reflect.Modifier;
 import java.util.List;
 
+import net.sourceforge.pmd.internal.util.AssertionUtil;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotationTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
@@ -26,6 +27,8 @@ import net.sourceforge.pmd.lang.java.typeresolution.TypeHelper;
  * <li>Take the node as the second parameter
  * <li>Systematically return false if the node argument is null
  * <li>Systematically throw if the other argument is null
+ * <li>Do not sanitize string arguments, they must be exactly canonical names,
+ * with no whitespace characters.
  * </ul>
  */
 public final class TypeTestUtil {
@@ -57,7 +60,7 @@ public final class TypeTestUtil {
      * @throws NullPointerException if the class parameter is null
      */
     public static boolean isA(/*@NonNull*/ Class<?> clazz, /*@Nullable*/ TypeNode node) {
-        requireParamNotNull("class", clazz);
+        AssertionUtil.requireParamNotNull("class",  clazz);
         if (node == null) {
             return false;
         } else if (node.getType() == clazz) {
@@ -94,7 +97,7 @@ public final class TypeTestUtil {
      * @throws NullPointerException if the class name parameter is null
      */
     public static boolean isA(/*@NonNull*/ String canonicalName, /*@Nullable*/ TypeNode node) {
-        requireParamNotNull("canonicalName", canonicalName);
+        AssertionUtil.assertValidJavaBinaryName(canonicalName);
         if (node == null) {
             return false;
         }
@@ -142,7 +145,7 @@ public final class TypeTestUtil {
      * @throws NullPointerException if the class parameter is null
      */
     public static boolean isExactlyA(/*@NonNull*/ Class<?> clazz, /*@Nullable*/ TypeNode node) {
-        requireParamNotNull("class", clazz);
+        AssertionUtil.requireParamNotNull("class", clazz);
         if (node == null) {
             return false;
         }
@@ -174,7 +177,7 @@ public final class TypeTestUtil {
      * @throws NullPointerException if the class name parameter is null
      */
     public static boolean isExactlyA(/*@Nullable*/ String canonicalName, TypeNode node /*@NonNull*/) {
-        requireParamNotNull("canonicalName", canonicalName);
+        AssertionUtil.assertValidJavaBinaryName(canonicalName);
         if (node == null) {
             return false;
         }
@@ -190,14 +193,6 @@ public final class TypeTestUtil {
             return false;
         }
         return canoname.equals(canonicalName);
-    }
-
-
-    // this is in AssertionUtil in 7.0
-    private static void requireParamNotNull(String name, Object o) {
-        if (o == null) {
-            throw new NullPointerException("Parameter '" + name + "' was null");
-        }
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/xpath/TypeIsExactlyFunction.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/xpath/TypeIsExactlyFunction.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.java.xpath;
 
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jaxen.Context;
 import org.jaxen.Function;
 import org.jaxen.FunctionCallException;
@@ -48,8 +49,9 @@ public class TypeIsExactlyFunction implements Function {
      * @param fullTypeName The fully qualified name of the class or any supertype
      * @return True if the type of the node matches, false otherwise.
      */
-    public static boolean typeIsExactly(final Node n, final String fullTypeName) {
+    public static boolean typeIsExactly(Node n, String fullTypeName) {
         if (n instanceof TypeNode) {
+            fullTypeName = StringUtils.deleteWhitespace(fullTypeName);
             return TypeTestUtil.isExactlyA(fullTypeName, (TypeNode) n);
         } else {
             throw new IllegalArgumentException("typeIsExactly function may only be called on a TypeNode.");

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/xpath/TypeIsFunction.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/xpath/TypeIsFunction.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.java.xpath;
 
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jaxen.Context;
 import org.jaxen.Function;
 import org.jaxen.FunctionCallException;
@@ -48,8 +49,9 @@ public class TypeIsFunction implements Function {
      * @param fullTypeName The fully qualified name of the class or any supertype
      * @return True if the type of the node matches, false otherwise.
      */
-    public static boolean typeIs(final Node n, final String fullTypeName) {
+    public static boolean typeIs(Node n, String fullTypeName) {
         if (n instanceof TypeNode) {
+            fullTypeName = StringUtils.deleteWhitespace(fullTypeName);
             return TypeTestUtil.isA(fullTypeName, (TypeNode) n);
         } else {
             throw new IllegalArgumentException("typeIs function may only be called on a TypeNode.");

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
@@ -1643,4 +1643,19 @@ public class UnusedPrivateMethodFP {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>#2454 [java] UnusedPrivateMethod violation for disabled annotation in 6.23.0</description>
+        <!-- Note: weird whitespace in the property is important        -->
+        <rule-property name="ignoredAnnotations">java
+            .lang.Deprecated</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class OOO {
+    @Deprecated
+    private void shutdown() {
+        server.shutdown();
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
The problem with #2454 is that the input to TypeTestUtil is not sanitized to remove whitespace from the property value.

We can either
* make TypeTestUtil lenient (as TypeHelper was)
* make TypeTestUtil stricter, and validate user input higher up in the call tree

I prefer solution 2, so TypeTestUtil now checks that its input is a binary name without whitespace. Annotatable, which is a bit higher in the call tree, still cleans up the input strings, so it doesn't change behavior.

In PMD 7 I think we should be more restrictive vis à vis this user input, and sanitize it directly in the properties (eg with property constraints, refs #1432). Then we're sure that every class name we handle is a valid binary name.

The AssertionUtil here is extracted from the pmd 7 branch

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #2454

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

