### PR TITLE
[java] CompareObjectsWithEqualsRule: False positive with Enums

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -40,6 +40,8 @@ Note: Support for Java 14 preview language features have been removed. The versi
 
 *   apex-documentation
     *   [#3075](https://github.com/pmd/pmd/issues/3075): \[apex] ApexDoc should support private access modifier
+*   java-errorprone
+    *   [#2716](https://github.com/pmd/pmd/issues/2716): \[java] CompareObjectsWithEqualsRule: False positive with Enums
 *   plsql
     *   [#3106](https://github.com/pmd/pmd/issues/3106): \[plsql] ParseException while parsing EXECUTE IMMEDIATE 'drop database link ' || linkname;
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CompareObjectsWithEquals.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CompareObjectsWithEquals.xml
@@ -349,4 +349,20 @@ public class C0 {
         ]]></code>
     </test-code>
 
+    <test-code>
+        <description>[java] CompareObjectsWithEqualsRule: False positive with Enums #2716</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class EnumTest {
+    enum Type {
+        A, B;
+    }
+    private final Type type = Type.A;
+    public String isTypeA(Type param) {
+        return param == type ? "Yes" : "No";
+    }
+}
+        ]]></code>
+    </test-code>
+
 </test-data>


### PR DESCRIPTION
Add a unit test to verify #2716

As described in the issue, with type resolution, this FP is not reproducible. Without type resolution, it is fixed since 6.30.0.

This uses the same test case as from https://github.com/pmd/pmd/commit/7c5fbb26ac402991f25837565c0aacbfbec9617b (pmd7). However, we probably get a merge conflict, or we get the test case twice. So, we need to watch out when merging master->pmd7.
