### PR TITLE
[plsql] Fix ParseException for EXECUTE IMMEDIATE str1||str2;

### DIFF
--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -2686,7 +2686,7 @@ ASTFetchStatement FetchStatement()  :
 ASTEmbeddedSqlStatement EmbeddedSqlStatement()  :
 {}
 {
-   <EXECUTE> <IMMEDIATE> (StringLiteral() | Expression())
+   <EXECUTE> <IMMEDIATE> Expression()
 	[ <INTO> Name() ("," Name())* ]
 	[ <USING> [ <IN> [ <OUT> ] | <OUT> ]  Expression() ("," [ <IN> [ <OUT> ] | <OUT> ] Expression())* ]
 	[ ( <RETURN> | <RETURNING> )  <INTO> Expression() ("," Expression())*] ";"

--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -2686,7 +2686,7 @@ ASTFetchStatement FetchStatement()  :
 ASTEmbeddedSqlStatement EmbeddedSqlStatement()  :
 {}
 {
-   <EXECUTE> <IMMEDIATE> Expression()
+   <EXECUTE> <IMMEDIATE> StringExpression()
 	[ <INTO> Name() ("," Name())* ]
 	[ <USING> [ <IN> [ <OUT> ] | <OUT> ]  Expression() ("," [ <IN> [ <OUT> ] | <OUT> ] Expression())* ]
 	[ ( <RETURN> | <RETURNING> )  <INTO> Expression() ("," Expression())*] ";"

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLParserTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLParserTest.java
@@ -73,4 +73,9 @@ public class PLSQLParserTest extends AbstractPLSQLParserTst {
     public void testCaseIssue1454() {
         plsql.parseResource("CaseIssue1454.pls");
     }
+
+    @Test
+    public void testCaseIssue3106() {
+        plsql.parse("CREATE OR REPLACE PROCEDURE bar\nIS\n  v_link varchar2(10) := 'xxx';\nBEGIN\n  EXECUTE IMMEDIATE 'drop database link ' || v_link;\nEND bar;");
+    }
 }

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLParserTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLParserTest.java
@@ -75,7 +75,7 @@ public class PLSQLParserTest extends AbstractPLSQLParserTst {
     }
 
     @Test
-    public void testCaseIssue3106() {
-        plsql.parse("CREATE OR REPLACE PROCEDURE bar\nIS\n  v_link varchar2(10) := 'xxx';\nBEGIN\n  EXECUTE IMMEDIATE 'drop database link ' || v_link;\nEND bar;");
+    public void testExecuteImmediateIssue3106() {
+        plsql.parseResource("ExecuteImmediateIssue3106.pls");
     }
 }

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/ExecuteImmediateIssue3106.pls
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/ExecuteImmediateIssue3106.pls
@@ -1,0 +1,11 @@
+--
+-- BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+--
+
+CREATE OR REPLACE PROCEDURE bar
+IS
+    v_link varchar2(10) := 'xxx';
+BEGIN
+    -- EXECUTE IMMEDIATE with an expression instead of just a literal or variable.
+    EXECUTE IMMEDIATE 'drop database link ' || v_link;
+END bar;


### PR DESCRIPTION
## Describe the PR

This fixes the ParseExeception for the PLSQL parser when it finds a statement like

    EXECUTE IMMEDIATE 'drop database link ' || v_link_name;

## Related issues

- Fixes #3106

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

