### PR TITLE
[java] Fix #3224 - UnusedAssignment crashes with nested records

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedAssignmentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedAssignmentRule.java
@@ -1099,7 +1099,7 @@ public class UnusedAssignmentRule extends AbstractJavaRule {
         static void useAllSelfFields(/*nullable*/SpanInfo staticState, SpanInfo instanceState, ClassScope classScope) {
             for (VariableNameDeclaration field : classScope.getVariableDeclarations().keySet()) {
                 ASTVariableDeclaratorId var = field.getDeclaratorId();
-                if (field.getAccessNodeParent().isStatic()) {
+                if (!field.isRecordComponent() && field.getAccessNodeParent().isStatic()) {
                     if (staticState != null) {
                         staticState.use(var);
                     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/VariableNameDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/VariableNameDeclaration.java
@@ -92,7 +92,7 @@ public class VariableNameDeclaration extends AbstractNameDeclaration implements 
                 && getAccessNodeParent().getFirstChildOfType(ASTType.class).getChild(0) instanceof ASTReferenceType;
     }
 
-    private boolean isRecordComponent() {
+    public boolean isRecordComponent() {
         return node.getParent() instanceof ASTRecordComponent;
     }
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedAssignment.xml
@@ -5,6 +5,16 @@
     xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
 
     <test-code>
+        <description>NPE on nested record decl #3224</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            class Test {
+                public record NestedRecord(int x, int y) { }
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
         <description>ok</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[


### PR DESCRIPTION
## Describe the PR

In pmd 6, `getAccessNodeParent` returns null for record components.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #3224

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

