### PR TITLE
[java] Update junit annotation rules

### DIFF
--- a/.ci/files/all-java.xml
+++ b/.ci/files/all-java.xml
@@ -27,10 +27,10 @@
     <rule ref="category/java/bestpractices.xml/ForLoopCanBeForeach"/>
     <rule ref="category/java/bestpractices.xml/ForLoopVariableCount"/>
     <rule ref="category/java/bestpractices.xml/GuardLogStatement"/>
-    <!-- <rule ref="category/java/bestpractices.xml/JUnit4SuitesShouldUseSuiteAnnotation"/> -->
-    <!-- <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseAfterAnnotation"/> -->
-    <!-- <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseBeforeAnnotation"/> -->
-    <!-- <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseTestAnnotation"/> -->
+    <rule ref="category/java/bestpractices.xml/JUnit4SuitesShouldUseSuiteAnnotation"/>
+    <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseAfterAnnotation"/>
+    <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseBeforeAnnotation"/>
+    <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseTestAnnotation"/>
     <rule ref="category/java/bestpractices.xml/JUnitAssertionsShouldIncludeMessage"/>
     <rule ref="category/java/bestpractices.xml/JUnitTestContainsTooManyAsserts"/>
     <rule ref="category/java/bestpractices.xml/JUnitTestsShouldIncludeAssert"/>

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -620,9 +620,8 @@ through the @RunWith(Suite.class) annotation.
             <property name="xpath">
                 <value>
 <![CDATA[
-//ClassOrInterfaceBodyDeclaration
-[MethodDeclaration[@Name='suite']/ResultType/Type/ReferenceType/ClassOrInterfaceType[pmd-java:typeIs('junit.framework.Test')]]
-[not(MethodDeclaration/Block/BlockStatement/Statement/ReturnStatement//ClassOrInterfaceType[pmd-java:typeIs('junit.framework.JUnit4TestAdapter')])]
+//MethodDeclaration[@Name='suite' and ClassOrInterfaceType[pmd-java:typeIs('junit.framework.Test')]]
+                   [not(.//ReturnStatement/*[pmd-java:typeIs('junit.framework.JUnit4TestAdapter')])]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -659,9 +659,8 @@ JUnit 5 introduced @AfterEach and @AfterAll annotations to execute methods after
             <property name="xpath">
                 <value>
 <![CDATA[
-//ClassOrInterfaceBodyDeclaration
-    [MethodDeclaration[@Name='tearDown']]
-    [not(Annotation/*/Name[
+//MethodDeclaration[@Name='tearDown']
+    [not(ModifierList/Annotation[
            pmd-java:typeIs('org.junit.After')
         or pmd-java:typeIs('org.junit.jupiter.api.AfterEach')
         or pmd-java:typeIs('org.junit.jupiter.api.AfterAll')

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -701,9 +701,8 @@ JUnit 5 introduced @BeforeEach and @BeforeAll annotations to execute methods bef
             <property name="xpath">
                 <value>
 <![CDATA[
-//ClassOrInterfaceBodyDeclaration
-    [MethodDeclaration[@Name='setUp']]
-    [not(Annotation/*/Name[
+//MethodDeclaration[@Name='setUp']
+    [not(ModifierList/Annotation[
            pmd-java:typeIs('org.junit.Before')
         or pmd-java:typeIs('org.junit.jupiter.api.BeforeEach')
         or pmd-java:typeIs('org.junit.jupiter.api.BeforeAll')

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -743,17 +743,19 @@ In JUnit 5, one of the following annotations should be used for tests: @Test, @R
             <property name="xpath">
                 <value>
 <![CDATA[
-//ClassOrInterfaceDeclaration[
-       matches(@SimpleName, $testClassPattern)
-        or ExtendsList/ClassOrInterfaceType[pmd-java:typeIs('junit.framework.TestCase')]]
-
-    /ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration[MethodDeclaration[@Public=true() and starts-with(@Name, 'test')]]
-    [not(Annotation//Name[
-        pmd-java:typeIs('org.junit.Test')
-        or pmd-java:typeIs('org.junit.jupiter.api.Test') or pmd-java:typeIs('org.junit.jupiter.api.RepeatedTest')
-        or pmd-java:typeIs('org.junit.jupiter.api.TestFactory') or pmd-java:typeIs('org.junit.jupiter.api.TestTemplate')
-        or pmd-java:typeIs('org.junit.jupiter.params.ParameterizedTest')
-    ])]
+//ClassOrInterfaceDeclaration[matches(@SimpleName, $testClassPattern) or pmd-java:typeIs('junit.framework.TestCase')]
+    (: a junit 3 method :)
+    /ClassOrInterfaceBody/MethodDeclaration[
+        @Visibility="public"
+        and starts-with(@Name, 'test')
+        and not(ModifierList/Annotation[
+          pmd-java:typeIs('org.junit.Test')
+          or pmd-java:typeIs('org.junit.jupiter.api.Test') or pmd-java:typeIs('org.junit.jupiter.api.RepeatedTest')
+          or pmd-java:typeIs('org.junit.jupiter.api.TestFactory') or pmd-java:typeIs('org.junit.jupiter.api.TestTemplate')
+          or pmd-java:typeIs('org.junit.jupiter.params.ParameterizedTest')
+          ]
+        )
+    ]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -659,12 +659,14 @@ JUnit 5 introduced @AfterEach and @AfterAll annotations to execute methods after
             <property name="xpath">
                 <value>
 <![CDATA[
-//MethodDeclaration[@Name='tearDown']
+//MethodDeclaration[@Name='tearDown' and @Arity=0]
     [not(ModifierList/Annotation[
            pmd-java:typeIs('org.junit.After')
         or pmd-java:typeIs('org.junit.jupiter.api.AfterEach')
         or pmd-java:typeIs('org.junit.jupiter.api.AfterAll')
         or pmd-java:typeIs('org.testng.annotations.AfterMethod')])]
+    (: Make sure this is a junit 4 class :)
+    [../MethodDeclaration[pmd-java:hasAnnotation('org.junit.Test')]]
 ]]>
                 </value>
             </property>
@@ -701,12 +703,15 @@ JUnit 5 introduced @BeforeEach and @BeforeAll annotations to execute methods bef
             <property name="xpath">
                 <value>
 <![CDATA[
-//MethodDeclaration[@Name='setUp']
+//MethodDeclaration[@Name='setUp' and @Arity=0]
     [not(ModifierList/Annotation[
            pmd-java:typeIs('org.junit.Before')
         or pmd-java:typeIs('org.junit.jupiter.api.BeforeEach')
         or pmd-java:typeIs('org.junit.jupiter.api.BeforeAll')
         or pmd-java:typeIs('org.testng.annotations.BeforeMethod')])]
+    (: Make sure this is a junit 4 class :)
+    [../MethodDeclaration[pmd-java:hasAnnotation('org.junit.Test')]]
+
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnit4SuitesShouldUseSuiteAnnotationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnit4SuitesShouldUseSuiteAnnotationTest.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
 import net.sourceforge.pmd.testframework.PmdRuleTst;
 
-@org.junit.Ignore("Rule has not been updated yet")
 public class JUnit4SuitesShouldUseSuiteAnnotationTest extends PmdRuleTst {
     // no additional unit tests
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnit4TestShouldUseAfterAnnotationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnit4TestShouldUseAfterAnnotationTest.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
 import net.sourceforge.pmd.testframework.PmdRuleTst;
 
-@org.junit.Ignore("Rule has not been updated yet")
 public class JUnit4TestShouldUseAfterAnnotationTest extends PmdRuleTst {
     // no additional unit tests
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnit4TestShouldUseBeforeAnnotationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnit4TestShouldUseBeforeAnnotationTest.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
 import net.sourceforge.pmd.testframework.PmdRuleTst;
 
-@org.junit.Ignore("Rule has not been updated yet")
 public class JUnit4TestShouldUseBeforeAnnotationTest extends PmdRuleTst {
     // no additional unit tests
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnit4TestShouldUseTestAnnotationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnit4TestShouldUseTestAnnotationTest.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
 import net.sourceforge.pmd.testframework.PmdRuleTst;
 
-@org.junit.Ignore("Rule has not been updated yet")
 public class JUnit4TestShouldUseTestAnnotationTest extends PmdRuleTst {
     // no additional unit tests
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit4SuitesShouldUseSuiteAnnotation.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit4SuitesShouldUseSuiteAnnotation.xml
@@ -8,14 +8,17 @@
         <description>Contains suite</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
-public class Foo extends TestCase{
+import junit.framework.Test;
+import junit.framework.TestCase;
+import junit.framework.TestSuite;
+
+public class Foo extends TestCase {
     public static Test suite() {
         TestSuite suite = new TestSuite("Tests");
-        suite.addTestSuite(MyTest.class);
+        suite.addTestSuite(Foo.class);
         return suite;
     }
-    @Test
-    public void foo() {
+    public void testFoo() {
     }
 }
         ]]></code>
@@ -25,10 +28,15 @@ public class Foo extends TestCase{
         <description>Contains JUnit4TestAdapter suite</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+import junit.framework.TestCase;
+import junit.framework.JUnit4TestAdapter;
+import junit.framework.Test;
+
 public class Foo extends TestCase{
     public static Test suite() {
         return new JUnit4TestAdapter(Foo.class);
     }
+
     @Test
     public void foo() {
     }
@@ -37,12 +45,19 @@ public class Foo extends TestCase{
     </test-code>
 
     <test-code>
-        <description>Uses propper suite</description>
+        <description>Uses proper suite</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
+
+import junit.framework.TestCase;
+
 @RunWith(Suite.class)
 @SuiteClasses(Foo.class)
-public class Foo extends TestCase{
+public class Foo extends TestCase {
     @Test
     public void foo() {
     }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit4TestShouldUseAfterAnnotation.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit4TestShouldUseAfterAnnotation.xml
@@ -104,4 +104,30 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>Contains tearDown, not a junit 4 test</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class Foo {
+                public void tearDown() {
+                }
+                public void foo() {
+                }
+            }
+            ]]></code>
+    </test-code>
+    <test-code>
+        <description>Contains tearDown with different signature</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            import org.junit.Test;
+            public class Foo {
+                public void tearDown(int something) {
+                }
+                @Test
+                public void foo() {
+                }
+            }
+            ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit4TestShouldUseAfterAnnotation.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit4TestShouldUseAfterAnnotation.xml
@@ -64,6 +64,8 @@ public class Foo {
     public void tearDown(Method m) {
       //...
     }
+    @Test
+    public void someTest() {}
 }
         ]]></code>
     </test-code>
@@ -79,6 +81,9 @@ public class Foo {
     public void tearDown() {
       //...
     }
+    @Test
+    public void someTest() {}
+
 }
         ]]></code>
     </test-code>
@@ -94,6 +99,8 @@ public class Foo {
     public void tearDown() {
       //...
     }
+    @Test
+    public void someTest() {}
 }
         ]]></code>
     </test-code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit4TestShouldUseAfterAnnotation.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit4TestShouldUseAfterAnnotation.xml
@@ -8,6 +8,7 @@
         <description>Contains tearDown</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
+import org.junit.Test;
 public class Foo {
     public void tearDown() {
     }
@@ -19,9 +20,11 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>Contains @tearDown</description>
+        <description>Contains @After tearDown</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+import org.junit.Test;
+import org.junit.After;
 public class Foo {
     @After
     public void tearDown() {
@@ -37,6 +40,8 @@ public class Foo {
         <description>Renamed tearDown</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+import org.junit.Test;
+import org.junit.After;
 public class Foo {
     @After
     public void clean() {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit4TestShouldUseBeforeAnnotation.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit4TestShouldUseBeforeAnnotation.xml
@@ -8,6 +8,7 @@
         <description>Contains setUp</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
+import org.junit.Test;
 public class Foo {
     public void setUp() {
     }
@@ -22,6 +23,8 @@ public class Foo {
         <description>Contains @setUp</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+import org.junit.Before;
+import org.junit.Test;
 public class Foo {
     @Before
     public void setUp() {
@@ -37,6 +40,8 @@ public class Foo {
         <description>Renamed setup</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+import org.junit.Before;
+import org.junit.Test;
 public class Foo {
     @Before
     public void configure() {
@@ -52,11 +57,15 @@ public class Foo {
         <description>#1400 False positive with JUnit4TestShouldUseBeforeAnnotation</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+import org.junit.Before;
+import org.junit.Test;
 public class Foo {
     @Before("@ResetEsSetup")
     public void setUp() {
         esSetup.execute(EsSetup.deleteAll());
     }
+    @Test
+    public void someTest() {}
 }
         ]]></code>
     </test-code>
@@ -72,6 +81,8 @@ public class Foo {
     public void setUp(Method m) {
       //...
     }
+    @Test
+    public void someTest() {}
 }
         ]]></code>
     </test-code>
@@ -87,6 +98,8 @@ public class Foo {
     public void setUp() {
       //...
     }
+    @Test
+    public void someTest() {}
 }
         ]]></code>
     </test-code>
@@ -102,6 +115,8 @@ public class Foo {
     public void setUp() {
       //...
     }
+    @Test
+    public void someTest() {}
 }
         ]]></code>
     </test-code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit4TestShouldUseBeforeAnnotation.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit4TestShouldUseBeforeAnnotation.xml
@@ -120,4 +120,33 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>Contains setUp, not a junit 4 test</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class Foo {
+                public void setUp() {
+                }
+                public void foo() {
+                }
+            }
+            ]]></code>
+    </test-code>
+    <test-code>
+        <description>Contains setUp with different signature</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            import org.junit.Test;
+
+            public class Foo {
+
+                public void setUp(int something) {
+                }
+
+                @Test
+                public void foo() {
+                }
+            }
+            ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit4TestShouldUseTestAnnotation.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit4TestShouldUseTestAnnotation.xml
@@ -9,7 +9,7 @@
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 import junit.framework.TestCase;
-public class Foo extends TestCase{
+public class Foo extends TestCase {
     public void testFoo() {
     }
 }
@@ -21,7 +21,8 @@ public class Foo extends TestCase{
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 import junit.framework.TestCase;
-public class Foo extends TestCase{
+import org.junit.Test;
+public class Foo extends TestCase {
     @Test
     public void testFoo() {
     }
@@ -34,6 +35,7 @@ public class Foo extends TestCase{
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 import junit.framework.TestCase;
+import org.junit.Test;
 public class Foo extends TestCase{
     @Test
     public void foo() {
@@ -47,6 +49,7 @@ public class Foo extends TestCase{
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 import junit.framework.TestCase;
+import org.junit.Test;
 public class Foo extends TestCase{
     public void testFoo() {
     }
@@ -62,6 +65,7 @@ public class Foo extends TestCase{
         <expected-problems>2</expected-problems>
         <code><![CDATA[
 import junit.framework.TestCase;
+import org.junit.Test;
 public class Foo extends TestCase{
     public void testOne() {
     }


### PR DESCRIPTION
## Describe the PR

Update 4 related rules in bestpractices.xml:

- JUnit4SuitesShouldUseSuiteAnnotation
- JUnit4TestShouldUseAfterAnnotation
- JUnit4TestShouldUseBeforeAnnotation
- JUnit4TestShouldUseTestAnnotation

Both `JUnit4TestShouldUse(After|Before)Annotation` now are more conservative when finding `setUp`/`tearDown` methods. 

## Related issues

- Items of #2701 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

