### PR TITLE
[java] Update security rules for pmd7

### DIFF
--- a/.ci/files/all-java.xml
+++ b/.ci/files/all-java.xml
@@ -320,7 +320,7 @@
 
     <!-- security.xml -->
 
-    <!-- <rule ref="category/java/security.xml/HardCodedCryptoKey"/> -->
-    <!-- <rule ref="category/java/security.xml/InsecureCryptoIv"/> -->
+    <rule ref="category/java/security.xml/HardCodedCryptoKey"/>
+    <rule ref="category/java/security.xml/InsecureCryptoIv"/>
 
 </ruleset>

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/TypesFromAst.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/TypesFromAst.java
@@ -184,12 +184,13 @@ final class TypesFromAst {
             if (qualifier != null) {
                 assert node.getImplicitEnclosing() == null
                     : "Qualified ctor calls should be handled lazily";
+                // note: this triggers recursive type resolution of the qualifier
                 JTypeMirror qualifierType = qualifier.getTypeMirror();
+                JClassSymbol symbol;
                 if (qualifierType instanceof JClassType) {
                     JClassType enclosing = (JClassType) qualifierType;
                     JClassType resolved = JavaResolvers.getMemberClassResolver(enclosing, node.getRoot().getPackageName(), node.getEnclosingType().getSymbol(), node.getSimpleName())
                                                        .resolveFirst(node.getSimpleName());
-                    JClassSymbol symbol;
                     if (resolved == null) {
                         // compile-time error
                         symbol = (JClassSymbol) node.getTypeSystem().UNKNOWN.getSymbol();
@@ -199,9 +200,12 @@ final class TypesFromAst {
                         assert actualEnclosing != null : "We got this symbol by looking into enclosing";
                         node.setImplicitEnclosing(actualEnclosing);
                     }
-                    node.setSymbol(symbol);
-                    return symbol;
+                } else {
+                    // qualifier is unresolved, compile-time error
+                    symbol = (JClassSymbol) node.getTypeSystem().UNKNOWN.getSymbol();
                 }
+                node.setSymbol(symbol);
+                return symbol;
             } // else fallthrough
         }
         throw new IllegalStateException("Disambiguation pass should resolve everything except qualified ctor calls");

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/AbstractHardCodedConstructorArgsVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/AbstractHardCodedConstructorArgsVisitor.java
@@ -15,11 +15,11 @@ import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 
-abstract class HardCodedConstructorArgsBaseRule extends AbstractJavaRulechainRule {
+abstract class AbstractHardCodedConstructorArgsVisitor extends AbstractJavaRulechainRule {
 
     private final Class<?> type;
 
-    HardCodedConstructorArgsBaseRule(Class<?> constructorType) {
+    AbstractHardCodedConstructorArgsVisitor(Class<?> constructorType) {
         super(ASTConstructorCall.class);
         this.type = constructorType;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/HardCodedConstructorArgsBaseRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/HardCodedConstructorArgsBaseRule.java
@@ -12,7 +12,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTStringLiteral;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableAccess;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
-import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 
@@ -20,8 +19,8 @@ abstract class HardCodedConstructorArgsBaseRule extends AbstractJavaRulechainRul
 
     private final Class<?> type;
 
-    HardCodedConstructorArgsBaseRule(Class<? extends JavaNode> ruleChainType, Class<?> constructorType) {
-        super(ruleChainType);
+    HardCodedConstructorArgsBaseRule(Class<?> constructorType) {
+        super(ASTConstructorCall.class);
         this.type = constructorType;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/HardCodedConstructorArgsBaseRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/HardCodedConstructorArgsBaseRule.java
@@ -1,0 +1,73 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.security;
+
+import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
+import net.sourceforge.pmd.lang.java.ast.ASTArrayAllocation;
+import net.sourceforge.pmd.lang.java.ast.ASTArrayInitializer;
+import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
+import net.sourceforge.pmd.lang.java.ast.ASTExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTStringLiteral;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableAccess;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
+import net.sourceforge.pmd.lang.java.ast.JavaNode;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+
+abstract class HardCodedConstructorArgsBaseRule extends AbstractJavaRulechainRule {
+
+    private final Class<?> type;
+
+    HardCodedConstructorArgsBaseRule(Class<? extends JavaNode> ruleChainType, Class<?> constructorType) {
+        super(ruleChainType);
+        this.type = constructorType;
+    }
+
+    @Override
+    public Object visit(ASTConstructorCall node, Object data) {
+        if (TypeTestUtil.isA(type, node)) {
+            ASTArgumentList arguments = node.getArguments();
+            if (arguments.size() > 0) {
+                validateProperKeyArgument(data, arguments.get(0));
+            }
+        }
+        return data;
+    }
+
+    /**
+     * Recursively resolves the argument again, if the variable initializer
+     * is itself a expression.
+     *
+     * <p>Then checks the expression for being a string literal or array
+     */
+    private void validateProperKeyArgument(Object data, ASTExpression firstArgumentExpression) {
+        if (firstArgumentExpression == null) {
+            return;
+        }
+
+        // named variable
+        if (firstArgumentExpression instanceof ASTVariableAccess) {
+            ASTVariableAccess varAccess = (ASTVariableAccess) firstArgumentExpression;
+            if (varAccess.getSignature() != null && varAccess.getSignature().getSymbol() != null) {
+                ASTVariableDeclaratorId varDecl = varAccess.getSignature().getSymbol().tryGetNode();
+                validateProperKeyArgument(data, varDecl.getInitializer());
+            }
+        }
+
+        // hard coded array
+        if (firstArgumentExpression instanceof ASTArrayAllocation) {
+            ASTArrayInitializer arrayInit = ((ASTArrayAllocation) firstArgumentExpression).getArrayInitializer();
+            if (arrayInit != null) {
+                addViolation(data, arrayInit);
+            }
+        }
+
+        // string literal
+        ASTStringLiteral literal = firstArgumentExpression.descendants(ASTStringLiteral.class).first();
+        if (literal != null) {
+            addViolation(data, literal);
+        }
+    }
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/HardCodedCryptoKeyRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/HardCodedCryptoKeyRule.java
@@ -11,7 +11,7 @@ package net.sourceforge.pmd.lang.java.rule.security;
  * @author sergeygorbaty
  * @since 6.4.0
  */
-public class HardCodedCryptoKeyRule extends HardCodedConstructorArgsBaseRule {
+public class HardCodedCryptoKeyRule extends AbstractHardCodedConstructorArgsVisitor {
 
     public HardCodedCryptoKeyRule() {
         super(javax.crypto.spec.SecretKeySpec.class);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/HardCodedCryptoKeyRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/HardCodedCryptoKeyRule.java
@@ -4,8 +4,6 @@
 
 package net.sourceforge.pmd.lang.java.rule.security;
 
-import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
-
 /**
  * Finds hard coded encryption keys that are passed to
  * javax.crypto.spec.SecretKeySpec(key, algorithm).
@@ -16,7 +14,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
 public class HardCodedCryptoKeyRule extends HardCodedConstructorArgsBaseRule {
 
     public HardCodedCryptoKeyRule() {
-        super(ASTConstructorCall.class, javax.crypto.spec.SecretKeySpec.class);
+        super(javax.crypto.spec.SecretKeySpec.class);
     }
 
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/HardCodedCryptoKeyRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/HardCodedCryptoKeyRule.java
@@ -4,16 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.security;
 
-import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
-import net.sourceforge.pmd.lang.java.ast.ASTArrayAllocation;
-import net.sourceforge.pmd.lang.java.ast.ASTArrayInitializer;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
-import net.sourceforge.pmd.lang.java.ast.ASTExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTStringLiteral;
-import net.sourceforge.pmd.lang.java.ast.ASTVariableAccess;
-import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
-import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
-import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 
 /**
  * Finds hard coded encryption keys that are passed to
@@ -22,53 +13,10 @@ import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
  * @author sergeygorbaty
  * @since 6.4.0
  */
-public class HardCodedCryptoKeyRule extends AbstractJavaRulechainRule {
-
-    private static final Class<?> SECRET_KEY_SPEC = javax.crypto.spec.SecretKeySpec.class;
+public class HardCodedCryptoKeyRule extends HardCodedConstructorArgsBaseRule {
 
     public HardCodedCryptoKeyRule() {
-        super(ASTConstructorCall.class);
+        super(ASTConstructorCall.class, javax.crypto.spec.SecretKeySpec.class);
     }
 
-    @Override
-    public Object visit(ASTConstructorCall node, Object data) {
-        if (TypeTestUtil.isA(SECRET_KEY_SPEC, node)) {
-            ASTArgumentList arguments = node.getArguments();
-            if (arguments.size() > 0) {
-                validateProperKeyArgument(data, arguments.get(0));
-            }
-        }
-        return data;
-    }
-
-    /**
-     * Recursively resolves the argument again, if the variable initializer
-     * is itself a expression.
-     *
-     * <p>Then checks the expression for being a string literal or array
-     */
-    private void validateProperKeyArgument(Object data, ASTExpression firstArgumentExpression) {
-        // named variable
-        if (firstArgumentExpression instanceof ASTVariableAccess) {
-            ASTVariableAccess varAccess = (ASTVariableAccess) firstArgumentExpression;
-            if (varAccess.getSignature() != null && varAccess.getSignature().getSymbol() != null) {
-                ASTVariableDeclaratorId varDecl = varAccess.getSignature().getSymbol().tryGetNode();
-                validateProperKeyArgument(data, varDecl.getInitializer());
-            }
-        }
-
-        // hard coded array
-        if (firstArgumentExpression instanceof ASTArrayAllocation) {
-            ASTArrayInitializer arrayInit = ((ASTArrayAllocation) firstArgumentExpression).getArrayInitializer();
-            if (arrayInit != null) {
-                addViolation(data, arrayInit);
-            }
-        }
-
-        // string literal
-        ASTStringLiteral literal = firstArgumentExpression.descendants(ASTStringLiteral.class).first();
-        if (literal != null) {
-            addViolation(data, literal);
-        }
-    }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/HardCodedCryptoKeyRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/HardCodedCryptoKeyRule.java
@@ -51,11 +51,13 @@ public class HardCodedCryptoKeyRule extends AbstractJavaRulechainRule {
         // named variable
         if (firstArgumentExpression instanceof ASTVariableAccess) {
             ASTVariableAccess varAccess = (ASTVariableAccess) firstArgumentExpression;
-            ASTVariableDeclaratorId varDecl = varAccess.getSignature().getSymbol().tryGetNode();
-            validateProperKeyArgument(data, varDecl.getInitializer());
+            if (varAccess.getSignature() != null && varAccess.getSignature().getSymbol() != null) {
+                ASTVariableDeclaratorId varDecl = varAccess.getSignature().getSymbol().tryGetNode();
+                validateProperKeyArgument(data, varDecl.getInitializer());
+            }
         }
 
-        // hard coded array ASTArrayAllocation
+        // hard coded array
         if (firstArgumentExpression instanceof ASTArrayAllocation) {
             ASTArrayInitializer arrayInit = ((ASTArrayAllocation) firstArgumentExpression).getArrayInitializer();
             if (arrayInit != null) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/HardCodedCryptoKeyRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/HardCodedCryptoKeyRule.java
@@ -1,21 +1,18 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.java.rule.security;
 
-import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.java.ast.ASTAllocationExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
-import net.sourceforge.pmd.lang.java.ast.ASTArguments;
+import net.sourceforge.pmd.lang.java.ast.ASTArrayAllocation;
 import net.sourceforge.pmd.lang.java.ast.ASTArrayInitializer;
-import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
-import net.sourceforge.pmd.lang.java.ast.ASTLiteral;
-import net.sourceforge.pmd.lang.java.ast.ASTName;
-import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
-import net.sourceforge.pmd.lang.java.ast.ASTVariableInitializer;
-import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
-import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
+import net.sourceforge.pmd.lang.java.ast.ASTExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTStringLiteral;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableAccess;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 
 /**
@@ -25,27 +22,20 @@ import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
  * @author sergeygorbaty
  * @since 6.4.0
  */
-public class HardCodedCryptoKeyRule extends AbstractJavaRule {
+public class HardCodedCryptoKeyRule extends AbstractJavaRulechainRule {
 
     private static final Class<?> SECRET_KEY_SPEC = javax.crypto.spec.SecretKeySpec.class;
 
     public HardCodedCryptoKeyRule() {
-        addRuleChainVisit(ASTAllocationExpression.class);
+        super(ASTConstructorCall.class);
     }
 
     @Override
-    public Object visit(ASTAllocationExpression node, Object data) {
-        if (TypeTestUtil.isA(SECRET_KEY_SPEC, node.getFirstChildOfType(ASTClassOrInterfaceType.class))) {
-            Node firstArgument = null;
-
-            ASTArguments arguments = node.getFirstChildOfType(ASTArguments.class);
+    public Object visit(ASTConstructorCall node, Object data) {
+        if (TypeTestUtil.isA(SECRET_KEY_SPEC, node)) {
+            ASTArgumentList arguments = node.getArguments();
             if (arguments.size() > 0) {
-                firstArgument = arguments.getFirstChildOfType(ASTArgumentList.class).getChild(0);
-            }
-
-            if (firstArgument != null) {
-                ASTPrimaryPrefix prefix = firstArgument.getFirstDescendantOfType(ASTPrimaryPrefix.class);
-                validateProperKeyArgument(data, prefix);
+                validateProperKeyArgument(data, arguments.get(0));
             }
         }
         return data;
@@ -55,38 +45,27 @@ public class HardCodedCryptoKeyRule extends AbstractJavaRule {
      * Recursively resolves the argument again, if the variable initializer
      * is itself a expression.
      *
-     * Then checks the expression for being a string literal or array
-     *
-     * @param data
-     * @param firstArgumentExpression
+     * <p>Then checks the expression for being a string literal or array
      */
-    private void validateProperKeyArgument(Object data, ASTPrimaryPrefix firstArgumentExpression) {
-        if (firstArgumentExpression == null) {
-            return;
+    private void validateProperKeyArgument(Object data, ASTExpression firstArgumentExpression) {
+        // named variable
+        if (firstArgumentExpression instanceof ASTVariableAccess) {
+            ASTVariableAccess varAccess = (ASTVariableAccess) firstArgumentExpression;
+            ASTVariableDeclaratorId varDecl = varAccess.getSignature().getSymbol().tryGetNode();
+            validateProperKeyArgument(data, varDecl.getInitializer());
         }
 
-        // named variable
-        ASTName namedVar = firstArgumentExpression.getFirstDescendantOfType(ASTName.class);
-        if (namedVar != null) {
-            // find where it's declared, if possible
-            if (namedVar != null && namedVar.getNameDeclaration() instanceof VariableNameDeclaration) {
-                VariableNameDeclaration varDecl = (VariableNameDeclaration) namedVar.getNameDeclaration();
-                ASTVariableInitializer initializer = varDecl.getAccessNodeParent().getFirstDescendantOfType(ASTVariableInitializer.class);
-                if (initializer != null) {
-                    validateProperKeyArgument(data, initializer.getFirstDescendantOfType(ASTPrimaryPrefix.class));
-                }
+        // hard coded array ASTArrayAllocation
+        if (firstArgumentExpression instanceof ASTArrayAllocation) {
+            ASTArrayInitializer arrayInit = ((ASTArrayAllocation) firstArgumentExpression).getArrayInitializer();
+            if (arrayInit != null) {
+                addViolation(data, arrayInit);
             }
         }
 
-        // hard coded array
-        ASTArrayInitializer arrayInit = firstArgumentExpression.getFirstDescendantOfType(ASTArrayInitializer.class);
-        if (arrayInit != null) {
-            addViolation(data, arrayInit);
-        }
-
         // string literal
-        ASTLiteral literal = firstArgumentExpression.getFirstDescendantOfType(ASTLiteral.class);
-        if (literal != null && literal.isStringLiteral()) {
+        ASTStringLiteral literal = firstArgumentExpression.descendants(ASTStringLiteral.class).first();
+        if (literal != null) {
             addViolation(data, literal);
         }
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/InsecureCryptoIvRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/InsecureCryptoIvRule.java
@@ -4,16 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.security;
 
-import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
-import net.sourceforge.pmd.lang.java.ast.ASTArrayAllocation;
-import net.sourceforge.pmd.lang.java.ast.ASTArrayInitializer;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
-import net.sourceforge.pmd.lang.java.ast.ASTExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTStringLiteral;
-import net.sourceforge.pmd.lang.java.ast.ASTVariableAccess;
-import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
-import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
-import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 
 /**
  * Finds hardcoded static Initialization Vectors vectors used with cryptographic
@@ -31,51 +22,9 @@ import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
  * @since 6.3.0
  *
  */
-public class InsecureCryptoIvRule extends AbstractJavaRulechainRule {
-
-    private static final Class<?> IV_PARAMETER_SPEC = javax.crypto.spec.IvParameterSpec.class;
+public class InsecureCryptoIvRule extends HardCodedConstructorArgsBaseRule {
 
     public InsecureCryptoIvRule() {
-        super(ASTConstructorCall.class);
-    }
-
-    @Override
-    public Object visit(ASTConstructorCall node, Object data) {
-        if (TypeTestUtil.isA(IV_PARAMETER_SPEC, node)) {
-            ASTArgumentList arguments = node.getArguments();
-            if (arguments.size() > 0) {
-                validateProperIv(data, arguments.get(0));
-            }
-        }
-        return data;
-    }
-
-    private void validateProperIv(Object data, ASTExpression firstArgumentExpression) {
-        if (firstArgumentExpression == null) {
-            return;
-        }
-
-        // named variable
-        if (firstArgumentExpression instanceof ASTVariableAccess) {
-            ASTVariableAccess varAccess = (ASTVariableAccess) firstArgumentExpression;
-            if (varAccess.getSignature() != null && varAccess.getSignature().getSymbol() != null) {
-                ASTVariableDeclaratorId varDecl = varAccess.getSignature().getSymbol().tryGetNode();
-                validateProperIv(data, varDecl.getInitializer());
-            }
-        }
-
-        // hard coded array
-        if (firstArgumentExpression instanceof ASTArrayAllocation) {
-            ASTArrayInitializer arrayInit = ((ASTArrayAllocation) firstArgumentExpression).getArrayInitializer();
-            if (arrayInit != null) {
-                addViolation(data, arrayInit);
-            }
-        }
-
-        // string literal
-        ASTStringLiteral literal = firstArgumentExpression.descendants(ASTStringLiteral.class).first();
-        if (literal != null) {
-            addViolation(data, literal);
-        }
+        super(ASTConstructorCall.class, javax.crypto.spec.IvParameterSpec.class);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/InsecureCryptoIvRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/InsecureCryptoIvRule.java
@@ -20,7 +20,7 @@ package net.sourceforge.pmd.lang.java.rule.security;
  * @since 6.3.0
  *
  */
-public class InsecureCryptoIvRule extends HardCodedConstructorArgsBaseRule {
+public class InsecureCryptoIvRule extends AbstractHardCodedConstructorArgsVisitor {
 
     public InsecureCryptoIvRule() {
         super(javax.crypto.spec.IvParameterSpec.class);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/InsecureCryptoIvRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/InsecureCryptoIvRule.java
@@ -4,8 +4,6 @@
 
 package net.sourceforge.pmd.lang.java.rule.security;
 
-import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
-
 /**
  * Finds hardcoded static Initialization Vectors vectors used with cryptographic
  * operations.
@@ -25,6 +23,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
 public class InsecureCryptoIvRule extends HardCodedConstructorArgsBaseRule {
 
     public InsecureCryptoIvRule() {
-        super(ASTConstructorCall.class, javax.crypto.spec.IvParameterSpec.class);
+        super(javax.crypto.spec.IvParameterSpec.class);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ExprMirror.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ExprMirror.java
@@ -462,7 +462,7 @@ public interface ExprMirror {
          *  <li>e.g. for {@code new Runnable() {}} (anonymous), returns {@code Runnable}.
          * </ul>
          */
-        JClassType getNewType();
+        @NonNull JTypeMirror getNewType();
 
         /**
          * True if this creates an anonymous class. Since java 9 those

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ExprMirror.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ExprMirror.java
@@ -19,6 +19,7 @@ import net.sourceforge.pmd.lang.java.symbols.JConstructorSymbol;
 import net.sourceforge.pmd.lang.java.types.JClassType;
 import net.sourceforge.pmd.lang.java.types.JMethodSig;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
+import net.sourceforge.pmd.lang.java.types.JTypeVar;
 import net.sourceforge.pmd.lang.java.types.OverloadSelectionResult;
 import net.sourceforge.pmd.lang.java.types.TypeOps;
 import net.sourceforge.pmd.lang.java.types.TypeSystem;
@@ -461,6 +462,10 @@ public interface ExprMirror {
          *  <li>e.g. for {@code new ArrayList<String>()}, returns {@code ArrayList<String>}.
          *  <li>e.g. for {@code new Runnable() {}} (anonymous), returns {@code Runnable}.
          * </ul>
+         *
+         * <p>Note that this returns a {@link JClassType} in valid code.
+         * Other return values may be eg {@link TypeSystem#UNKNOWN}, or
+         * a {@link JTypeVar}, but indicate malformed code.
          */
         @NonNull JTypeMirror getNewType();
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/Infer.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/Infer.java
@@ -351,7 +351,7 @@ public final class Infer {
     }
 
 
-    private JMethodSig instantiateMethodOrCtor(MethodCallSite site, MethodResolutionPhase phase, JMethodSig m) {
+    private @Nullable JMethodSig instantiateMethodOrCtor(MethodCallSite site, MethodResolutionPhase phase, JMethodSig m) {
         return site.getExpr() instanceof CtorInvocationMirror ? instantiateConstructor(m, site, phase)
                                                               : instantiateMethod(m, site, phase);
     }
@@ -366,9 +366,9 @@ public final class Infer {
      * @param site  Descriptor of the context of the call.
      * @param phase Phase in which the method is reviewed
      */
-    private JMethodSig instantiateMethod(JMethodSig m,
-                                         MethodCallSite site,
-                                         MethodResolutionPhase phase) {
+    private @Nullable JMethodSig instantiateMethod(JMethodSig m,
+                                                   MethodCallSite site,
+                                                   MethodResolutionPhase phase) {
         if (phase.requiresVarargs() && !m.isVarargs()) {
             return null; // don't log such a dumb mistake
         }
@@ -382,13 +382,21 @@ public final class Infer {
         }
     }
 
-    private JMethodSig instantiateConstructor(JMethodSig cons,
-                                              MethodCallSite site,
-                                              MethodResolutionPhase phase) {
+    private @Nullable JMethodSig instantiateConstructor(JMethodSig cons,
+                                                        MethodCallSite site,
+                                                        MethodResolutionPhase phase) {
 
         CtorInvocationMirror expr = (CtorInvocationMirror) site.getExpr();
 
-        JClassType newType = expr.getNewType();
+        JTypeMirror newTypeMaybeInvalid = expr.getNewType();
+        if (!(newTypeMaybeInvalid instanceof JClassType)) {
+            // no constructor, note also, that array type constructors
+            // don't go through these routines because there's no overloading
+            // of array ctors. They're handled entirely in LazyTypeResolver.
+            return null;
+        }
+
+        JClassType newType = (JClassType) newTypeMaybeInvalid;
         boolean isAdapted = needsAdaptation(expr, newType);
         JMethodSig adapted = isAdapted
                              ? adaptGenericConstructor(cons, newType, expr)
@@ -396,7 +404,7 @@ public final class Infer {
 
         site.maySkipInvocation(!isAdapted);
 
-        JMethodSig result = instantiateMethod(adapted, site, phase);
+        @Nullable JMethodSig result = instantiateMethod(adapted, site, phase);
         if (isAdapted && result != null) {
             // undo the adaptation
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/CtorInvocMirror.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/CtorInvocMirror.java
@@ -57,7 +57,7 @@ class CtorInvocMirror extends BaseInvocMirror<ASTConstructorCall> implements Cto
 
     @Override
     public @Nullable JTypeMirror unresolvedType() {
-        JClassType newT = getNewType();
+        JTypeMirror newT = getNewType();
         if (myNode.usesDiamondTypeArgs()) {
             if (myNode.getParent() instanceof ASTVariableDeclarator) {
                 // Foo<String> s = new Foo<>();
@@ -66,19 +66,20 @@ class CtorInvocMirror extends BaseInvocMirror<ASTConstructorCall> implements Cto
                     return explicitType.getTypeMirror();
                 }
             }
-            // eg new Foo<>() -> Foo</*error*/>
-            List<JTypeMirror> fakeTypeArgs = Collections.nCopies(newT.getSymbol().getTypeParameterCount(), factory.ts.ERROR);
-            newT = newT.withTypeArguments(fakeTypeArgs);
+            if (newT instanceof JClassType) {
+                JClassType classt = (JClassType) newT;
+                // eg new Foo<>() -> Foo</*error*/>
+                List<JTypeMirror> fakeTypeArgs = Collections.nCopies(classt.getSymbol().getTypeParameterCount(), factory.ts.ERROR);
+                newT = classt.withTypeArguments(fakeTypeArgs);
+            }
         }
         return newT;
     }
 
 
     private List<JMethodSig> getVisibleCandidates() {
-        JClassType newType = getNewType();
-        if (newType == null) {
-            return Collections.emptyList();
-        } else if (myNode.isAnonymousClass()) {
+        JTypeMirror newType = getNewType();
+        if (myNode.isAnonymousClass()) {
             return newType.isInterface() ? myNode.getTypeSystem().OBJECT.getConstructors()
                                          : newType.getConstructors();
         }
@@ -91,17 +92,19 @@ class CtorInvocMirror extends BaseInvocMirror<ASTConstructorCall> implements Cto
     }
 
     @Override
-    public JClassType getNewType() {
+    public @NonNull JTypeMirror getNewType() {
         JTypeMirror typeMirror = myNode.getTypeNode().getTypeMirror();
         if (typeMirror instanceof JClassType) {
             JClassType classTypeMirror = (JClassType) typeMirror;
             if (isDiamond()) {
-                classTypeMirror = classTypeMirror.withTypeArguments(classTypeMirror.getFormalTypeParams());
+                classTypeMirror = classTypeMirror.getGenericTypeDeclaration();
             }
             return classTypeMirror;
+        } else {
+            // this might happen if the type is not known (e.g. ts.UNKNOWN)
+            // or invalid (eg new T()), where T is a type variable
+            return typeMirror;
         }
-        // this might happen if the type is not known (e.g. SentinelType)
-        return null;
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/CtorInvocMirror.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/CtorInvocMirror.java
@@ -92,11 +92,16 @@ class CtorInvocMirror extends BaseInvocMirror<ASTConstructorCall> implements Cto
 
     @Override
     public JClassType getNewType() {
-        JClassType typeMirror = (JClassType) myNode.getTypeNode().getTypeMirror();
-        if (isDiamond()) {
-            typeMirror = typeMirror.withTypeArguments(typeMirror.getFormalTypeParams());
+        JTypeMirror typeMirror = myNode.getTypeNode().getTypeMirror();
+        if (typeMirror instanceof JClassType) {
+            JClassType classTypeMirror = (JClassType) typeMirror;
+            if (isDiamond()) {
+                classTypeMirror = classTypeMirror.withTypeArguments(classTypeMirror.getFormalTypeParams());
+            }
+            return classTypeMirror;
         }
-        return typeMirror;
+        // this might happen if the type is not known (e.g. SentinelType)
+        return null;
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/CtorInvocMirror.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/CtorInvocMirror.java
@@ -130,7 +130,7 @@ class CtorInvocMirror extends BaseInvocMirror<ASTConstructorCall> implements Cto
         }
 
         @Override
-        public JClassType getNewType() {
+        public @NonNull JClassType getNewType() {
             return getEnclosingType();
         }
 
@@ -169,7 +169,7 @@ class CtorInvocMirror extends BaseInvocMirror<ASTConstructorCall> implements Cto
         }
 
         @Override
-        public JClassType getNewType() {
+        public @NonNull JClassType getNewType() {
             // note that actually, for a qualified super ctor call,
             // the new type should be reparameterized using the LHS.
             // In valid code though, both are equivalent, todo unless the superclass is raw

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/security/HardCodedCryptoKeyTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/security/HardCodedCryptoKeyTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.lang.java.rule.security;
 
 import net.sourceforge.pmd.testframework.PmdRuleTst;
 
-@org.junit.Ignore("Rule has not been updated yet")
 public class HardCodedCryptoKeyTest extends PmdRuleTst {
     // no additional unit tests
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/security/InsecureCryptoIvTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/security/InsecureCryptoIvTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.lang.java.rule.security;
 
 import net.sourceforge.pmd.testframework.PmdRuleTst;
 
-@org.junit.Ignore("Rule has not been updated yet")
 public class InsecureCryptoIvTest extends PmdRuleTst {
     // no additional unit tests
 }

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/CtorInferenceTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/CtorInferenceTest.kt
@@ -5,6 +5,8 @@ package net.sourceforge.pmd.lang.java.types.internal.infer
 
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import net.sourceforge.pmd.lang.ast.test.shouldBeA
 import net.sourceforge.pmd.lang.java.ast.*
 import net.sourceforge.pmd.lang.java.symbols.JConstructorSymbol
 import net.sourceforge.pmd.lang.java.types.*
@@ -276,6 +278,32 @@ class CtorInferenceTest : ProcessorTestSpec({
                 it.symbol shouldBe innerCtor.symbol
                 it.symbol.tryGetNode() shouldBe innerCtor
             }
+        }
+    }
+
+    parserTest("Unresolved enclosing type for inner class ctor") {
+
+        val (acu, spy) = parser.parseWithTypeInferenceSpy(
+                """
+            class Scratch  {{
+                    someUnresolvedQualifier().new Inner();
+            }}
+            """)
+
+        val (ctor) = acu.ctorCalls().toList()
+
+        spy.shouldBeOk {
+            ctor.qualifier!!.shouldHaveType(ts.UNKNOWN)
+            ctor.typeNode.simpleName shouldBe "Inner"
+            ctor.typeNode.typeMirror.shouldBeSameInstanceAs(ctor.typeMirror)
+            ctor.typeNode shouldHaveType ts.UNKNOWN
+            // if we ever switch to creating a fake symbol
+            // .typeMirror.shouldBeA<JClassType> {
+            //     it.symbol.isUnresolved shouldBe true
+            //     it.symbol.simpleName shouldBe "Inner"
+            // }
+
+            ctor.methodType.shouldBe(ts.UNRESOLVED_METHOD)
         }
     }
 

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/ast/CtorInvocMirrorTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/ast/CtorInvocMirrorTest.kt
@@ -1,0 +1,50 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.types.internal.infer.ast
+
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall
+import net.sourceforge.pmd.lang.java.ast.ProcessorTestSpec
+import net.sourceforge.pmd.lang.java.types.shouldBeUnresolvedClass
+
+class CtorInvocMirrorTest : ProcessorTestSpec({
+
+    parserTest("Qualified constructor invocation with unresolved types") {
+        val acu = parser.parse(
+                """
+                class Foo {
+                    void bar() {
+                        Foo myObject = new Foo();
+                        myObject.new Nested();
+                    }
+                
+                    class Nested {}
+                }
+                """)
+        val invocation = acu.descendants(ASTConstructorCall::class.java).get(1)!!
+        invocation.typeMirror shouldNotBe null
+        invocation.typeMirror.shouldBeUnresolvedClass("Foo.Nested")
+    }
+
+    parserTest("Qualified constructor invocation with unresolved types uncompilable") {
+        val acu = parser.parse(
+                """
+                class Foo {
+                    void bar() {
+                        Foo myObject = new Foo();
+                        myObject.new Nested();
+                    }
+                
+                    //the nested type is not declared, so this code actually doesn't compile
+                    //but PMD should not crash
+                    //class Nested {}
+                }
+                """)
+        val invocation = acu.descendants(ASTConstructorCall::class.java).get(1)!!
+        invocation.typeMirror shouldNotBe null
+        invocation.typeMirror.shouldBeSameInstanceAs(invocation.typeSystem.UNKNOWN)
+    }
+})

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/security/xml/InsecureCryptoIv.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/security/xml/InsecureCryptoIv.xml
@@ -101,9 +101,9 @@ import java.security.SecureRandom;
 
 public class Foo {
     void encrypt() {
-        byte[] iv = new byte[16];
+        byte[] ivBytes = new byte[16];
         SecureRandom sprng = new SecureRandom();
-        sprng.nextBytes(iv);
+        sprng.nextBytes(ivBytes);
         IvParameterSpec ivs = new IvParameterSpec(ivBytes);
     }
 }


### PR DESCRIPTION
## Describe the PR

* Updated both rules HardCodedCryptoKey and InsecureCryptoIv
* Enabled the unit tests
* Introduced a common package-private base class, since both rules do actually the same - checking for hard coded constructor arguments

## Related issues

- Part of #2701 

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

