### PR TITLE
[java] GuardLogStatement: False negative with unguarded method call

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -16,6 +16,10 @@ This is a {{ site.pmd.release_type }} release.
 
 ### Fixed Issues
 
+*   java-bestpractices
+    *   [#3144](https://github.com/pmd/pmd/issues/3144): \[java] GuardLogStatement can have more detailed example
+    *   [#3155](https://github.com/pmd/pmd/pull/3155): \[java] GuardLogStatement: False negative with unguarded method call
+
 ### API Changes
 
 ### External Contributions

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -604,7 +604,7 @@ with lambdas. The available alternatives depend on the actual logging framework.
         <example>
 <![CDATA[
     // Add this for performance
-    if (log.isDebugEnabled() {
+    if (log.isDebugEnabled()) {
         log.debug("log something" + " and " + "concat strings");
     }
 

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -596,13 +596,26 @@ for (int i = 0, j = 0; i < 10; i++, j += 2) {
         <description>
 Whenever using a log level, one should check if the loglevel is actually enabled, or
 otherwise skip the associate String creation and manipulation.
+
+An alternative to checking the log level are substituting parameters, formatters or lazy logging
+with lambdas. The available alternatives depend on the actual logging framework.
         </description>
         <priority>2</priority>
         <example>
 <![CDATA[
     // Add this for performance
-    if (log.isDebugEnabled() { ...
+    if (log.isDebugEnabled() {
         log.debug("log something" + " and " + "concat strings");
+    }
+
+    // Avoid the guarding if statement with substituting parameters
+    log.debug("log something {} and {}", param1, param2);
+
+    // Avoid the guarding if statement with formatters
+    log.debug("log something %s and %s", param1, param2);
+
+    // Avoid the guarding if statement with lazy logging and lambdas
+    log.debug("log something expensive: {}", () -> calculateExpensiveLoggingText());
 ]]>
         </example>
     </rule>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
@@ -427,4 +427,39 @@ public class GuardLogStatement {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#3155 False negatives with unguarded method calls</description>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>5,6,7</expected-linenumbers>
+        <code><![CDATA[
+public class Logger {
+    private static final Logger LOGGER = new Logger();
+
+    public void bar() {
+        LOGGER.info("Message with param: {}", expensiveOperation()); // bad, expensiveOperation is executed regardless
+        LOGGER.info("Message with param: %s", this.expensiveOperation()); // bad, expensiveOperation is executed regardless
+        LOGGER.info(expensiveOperation()); // bad, expensiveOperation is executed regardless
+
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("Message with param: {}", expensiveOperation());
+        }
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info("Message with param: %s", expensiveOperation());
+        }
+        if (LOGGER.isInfoEnabled()) {
+            LOGGER.info(expensiveOperation());
+        }
+
+        LOGGER.info("Message with param: {}", () -> expensiveOperation());
+        LOGGER.info("Message with param: %s", () -> expensiveOperation());
+        LOGGER.info(()-> expensiveOperation());
+    }
+
+    private String expensiveOperation() {
+        return "...";
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
- Fixes #3144 (doc update, examples)
- Fixes false negative with method calls as arguments

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

