### PR TITLE
[java] Improve CompareObjectsWithEquals

### DIFF
--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -1118,6 +1118,9 @@ Use equals() to compare object references; avoid comparing them with ==.
                           [not(PrimarySuffix)]
                           [ancestor::MethodDeclaration[@Name = 'equals']])
     ]
+    (: Is not a field access with an all-caps identifier :)
+    [not(PrimaryExpression[not(PrimarySuffix) and PrimaryPrefix/Name[upper-case(@Image)=@Image]
+     or PrimaryExpression/PrimarySuffix[last()][upper-case(@Image)=@Image]])]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -1100,19 +1100,30 @@ public class Bar {
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#compareobjectswithequals">
         <description>
-Use equals() to compare object references; avoid comparing them with ==.
+Use `equals()` to compare object references; avoid comparing them with `==`.
+
+Since comparing objects with named constants is useful in some cases (eg, when
+defining constants for sentinel values), the rule ignores comparisons against
+fields with all-caps name (eg `this == SENTINEL`), which is a common naming
+convention for constant fields.
+
+You may allow some types to be compared by reference by listing the exceptions
+in the `typesThatCompareByReference` property.
         </description>
         <priority>3</priority>
         <properties>
             <property name="version" value="2.0"/>
+            <property name="typesThatCompareByReference" type="List[String]" delimiter="," description="List of canonical type names for which reference comparison is allowed.">
+                <value>java.lang.Enum,java.lang.Class</value>
+            </property>
             <property name="xpath">
                 <value>
 <![CDATA[
 //EqualityExpression
-    [count(PrimaryExpression
-        [pmd-java:typeIs('java.lang.Object')]
-        [not(pmd-java:typeIs('java.lang.Enum'))]
-        [not(pmd-java:typeIs('java.lang.Class'))]) = 2
+    [count(
+        PrimaryExpression[pmd-java:typeIs('java.lang.Object')]
+        [not(some $t in $typesThatCompareByReference satisfies pmd-java:typeIs($t))]
+       ) = 2
     ]
     [not(PrimaryExpression[PrimaryPrefix/@ThisModifier = true()]
                           [not(PrimarySuffix)]

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CompareObjectsWithEquals.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CompareObjectsWithEquals.xml
@@ -112,7 +112,7 @@ package net.sourceforge.pmd.lang.java.rule.errorprone.compareobjectswithequals;
 
 public class CompareObjectsWithEqualsSample {
     void array(int[] a, String[] b) {
-        if (a[1] == b[1]) {} // int == String - this comparison doesn't make sense
+        if (a[1] == b[1]) {} // int == String - this comparison doesn't make sense (and doesn't compile...)
     }
     void array2(int[] c, int[] d) {
         if (c[1] == d[1]) {}
@@ -362,6 +362,67 @@ public class EnumTest {
         return param == type ? "Yes" : "No";
     }
 }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>static constant #3205</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            class MyClass {
+                static final MyClass MISSING = new MyClass();
+
+                public static void isMissing(MyClass obj) {
+                    return obj == MISSING; // no violation expected...
+                }
+            }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>static constant in other class #3205</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            class MyClass {
+                static class Ts {
+                    static final MyClass MISSING = new MyClass();
+                }
+
+                public static void isMissing(MyClass obj) {
+                    return obj == Ts.MISSING; // no violation expected...
+                }
+            }
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>constant field on some object #3205</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            class MyClass {
+                static class Ts {
+                    final MyClass MISSING = new MyClass();
+                }
+
+                public static void isMissing(MyClass obj, Ts ts) {
+                    return obj == ts.MISSING; // no violation expected...
+                }
+            }
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>constant field on some object, more complicated expr #3205</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            class MyClass {
+                static class Ts {
+                    final MyClass MISSING = new MyClass();
+                    Ts id() { return this; }
+                }
+
+                public static void isMissing(MyClass obj, Ts ts) {
+                    return obj == (ts.id()).id().MISSING; // no violation expected...
+                }
+            }
         ]]></code>
     </test-code>
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CompareObjectsWithEquals.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CompareObjectsWithEquals.xml
@@ -425,5 +425,17 @@ public class EnumTest {
             }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>Property typesThatCompareByReference #3110</description>
+        <rule-property name="typesThatCompareByReference">java.lang.String</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            class MyClass {
+                public static void isMissing(String obj, Object ts) {
+                    return obj == ts;
+                }
+            }
+        ]]></code>
+    </test-code>
 
 </test-data>


### PR DESCRIPTION
## Describe the PR

Improve CompareObjectsWithEquals
- Fixes #3110: add a property with a list of exceptions. 
- Fixes #3205: ignore comparison against constants. "Constants" are found by looking for an all-caps identifier. There's no property to disable that, because I'm not sure it would be worth the complexity. In pmd 7 we could improve that to look at whether the field is a final one, using the symbol. The one thing I'm not sure about is, that some types should most likely never be compared by reference, even against constants (String)...

Also we could maybe whitelist comparing against `this` altogether, instead of looking for an enclosing `equals` method... Maybe not in this pr

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)
- [ ] Release notes
- [ ] Enhancement ticket for PMD 7 (change impl strategy to use symbol resolution instead of matching all caps names). **Do we need this anyway?** Results on spring look fine... we could just leave that be and wait for user input.

