### PR TITLE
[java] InvalidLogMessageFormat may examine the value of a different but identically named String variable

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -56,6 +56,7 @@ This is a {{ site.pmd.release_type }} release.
     *   [#3248](https://github.com/pmd/pmd/issues/3248): \[java] Documentation is wrong for SingletonClassReturningNewInstance rule
     *   [#3249](https://github.com/pmd/pmd/pull/3249): \[java] AvoidFieldNameMatchingTypeName: False negative with interfaces
     *   [#3268](https://github.com/pmd/pmd/pull/3268): \[java] ConstructorCallsOverridableMethod: IndexOutOfBoundsException with annotations
+    *   [#3284](https://github.com/pmd/pmd/issues/3284): \[java] InvalidLogMessageFormat may examine the value of a different but identically named String variable
 
 ### API Changes
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidLogMessageFormat.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidLogMessageFormat.xml
@@ -998,4 +998,27 @@ class TestInvalidLogMessageFormat {
             }
             ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[java] InvalidLogMessageFormat may examine the value of a different but identically named String variable #3284</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.slf4j.Logger;
+public class Foo {
+    public void aTest() {
+        Logger logger = null;
+
+        if (true) {
+            final String logMessage = "A message formatted with three parameters: {}, {}, {}";
+        }
+
+        if (true) {
+            final String logMessage = "A message formatted with only one parameter: {}";
+            final Object param = null;
+            logger.trace(logMessage, param);
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
identically named String variable

Uses symbol table to find a referenced variable.

## Related issues


- Fixes #3284

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

