### PR TITLE
[java] NullPointerException when running PMD under JRE 11 (fixes #3101)

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -40,6 +40,8 @@ Note: Support for Java 14 preview language features have been removed. The versi
 
 *   apex-documentation
     *   [#3075](https://github.com/pmd/pmd/issues/3075): \[apex] ApexDoc should support private access modifier
+*   java
+    *   [#3101](https://github.com/pmd/pmd/issues/3101): \[java] NullPointerException when running PMD under JRE 11
 *   plsql
     *   [#3106](https://github.com/pmd/pmd/issues/3106): \[plsql] ParseException while parsing EXECUTE IMMEDIATE 'drop database link ' || linkname;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/MethodTypeResolution.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/typeresolution/MethodTypeResolution.java
@@ -728,7 +728,13 @@ public final class MethodTypeResolution {
         List<JavaTypeDefinition> result = new ArrayList<>();
 
         for (int childIndex = 0; childIndex < typeArguments.getNumChildren(); ++childIndex) {
-            result.add(((TypeNode) typeArguments.getChild(childIndex)).getTypeDefinition());
+            JavaTypeDefinition typeDefinition = ((TypeNode) typeArguments.getChild(childIndex)).getTypeDefinition();
+            // avoid returning null. Null means, we couldn't resolve the explicit type of the type argument
+            // probably because of incomplete auxclasspath. In that case, we just use Object as the type.
+            if (typeDefinition == null) {
+                typeDefinition = JavaTypeDefinition.forClass(Object.class);
+            }
+            result.add(typeDefinition);
         }
 
         return result;

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
@@ -307,4 +307,9 @@ public class ParserCornersTest {
 
     private static final String CAST_LOOKAHEAD_PROBLEM =
         "public class BadClass {\n  public Class foo() {\n    return (byte[].class);\n  }\n}";
+
+    @Test
+    public void testGithubBug3101UnresolvedTypeParams() {
+        java.parseResource("GitHubBug3101.java");
+    }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/MyList.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/MyList.java
@@ -1,0 +1,13 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.typeresolution.testdata;
+
+/**
+ * @see <a href="https://github.com/pmd/pmd/issues/3101">[java] NullPointerException when running PMD under JRE 11 #3101</a>
+ */
+public interface MyList<E> {
+
+    <E> MyList<E> of(E e1);
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/MyListAbstract.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/typeresolution/testdata/MyListAbstract.java
@@ -1,0 +1,15 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.typeresolution.testdata;
+
+/**
+ * @see <a href="https://github.com/pmd/pmd/issues/3101">[java] NullPointerException when running PMD under JRE 11 #3101</a>
+ */
+public abstract class MyListAbstract<E> implements MyList<E> {
+
+    public <E> MyListAbstract<E> of(E e1) {
+        return null;
+    }
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/GitHubBug3101.java
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/GitHubBug3101.java
@@ -1,0 +1,20 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+import net.sourceforge.pmd.typeresolution.testdata.MyList;
+import net.sourceforge.pmd.typeresolution.testdata.MyListAbstract;
+
+/**
+ * Note: This class is not compiled (the source is only in src/test/resources). Hence we can't
+ * resolve {@code GitHubBug3101.Inner} and the explicit type arguments is not resolved.
+ *
+ * @see <a href="https://github.com/pmd/pmd/issues/3101">[java] NullPointerException when running PMD under JRE 11 #3101</a>
+ */
+public class GitHubBug3101 {
+    {
+        MyList<Inner> a = MyListAbstract.<Inner>of(new Inner());
+    }
+
+    private static class Inner { }
+}


### PR DESCRIPTION
## Describe the PR

If the explicit type arguments couldn't be resolved due to incomplete auxclasspath, we now use "Object" instead of null.

- Fixes #3101 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed) (release notes)

