### PR TITLE
[java] Improve ExprContext, fix FNs of UnnecessaryCast

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExpression.java
@@ -125,7 +125,7 @@ public interface ASTExpression
      */
     @Experimental
     default @NonNull ExprContext getConversionContext() {
-        return PolyResolution.getConversionContextForExternalUse(this);
+        return getRoot().getLazyTypeResolver().getConversionContextForExternalUse(this);
     }
 
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTStatementExpressionList.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTStatementExpressionList.java
@@ -4,7 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
-import java.util.Iterator;
+import net.sourceforge.pmd.lang.java.ast.ASTList.ASTNonEmptyList;
 
 /**
  * A list of statement expressions. Statement expressions are those
@@ -20,20 +20,15 @@ import java.util.Iterator;
  *
  * </pre>
  */
-public final class ASTStatementExpressionList extends AbstractStatement implements Iterable<ASTExpression> {
+public final class ASTStatementExpressionList extends ASTNonEmptyList<ASTExpression> implements ASTStatement {
 
     ASTStatementExpressionList(int id) {
-        super(id);
+        super(id, ASTExpression.class);
     }
 
 
     @Override
     protected <P, R> R acceptVisitor(JavaVisitor<? super P, ? extends R> visitor, P data) {
         return visitor.visit(this, data);
-    }
-
-    @Override
-    public Iterator<ASTExpression> iterator() {
-        return children(ASTExpression.class).iterator();
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/BinaryOp.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/BinaryOp.java
@@ -85,10 +85,9 @@ public enum BinaryOp implements InternalInterfaces.OperatorLike {
     /** Modulo {@code "%"} operator. */
     MOD("%");
 
-    /**
-     * Use with {@link #isInfixExprWithOperator(JavaNode, Set)}.
-     */
+    /** Use with {@link #isInfixExprWithOperator(JavaNode, Set)}. */
     public static final Set<BinaryOp> COMPARISON_OPS = CollectionUtil.immutableEnumSet(LE, GE, GT, LT);
+    public static final Set<BinaryOp> SHIFT_OPS = CollectionUtil.immutableEnumSet(LEFT_SHIFT, RIGHT_SHIFT, UNSIGNED_RIGHT_SHIFT);
 
     private final String code;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ExprContext.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ExprContext.java
@@ -105,6 +105,7 @@ public abstract class ExprContext {
 
     static ExprContext newNumericContext(JTypeMirror targetType) {
         if (targetType.isPrimitive()) {
+            assert targetType.isNumeric() : targetType;
             return new RegularCtx(targetType, CtxKind.Numeric);
         }
         return RegularCtx.NO_CTX; // error

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ExprContext.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ExprContext.java
@@ -67,6 +67,13 @@ public abstract class ExprContext {
         return new RegularCtx(targetType, CtxKind.OtherNonPoly);
     }
 
+    static ExprContext newNumericContext(JTypeMirror targetType) {
+        if (targetType.isPrimitive()) {
+            return new RegularCtx(targetType, CtxKind.Numeric);
+        }
+        return RegularCtx.NO_CTX; // error
+    }
+
     static ExprContext newCastCtx(JTypeMirror targetType) {
         return new RegularCtx(targetType, CtxKind.Cast);
     }
@@ -141,6 +148,22 @@ public abstract class ExprContext {
          */
         Cast,
 
+        /**
+         * Numeric context. May determine that an (un)boxing or
+         * primitive widening conversion occurs. These is the context for
+         * operands of arithmetic expressions, array indices.
+         * <p>For instance:
+         * <pre>{@code
+         * Integer integer;
+         *
+         * array[integer] // Integer is unboxed to int
+         * integer + 1    // Integer is unboxed to int
+         * 0 + 1.0        // int (left) is widened to double
+         * integer + 1.0  // Integer is unboxed to int, then widened to double
+         * }</pre>
+         */
+        Numeric,
+
         /** Kind for a standalone ternary (both branches are then in this context). */
         Ternary,
 
@@ -156,22 +179,10 @@ public abstract class ExprContext {
          * or the equivalent for a primitive type. They accept operands of any type.
          * This is the context for the operands of a string concatenation expression,
          * and for the message of an assert statement.
-         * <li>TODO Boolean contexts, which unbox their operand to a boolean.
+         * <li>Boolean contexts, which unbox their operand to a boolean.
          * They accept operands of type boolean or Boolean. This is the
          * context for e.g. the condition of an {@code if} statement, an
          * assert statement, etc.
-         * <li>Numeric contexts, which may determine that an (un)boxing or
-         * primitive widening conversion occurs. These is the context for
-         * operands of arithmetic expressions, array indices.
-         * <p>For instance:
-         * <pre>{@code
-         * Integer integer;
-         *
-         * array[integer] // Integer is unboxed to int
-         * integer + 1    // Integer is unboxed to int
-         * 0 + 1.0        // int (left) is widened to double
-         * integer + 1.0  // Integer is unboxed to int, then widened to double
-         * }</pre>
          * </ul>
          */
         OtherNonPoly,

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ExprContext.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ExprContext.java
@@ -83,8 +83,16 @@ public abstract class ExprContext {
         return kind == CtxKind.Cast;
     }
 
+    public boolean isNumeric() {
+        return kind == CtxKind.Numeric;
+    }
+
     boolean canGiveContextToPoly(boolean lambda) {
         return true;
+    }
+
+    public boolean isTernary() {
+        return kind == CtxKind.Ternary;
     }
 
     static ExprContext newAssignmentCtx(JTypeMirror targetType) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ExprContext.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ExprContext.java
@@ -7,7 +7,6 @@ package net.sourceforge.pmd.lang.java.ast;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.sourceforge.pmd.annotation.Experimental;
-import net.sourceforge.pmd.lang.java.types.JPrimitiveType;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.OverloadSelectionResult;
 
@@ -64,7 +63,7 @@ public abstract class ExprContext {
         return new RegularCtx(targetType, CtxKind.Assignment);
     }
 
-    static ExprContext newNumericCtx(JPrimitiveType targetType) {
+    static ExprContext newNonPolyContext(JTypeMirror targetType) {
         return new RegularCtx(targetType, CtxKind.OtherNonPoly);
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/LazyTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/LazyTypeResolver.java
@@ -55,6 +55,10 @@ final class LazyTypeResolver extends JavaVisitorBase<Void, @NonNull JTypeMirror>
         this.processor = processor;
     }
 
+    ExprContext getConversionContextForExternalUse(ASTExpression e) {
+        return polyResolution.getConversionContextForExternalUse(e);
+    }
+
     public JavaAstProcessor getProcessor() {
         return processor;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/PolyResolution.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/PolyResolution.java
@@ -46,7 +46,6 @@ final class PolyResolution {
     private final Infer infer;
     private final TypeSystem ts;
     private final JavaExprMirrors exprMirrors;
-    private final JClassType stringType;
     private final ExprContext booleanCtx;
     private final ExprContext stringCtx;
     private final ExprContext intCtx;
@@ -55,10 +54,10 @@ final class PolyResolution {
         this.infer = infer;
         this.ts = infer.getTypeSystem();
         this.exprMirrors = new JavaExprMirrors(infer);
-        this.stringType = (JClassType) TypesFromReflection.fromReflect(String.class, ts);
+        JClassType stringType = (JClassType) TypesFromReflection.fromReflect(String.class, ts);
         booleanCtx = ExprContext.newNonPolyContext(ts.BOOLEAN);
         stringCtx = ExprContext.newNonPolyContext(stringType);
-        intCtx = ExprContext.newNonPolyContext(ts.INT);
+        intCtx = ExprContext.newNumericContext(ts.INT);
     }
 
     JTypeMirror computePolyType(final TypeNode e) {
@@ -482,7 +481,7 @@ final class PolyResolution {
             case OR:
             case XOR:
             case AND:
-                return ctxType == ts.BOOLEAN ? booleanCtx : ExprContext.newNumericContext(ctxType);
+                return ctxType == ts.BOOLEAN ? booleanCtx : ExprContext.newNumericContext(ctxType); // NOMPD CompareObjectsWithEquals
             case LEFT_SHIFT:
             case RIGHT_SHIFT:
             case UNSIGNED_RIGHT_SHIFT:

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/PolyResolution.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/PolyResolution.java
@@ -21,12 +21,14 @@ import net.sourceforge.pmd.internal.util.AssertionUtil;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.java.ast.ExprContext.InvocCtx;
 import net.sourceforge.pmd.lang.java.ast.ExprContext.RegularCtx;
+import net.sourceforge.pmd.lang.java.types.JClassType;
 import net.sourceforge.pmd.lang.java.types.JMethodSig;
 import net.sourceforge.pmd.lang.java.types.JPrimitiveType;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.OverloadSelectionResult;
 import net.sourceforge.pmd.lang.java.types.TypeOps;
 import net.sourceforge.pmd.lang.java.types.TypeSystem;
+import net.sourceforge.pmd.lang.java.types.TypesFromReflection;
 import net.sourceforge.pmd.lang.java.types.internal.infer.ExprMirror.BranchingMirror;
 import net.sourceforge.pmd.lang.java.types.internal.infer.ExprMirror.FunctionalExprMirror;
 import net.sourceforge.pmd.lang.java.types.internal.infer.ExprMirror.InvocationMirror;
@@ -43,11 +45,19 @@ final class PolyResolution {
     private final Infer infer;
     private final TypeSystem ts;
     private final JavaExprMirrors exprMirrors;
+    private final JClassType stringType;
+    private final ExprContext booleanCtx;
+    private final ExprContext stringCtx;
+    private final ExprContext intCtx;
 
     PolyResolution(Infer infer) {
         this.infer = infer;
         this.ts = infer.getTypeSystem();
         this.exprMirrors = new JavaExprMirrors(infer);
+        this.stringType = (JClassType) TypesFromReflection.fromReflect(String.class, ts);
+        booleanCtx = ExprContext.newNonPolyContext(ts.BOOLEAN);
+        stringCtx = ExprContext.newNonPolyContext(stringType);
+        intCtx = ExprContext.newNonPolyContext(ts.INT);
     }
 
     JTypeMirror computePolyType(final TypeNode e) {
@@ -289,7 +299,7 @@ final class PolyResolution {
     /**
      * Not meant to be used by the main typeres paths, only for rules.
      */
-    static ExprContext getConversionContextForExternalUse(ASTExpression e) {
+    ExprContext getConversionContextForExternalUse(ASTExpression e) {
         return contextOf(e, false, false);
     }
 
@@ -351,7 +361,7 @@ final class PolyResolution {
      *
      * </pre>
      */
-    private static @NonNull ExprContext contextOf(final JavaNode node, boolean onlyInvoc, boolean internalUse) {
+    private @NonNull ExprContext contextOf(final JavaNode node, boolean onlyInvoc, boolean internalUse) {
         final JavaNode papa = node.getParent();
         if (papa instanceof ASTArgumentList) {
             // invocation context, return *the first method*
@@ -423,17 +433,30 @@ final class PolyResolution {
             // when the super ctor is generic/ the superclass is generic
             return ExprContext.newSuperCtorCtx(node.getEnclosingType().getTypeMirror().getSuperClass());
 
-        } else if (papa instanceof ASTArrayAccess && node.getIndexInParent() == 1) {
-            // array index
-            return ExprContext.newNumericCtx(papa.getTypeSystem().INT);
-        } else if (papa instanceof ASTConditionalExpression && node.getIndexInParent() != 0) {
-            assert ((ASTConditionalExpression) papa).isStandalone() && !internalUse
-                : "Expected standalone ternary, otherwise doesCascadeContext(..) would have returned true";
-            return ExprContext.newStandaloneTernaryCtx(((ASTConditionalExpression) papa).getTypeMirror());
-        } else {
-            // stop recursion
-            return RegularCtx.NO_CTX;
         }
+
+        if (!internalUse) {
+            // Only ASTExpression#getConversionContext needs this level of detail
+            // These anyway do not give a context to poly expression so can be ignored
+            // for poly resolution.
+
+            if (papa instanceof ASTArrayAccess && node.getIndexInParent() == 1) {
+                // array index
+                return intCtx;
+            } else if (papa instanceof ASTAssertStatement) {
+
+                return node.getIndexInParent() == 0 ? booleanCtx // condition
+                                                    : stringCtx; // message
+
+            } else if (papa instanceof ASTConditionalExpression && node.getIndexInParent() != 0) {
+                assert ((ASTConditionalExpression) papa).isStandalone()
+                    : "Expected standalone ternary, otherwise doesCascadeContext(..) would have returned true";
+                return ExprContext.newStandaloneTernaryCtx(((ASTConditionalExpression) papa).getTypeMirror());
+            }
+        }
+
+        // stop recursion
+        return RegularCtx.NO_CTX;
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/PolyResolution.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/PolyResolution.java
@@ -463,11 +463,17 @@ final class PolyResolution {
 
             return booleanCtx; // condition
 
-        } else if (papa instanceof ASTConditionalExpression && node.getIndexInParent() != 0) {
-            assert ((ASTConditionalExpression) papa).isStandalone()
-                : "Expected standalone ternary, otherwise doesCascadeContext(..) would have returned true";
+        } else if (papa instanceof ASTConditionalExpression) {
 
-            return ExprContext.newStandaloneTernaryCtx(((ASTConditionalExpression) papa).getTypeMirror());
+            if (node.getIndexInParent() == 0) {
+                return booleanCtx; // the condition
+            } else {
+                // a branch
+                assert ((ASTConditionalExpression) papa).isStandalone()
+                    : "Expected standalone ternary, otherwise doesCascadeContext(..) would have returned true";
+
+                return ExprContext.newStandaloneTernaryCtx(((ASTConditionalExpression) papa).getTypeMirror());
+            }
 
         } else if (papa instanceof ASTInfixExpression) {
             // numeric contexts, maybe
@@ -521,7 +527,10 @@ final class PolyResolution {
         if (child.getParent() != node) {
             // means the "node" is a "stop recursion because no context" result in contextOf
             return false;
-        } else if (!internalUse && node instanceof ASTConditionalExpression) {
+        } else if (!internalUse
+            && node instanceof ASTConditionalExpression
+            && child.getIndexInParent() != 0) {
+            // conditional branch
             ((ASTConditionalExpression) node).getTypeMirror(); // force resolution
             return !((ASTConditionalExpression) node).isStandalone();
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/PolyResolution.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/PolyResolution.java
@@ -481,7 +481,7 @@ final class PolyResolution {
             case OR:
             case XOR:
             case AND:
-                return ctxType == ts.BOOLEAN ? booleanCtx : ExprContext.newNumericContext(ctxType); // NOMPD CompareObjectsWithEquals
+                return ctxType == ts.BOOLEAN ? booleanCtx : ExprContext.newNumericContext(ctxType); // NOPMD CompareObjectsWithEquals
             case LEFT_SHIFT:
             case RIGHT_SHIFT:
             case UNSIGNED_RIGHT_SHIFT:

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/PolyResolution.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/PolyResolution.java
@@ -448,6 +448,10 @@ final class PolyResolution {
                 return node.getIndexInParent() == 0 ? booleanCtx // condition
                                                     : stringCtx; // message
 
+            } else if (papa instanceof ASTIfStatement || papa instanceof ASTLoopStatement && !(papa instanceof ASTForeachStatement)) {
+
+                return booleanCtx; // condition
+
             } else if (papa instanceof ASTConditionalExpression && node.getIndexInParent() != 0) {
                 assert ((ASTConditionalExpression) papa).isStandalone()
                     : "Expected standalone ternary, otherwise doesCascadeContext(..) would have returned true";

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryCastRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryCastRule.java
@@ -4,17 +4,34 @@
 
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
+import static net.sourceforge.pmd.lang.java.ast.BinaryOp.ADD;
+import static net.sourceforge.pmd.lang.java.ast.BinaryOp.DIV;
+import static net.sourceforge.pmd.lang.java.ast.BinaryOp.GE;
+import static net.sourceforge.pmd.lang.java.ast.BinaryOp.GT;
+import static net.sourceforge.pmd.lang.java.ast.BinaryOp.LE;
+import static net.sourceforge.pmd.lang.java.ast.BinaryOp.LT;
+import static net.sourceforge.pmd.lang.java.ast.BinaryOp.MOD;
+import static net.sourceforge.pmd.lang.java.ast.BinaryOp.MUL;
+import static net.sourceforge.pmd.lang.java.ast.BinaryOp.SHIFT_OPS;
+import static net.sourceforge.pmd.lang.java.ast.BinaryOp.SUB;
+import static net.sourceforge.pmd.lang.java.ast.BinaryOp.isInfixExprWithOperator;
+
+import java.util.EnumSet;
+
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.sourceforge.pmd.lang.java.ast.ASTCastExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTConditionalExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTInfixExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTLambdaExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodReference;
+import net.sourceforge.pmd.lang.java.ast.BinaryOp;
 import net.sourceforge.pmd.lang.java.ast.ExprContext;
 import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.TypeConversion;
 import net.sourceforge.pmd.lang.java.types.TypeOps;
@@ -24,6 +41,9 @@ import net.sourceforge.pmd.lang.java.types.TypeOps;
  * type, or may be converted to it implicitly.
  */
 public class UnnecessaryCastRule extends AbstractJavaRulechainRule {
+
+    private static final EnumSet<BinaryOp> BINARY_PROMOTED_OPS =
+        EnumSet.of(LE, GE, GT, LT, ADD, SUB, MUL, DIV, MOD);
 
     public UnnecessaryCastRule() {
         super(ASTCastExpression.class);
@@ -69,49 +89,41 @@ public class UnnecessaryCastRule extends AbstractJavaRulechainRule {
             // Eg `SuperItf obj = (SubItf) ()-> {};`
             // If we remove the cast, even if it might compile,
             // the object will not implement SubItf anymore.
-            return null;
-        }
-
-        if (context.isMissing()) {
-            // we have a more limited set of violation conditions here
-
-            if (!operandType.isBottom() // casts on a null literal are necessary
-                && operandType.isSubtypeOf(coercionType)) {
-                reportCast(castExpr, data);
-            }
-            return null;
-        }
-        // context is not missing from here on
-
-        boolean isInTernary = castExpr.getParent() instanceof ASTConditionalExpression;
-
-        if (castIsUnnecessary(context, coercionType, operandType, isInTernary)) {
+        } else if (isCastUnnecessary(castExpr, context, coercionType, operandType)) {
             reportCast(castExpr, data);
         }
         return null;
+    }
+
+    private boolean isCastUnnecessary(ASTCastExpression castExpr, @NonNull ExprContext context, JTypeMirror coercionType, JTypeMirror operandType) {
+        if (operandType.equals(coercionType)) {
+            // with the exception of the lambda thing above, casts to
+            // the same type are always unnecessary
+            return true;
+        } else if (context.isMissing()) {
+            // then we have fewer violation conditions
+
+            return !operandType.isBottom() // casts on a null literal are necessary
+                && operandType.isSubtypeOf(coercionType);
+        }
+
+        return !isCastDeterminingContext(castExpr, context, coercionType)
+            && castIsUnnecessaryToMatchContext(context, coercionType, operandType);
     }
 
     private void reportCast(ASTCastExpression castExpr, Object data) {
         addViolation(data, castExpr, PrettyPrintingUtil.prettyPrintType(castExpr.getCastType()));
     }
 
-    private boolean castIsUnnecessary(@NonNull ExprContext context, JTypeMirror coercionType, JTypeMirror operandType, boolean isInTernary) {
-        if (isInTernary) {
-            return castIsUnnecessaryInTernary(operandType, coercionType);
-        } else {
-            return castIsUnnecessary(context, operandType, coercionType);
-        }
-    }
-
-    private static boolean castIsUnnecessary(ExprContext context,
-                                             JTypeMirror operandType,
-                                             JTypeMirror coercionType) {
+    private static boolean castIsUnnecessaryToMatchContext(ExprContext context,
+                                                           JTypeMirror coercionType,
+                                                           JTypeMirror operandType) {
         if (context.isInvocationContext()) {
             // todo unsupported for now, the cast may be disambiguating overloads
             return false;
         }
-        JTypeMirror contextType = context.getTargetType();
 
+        JTypeMirror contextType = context.getTargetType();
         if (contextType == null) {
             return false; // should not occur in valid code
         }
@@ -132,11 +144,39 @@ public class UnnecessaryCastRule extends AbstractJavaRulechainRule {
     }
 
     /**
-     * A cast in a ternary branch may be necessary in more cases
-     * as both branches influence the target type.
+     * Returns whether the context type actually depends on the cast.
+     * This means our analysis as written above won't work, and usually
+     * that the cast is necessary, because there's some primitive conversions
+     * happening, or some other corner case.
      */
-    private static boolean castIsUnnecessaryInTernary(JTypeMirror operandType, JTypeMirror coercionType) {
-        return operandType.equals(coercionType);
+    private static boolean isCastDeterminingContext(ASTCastExpression castExpr, ExprContext context, @NonNull JTypeMirror coercionType) {
+
+        if (castExpr.getParent() instanceof ASTConditionalExpression && castExpr.getIndexInParent() != 0) {
+            // a branch of a ternary
+            return true;
+        }
+
+        if (context.isNumeric() && castExpr.getParent() instanceof ASTInfixExpression) {
+            ASTInfixExpression parent = (ASTInfixExpression) castExpr.getParent();
+
+            if (isInfixExprWithOperator(parent, SHIFT_OPS)) {
+                // then the cast is determining the width of expr
+                assert castExpr == parent.getLeftOperand(); // second operand doesn't have a numeric context
+                return true;
+            } else if (isInfixExprWithOperator(parent, BINARY_PROMOTED_OPS)) {
+                ASTExpression otherOperand = JavaRuleUtil.getOtherOperandIfInInfixExpr(castExpr);
+
+                return otherOperand instanceof ASTCastExpression // remove FPs
+                    // Ie, the type that is taken by the binary promotion
+                    // is the type of the cast, not the type of the operand.
+                    // Eg in
+                    //     int i; ((double) i) * i
+                    // the only reason the mult expr has type double is because of the cast
+                    || TypeOps.isStrictSubtype(otherOperand.getTypeMirror(), coercionType);
+            }
+
+        }
+        return false;
     }
 
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryCastRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryCastRule.java
@@ -74,7 +74,9 @@ public class UnnecessaryCastRule extends AbstractJavaRulechainRule {
 
         if (context.isMissing()) {
             // we have a more limited set of violation conditions here
-            if (!operandType.isBottom() && operandType.isSubtypeOf(coercionType)) {
+
+            if (!operandType.isBottom() // casts on a null literal are necessary
+                && operandType.isSubtypeOf(coercionType)) {
                 reportCast(castExpr, data);
             }
             return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
@@ -827,6 +827,10 @@ public final class TypeOps {
         }
     }
 
+    public static boolean isStrictSubtype(@NonNull JTypeMirror t, @NonNull JTypeMirror s) {
+        return !t.equals(s) && t.isSubtypeOf(s);
+    }
+
     // </editor-fold>
 
     // <editor-fold  defaultstate="collapsed" desc="Substitution">

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeSystem.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeSystem.java
@@ -212,7 +212,6 @@ public final class TypeSystem {
         FLOAT = createPrimitive(PrimitiveTypeKind.FLOAT, Float.class);
         DOUBLE = createPrimitive(PrimitiveTypeKind.DOUBLE, Double.class);
 
-        // this relies on the fact that setOf always returns immutable sets
         BOOLEAN.superTypes = immutableSetOf(BOOLEAN);
         CHAR.superTypes = immutableSetOf(CHAR, INT, LONG, FLOAT, DOUBLE);
         BYTE.superTypes = immutableSetOf(BYTE, SHORT, INT, LONG, FLOAT, DOUBLE);

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/ConversionContextTests.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/ConversionContextTests.kt
@@ -165,6 +165,23 @@ class ConversionContextTests : ProcessorTestSpec({
         }
     }
 
+    parserTest("Test context of ternary condition") {
+
+        val (acu, spy) = parser.parseWithTypeInferenceSpy("""
+            class Scratch {
+                static void m(Boolean boxedBool, boolean bool, String str, int[] ints) {
+                    str = (boolean) boxedBool ? "a" : "b";
+                }
+            }
+        """)
+
+        val (booleanCast) = acu.descendants(ASTCastExpression::class.java).toList()
+
+        spy.shouldBeOk {
+            booleanCast.conversionContext::getTargetType shouldBe boolean
+        }
+    }
+
     parserTest("Test numeric context") {
 
         val (acu, spy) = parser.parseWithTypeInferenceSpy("""

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/ConversionContextTests.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/ConversionContextTests.kt
@@ -7,7 +7,9 @@ package net.sourceforge.pmd.lang.java.types.internal.infer
 
 import net.sourceforge.pmd.lang.ast.test.shouldBe
 import net.sourceforge.pmd.lang.java.ast.ASTExpression
+import net.sourceforge.pmd.lang.java.ast.ASTVariableAccess
 import net.sourceforge.pmd.lang.java.ast.ProcessorTestSpec
+import net.sourceforge.pmd.lang.java.types.STRING
 import net.sourceforge.pmd.lang.java.types.parseWithTypeInferenceSpy
 import net.sourceforge.pmd.lang.java.types.shouldHaveType
 
@@ -93,6 +95,27 @@ class ConversionContextTests : ProcessorTestSpec({
 
             integerCast.conversionContext::getTargetType shouldBe int
             num4.conversionContext::getTargetType shouldBe int
+        }
+    }
+    parserTest("Test context of assert stmt") {
+
+        val (acu, spy) = parser.parseWithTypeInferenceSpy("""
+            class Foo {
+                static void m(Boolean boxedBool, boolean bool, String str) {
+                    assert boxedBool;
+                    assert bool;
+                    assert bool : str;
+                }
+            }
+        """)
+
+        val (boxedBool, bool, bool2, str) = acu.descendants(ASTVariableAccess::class.java).toList()
+
+        spy.shouldBeOk {
+            boxedBool.conversionContext::getTargetType shouldBe ts.BOOLEAN
+            bool.conversionContext::getTargetType shouldBe ts.BOOLEAN
+            bool2.conversionContext::getTargetType shouldBe ts.BOOLEAN
+            str.conversionContext::getTargetType shouldBe ts.STRING
         }
     }
 })

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/ConversionContextTests.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/ConversionContextTests.kt
@@ -6,9 +6,11 @@
 package net.sourceforge.pmd.lang.java.types.internal.infer
 
 import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
 import net.sourceforge.pmd.lang.ast.test.component6
 import net.sourceforge.pmd.lang.ast.test.shouldBe
 import net.sourceforge.pmd.lang.java.ast.*
+import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil
 import net.sourceforge.pmd.lang.java.types.STRING
 import net.sourceforge.pmd.lang.java.types.parseWithTypeInferenceSpy
 import net.sourceforge.pmd.lang.java.types.shouldHaveType
@@ -214,6 +216,32 @@ class ConversionContextTests : ProcessorTestSpec({
                 withClue(it) {
                     it.leftOperand.conversionContext::getTargetType shouldBe ts.DOUBLE
                     it.rightOperand.conversionContext::getTargetType shouldBe ts.DOUBLE
+                }
+            }
+        }
+    }
+    parserTest("String contexts") {
+
+        val (acu, spy) = parser.parseWithTypeInferenceSpy("""
+            class Scratch {
+                static void m(int i) {
+                    eat(" " + i);
+                    eat(i + " ");
+                    eat(" " + " ");
+                    eat(" " + i + i);
+                }
+                void eat(Object d) {}
+            }
+        """)
+
+        val concats = acu.descendants(ASTInfixExpression::class.java).toList()
+
+        spy.shouldBeOk {
+            concats.forEach {
+                withClue(it) {
+                    JavaRuleUtil.isStringConcatExpr(it) shouldBe true
+                    it.leftOperand.conversionContext::getTargetType shouldBe ts.STRING
+                    it.rightOperand.conversionContext::getTargetType shouldBe ts.STRING
                 }
             }
         }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/ParserCornerCases.txt
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/ParserCornerCases.txt
@@ -344,7 +344,7 @@
    |           |  |  +- VariableAccess[@AccessType = "READ", @CompileTimeConstant = "false", @Image = "i", @Name = "i", @ParenthesisDepth = "0", @Parenthesized = "false"]
    |           |  |  +- NumericLiteral[@Base = "10", @CompileTimeConstant = "true", @DoubleLiteral = "false", @FloatLiteral = "false", @Image = "10", @IntLiteral = "true", @Integral = "true", @LongLiteral = "false", @ParenthesisDepth = "0", @Parenthesized = "false", @ValueAsDouble = "10.0", @ValueAsFloat = "10.0", @ValueAsInt = "10", @ValueAsLong = "10"]
    |           |  +- ForUpdate[]
-   |           |  |  +- StatementExpressionList[]
+   |           |  |  +- StatementExpressionList[@Size = "1"]
    |           |  |     +- UnaryExpression[@CompileTimeConstant = "false", @Operator = "++", @ParenthesisDepth = "0", @Parenthesized = "false"]
    |           |  |        +- VariableAccess[@AccessType = "WRITE", @CompileTimeConstant = "false", @Image = "i", @Name = "i", @ParenthesisDepth = "0", @Parenthesized = "false"]
    |           |  +- Block[@Size = "0", @containsComment = "false"]

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/ParserCornerCases18.txt
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/ParserCornerCases18.txt
@@ -1075,7 +1075,7 @@
          |        |  +- MethodCall[@CompileTimeConstant = "false", @Image = "hasNext", @MethodName = "hasNext", @ParenthesisDepth = "0", @Parenthesized = "false"]
          |        |     +- ArgumentList[@Size = "0"]
          |        +- ForUpdate[]
-         |        |  +- StatementExpressionList[]
+         |        |  +- StatementExpressionList[@Size = "1"]
          |        |     +- UnaryExpression[@CompileTimeConstant = "false", @Operator = "--", @ParenthesisDepth = "0", @Parenthesized = "false"]
          |        |        +- VariableAccess[@AccessType = "WRITE", @CompileTimeConstant = "false", @Image = "i", @Name = "i", @ParenthesisDepth = "0", @Parenthesized = "false"]
          |        +- ExpressionStatement[]

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
@@ -684,6 +684,30 @@ class Scratch {
             ]]></code>
     </test-code>
     <test-code>
+        <description>Casts in shift exprs</description>
+        <expected-problems>7</expected-problems>
+        <expected-linenumbers>5,8,9,10,12,13,14</expected-linenumbers>
+        <code><![CDATA[
+            class Scratch {
+                static void m(int i, short s, long l, Integer boxedInt) {
+                    l  = (long) i << 2; // "necessary"
+                    l  = (long) i << 34; // definitely necessary
+                    l  = (long) (i << 34); // unnecessary, l5
+
+                    i = i << (int) l;          // necessary
+                    i = i << (int) boxedInt;   // unnecessary
+                    i = (int) i << boxedInt;   // unnecessary
+                    i = (int) (i << boxedInt); // unnecessary
+
+                    i = (int) s << boxedInt;   // unnecessary, widened anyway
+                    i = ((int) s) << boxedInt; // unnecessary, same expression with unnecessary parens
+                    i = (int) (s << boxedInt); // unnecessary
+
+                }
+            }
+            ]]></code>
+    </test-code>
+    <test-code>
         <description>Casts in arithmetic smaller than int </description>
         <expected-problems>9</expected-problems>
         <code><![CDATA[
@@ -699,6 +723,20 @@ class Scratch {
                     i = i * (short) s; // 10
                     i = i * (int) c;
                     i = i * (char) c; // 11
+                }
+            }
+            ]]></code>
+    </test-code>
+    <test-code>
+        <description>Casts in arithmetic with unboxing + widening</description>
+        <expected-problems>4</expected-problems>
+        <code><![CDATA[
+            class Scratch {
+                static void m(Integer i, Double d, Object lhs) {
+                    lhs = (int) i * 1.0;
+                    lhs = (double) d * 1.01;
+                    lhs = 1.01 * (int) i;
+                    lhs = 1.01 * (double) d;
                 }
             }
             ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
@@ -617,4 +617,31 @@ class Scratch {
             }
             ]]></code>
     </test-code>
+    <test-code>
+        <description>Loops</description>
+        <expected-problems>5</expected-problems>
+        <code><![CDATA[
+            class Scratch {
+                static void m(Boolean boxedBool, boolean bool, String str, int[] ints) {
+                    if ((boolean) boxedBool);
+                    while ((boolean) boxedBool);
+                    for (int i = 0; (boolean) boxedBool; i++) {}
+                    do; while ((boolean) boxedBool);
+                    for (int i : (int[]) ints);
+                }
+            }
+            ]]></code>
+    </test-code>
+    <test-code>
+        <description>Missing context identity cast</description>
+        <expected-problems>2</expected-problems>
+        <code><![CDATA[
+            class Scratch {
+                static void m(Boolean boxedBool) {
+                    ((Boolean) boxedBool).booleanValue(); // same type
+                    ((Object) boxedBool).toString(); // supertype
+                }
+            }
+            ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
@@ -683,4 +683,35 @@ class Scratch {
             }
             ]]></code>
     </test-code>
+    <test-code>
+        <description>Casts in arithmetic smaller than int </description>
+        <expected-problems>9</expected-problems>
+        <code><![CDATA[
+            class Scratch {
+                // they're all unecessary
+                static void m(int i, byte b, char c, short s) {
+                    i = b * (int) b; // 4
+                    i = (int) b * b;
+                    i = b * (int) s; // 6
+                    i = b * (int) c;
+                    i = b * (short) b; // 8
+                    i = i * (short) b;
+                    i = i * (short) s; // 10
+                    i = i * (int) c;
+                    i = i * (char) c; // 11
+                }
+            }
+            ]]></code>
+    </test-code>
+    <test-code>
+        <description>"Narrowing" cast from char to short is necessary</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            class Scratch {
+                static void m(int i, byte b, char c, short s) {
+                    i = i * (short) c;
+                }
+            }
+            ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
@@ -637,9 +637,24 @@ class Scratch {
         <expected-problems>2</expected-problems>
         <code><![CDATA[
             class Scratch {
+
                 static void m(Boolean boxedBool) {
                     ((Boolean) boxedBool).booleanValue(); // same type
                     ((Object) boxedBool).toString(); // supertype
+                }
+            }
+            ]]></code>
+    </test-code>
+    <test-code>
+        <description>Casts in arithmetic</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <code><![CDATA[
+            class Scratch {
+                static void m(int i, double d) {
+                    Object o;
+                    o = ((double) i) * d; // unnecessary
+                    o = ((double) i) * i; // necessary
                 }
             }
             ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
@@ -604,4 +604,17 @@ class Scratch {
 }
             ]]></code>
     </test-code>
+    <test-code>
+        <description>Assert statements</description>
+        <expected-problems>3</expected-problems>
+        <code><![CDATA[
+            class Scratch {
+                static void m(Boolean boxedBool, boolean bool, String str) {
+                    assert (boolean) boxedBool;
+                    assert (boolean) bool;
+                    assert bool : (String) str;
+                }
+            }
+            ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
@@ -746,8 +746,53 @@ class Scratch {
         <expected-problems>0</expected-problems>
         <code><![CDATA[
             class Scratch {
+
                 static void m(int i, byte b, char c, short s) {
                     i = i * (short) c;
+                }
+            }
+            ]]></code>
+    </test-code>
+    <test-code>
+        <description>char cast to int in string context is ok</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            class Scratch {
+
+                static void m(String s, char c) {
+                    // the toString is different -> necessary (string contexts aren't implemented yet)
+                    s = "(" + (int) c + ")" + c;
+                }
+            }
+            ]]></code>
+    </test-code>
+    <test-code>
+        <description>String cast determining context</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+            class Scratch {
+                static void m(Object a, Object b) {
+                    String s = a + (String) b   // necessary, determines context
+                            + a + (String) b    // technically unnecessary, but narrowing
+                            + a + (String) null // unnecessary
+                            ;
+                }
+            }
+            ]]></code>
+    </test-code>
+    <test-code>
+        <description>Cast on both sides of arithmetic</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <expected-messages>
+            <message>Unnecessary cast (int)</message>
+        </expected-messages>
+        <code><![CDATA[
+            class Scratch {
+                static void m(short s, Object b) {
+                    b = (int) s
+                            + (long) s;
                 }
             }
             ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
@@ -618,7 +618,7 @@ class Scratch {
             ]]></code>
     </test-code>
     <test-code>
-        <description>Loops</description>
+        <description>Conditionals and loop statements</description>
         <expected-problems>5</expected-problems>
         <code><![CDATA[
             class Scratch {
@@ -628,6 +628,30 @@ class Scratch {
                     for (int i = 0; (boolean) boxedBool; i++) {}
                     do; while ((boolean) boxedBool);
                     for (int i : (int[]) ints);
+                }
+            }
+            ]]></code>
+    </test-code>
+    <test-code>
+        <description>Conditional expr condition</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+            class Scratch {
+                static void m(Boolean boxedBool, boolean bool, String str, int[] ints) {
+                    str = (boolean) boxedBool ? "a" : "b";
+                }
+            }
+            ]]></code>
+    </test-code>
+    <test-code>
+        <description>Necessary cast for condition</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            class Scratch {
+                static void m(Object obj) {
+                    // both are necessary
+                    if ((Boolean) obj
+                        || (boolean) obj);
                 }
             }
             ]]></code>


### PR DESCRIPTION
## Describe the PR

Fix some FNs of UnnecessaryCast (the 7.0 version, #3204) by improving the underlying context machinery. Some of the new FNs are unboxing casts for a Boolean in eg
```java
assert (boolean) boxedBool;
if ((boolean) boxedBool);
```
but also casts in arithmetic expressions:
```java
// given: int i;
i * (int) i
i << (int) i
```

I think this could be added to the pmd 7 release notes as is.

## Ready?

TODO:
```java
char c;
"(" + (int) c + ")" + c; // the toString is different -> necessary (string contexts aren't implemented yet)

Integer integer;
(int) integer + 1.0 // integer is unboxed to int, then widened to double -> unnecessary
```

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

