### PR TITLE
[doc] Fix sample code indentation in documentation

### DIFF
--- a/docs/pages/pmd/userdocs/configuring_rules.md
+++ b/docs/pages/pmd/userdocs/configuring_rules.md
@@ -60,8 +60,8 @@ All property assignments must be enclosed in a `properties` element, which is it
 
 Some properties take multiple values (a list), in which case you can provide them all by delimiting them with a delimiter character. It is usually a pipe ('\|'), or a comma (',') for numeric properties, e.g.
 ```xml
- <property name="legalCollectionTypes"
-           value="java.util.ArrayList|java.util.Vector|java.util.HashMap"/>
+<property name="legalCollectionTypes"
+          value="java.util.ArrayList|java.util.Vector|java.util.HashMap"/>
 ```
 
 These properties are referred to as **multivalued properties** in this documentation.

--- a/docs/pages/pmd/userdocs/cpd/cpd.md
+++ b/docs/pages/pmd/userdocs/cpd/cpd.md
@@ -253,14 +253,14 @@ For details, see [CPD Report Formats](pmd_userdocs_cpd_report_formats.html).
 Andy Glover wrote an Ant task for CPD; here's how to use it:
 
 ```xml
-    <target name="cpd">
-        <taskdef name="cpd" classname="net.sourceforge.pmd.cpd.CPDTask" />
-        <cpd minimumTokenCount="100" outputFile="/home/tom/cpd.txt">
-            <fileset dir="/home/tom/tmp/ant">
-                <include name="**/*.java"/>
-            </fileset>
-        </cpd>
-    </target>
+<target name="cpd">
+    <taskdef name="cpd" classname="net.sourceforge.pmd.cpd.CPDTask" />
+    <cpd minimumTokenCount="100" outputFile="/home/tom/cpd.txt">
+        <fileset dir="/home/tom/tmp/ant">
+            <include name="**/*.java"/>
+        </fileset>
+    </cpd>
+</target>
 ```
 
 <!--  TODO avoid duplicating the descriptions! -->
@@ -352,7 +352,7 @@ Also, you can get an HTML report from CPD by using the XSLT script in pmd/etc/xs
 the CPD task as usual and right after it invoke the Ant XSLT script like this:
 
 ```xml
-    <xslt in="cpd.xml" style="etc/xslt/cpdhtml.xslt" out="cpd.html" />
+<xslt in="cpd.xml" style="etc/xslt/cpdhtml.xslt" out="cpd.html" />
 ```
 
 ## GUI
@@ -378,23 +378,23 @@ Arbitrary blocks of code can be ignored through comments on **Java**, **C/C++**,
 **Kotlin**, **Lua**, **Matlab**, **Objective-C**, **PL/SQL**, **Python**, **Scala**, **Swift** and **C#** by including the keywords `CPD-OFF` and `CPD-ON`.
 
 ```java
-    public Object someParameterizedFactoryMethod(int x) throws Exception {
-        // some unignored code
+public Object someParameterizedFactoryMethod(int x) throws Exception {
+    // some unignored code
 
-        // tell cpd to start ignoring code - CPD-OFF
+    // tell cpd to start ignoring code - CPD-OFF
 
-        // mission critical code, manually loop unroll
-        goDoSomethingAwesome(x + x / 2);
-        goDoSomethingAwesome(x + x / 2);
-        goDoSomethingAwesome(x + x / 2);
-        goDoSomethingAwesome(x + x / 2);
-        goDoSomethingAwesome(x + x / 2);
-        goDoSomethingAwesome(x + x / 2);
+    // mission critical code, manually loop unroll
+    goDoSomethingAwesome(x + x / 2);
+    goDoSomethingAwesome(x + x / 2);
+    goDoSomethingAwesome(x + x / 2);
+    goDoSomethingAwesome(x + x / 2);
+    goDoSomethingAwesome(x + x / 2);
+    goDoSomethingAwesome(x + x / 2);
 
-        // resume CPD analysis - CPD-ON
+    // resume CPD analysis - CPD-ON
 
-        // further code will *not* be ignored
-    }
+    // further code will *not* be ignored
+}
 ```
 
 Additionally, **Java** allows to toggle suppression by adding the annotations
@@ -405,15 +405,15 @@ This approach however, is limited to the locations were `@SuppressWarnings` is a
 It's legacy and the new comment's based approach should be favored.
 
 ```java
-    //enable suppression
-    @SuppressWarnings("CPD-START")
-    public Object someParameterizedFactoryMethod(int x) throws Exception {
-        // any code here will be ignored for the duplication detection
-    }
-    //disable suppression
-    @SuppressWarnings("CPD-END)
-    public void nextMethod() {
-    }
+//enable suppression
+@SuppressWarnings("CPD-START")
+public Object someParameterizedFactoryMethod(int x) throws Exception {
+    // any code here will be ignored for the duplication detection
+}
+//disable suppression
+@SuppressWarnings("CPD-END)
+public void nextMethod() {
+}
 ```
 
 Other languages currently have no support to suppress CPD reports. In the future,

--- a/docs/pages/pmd/userdocs/tools/maven.md
+++ b/docs/pages/pmd/userdocs/tools/maven.md
@@ -26,17 +26,17 @@ report additionally in `<reporting><plugins/></reporting>` elements. Here's an e
 section:
 
 ```xml
-    <build>
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-pmd-plugin</artifactId>
-                    <version>{{ page.mpmd_version }}</version>
-                </plugin>
-            </plugins>
-        </pluginManagement>
-    </build>
+<build>
+    <pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-pmd-plugin</artifactId>
+                <version>{{ page.mpmd_version }}</version>
+            </plugin>
+        </plugins>
+    </pluginManagement>
+</build>
 ```
 
 When defining the version in the pluginManagment section, then it doesn't need to be specified in the normal plugins
@@ -123,22 +123,22 @@ To specify a ruleset, simply edit the previous configuration:
 
 
 ``` xml
-    <reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-pmd-plugin</artifactId>
-                <version>{{ page.mpmd_version }}</version>
-                <configuration>
-                    <rulesets>
-                        <ruleset>/rulesets/java/quickstart.xml</ruleset>
-                        <ruleset>d:\rulesets\my-ruleset.xml</ruleset>
-                        <ruleset>http://localhost/design.xml</ruleset>
-                    </rulesets>
-                </configuration>
-            </plugin>
-        </plugins>
-    </reporting>
+<reporting>
+    <plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-pmd-plugin</artifactId>
+            <version>{{ page.mpmd_version }}</version>
+            <configuration>
+                <rulesets>
+                    <ruleset>/rulesets/java/quickstart.xml</ruleset>
+                    <ruleset>d:\rulesets\my-ruleset.xml</ruleset>
+                    <ruleset>http://localhost/design.xml</ruleset>
+                </rulesets>
+            </configuration>
+        </plugin>
+    </plugins>
+</reporting>
 ```
 
 The value of the 'ruleset' element can either be a relative address, an absolute address or even an url.
@@ -156,17 +156,17 @@ When using the Maven PMD plugin 3.8 or later along with PMD 5.6.0 or later, you 
 speed up PMD's execution while retaining the quality of the analysis. You can additionally customize where the cache is stored::
 
 ```xml
-    <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-pmd-plugin</artifactId>
-        <version>{{ page.mpmd_version }}</version> <!-- or use version from pluginManagement -->
-        <configuration>
-            <!-- enable incremental analysis -->
-            <analysisCache>true</analysisCache>
-            <!-- analysisCacheLocation: optional - points to the following location by default -->
-            <analysisCacheLocation>${project.build.directory}/pmd/pmd.cache</analysisCacheLocation>
-        </configuration>
-    </plugin>
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-pmd-plugin</artifactId>
+    <version>{{ page.mpmd_version }}</version> <!-- or use version from pluginManagement -->
+    <configuration>
+        <!-- enable incremental analysis -->
+        <analysisCache>true</analysisCache>
+        <!-- analysisCacheLocation: optional - points to the following location by default -->
+        <analysisCacheLocation>${project.build.directory}/pmd/pmd.cache</analysisCacheLocation>
+    </configuration>
+</plugin>
 ```
 
 #### Other configurations
@@ -175,17 +175,17 @@ The Maven PMD plugin allows you to configure CPD, targetJDK, and the use of XRef
 the report to html source files, and the file encoding:
 
 ```xml
-    <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-pmd-plugin</artifactId>
-        <version>{{ page.mpmd_version }}</version> <!-- or use version from pluginManagement -->
-        <configuration>
-            <linkXRef>true</linkXRef>
-            <sourceEncoding>ISO-8859-1</sourceEncoding>
-            <minimumTokens>30</minimumTokens>
-            <targetJdk>1.4</targetJdk>
-        </configuration>
-    </plugin>
+<plugin>
+    <groupId>org.apache.maven.plugins</groupId>
+    <artifactId>maven-pmd-plugin</artifactId>
+    <version>{{ page.mpmd_version }}</version> <!-- or use version from pluginManagement -->
+    <configuration>
+        <linkXRef>true</linkXRef>
+        <sourceEncoding>ISO-8859-1</sourceEncoding>
+        <minimumTokens>30</minimumTokens>
+        <targetJdk>1.4</targetJdk>
+    </configuration>
+</plugin>
 ```
 
 #### Upgrading the PMD version at runtime


### PR DESCRIPTION
Affected pages:

* [CPD](https://pmd.github.io/latest/pmd_userdocs_cpd.html)
* [PMD: configuring rules](https://pmd.github.io/latest/pmd_userdocs_configuring_rules.html)
* [PMD: Maven plugin](https://pmd.github.io/latest/pmd_userdocs_tools_maven.html)