### PR TITLE
[apex] ApexCRUDViolationRule: Do not assume method is VF getter to avoid CRUD checks

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
@@ -56,7 +56,6 @@ import com.google.common.collect.ListMultimap;
  *
  */
 public class ApexCRUDViolationRule extends AbstractApexRule {
-    private static final Pattern VOID_OR_STRING_PATTERN = Pattern.compile("^(string|void)$", Pattern.CASE_INSENSITIVE);
     private static final Pattern SELECT_FROM_PATTERN = Pattern.compile("[\\S|\\s]+?FROM[\\s]+?(\\w+)",
             Pattern.CASE_INSENSITIVE);
 
@@ -514,7 +513,6 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
             collectCRUDMethodLevelChecks(prevCall);
         }
 
-        boolean isGetter = false;
         String returnType = null;
 
         final ASTMethod wrappingMethod = node.getFirstParentOfType(ASTMethod.class);
@@ -527,7 +525,6 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
         }
 
         if (wrappingMethod != null) {
-            isGetter = isMethodAGetter(wrappingMethod);
             returnType = getReturnType(wrappingMethod);
         }
 
@@ -538,13 +535,11 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
             StringBuilder typeCheck = new StringBuilder().append(variableDecl.getDefiningType())
                     .append(":").append(type);
 
-            if (!isGetter) {
-                if (typesFromSOQL.isEmpty()) {
-                    validateCRUDCheckPresent(node, data, ANY, typeCheck.toString());
-                } else {
-                    for (String typeFromSOQL : typesFromSOQL) {
-                        validateCRUDCheckPresent(node, data, ANY, typeFromSOQL);
-                    }
+            if (typesFromSOQL.isEmpty()) {
+                validateCRUDCheckPresent(node, data, ANY, typeCheck.toString());
+            } else {
+                for (String typeFromSOQL : typesFromSOQL) {
+                    validateCRUDCheckPresent(node, data, ANY, typeFromSOQL);
                 }
             }
 
@@ -557,15 +552,12 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
                 String variableWithClass = Helper.getFQVariableName(variable);
                 if (varToTypeMapping.containsKey(variableWithClass)) {
                     String type = varToTypeMapping.get(variableWithClass);
-                    if (!isGetter) {
-                        if (typesFromSOQL.isEmpty()) {
-                            validateCRUDCheckPresent(node, data, ANY, type);
-                        } else {
-                            for (String typeFromSOQL : typesFromSOQL) {
-                                validateCRUDCheckPresent(node, data, ANY, typeFromSOQL);
-                            }
+                    if (typesFromSOQL.isEmpty()) {
+                        validateCRUDCheckPresent(node, data, ANY, type);
+                    } else {
+                        for (String typeFromSOQL : typesFromSOQL) {
+                            validateCRUDCheckPresent(node, data, ANY, typeFromSOQL);
                         }
-
                     }
                 }
             }
@@ -574,13 +566,11 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
 
         final ASTReturnStatement returnStatement = node.getFirstParentOfType(ASTReturnStatement.class);
         if (returnStatement != null) {
-            if (!isGetter) {
-                if (typesFromSOQL.isEmpty()) {
-                    validateCRUDCheckPresent(node, data, ANY, returnType);
-                } else {
-                    for (String typeFromSOQL : typesFromSOQL) {
-                        validateCRUDCheckPresent(node, data, ANY, typeFromSOQL);
-                    }
+            if (typesFromSOQL.isEmpty()) {
+                validateCRUDCheckPresent(node, data, ANY, returnType);
+            } else {
+                for (String typeFromSOQL : typesFromSOQL) {
+                    validateCRUDCheckPresent(node, data, ANY, typeFromSOQL);
                 }
             }
         }
@@ -601,14 +591,5 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     private String getReturnType(final ASTMethod method) {
         return new StringBuilder().append(method.getDefiningType()).append(":")
                 .append(method.getReturnType()).toString();
-    }
-
-    private boolean isMethodAGetter(final ASTMethod method) {
-        final boolean startsWithGet = method.getCanonicalName().startsWith("get");
-        final boolean voidOrString = VOID_OR_STRING_PATTERN
-                .matcher(method.getReturnType()).matches();
-        final boolean noParams = method.findChildrenOfType(ASTParameter.class).isEmpty();
-
-        return startsWithGet && noParams && !voidOrString;
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
@@ -32,7 +32,6 @@ import net.sourceforge.pmd.lang.apex.ast.ASTIfElseBlockStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
 import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTNewKeyValueObjectExpression;
-import net.sourceforge.pmd.lang.apex.ast.ASTParameter;
 import net.sourceforge.pmd.lang.apex.ast.ASTProperty;
 import net.sourceforge.pmd.lang.apex.ast.ASTReferenceExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTReturnStatement;

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
@@ -135,8 +135,8 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>VF built-in CRUD checks via getter</description>
-        <expected-problems>0</expected-problems>
+        <description>VF built-in CRUD checks via getter, but cannot determine if is really VF</description>
+        <expected-problems>2</expected-problems>
         <code><![CDATA[
 public class Foo {
     public Contact getFoo() {
@@ -148,35 +148,6 @@ public class Foo {
     public Contact getBaz() {
         String tempID = 'someID';
          return  [SELECT Name FROM Contact WHERE Id=:tempID];
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Bypassing VF built-in CRUD checks via getter method
-        </description>
-        <expected-problems>1</expected-problems>
-        <code><![CDATA[
-public class Foo {
-    public String getUserName() {
-        String tempID = 'someID';
-         Contact c = [SELECT Name FROM Contact WHERE Id=:tempID];
-         return c.Name;
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>No VF provided CRUD checks via getter method
-        </description>
-        <expected-problems>1</expected-problems>
-        <code><![CDATA[
-public class Foo {
-    public Contact justGiveMeFoo() {
-        String tempID = 'someID';
-         return [SELECT Name FROM Contact WHERE Id=:tempID];
     }
 }
         ]]></code>


### PR DESCRIPTION
## Describe the PR

Remove assumption (and therefore bypassing of CRUD check) that a method is a Visualforce getter based on its signature. Naming doesn't guarantee it actually is a VF getter.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #3210

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

