### PR TITLE
[java] Deprecate some performance rules

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -32,6 +32,12 @@ This is a {{ site.pmd.release_type }} release.
 
 ### API Changes
 
+### Deprecated rules
+
+* java-performance
+  * [SimplifyStartsWith](https://pmd.github.io/latest/pmd_rules_java_performance.html#simplifystartswith): the suggested code transformation has an insignificant performance impact, and decreases readability.
+
+
 ### External Contributions
 
 *   [#2666](https://github.com/pmd/pmd/pull/2666): \[swift] Manage swift5 string literals - [kenji21](https://github.com/kenji21)

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -35,6 +35,7 @@ This is a {{ site.pmd.release_type }} release.
 ### Deprecated rules
 
 * java-performance
+  * [AvoidUsingShortType](https://pmd.github.io/latest/pmd_rules_java_performance.html#avoidusingshorttype): arithmetic on shorts is not significantly slower than on ints, whereas using shorts may provide significant memory savings in arrays.
   * [SimplifyStartsWith](https://pmd.github.io/latest/pmd_rules_java_performance.html#simplifystartswith): the suggested code transformation has an insignificant performance impact, and decreases readability.
 
 

--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -696,8 +696,11 @@ public class C {
           since="3.1"
           message="This call to String.startsWith can be rewritten using String.charAt(0)"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
+          deprecated="true"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_performance.html#simplifystartswith">
         <description>
+Note: this rule is deprecated for removal, as the optimization is insignificant.
+
 Calls to `string.startsWith("x")` with a string literal of length 1 can be rewritten using `string.charAt(0)`,
 at the expense of some readability. To prevent `IndexOutOfBoundsException` being thrown by the `charAt` method,
 ensure that the string is not empty by making an additional check first.

--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -275,8 +275,11 @@ public class Something {
           message="Do not use the short type"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           typeResolution="true"
+          deprecated="true"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_performance.html#avoidusingshorttype">
         <description>
+Note: this rule is deprecated, as its rationale does not hold.
+
 Java uses the 'short' type to reduce memory usage, not to optimize calculation. In fact, the JVM does not have any
 arithmetic capabilities for the short type: the JVM must convert the short into an int, do the proper calculation
 and convert the int back to a short. Thus any storage gains found through use of the 'short' type may be offset by


### PR DESCRIPTION
## Describe the PR

Deprecates AvoidUsingShortType and SimplifyStartsWith, according to #2296 and #2740 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

