### PR TITLE
[java] Fix LiteralsFirstInComparison ignoring constants

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -18,6 +18,8 @@ This is a {{ site.pmd.release_type }} release.
 
 *   doc
     *   [#3230](https://github.com/pmd/pmd/issues/3230): \[doc] Remove "Edit me" button for language index pages
+*   java-bestpractices
+    *   [#3236](https://github.com/pmd/pmd/issues/3236): \[java] LiteralsFirstInComparisons should consider constant fields (cont'd)
 *   java-codestyle
     *   [#2655](https://github.com/pmd/pmd/issues/2655): \[java] UnnecessaryImport false positive for on-demand imports
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
@@ -125,29 +125,27 @@ public class LiteralsFirstInComparisonsRule extends AbstractJavaRule {
     }
 
     private boolean isStringLiteralFirstArgumentOfSuffix(ASTPrimarySuffix primarySuffix) {
-        try {
-            JavaNode firstLiteralArg = getFirstLiteralArgument(primarySuffix);
-            JavaNode firstNameArg = getFirstNameArgument(primarySuffix);
-            return isStringLiteral(firstLiteralArg) || isConstantString(firstNameArg);
-        } catch (NullPointerException e) {
+        JavaNode argumentPrimaryPrefix = getArgumentPrimaryPrefix(primarySuffix);
+        if (argumentPrimaryPrefix == null) {
             return false;
         }
-    }
-
-    private JavaNode getFirstLiteralArgument(ASTPrimarySuffix primarySuffix) {
-        return getArgumentPrimaryPrefix(primarySuffix).getFirstChildOfType(ASTLiteral.class);
-    }
-
-    private JavaNode getFirstNameArgument(ASTPrimarySuffix primarySuffix) {
-        return getArgumentPrimaryPrefix(primarySuffix).getFirstChildOfType(ASTName.class);
+        JavaNode firstLiteralArg = argumentPrimaryPrefix.getFirstChildOfType(ASTLiteral.class);
+        JavaNode firstNameArg = argumentPrimaryPrefix.getFirstChildOfType(ASTName.class);
+        return isStringLiteral(firstLiteralArg) || isConstantString(firstNameArg);
     }
 
     private JavaNode getArgumentPrimaryPrefix(ASTPrimarySuffix primarySuffix) {
-        ASTArguments arguments = primarySuffix.getFirstChildOfType(ASTArguments.class);
-        ASTArgumentList argumentList = arguments.getFirstChildOfType(ASTArgumentList.class);
-        ASTExpression expression = argumentList.getFirstChildOfType(ASTExpression.class);
+        ASTExpression expression = primarySuffix.getFirstChildOfType(ASTArguments.class)
+                                                .getFirstChildOfType(ASTArgumentList.class)
+                                                .getFirstChildOfType(ASTExpression.class);
+
+        assert expression != null : "We checked before that we had exactly one argument, so this cannot fail";
+
         ASTPrimaryExpression primaryExpression = expression.getFirstChildOfType(ASTPrimaryExpression.class);
-        return primaryExpression.getFirstChildOfType(ASTPrimaryPrefix.class);
+        if (primaryExpression != null) {
+            return primaryExpression.getChild(0);
+        }
+        return null;
     }
 
     private boolean isStringLiteral(JavaNode node) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
@@ -4,12 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
-import java.util.List;
-
 import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTArguments;
-import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBody;
-import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBodyDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTConditionalAndExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTConditionalOrExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTEqualityExpression;
@@ -21,9 +17,11 @@ import net.sourceforge.pmd.lang.java.ast.ASTNullLiteral;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
-import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclarator;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
+import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
+import net.sourceforge.pmd.lang.symboltable.NameDeclaration;
 
 public class LiteralsFirstInComparisonsRule extends AbstractJavaRule {
 
@@ -47,20 +45,22 @@ public class LiteralsFirstInComparisonsRule extends AbstractJavaRule {
 
     private boolean hasStringLiteralFirst(ASTPrimaryExpression expression) {
         ASTPrimaryPrefix primaryPrefix = expression.getFirstChildOfType(ASTPrimaryPrefix.class);
-        ASTLiteral firstLiteral = primaryPrefix.getFirstDescendantOfType(ASTLiteral.class);
+        ASTLiteral firstLiteral = primaryPrefix.getFirstChildOfType(ASTLiteral.class);
         return firstLiteral != null && firstLiteral.isStringLiteral();
     }
 
     private boolean isNullableComparisonWithStringLiteral(ASTPrimaryExpression expression) {
         String opName = getOperationName(expression);
         ASTPrimarySuffix argsSuffix = getSuffixOfArguments(expression);
-        return opName != null && argsSuffix != null && isStringLiteralComparison(opName, argsSuffix)
-                && isNotWithinNullComparison(expression);
+        return opName != null && argsSuffix != null
+            && isStringLiteralComparison(opName, argsSuffix)
+            && isNotWithinNullComparison(expression);
     }
 
     private String getOperationName(ASTPrimaryExpression primaryExpression) {
-        return isMethodsChain(primaryExpression) ? getOperationNameBySuffix(primaryExpression)
-                : getOperationNameByPrefix(primaryExpression);
+        return isMethodsChain(primaryExpression)
+               ? getOperationNameBySuffix(primaryExpression)
+               : getOperationNameByPrefix(primaryExpression);
     }
 
     private boolean isMethodsChain(ASTPrimaryExpression primaryExpression) {
@@ -90,12 +90,11 @@ public class LiteralsFirstInComparisonsRule extends AbstractJavaRule {
     }
 
     private ASTPrimarySuffix getPrimarySuffixAtIndexFromEnd(ASTPrimaryExpression primaryExpression, int indexFromEnd) {
-        List<ASTPrimarySuffix> primarySuffixes = primaryExpression.findChildrenOfType(ASTPrimarySuffix.class);
-        if (!primarySuffixes.isEmpty()) {
-            int suffixIndex = primarySuffixes.size() - 1 - indexFromEnd;
-            return primarySuffixes.get(suffixIndex);
+        int index = primaryExpression.getNumChildren() - 1 - indexFromEnd;
+        if (index <= 0) {
+            return null;
         }
-        return null;
+        return (ASTPrimarySuffix) primaryExpression.getChild(index);
     }
 
     private boolean isStringLiteralComparison(String opName, ASTPrimarySuffix argsSuffix) {
@@ -162,17 +161,13 @@ public class LiteralsFirstInComparisonsRule extends AbstractJavaRule {
     private boolean isConstantString(JavaNode node) {
         if (node instanceof ASTName) {
             ASTName name = (ASTName) node;
-            ASTClassOrInterfaceBody classBody = name.getFirstParentOfType(ASTClassOrInterfaceBody.class);
-            ASTClassOrInterfaceBodyDeclaration classOrInterfaceBodyDeclaration = classBody.getFirstChildOfType(ASTClassOrInterfaceBodyDeclaration.class);
-            List<ASTFieldDeclaration> fieldDeclarations = classOrInterfaceBodyDeclaration.findChildrenOfType(ASTFieldDeclaration.class);
-            for (ASTFieldDeclaration fieldDeclaration : fieldDeclarations) {
-                ASTVariableDeclarator declaration = fieldDeclaration.getFirstChildOfType(ASTVariableDeclarator.class);
-                if (declaration.getName().equals(name.getImage())
-                        && String.class.equals(declaration.getType())
-                        && fieldDeclaration.isFinal()
-                        && fieldDeclaration.isStatic()) {
-                    return true;
-                }
+            NameDeclaration resolved = name.getNameDeclaration();
+            if (resolved instanceof VariableNameDeclaration
+                && resolved.getNode() instanceof ASTVariableDeclaratorId) {
+                ASTVariableDeclaratorId resolvedNode = (ASTVariableDeclaratorId) resolved.getNode();
+                return resolvedNode.isFinal()
+                    && resolvedNode.isField()
+                    && resolvedNode.getFirstParentOfType(ASTFieldDeclaration.class).isStatic();
             }
         }
         return false;

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LiteralsFirstInComparisons.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LiteralsFirstInComparisons.xml
@@ -370,4 +370,43 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>#3236 [java] LiteralsFirstInComparisons should consider constant fields (cont'd)</description>
+        <expected-problems>5</expected-problems>
+        <expected-linenumbers>6,8,17,24,26</expected-linenumbers>
+        <code><![CDATA[
+            class DT1 {
+                public static final String Q = "q";
+                public static final String T = "t";
+
+                public static int convert(String type) {
+                    if (type.equals(Q)) { // 6
+                        return 1;
+                    } else if (type.equals(T)) { // 8
+                        return 2;
+                    } else {
+                        return 3;
+                    }
+                }
+                public static int convert2(String type) {
+                    if (Q.equals(type)) { // 15
+                        return 1;
+                    } else if (type.equals(T)) { // 17
+                        return 2;
+                    } else {
+                        return 3;
+                    }
+                }
+                public static int convert3(String type) {
+                    if (type.equals("q")) { // 24
+                        return 1;
+                    } else if (type.equals("t")) { // 26
+                        return 2;
+                    } else {
+                        return 3;
+                    }
+                }
+            }
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #3236 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

