### PR TITLE
[apex] New AvoidDebugStatements rule to mitigate performance impact

### DIFF
--- a/pmd-apex/src/main/resources/category/apex/performance.xml
+++ b/pmd-apex/src/main/resources/category/apex/performance.xml
@@ -9,6 +9,39 @@
 Rules that flag suboptimal code.
     </description>
 
+    <rule name="AvoidDebugStatements"
+          language="apex"
+          since="6.36.0"
+          message="Avoid debug statements since they impact on performance"
+          class="net.sourceforge.pmd.lang.apex.rule.ApexXPathRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_performance.html#avoiddebugstatements">
+        <description>
+Debug statements contibute to longer transactions and consume
+Apex CPU time even when there&apos;s no active debug trace.
+        </description>
+        <priority>3</priority>
+        <properties>
+            <property name="version" value="2.0"/>
+            <property name="xpath">
+                <value>
+<![CDATA[
+//MethodCallExpression[lower-case(@FullMethodName)='system.debug']
+]]>
+                </value>
+            </property>
+        </properties>
+        <example>
+<![CDATA[
+public class Foo {
+    public void bar() {
+        List<Account> accs = [SELECT Name, Owner.Name FROM Account];
+        System.debug(accs);
+    }
+}
+]]>
+        </example>
+    </rule>
+
     <rule name="AvoidDmlStatementsInLoops"
           language="apex"
           since="5.5.0"

--- a/pmd-apex/src/main/resources/category/apex/performance.xml
+++ b/pmd-apex/src/main/resources/category/apex/performance.xml
@@ -38,16 +38,15 @@ For other valid use cases that the statement is in fact valid make use of the `@
 public class Foo {
     public void bar() {
         Account acc = [SELECT Name, Owner.Name FROM Account LIMIT 1];
-        System.debug(accs);
+        System.debug(accs); // will get reported
     }
 
     @SuppressWarnings('PMD.AvoidDebugStatements')
     public void baz() {
-
         try {
             Account myAccount = bar();
         } catch (Exception e) {
-            System.debug(LoggingLevel.ERROR, e.getMessage());
+            System.debug(LoggingLevel.ERROR, e.getMessage()); // good to go
         }
     }
 }

--- a/pmd-apex/src/main/resources/category/apex/performance.xml
+++ b/pmd-apex/src/main/resources/category/apex/performance.xml
@@ -16,8 +16,11 @@ Rules that flag suboptimal code.
           class="net.sourceforge.pmd.lang.apex.rule.ApexXPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_performance.html#avoiddebugstatements">
         <description>
-Debug statements contribute to longer transactions and consume
-Apex CPU time even when there&apos;s no active debug trace.
+Debug statements contribute to longer transactions and consume Apex CPU time even when debug logs are not being captured.
+
+When possible make use of other debugging techniques such as the Apex Replay Debugger and Checkpoints that could cover *most* use cases.
+
+For other valid use cases that the statement is in fact valid make use of the `@SuppressWarnings` annotation or the `//NOPMD` comment.
         </description>
         <priority>3</priority>
         <properties>
@@ -34,8 +37,18 @@ Apex CPU time even when there&apos;s no active debug trace.
 <![CDATA[
 public class Foo {
     public void bar() {
-        List<Account> accs = [SELECT Name, Owner.Name FROM Account];
+        Account acc = [SELECT Name, Owner.Name FROM Account LIMIT 1];
         System.debug(accs);
+    }
+
+    @SuppressWarnings('PMD.AvoidDebugStatements')
+    public void baz() {
+
+        try {
+            Account myAccount = bar();
+        } catch (Exception e) {
+            System.debug(LoggingLevel.ERROR, e.getMessage());
+        }
     }
 }
 ]]>

--- a/pmd-apex/src/main/resources/category/apex/performance.xml
+++ b/pmd-apex/src/main/resources/category/apex/performance.xml
@@ -16,7 +16,7 @@ Rules that flag suboptimal code.
           class="net.sourceforge.pmd.lang.apex.rule.ApexXPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_performance.html#avoiddebugstatements">
         <description>
-Debug statements contibute to longer transactions and consume
+Debug statements contribute to longer transactions and consume
 Apex CPU time even when there&apos;s no active debug trace.
         </description>
         <priority>3</priority>

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/performance/AvoidDebugStatementsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/performance/AvoidDebugStatementsTest.java
@@ -1,0 +1,11 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.rule.performance;
+
+import net.sourceforge.pmd.testframework.PmdRuleTst;
+
+public class AvoidDebugStatementsTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/performance/xml/AvoidDebugStatements.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/performance/xml/AvoidDebugStatements.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+    <test-code>
+        <description>No debug statements</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public static void bar() {
+        System.enqueueJob(new MayQueueable());
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Debug statements with a purpose</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+@SuppressWarnings('PMD.AvoidDebugStatements') //logging classes may need the debugs
+public class LoggingManager {
+    public static void log(LoggingLevel leve, Object data) {
+        System.debug(level, data);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Unnecesary debug statements</description>
+        <expected-problems>2</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public static void bar() {
+        System.debug(LoggingLevel.INFO, 'Testing ' + new List<Account>{new Account(Name = 'Test')});
+        system.debug('simple');
+    }
+}
+        ]]></code>
+    </test-code>
+
+</test-data>


### PR DESCRIPTION
## Describe the PR

Flags usage of `System.debug` statements since it's demonstrated that impacts performance even when no debug traces are active. Also promoting the usage of Apex Replay Debugger and Checkpoints that doesn't pollute the code and grants most of the functionality.

## Related issues

- Fixes #3307

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

