### PR TITLE
[core] Fix #2639, create report file directories if they do not exist

### DIFF
--- a/docs/pages/pmd/userdocs/cli_reference.md
+++ b/docs/pages/pmd/userdocs/cli_reference.md
@@ -111,7 +111,7 @@ The tool comes with a rather extensive help text, simply running with `-help`!
     %}
     {% include custom/cli_option_row.html options="-reportfile,-r"
                option_arg="path"
-               description="Path to a file in which the report output will be sent. By default the report is printed on standard output."
+               description="Path to a file to which report output is written. The file is created if it does not exist. If this option is not specified, the report is rendered to standard output."
     %}
     {% include custom/cli_option_row.html options="-shortnames"
                description="Prints shortened filenames in the report."

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -27,6 +27,8 @@ This is a {{ site.pmd.release_type }} release.
 
 *   apex
     *   [#3243](https://github.com/pmd/pmd/pull/3243): \[apex] Correct findBoundary when traversing AST
+*   core
+    *   [#2639](https://github.com/pmd/pmd/issues/2639): \[core] PMD CLI output file is not created if directory or directories in path don't exist
 *   doc
     *   [#3230](https://github.com/pmd/pmd/issues/3230): \[doc] Remove "Edit me" button for language index pages
 *   dist

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cli/PMDParameters.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cli/PMDParameters.java
@@ -89,7 +89,10 @@ public class PMDParameters {
             converter = PropertyConverter.class)
     private List<Properties> properties = new ArrayList<>();
 
-    @Parameter(names = { "-reportfile", "-r" }, description = "Sends report output to a file; default to System.out.")
+    @Parameter(names = { "-reportfile", "-r" },
+               description = "Path to a file to which report output is written. "
+                   + "The file is created if it does not exist. "
+                   + "If this option is not specified, the report is rendered to standard output.")
     private String reportfile = null;
 
     @Parameter(names = { "-version", "-v" }, description = "Specify version of a language PMD should use.")

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/IOUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/IOUtil.java
@@ -15,6 +15,7 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.charset.UnsupportedCharsetException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 
@@ -62,16 +63,23 @@ public final class IOUtil {
 
     /**
      * Creates a writer that writes to the given file or to stdout.
+     * The file is created if it does not exist.
      *
      * <p>Warning: This writer always uses the system default charset.
      *
      * @param reportFile the file name (optional)
-     * @return the writer, never <code>null</code>
+     *
+     * @return the writer, never null
      */
     public static Writer createWriter(String reportFile) {
         try {
-            return StringUtils.isBlank(reportFile) ? createWriter()
-                    : Files.newBufferedWriter(new File(reportFile).toPath(), getDefaultCharset());
+            if (StringUtils.isBlank(reportFile)) {
+                return createWriter();
+            }
+            Path path = new File(reportFile).toPath();
+            Files.createDirectories(path.getParent()); // ensure parent dir exists
+            // this will create the file if it doesn't exist
+            return Files.newBufferedWriter(path, getDefaultCharset());
         } catch (IOException e) {
             throw new IllegalArgumentException(e);
         }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cli/CoreCliTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cli/CoreCliTest.java
@@ -1,0 +1,123 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.cli;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+import org.junit.rules.TemporaryFolder;
+
+import net.sourceforge.pmd.PMD;
+
+/**
+ *
+ */
+public class CoreCliTest {
+
+    private static final String DUMMY_RULESET = "net/sourceforge/pmd/cli/FakeRuleset.xml";
+    private static final String STRING_TO_REPLACE = "__should_be_replaced__";
+
+    @Rule
+    public TemporaryFolder tempDir = new TemporaryFolder();
+    @Rule
+    public RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+    private Path srcDir;
+
+    @Before
+    public void setup() throws IOException {
+        // set current directory to wd
+        Path root = tempRoot();
+        System.setProperty("user.dir", root.toString());
+
+        // create a few files
+        srcDir = Files.createDirectories(root.resolve("src"));
+        writeString(srcDir.resolve("someSource.dummy"), "dummy text");
+    }
+
+
+    @Test
+    public void testPreExistingReportFile() throws IOException {
+        Path reportFile = tempRoot().resolve("out/reportFile.txt");
+        // now we create the file
+        Files.createDirectories(reportFile.getParent());
+        writeString(reportFile, STRING_TO_REPLACE);
+
+        assertTrue("Report file should exist", Files.exists(reportFile));
+
+        runPmdSuccessfully("-d", srcDir, "-R", DUMMY_RULESET, "-r", reportFile);
+
+        assertNotEquals(readString(reportFile), STRING_TO_REPLACE);
+    }
+
+    @Test
+    public void testNonExistentReportFile() {
+        Path reportFile = tempRoot().resolve("out/reportFile.txt");
+
+        assertFalse("Report file should not exist", Files.exists(reportFile));
+
+        runPmdSuccessfully("-d", srcDir, "-R", DUMMY_RULESET, "-r", reportFile);
+
+        assertTrue("Report file should have been created", Files.exists(reportFile));
+    }
+
+
+
+
+
+
+    // utilities
+
+
+
+    private Path tempRoot() {
+        return tempDir.getRoot().toPath();
+    }
+
+
+    private static void runPmdSuccessfully(Object... args) {
+        runPmd(0, args);
+    }
+
+    private static String[] argsToString(Object... args) {
+        String[] result = new String[args.length];
+        for (int i = 0; i < args.length; i++) {
+            result[i] = args[i].toString();
+        }
+        return result;
+    }
+
+    // available in Files on java 11+
+    private static void writeString(Path path, String text) throws IOException {
+        ByteBuffer encoded = StandardCharsets.UTF_8.encode(text);
+        Files.write(path, encoded.array());
+    }
+
+
+    // available in Files on java 11+
+    private static String readString(Path path) throws IOException {
+        byte[] bytes = Files.readAllBytes(path);
+        ByteBuffer buf = ByteBuffer.wrap(bytes);
+        return StandardCharsets.UTF_8.decode(buf).toString();
+    }
+
+    private static void runPmd(int expectedExitCode, Object[] args) {
+        int actualExitCode = PMD.run(argsToString(args));
+        assertEquals("Exit code", expectedExitCode, actualExitCode);
+    }
+
+
+}

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/cli/FakeRuleset.xml
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/cli/FakeRuleset.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<ruleset name="Test Ruleset" xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+
+    <description>
+  Ruleset used by test RuleSetFactoryTest
+  </description>
+
+    <rule name="Ruleset3Rule1" language="dummy" since="1.0" message="Test Rule 1" class="net.sourceforge.pmd.lang.rule.MockRule"
+        externalInfoUrl="${pmd.website.baseurl}/rules/test/TestRuleset3.xml#Ruleset3Rule1">
+        <description>
+Just for test
+     </description>
+        <priority>3</priority>
+        <example>
+ <![CDATA[
+ ]]>
+     </example>
+    </rule>
+
+    <rule name="Ruleset3Rule2" language="dummy" since="1.0" message="Test Rule 2" class="net.sourceforge.pmd.lang.rule.MockRule"
+        externalInfoUrl="${pmd.website.baseurl}/rules/test/TestRuleset3.xml#Ruleset3Rule1">
+        <description>
+Just for test
+     </description>
+        <priority>3</priority>
+        <example>
+ <![CDATA[
+ ]]>
+     </example>
+    </rule>
+</ruleset>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/cli/CLITest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/cli/CLITest.java
@@ -7,7 +7,6 @@ package net.sourceforge.pmd.cli;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.regex.Pattern;
 
 import org.junit.Assert;
@@ -39,7 +38,7 @@ public class CLITest extends BaseCLITest {
     }
 
     @Test
-    public void changeJavaVersion() throws IOException {
+    public void changeJavaVersion() {
         String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "category/java/design.xml", "-version", "1.5", "-language",
             "java", "-debug", };
         String resultFilename = runTest(args, "chgJavaVersion");
@@ -54,14 +53,14 @@ public class CLITest extends BaseCLITest {
     }
 
     @Test
-    public void exitStatusWithViolations() throws IOException {
+    public void exitStatusWithViolations() {
         String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "category/java/errorprone.xml", };
         String resultFilename = runTest(args, "exitStatusWithViolations", 4);
         assertTrue(FileUtil.findPatternInFile(new File(resultFilename), "Avoid empty if"));
     }
 
     @Test
-    public void exitStatusWithViolationsAndWithoutFailOnViolations() throws IOException {
+    public void exitStatusWithViolationsAndWithoutFailOnViolations() {
         String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "category/java/errorprone.xml", "-failOnViolation", "false", };
         String resultFilename = runTest(args, "exitStatusWithViolationsAndWithoutFailOnViolations", 0);
         assertTrue(FileUtil.findPatternInFile(new File(resultFilename), "Avoid empty if"));
@@ -71,7 +70,7 @@ public class CLITest extends BaseCLITest {
      * See https://sourceforge.net/p/pmd/bugs/1231/
      */
     @Test
-    public void testWrongRuleset() throws Exception {
+    public void testWrongRuleset() {
         String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "category/java/designn.xml", };
         String filename = TEST_OUPUT_DIRECTORY + "testWrongRuleset.txt";
         createTestOutputFile(filename);
@@ -85,7 +84,7 @@ public class CLITest extends BaseCLITest {
      * See https://sourceforge.net/p/pmd/bugs/1231/
      */
     @Test
-    public void testWrongRulesetWithRulename() throws Exception {
+    public void testWrongRulesetWithRulename() {
         String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "category/java/designn.xml/UseCollectionIsEmpty", };
         String filename = TEST_OUPUT_DIRECTORY + "testWrongRuleset.txt";
         createTestOutputFile(filename);
@@ -99,7 +98,7 @@ public class CLITest extends BaseCLITest {
      * See https://sourceforge.net/p/pmd/bugs/1231/
      */
     @Test
-    public void testWrongRulename() throws Exception {
+    public void testWrongRulename() {
         String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "category/java/design.xml/ThisRuleDoesNotExist", };
         String filename = TEST_OUPUT_DIRECTORY + "testWrongRuleset.txt";
         createTestOutputFile(filename);


### PR DESCRIPTION
## Describe the PR

(The bug was that the parent directories of the report file were not created. The file itself was already properly created.)

Fixes #2639 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

