### PR TITLE
[java] Fix #1175 - UnusedPrivateMethod FP with Junit 5 @MethodSource

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -18,8 +18,11 @@ This is a {{ site.pmd.release_type }} release.
 
 *   doc
     *   [#3230](https://github.com/pmd/pmd/issues/3230): \[doc] Remove "Edit me" button for language index pages
+*   java-bestpractices
+    *   [#1175](https://github.com/pmd/pmd/issues/1175): \[java] UnusedPrivateMethod FP with Junit 5 @MethodSource
 *   java-codestyle
     *   [#2655](https://github.com/pmd/pmd/issues/2655): \[java] UnnecessaryImport false positive for on-demand imports
+
 
 ### API Changes
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/StringUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/StringUtil.java
@@ -732,6 +732,27 @@ public final class StringUtil {
         return sb.toString();
     }
 
+    /**
+     * If the string starts and ends with the delimiter, returns the substring
+     * within the delimiters. Otherwise returns the original string.
+     */
+    public static String removeSurrounding(String string, char delimiter) {
+        if (!string.isEmpty()
+            && string.charAt(0) == delimiter
+            && string.charAt(string.length() - 1) == delimiter) {
+            return string.substring(1, string.length() - 1);
+        }
+        return string;
+    }
+
+    /**
+     * Like {@link #removeSurrounding(String, char) removeSurrounding} with
+     * a double quote as a delimiter.
+     */
+    public static String removeDoubleQuotes(String string) {
+        return removeSurrounding(string, '"');
+    }
+
 
     /**
      * Returns an empty array of string

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/StringUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/StringUtil.java
@@ -734,10 +734,17 @@ public final class StringUtil {
 
     /**
      * If the string starts and ends with the delimiter, returns the substring
-     * within the delimiters. Otherwise returns the original string.
+     * within the delimiters. Otherwise returns the original string. The
+     * start and end delimiter must be 2 separate instances.
+     * <pre>{@code
+     * removeSurrounding("",     _ )  = ""
+     * removeSurrounding("q",   'q')  = "q"
+     * removeSurrounding("qq",  'q')  = ""
+     * removeSurrounding("q_q", 'q')  = "_"
+     * }</pre>
      */
     public static String removeSurrounding(String string, char delimiter) {
-        if (!string.isEmpty()
+        if (string.length() >= 2
             && string.charAt(0) == delimiter
             && string.charAt(string.length() - 1) == delimiter) {
             return string.substring(1, string.length() - 1);

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/StringUtilTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/StringUtilTest.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.util;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
@@ -96,5 +98,13 @@ public class StringUtilTest {
         String test = "é";
         StringUtil.appendXmlEscaped(sb, test, true);
         assertEquals("é", sb.toString());
+    }
+
+    @Test
+    public void testRemoveSurrounding() {
+        assertThat(StringUtil.removeSurrounding("", 'q'), equalTo(""));
+        assertThat(StringUtil.removeSurrounding("q", 'q'), equalTo("q"));
+        assertThat(StringUtil.removeSurrounding("qq", 'q'), equalTo(""));
+        assertThat(StringUtil.removeSurrounding("qqq", 'q'), equalTo("q"));
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeTestUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeTestUtil.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Modifier;
 import java.util.List;
 
 import net.sourceforge.pmd.internal.util.AssertionUtil;
+import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotationTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
@@ -15,6 +16,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
 import net.sourceforge.pmd.lang.java.ast.ASTEnumDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTImplementsList;
 import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTName;
 import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.typeresolution.TypeHelper;
 
@@ -221,6 +223,12 @@ public final class TypeTestUtil {
     }
 
     private static boolean fallbackIsA(TypeNode n, String canonicalName, boolean considerSubtype) {
+        if (n instanceof ASTAnnotation) {
+            // the annotation node has no image itself
+            n = n.getFirstDescendantOfType(ASTName.class);
+            assert n != null;
+        }
+
         if (n.getImage() != null && !n.getImage().contains(".") && canonicalName.contains(".")) {
             // simple name detected, check the imports to get the full name and use that for fallback
             List<ASTImportDeclaration> imports = n.getRoot().findChildrenOfType(ASTImportDeclaration.class);

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
@@ -1700,4 +1700,31 @@ public class Outer {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>#1175 False positive with Junit 5 MethodSource</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.stream.Stream;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+
+public class Outer {
+    private static Stream<Arguments> basenameKeyArguments() {
+        return Stream.of(
+                Arguments.of("simple", "simple"),
+                Arguments.of("simple", "one/two/many/simple"),
+                Arguments.of("simple", "//////an/////awful/key////simple")
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("basenameKeyArguments")
+    void basenameKeyTest(final String expected, final String testString) {
+        assertEquals(expected, NetworkTable.basenameKey(testString));
+    }
+
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #1175

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

