### PR TITLE
[java] ConsecutiveLiteralAppends and InsufficientStringBufferDeclaration: FP with switch expressions

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -16,6 +16,9 @@ This is a {{ site.pmd.release_type }} release.
 
 ### Fixed Issues
 
+*   java-performance
+    *   [#3152](https://github.com/pmd/pmd/issues/3152): \[java] ConsecutiveLiteralAppends and InsufficientStringBufferDeclaration: FP with switch expressions
+
 ### API Changes
 
 ### External Contributions

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveLiteralAppendsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveLiteralAppendsRule.java
@@ -28,6 +28,8 @@ import net.sourceforge.pmd.lang.java.ast.ASTName;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchLabel;
+import net.sourceforge.pmd.lang.java.ast.ASTSwitchLabeledBlock;
+import net.sourceforge.pmd.lang.java.ast.ASTSwitchLabeledExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableInitializer;
@@ -80,6 +82,8 @@ public class ConsecutiveLiteralAppendsRule extends AbstractJavaRule {
         BLOCK_PARENTS.add(ASTCatchStatement.class);
         BLOCK_PARENTS.add(ASTFinallyStatement.class);
         BLOCK_PARENTS.add(ASTLambdaExpression.class);
+        BLOCK_PARENTS.add(ASTSwitchLabeledBlock.class);
+        BLOCK_PARENTS.add(ASTSwitchLabeledExpression.class);
     }
 
     private static final PropertyDescriptor<Integer> THRESHOLD_DESCRIPTOR
@@ -91,6 +95,7 @@ public class ConsecutiveLiteralAppendsRule extends AbstractJavaRule {
 
     public ConsecutiveLiteralAppendsRule() {
         definePropertyDescriptor(THRESHOLD_DESCRIPTOR);
+        addRuleChainVisit(ASTVariableDeclaratorId.class);
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
@@ -25,6 +25,8 @@ import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchLabel;
+import net.sourceforge.pmd.lang.java.ast.ASTSwitchLabeledBlock;
+import net.sourceforge.pmd.lang.java.ast.ASTSwitchLabeledExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
@@ -44,13 +46,19 @@ public class InsufficientStringBufferDeclarationRule extends AbstractJavaRule {
     private static final Set<Class<? extends Node>> BLOCK_PARENTS;
 
     static {
-        BLOCK_PARENTS = new HashSet<>(2);
+        BLOCK_PARENTS = new HashSet<>();
         BLOCK_PARENTS.add(ASTIfStatement.class);
         BLOCK_PARENTS.add(ASTSwitchStatement.class);
+        BLOCK_PARENTS.add(ASTSwitchLabeledBlock.class);
+        BLOCK_PARENTS.add(ASTSwitchLabeledExpression.class);
     }
 
     // as specified in StringBuffer and StringBuilder
     public static final int DEFAULT_BUFFER_SIZE = 16;
+
+    public InsufficientStringBufferDeclarationRule() {
+        addRuleChainVisit(ASTVariableDeclaratorId.class);
+    }
 
     @Override
     public Object visit(ASTVariableDeclaratorId node, Object data) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/ConsecutiveLiteralAppends.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/ConsecutiveLiteralAppends.xml
@@ -1497,4 +1497,37 @@ public class Foo {
             }
             ]]></code>
     </test-code>
+    <test-code>
+        <description>[java] ConsecutiveLiteralAppends and InsufficientStringBufferDeclaration: FP with switch expressions #3152</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class FalsePositive {
+
+    public static String escapeHTML(String text) {
+        int length = text.length();
+        int index = findHTMLReservedChar(text);
+        if (index == length) return text;
+        var builder = new StringBuilder(length * 2); // Rule:InsufficientStringBufferDeclaration Priority:3 StringBuffer constructor is initialized with size 16, but has at least 29 characters appended..
+        for (int i = 0; i < index; i++) builder.append(text.charAt(i));
+        for (; index < length; index++) {
+            char ch = text.charAt(index);
+            switch (ch) {
+                case '<' -> { builder.append("&lt;"); } // Rule:ConsecutiveLiteralAppends Priority:3 StringBuffer (or StringBuilder).append is called 6 consecutive times with literals. Use a single append with a single combined String..
+                case '>' -> builder.append("&gt;");
+                case '"' -> builder.append("&quot;");
+                case '&' -> builder.append("&amp;");
+                case '\'' -> builder.append("&#39;");
+                case '/' -> builder.append("&#47;");
+                default -> builder.append(ch);
+            }
+        }
+        return builder.toString();
+    }
+
+    private static int findHTMLReservedChar(String text) {
+        return 0;
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/InsufficientStringBufferDeclaration.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/InsufficientStringBufferDeclaration.xml
@@ -1068,4 +1068,37 @@ public class Test {
             }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>[java] ConsecutiveLiteralAppends and InsufficientStringBufferDeclaration: FP with switch expressions #3152</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class FalsePositive {
+
+    public static String escapeHTML(String text) {
+        int length = text.length();
+        int index = findHTMLReservedChar(text);
+        if (index == length) return text;
+        var builder = new StringBuilder(length * 2); // Rule:InsufficientStringBufferDeclaration Priority:3 StringBuffer constructor is initialized with size 16, but has at least 29 characters appended..
+        for (int i = 0; i < index; i++) builder.append(text.charAt(i));
+        for (; index < length; index++) {
+            char ch = text.charAt(index);
+            switch (ch) {
+                case '<' -> { builder.append("&lt;"); } // Rule:ConsecutiveLiteralAppends Priority:3 StringBuffer (or StringBuilder).append is called 6 consecutive times with literals. Use a single append with a single combined String..
+                case '>' -> builder.append("&gt;");
+                case '"' -> builder.append("&quot;");
+                case '&' -> builder.append("&amp;");
+                case '\'' -> builder.append("&#39;");
+                case '/' -> builder.append("&#47;");
+                default -> builder.append(ch);
+            }
+        }
+        return builder.toString();
+    }
+
+    private static int findHTMLReservedChar(String text) {
+        return 0;
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
- Fixes #3152

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

