### PR TITLE
[java] FieldDeclarationsShouldBeAtStartOfClass: false negative with anon classes

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -20,6 +20,7 @@ This is a {{ site.pmd.release_type }} release.
     *   [#3230](https://github.com/pmd/pmd/issues/3230): \[doc] Remove "Edit me" button for language index pages
 *   java-codestyle
     *   [#2655](https://github.com/pmd/pmd/issues/2655): \[java] UnnecessaryImport false positive for on-demand imports
+    *   [#3262](https://github.com/pmd/pmd/pull/3262): \[java] FieldDeclarationsShouldBeAtStartOfClass: false negative with anon classes
 
 ### API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldDeclarationsShouldBeAtStartOfClassRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/FieldDeclarationsShouldBeAtStartOfClassRule.java
@@ -48,6 +48,7 @@ public class FieldDeclarationsShouldBeAtStartOfClassRule extends AbstractJavaRul
         definePropertyDescriptor(ignoreEnumDeclarations);
         definePropertyDescriptor(ignoreAnonymousClassDeclarations);
         definePropertyDescriptor(ignoreInterfaceDeclarations);
+        addRuleChainVisit(ASTFieldDeclaration.class);
     }
 
     @Override

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/FieldDeclarationsShouldBeAtStartOfClass.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/FieldDeclarationsShouldBeAtStartOfClass.xml
@@ -129,6 +129,7 @@ public class MyClass {
         <description>#1244 FieldDeclarationsShouldBeAtStartOfClass and anonymous classes, fail</description>
         <rule-property name="ignoreAnonymousClassDeclarations">false</rule-property>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>9</expected-linenumbers>
         <code><![CDATA[
 public class MyClass {
     private final String name;
@@ -216,6 +217,44 @@ public class TestFieldDeclarations {
     }
 
     private static final int TAKE_PHOTO_RC = 334; // line 6
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>False negative with anon classes (1)</description>
+        <rule-property name="ignoreAnonymousClassDeclarations">false</rule-property>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>4,5,7</expected-linenumbers>
+        <code><![CDATA[
+public class TestFieldDeclarations {
+    class Inner {
+        void method1() { }
+        private int field1; // violation 1
+        private Inner anon = new Inner() { // violation 2 - field "anon"
+            void method2() { }
+            private int field2; // violation 3
+        };
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>False negative with anon classes (2)</description>
+        <rule-property name="ignoreAnonymousClassDeclarations">true</rule-property>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>4,7</expected-linenumbers>
+        <code><![CDATA[
+public class TestFieldDeclarations {
+    class Inner {
+        void method1() { }
+        private int field1; // violation 1
+        private Inner anon = new Inner() { // ignored due to ignoreAnonymousClassDeclarations
+            void method2() { }
+            private int field2; // violation 2
+        };
+    }
 }
         ]]></code>
     </test-code>


### PR DESCRIPTION
## Describe the PR

This fixes a false negative found in #2687 :
https://github.com/checkstyle/checkstyle/blob/checkstyle-8.10/src/it/resources/com/google/checkstyle/test/chapter4formatting/rule4821onevariableperline/InputMultipleVariableDeclarations.java#L66

Code sample:

```java
public class TestFieldDeclarations {
    class Inner {
        void method1() { }
        private int field1; // violation 1
        private Inner anon = new Inner() { // ignored due to ignoreAnonymousClassDeclarations
            void method2() { }
            private int field2; // violation 2
        };
    }
}
```

Violation 2 is currently not detected.

:warning: This rule is already updated on the pmd7 branch!

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

