### PR TITLE
[java] MethodArgumentCouldBeFinal: false negatives with interfaces and inner classes

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -20,6 +20,7 @@ This is a {{ site.pmd.release_type }} release.
     *   [#3230](https://github.com/pmd/pmd/issues/3230): \[doc] Remove "Edit me" button for language index pages
 *   java-codestyle
     *   [#2655](https://github.com/pmd/pmd/issues/2655): \[java] UnnecessaryImport false positive for on-demand imports
+    *   [#3265](https://github.com/pmd/pmd/pull/3265): \[java] MethodArgumentCouldBeFinal: false negatives with interfaces and inner classes
 
 ### API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/MethodArgumentCouldBeFinalRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/MethodArgumentCouldBeFinalRule.java
@@ -18,13 +18,18 @@ import net.sourceforge.pmd.lang.symboltable.Scope;
 
 public class MethodArgumentCouldBeFinalRule extends AbstractOptimizationRule {
 
+    public MethodArgumentCouldBeFinalRule() {
+        addRuleChainVisit(ASTConstructorDeclaration.class);
+        addRuleChainVisit(ASTMethodDeclaration.class);
+    }
+
     @Override
     public Object visit(ASTMethodDeclaration meth, Object data) {
         if (meth.isNative() || meth.isAbstract()) {
             return data;
         }
         this.lookForViolation(meth.getScope(), data);
-        return super.visit(meth, data);
+        return data;
     }
 
     private void lookForViolation(Scope scope, Object data) {
@@ -41,7 +46,7 @@ public class MethodArgumentCouldBeFinalRule extends AbstractOptimizationRule {
     @Override
     public Object visit(ASTConstructorDeclaration constructor, Object data) {
         this.lookForViolation(constructor.getScope(), data);
-        return super.visit(constructor, data);
+        return data;
     }
 
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/AvoidReassigningLoopVariables.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/AvoidReassigningLoopVariables.xml
@@ -727,4 +727,58 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Consider also default methods in interface</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public interface InterfaceWithDefaultMethod {
+    default void foo(int bar) {
+        for (int i=0; i < 10; i++) {
+            doSomethingWith(i);
+            i = 5; // not OK
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Consider also classes in interface</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code><![CDATA[
+public interface InterfaceWithClass {
+    class Inner {
+        void foo(int bar) {
+            for (int i=0; i < 10; i++) {
+                doSomethingWith(i);
+                i = 5; // not OK
+            }
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Consider also anonymous classes</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+public class ClassWithAnon {
+    void bar() {
+        ClassWithAnon anon = new ClassWithAnon() {
+            void foo(int bar) {
+                for (int i=0; i < 10; i++) {
+                    doSomethingWith(i);
+                    i = 5; // not OK
+                }
+            }
+        };
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/MethodArgumentCouldBeFinal.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/MethodArgumentCouldBeFinal.xml
@@ -157,4 +157,40 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>False negative with default methods in interface</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>2,7</expected-linenumbers>
+        <code><![CDATA[
+public interface DefaultMethodInInterface {
+    default String toString(Object one) {
+        return toString(one, one);
+    }
+    String toString(Object one, Object two);
+
+    default Object justReturn(Object o) {
+        return o;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>False negative with classes in interfaces</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,6</expected-linenumbers>
+        <code><![CDATA[
+public interface InterfaceWithClass {
+    class Inner {
+        public Inner(Object o) {
+            Object a = o;
+        }
+        public Object justReturn(Object o) {
+            return o;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/MethodArgumentCouldBeFinal.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/MethodArgumentCouldBeFinal.xml
@@ -159,7 +159,7 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>False negative with default methods in interface</description>
+        <description>#3265 False negative with default methods in interface</description>
         <expected-problems>2</expected-problems>
         <expected-linenumbers>2,7</expected-linenumbers>
         <code><![CDATA[
@@ -177,7 +177,7 @@ public interface DefaultMethodInInterface {
     </test-code>
 
     <test-code>
-        <description>False negative with classes in interfaces</description>
+        <description>#3265 False negative with classes in interfaces</description>
         <expected-problems>2</expected-problems>
         <expected-linenumbers>3,6</expected-linenumbers>
         <code><![CDATA[


### PR DESCRIPTION
## Describe the PR

This fixes a couple of false negatives in [MethodArgumentCouldBeFinal](https://pmd.github.io/latest/pmd_rules_java_codestyle.html#methodargumentcouldbefinal) which have been found in #2687 .
It also adds additional test cases for [AvoidReassigningLoopVariables](https://pmd.github.io/latest/pmd_rules_java_bestpractices.html#avoidreassigningloopvariables), but this rule already worked correctly (by using rulechain).

Note: :warning: The rule MethodArgumentCouldBeFinal has already been updated in pmd7 branch.

Here's the code sample:

```java
public interface DefaultMethodInInterface {
    default String toString(Object one) { // one could be final
        return toString(one, one);
    }
    String toString(Object one, Object two);

    default Object justReturn(Object o) { // o cold be final
        return o;
    }
}

public interface InterfaceWithClass {
    class Inner {
        public Inner(Object o) { // o could be final
            Object a = o;
        }
        public Object justReturn(Object o) { // o could be final
            return o;
        }
    }
}
```

Original code samples:
    *   fixes FN (default in interface): https://github.com/checkstyle/checkstyle/blob/checkstyle-8.10/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/defaultcomeslast/InputDefaultComesLastDefaultMethodsInInterface.java#L9
    *   fixes FN (default in interface): https://github.com/spring-projects/spring-framework/blob/v5.0.6.RELEASE/spring-beans/src/main/java/org/springframework/beans/factory/config/BeanPostProcessor.java#L59
    *   fixes FN: https://github.com/checkstyle/checkstyle/blob/checkstyle-8.10/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/defaultcomeslast/InputDefaultComesLastDefaultMethodsInInterface.java#L13
    *   fixes FN (inner interface): https://github.com/checkstyle/checkstyle/blob/checkstyle-8.10/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/unnecessaryparentheses/InputUnnecessaryParenthesesLambdas.java#L30


## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

