### PR TITLE
[java] AvoidFieldNameMatchingTypeName: False negative with interfaces

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -18,6 +18,8 @@ This is a {{ site.pmd.release_type }} release.
 
 *   doc
     *   [#3230](https://github.com/pmd/pmd/issues/3230): \[doc] Remove "Edit me" button for language index pages
+*   java-errorprone
+    *   [#3249](https://github.com/pmd/pmd/pull/3249): \[java] AvoidFieldNameMatchingTypeName: False negative with interfaces
 
 ### API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidFieldNameMatchingTypeNameRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidFieldNameMatchingTypeNameRule.java
@@ -10,12 +10,8 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
 public class AvoidFieldNameMatchingTypeNameRule extends AbstractJavaRule {
 
-    @Override
-    public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
-        if (node.isInterface()) {
-            return data;
-        }
-        return super.visit(node, data);
+    public AvoidFieldNameMatchingTypeNameRule() {
+        addRuleChainVisit(ASTFieldDeclaration.class);
     }
 
     @Override

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -398,7 +398,7 @@ public class Foo {
           class="net.sourceforge.pmd.lang.java.rule.errorprone.AvoidFieldNameMatchingTypeNameRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#avoidfieldnamematchingtypename">
         <description>
-It is somewhat confusing to have a field name matching the declaring class name.
+It is somewhat confusing to have a field name matching the declaring type name.
 This probably means that type and/or field names should be chosen more carefully.
         </description>
         <priority>3</priority>
@@ -406,6 +406,9 @@ This probably means that type and/or field names should be chosen more carefully
 <![CDATA[
 public class Foo extends Bar {
     int foo;    // There is probably a better name that can be used
+}
+public interface Operation {
+    int OPERATION = 1; // There is probably a better name that can be used
 }
 ]]>
         </example>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidFieldNameMatchingTypeName.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidFieldNameMatchingTypeName.xml
@@ -57,4 +57,21 @@ public interface Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>false negative with fields in interfaces and nested classes</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>4,7</expected-linenumbers>
+        <code><![CDATA[
+interface Operation {
+    Object apply();
+
+    final Operation OPERATION = () -> { return null; };
+
+    class Inner {
+        int inner;
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Fields in interfaces and nested classes have not been considered, e.g.

```java
interface Operation {
    Object apply();

    final Operation OPERATION = () -> { return null; };  // Violation expected here

    class Inner {
        int inner; // Violation expected here
    }
}
```

This was originally found by #2687 in https://github.com/checkstyle/checkstyle/blob/checkstyle-8.10/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/finallocalvariable/InputFinalLocalVariableNameLambda.java#L31

It's fixed by using rulechain and skipping interfaces. The rule name just mentions "type name", in the rule description for [AvoidFieldNameMatchingTypeName](https://pmd.github.io/latest/pmd_rules_java_errorprone.html#avoidfieldnamematchingtypename) it says "class". But I don't see a reason, why to exclude interfaces here.

Note: This rule has not been converted on the pmd7 branch yet (#2701).

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

