### PR TITLE
[java] New rule: UseStandardCharsets

### DIFF
--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -1838,23 +1838,24 @@ public class Foo {
         message="Please use StandardCharsets constants"
         class="net.sourceforge.pmd.lang.rule.XPathRule"
         externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_bestpractices.html#usestandardcharsets">
-    <description>
-      StandardCharsets has constants for various common character
-      sets, they should be used instead of calling &quot;Charset.forName(name)&quot;
-    </description>
-    <priority>3</priority>
-    <properties>
-      <property name="version" value="2.0"/>
-      <property name="xpath">
-        <value>
-          <![CDATA[
-//PrimaryExpression[PrimaryPrefix/Name/@Image = 'Charset.forName']/PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Literal[@Image = '"US-ASCII"' or @Image = '"ISO-8859-1"'  or @Image = '"UTF-8"'  or @Image = '"UTF-16BE"'  or @Image = '"UTF-16LE"'  or @Image = '"UTF-16"']
+      <description>
+Starting with Java 7, StandardCharsets provides constants for common Charset objects, such as UTF-8.
+Using the constants is less error prone, and can provide a small performance advantage compared to `Charset.forName(...)`
+since no scan across the internal `Charset` caches is needed.
+      </description>
+      <priority>3</priority>
+      <properties>
+          <property name="version" value="2.0"/>
+          <property name="xpath">
+            <value>
+<![CDATA[
+//PrimaryExpression[PrimaryPrefix/Name/@Image = 'Charset.forName']/PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Literal[@Image = ('"US-ASCII"', '"ISO-8859-1"', '"UTF-8"', '"UTF-16BE"', '"UTF-16LE"', '"UTF-16"')]
 ]]>
-        </value>
-      </property>
-    </properties>
-    <example>
-      <![CDATA[
+            </value>
+          </property>
+      </properties>
+      <example>
+<![CDATA[
 public class UseStandardCharsets {
     public void run() {
         
@@ -1870,7 +1871,7 @@ public class UseStandardCharsets {
     }
 }
 ]]>
-    </example>
+      </example>
   </rule>
 
   <rule name="UseTryWithResources"

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -1831,7 +1831,49 @@ public class Foo {
         </example>
     </rule>
 
-    <rule name="UseTryWithResources"
+  <rule name="UseStandardCharsets"
+        language="java"
+        since="6.34"
+        minimumLanguageVersion="1.7"
+        message="Please use StandardCharsets constants"
+        class="net.sourceforge.pmd.lang.rule.XPathRule"
+        externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_bestpractices.html#usestandardcharsets">
+    <description>
+      StandardCharsets has constants for various common character
+      sets, they should be used instead of calling &quot;Charset.forName(name)&quot;
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="version" value="2.0"/>
+      <property name="xpath">
+        <value>
+          <![CDATA[
+//PrimaryExpression[PrimaryPrefix/Name/@Image = 'Charset.forName']/PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Literal[@Image = '"US-ASCII"' or @Image = '"ISO-8859-1"'  or @Image = '"UTF-8"'  or @Image = '"UTF-16BE"'  or @Image = '"UTF-16LE"'  or @Image = '"UTF-16"']
+]]>
+        </value>
+      </property>
+    </properties>
+    <example>
+      <![CDATA[
+public class UseStandardCharsets {
+    public void run() {
+        
+        // looking up the charset dynamically
+        try (OutputStreamWriter osw = new OutputStreamWriter(out, Charset.forName("UTF-8"))) {
+            osw.write("test");
+        }
+
+        // best to use StandardCharsets
+        try (OutputStreamWriter osw = new OutputStreamWriter(out, StandardCharsets.UTF_8)) {
+            osw.write("test");
+        }
+    }
+}
+]]>
+    </example>
+  </rule>
+
+  <rule name="UseTryWithResources"
           language="java"
           minimumLanguageVersion="1.7"
           since="6.12.0"

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseStandardCharsetsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseStandardCharsetsTest.java
@@ -1,0 +1,11 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices;
+
+import net.sourceforge.pmd.testframework.PmdRuleTst;
+
+public class UseStandardCharsetsTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UseStandardCharsets.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UseStandardCharsets.xml
@@ -138,16 +138,16 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>pass, UTF-8 from StadardCharsets</description>
+        <description>pass, UTF-8 from StandardCharsets</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 import java.io.OutputStreamWriter;
-import java.nio.charset.StadardCharsets;
+import java.nio.charset.StandardCharsets;
 
 public class Foo {
     public static void charset() {
          // looking up the charset dynamically
-        try (OutputStreamWriter osw = new OutputStreamWriter(out, StadardCharsets.UTF_8)) {
+        try (OutputStreamWriter osw = new OutputStreamWriter(out, StandardCharsets.UTF_8)) {
             osw.write("test");
         }
     }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UseStandardCharsets.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UseStandardCharsets.xml
@@ -1,0 +1,158 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+
+    <test-code>
+        <description>fail, US-ASCII</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+
+public class Foo {
+    public static void charset() {
+         // looking up the charset dynamically
+        try (OutputStreamWriter osw = new OutputStreamWriter(out, Charset.forName("US-ASCII"))) {
+            osw.write("test");
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>fail, ISO-8859-1</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+
+public class Foo {
+    public static void charset() {
+         // looking up the charset dynamically
+        try (OutputStreamWriter osw = new OutputStreamWriter(out, Charset.forName("ISO-8859-1"))) {
+            osw.write("test");
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>fail, UTF-8</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+
+public class Foo {
+    public static void charset() {
+         // looking up the charset dynamically
+        try (OutputStreamWriter osw = new OutputStreamWriter(out, Charset.forName("UTF-8"))) {
+            osw.write("test");
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>fail, UTF-16BE</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+
+public class Foo {
+    public static void charset() {
+         // looking up the charset dynamically
+        try (OutputStreamWriter osw = new OutputStreamWriter(out, Charset.forName("UTF-16BE"))) {
+            osw.write("test");
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>fail, UTF-16LE</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+
+public class Foo {
+    public static void charset() {
+         // looking up the charset dynamically
+        try (OutputStreamWriter osw = new OutputStreamWriter(out, Charset.forName("UTF-16LE"))) {
+            osw.write("test");
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>fail, UTF-16</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+
+public class Foo {
+    public static void charset() {
+         // looking up the charset dynamically
+        try (OutputStreamWriter osw = new OutputStreamWriter(out, Charset.forName("UTF-16"))) {
+            osw.write("test");
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>pass, ISO-8859-2, no constant for it</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
+
+public class Foo {
+    public static void charset() {
+         // looking up the charset dynamically
+        try (OutputStreamWriter osw = new OutputStreamWriter(out, Charset.forName("ISO-8859-2"))) {
+            osw.write("test");
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>pass, UTF-8 from StadardCharsets</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.OutputStreamWriter;
+import java.nio.charset.StadardCharsets;
+
+public class Foo {
+    public static void charset() {
+         // looking up the charset dynamically
+        try (OutputStreamWriter osw = new OutputStreamWriter(out, StadardCharsets.UTF_8)) {
+            osw.write("test");
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+    
+</test-data>


### PR DESCRIPTION
## Describe the PR

(My first PR against PMD. Hopefully I did not screw up too badly :-D)

Starting with Java 7, StandardCharsets provides constants for common Charset objects, such as UTF-8.
Using the constants is less error prone, and can provide a small performance advantage compared to Charset.forName(...)
since no scan across the internal Charset caches is needed.

More discussion available in the linked issue

## Related issues

- Fixes #3190

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

Unsure about the last point, the xml rule definition contains description and example, is there anything else to add?