### PR TITLE
[apex] ApexCRUDViolation: COUNT is indeed CRUD checkable since it exposes data (false-negative)

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
@@ -504,7 +504,6 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
     }
 
     private void checkForAccessibility(final ASTSoqlExpression node, Object data) {
-        final boolean isCount = node.getCanonicalQuery().startsWith("SELECT COUNT()");
         final Set<String> typesFromSOQL = getTypesFromSOQLQuery(node);
 
         final Set<ASTMethodCallExpression> prevCalls = getPreviousMethodCalls(node);
@@ -517,9 +516,8 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
         final ASTMethod wrappingMethod = node.getFirstParentOfType(ASTMethod.class);
         final ASTUserClass wrappingClass = node.getFirstParentOfType(ASTUserClass.class);
 
-        if (isCount
-                || wrappingClass != null && Helper.isTestMethodOrClass(wrappingClass)
-                || wrappingMethod != null && Helper.isTestMethodOrClass(wrappingMethod)) {
+        if (wrappingClass != null && Helper.isTestMethodOrClass(wrappingClass)
+            || wrappingMethod != null && Helper.isTestMethodOrClass(wrappingMethod)) {
             return;
         }
 

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
@@ -856,8 +856,8 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>Count does not expose data and CRUD checks are unnecessary</description>
-        <expected-problems>0</expected-problems>
+        <description>Count does expose data and CRUD checks are necessary</description>
+        <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Foo {
     public Integer getBaz() {
@@ -868,9 +868,9 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>Count does not leak data and CRUD checks are unnecessary
+        <description>Count does leak data and CRUD checks are necessary
         </description>
-        <expected-problems>0</expected-problems>
+        <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Foo {
     public void getBaz() {


### PR DESCRIPTION
## Describe the PR

`COUNT()` queries do expose data that should be enforced before querying since could expose the ability to count records on an object that the user may not have access to.

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #3202

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by travis)
- [ ] Added (in-code) documentation (if needed)

