### PR TITLE
[java] Infinite loop when parsing invalid code nested in lambdas

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -16,6 +16,9 @@ This is a {{ site.pmd.release_type }} release.
 
 ### Fixed Issues
 
+*   java
+    *   [#3117](https://github.com/pmd/pmd/issues/3117): \[java] Infinite loop when parsing invalid code nested in lambdas
+
 ### API Changes
 
 ### External Contributions

--- a/pmd-java/etc/grammar/Java.jjt
+++ b/pmd-java/etc/grammar/Java.jjt
@@ -237,6 +237,11 @@ options {
   TRACK_TOKENS = true;
   NODE_PACKAGE="net.sourceforge.pmd.lang.java.ast";
 
+  // disable the calculation of expected tokens when a parse error occurs
+  // depending on the possible allowed next tokens, this
+  // could be expensive (see https://github.com/pmd/pmd/issues/3117)
+  //ERROR_REPORTING = false;
+
   //DEBUG_PARSER = true;
   //DEBUG_LOOKAHEAD = true;
   //DEBUG_TOKEN_MANAGER = true;
@@ -2131,9 +2136,9 @@ void StatementExpression() :
 |
   PreDecrementExpression()
 |
-  LOOKAHEAD( PrimaryExpression() AssignmentOperator() ) PrimaryExpression() AssignmentOperator() Expression()
-|
-  PostfixExpression()
+  // using PostfixExpression here allows us to skip the part of the production tree
+  // between Expression() and PostfixExpression()
+  PostfixExpression() [ AssignmentOperator() Expression() ]
 }
 
 void SwitchStatement():

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
@@ -226,6 +226,13 @@ public class ParserCornersTest {
         java8.parseResource("GitHubBug309.java");
     }
 
+    @Test(timeout = 30000)
+    public void testInfiniteLoopInLookahead() {
+        expect.expect(ParseException.class);
+        // https://github.com/pmd/pmd/issues/3117
+        java8.parseResource("InfiniteLoopInLookahead.java");
+    }
+
     /**
      * This triggered bug #1484 UnusedLocalVariable - false positive -
      * parenthesis

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/InfiniteLoopInLookahead.java
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/InfiniteLoopInLookahead.java
@@ -1,0 +1,28 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+import java.util.*;
+
+public class InfiniteLoopInLookahead {
+
+    public void exam1(List resList) {
+        resList.forEach(a -> {
+            resList.forEach(b -> {
+                resList.forEach(c -> {
+                    resList.forEach(d -> {
+                        resList.forEach(e -> {
+                            resList.forEach(f -> {
+                                resList.forEach(g -> {
+                                    resList.forEach(h -> {
+                                        resList // note: missing semicolon -> parse error here...
+                                    });
+                                });
+                            });
+                        });
+                    });
+                });
+            });
+        });
+    }
+}


### PR DESCRIPTION
- fixes #3117
- backports part of StatementExpression production from pmd7

When the parse exception occurs, javacc tries to figure out, which tokens instead of the current one and which next tokens would make a valid source code. And there seems to be lots of options...

One way would be, to disable this feature (via ERROR_REPORTING=false). But I found the difference in the grammars between pmd6/pmd7: It's in the StatementExpression.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [x] Added (in-code) documentation (if needed)

