### PR TITLE
[java] Fix #3169 - NPE in CheckSkipResult

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -29,6 +29,7 @@ This is a {{ site.pmd.release_type }} release.
     *   [#3190](https://github.com/pmd/pmd/issues/3190): \[java] Use StandardCharsets instead of Charset.forName
 *   java-errorprone
     *   [#2757](https://github.com/pmd/pmd/issues/2757): \[java] CloseResource: support Lombok's @Cleanup annotation
+    *   [#3169](https://github.com/pmd/pmd/issues/3169): \[java] CheckSkipResult: NPE when using pattern bindings
 
 ### API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclaratorId.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclaratorId.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import java.util.Collections;
 import java.util.List;
 
 import net.sourceforge.pmd.annotation.InternalApi;
@@ -72,7 +73,8 @@ public class ASTVariableDeclaratorId extends AbstractJavaTypeNode implements Dim
     }
 
     public List<NameOccurrence> getUsages() {
-        return getScope().getDeclarations(VariableNameDeclaration.class).get(nameDeclaration);
+        List<NameOccurrence> usages = getScope().getDeclarations(VariableNameDeclaration.class).get(nameDeclaration);
+        return usages == null ? Collections.<NameOccurrence>emptyList() : usages;
     }
 
     @Deprecated

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CheckSkipResult.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CheckSkipResult.xml
@@ -93,4 +93,19 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>NPE when using Pattern matching variables #3169</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            import java.io.InputStream;
+
+            public class Foo {
+                public void service(Object servletRequest) {
+                    if (servletRequest instanceof InputStream nanoRequest) {
+                        // ...
+                    }
+                }
+            }
+            ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Now getUsages should not return null. Note that the variableNameDeclaration may still be null, but see 

https://github.com/pmd/pmd/blob/ac94110fc4e7e40fa85bc0804abb22c54c5ccb0c/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symboltable/ScopeAndDeclarationFinder.java#L278-L283

## Related issues

- Fixes #3169 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

