### PR TITLE
[core] Make more rules be recognized as rulechain (saxon HE)

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleTargetSelector.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleTargetSelector.java
@@ -13,6 +13,7 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 
 import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.ast.RootNode;
 import net.sourceforge.pmd.lang.rule.internal.TargetSelectorInternal;
@@ -83,6 +84,11 @@ public abstract class RuleTargetSelector extends TargetSelectorInternal {
      */
     public static RuleTargetSelector forRootOnly() {
         return ClassRulechainVisits.ROOT_ONLY;
+    }
+
+    @InternalApi
+    public boolean isRuleChain() {
+        return this != ClassRulechainVisits.ROOT_ONLY; // NOPMD #3205
     }
 
     private static final class StringRulechainVisits extends RuleTargetSelector {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/RuleChainAnalyzer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/RuleChainAnalyzer.java
@@ -169,17 +169,4 @@ public class RuleChainAnalyzer extends SaxonExprVisitor {
         return PmdDocumentSorter.INSTANCE;
     }
 
-    /**
-     * Split union expressions into their components.
-     */
-    public static Iterable<Expression> splitUnions(Expression expr) {
-        SplitUnions unions = new SplitUnions();
-        unions.visit(expr);
-        if (unions.getExpressions().isEmpty()) {
-            return Collections.singletonList(expr);
-        } else {
-            return unions.getExpressions();
-        }
-    }
-
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonExprTransformations.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonExprTransformations.java
@@ -1,0 +1,107 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+
+package net.sourceforge.pmd.lang.rule.xpath.internal;
+
+import java.util.Collections;
+
+import net.sf.saxon.expr.AxisExpression;
+import net.sf.saxon.expr.Expression;
+import net.sf.saxon.expr.FilterExpression;
+import net.sf.saxon.expr.RootExpression;
+import net.sf.saxon.expr.SlashExpression;
+import net.sf.saxon.om.AxisInfo;
+import net.sf.saxon.pattern.AnyNodeTest;
+import net.sf.saxon.pattern.NodeTest;
+
+/**
+ * Utilities to transform saxon expression trees.
+ */
+final class SaxonExprTransformations {
+
+    private SaxonExprTransformations() {
+        // utility class
+    }
+
+    private static final SaxonExprVisitor FILTER_HOISTER = new SaxonExprVisitor() {
+
+        @Override
+        public Expression visit(SlashExpression e) {
+            Expression left = super.visit(e.getLhsExpression());
+            Expression right = super.visit(e.getRhsExpression());
+            if (right instanceof FilterExpression) {
+                Expression middle = ((FilterExpression) right).getBase();
+                Expression filter = ((FilterExpression) right).getFilter();
+                return new FilterExpression(new SlashExpression(left, middle), filter);
+            }
+            return super.visit(e);
+        }
+    };
+
+    private static final SaxonExprVisitor ROOT_REDUCER = new SaxonExprVisitor() {
+
+        @Override
+        public Expression visit(SlashExpression e) {
+            Expression left = super.visit(e.getLhsExpression());
+            Expression right = super.visit(e.getRhsExpression());
+
+            if (right instanceof AxisExpression
+                && ((AxisExpression) right).getAxis() == AxisInfo.CHILD
+                && left instanceof SlashExpression) {
+
+                Expression leftLeft = ((SlashExpression) left).getLhsExpression();
+                Expression leftRight = ((SlashExpression) left).getRhsExpression();
+
+                if (leftLeft instanceof RootExpression && leftRight instanceof AxisExpression) {
+                    if (((AxisExpression) leftRight).getAxis() == AxisInfo.DESCENDANT_OR_SELF
+                        && isAnyNode(((AxisExpression) leftRight).getNodeTest())) {
+                        // ok!
+                        left = leftLeft; // the root expression
+                        right = new AxisExpression(AxisInfo.DESCENDANT, ((AxisExpression) right).getNodeTest());
+                    }
+                }
+            }
+
+            return new SlashExpression(left, right);
+        }
+
+        private boolean isAnyNode(NodeTest nodeTest) {
+            return nodeTest == null || nodeTest instanceof AnyNodeTest;
+        }
+    };
+
+    /**
+     * Turn {@code a/(b[c])} into {@code (a/b)[c]}. This is to somewhat
+     * normalize the expression as Saxon parses this inconsistently.
+     */
+    static Expression hoistFilters(Expression expression) {
+        return FILTER_HOISTER.visit(expression);
+    }
+
+    /**
+     * Turn {@code ((root)/descendant-or-self::node())/child::someTest}
+     * into {@code ((root)/descendant::someTest)}. The latter is the pattern
+     * detected by the rulechain analyser.
+     */
+    static Expression reduceRoot(Expression expression) {
+        return ROOT_REDUCER.visit(expression);
+    }
+
+    /**
+     * Splits a venn expression with the union operator into single expressions.
+     *
+     * <p>E.g. "//A | //B | //C" will result in 3 expressions "//A", "//B", and "//C".
+     */
+    static Iterable<Expression> splitUnions(Expression expr) {
+        SplitUnions unions = new SplitUnions();
+        unions.visit(expr);
+        if (unions.getExpressions().isEmpty()) {
+            return Collections.singletonList(expr);
+        } else {
+            return unions.getExpressions();
+        }
+    }
+
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/XPathRuleTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/XPathRuleTest.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.java.rule;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.List;
@@ -92,11 +93,28 @@ public class XPathRuleTest extends RuleTst {
     }
 
     @Test
-    public void testNoFnPrefixOnSaxon() throws Exception {
+    public void testNoFnPrefixOnSaxon() {
         XPathRule rule = makeXPath("//VariableDeclaratorId[matches(@Name, 'fiddle')]");
         Report report = getReportForTestString(rule, TEST2);
         RuleViolation rv = report.getViolations().get(0);
         assertEquals(3, rv.getBeginLine());
+    }
+
+    @Test
+    public void testSimpleQueryIsRuleChain() {
+        // ((/)/descendant::element(Q{}VariableDeclaratorId))[matches(convertUntyped(data(@Name)), "fiddle", "")]
+        assertIsRuleChain("//VariableDeclaratorId[matches(@Name, 'fiddle')]");
+    }
+
+    @Test
+    public void testSimpleQueryIsRuleChain2() {
+        // docOrder(((/)/descendant-or-self::node())/(child::element(ClassOrInterfaceType)[typeIs("java.util.Vector")]))
+        assertIsRuleChain("//ClassOrInterfaceType[pmd-java:typeIs('java.util.Vector')]");
+    }
+
+    private void assertIsRuleChain(String xpath) {
+        XPathRule rule = makeXPath(xpath);
+        assertTrue("Not recognized as a rulechain query: " + xpath, rule.getTargetSelector().isRuleChain());
     }
 
 


### PR DESCRIPTION
## Describe the PR

I noticed many java XPath rules were not recognized as rulechain ones and investigated. Saxon parses some expressions somewhat inconsistently. Now we have a normalization step that should bring more rules in line with what the RuleChainAnalyser expects.

Java rules that were not recognized as Rulechain and that now are:
- AvoidDecimalLiteralsInBigDecimalConstructor
- AvoidPrintStackTrace
- AvoidSynchronizedAtMethodLevel
- AvoidUsingVolatile
- DoNotUseThreads
- DontCallThreadRun
- EmptyMethodInAbstractClassShouldBeAbstract
- JUnit4TestShouldUseTestAnnotation
- LocalHomeNamingConvention
- LocalInterfaceSessionNamingConvention
- MDBAndSessionBeanNamingConvention
- RemoteInterfaceNamingConvention
- RemoteSessionInterfaceNamingConvention
- ReplaceHashtableWithMap
- ReplaceVectorWithList
- SimplifyStartsWith
- StringToString
- UseAssertEqualsInsteadOfAssertTrue
- UseAssertNullInsteadOfAssertTrue
- UseAssertSameInsteadOfAssertTrue
- UseAssertTrueInsteadOfAssertEquals
- UseStringBufferLength

## Related issues

- #2523

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

