### PR TITLE
[apex] ExcessiveClassLength multiple warning on the same class

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -16,6 +16,9 @@ This is a {{ site.pmd.release_type }} release.
 
 ### Fixed Issues
 
+*   apex-design
+    *   [#3142](https://github.com/pmd/pmd/issues/3142): \[apex] ExcessiveClassLength multiple warning on the same class
+
 ### API Changes
 
 ### External Contributions

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethod.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethod.java
@@ -35,7 +35,44 @@ public class ASTMethod extends AbstractApexNode<Method> implements ApexQualifiab
     }
 
     @Override
+    public int getBeginLine() {
+        if (!hasRealLoc()) {
+            // this is a synthetic method, only in the AST, not in the source
+            // search for the last sibling with real location from the end
+            // and place this synthetic method after it.
+            for (int i = getParent().getNumChildren() - 1; i >= 0; i--) {
+                ApexNode<?> sibling = getParent().getChild(i);
+                if (sibling.hasRealLoc()) {
+                    return sibling.getEndLine();
+                }
+            }
+        }
+        return super.getBeginLine();
+    }
+
+    @Override
+    public int getBeginColumn() {
+        if (!hasRealLoc()) {
+            // this is a synthetic method, only in the AST, not in the source
+            // search for the last sibling with real location from the end
+            // and place this synthetic method after it.
+            for (int i = getParent().getNumChildren() - 1; i >= 0; i--) {
+                ApexNode<?> sibling = getParent().getChild(i);
+                if (sibling.hasRealLoc()) {
+                    return sibling.getEndColumn();
+                }
+            }
+        }
+        return super.getBeginColumn();
+    }
+
+    @Override
     public int getEndLine() {
+        if (!hasRealLoc()) {
+            // this is a synthetic method, only in the AST, not in the source
+            return this.getBeginLine();
+        }
+
         ASTBlockStatement block = getFirstChildOfType(ASTBlockStatement.class);
         if (block != null) {
             return block.getEndLine();
@@ -46,6 +83,11 @@ public class ASTMethod extends AbstractApexNode<Method> implements ApexQualifiab
 
     @Override
     public int getEndColumn() {
+        if (!hasRealLoc()) {
+            // this is a synthetic method, only in the AST, not in the source
+            return this.getBeginColumn();
+        }
+
         ASTBlockStatement block = getFirstChildOfType(ASTBlockStatement.class);
         if (block != null) {
             return block.getEndColumn();

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexRootNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexRootNode.java
@@ -20,12 +20,25 @@ public abstract class ApexRootNode<T extends AstNode> extends AbstractApexNode<T
         super(node);
     }
 
-    // For top level classes, the end is the end of file.
     @Override
     void calculateLineNumbers(SourceCodePositioner positioner) {
         super.calculateLineNumbers(positioner);
-        this.endLine = positioner.getLastLine();
-        this.endColumn = positioner.getLastLineColumn();
+        
+        if (getParent() == null) {
+            // For top level classes, the end is the end of file.
+            this.endLine = positioner.getLastLine();
+            this.endColumn = positioner.getLastLineColumn();
+        } else {
+            // For nested classes, look for the position of the last child, which has a real location
+            for (int i = getNumChildren() - 1; i >= 0; i--) {
+                ApexNode<?> child = getChild(i);
+                if (child.hasRealLoc()) {
+                    this.endLine = child.getEndLine();
+                    this.endColumn = child.getEndColumn();
+                    break;
+                }
+            }
+        }
     }
 
     /**

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexTreeBuilder.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexTreeBuilder.java
@@ -283,7 +283,6 @@ public final class ApexTreeBuilder extends AstVisitor<AdditionalPassScope> {
     public <T extends AstNode> ApexNode<T> build(T astNode) {
         // Create a Node
         AbstractApexNode<T> node = createNodeAdapter(astNode);
-        node.calculateLineNumbers(sourceCodePositioner);
         node.handleSourceCode(sourceCode);
 
         // Append to parent
@@ -304,6 +303,11 @@ public final class ApexTreeBuilder extends AstVisitor<AdditionalPassScope> {
             // add the comments only at the end of the processing as the last step
             addFormalComments();
         }
+
+        // calculate line numbers after the tree is built
+        // so that we can look at parent/children to figure
+        // out the positions if necessary.
+        node.calculateLineNumbers(sourceCodePositioner);
 
         return node;
     }

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexParserTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexParserTest.java
@@ -179,6 +179,42 @@ public class ApexParserTest extends ApexParserTestBase {
         Assert.assertEquals(487, count);
     }
 
+    @Test
+    public void verifyLineColumnNumbersInnerClasses() throws Exception {
+        String source = IOUtils.toString(ApexParserTest.class.getResourceAsStream("InnerClassLocations.cls"),
+                StandardCharsets.UTF_8);
+        ApexNode<Compilation> rootNode = parse(source);
+        Assert.assertNotNull(rootNode);
+
+        visitPosition(rootNode, 0);
+
+        Assert.assertEquals("InnerClassLocations", rootNode.getImage());
+        // Note: Apex parser doesn't provide positions for "public class" keywords. The
+        // position of the UserClass node is just the identifier. So, the node starts
+        // with the identifier and not with the first keyword in the file...
+        assertPosition(rootNode, 1, 14, 16, 2);
+
+        List<ASTUserClass> classes = rootNode.findDescendantsOfType(ASTUserClass.class);
+        Assert.assertEquals(2, classes.size());
+        Assert.assertEquals("bar1", classes.get(0).getImage());
+        List<ASTMethod> methods = classes.get(0).findChildrenOfType(ASTMethod.class);
+        Assert.assertEquals(2, methods.size()); // m() and synthetic clone()
+        Assert.assertEquals("m", methods.get(0).getImage());
+        assertPosition(methods.get(0), 4, 21, 7, 9);
+        Assert.assertEquals("clone", methods.get(1).getImage());
+        assertPosition(methods.get(1), 7, 9, 7, 9);
+
+        // Position of the first inner class: starts with the identifier "bar1" and ends with
+        // the last real method m(). The last bracket it actually on the next line 8, but we
+        // don't see this in the AST.
+        assertPosition(classes.get(0), 3, 18, 7, 9);
+
+        Assert.assertEquals("bar2", classes.get(1).getImage());
+        assertPosition(classes.get(1), 10, 18, 14, 9);
+    }
+
+    // TEST HELPER
+
     private int visitPosition(Node node, int count) {
         int result = count + 1;
         Assert.assertTrue(node.getBeginLine() > 0);
@@ -190,8 +226,6 @@ public class ApexParserTest extends ApexParserTestBase {
         }
         return result;
     }
-
-    // TEST HELPER
 
     private static void assertPosition(Node node, int beginLine, int beginColumn, int endLine, int endColumn) {
         assertEquals("Wrong begin line", beginLine, node.getBeginLine());

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexParserTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexParserTest.java
@@ -183,6 +183,7 @@ public class ApexParserTest extends ApexParserTestBase {
     public void verifyLineColumnNumbersInnerClasses() throws Exception {
         String source = IOUtils.toString(ApexParserTest.class.getResourceAsStream("InnerClassLocations.cls"),
                 StandardCharsets.UTF_8);
+        source = source.replaceAll("\r\n", "\n");
         ApexNode<Compilation> rootNode = parse(source);
         Assert.assertNotNull(rootNode);
 

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/ast/InnerClassLocations.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/ast/InnerClassLocations.cls
@@ -1,0 +1,16 @@
+public class InnerClassLocations {
+
+    public class bar1 {
+        public void m() {
+            System.out.println('foo');
+            System.out.println('foo');
+        }
+    }
+
+    public class bar2 {
+        public void m() {
+            System.out.println('foo');
+            System.out.println('foo');
+        }
+    }
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/xml/ExcessiveClassLength.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/xml/ExcessiveClassLength.xml
@@ -91,4 +91,29 @@ public class SomeClass {
 }
        ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[apex] ExcessiveClassLength multiple warning on the same class #3142</description>
+        <rule-property name="minimum">10</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>1</expected-linenumbers>
+        <code><![CDATA[
+public class FooSmaller {
+
+    public class bar1 {
+        public void m() {
+            System.out.println('foo');
+            System.out.println('foo');
+        }
+    }
+
+    public class bar2 {
+        public void m() {
+            System.out.println('foo');
+            System.out.println('foo');
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
- fixes #3142

Not perfect, but better than before. The classes at least look ok, but the synthetic methods/nodes (like UserClassMethods, BridgeMethodCreator) look still weird.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

