### PR TITLE
[java] InvalidLogMessageFormat fix FP with StringFormattedMessage and ParameterizedMessage

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -40,6 +40,8 @@ Note: Support for Java 14 preview language features have been removed. The versi
 
 *   apex-documentation
     *   [#3075](https://github.com/pmd/pmd/issues/3075): \[apex] ApexDoc should support private access modifier
+*   java-errorprone
+    *   [#3133](https://github.com/pmd/pmd/issues/3133): \[java] InvalidLogMessageFormat FP with StringFormattedMessage and ParameterizedMessage
 *   plsql
     *   [#3106](https://github.com/pmd/pmd/issues/3106): \[plsql] ParseException while parsing EXECUTE IMMEDIATE 'drop database link ' \|\| linkname;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidLogMessageFormatRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidLogMessageFormatRule.java
@@ -12,11 +12,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import org.apache.commons.lang3.StringUtils;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
+import net.sourceforge.pmd.lang.java.ast.ASTArrayInitializer;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBody;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
 import net.sourceforge.pmd.lang.java.ast.ASTEnumBody;
@@ -34,21 +35,30 @@ import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableInitializer;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
+import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.lang.symboltable.NameDeclaration;
 
 public class InvalidLogMessageFormatRule extends AbstractJavaRule {
+
+    /**
+     * Finds placeholder for ParameterizedMessages and format specifiers
+     * for StringFormattedMessages.
+     */
+    private static final Pattern PLACEHOLDER_AND_FORMAT_SPECIFIER = 
+            Pattern.compile("(\\{\\})|(%(?:\\d\\$)?(?:\\w+)?(?:\\d+)?(?:\\.\\d+)?\\w)");
+
     private static final Map<String, Set<String>> LOGGERS;
 
     static {
         Map<String, Set<String>> loggersMap = new HashMap<>();
 
         loggersMap.put("org.slf4j.Logger", Collections
-                .unmodifiableSet(new HashSet<String>(Arrays.asList("trace", "debug", "info", "warn", "error"))));
+                .unmodifiableSet(new HashSet<>(Arrays.asList("trace", "debug", "info", "warn", "error"))));
         loggersMap.put("org.apache.logging.log4j.Logger", Collections
-                .unmodifiableSet(new HashSet<String>(Arrays.asList("trace", "debug", "info", "warn", "error", "fatal", "all"))));
+                .unmodifiableSet(new HashSet<>(Arrays.asList("trace", "debug", "info", "warn", "error", "fatal", "all"))));
 
         LOGGERS = loggersMap;
     }
@@ -114,10 +124,20 @@ public class InvalidLogMessageFormatRule extends AbstractJavaRule {
             removeThrowableParam(argumentList);
         }
 
-        if (argumentList.size() < expectedArguments) {
+        int providedArguments = argumentList.size();
+
+        // last argument could be an array with parameters
+        if (argumentList.size() == 1 && TypeTestUtil.isA("java.lang.Object[]", argumentList.get(0))) {
+            ASTArrayInitializer arrayInitializer = argumentList.get(0).getFirstDescendantOfType(ASTArrayInitializer.class);
+            if (arrayInitializer != null) {
+                providedArguments = arrayInitializer.getNumChildren();
+            }
+        }
+
+        if (providedArguments < expectedArguments) {
             addViolationWithMessage(data, node,
                     "Missing arguments," + getExpectedMessage(argumentList, expectedArguments));
-        } else if (argumentList.size() > expectedArguments) {
+        } else if (providedArguments > expectedArguments) {
             addViolationWithMessage(data, node,
                     "Too many arguments," + getExpectedMessage(argumentList, expectedArguments));
         }
@@ -131,7 +151,7 @@ public class InvalidLogMessageFormatRule extends AbstractJavaRule {
         return TypeTestUtil.isA(Throwable.class, last.getFirstDescendantOfType(ASTClassOrInterfaceType.class));
     }
 
-    private boolean hasTypeThrowable(ASTPrimaryExpression last) {
+    private boolean hasTypeThrowable(TypeNode last) {
         // if the type could be determined already
         return last.getType() != null && TypeTestUtil.isA(Throwable.class, last);
     }
@@ -159,9 +179,10 @@ public class InvalidLogMessageFormatRule extends AbstractJavaRule {
             return;
         }
         int lastIndex = params.size() - 1;
-        ASTPrimaryExpression last = params.get(lastIndex).getFirstDescendantOfType(ASTPrimaryExpression.class);
+        ASTExpression lastExpression = params.get(lastIndex);
+        ASTPrimaryExpression last = lastExpression.getFirstDescendantOfType(ASTPrimaryExpression.class);
 
-        if (isNewThrowable(last) || hasTypeThrowable(last) || isReferencingThrowable(last) || isLambdaParameter(last)) {
+        if (isNewThrowable(last) || hasTypeThrowable(lastExpression) || isReferencingThrowable(last) || isLambdaParameter(last)) {
             params.remove(lastIndex);
         }
     }
@@ -250,7 +271,13 @@ public class InvalidLogMessageFormatRule extends AbstractJavaRule {
         // together...
         int result = 0;
         for (ASTLiteral stringLiteral : literals) {
-            result += StringUtils.countMatches(stringLiteral.getImage(), "{}");
+            Matcher matcher = PLACEHOLDER_AND_FORMAT_SPECIFIER.matcher(stringLiteral.getImage());
+            while (matcher.find()) {
+                String format = matcher.group();
+                if (!"%%".equals(format) && !"%n".equals(format)) {
+                    result++;
+                }
+            }
         }
         return result;
     }

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2166,11 +2166,15 @@ Class c = String.class;
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#invalidlogmessageformat">
         <description>
 Check for messages in slf4j and log4j2 (since 6.19.0) loggers with non matching number of arguments and placeholders.
+
+Since 6.32.0 in addition to parameterized message placeholders (`{}`) also format specifiers of string formatted
+messages are supported (`%s`).
         </description>
         <priority>5</priority>
         <example>
 <![CDATA[
 LOGGER.error("forget the arg {}");
+LOGGER.error("forget the arg %s");
 LOGGER.error("too many args {}", "arg1", "arg2");
 LOGGER.error("param {}", "arg1", new IllegalStateException("arg")); //The exception is shown separately, so is correct.
 ]]>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidLogMessageFormat.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidLogMessageFormat.xml
@@ -887,4 +887,45 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[java] InvalidLogMessageFormat FP with StringFormattedMessage and ParameterizedMessage #3133</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>10,14</expected-linenumbers>
+        <expected-messages>
+            <message>Missing arguments, expected 2 arguments but have 1</message>
+            <message>Too many arguments, expected 1 argument but have 2</message>
+        </expected-messages>
+        <code><![CDATA[
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class TestInvalidLogMessageFormat {
+    Logger log = LoggerFactory.getLogger(TestInvalidLogMessageFormat.class);
+
+    public void testPMD() {
+        /* whistled, fp*/ log.debug("param %10s %% %n %%", "1"); // string formatted message
+
+        /*10:violation*/ log.debug("param %.2d%s", "expected 2 params, given 1");
+        try {
+            throw new Exception();
+        } catch (Exception e) {
+            /*14:violation*/ log.debug("param %s", "expected 1 params, given 2", "too many params", e);
+        }
+    }
+
+    protected void logProblem(String type, Object val) {
+        if (log.isDebugEnabled() && val instanceof Throwable) {
+            /*whistled, fp*/ log.debug("Trace for "+type+" reading "+getBriefDescription()+": "+val, (Throwable)val);
+        }
+
+        if (log.isDebugEnabled()) {
+            /*whistled, fp*/ log.debug("Recurring {} reading {} in {} (still in grace period): {}", new Object[] {type, this, getBriefDescription(), val});
+        }
+    }
+
+    private String getBriefDescription() { return ""; }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

- Fixes #3133

~Hm... basically this adds now support for StringFormattedMessages, which not documented.... maybe we should update the rule doc?~ :heavy_check_mark: 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed).

