### PR TITLE
[java] UnusedPrivateMethod false positive when passing in lombok.val as argument

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -16,6 +16,9 @@ This is a {{ site.pmd.release_type }} release.
 
 ### Fixed Issues
 
+*   java-bestpractices
+    *   [#3118](https://github.com/pmd/pmd/issues/3118): \[java] UnusedPrivateMethod false positive when passing in lombok.val as argument
+
 ### API Changes
 
 ### External Contributions

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
@@ -31,6 +31,10 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
     private static final Set<String> SERIALIZATION_METHODS = new HashSet<>(Arrays.asList(
             "readObject", "writeObject", "readResolve", "writeReplace"));
 
+    public UnusedPrivateMethodRule() {
+        addRuleChainVisit(ASTClassOrInterfaceDeclaration.class);
+    }
+
     @Override
     protected Collection<String> defaultSuppressionAnnotations() {
         return Collections.singletonList("java.lang.Deprecated");

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/ClassScope.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/ClassScope.java
@@ -532,9 +532,10 @@ public class ClassScope extends AbstractJavaScope {
                     type = convertToSimpleType(classInterface);
                 }
             }
-            if (type == null && !parameterTypes.isEmpty()) {
+            if ((type == null || "lombok.val".equals(type.getTypeImage())) && !parameterTypes.isEmpty()) {
                 // replace the unknown type with the correct parameter type
-                // of the method.
+                // of the method. unknown type could be a "var" (local variable type inference)
+                // or a lombok.val type.
                 // in case the argument is itself a method call, we can't
                 // determine the result type of the called
                 // method. Therefore the parameter type is used.

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
@@ -1658,4 +1658,23 @@ public class OOO {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[java] UnusedPrivateMethod false positive when passing in lombok.val as argument #3118</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import lombok.val;
+
+public class ValExample {
+    public void example() {
+        val example = "value";
+        aPrivateMethod(example);
+    }
+
+    private void aPrivateMethod(String s) {
+        System.out.println(s);
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
@@ -1677,4 +1677,27 @@ public class ValExample {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>False negative with unused private method in nested classes</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>2,4</expected-linenumbers>
+        <code><![CDATA[
+public class Outer {
+    private void outerUnusedMethod() {}
+    public class Inner {
+        private void innerUnusedMethod() {} // false negative
+        private void innerUsedByInnerMethod() {}
+        public void publicInnerMethod() {
+            innerUsedByInnerMethod();
+        }
+        private void innerUsedByOuterMethod() {}
+    }
+    public void publicOuterMethod() {
+        Inner inner = new Inner();
+        inner.innerUsedByOuterMethod();
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
- Fixes #3118
- Is as good as "var", which means, we don't check / determine
  the actual type. Could lead to false negatives, when overloaded
  methods are used.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

