### PR TITLE
[apex] added rule to detect inaccessible AuraEnabled getters

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/InaccessibleAuraEnabledGetterRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/InaccessibleAuraEnabledGetterRule.java
@@ -1,0 +1,64 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.rule.errorprone;
+
+import java.util.List;
+
+import net.sourceforge.pmd.lang.apex.ast.ASTAnnotation;
+import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
+import net.sourceforge.pmd.lang.apex.ast.ASTModifierNode;
+import net.sourceforge.pmd.lang.apex.ast.ASTProperty;
+import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+
+/**
+ * In the Summer '21 release, a mandatory security update enforces access modifiers on Apex properties in Lightning component markup.
+ * The update prevents access to private or protected Apex getters from Aura and Lightning Web Components.
+ * @author p.ozil
+ */
+public class InaccessibleAuraEnabledGetterRule extends AbstractApexRule {
+
+	public InaccessibleAuraEnabledGetterRule() {
+		addRuleChainVisit(ASTProperty.class);
+	}
+	
+	@Override
+    public Object visit(ASTProperty node, Object data) {
+		// Find @AuraEnabled property
+		ASTModifierNode propModifiers = node.getModifiers();
+		if (hasAuraEnabledAnnotation(propModifiers)) {
+			// Find getters/setters if any
+			List<ASTMethod> methods = node.findChildrenOfType(ASTMethod.class);
+			for (ASTMethod method : methods) {
+				// Find getter method
+				if (!"void".equals(method.getReturnType())) {
+					// Ensure getter is not private or protected
+					ASTModifierNode methodModifiers = method.getModifiers();
+					if (isPrivate(methodModifiers) || isProtected(methodModifiers)) {
+						addViolation(data, node);
+					}
+				}
+			}
+		}
+		return data;
+	}
+	
+	private boolean isPrivate(ASTModifierNode modifierNode) {
+        return modifierNode != null && modifierNode.isPrivate();
+    }
+	
+	private boolean isProtected(ASTModifierNode modifierNode) {
+        return modifierNode != null && modifierNode.isProtected();
+    }
+	
+	private boolean hasAuraEnabledAnnotation(ASTModifierNode modifierNode) {
+        List<ASTAnnotation> annotations = modifierNode.findChildrenOfType(ASTAnnotation.class);
+        for (ASTAnnotation annotation : annotations) {
+            if (annotation.hasImageEqualTo("AuraEnabled")) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/InaccessibleAuraEnabledGetterRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/InaccessibleAuraEnabledGetterRule.java
@@ -13,46 +13,49 @@ import net.sourceforge.pmd.lang.apex.ast.ASTProperty;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 
 /**
- * In the Summer '21 release, a mandatory security update enforces access modifiers on Apex properties in Lightning component markup.
- * The update prevents access to private or protected Apex getters from Aura and Lightning Web Components.
+ * In the Summer '21 release, a mandatory security update enforces access
+ * modifiers on Apex properties in Lightning component markup. The update
+ * prevents access to private or protected Apex getters from Aura and Lightning
+ * Web Components.
+ * 
  * @author p.ozil
  */
 public class InaccessibleAuraEnabledGetterRule extends AbstractApexRule {
 
-	public InaccessibleAuraEnabledGetterRule() {
-		addRuleChainVisit(ASTProperty.class);
-	}
-	
-	@Override
+    public InaccessibleAuraEnabledGetterRule() {
+        addRuleChainVisit(ASTProperty.class);
+    }
+
+    @Override
     public Object visit(ASTProperty node, Object data) {
-		// Find @AuraEnabled property
-		ASTModifierNode propModifiers = node.getModifiers();
-		if (hasAuraEnabledAnnotation(propModifiers)) {
-			// Find getters/setters if any
-			List<ASTMethod> methods = node.findChildrenOfType(ASTMethod.class);
-			for (ASTMethod method : methods) {
-				// Find getter method
-				if (!"void".equals(method.getReturnType())) {
-					// Ensure getter is not private or protected
-					ASTModifierNode methodModifiers = method.getModifiers();
-					if (isPrivate(methodModifiers) || isProtected(methodModifiers)) {
-						addViolation(data, node);
-					}
-				}
-			}
-		}
-		return data;
-	}
-	
-	private boolean isPrivate(ASTModifierNode modifierNode) {
+        // Find @AuraEnabled property
+        ASTModifierNode propModifiers = node.getModifiers();
+        if (hasAuraEnabledAnnotation(propModifiers)) {
+            // Find getters/setters if any
+            List<ASTMethod> methods = node.findChildrenOfType(ASTMethod.class);
+            for (ASTMethod method : methods) {
+                // Find getter method
+                if (!"void".equals(method.getReturnType())) {
+                    // Ensure getter is not private or protected
+                    ASTModifierNode methodModifiers = method.getModifiers();
+                    if (isPrivate(methodModifiers) || isProtected(methodModifiers)) {
+                        addViolation(data, node);
+                    }
+                }
+            }
+        }
+        return data;
+    }
+
+    private boolean isPrivate(ASTModifierNode modifierNode) {
         return modifierNode != null && modifierNode.isPrivate();
     }
-	
-	private boolean isProtected(ASTModifierNode modifierNode) {
+
+    private boolean isProtected(ASTModifierNode modifierNode) {
         return modifierNode != null && modifierNode.isProtected();
     }
-	
-	private boolean hasAuraEnabledAnnotation(ASTModifierNode modifierNode) {
+
+    private boolean hasAuraEnabledAnnotation(ASTModifierNode modifierNode) {
         List<ASTAnnotation> annotations = modifierNode.findChildrenOfType(ASTAnnotation.class);
         for (ASTAnnotation annotation : annotations) {
             if (annotation.hasImageEqualTo("AuraEnabled")) {

--- a/pmd-apex/src/main/resources/category/apex/errorprone.xml
+++ b/pmd-apex/src/main/resources/category/apex/errorprone.xml
@@ -456,10 +456,10 @@ private class TestClass {
         </description>
         <priority>3</priority>
         <example>
-<![CDATA[// Violating
+<![CDATA[
 public class Foo {
     @AuraEnabled
-    public Integer counter { private get; set; }
+    public Integer counter { private get; set; } // Violating - Private getter is inaccessible to Lightning components
 
     @AuraEnabled
     public static Foo bar()
@@ -469,26 +469,13 @@ public class Foo {
         return foo;
     }
 }
-
+]]>
+        </example>
+        <example>
+<![CDATA[
 public class Foo {
     @AuraEnabled
-    public static Baz bar()
-    {
-    	Baz baz = new Baz();
-        baz.counter = 2; 
-        return baz;
-    }
-    
-    private class Baz {
-        @AuraEnabled
-        public Integer counter { protected get; set; }
-    }
-}
-
-// Compliant
-public class Foo {
-    @AuraEnabled
-    public Integer counter { get; set; }
+    public Integer counter { protected get; set; } // Violating - Protected getter is inaccessible to Lightning components
 
     @AuraEnabled
     public static Foo bar()
@@ -498,19 +485,20 @@ public class Foo {
         return foo;
     }
 }
-
+]]>
+        </example>
+        <example>
+<![CDATA[
 public class Foo {
     @AuraEnabled
-    public static Baz bar()
+    public Integer counter { get; set; } // Compliant - Public getter is accessible to Lightning components
+
+    @AuraEnabled
+    public static Foo bar()
     {
-    	Baz baz = new Baz();
-        baz.counter = 2; 
-        return baz;
-    }
-    
-    private class Baz {
-        @AuraEnabled
-        public Integer counter { get; set; }
+        Foo foo = new Foo();
+        foo.counter = 2; 
+        return foo;
     }
 }
 ]]>

--- a/pmd-apex/src/main/resources/category/apex/errorprone.xml
+++ b/pmd-apex/src/main/resources/category/apex/errorprone.xml
@@ -443,4 +443,77 @@ private class TestClass {
 ]]>
        </example>
     </rule>
+    
+        <rule name="InaccessibleAuraEnabledGetter"
+          language="apex"
+          since="6.36.0"
+          message="AuraEnabled getter must be public or global if is referenced in Lightning components"
+          class="net.sourceforge.pmd.lang.apex.rule.errorprone.InaccessibleAuraEnabledGetterRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#inaccessibleauraenabledgetter">
+        <description>
+			In the Summer '21 release, a mandatory security update enforces access modifiers on Apex properties in Lightning component markup.
+			The update prevents access to private or protected Apex getters from Aura and Lightning Web Components.
+        </description>
+        <priority>3</priority>
+        <example>
+<![CDATA[// Violating
+public class Foo {
+    @AuraEnabled
+    public Integer counter { private get; set; }
+
+    @AuraEnabled
+    public static Foo bar()
+    {
+        Foo foo = new Foo();
+        foo.counter = 2; 
+        return foo;
+    }
+}
+
+public class Foo {
+    @AuraEnabled
+    public static Baz bar()
+    {
+    	Baz baz = new Baz();
+        baz.counter = 2; 
+        return baz;
+    }
+    
+    private class Baz {
+        @AuraEnabled
+        public Integer counter { protected get; set; }
+    }
+}
+
+// Compliant
+public class Foo {
+    @AuraEnabled
+    public Integer counter { get; set; }
+
+    @AuraEnabled
+    public static Foo bar()
+    {
+        Foo foo = new Foo();
+        foo.counter = 2; 
+        return foo;
+    }
+}
+
+public class Foo {
+    @AuraEnabled
+    public static Baz bar()
+    {
+    	Baz baz = new Baz();
+        baz.counter = 2; 
+        return baz;
+    }
+    
+    private class Baz {
+        @AuraEnabled
+        public Integer counter { get; set; }
+    }
+}
+]]>
+        </example>
+    </rule>
 </ruleset>

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/InaccessibleAuraEnabledGetterTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/InaccessibleAuraEnabledGetterTest.java
@@ -1,0 +1,11 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.rule.errorprone;
+
+import net.sourceforge.pmd.testframework.PmdRuleTst;
+
+public class InaccessibleAuraEnabledGetterTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/xml/InaccessibleAuraEnabledGetter.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/xml/InaccessibleAuraEnabledGetter.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+    <test-code>
+        <description>Failure Case: Inaccessible private AuraEnabled getter</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @AuraEnabled
+    public Integer counter { private get; set; }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Failure Case: Inaccessible protected AuraEnabled getter</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @AuraEnabled
+    public Integer counter { protected get; set; }
+}
+        ]]></code>
+    </test-code>
+    
+    <test-code>
+        <description>Success Case: Inaccessible AuraEnabled getter</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @AuraEnabled
+    public Integer counter { get; set; }
+}
+        ]]></code>
+    </test-code>
+</test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/xml/InaccessibleAuraEnabledGetter.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/xml/InaccessibleAuraEnabledGetter.xml
@@ -10,7 +10,7 @@
         <code><![CDATA[
 public class Foo {
     @AuraEnabled
-    public Integer counter { private get; set; }
+    public Integer counter { private get; set; } // Violating - Private getter is inaccessible to Lightning components
 }
         ]]></code>
     </test-code>
@@ -21,7 +21,7 @@ public class Foo {
         <code><![CDATA[
 public class Foo {
     @AuraEnabled
-    public Integer counter { protected get; set; }
+    public Integer counter { protected get; set; } // Violating - Protected getter is inaccessible to Lightning components
 }
         ]]></code>
     </test-code>
@@ -32,7 +32,7 @@ public class Foo {
         <code><![CDATA[
 public class Foo {
     @AuraEnabled
-    public Integer counter { get; set; }
+    public Integer counter { get; set; } // Compliant - Public getter is accessible to Lightning components
 }
         ]]></code>
     </test-code>


### PR DESCRIPTION
## Describe the PR

In the Summer '21 release, a mandatory [security update](https://help.salesforce.com/articleView?id=release-notes.rn_lc_enforce_prop_modifiers_cruc.htm&type=5&release=232) enforces access modifiers on Apex properties in Lightning component markup. The update prevents access to private or protected Apex getters from Aura and Lightning Web Components.
This rule detects and reports such getters.

## Related issues

- Fixes #3321 

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

