### PR TITLE
[ci] Stop logging download progress in CI

### DIFF
--- a/.ci/build-pr-win-macos.sh
+++ b/.ci/build-pr-win-macos.sh
@@ -24,7 +24,7 @@ log_group_start "Downloading maven dependencies"
 log_group_end
 
 log_group_start "Building with maven"
-    ./mvnw -e -V clean verify ${PMD_EXTRA_OPT}
+    ./mvnw -e -V -B clean verify ${PMD_EXTRA_OPT}
 log_group_end
 
 

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -121,7 +121,7 @@ function pmd_ci_build_run() {
         log_info "This is a snapshot build"
     fi
 
-    ./mvnw clean deploy -P${mvn_profiles} -e -V -Djava7.home=${HOME}/oraclejdk7 --no-transfer-progress
+    ./mvnw clean deploy -P${mvn_profiles} -e -B -V -Djava7.home=${HOME}/oraclejdk7
 }
 
 #

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -121,7 +121,7 @@ function pmd_ci_build_run() {
         log_info "This is a snapshot build"
     fi
 
-    ./mvnw clean deploy -P${mvn_profiles} -e -V -Djava7.home=${HOME}/oraclejdk7
+    ./mvnw clean deploy -P${mvn_profiles} -e -V -Djava7.home=${HOME}/oraclejdk7 --no-transfer-progress
 }
 
 #

--- a/.ci/inc/maven-dependencies.inc
+++ b/.ci/inc/maven-dependencies.inc
@@ -23,19 +23,20 @@ function maven_dependencies_resolve() {
     # build first the modules, that have dependencies between themselves
     # first build pmd-lang-test, pmd-test and pmd-core - used by all modules
     ./mvnw clean install -pl pmd-core,pmd-test,pmd-lang-test -DskipTests -Dpmd.skip=true \
-           -Dcheckstyle.skip=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true
+           --no-transfer-progress -Dcheckstyle.skip=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true
     # then build dependencies for pmd-visualforce needs: pmd-apex->pmd-apex-jorje+pmd-test+pmd-core
     ./mvnw clean install -pl pmd-core,pmd-test,pmd-lang-test,pmd-apex-jorje,pmd-apex -DskipTests -Dpmd.skip=true \
-           -Dcheckstyle.skip=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true
+           --no-transfer-progress -Dcheckstyle.skip=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true
 
     # the resolve most other projects. The excluded projects depend on other projects in the reactor, which is not
     # completely built yet, so these are excluded.
-    ./mvnw dependency:resolve -pl '!pmd-dist,!pmd-java8,!pmd-doc,!pmd-scala'
+    ./mvnw dependency:resolve -pl '!pmd-dist,!pmd-java8,!pmd-doc,!pmd-scala' --no-transfer-progress
 
-    ./mvnw dependency:get -DgroupId=org.jetbrains.dokka \
+    ./mvnw dependency:get --no-transfer-progress \
+           -DgroupId=org.jetbrains.dokka \
            -DartifactId=dokka-maven-plugin \
            -Dversion=${dokka_version} \
            -Dpackaging=jar \
            -DremoteRepositories=jcenter::default::https://jcenter.bintray.com/
-    ./mvnw dependency:resolve-plugins -DexcludeGroupIds=org.jetbrains.dokka -Psign
+    ./mvnw dependency:resolve-plugins --no-transfer-progress -DexcludeGroupIds=org.jetbrains.dokka -Psign
 }

--- a/.ci/inc/maven-dependencies.inc
+++ b/.ci/inc/maven-dependencies.inc
@@ -30,13 +30,13 @@ function maven_dependencies_resolve() {
 
     # the resolve most other projects. The excluded projects depend on other projects in the reactor, which is not
     # completely built yet, so these are excluded.
-    ./mvnw dependency:resolve -pl '!pmd-dist,!pmd-java8,!pmd-doc,!pmd-scala' --no-transfer-progress
+    ./mvnw dependency:resolve -pl '!pmd-dist,!pmd-java8,!pmd-doc,!pmd-scala'  -Dsilent --no-transfer-progress
 
-    ./mvnw dependency:get --no-transfer-progress \
+    ./mvnw dependency:get --no-transfer-progress -Dsilent \
            -DgroupId=org.jetbrains.dokka \
            -DartifactId=dokka-maven-plugin \
            -Dversion=${dokka_version} \
            -Dpackaging=jar \
            -DremoteRepositories=jcenter::default::https://jcenter.bintray.com/
-    ./mvnw dependency:resolve-plugins --no-transfer-progress -DexcludeGroupIds=org.jetbrains.dokka -Psign
+    ./mvnw dependency:resolve-plugins --no-transfer-progress -Dsilent -DexcludeGroupIds=org.jetbrains.dokka -Psign
 }

--- a/.ci/inc/maven-dependencies.inc
+++ b/.ci/inc/maven-dependencies.inc
@@ -23,20 +23,20 @@ function maven_dependencies_resolve() {
     # build first the modules, that have dependencies between themselves
     # first build pmd-lang-test, pmd-test and pmd-core - used by all modules
     ./mvnw clean install -pl pmd-core,pmd-test,pmd-lang-test -DskipTests -Dpmd.skip=true \
-           --no-transfer-progress -Dcheckstyle.skip=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true
+           -B -Dcheckstyle.skip=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true
     # then build dependencies for pmd-visualforce needs: pmd-apex->pmd-apex-jorje+pmd-test+pmd-core
     ./mvnw clean install -pl pmd-core,pmd-test,pmd-lang-test,pmd-apex-jorje,pmd-apex -DskipTests -Dpmd.skip=true \
-           --no-transfer-progress -Dcheckstyle.skip=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true
+           -B -Dcheckstyle.skip=true -Dmaven.javadoc.skip=true -Dmaven.source.skip=true
 
     # the resolve most other projects. The excluded projects depend on other projects in the reactor, which is not
     # completely built yet, so these are excluded.
-    ./mvnw dependency:resolve -pl '!pmd-dist,!pmd-java8,!pmd-doc,!pmd-scala'  -Dsilent --no-transfer-progress
+    ./mvnw dependency:resolve -pl '!pmd-dist,!pmd-java8,!pmd-doc,!pmd-scala'  -Dsilent -B
 
-    ./mvnw dependency:get --no-transfer-progress -Dsilent \
+    ./mvnw dependency:get -B -Dsilent \
            -DgroupId=org.jetbrains.dokka \
            -DartifactId=dokka-maven-plugin \
            -Dversion=${dokka_version} \
            -Dpackaging=jar \
            -DremoteRepositories=jcenter::default::https://jcenter.bintray.com/
-    ./mvnw dependency:resolve-plugins --no-transfer-progress -Dsilent -DexcludeGroupIds=org.jetbrains.dokka -Psign
+    ./mvnw dependency:resolve-plugins -B -Dsilent -DexcludeGroupIds=org.jetbrains.dokka -Psign
 }


### PR DESCRIPTION
## Describe the PR

Use the `--no-transfer-progress` Maven option in the CI scripts.  We could also use batch mode (`-B`), but i'm not sure what else that changes

See also https://stackoverflow.com/questions/21638697/disable-maven-download-progress-indication 

I hope, this removes the rows of download progress from the build log. In a normal terminal these lines overwrite each other so it's not so noisy.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #3067

## Ready?

I tried this out quickly in a docker but I'm not sure if there are other things it would break, or if I updated all the relevant places. 

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

