### PR TITLE
[java] GuardLogStatement: False positive with compile-time constant arguments

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -36,6 +36,7 @@ This is a {{ site.pmd.release_type }} release.
 *   java
     *   [#3269](https://github.com/pmd/pmd/pull/3269): \[java] Fix NPE in MethodTypeResolution
 *   java-bestpractices
+    *   [#957](https://github.com/pmd/pmd/issues/957): \[java] GuardLogStatement: False positive with compile-time constant arguments
     *   [#1175](https://github.com/pmd/pmd/issues/1175): \[java] UnusedPrivateMethod FP with Junit 5 @MethodSource
     *   [#2219](https://github.com/pmd/pmd/issues/2219): \[java] Document Reasons to Avoid Reassigning Parameters
     *   [#2737](https://github.com/pmd/pmd/issues/2737): \[java] Fix misleading rule message on rule SwitchStmtsShouldHaveDefault with non-exhaustive enum switch

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
@@ -150,7 +150,17 @@ public class GuardLogStatementRule extends AbstractJavaRule implements Rule {
                 return !isConstantStringExpression(child);
             }
         }
-        return false;
+
+        // if there is only one argument and this is a AdditiveExpression, we assume, it is the message
+        // and this is a string concatenation even we are not sure, that the type is string.
+        // this can happen for lambda parameters.
+        return isSingleAdditiveExpression(argumentList);
+    }
+
+    private boolean isSingleAdditiveExpression(ASTArgumentList argumentList) {
+        return argumentList.size() == 1
+                && argumentList.getChild(0).getNumChildren() == 1
+                && argumentList.getChild(0).getChild(0) instanceof ASTAdditiveExpression;
     }
 
     private boolean isConstantStringExpression(JavaNode expr) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
@@ -143,7 +143,9 @@ public class GuardLogStatementRule extends AbstractJavaRule implements Rule {
         }
         ASTArgumentList argumentList = node.getFirstChildOfType(ASTArguments.class).getFirstChildOfType(ASTArgumentList.class);
         for (JavaNode child : argumentList.children()) {
-            if (child instanceof TypeNode && TypeTestUtil.isA(String.class, (TypeNode) child)) {
+            if (child.hasDescendantOfType(ASTAdditiveExpression.class)
+                && child instanceof TypeNode
+                && TypeTestUtil.isA(String.class, (TypeNode) child)) {
                 // only consider the first String argument - which is the log message - and return here
                 return !isConstantStringExpression(child);
             }

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -618,19 +618,19 @@ with lambdas. The available alternatives depend on the actual logging framework.
         <priority>2</priority>
         <example>
 <![CDATA[
-    // Add this for performance
-    if (log.isDebugEnabled()) {
-        log.debug("log something" + " and " + "concat strings");
-    }
+// Add this for performance
+if (log.isDebugEnabled()) {
+    log.debug("log something" + param1 + " and " + param2 + "concat strings");
+}
 
-    // Avoid the guarding if statement with substituting parameters
-    log.debug("log something {} and {}", param1, param2);
+// Avoid the guarding if statement with substituting parameters
+log.debug("log something {} and {}", param1, param2);
 
-    // Avoid the guarding if statement with formatters
-    log.debug("log something %s and %s", param1, param2);
+// Avoid the guarding if statement with formatters
+log.debug("log something %s and %s", param1, param2);
 
-    // Avoid the guarding if statement with lazy logging and lambdas
-    log.debug("log something expensive: {}", () -> calculateExpensiveLoggingText());
+// Avoid the guarding if statement with lazy logging and lambdas
+log.debug("log something expensive: {}", () -> calculateExpensiveLoggingText());
 ]]>
         </example>
     </rule>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
@@ -16,7 +16,7 @@ public class Foo {
 
     private void foo() {
         if ( logger.isDebugEnabled() )
-            logger.debug("Debug statement");
+            logger.debug("Debug statement:" + this);
     }
 }
         ]]></code>
@@ -34,7 +34,7 @@ public class Test {
     public void test() {
         // good:
         if (__log.isDebugEnabled()) {
-        __log.debug("bla" + "",e );
+        __log.debug("bla" + this, e);
         }
     }
 }
@@ -51,7 +51,7 @@ public class Foo {
 
     private void foo(Logger logger) {
         if ( logger.isLoggable(Level.FINE) ) {
-            logger.fine("debug message" + "");
+            logger.fine("debug message: " + this);
         }
     }
 }
@@ -69,7 +69,7 @@ public class Foo {
     private static final Logger logger = LogManager.getLogger(Foo.class);
 
     private void foo() {
-        logger.debug("Debug statement" + "");
+        logger.debug("Debug statement: " + this);
     }
 }
         ]]></code>
@@ -88,11 +88,11 @@ public class Foo {
     private static final Logger logger = LogManager.getLogger(Foo.class);
 
     private void foo() {
-        logger.debug("Debug statement" + "");
+        logger.debug("Debug statement: " + this);
     }
 
     private void bar() {
-        logger.info("No guard, but'is OK with properties configuration" + "");
+        logger.info("No guard, but'is OK with properties configuration: " + this);
     }
 }
         ]]></code>
@@ -110,14 +110,14 @@ public class Test {
     public void test() {
 
         // bad:
-        __log.debug("log something" + " and " + "concat strings");
+        __log.debug("log something" + this + " and " + "concat strings");
 
         // bad:
-        __log.debug("log something" + " and " + "concat strings", e);
+        __log.debug("log something" + this + " and " + "concat strings", e);
 
         // good:
         if (__log.isDebugEnabled()) {
-        __log.debug("bla" + "",e );
+        __log.debug("bla" + this, e);
         }
     }
 }
@@ -136,7 +136,7 @@ public class Test {
     public void test() {
         if (true) {
             // bad:
-            __log.debug("log something" + " and " + "concat strings");
+            __log.debug("log something" + this + " and " + "concat strings");
             // this is useless:
             __log.isDebugEnabled();
         }
@@ -154,7 +154,7 @@ import java.util.logging.Logger;
 public class Foo {
 
     private void foo(Logger logger) {
-        logger.fine("debug message" + "");
+        logger.fine("debug message: " + this);
     }
 }
         ]]></code>
@@ -248,7 +248,7 @@ public class Test {
 
         // good:
         if (__log.isDebugEnabled()) {
-        __log.debug("bla" + "",e );
+        __log.debug("bla: " + this, e);
         }
     }
 }
@@ -285,7 +285,7 @@ public class Foo {
     Logger LOGGER;
 
     public void foo() {
-        LOGGER.severe("This is a severe message" + " and concat");
+        LOGGER.severe("This is a severe message" + this + " and concat");
     }
 }
         ]]></code>
@@ -303,9 +303,9 @@ public class Foo {
     Logger LOGGER;
 
     public void foo() {
-        LOGGER.log(Level.FINE, "This is a severe message" + " and concat"); // violation
+        LOGGER.log(Level.FINE, "This is a severe message" + this + " and concat"); // violation
         if (LOGGER.isLoggable(Level.FINE)) {
-            LOGGER.log(Level.FINE, "This is a severe message" + " and concat"); // no violation
+            LOGGER.log(Level.FINE, "This is a severe message" + this + " and concat"); // no violation
         }
     }
 }
@@ -375,7 +375,7 @@ public class Foo {
 
     public void foo() {
         if (LOGGER.isLoggable(Level.INFO)) { // should have been level FINE
-            LOGGER.log(Level.FINE, "This is a severe message" + " and concat");
+            LOGGER.log(Level.FINE, "This is a severe message" + this + " and concat");
         }
     }
 }
@@ -390,7 +390,9 @@ public class Logger {
     private static final Logger LOGGER = new Logger();
 
     public void bar() {
-        LOGGER.info(() -> "Bla " + " bla"); // The lambda is free to do whatever it likes
+        String msg;
+        msg = "test";
+        LOGGER.info(() -> "Bla " + msg + " bla"); // The lambda is free to do whatever it likes
     }
 
     @Override
@@ -422,7 +424,7 @@ public class GuardLogStatement {
         <code><![CDATA[
 public class GuardLogStatement {
     public String foo() {
-        return ThisIsNotALogger.error("message " + "");
+        return ThisIsNotALogger.error("message " + this);
     }
 }
         ]]></code>
@@ -458,6 +460,36 @@ public class Logger {
 
     private String expensiveOperation() {
         return "...";
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] GuardLogStatement: False positive with compile-time constant arguments #957</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Logger {
+    private static final Logger LOGGER = new Logger();
+    private static final String CONSTANT = "a constant";
+
+    public void case1() {
+        LOGGER.debug("log something" + " and " + "concat strings"); // the same as "log something and concat strings"
+    }
+
+    public void case2() {
+        final String constantPrefix = "log something";
+        final String constantSuffix = "concat strings";
+        LOGGER.debug(constantPrefix + " and " + constantSuffix ); // the same as "log something and concat strings"
+    }
+
+    public void case3() {
+        LOGGER.debug("Prefix " + CONSTANT);
+    }
+
+    public void case4() {
+        LOGGER.debug("Some long string that has been " + 
+            "separated into two constants. Contains value: {}", param);
     }
 }
         ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
@@ -507,11 +507,36 @@ public class Logger {
     private void runTestLambda(TestLambda test) {
         test.apply("one", "two");
     }
+}
+        ]]></code>
+    </test-code>
 
-    public void case6() {
+    <test-code>
+        <description>false negative inside lambdas</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>19,21</expected-linenumbers>
+        <code><![CDATA[
+public class Logger {
+    private static final Logger LOGGER = new Logger();
+
+    private interface TestLambda {
+        void apply(String arg1, String arg2);
+    }
+    private void runTestLambda(TestLambda test) {
+        test.apply("one", "two");
+    }
+
+    public void case1_no_violation() {
         runTestLambda((String a, String b) -> {
             LOGGER.debug(a);
         });
+    }
+
+    public void case2_violation() {
+        runTestLambda((String a, String b) -> {
+            LOGGER.debug(a + b);
+        });
+        runTestLambda((s1, s2) -> {LOGGER.debug(s1 + s2);});
     }
 }
         ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
@@ -491,6 +491,28 @@ public class Logger {
         LOGGER.debug("Some long string that has been " + 
             "separated into two constants. Contains value: {}", param);
     }
+
+    private void log(int line, String key) {
+        System.out.println(line + ":" + key);
+    }
+
+    public void case5(int line, String key) {
+        log(line, key);
+        LOGGER.debug(key);
+    }
+
+    private interface TestLambda {
+        void apply(String arg1, String arg2);
+    }
+    private void runTestLambda(TestLambda test) {
+        test.apply("one", "two");
+    }
+
+    public void case6() {
+        runTestLambda((String a, String b) -> {
+            LOGGER.debug(a);
+        });
+    }
 }
         ]]></code>
     </test-code>


### PR DESCRIPTION
arguments

## Related issues

- Fixes #957

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

