### PR TITLE
[java] New rule: JUnit5TestShouldBePackagePrivate

### DIFF
--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -847,7 +847,7 @@ public class MyTest {
         </properties>
         <example>
             <![CDATA[
-public class MyTest {
+class MyTest {
     @Test
     public void testBad() {
         doSomething();

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -823,6 +823,7 @@ if they're package-private. Marking them as such is a good practice to limit the
 <![CDATA[
 //ClassOrInterfaceDeclaration[
     (: a Junit 5 test class, ie, it has methods with the annotation :)
+    @Interface=false() and
     ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration
         [Annotation//Name[
             pmd-java:typeIs('org.junit.jupiter.api.Test') or pmd-java:typeIs('org.junit.jupiter.api.RepeatedTest')

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -804,22 +804,24 @@ public class MyTest {
 
     <rule name="JUnit5TestShouldBePackagePrivate"
           language="java"
-          since="6.35"
-          message="JUnit 5 tests that use @Test, @RepeatedTest, @TestFactory, @TestTemplate or @ParameterizedTest should be package private."
+          since="6.35.0"
+          message="JUnit 5 tests should be package-private."
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           typeResolution="true"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_bestpractices.html#junit5testshouldbepackageprivate">
         <description>
-            JUnit 5 tests should be package private at the class level and for each method that uses @Test, @RepeatedTest, @TestFactory, @TestTemplate or @ParameterizedTest.
+JUnit 5 tests should be package private at the class level and for each method that uses @Test, @RepeatedTest,
+@TestFactory, @TestTemplate or @ParameterizedTest.
+Contrary to JUnit4 tests that required public visibility to be run by the engine, JUnit5 tests may be run
+only with package private visibility. Marking them as such is a good practice to limit their visibility.
         </description>
         <priority>3</priority>
         <properties>
             <property name="version" value="2.0"/>
             <property name="xpath">
                 <value>
-                    <![CDATA[
+<![CDATA[
 //ClassOrInterfaceDeclaration[
-       matches(@SimpleName, $testClassPattern) and
        @Abstract=false() and
        @PackagePrivate=false()]
        [ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration
@@ -830,8 +832,7 @@ public class MyTest {
             or pmd-java:typeIs('org.junit.jupiter.params.ParameterizedTest')
         ]]]
 |
-//ClassOrInterfaceDeclaration[
-       matches(@SimpleName, $testClassPattern)]
+//ClassOrInterfaceDeclaration
     /ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration
         [MethodDeclaration[@PackagePrivate=false()]]
         [Annotation//Name[
@@ -841,32 +842,22 @@ public class MyTest {
         ]]
 ]]>
                 </value>
-            </property>
-            <property name="testClassPattern" type="Regex" description="The regex pattern used to identify test classes" value="Test" />
-            <property name="version" value="2.0"/>
+            </property><property name="version" value="2.0"/>
         </properties>
         <example>
             <![CDATA[
-class MyTest {
+class MyTest { // not public, that's fine
     @Test
-    public void testBad() {
-        doSomething();
-    }
+    public void testBad() { } // should not have a public modifier
 
     @Test
-    private void testNotRun() {
-        doSomething();
-    }
+    protected void testAlsoBad() { } // should not have a protected modifier
 
     @Test
-    void testGood() {
-        doSomething();
-    }
+    private void testNoRun() { } // should not have a private modifier
 
     @Test
-    protected void testAcceptable() {
-        doSomething();
-    }
+    void testGood() { } // package private as expected
 }
 ]]>
         </example>

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -832,14 +832,14 @@ if they're package-private. Marking them as such is a good practice to limit the
         ]]
         [MethodDeclaration]
 ]/(
-    self::*[@Abstract=false() and @PackagePrivate=false()]
+    self::*[@Abstract=false() and (@Public=true() or @Protected=true())]
 |   ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration
         [Annotation//Name[
             pmd-java:typeIs('org.junit.jupiter.api.Test') or pmd-java:typeIs('org.junit.jupiter.api.RepeatedTest')
             or pmd-java:typeIs('org.junit.jupiter.api.TestFactory') or pmd-java:typeIs('org.junit.jupiter.api.TestTemplate')
             or pmd-java:typeIs('org.junit.jupiter.params.ParameterizedTest')
         ]]
-        /MethodDeclaration[@PackagePrivate=false()]
+        /MethodDeclaration[@Public=true() or @Protected=true()]
 )
 ]]>
                 </value>

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -812,8 +812,8 @@ public class MyTest {
         <description>
 JUnit 5 tests should be package private at the class level and for each method that uses @Test, @RepeatedTest,
 @TestFactory, @TestTemplate or @ParameterizedTest.
-Contrary to JUnit4 tests that required public visibility to be run by the engine, JUnit5 tests may be run
-only with package private visibility. Marking them as such is a good practice to limit their visibility.
+Contrary to JUnit4 tests that required public visibility to be run by the engine, JUnit5 tests can also be run
+if they're package-private. Marking them as such is a good practice to limit their visibility.
         </description>
         <priority>3</priority>
         <properties>
@@ -822,27 +822,27 @@ only with package private visibility. Marking them as such is a good practice to
                 <value>
 <![CDATA[
 //ClassOrInterfaceDeclaration[
-       @Abstract=false() and
-       @PackagePrivate=false()]
-       [ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration
-        [MethodDeclaration]
+    (: a Junit 5 test class, ie, it has methods with the annotation :)
+    ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration
         [Annotation//Name[
             pmd-java:typeIs('org.junit.jupiter.api.Test') or pmd-java:typeIs('org.junit.jupiter.api.RepeatedTest')
             or pmd-java:typeIs('org.junit.jupiter.api.TestFactory') or pmd-java:typeIs('org.junit.jupiter.api.TestTemplate')
             or pmd-java:typeIs('org.junit.jupiter.params.ParameterizedTest')
-        ]]]
-|
-//ClassOrInterfaceDeclaration
-    /ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration
+        ]]
+        [MethodDeclaration]
+]/(
+    self::*[@Abstract=false() and @PackagePrivate=false()]
+|   ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration
         [Annotation//Name[
             pmd-java:typeIs('org.junit.jupiter.api.Test') or pmd-java:typeIs('org.junit.jupiter.api.RepeatedTest')
             or pmd-java:typeIs('org.junit.jupiter.api.TestFactory') or pmd-java:typeIs('org.junit.jupiter.api.TestTemplate')
             or pmd-java:typeIs('org.junit.jupiter.params.ParameterizedTest')
         ]]
         /MethodDeclaration[@PackagePrivate=false()]
+)
 ]]>
                 </value>
-            </property><property name="version" value="2.0"/>
+            </property>
         </properties>
         <example>
             <![CDATA[

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -834,12 +834,12 @@ only with package private visibility. Marking them as such is a good practice to
 |
 //ClassOrInterfaceDeclaration
     /ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration
-        [MethodDeclaration[@PackagePrivate=false()]]
         [Annotation//Name[
             pmd-java:typeIs('org.junit.jupiter.api.Test') or pmd-java:typeIs('org.junit.jupiter.api.RepeatedTest')
             or pmd-java:typeIs('org.junit.jupiter.api.TestFactory') or pmd-java:typeIs('org.junit.jupiter.api.TestTemplate')
             or pmd-java:typeIs('org.junit.jupiter.params.ParameterizedTest')
         ]]
+        /MethodDeclaration[@PackagePrivate=false()]
 ]]>
                 </value>
             </property><property name="version" value="2.0"/>

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -802,13 +802,13 @@ public class MyTest {
         </example>
     </rule>
 
-    <!-- TODO add externalInfoUrl to the rationale -->
     <rule name="JUnit5TestShouldBePackagePrivate"
           language="java"
-          since="4.0"
+          since="6.35"
           message="JUnit 5 tests that use @Test, @RepeatedTest, @TestFactory, @TestTemplate or @ParameterizedTest should be package private."
           class="net.sourceforge.pmd.lang.rule.XPathRule"
-          typeResolution="true">
+          typeResolution="true"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_bestpractices.html#junit5testshouldbepackageprivate">
         <description>
             JUnit 5 tests should be package private at the class level and for each method that uses @Test, @RepeatedTest, @TestFactory, @TestTemplate or @ParameterizedTest.
         </description>

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -802,6 +802,76 @@ public class MyTest {
         </example>
     </rule>
 
+    <!-- TODO add externalInfoUrl to the rationale -->
+    <rule name="JUnit5TestShouldBePackagePrivate"
+          language="java"
+          since="4.0"
+          message="JUnit 5 tests that use @Test, @RepeatedTest, @TestFactory, @TestTemplate or @ParameterizedTest should be package private."
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          typeResolution="true">
+        <description>
+            JUnit 5 tests should be package private at the class level and for each method that uses @Test, @RepeatedTest, @TestFactory, @TestTemplate or @ParameterizedTest.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="version" value="2.0"/>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
+//ClassOrInterfaceDeclaration[
+       matches(@SimpleName, $testClassPattern) and
+       @Abstract=false() and
+       @PackagePrivate=false()]
+       [ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration
+        [MethodDeclaration]
+        [Annotation//Name[
+            pmd-java:typeIs('org.junit.jupiter.api.Test') or pmd-java:typeIs('org.junit.jupiter.api.RepeatedTest')
+            or pmd-java:typeIs('org.junit.jupiter.api.TestFactory') or pmd-java:typeIs('org.junit.jupiter.api.TestTemplate')
+            or pmd-java:typeIs('org.junit.jupiter.params.ParameterizedTest')
+        ]]]
+|
+//ClassOrInterfaceDeclaration[
+       matches(@SimpleName, $testClassPattern)]
+    /ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration
+        [MethodDeclaration[@PackagePrivate=false()]]
+        [Annotation//Name[
+            pmd-java:typeIs('org.junit.jupiter.api.Test') or pmd-java:typeIs('org.junit.jupiter.api.RepeatedTest')
+            or pmd-java:typeIs('org.junit.jupiter.api.TestFactory') or pmd-java:typeIs('org.junit.jupiter.api.TestTemplate')
+            or pmd-java:typeIs('org.junit.jupiter.params.ParameterizedTest')
+        ]]
+]]>
+                </value>
+            </property>
+            <property name="testClassPattern" type="Regex" description="The regex pattern used to identify test classes" value="Test" />
+            <property name="version" value="2.0"/>
+        </properties>
+        <example>
+            <![CDATA[
+public class MyTest {
+    @Test
+    public void testBad() {
+        doSomething();
+    }
+
+    @Test
+    private void testNotRun() {
+        doSomething();
+    }
+
+    @Test
+    void testGood() {
+        doSomething();
+    }
+
+    @Test
+    protected void testAcceptable() {
+        doSomething();
+    }
+}
+]]>
+        </example>
+    </rule>
+
     <rule name="JUnitAssertionsShouldIncludeMessage"
           language="java"
           since="1.04"

--- a/pmd-java/src/main/resources/rulesets/java/quickstart.xml
+++ b/pmd-java/src/main/resources/rulesets/java/quickstart.xml
@@ -27,6 +27,7 @@
     <!-- <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseAfterAnnotation" /> -->
     <!-- <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseBeforeAnnotation" /> -->
     <!-- <rule ref="category/java/bestpractices.xml/JUnit4TestShouldUseTestAnnotation" /> -->
+    <!-- <rule ref="category/java/bestpractices.xml/JUnit5TestShouldBePackagePrivate" /> -->
     <!-- <rule ref="category/java/bestpractices.xml/JUnitAssertionsShouldIncludeMessage" /> -->
     <!-- <rule ref="category/java/bestpractices.xml/JUnitTestContainsTooManyAsserts" /> -->
     <!-- <rule ref="category/java/bestpractices.xml/JUnitTestsShouldIncludeAssert" /> -->

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnit5TestShouldBePackagePrivateTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnit5TestShouldBePackagePrivateTest.java
@@ -1,0 +1,11 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices;
+
+import net.sourceforge.pmd.testframework.PmdRuleTst;
+
+public class JUnit5TestShouldBePackagePrivateTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit5TestShouldBePackagePrivate.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit5TestShouldBePackagePrivate.xml
@@ -7,6 +7,7 @@
     <test-code>
         <description>Public modifier is not necessary on a test method nor on the class</description>
         <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,5</expected-linenumbers>
         <code><![CDATA[
 import org.junit.jupiter.api.Test;
 
@@ -59,6 +60,7 @@ public interface MyTests {
     <test-code>
         <description>Non package private modifiers on all JUnit5 test types should be rejected</description>
         <expected-problems>6</expected-problems>
+        <expected-linenumbers>8,10,13,16,19,23</expected-linenumbers>
         <code><![CDATA[
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.RepeatedTest;

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit5TestShouldBePackagePrivate.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit5TestShouldBePackagePrivate.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+    <test-code>
+        <description>Public modifier is not necessary on a test method nor on the class</description>
+        <expected-problems>2</expected-problems>
+        <code><![CDATA[
+import org.junit.jupiter.api.Test;
+
+public class MyTests {
+    @Test
+    public void testRegular() { }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Package private modifiers are what is required</description>
+        <expected-problems>0    </expected-problems>
+        <code><![CDATA[
+import org.junit.jupiter.api.Test;
+
+class MyTests {
+    @Test
+    void testRegular() { }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Non package private modifiers on all JUnit5 test types should be rejected</description>
+        <expected-problems>6</expected-problems>
+        <code><![CDATA[
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.TestFactory;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+protected class MyTests {
+    @Test
+    public void testRegular() { }
+
+    @RepeatedTest(2)
+    protected void testRepeated() { }
+
+    @TestFactory
+    private void testFactory() { }
+
+    @TestTemplate
+    public void testTemplate() { }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"Hello", "World"})
+    protected void testParameterized(final String value) { }
+}
+        ]]></code>
+    </test-code>
+</test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit5TestShouldBePackagePrivate.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit5TestShouldBePackagePrivate.xml
@@ -19,13 +19,39 @@ public class MyTests {
 
     <test-code>
         <description>Package private modifiers are what is required</description>
-        <expected-problems>0    </expected-problems>
+        <expected-problems>0</expected-problems>
         <code><![CDATA[
 import org.junit.jupiter.api.Test;
 
 class MyTests {
     @Test
     void testRegular() { }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Public modifier is allowed on an abstract test classes</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.junit.jupiter.api.Test;
+
+public abstract class MyTests {
+    @Test
+    void testRegular() { }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Public modifier is allowed on test interfaces</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.junit.jupiter.api.Test;
+
+public interface MyTests {
+    @Test
+    default void testRegular() { }
 }
         ]]></code>
     </test-code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit5TestShouldBePackagePrivate.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit5TestShouldBePackagePrivate.xml
@@ -32,6 +32,35 @@ class MyTests {
     </test-code>
 
     <test-code>
+        <description>Private method modifiers should be reported by rule 'JUnit5TestNoPrivateModifier' and ignored by rule 'JUnit5TestShouldBePackagePrivate'</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.junit.jupiter.api.Test;
+
+class MyTests {
+  @Test
+  private void ignoredTest() {}
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Private modifiers for inner classes should be reported by rule 'JUnit5TestNoPrivateModifier' and ignored by rule 'JUnit5TestShouldBePackagePrivate'</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.junit.jupiter.api.Test;
+
+class MyTests {
+
+  private static class InnerPrivateClass {
+    @Test
+    void testFoo() {}
+  }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>Public modifier is allowed on an abstract test classes</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
@@ -58,9 +87,9 @@ public interface MyTests {
     </test-code>
 
     <test-code>
-        <description>Non package private modifiers on all JUnit5 test types should be rejected</description>
-        <expected-problems>6</expected-problems>
-        <expected-linenumbers>8,10,13,16,19,23</expected-linenumbers>
+        <description>Public and protected modifiers on all JUnit5 test types should be rejected</description>
+        <expected-problems>5</expected-problems>
+        <expected-linenumbers>8,10,13,19,23</expected-linenumbers>
         <code><![CDATA[
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.RepeatedTest;

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit5TestShouldBePackagePrivate.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnit5TestShouldBePackagePrivate.xml
@@ -60,4 +60,16 @@ protected class MyTests {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Public JUnit4 tests are not flagged</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.junit.Test;
+public class Foo {
+    @Test
+    public void testFoo() { }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Add the rule to check that JUnit5 tests methods and classes are package private.
Add unit tests

## Describe the PR

Propose a codestyle rule for Jupiter / JUnit5 tests according to the feedback received from @adangel in the issue.

Not sure how to add the 'externalInfoURL', so simply pointed at the rule name, assuming that the site is generated from the XML rule file

## Related issues

- Fixes #3239 
- Relates #3288 - that's another rule to handle private tests

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

