### PR TITLE
[java] AvoidReassigningParameters reports violations on wrong line numbers

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -35,6 +35,7 @@ This is a {{ site.pmd.release_type }} release.
     *   [#3269](https://github.com/pmd/pmd/pull/3269): \[java] Fix NPE in MethodTypeResolution
 *   java-bestpractices
     *   [#1175](https://github.com/pmd/pmd/issues/1175): \[java] UnusedPrivateMethod FP with Junit 5 @MethodSource
+    *   [#2219](https://github.com/pmd/pmd/issues/2219): \[java] Document Reasons to Avoid Reassigning Parameters
     *   [#2737](https://github.com/pmd/pmd/issues/2737): \[java] Fix misleading rule message on rule SwitchStmtsShouldHaveDefault with non-exhaustive enum switch
     *   [#3236](https://github.com/pmd/pmd/issues/3236): \[java] LiteralsFirstInComparisons should consider constant fields (cont'd)
     *   [#3254](https://github.com/pmd/pmd/issues/3254): \[java] AvoidReassigningParameters reports violations on wrong line numbers

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -18,6 +18,8 @@ This is a {{ site.pmd.release_type }} release.
 
 *   doc
     *   [#3230](https://github.com/pmd/pmd/issues/3230): \[doc] Remove "Edit me" button for language index pages
+*   java-bestpractices
+    *   [#3254](https://github.com/pmd/pmd/issues/3254): \[java] AvoidReassigningParameters reports violations on wrong line numbers
 
 ### API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningParametersRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningParametersRule.java
@@ -40,9 +40,9 @@ public class AvoidReassigningParametersRule extends AbstractJavaRule {
                         && jocc.getNameForWhichThisIsAQualifier() == null && !jocc.useThisOrSuper() && !decl.isVarargs()
                         && (!decl.isArray()
                                 || jocc.getLocation().getParent().getParent().getNumChildren() == 1)) {
-                    // not an array or no primary suffix to access the array
-                    // values
-                    addViolation(data, decl.getNode(), decl.getImage());
+                    // not an array or no primary suffix to access the array values
+                    // note: this reports each assignment separately
+                    addViolation(data, occ.getLocation(), decl.getImage());
                 }
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningParametersRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningParametersRule.java
@@ -41,8 +41,10 @@ public class AvoidReassigningParametersRule extends AbstractJavaRule {
                         && (!decl.isArray()
                                 || jocc.getLocation().getParent().getParent().getNumChildren() == 1)) {
                     // not an array or no primary suffix to access the array values
-                    // note: this reports each assignment separately
                     addViolation(data, occ.getLocation(), decl.getImage());
+
+                    // only the first assignment should be reported
+                    break;
                 }
             }
         }

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -301,14 +301,29 @@ public class Foo {
           class="net.sourceforge.pmd.lang.java.rule.bestpractices.AvoidReassigningParametersRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_bestpractices.html#avoidreassigningparameters">
         <description>
-Reassigning values to incoming parameters is not recommended.  Use temporary local variables instead.
+Reassigning values to incoming parameters of a method or constructor is not recommended, as this can
+make the code more difficult to understand. The code is often read with the assumption that parameter values
+don't change and an assignment violates therefore the principle of least astonishment. This is especially a
+problem if the parameter is documented e.g. in the method's javadoc and the new content differs from the original
+documented content.
+
+Use temporary local variables instead. This allows you to assign a new name, which makes the code better
+understandable.
+
+Note that this rule considers both methods and constructors. If there are multiple assignments for a formal
+parameter, then only the first assignment is reported.
         </description>
         <priority>2</priority>
         <example>
 <![CDATA[
-public class Foo {
-  private void foo(String bar) {
-    bar = "something else";
+public class Hello {
+  private void greet(String name) {
+    name = name.trim();
+    System.out.println("Hello " + name);
+
+    // preferred
+    String trimmedName = name.trim();
+    System.out.println("Hello " + trimmedName);
   }
 }
 ]]>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/AvoidReassigningParameters.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/AvoidReassigningParameters.xml
@@ -234,4 +234,18 @@ public class AvoidReassigningParameters {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#3254 AvoidReassigningParameters reports wrong line numbers</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,4</expected-linenumbers>
+        <code><![CDATA[
+public class AvoidReassigningParameters {
+    public void a(String b) {
+        b = "1";
+        b = "2";
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/AvoidReassigningParameters.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/AvoidReassigningParameters.xml
@@ -7,6 +7,7 @@
     <test-code>
         <description>reassigned parameter, bad</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     void foo(int bar) {
@@ -29,6 +30,7 @@ public class Foo {
     <test-code>
         <description>instance variable and parameter have same name</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     private int bar;
@@ -95,6 +97,7 @@ public class Foo {
     <test-code>
         <description>throws a stacktrace</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     void foo(int x) {
@@ -110,6 +113,7 @@ public class Foo {
     <test-code>
         <description>postfix increment in array dereference is bad</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     void foo(int x) {
@@ -134,6 +138,7 @@ public class Foo {
     <test-code>
         <description>assignment to array</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     int y[];
@@ -146,7 +151,8 @@ public class Foo {
 
     <test-code>
         <description>The rule should also detect parameter reassignment in constructors (at least to help young programmers still learning java basic)</description>
-        <expected-problems>3</expected-problems>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,5</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     public Foo(int arg, String arg2, Object arg3) {
@@ -174,6 +180,7 @@ public class RealClass extends AbstractClass {
     <test-code>
         <description>parameter name starting with "this" or "super" should still be flagged</description>
         <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,4</expected-linenumbers>
         <code><![CDATA[
 public class RealClass {
     public void setString(int thisParam, int superParam) {
@@ -237,13 +244,13 @@ public class AvoidReassigningParameters {
 
     <test-code>
         <description>#3254 AvoidReassigningParameters reports wrong line numbers</description>
-        <expected-problems>2</expected-problems>
-        <expected-linenumbers>3,4</expected-linenumbers>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
         <code><![CDATA[
 public class AvoidReassigningParameters {
     public void a(String b) {
         b = "1";
-        b = "2";
+        b = "2"; // this is not reported, only the first assignment is
     }
 }
         ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/AvoidReassigningParameters.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/AvoidReassigningParameters.xml
@@ -5,6 +5,24 @@
     xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
 
     <test-code>
+        <description>example</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <code><![CDATA[
+public class Hello {
+  private void greet(String name) {
+    name = name.trim();
+    System.out.println("Hello " + name);
+
+    // preferred
+    String trimmedName = name.trim();
+    System.out.println("Hello " + trimmedName);
+  }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>reassigned parameter, bad</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>3</expected-linenumbers>


### PR DESCRIPTION
- Fixes #3254
- Fixes #2219

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

