### PR TITLE
[java] Update UnnecessaryImport to recognize usage of imported types in javadoc's `@exception` tag

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryImportRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryImportRule.java
@@ -52,6 +52,7 @@ public class UnnecessaryImportRule extends AbstractJavaRule {
      * {@value package.class#field}
      *
      * @throws package.class label
+     * @exception package.class label
      */
     private static final Pattern SEE_PATTERN = Pattern
         .compile("@see\\s+((?:\\p{Alpha}\\w*\\.)*(?:\\p{Alpha}\\w*))?(?:#\\w*(?:\\(([.\\w\\s,\\[\\]]*)\\))?)?");
@@ -63,7 +64,9 @@ public class UnnecessaryImportRule extends AbstractJavaRule {
 
     private static final Pattern THROWS_PATTERN = Pattern.compile("@throws\\s+(\\p{Alpha}\\w*)");
 
-    private static final Pattern[] PATTERNS = { SEE_PATTERN, LINK_PATTERNS, VALUE_PATTERN, THROWS_PATTERN };
+    private static final Pattern EXCEPTION_PATTERN = Pattern.compile("@exception\\s+(\\p{Alpha}\\w*)");
+
+    private static final Pattern[] PATTERNS = { SEE_PATTERN, LINK_PATTERNS, VALUE_PATTERN, THROWS_PATTERN, EXCEPTION_PATTERN };
 
     /**
      * The deprecated rule {@link UnusedImportsRule} extends this class

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryImport.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryImport.xml
@@ -203,6 +203,7 @@ import java.util.List;
 import java.util.LinkedList;
 import java.util.File;
 import java.util.NoSuchElementException;
+import java.io.IOException;
 
 public class Foo {
     /**
@@ -212,6 +213,7 @@ public class Foo {
      * {@value  Calendar#DATE}
      * @see File
      * @throws NoSuchElementException no such element
+     * @exception IOException IO operation exception
      */
     public void test() {}
 }


### PR DESCRIPTION
## Describe the PR

Update [UnnecessaryImport](https://pmd.github.io/latest/pmd_rules_java_codestyle.html#unnecessaryimport) to recognize usage of imported types in javadoc's `@exception` tag.

This fixes a false positive.

According to the javadoc docs, this tag is equivalent to `@throws` and not deprecated:
https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDCEAHH

> **@exception** **_class-name description_**
>
>    Introduced in JDK 1.0
>
>    Identical to the @throws tag. See [@throws _class-name description_](https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDCHAHD).

## Related issues

https://github.com/pmd/pmd/commit/77e3c19cb28e0250f67348691c2dfe421a187eab#r51465948

## Ready?


- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

-----
First commit locally failed - as expected.