### PR TITLE
Add FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,5 @@
+#
+# https://docs.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository
+#
+github: pmd
+open_collective: pmd


### PR DESCRIPTION
Adds the two funding possiblities we support as the github sponsors button.

See https://docs.github.com/en/github/administering-a-repository/displaying-a-sponsor-button-in-your-repository for more info.
