### PR TITLE
[java] ConsecutiveLiteralAppend false-positive with builder inside lambda

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -16,6 +16,9 @@ This is a {{ site.pmd.release_type }} release.
 
 ### Fixed Issues
 
+*   java-performance
+    *   [#2427](https://github.com/pmd/pmd/issues/2427): \[java] ConsecutiveLiteralAppend false-positive with builder inside lambda
+
 ### API Changes
 
 ### External Contributions

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/ConsecutiveLiteralAppends.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/ConsecutiveLiteralAppends.xml
@@ -1497,4 +1497,32 @@ public class Foo {
             }
             ]]></code>
     </test-code>
+    <test-code>
+        <description>[java] ConsecutiveLiteralAppend false-positive with builder inside lambda #2427</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.Map;
+import java.util.Collection;
+import java.util.function.Consumer;
+
+public class FalsePositive {
+
+    public void fp1(Map<Class<?>, Consumer<?>> consumerMap, final StringBuilder builder) {
+        consumerMap.put(Collection.class, o -> {
+            builder.append('['); 
+            Collection<?> collection = (Collection<?>) o;
+            collection.forEach(t -> builder.append(t));
+            builder.append(']'); // here reported (with pmd 6.22.0)
+        });
+
+        consumerMap.put(Map.class, o -> {
+            builder.append('{');
+            Map<?, ?> map = (Map<?, ?>) o;
+            map.forEach((k, v) -> builder.append(k).append('=').append(v));
+            builder.append('}');
+        });
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Add test case for #2427, already fixed since PMD 6.25.0

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

