### PR TITLE
[java] ConstructorCallsOverridableMethod: IndexOutOfBoundsException with annotations

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -23,6 +23,8 @@ This is a {{ site.pmd.release_type }} release.
     *   [#3262](https://github.com/pmd/pmd/pull/3262): \[java] FieldDeclarationsShouldBeAtStartOfClass: false negative with anon classes
     *   [#3265](https://github.com/pmd/pmd/pull/3265): \[java] MethodArgumentCouldBeFinal: false negatives with interfaces and inner classes
     *   [#3266](https://github.com/pmd/pmd/pull/3266): \[java] LocalVariableCouldBeFinal: false negatives with interfaces, anon classes
+*   java-errorprone
+    *   [#3268](https://github.com/pmd/pmd/pull/3268): \[java] ConstructorCallsOverridableMethod: IndexOutOfBoundsException with annotations
 
 ### API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConstructorCallsOverridableMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConstructorCallsOverridableMethodRule.java
@@ -14,6 +14,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.java.ast.ASTAnnotationTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTArguments;
 import net.sourceforge.pmd.lang.java.ast.ASTBooleanLiteral;
@@ -857,6 +858,12 @@ public final class ConstructorCallsOverridableMethodRule extends AbstractJavaRul
     @Override
     public Object visit(ASTEnumDeclaration node, Object data) {
         // just skip Enums
+        return data;
+    }
+
+    @Override
+    public Object visit(ASTAnnotationTypeDeclaration node, Object data) {
+        // just skip Annotations
         return data;
     }
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ConstructorCallsOverridableMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ConstructorCallsOverridableMethod.xml
@@ -285,4 +285,23 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>IndexOutOfBoundsException with annotation</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+package sample;
+
+import java.lang.annotation.*;
+
+@interface CustomAnnotation {
+    Object object = new Object() {
+        @Override
+        public String toString() {
+            return new String(new StringBuilder("Hello").append(",World"));
+        }
+    }.toString();
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

This fixes a IOOBE with annotations in the rule [ConstructorCallsOverridableMethod](https://pmd.github.io/latest/pmd_rules_java_errorprone.html#constructorcallsoverridablemethod). From now on, annotations are ignored like enums.

The bug was mentioned here: https://chunk.io/pmd/c971f51d18f6444aab9ee0363d6d1204/diff/checkstyle/index.html#section-errors
while analyzing: https://github.com/checkstyle/checkstyle/blob/checkstyle-8.10/src/test/resources/com/puppycrawl/tools/checkstyle/checks/indentation/indentation/InputIndentationCustomAnnotation.java

For reference, the original stacktrace:

```
java.lang.IndexOutOfBoundsException: Index -1 out of bounds for length 0
	at java.base/jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64)
	at java.base/jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70)
	at java.base/jdk.internal.util.Preconditions.checkIndex(Preconditions.java:248)
	at java.base/java.util.Objects.checkIndex(Objects.java:372)
	at java.base/java.util.ArrayList.get(ArrayList.java:459)
	at net.sourceforge.pmd.lang.java.rule.errorprone.ConstructorCallsOverridableMethodRule.getCurrentEvalPackage(ConstructorCallsOverridableMethodRule.java:626)
	at net.sourceforge.pmd.lang.java.rule.errorprone.ConstructorCallsOverridableMethodRule.visit(ConstructorCallsOverridableMethodRule.java:933)
	at net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration.jjtAccept(ASTMethodDeclaration.java:37)
```

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

