### PR TITLE
[java] Minor typo in quickstart ruleset

### DIFF
--- a/pmd-java/src/main/resources/rulesets/java/quickstart.xml
+++ b/pmd-java/src/main/resources/rulesets/java/quickstart.xml
@@ -143,7 +143,7 @@
     <!-- <rule ref="category/java/design.xml/ImmutableField" /> -->
     <!-- <rule ref="category/java/design.xml/LawOfDemeter" /> -->
     <rule ref="category/java/design.xml/LogicInversion"/>
-    <!-- <rule ref="category/java/design.xml/LoosePackageCouling"> -->
+    <!-- <rule ref="category/java/design.xml/LoosePackageCoupling"> -->
     <!--     <properties> -->
     <!--         <property name="packages" value="org.sample,org.sample2" /> -->
     <!--         <property name="classes" value="org.sample.SampleInterface,org.sample2.SampleInterface" /> -->


### PR DESCRIPTION
Fixed package name from LoosePackageCouling -> LoosePackageCoupling.

## Describe the PR

There was a minor typo in `rulesets/java/quickstart.xml`
