### PR TITLE
[javascript] Update Rhino library to 1.7.13

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -16,7 +16,8 @@ This will create the zip files in the directory `pmd-dist/target`:
 
 That's all !
 
-**Note:** While Java 11 is required for building, running PMD only requires Java 7 (or Java 8 for Apex and the Designer).
+**Note:** While Java 11 is required for building, running PMD only requires Java 7
+(or Java 8 for Apex, JavaScript, Scala, Visualforce, and the Designer).
 
 **Note:** With PMD 6.24.0, we are creating [Reproducible Builds](https://reproducible-builds.org/). Since we use
 [Maven](https://maven.apache.org/guides/mini/guide-reproducible-builds.html) for building, the following

--- a/docs/pages/pmd/devdocs/building.md
+++ b/docs/pages/pmd/devdocs/building.md
@@ -12,7 +12,8 @@ author: Tom Copeland, Xavier Le Vourch <xlv@users.sourceforge.net>
 
 *   JDK 11 or higher
 
-{% include note.html content="While Java 11 is required for building, running PMD only requires Java 7 (or Java 8 for Apex, Scala, Visualforce, and the Designer)." %}
+{% include note.html content="While Java 11 is required for building, running PMD only requires Java 7
+(or Java 8 for Apex, JavaScript, Scala, Visualforce, and the Designer)." %}
 
 You’ll need to either check out the source code or download the latest source release. Assuming you’ve got the latest source release, unzip it to a directory:
 

--- a/docs/pages/pmd/userdocs/installation.md
+++ b/docs/pages/pmd/userdocs/installation.md
@@ -11,7 +11,13 @@ sidebar: pmd_sidebar
 
 ### Requirements
 
-*   [Java JRE](http://www.oracle.com/technetwork/java/javase/downloads/index.html) 1.7 or higher
+*   [Java JRE](http://www.oracle.com/technetwork/java/javase/downloads/index.html),
+    OpenJDK from [Azul](https://www.azul.com/downloads/zulu-community/)
+    or [AdoptOpenJDK](https://adoptopenjdk.net/) 1.7 or higher.
+    
+    **Note:** For analyzing Apex, JavaScript, Scala or VisualForce or running the [Designer](pmd_userdocs_extending_designer_reference.html)
+    at least Java 8 is required.
+    
 *   A zip archiver, e.g.:
     
     * For Windows: [Winzip](http://winzip.com) or the free [7-zip](http://www.7-zip.org/)

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -18,8 +18,8 @@ This is a {{ site.pmd.release_type }} release.
 
 The latest version of [Rhino](https://github.com/mozilla/rhino), the implementation of JavaScript we use
 for parsing JavaScript code, requires at least Java 8. Therefore we decided to upgrade the pmd-javascript
-module to Java 8 as well. This means, that from now on, a Java 8 or later runtime is required in order
-to analyze JavaScript code. Note, that PMD core still stays the at Java 7.
+module to Java 8 as well. This means that from now on, a Java 8 or later runtime is required in order
+to analyze JavaScript code. Note that PMD core still only requires Java 7.
 
 ### Fixed Issues
 
@@ -32,4 +32,3 @@ to analyze JavaScript code. Note, that PMD core still stays the at Java 7.
 ### External Contributions
 
 {% endtocmaker %}
-

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -14,7 +14,18 @@ This is a {{ site.pmd.release_type }} release.
 
 ### New and noteworthy
 
+#### Javascript module now requires at least Java 8
+
+The latest version of [Rhino](https://github.com/mozilla/rhino), the implementation of JavaScript we use
+for parsing JavaScript code, requires at least Java 8. Therefore we decided to upgrade the pmd-javascript
+module to Java 8 as well. This means, that from now on, a Java 8 or later runtime is required in order
+to analyze JavaScript code. Note, that PMD core still stays the at Java 7.
+
 ### Fixed Issues
+
+*   pmd-javascript
+    *   [#699](https://github.com/pmd/pmd/issues/699): \[javascript] Update Rhino library to 1.7.13
+    *   [#2081](https://github.com/pmd/pmd/issues/2081): \[javascript] Failing with OutOfMemoryError parsing a Javascript file
 
 ### API Changes
 

--- a/pmd-dist/pom.xml
+++ b/pmd-dist/pom.xml
@@ -140,11 +140,6 @@
         </dependency>
         <dependency>
             <groupId>net.sourceforge.pmd</groupId>
-            <artifactId>pmd-javascript</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-jsp</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -247,6 +242,11 @@
                 <dependency>
                     <groupId>net.sourceforge.pmd</groupId>
                     <artifactId>pmd-apex</artifactId>
+                    <version>${project.version}</version>
+                </dependency>
+                <dependency>
+                    <groupId>net.sourceforge.pmd</groupId>
+                    <artifactId>pmd-javascript</artifactId>
                     <version>${project.version}</version>
                 </dependency>
                 <dependency>

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/AllRulesIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/AllRulesIT.java
@@ -22,8 +22,8 @@ public class AllRulesIT extends AbstractBinaryDistributionTest {
     @Parameters
     public static Iterable<String> languagesToTest() {
         if (PMDExecutor.isJava7Test()) {
-            // note: apex, scala, and visualforce require java8
-            return Arrays.asList("java", "javascript", "jsp", "modelica",
+            // note: apex, javascript, scala, and visualforce require java8
+            return Arrays.asList("java", "jsp", "modelica",
                     "plsql", "pom", "velocitytemplate", "xml", "xsl");
         }
         // note: scala and wsdl have no rules

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistributionIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistributionIT.java
@@ -25,10 +25,10 @@ public class BinaryDistributionIT extends AbstractBinaryDistributionTest {
     private static final String SUPPORTED_LANGUAGES_PMD;
 
     static {
-        // note: apex, visualforce, and scala require java8
+        // note: apex, javascript, visualforce, and scala require java8
         if (PMDExecutor.isJava7Test()) {
-            SUPPORTED_LANGUAGES_CPD = "Supported languages: [cpp, cs, dart, ecmascript, fortran, go, groovy, java, jsp, kotlin, lua, matlab, modelica, objectivec, perl, php, plsql, python, ruby, swift, xml]";
-            SUPPORTED_LANGUAGES_PMD = "ecmascript, java, jsp, modelica, plsql, pom, vm, wsdl, xml, xsl";
+            SUPPORTED_LANGUAGES_CPD = "Supported languages: [cpp, cs, dart, fortran, go, groovy, java, jsp, kotlin, lua, matlab, modelica, objectivec, perl, php, plsql, python, ruby, swift, xml]";
+            SUPPORTED_LANGUAGES_PMD = "java, jsp, modelica, plsql, pom, vm, wsdl, xml, xsl";
         } else {
             SUPPORTED_LANGUAGES_CPD = "Supported languages: [apex, cpp, cs, dart, ecmascript, fortran, go, groovy, java, jsp, kotlin, lua, matlab, modelica, objectivec, perl, php, plsql, python, ruby, scala, swift, vf, xml]";
             SUPPORTED_LANGUAGES_PMD = "apex, ecmascript, java, jsp, modelica, plsql, pom, scala, vf, vm, wsdl, xml, xsl";

--- a/pmd-javascript/pom.xml
+++ b/pmd-javascript/pom.xml
@@ -11,6 +11,10 @@
         <relativePath>../</relativePath>
     </parent>
 
+    <properties>
+        <java.version>8</java.version>
+    </properties>
+
     <build>
         <resources>
             <resource>
@@ -78,6 +82,7 @@
         <dependency>
             <groupId>org.mozilla</groupId>
             <artifactId>rhino</artifactId>
+            <version>1.7.13</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/EcmascriptParserTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/EcmascriptParserTest.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.ecmascript.ast;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.Reader;
@@ -180,5 +181,14 @@ public class EcmascriptParserTest extends EcmascriptParserTestBase {
                                            + "x <<= 2; x >>= 2; x >>>= 2; }");
         ASTAssignment infix = rootNode.getFirstDescendantOfType(ASTAssignment.class);
         assertEquals("^=", infix.getImage());
+    }
+
+    /**
+     * [javascript] Failing with OutOfMemoryError parsing a Javascript file #2081
+     */
+    @Test(timeout = 5000L)
+    public void shouldNotFailWithOutOfMemory() {
+        ASTAstRoot rootNode = js.parse("(``\n);");
+        assertNotNull(rootNode);
     }
 }

--- a/pmd-javascript/src/test/resources/net/sourceforge/pmd/lang/ecmascript/ast/testdata/jquery-selector.txt
+++ b/pmd-javascript/src/test/resources/net/sourceforge/pmd/lang/ecmascript/ast/testdata/jquery-selector.txt
@@ -1,4 +1,5 @@
 +- AstRoot
+   +- Comment
    +- EmptyStatement
    +- EmptyStatement
    +- EmptyStatement
@@ -9,6 +10,7 @@
    +- EmptyStatement
    +- EmptyStatement
    +- EmptyStatement
+   +- Comment
    +- EmptyStatement
    +- EmptyStatement
    +- EmptyStatement
@@ -338,6 +340,7 @@
                   |  |        +- IfStatement
                   |  |        |  +- Name
                   |  |        |  +- Scope
+                  |  |        |     +- Comment
                   |  |        |     +- ReturnStatement
                   |  |        |        +- Name
                   |  |        +- ReturnStatement
@@ -451,6 +454,7 @@
                   |     |     +- InfixExpression
                   |     |        +- Name
                   |     |        +- ArrayLiteral
+                  |     +- Comment
                   |     +- IfStatement
                   |     |  +- InfixExpression
                   |     |  |  +- InfixExpression
@@ -491,6 +495,8 @@
                   |     |     +- IfStatement
                   |     |        +- Name
                   |     |        +- Scope
+                  |     |           +- Comment
+                  |     |           +- Comment
                   |     |           +- IfStatement
                   |     |           |  +- InfixExpression
                   |     |           |  |  +- InfixExpression
@@ -505,6 +511,7 @@
                   |     |           |  |           |  +- Name
                   |     |           |  |           +- Name
                   |     |           |  +- Scope
+                  |     |           |     +- Comment
                   |     |           |     +- IfStatement
                   |     |           |        +- ParenthesizedExpression
                   |     |           |        |  +- Assignment
@@ -513,59 +520,62 @@
                   |     |           |        |        +- Name
                   |     |           |        |        +- NumberLiteral
                   |     |           |        +- Scope
+                  |     |           |        |  +- Comment
                   |     |           |        |  +- IfStatement
-                  |     |           |        |     +- InfixExpression
-                  |     |           |        |     |  +- Name
-                  |     |           |        |     |  +- NumberLiteral
-                  |     |           |        |     +- Scope
-                  |     |           |        |     |  +- IfStatement
-                  |     |           |        |     |  |  +- ParenthesizedExpression
-                  |     |           |        |     |  |  |  +- Assignment
-                  |     |           |        |     |  |  |     +- Name
-                  |     |           |        |     |  |  |     +- FunctionCall
-                  |     |           |        |     |  |  |        +- PropertyGet
-                  |     |           |        |     |  |  |        |  +- Name
-                  |     |           |        |     |  |  |        |  +- Name
-                  |     |           |        |     |  |  |        +- Name
-                  |     |           |        |     |  |  +- Scope
-                  |     |           |        |     |  |     +- ExpressionStatement
-                  |     |           |        |     |  |        +- FunctionCall
-                  |     |           |        |     |  |           +- PropertyGet
-                  |     |           |        |     |  |           |  +- Name
-                  |     |           |        |     |  |           |  +- Name
-                  |     |           |        |     |  |           +- Name
-                  |     |           |        |     |  |           +- Name
-                  |     |           |        |     |  +- ReturnStatement
-                  |     |           |        |     |     +- Name
-                  |     |           |        |     +- Scope
-                  |     |           |        |        +- IfStatement
-                  |     |           |        |           +- InfixExpression
-                  |     |           |        |           |  +- Name
-                  |     |           |        |           |  +- InfixExpression
-                  |     |           |        |           |     +- ParenthesizedExpression
-                  |     |           |        |           |     |  +- Assignment
-                  |     |           |        |           |     |     +- Name
-                  |     |           |        |           |     |     +- FunctionCall
-                  |     |           |        |           |     |        +- PropertyGet
-                  |     |           |        |           |     |        |  +- Name
-                  |     |           |        |           |     |        |  +- Name
-                  |     |           |        |           |     |        +- Name
-                  |     |           |        |           |     +- FunctionCall
-                  |     |           |        |           |        +- PropertyGet
-                  |     |           |        |           |        |  +- Name
-                  |     |           |        |           |        |  +- Name
-                  |     |           |        |           |        +- Name
-                  |     |           |        |           |        +- Name
-                  |     |           |        |           +- Scope
-                  |     |           |        |              +- ExpressionStatement
-                  |     |           |        |              |  +- FunctionCall
-                  |     |           |        |              |     +- PropertyGet
-                  |     |           |        |              |     |  +- Name
-                  |     |           |        |              |     |  +- Name
-                  |     |           |        |              |     +- Name
-                  |     |           |        |              |     +- Name
-                  |     |           |        |              +- ReturnStatement
-                  |     |           |        |                 +- Name
+                  |     |           |        |  |  +- InfixExpression
+                  |     |           |        |  |  |  +- Name
+                  |     |           |        |  |  |  +- NumberLiteral
+                  |     |           |        |  |  +- Scope
+                  |     |           |        |  |  |  +- IfStatement
+                  |     |           |        |  |  |  |  +- ParenthesizedExpression
+                  |     |           |        |  |  |  |  |  +- Assignment
+                  |     |           |        |  |  |  |  |     +- Name
+                  |     |           |        |  |  |  |  |     +- FunctionCall
+                  |     |           |        |  |  |  |  |        +- PropertyGet
+                  |     |           |        |  |  |  |  |        |  +- Name
+                  |     |           |        |  |  |  |  |        |  +- Name
+                  |     |           |        |  |  |  |  |        +- Name
+                  |     |           |        |  |  |  |  +- Scope
+                  |     |           |        |  |  |  |     +- ExpressionStatement
+                  |     |           |        |  |  |  |        +- FunctionCall
+                  |     |           |        |  |  |  |           +- PropertyGet
+                  |     |           |        |  |  |  |           |  +- Name
+                  |     |           |        |  |  |  |           |  +- Name
+                  |     |           |        |  |  |  |           +- Name
+                  |     |           |        |  |  |  |           +- Name
+                  |     |           |        |  |  |  +- ReturnStatement
+                  |     |           |        |  |  |  |  +- Name
+                  |     |           |        |  |  |  +- Comment
+                  |     |           |        |  |  +- Scope
+                  |     |           |        |  |     +- IfStatement
+                  |     |           |        |  |        +- InfixExpression
+                  |     |           |        |  |        |  +- Name
+                  |     |           |        |  |        |  +- InfixExpression
+                  |     |           |        |  |        |     +- ParenthesizedExpression
+                  |     |           |        |  |        |     |  +- Assignment
+                  |     |           |        |  |        |     |     +- Name
+                  |     |           |        |  |        |     |     +- FunctionCall
+                  |     |           |        |  |        |     |        +- PropertyGet
+                  |     |           |        |  |        |     |        |  +- Name
+                  |     |           |        |  |        |     |        |  +- Name
+                  |     |           |        |  |        |     |        +- Name
+                  |     |           |        |  |        |     +- FunctionCall
+                  |     |           |        |  |        |        +- PropertyGet
+                  |     |           |        |  |        |        |  +- Name
+                  |     |           |        |  |        |        |  +- Name
+                  |     |           |        |  |        |        +- Name
+                  |     |           |        |  |        |        +- Name
+                  |     |           |        |  |        +- Scope
+                  |     |           |        |  |           +- ExpressionStatement
+                  |     |           |        |  |           |  +- FunctionCall
+                  |     |           |        |  |           |     +- PropertyGet
+                  |     |           |        |  |           |     |  +- Name
+                  |     |           |        |  |           |     |  +- Name
+                  |     |           |        |  |           |     +- Name
+                  |     |           |        |  |           |     +- Name
+                  |     |           |        |  |           +- ReturnStatement
+                  |     |           |        |  |              +- Name
+                  |     |           |        |  +- Comment
                   |     |           |        +- IfStatement
                   |     |           |           +- ElementGet
                   |     |           |           |  +- Name
@@ -583,7 +593,8 @@
                   |     |           |           |  |        |  +- Name
                   |     |           |           |  |        +- Name
                   |     |           |           |  +- ReturnStatement
-                  |     |           |           |     +- Name
+                  |     |           |           |  |  +- Name
+                  |     |           |           |  +- Comment
                   |     |           |           +- IfStatement
                   |     |           |              +- InfixExpression
                   |     |           |              |  +- ParenthesizedExpression
@@ -636,6 +647,13 @@
                   |     |                 |  +- Assignment
                   |     |                 |     +- Name
                   |     |                 |     +- Name
+                  |     |                 +- Comment
+                  |     |                 +- Comment
+                  |     |                 +- Comment
+                  |     |                 +- Comment
+                  |     |                 +- Comment
+                  |     |                 +- Comment
+                  |     |                 +- Comment
                   |     |                 +- IfStatement
                   |     |                 |  +- InfixExpression
                   |     |                 |  |  +- InfixExpression
@@ -654,6 +672,7 @@
                   |     |                 |  |           |  +- Name
                   |     |                 |  |           +- Name
                   |     |                 |  +- Scope
+                  |     |                 |     +- Comment
                   |     |                 |     +- ExpressionStatement
                   |     |                 |     |  +- Assignment
                   |     |                 |     |     +- Name
@@ -670,6 +689,8 @@
                   |     |                 |     |        |        +- Name
                   |     |                 |     |        |        +- Name
                   |     |                 |     |        +- Name
+                  |     |                 |     +- Comment
+                  |     |                 |     +- Comment
                   |     |                 |     +- IfStatement
                   |     |                 |     |  +- InfixExpression
                   |     |                 |     |  |  +- InfixExpression
@@ -680,6 +701,7 @@
                   |     |                 |     |  |        +- Name
                   |     |                 |     |  |        +- Name
                   |     |                 |     |  +- Scope
+                  |     |                 |     |     +- Comment
                   |     |                 |     |     +- IfStatement
                   |     |                 |     |        +- ParenthesizedExpression
                   |     |                 |     |        |  +- Assignment
@@ -800,6 +822,7 @@
                   |           +- Name
                   |           +- Name
                   |           +- Name
+                  +- Comment
                   +- FunctionNode
                   |  +- Name
                   |  +- Block
@@ -812,6 +835,7 @@
                   |     |  +- Name
                   |     |  +- Name
                   |     |  +- Block
+                  |     |     +- Comment
                   |     |     +- IfStatement
                   |     |     |  +- InfixExpression
                   |     |     |  |  +- FunctionCall
@@ -825,6 +849,7 @@
                   |     |     |  |     +- Name
                   |     |     |  |     +- Name
                   |     |     |  +- Scope
+                  |     |     |     +- Comment
                   |     |     |     +- ExpressionStatement
                   |     |     |        +- UnaryExpression
                   |     |     |           +- ElementGet
@@ -844,6 +869,7 @@
                   |     |              +- Name
                   |     +- ReturnStatement
                   |        +- Name
+                  +- Comment
                   +- FunctionNode
                   |  +- Name
                   |  +- Name
@@ -856,6 +882,7 @@
                   |     |     +- KeywordLiteral
                   |     +- ReturnStatement
                   |        +- Name
+                  +- Comment
                   +- FunctionNode
                   |  +- Name
                   |  +- Name
@@ -875,6 +902,7 @@
                   |                       |  +- Name
                   |                       |  +- Name
                   |                       +- Name
+                  +- Comment
                   +- FunctionNode
                   |  +- Name
                   |  +- Name
@@ -900,19 +928,31 @@
                   |                       |  +- Name
                   |                       |  +- Name
                   |                       +- Name
+                  +- Comment
                   +- FunctionNode
                   |  +- Name
                   |  +- Name
                   |  +- Block
+                  |     +- Comment
                   |     +- ReturnStatement
                   |        +- FunctionNode
                   |           +- Name
                   |           +- Block
+                  |              +- Comment
+                  |              +- Comment
+                  |              +- Comment
                   |              +- IfStatement
                   |              |  +- InfixExpression
                   |              |  |  +- StringLiteral
                   |              |  |  +- Name
                   |              |  +- Scope
+                  |              |  |  +- Comment
+                  |              |  |  +- Comment
+                  |              |  |  +- Comment
+                  |              |  |  +- Comment
+                  |              |  |  +- Comment
+                  |              |  |  +- Comment
+                  |              |  |  +- Comment
                   |              |  |  +- IfStatement
                   |              |  |  |  +- InfixExpression
                   |              |  |  |  |  +- PropertyGet
@@ -924,6 +964,7 @@
                   |              |  |  |  |     |  +- Name
                   |              |  |  |  |     +- KeywordLiteral
                   |              |  |  |  +- Scope
+                  |              |  |  |     +- Comment
                   |              |  |  |     +- IfStatement
                   |              |  |  |     |  +- InfixExpression
                   |              |  |  |     |  |  +- StringLiteral
@@ -971,11 +1012,14 @@
                   |              |  |  |                 |  +- Name
                   |              |  |  |                 +- Name
                   |              |  |  +- ReturnStatement
-                  |              |  |     +- InfixExpression
-                  |              |  |        +- PropertyGet
-                  |              |  |        |  +- Name
-                  |              |  |        |  +- Name
-                  |              |  |        +- Name
+                  |              |  |  |  +- InfixExpression
+                  |              |  |  |     +- PropertyGet
+                  |              |  |  |     |  +- Name
+                  |              |  |  |     |  +- Name
+                  |              |  |  |     +- Name
+                  |              |  |  +- Comment
+                  |              |  |  +- Comment
+                  |              |  |  +- Comment
                   |              |  +- IfStatement
                   |              |     +- InfixExpression
                   |              |     |  +- StringLiteral
@@ -989,6 +1033,7 @@
                   |              |              +- Name
                   |              +- ReturnStatement
                   |                 +- KeywordLiteral
+                  +- Comment
                   +- FunctionNode
                   |  +- Name
                   |  +- Name
@@ -1028,6 +1073,7 @@
                   |                             |     +- PropertyGet
                   |                             |        +- Name
                   |                             |        +- Name
+                  |                             +- Comment
                   |                             +- WhileLoop
                   |                                +- UnaryExpression
                   |                                |  +- Name
@@ -1056,6 +1102,7 @@
                   |                                                        +- ElementGet
                   |                                                           +- Name
                   |                                                           +- Name
+                  +- Comment
                   +- FunctionNode
                   |  +- Name
                   |  +- Name
@@ -1071,6 +1118,7 @@
                   |              |  |     +- Name
                   |              |  +- StringLiteral
                   |              +- Name
+                  +- Comment
                   +- FunctionNode
                   |  +- Name
                   |  +- Name
@@ -1088,6 +1136,11 @@
                   |     |        |  |  +- Name
                   |     |        |  +- Name
                   |     |        +- Name
+                  |     +- Comment
+                  |     +- Comment
+                  |     +- Comment
+                  |     +- Comment
+                  |     +- Comment
                   |     +- IfStatement
                   |     |  +- InfixExpression
                   |     |  |  +- InfixExpression
@@ -1119,6 +1172,12 @@
                   |     |           |  +- Name
                   |     |           |  +- Name
                   |     |           +- Name
+                  |     +- Comment
+                  |     +- Comment
+                  |     +- Comment
+                  |     +- Comment
+                  |     +- Comment
+                  |     +- Comment
                   |     +- IfStatement
                   |        +- InfixExpression
                   |        |  +- InfixExpression
@@ -1137,6 +1196,7 @@
                   |        |        |  +- Name
                   |        |        +- Name
                   |        +- Scope
+                  |           +- Comment
                   |           +- ExpressionStatement
                   |              +- FunctionCall
                   |                 +- PropertyGet
@@ -1288,11 +1348,12 @@
                   |           |     |           |  +- StringLiteral
                   |           |     |           +- Scope
                   |           |     |           |  +- ReturnStatement
-                  |           |     |           |     +- FunctionCall
-                  |           |     |           |        +- PropertyGet
-                  |           |     |           |        |  +- Name
-                  |           |     |           |        |  +- Name
-                  |           |     |           |        +- Name
+                  |           |     |           |  |  +- FunctionCall
+                  |           |     |           |  |     +- PropertyGet
+                  |           |     |           |  |     |  +- Name
+                  |           |     |           |  |     |  +- Name
+                  |           |     |           |  |     +- Name
+                  |           |     |           |  +- Comment
                   |           |     |           +- Scope
                   |           |     |              +- ReturnStatement
                   |           |     |                 +- FunctionCall
@@ -1376,6 +1437,7 @@
                   |           |     |        |        |  +- Name
                   |           |     |        |        +- Name
                   |           |     |        |        +- Name
+                  |           |     |        +- Comment
                   |           |     |        +- ExpressionStatement
                   |           |     |        |  +- Assignment
                   |           |     |        |     +- ElementGet
@@ -1431,6 +1493,7 @@
                   |           |     |  +- FunctionNode
                   |           |     |     +- Name
                   |           |     |     +- Block
+                  |           |     |        +- Comment
                   |           |     |        +- ExpressionStatement
                   |           |     |        |  +- Assignment
                   |           |     |        |     +- ElementGet
@@ -1454,6 +1517,7 @@
                   |           |     |        |  |  |  +- NumberLiteral
                   |           |     |        |  |  +- StringLiteral
                   |           |     |        |  +- Scope
+                  |           |     |        |  |  +- Comment
                   |           |     |        |  |  +- IfStatement
                   |           |     |        |  |  |  +- UnaryExpression
                   |           |     |        |  |  |  |  +- ElementGet
@@ -1502,26 +1566,27 @@
                   |           |     |        |  |  |                          |  +- NumberLiteral
                   |           |     |        |  |  |                          +- StringLiteral
                   |           |     |        |  |  +- ExpressionStatement
-                  |           |     |        |  |     +- Assignment
-                  |           |     |        |  |        +- ElementGet
-                  |           |     |        |  |        |  +- Name
-                  |           |     |        |  |        |  +- NumberLiteral
-                  |           |     |        |  |        +- UnaryExpression
-                  |           |     |        |  |           +- ParenthesizedExpression
-                  |           |     |        |  |              +- InfixExpression
-                  |           |     |        |  |                 +- ParenthesizedExpression
-                  |           |     |        |  |                 |  +- InfixExpression
-                  |           |     |        |  |                 |     +- ElementGet
-                  |           |     |        |  |                 |     |  +- Name
-                  |           |     |        |  |                 |     |  +- NumberLiteral
-                  |           |     |        |  |                 |     +- ElementGet
-                  |           |     |        |  |                 |        +- Name
-                  |           |     |        |  |                 |        +- NumberLiteral
-                  |           |     |        |  |                 +- InfixExpression
-                  |           |     |        |  |                    +- ElementGet
-                  |           |     |        |  |                    |  +- Name
-                  |           |     |        |  |                    |  +- NumberLiteral
-                  |           |     |        |  |                    +- StringLiteral
+                  |           |     |        |  |  |  +- Assignment
+                  |           |     |        |  |  |     +- ElementGet
+                  |           |     |        |  |  |     |  +- Name
+                  |           |     |        |  |  |     |  +- NumberLiteral
+                  |           |     |        |  |  |     +- UnaryExpression
+                  |           |     |        |  |  |        +- ParenthesizedExpression
+                  |           |     |        |  |  |           +- InfixExpression
+                  |           |     |        |  |  |              +- ParenthesizedExpression
+                  |           |     |        |  |  |              |  +- InfixExpression
+                  |           |     |        |  |  |              |     +- ElementGet
+                  |           |     |        |  |  |              |     |  +- Name
+                  |           |     |        |  |  |              |     |  +- NumberLiteral
+                  |           |     |        |  |  |              |     +- ElementGet
+                  |           |     |        |  |  |              |        +- Name
+                  |           |     |        |  |  |              |        +- NumberLiteral
+                  |           |     |        |  |  |              +- InfixExpression
+                  |           |     |        |  |  |                 +- ElementGet
+                  |           |     |        |  |  |                 |  +- Name
+                  |           |     |        |  |  |                 |  +- NumberLiteral
+                  |           |     |        |  |  |                 +- StringLiteral
+                  |           |     |        |  |  +- Comment
                   |           |     |        |  +- IfStatement
                   |           |     |        |     +- ElementGet
                   |           |     |        |     |  +- Name
@@ -1572,19 +1637,20 @@
                   |           |              |  |  +- NumberLiteral
                   |           |              |  +- Scope
                   |           |              |  |  +- ExpressionStatement
-                  |           |              |  |     +- Assignment
-                  |           |              |  |        +- ElementGet
-                  |           |              |  |        |  +- Name
-                  |           |              |  |        |  +- NumberLiteral
-                  |           |              |  |        +- InfixExpression
-                  |           |              |  |           +- ElementGet
-                  |           |              |  |           |  +- Name
-                  |           |              |  |           |  +- NumberLiteral
-                  |           |              |  |           +- InfixExpression
-                  |           |              |  |              +- ElementGet
-                  |           |              |  |              |  +- Name
-                  |           |              |  |              |  +- NumberLiteral
-                  |           |              |  |              +- StringLiteral
+                  |           |              |  |  |  +- Assignment
+                  |           |              |  |  |     +- ElementGet
+                  |           |              |  |  |     |  +- Name
+                  |           |              |  |  |     |  +- NumberLiteral
+                  |           |              |  |  |     +- InfixExpression
+                  |           |              |  |  |        +- ElementGet
+                  |           |              |  |  |        |  +- Name
+                  |           |              |  |  |        |  +- NumberLiteral
+                  |           |              |  |  |        +- InfixExpression
+                  |           |              |  |  |           +- ElementGet
+                  |           |              |  |  |           |  +- Name
+                  |           |              |  |  |           |  +- NumberLiteral
+                  |           |              |  |  |           +- StringLiteral
+                  |           |              |  |  +- Comment
                   |           |              |  +- IfStatement
                   |           |              |     +- InfixExpression
                   |           |              |     |  +- Name
@@ -1620,6 +1686,7 @@
                   |           |              |     |                    +- Name
                   |           |              |     |                    +- Name
                   |           |              |     +- Scope
+                  |           |              |        +- Comment
                   |           |              |        +- ExpressionStatement
                   |           |              |        |  +- Assignment
                   |           |              |        |     +- ElementGet
@@ -2046,6 +2113,7 @@
                   |           |     |                    +- IfStatement
                   |           |     |                       +- Name
                   |           |     |                       +- Scope
+                  |           |     |                          +- Comment
                   |           |     |                          +- IfStatement
                   |           |     |                          |  +- Name
                   |           |     |                          |  +- Scope
@@ -2079,6 +2147,7 @@
                   |           |     |                          |     |     |        +- Scope
                   |           |     |                          |     |     |           +- ReturnStatement
                   |           |     |                          |     |     |              +- KeywordLiteral
+                  |           |     |                          |     |     +- Comment
                   |           |     |                          |     |     +- ExpressionStatement
                   |           |     |                          |     |        +- Assignment
                   |           |     |                          |     |           +- Name
@@ -2106,11 +2175,13 @@
                   |           |     |                          |           +- PropertyGet
                   |           |     |                          |              +- Name
                   |           |     |                          |              +- Name
+                  |           |     |                          +- Comment
                   |           |     |                          +- IfStatement
                   |           |     |                          |  +- InfixExpression
                   |           |     |                          |  |  +- Name
                   |           |     |                          |  |  +- Name
                   |           |     |                          |  +- Scope
+                  |           |     |                          |  |  +- Comment
                   |           |     |                          |  |  +- ExpressionStatement
                   |           |     |                          |  |  |  +- Assignment
                   |           |     |                          |  |  |     +- Name
@@ -2187,6 +2258,7 @@
                   |           |     |                          |  |     |                 +- Name
                   |           |     |                          |  |     |                 +- Name
                   |           |     |                          |  |     +- Scope
+                  |           |     |                          |  |        +- Comment
                   |           |     |                          |  |        +- IfStatement
                   |           |     |                          |  |           +- InfixExpression
                   |           |     |                          |  |           |  +- InfixExpression
@@ -2212,6 +2284,7 @@
                   |           |     |                          |  |              |        +- Name
                   |           |     |                          |  |              +- BreakStatement
                   |           |     |                          |  +- Scope
+                  |           |     |                          |     +- Comment
                   |           |     |                          |     +- IfStatement
                   |           |     |                          |     |  +- Name
                   |           |     |                          |     |  +- Scope
@@ -2257,6 +2330,7 @@
                   |           |     |                          |        |  +- Name
                   |           |     |                          |        |  +- KeywordLiteral
                   |           |     |                          |        +- Scope
+                  |           |     |                          |           +- Comment
                   |           |     |                          |           +- WhileLoop
                   |           |     |                          |              +- ParenthesizedExpression
                   |           |     |                          |              |  +- Assignment
@@ -2299,6 +2373,7 @@
                   |           |     |                          |                    |  +- UnaryExpression
                   |           |     |                          |                    |     +- Name
                   |           |     |                          |                    +- Scope
+                  |           |     |                          |                       +- Comment
                   |           |     |                          |                       +- IfStatement
                   |           |     |                          |                       |  +- Name
                   |           |     |                          |                       |  +- Scope
@@ -2329,6 +2404,7 @@
                   |           |     |                          |                          |  +- Name
                   |           |     |                          |                          +- Scope
                   |           |     |                          |                             +- BreakStatement
+                  |           |     |                          +- Comment
                   |           |     |                          +- ExpressionStatement
                   |           |     |                          |  +- Assignment
                   |           |     |                          |     +- Name
@@ -2356,6 +2432,10 @@
                   |           |           +- Name
                   |           |           +- Name
                   |           |           +- Block
+                  |           |              +- Comment
+                  |           |              +- Comment
+                  |           |              +- Comment
+                  |           |              +- Comment
                   |           |              +- VariableDeclaration
                   |           |              |  +- VariableInitializer
                   |           |              |  |  +- Name
@@ -2381,6 +2461,9 @@
                   |           |              |              +- InfixExpression
                   |           |              |                 +- StringLiteral
                   |           |              |                 +- Name
+                  |           |              +- Comment
+                  |           |              +- Comment
+                  |           |              +- Comment
                   |           |              +- IfStatement
                   |           |              |  +- ElementGet
                   |           |              |  |  +- Name
@@ -2487,6 +2570,9 @@
                   |                 |     +- FunctionNode
                   |                 |        +- Name
                   |                 |        +- Block
+                  |                 |           +- Comment
+                  |                 |           +- Comment
+                  |                 |           +- Comment
                   |                 |           +- VariableDeclaration
                   |                 |           |  +- VariableInitializer
                   |                 |           |  |  +- Name
@@ -2533,6 +2619,7 @@
                   |                 |                 |        |     +- PropertyGet
                   |                 |                 |        |        +- Name
                   |                 |                 |        |        +- Name
+                  |                 |                 |        +- Comment
                   |                 |                 |        +- WhileLoop
                   |                 |                 |           +- UnaryExpression
                   |                 |                 |           |  +- Name
@@ -2575,6 +2662,7 @@
                   |                 |                       |     +- KeywordLiteral
                   |                 |                       |     +- Name
                   |                 |                       |     +- Name
+                  |                 |                       +- Comment
                   |                 |                       +- ExpressionStatement
                   |                 |                       |  +- Assignment
                   |                 |                       |     +- ElementGet
@@ -2652,6 +2740,7 @@
                   |                 |     +- FunctionNode
                   |                 |        +- Name
                   |                 |        +- Block
+                  |                 |           +- Comment
                   |                 |           +- IfStatement
                   |                 |           |  +- UnaryExpression
                   |                 |           |  |  +- FunctionCall
@@ -2830,6 +2919,8 @@
                   |                 |  +- FunctionNode
                   |                 |     +- Name
                   |                 |     +- Block
+                  |                 |        +- Comment
+                  |                 |        +- Comment
                   |                 |        +- ReturnStatement
                   |                 |           +- InfixExpression
                   |                 |              +- ParenthesizedExpression
@@ -2859,11 +2950,16 @@
                   |                 |  +- FunctionNode
                   |                 |     +- Name
                   |                 |     +- Block
+                  |                 |        +- Comment
+                  |                 |        +- Comment
+                  |                 |        +- Comment
+                  |                 |        +- Comment
                   |                 |        +- IfStatement
                   |                 |        |  +- PropertyGet
                   |                 |        |  |  +- Name
                   |                 |        |  |  +- Name
                   |                 |        |  +- Scope
+                  |                 |        |     +- Comment
                   |                 |        |     +- ExpressionStatement
                   |                 |        |        +- PropertyGet
                   |                 |        |           +- PropertyGet
@@ -2881,6 +2977,10 @@
                   |                 |  +- FunctionNode
                   |                 |     +- Name
                   |                 |     +- Block
+                  |                 |        +- Comment
+                  |                 |        +- Comment
+                  |                 |        +- Comment
+                  |                 |        +- Comment
                   |                 |        +- ForLoop
                   |                 |        |  +- Assignment
                   |                 |        |  |  +- Name
@@ -3182,6 +3282,7 @@
                   |        |  +- Name
                   |        |  +- Name
                   |        +- Name
+                  +- Comment
                   +- ForInLoop
                   |  +- Name
                   |  +- ObjectLiteral
@@ -3231,6 +3332,7 @@
                   |           +- FunctionCall
                   |              +- Name
                   |              +- Name
+                  +- Comment
                   +- FunctionNode
                   |  +- Name
                   |  +- Block
@@ -3309,6 +3411,7 @@
                   |     +- WhileLoop
                   |     |  +- Name
                   |     |  +- Scope
+                  |     |     +- Comment
                   |     |     +- IfStatement
                   |     |     |  +- InfixExpression
                   |     |     |  |  +- UnaryExpression
@@ -3325,6 +3428,7 @@
                   |     |     |     +- IfStatement
                   |     |     |     |  +- Name
                   |     |     |     |  +- Scope
+                  |     |     |     |     +- Comment
                   |     |     |     |     +- ExpressionStatement
                   |     |     |     |        +- Assignment
                   |     |     |     |           +- Name
@@ -3352,6 +3456,7 @@
                   |     |     |  +- Assignment
                   |     |     |     +- Name
                   |     |     |     +- KeywordLiteral
+                  |     |     +- Comment
                   |     |     +- IfStatement
                   |     |     |  +- ParenthesizedExpression
                   |     |     |  |  +- Assignment
@@ -3468,6 +3573,9 @@
                   |     |        |  +- Name
                   |     |        +- Scope
                   |     |           +- BreakStatement
+                  |     +- Comment
+                  |     +- Comment
+                  |     +- Comment
                   |     +- IfStatement
                   |     |  +- Name
                   |     |  +- Scope
@@ -3606,6 +3714,7 @@
                   |                 |     +- ArrayLiteral
                   |                 |        +- Name
                   |                 |        +- Name
+                  |                 +- Comment
                   |                 +- IfStatement
                   |                 |  +- Name
                   |                 |  +- Scope
@@ -3702,6 +3811,7 @@
                   |                 |                       |        |  +- NumberLiteral
                   |                 |                       |        +- Name
                   |                 |                       +- Scope
+                  |                 |                       |  +- Comment
                   |                 |                       |  +- ReturnStatement
                   |                 |                       |     +- ParenthesizedExpression
                   |                 |                       |        +- Assignment
@@ -3712,12 +3822,14 @@
                   |                 |                       |              +- Name
                   |                 |                       |              +- NumberLiteral
                   |                 |                       +- Scope
+                  |                 |                          +- Comment
                   |                 |                          +- ExpressionStatement
                   |                 |                          |  +- Assignment
                   |                 |                          |     +- ElementGet
                   |                 |                          |     |  +- Name
                   |                 |                          |     |  +- Name
                   |                 |                          |     +- Name
+                  |                 |                          +- Comment
                   |                 |                          +- IfStatement
                   |                 |                             +- ParenthesizedExpression
                   |                 |                             |  +- Assignment
@@ -3985,6 +4097,8 @@
                   |                 +- IfStatement
                   |                 |  +- Name
                   |                 |  +- Scope
+                  |                 |  |  +- Comment
+                  |                 |  |  +- Comment
                   |                 |  |  +- ExpressionStatement
                   |                 |  |  |  +- Assignment
                   |                 |  |  |     +- Name
@@ -4000,6 +4114,7 @@
                   |                 |  |  |        |           +- Name
                   |                 |  |  |        +- ArrayLiteral
                   |                 |  |  |        +- Name
+                  |                 |  |  +- Comment
                   |                 |  |  +- ExpressionStatement
                   |                 |  |     +- FunctionCall
                   |                 |  |        +- Name
@@ -4012,6 +4127,7 @@
                   |                 |        +- Assignment
                   |                 |           +- Name
                   |                 |           +- Name
+                  |                 +- Comment
                   |                 +- IfStatement
                   |                 |  +- Name
                   |                 |  +- Scope
@@ -4029,6 +4145,7 @@
                   |                 |     |     +- ArrayLiteral
                   |                 |     |     +- Name
                   |                 |     |     +- Name
+                  |                 |     +- Comment
                   |                 |     +- ExpressionStatement
                   |                 |     |  +- Assignment
                   |                 |     |     +- Name
@@ -4074,6 +4191,7 @@
                   |                    |        +- IfStatement
                   |                    |        |  +- Name
                   |                    |        |  +- Scope
+                  |                    |        |     +- Comment
                   |                    |        |     +- ExpressionStatement
                   |                    |        |     |  +- Assignment
                   |                    |        |     |     +- Name
@@ -4096,6 +4214,7 @@
                   |                    |        |     |        |        +- Name
                   |                    |        |     |        |        +- Name
                   |                    |        |     |        +- Scope
+                  |                    |        |     |           +- Comment
                   |                    |        |     |           +- ExpressionStatement
                   |                    |        |     |              +- FunctionCall
                   |                    |        |     |                 +- PropertyGet
@@ -4316,6 +4435,7 @@
                   |     |              |                 +- Name
                   |     |              |                 +- Name
                   |     |              |                 +- Name
+                  |     |              +- Comment
                   |     |              +- ExpressionStatement
                   |     |              |  +- Assignment
                   |     |              |     +- Name
@@ -4376,11 +4496,13 @@
                   |     |           |           |  +- Name
                   |     |           |           |  +- Name
                   |     |           |           +- Name
+                  |     |           +- Comment
                   |     |           +- IfStatement
                   |     |           |  +- ElementGet
                   |     |           |  |  +- Name
                   |     |           |  |  +- Name
                   |     |           |  +- Scope
+                  |     |           |     +- Comment
                   |     |           |     +- ExpressionStatement
                   |     |           |     |  +- Assignment
                   |     |           |     |     +- Name
@@ -4583,6 +4705,10 @@
                   |     |           +- IfStatement
                   |     |           |  +- Name
                   |     |           |  +- Scope
+                  |     |           |     +- Comment
+                  |     |           |     +- Comment
+                  |     |           |     +- Comment
+                  |     |           |     +- Comment
                   |     |           |     +- ExpressionStatement
                   |     |           |        +- Assignment
                   |     |           |           +- Name
@@ -4615,6 +4741,10 @@
                   |     |           |     |     |  +- Assignment
                   |     |           |     |     |     +- Name
                   |     |           |     |     |     +- NumberLiteral
+                  |     |           |     |     +- Comment
+                  |     |           |     |     +- Comment
+                  |     |           |     |     +- Comment
+                  |     |           |     |     +- Comment
                   |     |           |     |     +- IfStatement
                   |     |           |     |     |  +- InfixExpression
                   |     |           |     |     |  |  +- UnaryExpression
@@ -4670,6 +4800,7 @@
                   |     |           |     +- IfStatement
                   |     |           |        +- Name
                   |     |           |        +- Scope
+                  |     |           |           +- Comment
                   |     |           |           +- IfStatement
                   |     |           |           |  +- ParenthesizedExpression
                   |     |           |           |  |  +- Assignment
@@ -4691,10 +4822,19 @@
                   |     |           |                       |  +- Name
                   |     |           |                       |  +- Name
                   |     |           |                       +- Name
+                  |     |           +- Comment
+                  |     |           +- Comment
                   |     |           +- ExpressionStatement
                   |     |           |  +- Assignment
                   |     |           |     +- Name
                   |     |           |     +- Name
+                  |     |           +- Comment
+                  |     |           +- Comment
+                  |     |           +- Comment
+                  |     |           +- Comment
+                  |     |           +- Comment
+                  |     |           +- Comment
+                  |     |           +- Comment
                   |     |           +- IfStatement
                   |     |           |  +- InfixExpression
                   |     |           |  |  +- Name
@@ -4725,6 +4865,7 @@
                   |     |           |     +- IfStatement
                   |     |           |     |  +- Name
                   |     |           |     |  +- Scope
+                  |     |           |     |     +- Comment
                   |     |           |     |     +- IfStatement
                   |     |           |     |     |  +- InfixExpression
                   |     |           |     |     |  |  +- Name
@@ -4768,6 +4909,7 @@
                   |     |           |     |     |  +- Name
                   |     |           |     |     +- Name
                   |     |           |     |     +- Name
+                  |     |           |     +- Comment
                   |     |           |     +- IfStatement
                   |     |           |        +- InfixExpression
                   |     |           |        |  +- Name
@@ -4840,6 +4982,7 @@
                   |     |  +- UnaryExpression
                   |     |  |  +- Name
                   |     |  +- Scope
+                  |     |     +- Comment
                   |     |     +- IfStatement
                   |     |     |  +- UnaryExpression
                   |     |     |  |  +- Name
@@ -4886,6 +5029,7 @@
                   |     |     |                 |  +- Name
                   |     |     |                 |  +- Name
                   |     |     |                 +- Name
+                  |     |     +- Comment
                   |     |     +- ExpressionStatement
                   |     |     |  +- Assignment
                   |     |     |     +- Name
@@ -4896,6 +5040,7 @@
                   |     |     |           +- Name
                   |     |     |           +- Name
                   |     |     |           +- Name
+                  |     |     +- Comment
                   |     |     +- ExpressionStatement
                   |     |        +- Assignment
                   |     |           +- PropertyGet
@@ -4904,6 +5049,7 @@
                   |     |           +- Name
                   |     +- ReturnStatement
                   |        +- Name
+                  +- Comment
                   +- FunctionNode
                   |  +- Name
                   |  +- Name
@@ -4951,6 +5097,8 @@
                   |     |     +- InfixExpression
                   |     |        +- Name
                   |     |        +- ArrayLiteral
+                  |     +- Comment
+                  |     +- Comment
                   |     +- IfStatement
                   |     |  +- InfixExpression
                   |     |  |  +- PropertyGet
@@ -4958,6 +5106,7 @@
                   |     |  |  |  +- Name
                   |     |  |  +- NumberLiteral
                   |     |  +- Scope
+                  |     |     +- Comment
                   |     |     +- ExpressionStatement
                   |     |     |  +- Assignment
                   |     |     |     +- Name
@@ -5038,7 +5187,8 @@
                   |     |     |     |  |  +- Name
                   |     |     |     |  +- Scope
                   |     |     |     |  |  +- ReturnStatement
-                  |     |     |     |  |     +- Name
+                  |     |     |     |  |  |  +- Name
+                  |     |     |     |  |  +- Comment
                   |     |     |     |  +- IfStatement
                   |     |     |     |     +- Name
                   |     |     |     |     +- Scope
@@ -5088,6 +5238,7 @@
                   |     |           |     +- ElementGet
                   |     |           |        +- Name
                   |     |           |        +- Name
+                  |     |           +- Comment
                   |     |           +- IfStatement
                   |     |           |  +- ElementGet
                   |     |           |  |  +- PropertyGet
@@ -5111,6 +5262,7 @@
                   |     |              |        |  +- Name
                   |     |              |        +- Name
                   |     |              +- Scope
+                  |     |                 +- Comment
                   |     |                 +- IfStatement
                   |     |                    +- ParenthesizedExpression
                   |     |                    |  +- Assignment
@@ -5145,6 +5297,7 @@
                   |     |                    |           |        +- Name
                   |     |                    |           +- Name
                   |     |                    +- Scope
+                  |     |                       +- Comment
                   |     |                       +- ExpressionStatement
                   |     |                       |  +- FunctionCall
                   |     |                       |     +- PropertyGet
@@ -5208,6 +5361,7 @@
                   |     |           +- Name
                   |     +- ReturnStatement
                   |        +- Name
+                  +- Comment
                   +- ExpressionStatement
                   |  +- FunctionCall
                   |     +- Name

--- a/pom.xml
+++ b/pom.xml
@@ -688,11 +688,6 @@
                 <classifier>dom</classifier>
             </dependency>
             <dependency>
-                <groupId>org.mozilla</groupId>
-                <artifactId>rhino</artifactId>
-                <version>1.7.7.2</version>
-            </dependency>
-            <dependency>
                 <groupId>net.java.dev.javacc</groupId>
                 <artifactId>javacc</artifactId>
                 <version>${javacc.version}</version>
@@ -1066,7 +1061,6 @@
         <module>pmd-groovy</module>
         <module>pmd-lua</module>
         <module>pmd-java</module>
-        <module>pmd-javascript</module>
         <module>pmd-jsp</module>
         <module>pmd-kotlin</module>
         <module>pmd-matlab</module>
@@ -1086,6 +1080,7 @@
         <module>pmd-apex-jorje</module>
         <module>pmd-apex</module>
         <module>pmd-java8</module>
+        <module>pmd-javascript</module>
         <module>pmd-doc</module>
         <module>pmd-lang-test</module>
         <module>pmd-scala</module> <!-- deprecated -->


### PR DESCRIPTION
*   Convert pmd-javascript to a java8 module
*   Fixes #699
*   Fixes #2081

This PR replaces the older #2906 

Note: This introduces some incompatibility: From now on, at least Java 8 is required to analyze JavaScript code.
We did a similar upgrade with VisualForce in [6.30.0](https://github.com/pmd/pmd/releases/tag/pmd_releases%2F6.30.0).

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

