### PR TITLE
[java] OnlyOneReturn: false negative with anonymous class

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -42,6 +42,7 @@ This is a {{ site.pmd.release_type }} release.
     *   [#3262](https://github.com/pmd/pmd/pull/3262): \[java] FieldDeclarationsShouldBeAtStartOfClass: false negative with anon classes
     *   [#3265](https://github.com/pmd/pmd/pull/3265): \[java] MethodArgumentCouldBeFinal: false negatives with interfaces and inner classes
     *   [#3266](https://github.com/pmd/pmd/pull/3266): \[java] LocalVariableCouldBeFinal: false negatives with interfaces, anon classes
+    *   [#3274](https://github.com/pmd/pmd/pull/3274): \[java] OnlyOneReturn: false negative with anonymous class
 *   java-design
     *   [#2780](https://github.com/pmd/pmd/issues/2780): \[java] DataClass example from documentation results in false-negative
 *   java-errorprone

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/OnlyOneReturnRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/OnlyOneReturnRule.java
@@ -8,27 +8,18 @@ import java.util.Iterator;
 import java.util.List;
 
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTReturnStatement;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
 public class OnlyOneReturnRule extends AbstractJavaRule {
 
-    @Override
-    public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
-        if (node.isInterface()) {
-            return data;
-        }
-        return super.visit(node, data);
+    public OnlyOneReturnRule() {
+        addRuleChainVisit(ASTMethodDeclaration.class);
     }
 
     @Override
     public Object visit(ASTMethodDeclaration node, Object data) {
-        if (node.isAbstract()) {
-            return data;
-        }
-
         List<ASTReturnStatement> returnNodes = node.findDescendantsOfType(ASTReturnStatement.class);
 
         if (returnNodes.size() > 1) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/OnlyOneReturn.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/OnlyOneReturn.xml
@@ -119,7 +119,7 @@ public class OnlyOneReturn {
     </test-code>
 
     <test-code>
-        <description>False positive with anonymous class #3274</description>
+        <description>False negative with anonymous class #3274</description>
         <expected-problems>2</expected-problems>
         <expected-linenumbers>6,7</expected-linenumbers>
         <code><![CDATA[

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/OnlyOneReturn.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/OnlyOneReturn.xml
@@ -117,4 +117,25 @@ public class OnlyOneReturn {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>False positive with anonymous class #3274</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>6,7</expected-linenumbers>
+        <code><![CDATA[
+public class OnlyOneReturn {
+    void foo() {
+        Object o = new Object() {
+            void method(int i) {
+                switch (i) {
+                    case 1: return;
+                    case 2: return;
+                }
+                return;
+            }
+        };
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
Converts the rule [OnlyOneReturn](https://pmd.github.io/latest/pmd_rules_java_codestyle.html#onlyonereturn) to use rulechain. Now all method
declarations are visited regardless where they are
nested.

This FN has been found via #2687.

Example code:

```java
public class OnlyOneReturn {
    void foo() {
        Object o = new Object() {
            void method(int i) {
                switch (i) {
                    case 1: return;  // missing violation
                    case 2: return; // missing violation
                }
                return;
            }
        };
    }
}
```

Note: this rule has already been converted in pmd7

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

