### PR TITLE
Deprecate duplicate imports imports from same package

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -14,6 +14,15 @@ This is a {{ site.pmd.release_type }} release.
 
 ### New and noteworthy
 
+#### Deprecated rules
+
+*   java-codestyle
+    *   {% rule java/codestyle/DuplicateImports %}: use the rule {% rule java/bestpractices/UnusedImports %} instead, since it now reports duplicate imports
+
+*   java-errorprone
+    *   {% rule java/errorprone/ImportFromSamePackage %}: use the rule {% rule java/bestpractices/UnusedImports %} instead, since it now reports imports from the same package
+
+
 ### Fixed Issues
 
 ### API Changes

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/ImportWrapper.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/ImportWrapper.java
@@ -20,7 +20,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
 /**
  * Helper class to analyze {@link ASTImportDeclaration}s.
  */
-public class ImportWrapper {
+public final class ImportWrapper {
     private static final Logger LOG = Logger.getLogger(ImportWrapper.class.getName());
 
     private final ASTImportDeclaration node;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/ImportWrapper.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/ImportWrapper.java
@@ -15,7 +15,6 @@ import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
 
 /**
@@ -117,7 +116,7 @@ public class ImportWrapper {
         return fullname;
     }
 
-    public Node getNode() {
+    public ASTImportDeclaration getNode() {
         return node;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/PrettyPrintingUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/PrettyPrintingUtil.java
@@ -10,6 +10,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTEnumDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTFormalParameters;
+import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodOrConstructorDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTRecordDeclaration;
@@ -75,6 +76,14 @@ public final class PrettyPrintingUtil {
             return "record";
         }
         return "class";
+    }
+
+    public static String prettyImport(ASTImportDeclaration importDecl) {
+        String name = importDecl.getImportedName();
+        if (importDecl.isImportOnDemand()) {
+            return name + ".*";
+        }
+        return name;
     }
 
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
@@ -115,22 +115,7 @@ public class UnusedImportsRule extends AbstractJavaRule {
 
     @Override
     public Object visit(ASTImportDeclaration node, Object data) {
-        if (node.isImportOnDemand()) {
-            ASTName importedType = (ASTName) node.getChild(0);
-            imports.add(new ImportWrapper(importedType.getImage(), null, node, node.isStatic()));
-        } else {
-            if (!node.isImportOnDemand()) {
-                ASTName importedType = (ASTName) node.getChild(0);
-                String className;
-                if (isQualifiedName(importedType)) {
-                    int lastDot = importedType.getImage().lastIndexOf('.') + 1;
-                    className = importedType.getImage().substring(lastDot);
-                } else {
-                    className = importedType.getImage();
-                }
-                imports.add(new ImportWrapper(importedType.getImage(), className, node));
-            }
-        }
+        imports.add(new ImportWrapper(node));
         return data;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
@@ -119,11 +119,11 @@ public class UnusedImportsRule extends AbstractJavaRule {
         if (Objects.equals(node.getPackageName(), thisPackageName)) {
             // import for the same package
             addViolationWithMessage(data, node, IMPORT_FROM_SAME_PACKAGE_MESSAGE,
-                                    new String[] {PrettyPrintingUtil.prettyImport(node)});
+                                    new String[] { PrettyPrintingUtil.prettyImport(node) });
         } else if (!imports.add(new ImportWrapper(node))) {
             // duplicate
             addViolationWithMessage(data, node, DUPLICATE_IMPORT_MESSAGE,
-                                    new String[] {PrettyPrintingUtil.prettyImport(node)});
+                                    new String[] { PrettyPrintingUtil.prettyImport(node) });
         }
         return data;
     }
@@ -228,7 +228,8 @@ public class UnusedImportsRule extends AbstractJavaRule {
     private void removeReferenceSingleImport(String referenceName) {
         int firstDot = referenceName.indexOf('.');
         String expectedImport = firstDot < 0 ? referenceName : referenceName.substring(0, firstDot);
-        for (Iterator<ImportWrapper> iterator = imports.iterator(); iterator.hasNext(); ) {
+        Iterator<ImportWrapper> iterator = imports.iterator();
+        while (iterator.hasNext()) {
             ImportWrapper anImport = iterator.next();
             if (!anImport.isOnDemand() && anImport.getName().equals(expectedImport)) {
                 iterator.remove();
@@ -237,7 +238,8 @@ public class UnusedImportsRule extends AbstractJavaRule {
     }
 
     private void removeOnDemandForPackageName(String fullName) {
-        for (Iterator<ImportWrapper> iterator = imports.iterator(); iterator.hasNext(); ) {
+        Iterator<ImportWrapper> iterator = imports.iterator();
+        while (iterator.hasNext()) {
             ImportWrapper anImport = iterator.next();
             if (anImport.isOnDemand() && anImport.getFullName().equals(fullName)) {
                 iterator.remove();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsRule.java
@@ -25,6 +25,7 @@ import net.sourceforge.pmd.lang.java.ast.Comment;
 import net.sourceforge.pmd.lang.java.ast.FormalComment;
 import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.ast.internal.ImportWrapper;
+import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
 public class UnusedImportsRule extends AbstractJavaRule {
@@ -68,7 +69,7 @@ public class UnusedImportsRule extends AbstractJavaRule {
             visit((ASTPackageDeclaration) node.getChild(0), data);
         }
         for (ImportWrapper wrapper : imports) {
-            addViolation(data, wrapper.getNode(), wrapper.getFullName());
+            addViolation(data, wrapper.getNode(), PrettyPrintingUtil.prettyImport(wrapper.getNode()));
         }
         return data;
     }
@@ -109,7 +110,10 @@ public class UnusedImportsRule extends AbstractJavaRule {
 
     @Override
     public Object visit(ASTImportDeclaration node, Object data) {
-        imports.add(new ImportWrapper(node));
+        if (!imports.add(new ImportWrapper(node))) {
+            // duplicate
+            addViolationWithMessage(data, node, "Duplicate import ''{0}''", new String[] {PrettyPrintingUtil.prettyImport(node)});
+        }
         return data;
     }
 
@@ -160,7 +164,6 @@ public class UnusedImportsRule extends AbstractJavaRule {
             }
         }
     }
-
 
 
     protected Pair<String, String> getImportWrapper(Node node) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/DuplicateImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/DuplicateImportsRule.java
@@ -33,13 +33,12 @@ public class DuplicateImportsRule extends AbstractJavaRule {
         // import java.io.File;
         for (ImportWrapper thisImportOnDemand : importOnDemandImports) {
             for (ImportWrapper thisSingleTypeImport : singleTypeImports) {
-                String singleTypeFullName = thisSingleTypeImport.getName(); // java.io.File
+                String singleTypeFullName = thisSingleTypeImport.getFullName(); // java.io.File
 
-                int lastDot = singleTypeFullName.lastIndexOf('.');
-                String singleTypePkg = singleTypeFullName.substring(0, lastDot); // java.io
-                String singleTypeName = singleTypeFullName.substring(lastDot + 1); // File
+                String singleTypePkg = thisSingleTypeImport.getPackageName(); // java.io
+                String singleTypeName = thisSingleTypeImport.getName(); // File
 
-                if (thisImportOnDemand.getName().equals(singleTypePkg)
+                if (thisImportOnDemand.getFullName().equals(singleTypePkg)
                         && !isDisambiguationImport(node, singleTypePkg, singleTypeName)) {
                     addViolation(data, thisSingleTypeImport.getNode(), singleTypeFullName);
                 }
@@ -61,15 +60,15 @@ public class DuplicateImportsRule extends AbstractJavaRule {
         // Loop over .* imports
         for (ImportWrapper thisImportOnDemand : importOnDemandImports) {
             // Skip same package
-            if (!thisImportOnDemand.getName().equals(singleTypePkg)) {
+            if (!thisImportOnDemand.getFullName().equals(singleTypePkg)) {
                 if (!thisImportOnDemand.isStaticOnDemand()) {
-                    String fullyQualifiedClassName = thisImportOnDemand.getName() + "." + singleTypeName;
+                    String fullyQualifiedClassName = thisImportOnDemand.getFullName() + "." + singleTypeName;
                     if (node.getClassTypeResolver().classNameExists(fullyQualifiedClassName)) {
                         // Class exists in another imported package
                         return true;
                     }
                 } else {
-                    Class<?> importClass = node.getClassTypeResolver().loadClassOrNull(thisImportOnDemand.getName());
+                    Class<?> importClass = node.getClassTypeResolver().loadClassOrNull(thisImportOnDemand.getFullName());
                     if (importClass != null) {
                         try {
                             for (Method m : importClass.getMethods()) {
@@ -94,8 +93,7 @@ public class DuplicateImportsRule extends AbstractJavaRule {
 
     @Override
     public Object visit(ASTImportDeclaration node, Object data) {
-        ImportWrapper wrapper = new ImportWrapper(node.getImportedName(), node.getImportedName(),
-                node, node.isStatic() && node.isImportOnDemand());
+        ImportWrapper wrapper = new ImportWrapper(node);
 
         // blahhhh... this really wants to be ASTImportDeclaration to be
         // polymorphic...

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/DuplicateImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/DuplicateImportsRule.java
@@ -16,6 +16,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
 import net.sourceforge.pmd.lang.java.ast.internal.ImportWrapper;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
+@Deprecated
 public class DuplicateImportsRule extends AbstractJavaRule {
     private static final Logger LOG = Logger.getLogger(DuplicateImportsRule.class.getName());
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ImportFromSamePackageRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ImportFromSamePackageRule.java
@@ -10,6 +10,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.symboltable.SourceFileScope;
 
+@Deprecated
 public class ImportFromSamePackageRule extends AbstractJavaRule {
 
     @Override

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -1512,13 +1512,14 @@ public class Foo {
     <rule name="UnusedImports"
           language="java"
           since="1.0"
-          message="Avoid unused imports such as ''{0}''"
+          message="Unused import ''{0}''"
           class="net.sourceforge.pmd.lang.java.rule.bestpractices.UnusedImportsRule"
           typeResolution="true"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_bestpractices.html#unusedimports">
         <description>
-Avoid unused import statements to prevent unwanted dependencies.
-This rule will also find unused on demand imports, i.e. import com.foo.*.
+Reports import statements that are not used within the file. This also reports
+duplicate imports, and imports from the same package. The simplest fix is just
+to delete those imports.
         </description>
         <priority>4</priority>
         <example>

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -618,10 +618,13 @@ public class Foo {}
           language="java"
           since="0.5"
           message="Avoid duplicate imports such as ''{0}''"
+          deprecated="true"
           class="net.sourceforge.pmd.lang.java.rule.codestyle.DuplicateImportsRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#duplicateimports">
         <description>
 Duplicate or overlapping import statements should be avoided.
+
+This rule is deprecated since PMD 6.34.0. Use the rule UnusedImports from category bestpractices instead.
         </description>
         <priority>4</priority>
         <example>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2099,11 +2099,14 @@ public class Foo {
     <rule name="ImportFromSamePackage"
           language="java"
           since="1.02"
+          deprecated="true"
           message="No need to import a type that lives in the same package"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.ImportFromSamePackageRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#importfromsamepackage">
         <description>
 There is no need to import a type that lives in the same package.
+
+This rule is deprecated since PMD 6.34.0. Use the rule UnusedImports from category bestpractices instead.
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/main/resources/rulesets/java/quickstart.xml
+++ b/pmd-java/src/main/resources/rulesets/java/quickstart.xml
@@ -92,7 +92,6 @@
     <rule ref="category/java/codestyle.xml/ControlStatementBraces"/>
     <!--<rule ref="category/java/codestyle.xml/DefaultPackage"/>-->
     <rule ref="category/java/codestyle.xml/DontImportJavaLang"/>
-    <rule ref="category/java/codestyle.xml/DuplicateImports"/>
     <!-- <rule ref="category/java/codestyle.xml/EmptyMethodInAbstractClassShouldBeAbstract" /> -->
     <rule ref="category/java/codestyle.xml/ExtendsObject"/>
     <!-- <rule ref="category/java/codestyle.xml/FieldDeclarationsShouldBeAtStartOfClass" /> -->
@@ -225,7 +224,6 @@
     <!-- <rule ref="category/java/errorprone.xml/FinalizeOverloaded" /> -->
     <!-- <rule ref="category/java/errorprone.xml/FinalizeShouldBeProtected" /> -->
     <rule ref="category/java/errorprone.xml/IdempotentOperations"/>
-    <rule ref="category/java/errorprone.xml/ImportFromSamePackage"/>
     <rule ref="category/java/errorprone.xml/InstantiationToGetClass"/>
     <!-- <rule ref="category/java/errorprone.xml/InvalidLogMessageFormat" /> -->
     <rule ref="category/java/errorprone.xml/JumbledIncrementer"/>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsTest.java
@@ -7,5 +7,16 @@ package net.sourceforge.pmd.lang.java.rule.bestpractices;
 import net.sourceforge.pmd.testframework.PmdRuleTst;
 
 public class UnusedImportsTest extends PmdRuleTst {
-    // no additional unit tests
+    // these 2 methods are used for a test case, do not delete
+
+    public static void assertTrue(String message, boolean condition) {
+        if (!condition) {
+            System.out.println(message);
+        }
+    }
+    public static void assertSomething(String message, boolean condition) {
+        if (!condition) {
+            System.out.println(message);
+        }
+    }
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedImportsTest.java
@@ -14,6 +14,7 @@ public class UnusedImportsTest extends PmdRuleTst {
             System.out.println(message);
         }
     }
+
     public static void assertSomething(String message, boolean condition) {
         if (!condition) {
             System.out.println(message);

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedImports.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedImports.xml
@@ -581,4 +581,151 @@ import static javax.swing.WindowConstants.*; //warn
 class NPEImport {}
         ]]></code>
     </test-code>
+
+    <!-- Test cases for duplicate imports -->
+
+    <test-code>
+        <description>duplicate single type imports</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>2,3</expected-linenumbers>
+        <expected-messages>
+            <message>Avoid unused imports such as 'java.util.*'</message>
+            <message>Duplicate import 'java.io.File'</message>
+        </expected-messages>
+        <code><![CDATA[
+            import java.io.File;
+            import java.util.*;
+            import java.io.File;
+            public class Foo {
+                File f;
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>duplicate wildcard imports</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>2</expected-linenumbers>
+        <expected-messages>
+            <message>Duplicate import 'java.io.*'</message>
+        </expected-messages>
+        <code><![CDATA[
+            import java.io.*;
+            import java.io.*;
+            public class Foo {
+                File f;
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>single type import after wildcard import</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>1</expected-linenumbers>
+        <expected-messages>
+            <message>Avoid unused imports such as 'java.io.*'</message>
+        </expected-messages>
+        <code><![CDATA[
+            import java.io.*;
+            import java.io.File;
+            public class Foo {
+                File f;
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>subpackage import, ok</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            import java.util.*;
+            import java.util.logging.*;
+            public class Foo {
+                List c; Logger f;
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>674394, disambiguation import should be allowed</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            import java.awt.*;
+            import java.util.*;
+            import java.util.List; //False positive
+
+            class Foo{
+                Color color;
+                List list;
+                Set set;
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>674394, disambiguation import because of conflict with java.lang</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>1</expected-linenumbers>
+        <code><![CDATA[
+            import foo.*;
+            import foo.System;  //False positive
+
+            class Foo {
+                System system;  //No, I do not mean java.lang.System
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#1306 False positive on duplicate when using static imports</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            import static org.junit.Assert.*;
+            import static net.sourceforge.pmd.lang.java.rule.bestpractices.UnusedImportsTest.*;
+            import static org.junit.Assert.assertTrue;
+            // this import is needed for disambiguation - as DuplicateImportsTest
+            // defines assertTrue with the same signature, too.
+
+            public class DuplicateImports {
+                static {
+                    assertTrue("", true); // the one from the disambiguation import
+                    assertSomething("", true); // from UnusedImportsTest.*
+                    assertFalse("", true); // from Assert.*
+                }
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Static on-demand import is used</description>
+        <expected-problems>0</expected-problems>
+        <!-- Technically we could report assertTrue, but for now we don't. -->
+        <code><![CDATA[
+            import static org.junit.Assert.*;
+            import static org.junit.Assert.assertTrue;
+
+            public class DuplicateImports {
+                static {
+                    assertTrue("", true);
+                    assertFalse("", true);
+                }
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] DuplicateImports reported for the same import... and import static... #2546</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>1</expected-linenumbers>
+        <code><![CDATA[
+            import java.util.Collections.*;
+            import static java.util.Collections.*;
+
+            public class DuplicateImports {
+                static {
+                    emptyList();
+                }
+            }
+            ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedImports.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedImports.xml
@@ -604,7 +604,7 @@ class NPEImport {}
         <expected-problems>2</expected-problems>
         <expected-linenumbers>2,3</expected-linenumbers>
         <expected-messages>
-            <message>Avoid unused imports such as 'java.util.*'</message>
+            <message>Unused import 'java.util.*'</message>
             <message>Duplicate import 'java.io.File'</message>
         </expected-messages>
         <code><![CDATA[
@@ -638,7 +638,7 @@ class NPEImport {}
         <expected-problems>1</expected-problems>
         <expected-linenumbers>1</expected-linenumbers>
         <expected-messages>
-            <message>Avoid unused imports such as 'java.io.*'</message>
+            <message>Unused import 'java.io.*'</message>
         </expected-messages>
         <code><![CDATA[
             import java.io.*;

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedImports.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedImports.xml
@@ -122,8 +122,22 @@ public class Foo {}
 
     <test-code>
         <description>import from default package</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>Unnecessary import from the current package 'Bar'</message>
+        </expected-messages>
+        <code><![CDATA[
+import Bar;
+public class Foo {
+    public Bar foo() {}
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>import from default package from somewhere else</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+package somewhere;
 import Bar;
 public class Foo {
     public Bar foo() {}
@@ -135,6 +149,7 @@ public class Foo {
         <description>import from default package</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
+package somewhere;
 import Bar;
 public class Foo {
     public void foo() {}
@@ -726,6 +741,44 @@ class NPEImport {}
                     emptyList();
                 }
             }
+            ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>ImportFromSamePackage: simple failure</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+            package foo;
+            import foo.Bar;
+            public class Baz {
+                Bar bar;
+            }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>ImportFromSamePackage: class in default package importing from sub package</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            package foo;
+            import foo.buz.Bar;
+            public class Baz{
+                Bar b;
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>ImportFromSamePackage: importing all from same package</description>
+        <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>Unnecessary import from the current package 'foo.bar.*'</message>
+        </expected-messages>
+        <code><![CDATA[
+            package foo.bar;
+            import foo.bar.*;
+            public class Baz{}
             ]]></code>
     </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Deprecate DuplicateImports and ImportsFromSamePackage, merge their functionality into UnusedImports.

I'm thinking this could actually be a new rule, called UnnecessaryImport. That's because a duplicate import may be *used* (so it's not an UnusedImport), although it's unnecessary. OTOH, unused, duplicate, and same-package imports are all unnecessary. We could also merge DontImportJavaLang into the new rule.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #3128 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

