### PR TITLE
[core] Trim property values

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -40,6 +40,8 @@ Note: Support for Java 14 preview language features have been removed. The versi
 
 *   apex-documentation
     *   [#3075](https://github.com/pmd/pmd/issues/3075): \[apex] ApexDoc should support private access modifier
+*   java-errorprone
+    *   [#3089](https://github.com/pmd/pmd/issues/3089): \[java] CloseResource rule throws exception on spaces in property types
 *   plsql
     *   [#3106](https://github.com/pmd/pmd/issues/3106): \[plsql] ParseException while parsing EXECUTE IMMEDIATE 'drop database link ' \|\| linkname;
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/AbstractMultiValueProperty.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/AbstractMultiValueProperty.java
@@ -179,7 +179,7 @@ import net.sourceforge.pmd.Rule;
             return Collections.emptyList();
         }
 
-        String[] strValues = valueString.split(Pattern.quote("" + multiValueDelimiter()));
+        String[] strValues = valueString.split(Pattern.quote(String.valueOf(multiValueDelimiter())));
 
         List<V> values = new ArrayList<>(strValues.length);
         for (String strValue : strValues) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/ValueParserConstants.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/ValueParserConstants.java
@@ -40,7 +40,7 @@ public final class ValueParserConstants {
     static final ValueParser<Method> METHOD_PARSER = new ValueParser<Method>() {
         @Override
         public Method valueOf(String value) throws IllegalArgumentException {
-            return methodFrom(value, CLASS_METHOD_DELIMITER, METHOD_ARG_DELIMITER);
+            return methodFrom(StringUtils.trim(value), CLASS_METHOD_DELIMITER, METHOD_ARG_DELIMITER);
         }
 
 
@@ -158,21 +158,21 @@ public final class ValueParserConstants {
     static final ValueParser<String> STRING_PARSER = new ValueParser<String>() {
         @Override
         public String valueOf(String value) {
-            return value;
+            return StringUtils.trim(value);
         }
     };
     /** Extracts integers. */
     static final ValueParser<Integer> INTEGER_PARSER = new ValueParser<Integer>() {
         @Override
         public Integer valueOf(String value) {
-            return Integer.valueOf(value);
+            return Integer.valueOf(StringUtils.trim(value));
         }
     };
     /** Extracts booleans. */
     static final ValueParser<Boolean> BOOLEAN_PARSER = new ValueParser<Boolean>() {
         @Override
         public Boolean valueOf(String value) {
-            return Boolean.valueOf(value);
+            return Boolean.valueOf(StringUtils.trim(value));
         }
     };
     /** Extracts floats. */
@@ -186,7 +186,7 @@ public final class ValueParserConstants {
     static final ValueParser<Long> LONG_PARSER = new ValueParser<Long>() {
         @Override
         public Long valueOf(String value) {
-            return Long.valueOf(value);
+            return Long.valueOf(StringUtils.trim(value));
         }
     };
     /** Extracts doubles. */
@@ -200,7 +200,7 @@ public final class ValueParserConstants {
     static final ValueParser<File> FILE_PARSER = new ValueParser<File>() {
         @Override
         public File valueOf(String value) throws IllegalArgumentException {
-            return new File(value);
+            return new File(StringUtils.trim(value));
         }
     };
 
@@ -216,17 +216,19 @@ public final class ValueParserConstants {
     static final ValueParser<Class> CLASS_PARSER = new ValueParser<Class>() {
         @Override
         public Class valueOf(String value) throws IllegalArgumentException {
-            if (StringUtils.isBlank(value)) {
+            String className = StringUtils.trimToNull(value);
+
+            if (className == null) {
                 return null;
             }
 
-            Class<?> cls = ClassUtil.getTypeFor(value);
+            Class<?> cls = ClassUtil.getTypeFor(className);
             if (cls != null) {
                 return cls;
             }
 
             try {
-                return Class.forName(value);
+                return Class.forName(className);
             } catch (ClassNotFoundException ex) {
                 throw new IllegalArgumentException(value);
             }
@@ -248,10 +250,11 @@ public final class ValueParserConstants {
         return new ValueParser<T>() {
             @Override
             public T valueOf(String value) throws IllegalArgumentException {
-                if (!mappings.containsKey(value)) {
-                    throw new IllegalArgumentException("Value was not in the set " + mappings.keySet());
+                String trimmedValue = StringUtils.trim(value);
+                if (!mappings.containsKey(trimmedValue)) {
+                    throw new IllegalArgumentException("Value " + value + " was not in the set " + mappings.keySet());
                 }
-                return mappings.get(value);
+                return mappings.get(trimmedValue);
             }
         };
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/properties/PropertyDescriptorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/properties/PropertyDescriptorTest.java
@@ -157,6 +157,7 @@ public class PropertyDescriptorTest {
         assertEquals("hello", descriptor.description());
         assertEquals(Integer.valueOf(1), descriptor.defaultValue());
         assertEquals(Integer.valueOf(5), descriptor.valueFrom("5"));
+        assertEquals(Integer.valueOf(5), descriptor.valueFrom(" 5 "));
 
         PropertyDescriptor<List<Integer>> listDescriptor = PropertyFactory.intListProperty("intListProp")
                 .desc("hello")
@@ -166,6 +167,7 @@ public class PropertyDescriptorTest {
         assertEquals("hello", listDescriptor.description());
         assertEquals(Arrays.asList(1, 2), listDescriptor.defaultValue());
         assertEquals(Arrays.asList(5, 7), listDescriptor.valueFrom("5,7"));
+        assertEquals(Arrays.asList(5, 7), listDescriptor.valueFrom(" 5 , 7 "));
     }
 
     @Test
@@ -189,6 +191,7 @@ public class PropertyDescriptorTest {
         assertEquals("hello", descriptor.description());
         assertEquals(Double.valueOf(1.0), descriptor.defaultValue());
         assertEquals(Double.valueOf(2.0), descriptor.valueFrom("2.0"));
+        assertEquals(Double.valueOf(2.0), descriptor.valueFrom("  2.0  "));
 
         PropertyDescriptor<List<Double>> listDescriptor = PropertyFactory.doubleListProperty("doubleListProp")
                 .desc("hello")
@@ -198,6 +201,7 @@ public class PropertyDescriptorTest {
         assertEquals("hello", listDescriptor.description());
         assertEquals(Arrays.asList(1.0, 2.0), listDescriptor.defaultValue());
         assertEquals(Arrays.asList(2.0, 3.0), listDescriptor.valueFrom("2.0,3.0"));
+        assertEquals(Arrays.asList(2.0, 3.0), listDescriptor.valueFrom(" 2.0 , 3.0 "));
     }
 
     @Test
@@ -221,6 +225,7 @@ public class PropertyDescriptorTest {
         assertEquals("hello", descriptor.description());
         assertEquals("default value", descriptor.defaultValue());
         assertEquals("foo", descriptor.valueFrom("foo"));
+        assertEquals("foo", descriptor.valueFrom("  foo   "));
 
         PropertyDescriptor<List<String>> listDescriptor = PropertyFactory.stringListProperty("stringListProp")
                 .desc("hello")
@@ -230,6 +235,7 @@ public class PropertyDescriptorTest {
         assertEquals("hello", listDescriptor.description());
         assertEquals(Arrays.asList("v1", "v2"), listDescriptor.defaultValue());
         assertEquals(Arrays.asList("foo", "bar"), listDescriptor.valueFrom("foo|bar"));
+        assertEquals(Arrays.asList("foo", "bar"), listDescriptor.valueFrom("  foo |  bar  "));
     }
 
     private enum SampleEnum { A, B, C }

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2497,7 +2497,7 @@ See the property `annotations`.
         </description>
         <priority>3</priority>
         <properties>
-            <property name="annotations" type="List[String]" delimiter="," value="org.springframework.beans.factory.annotation.Autowired, javax.inject.Inject" description="If a constructor is annotated with one of these annotations, then the class is ignored."/>
+            <property name="annotations" type="List[String]" delimiter="," value="org.springframework.beans.factory.annotation.Autowired,javax.inject.Inject" description="If a constructor is annotated with one of these annotations, then the class is ignored."/>
             <property name="version" value="2.0"/>
             <property name="xpath">
                 <value>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
@@ -1518,4 +1518,28 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[java] CloseResource rule throws exception on spaces in property types #3089</description>
+        <!-- all whitespaces for the properties are important for the test: leading, tailing, and in the middle -->
+        <rule-property name="types"> java.sql.Connection , java.sql.Statement , java.sql.ResultSet </rule-property>
+        <rule-property name="allowedResourceTypes"> java.io.ByteArrayOutputStream | java.io.ByteArrayInputStream | java.io.StringWriter | java.io.CharArrayWriter | java.util.stream.Stream | java.util.stream.IntStream | java.util.stream.LongStream | java.util.stream.DoubleStream </rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.*;
+public class Foo {
+    public void bar() {
+        InputStream in = null;
+        try {
+            in = new FileInputStream("test");
+        } catch (IOException ignored) {
+        } finally {
+            if (in != null) {
+                in.close();
+            }
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
- Most single-valued properties are trimmed
- Some types keep whitespaces, e.g. Character and Regex

Fixes #3089

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

