### PR TITLE
[java] Improve rule UnnecessaryReturn to detect more cases

### DIFF
--- a/.ci/files/all-java.xml
+++ b/.ci/files/all-java.xml
@@ -110,7 +110,7 @@
     <rule ref="category/java/codestyle.xml/UnnecessaryFullyQualifiedName"/>
     <rule ref="category/java/codestyle.xml/UnnecessaryLocalBeforeReturn"/>
     <!-- <rule ref="category/java/codestyle.xml/UnnecessaryModifier"/> -->
-    <!-- <rule ref="category/java/codestyle.xml/UnnecessaryReturn"/> -->
+    <rule ref="category/java/codestyle.xml/UnnecessaryReturn"/>
     <!-- <rule ref="category/java/codestyle.xml/UseDiamondOperator"/> -->
     <rule ref="category/java/codestyle.xml/UseShortArrayInitializer"/>
     <rule ref="category/java/codestyle.xml/UseUnderscoresInNumericLiterals"/>

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
@@ -23,6 +23,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.sourceforge.pmd.lang.ast.GenericToken;
+import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.ast.NodeStream;
 import net.sourceforge.pmd.lang.ast.impl.javacc.JavaccToken;
 import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
@@ -709,5 +710,13 @@ public final class JavaRuleUtil {
 
     private static boolean isStringConcatExpression(ASTExpression e) {
         return BinaryOp.isInfixExprWithOperator(e, BinaryOp.ADD) && TypeTestUtil.isA(String.class, e);
+    }
+
+    /**
+     * Returns true if the node is the last child of its parent (or is the root node).
+     */
+    public static boolean isLastChild(Node it) {
+        Node parent = it.getParent();
+        return parent == null || it.getIndexInParent() == parent.getNumChildren() - 1;
     }
 }

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1624,11 +1624,12 @@ public class Bar {
     <rule name="UnnecessaryReturn"
           language="java"
           since="1.3"
-          message="Avoid unnecessary return statements"
+          message="Unnecessary return statement"
           class="net.sourceforge.pmd.lang.java.rule.codestyle.UnnecessaryReturnRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#unnecessaryreturn">
         <description>
-Avoid the use of unnecessary return statements.
+Avoid the use of unnecessary return statements. A return is unnecessary when no
+instructions follow anyway.
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryReturnTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryReturnTest.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.lang.java.rule.codestyle;
 
 import net.sourceforge.pmd.testframework.PmdRuleTst;
 
-@org.junit.Ignore("Rule has not been updated yet")
 public class UnnecessaryReturnTest extends PmdRuleTst {
     // no additional unit tests
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryReturn.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryReturn.xml
@@ -30,8 +30,8 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>ok since return is in sub block</description>
-        <expected-problems>0</expected-problems>
+        <description>not ok from within if</description>
+        <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Foo {
     void bar() {
@@ -62,7 +62,21 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>return inside a catch - ok</description>
+        <description>return inside a catch</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        try {
+        } catch(Exception e){
+            return;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>return inside a catch - no problem</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -71,6 +85,89 @@ public class Foo {
         } catch(Exception e){
             return;
         }
+        toString();
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Catch within initializer</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    static {
+        try {
+        } catch(Exception e){
+            return;
+        }
+        toString();
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Catch within initializer - violation</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    static {
+        try {
+        } catch(Exception e){
+            return;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Catch within initializer - violation</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    static {
+        try {
+        } catch(Exception e) {
+            return;
+        } finally {
+            printSomething();
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>If within initializer - violation</description>
+        <expected-problems>2</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    static {
+        int i;
+        if (foo()) {
+            i = 0;
+            return;
+        } else if (bar()) {
+            i = 1;
+            return;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>If within initializer - no violation</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    static {
+        int i;
+        if (foo()) {
+            i = 0;
+            return;
+        } else if (bar()) {
+            i = 1;
+            return;
+        }
+        System.out.println(i);
     }
 }
         ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryReturn.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryReturn.xml
@@ -336,4 +336,38 @@ public class Foo {
             }
             ]]></code>
     </test-code>
+    <test-code>
+        <description>Return in loop (like break)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            import java.util.List;
+            public class Foo {
+
+                protected boolean process(String str) {return str.isEmpty();}
+
+                protected void process(List<String> list) {
+                    for (String resource : list) {
+                        boolean found = process(resource);
+                        if (resource.isEmpty() || found) {
+                            return; // necessary, it's like a break from the loop
+                        }
+                    }
+                }
+            }
+            ]]></code>
+    </test-code>
+    <test-code regressionTest="false">
+        <description>Ignore local class statements</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+            public class Foo {
+                protected void process() {
+                    if (System.out == null) return;
+                    // This could be ignore because it doesn't contribute to control flow.
+                    // But this is rare enough that it hasn't been implemented
+                    class Foo {}
+                }
+            }
+            ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryReturn.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryReturn.xml
@@ -5,7 +5,7 @@
         xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
 
     <test-code>
-        <description>bad</description>
+        <description>End of a method</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
             public class Foo {
@@ -31,12 +31,30 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>not ok from within if</description>
+        <description>Return within if</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Foo {
     void bar() {
-        if (false) return;
+        if (System.out != null) return;
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Return within if, has follower</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        if (System.out != null) return;
+
+        if (System.in != null) {
+            return; // unnecessary
+        } else {
+            System.out.println("ok");
+        }
     }
 }
         ]]></code>
@@ -291,6 +309,29 @@ public class Foo {
                             return; // necessary
                         }
                     };
+                }
+            }
+            ]]></code>
+    </test-code>
+    <test-code>
+        <description>Return in lambda x ctor</description>
+        <expected-problems>2</expected-problems>
+        <code><![CDATA[
+            public class Foo {
+
+                interface Lambda { void run();}
+
+                static void foo(Lambda lambda) {}
+
+                public Foo() {
+                    foo(() -> {return;}); // unnecessary
+                    foo(() -> {
+                        if (System.out == null)
+                            return;  // unnecessary
+                        else {
+                            System.out.println("djiedeid");
+                        }
+                    }); // unnecessary
                 }
             }
             ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryReturn.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryReturn.xml
@@ -1,20 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <test-data
-    xmlns="http://pmd.sourceforge.net/rule-tests"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
 
     <test-code>
         <description>bad</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
-public class Foo {
-    void bar() {
-        int y = 3;
-        return;
-    }
-}
-        ]]></code>
+            public class Foo {
+
+                void bar() {
+                    int y = 3;
+                    return;
+                }
+            }
+            ]]></code>
     </test-code>
 
     <test-code>
@@ -170,6 +171,128 @@ public class Foo {
         System.out.println(i);
     }
 }
-        ]]></code>
+            ]]></code>
+    </test-code>
+    <test-code>
+        <description>Return in fallthrough switch</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>11</expected-linenumbers>
+        <code><![CDATA[
+            public class Foo {
+                {
+                    int i, j;
+                    switch (i) {
+                    case 1:
+                        return;
+                    case 2:
+                        j = 2;
+                    case 4:
+                        j = 5;
+                        return; // this one is unnecessary
+                    }
+                }
+            }
+            ]]></code>
+    </test-code>
+    <test-code>
+        <description>Return in fallthrough switch (with blocks)</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>15</expected-linenumbers>
+        <code><![CDATA[
+            public class Foo {
+                // Note that those blocks are useless, they just limit the scope of locals,
+                // and don't act on control flow. So this is identical as the above.
+                {
+                    int i, j;
+                    switch (i) {
+                    case 1: {
+                        return;
+                    }
+                    case 2: {
+                        j = 2;
+                    }
+                    case 4: {
+                        j = 5;
+                        return; // this one is unnecessary
+                    }
+                    }
+                }
+            }
+            ]]></code>
+    </test-code>
+    <test-code>
+        <description>Return in switch arrow: violation</description>
+        <expected-problems>2</expected-problems>
+        <code><![CDATA[
+            public class Foo {
+
+                static {
+                    int i, j;
+                    switch (i) {
+                    case 1 -> {
+                        j = 1;
+                        return; // unnecessary
+                    }
+                    case 2 -> {
+                        j = 2;
+                    }
+                    case 4 -> {
+                        j = 5;
+                        return; // unnecessary
+                    }
+                    }
+                }
+            }
+            ]]></code>
+    </test-code>
+    <test-code>
+        <description>Return in switch arrow: no violation</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class Foo {
+
+                static {
+                    int i, j;
+                    switch (i) {
+                    case 1 -> {
+                        j = 1;
+                        return; // necessary
+                    }
+                    case 2 -> {
+                        j = 2;
+                    }
+                    case 4 -> {
+                        j = 5;
+                        return; // necessary
+                    }
+                    }
+                    System.out.println(j);
+                }
+            }
+            ]]></code>
+    </test-code>
+    <test-code>
+        <description>Return in switch expression: no violation</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class Foo {
+
+                static {
+                    int i, j;
+                    int k = switch (i) {
+                        case 1 -> {
+                            return; // necessary
+                        }
+                        case 2 -> {
+                            j = 2;
+                        }
+                        case 4 -> {
+                            j = 5;
+                            return; // necessary
+                        }
+                    };
+                }
+            }
+            ]]></code>
     </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Update UnnecessaryReturn. The rule is more general than before, so I guess there will be fps to find out. But it will also be much more useful. Namely it now checks return statements in initializers, constructors, and lambdas properly. Also it doesn't flag just a return statement at the very end of a method, which is exceedingly rare and useless, but recurses to find out whether we're at the end of the control flow graph of the method. So it should handle arbitrarily complex code.

## Related issues

- Item of #2701

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)
- [ ] Document the improvement somewhere (release notes?)
- [x] Tests with lambdas
