### PR TITLE
[apex] ApexDoc optionally report private and protected

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/documentation/ApexDocRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/documentation/ApexDocRule.java
@@ -26,9 +26,6 @@ import net.sourceforge.pmd.properties.PropertyDescriptor;
 
 public class ApexDocRule extends AbstractApexRule {
 
-    private boolean reportPrivate;
-    private boolean reportProtected;
-
     private static final Pattern DESCRIPTION_PATTERN = Pattern.compile("@description\\s");
     private static final Pattern RETURN_PATTERN = Pattern.compile("@return\\s");
     private static final Pattern PARAM_PATTERN = Pattern.compile("@param\\s+(\\w+)\\s");
@@ -59,21 +56,18 @@ public class ApexDocRule extends AbstractApexRule {
 
     @Override
     public Object visit(ASTUserClass node, Object data) {
-        init();
         handleClassOrInterface(node, data);
         return data;
     }
 
     @Override
     public Object visit(ASTUserInterface node, Object data) {
-        init();
         handleClassOrInterface(node, data);
         return data;
     }
 
     @Override
     public Object visit(ASTMethod node, Object data) {
-        init();
         if (node.getParent() instanceof ASTProperty) {
             // Skip property methods, doc is required on the property itself
             return data;
@@ -113,7 +107,6 @@ public class ApexDocRule extends AbstractApexRule {
 
     @Override
     public Object visit(ASTProperty node, Object data) {
-        init();
         ApexDocComment comment = getApexDocComment(node);
         if (comment == null) {
             if (shouldHaveApexDocs(node)) {
@@ -126,11 +119,6 @@ public class ApexDocRule extends AbstractApexRule {
         }
 
         return data;
-    }
-
-    protected void init() {
-        reportPrivate = getProperty(REPORT_PRIVATE_DESCRIPTOR);
-        reportProtected = getProperty(REPORT_PROTECTED_DESCRIPTOR);
     }
 
     private void handleClassOrInterface(ApexNode<?> node, Object data) {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/documentation/ApexDocRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/documentation/ApexDocRule.java
@@ -160,8 +160,8 @@ public class ApexDocRule extends AbstractApexRule {
 
         ASTModifierNode modifier = node.getFirstChildOfType(ASTModifierNode.class);
         if (modifier != null) {
-            Boolean flagPrivate = reportPrivate && modifier.isPrivate();
-            Boolean flagProtected = reportProtected && modifier.isProtected();
+            boolean flagPrivate = getProperty(REPORT_PRIVATE_DESCRIPTOR) && modifier.isPrivate();
+            boolean flagProtected = getProperty(REPORT_PROTECTED_DESCRIPTOR) && modifier.isProtected();
             return (modifier.isPublic() || modifier.isGlobal() || flagPrivate || flagProtected) && !modifier.isOverride();
         }
         return false;

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/documentation/xml/ApexDoc.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/documentation/xml/ApexDoc.xml
@@ -49,6 +49,15 @@ private class Foo { }
     </test-code>
 
     <test-code>
+        <description>private class should have comment if specified</description>
+        <rule-property name="reportPrivate">true</rule-property>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+private class Foo { }
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>class comment should have description</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>3</expected-linenumbers>
@@ -110,6 +119,15 @@ private interface Foo { }
     </test-code>
 
     <test-code>
+        <description>private interface should have comment if specified</description>
+        <rule-property name="reportPrivate">true</rule-property>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+private interface Foo { }
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>interface comment should have description</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
@@ -164,6 +182,62 @@ public class Foo {
  */
 public class Foo {
     global void bar() { }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>private method does not need comment</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+/**
+ * @description Foo
+ */
+public class Foo {
+    private void bar() { }
+}
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>private method should have comment if specified</description>
+        <rule-property name="reportPrivate">true</rule-property>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+/**
+ * @description Foo
+ */
+public class Foo {
+    private void bar() { }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>protected method does not need comment</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+/**
+ * @description Foo
+ */
+public class Foo {
+    protected void bar() { }
+}
+        ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>protected method should have comment if specified</description>
+        <rule-property name="reportProtected">true</rule-property>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+/**
+ * @description Foo
+ */
+public class Foo {
+    protected void bar() { }
 }
         ]]></code>
     </test-code>
@@ -355,6 +429,60 @@ public class Foo {
         ]]></code>
     </test-code>
 
+    <test-code>
+        <description>private property does not need a comment</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+/**
+ * @description Foo
+ */
+public class Foo {
+    private Object Bar { get; set; }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>private property should have a comment if specified</description>
+        <rule-property name="reportPrivate">true</rule-property>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+/**
+ * @description Foo
+ */
+public class Foo {
+    private Object Bar { get; set; }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>protected property does not need a comment</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+/**
+ * @description Foo
+ */
+public class Foo {
+    protected Object Bar { get; set; }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>protected property should have a comment if specified</description>
+        <rule-property name="reportProtected">true</rule-property>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+/**
+ * @description Foo
+ */
+public class Foo {
+    protected Object Bar { get; set; }
+}
+        ]]></code>
+    </test-code>
+    
     <test-code>
         <description>property comment should have description</description>
         <expected-problems>1</expected-problems>


### PR DESCRIPTION
## Describe the PR

Grants the ability to report missing ApexDoc in classes, methods and properties that have a `private` or `protected` access modifier.

Two new properties have been added to the ApexDoc rule  

* `reportPrivate`
* `reportProtected`

Those have a `false` default value to avoid inconsistent behaviour with existing rulesets.


## Related issues

- Fixes #3075

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

