### PR TITLE
[core] Adds fullDescription and tags in SARIF report

### DIFF
--- a/docs/report-examples/pmd-report.sarif.json
+++ b/docs/report-examples/pmd-report.sarif.json
@@ -14,10 +14,16 @@
               "shortDescription": {
                 "text": "Apex classes should declare a sharing model if DML or SOQL/SOSL is used"
               },
+              "fullDescription": {
+                "text": "Detect classes declared without explicit sharing mode if DML methods are used. This forces the developer to take access restrictions into account before modifying objects."
+              },
               "helpUri": "https://pmd.github.io/pmd/pmd_rules_apex_security.html#apexsharingviolations",
               "properties": {
                 "ruleset": "Security",
-                "priority": 3
+                "priority": 3,
+                "tags":[
+                  "Security"
+                ]
               }
             },
             {
@@ -25,10 +31,16 @@
               "shortDescription": {
                 "text": "Missing ApexDoc comment"
               },
+              "fullDescription": {
+                "text": "This rule validates that: ApexDoc comments are present for classes, methods, and properties that are public or global, excluding overrides and test classes (as well as the contents of test classes)."
+              },
               "helpUri": "https://pmd.github.io/pmd/pmd_rules_apex_documentation.html#apexdoc",
               "properties": {
                 "ruleset": "Documentation",
-                "priority": 3
+                "priority": 3,
+                "tags": [
+                  "Documentation"
+                ]
               }
             }
           ]

--- a/docs/report-examples/pmd-report.sarif.json
+++ b/docs/report-examples/pmd-report.sarif.json
@@ -18,6 +18,9 @@
                 "text": "Detect classes declared without explicit sharing mode if DML methods are used. This forces the developer to take access restrictions into account before modifying objects."
               },
               "helpUri": "https://pmd.github.io/pmd/pmd_rules_apex_security.html#apexsharingviolations",
+              "help": {
+                "text": "Detect classes declared without explicit sharing mode if DML methods are used. This forces the developer to take access restrictions into account before modifying objects."
+              },
               "properties": {
                 "ruleset": "Security",
                 "priority": 3,
@@ -35,6 +38,9 @@
                 "text": "This rule validates that: ApexDoc comments are present for classes, methods, and properties that are public or global, excluding overrides and test classes (as well as the contents of test classes)."
               },
               "helpUri": "https://pmd.github.io/pmd/pmd_rules_apex_documentation.html#apexdoc",
+              "help": {
+                "text": "This rule validates that: ApexDoc comments are present for classes, methods, and properties that are public or global, excluding overrides and test classes (as well as the contents of test classes)."
+              },
               "properties": {
                 "ruleset": "Documentation",
                 "priority": 3,

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/internal/sarif/SarifLog.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/internal/sarif/SarifLog.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.renderers.internal.sarif;
 
 import java.util.List;
+import java.util.Set;
 
 import com.google.gson.annotations.SerializedName;
 
@@ -552,10 +553,10 @@ public class SarifLog {
         /**
          * A set of distinct strings that provide additional information. This is SARIF 2.1.0 Schema.
          */
-        private String[] tags;
+        private Set<String> tags;
 
         @java.lang.SuppressWarnings("all")
-        PropertyBag(final String ruleset, final Integer priority, final String[] tags) {
+        PropertyBag(final String ruleset, final Integer priority, final Set<String> tags) {
             this.ruleset = ruleset;
             this.priority = priority;
             this.tags = tags;
@@ -569,7 +570,7 @@ public class SarifLog {
             @java.lang.SuppressWarnings("all")
             private Integer priority;
             @java.lang.SuppressWarnings("all")
-            private String[] tags;
+            private Set<String> tags;
 
             @java.lang.SuppressWarnings("all")
             PropertyBagBuilder() {
@@ -600,7 +601,7 @@ public class SarifLog {
              * @return {@code this}.
              */
             @java.lang.SuppressWarnings("all")
-            public SarifLog.PropertyBag.PropertyBagBuilder tags(final String[] tags) {
+            public SarifLog.PropertyBag.PropertyBagBuilder tags(final Set<String> tags) {
                 this.tags = tags;
                 return this;
             }
@@ -642,7 +643,7 @@ public class SarifLog {
          * A set of distinct strings that provide additional information. This is SARIF 2.1.0 Schema.
          */
         @java.lang.SuppressWarnings("all")
-        public String[] getTags() {
+        public Set<String> getTags() {
             return this.tags;
         }
 
@@ -671,7 +672,7 @@ public class SarifLog {
          * @return {@code this}.
          */
         @java.lang.SuppressWarnings("all")
-        public SarifLog.PropertyBag setTags(final String[] tags) {
+        public SarifLog.PropertyBag setTags(final Set<String> tags) {
             this.tags = tags;
             return this;
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/internal/sarif/SarifLog.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/internal/sarif/SarifLog.java
@@ -549,11 +549,16 @@ public class SarifLog {
          * The pmd priority of the rule.
          */
         private Integer priority;
+        /**
+         * A set of distinct strings that provide additional information. This is SARIF 2.1.0 Schema.
+         */
+        private String[] tags;
 
         @java.lang.SuppressWarnings("all")
-        PropertyBag(final String ruleset, final Integer priority) {
+        PropertyBag(final String ruleset, final Integer priority, final String[] tags) {
             this.ruleset = ruleset;
             this.priority = priority;
+            this.tags = tags;
         }
 
 
@@ -563,6 +568,8 @@ public class SarifLog {
             private String ruleset;
             @java.lang.SuppressWarnings("all")
             private Integer priority;
+            @java.lang.SuppressWarnings("all")
+            private String[] tags;
 
             @java.lang.SuppressWarnings("all")
             PropertyBagBuilder() {
@@ -588,15 +595,25 @@ public class SarifLog {
                 return this;
             }
 
+            /**
+             * A set of distinct strings that provide additional information. This is SARIF 2.1.0 Schema.
+             * @return {@code this}.
+             */
+            @java.lang.SuppressWarnings("all")
+            public SarifLog.PropertyBag.PropertyBagBuilder tags(final String[] tags) {
+                this.tags = tags;
+                return this;
+            }
+
             @java.lang.SuppressWarnings("all")
             public SarifLog.PropertyBag build() {
-                return new SarifLog.PropertyBag(this.ruleset, this.priority);
+                return new SarifLog.PropertyBag(this.ruleset, this.priority, this.tags);
             }
 
             @java.lang.Override
             @java.lang.SuppressWarnings("all")
             public java.lang.String toString() {
-                return "SarifLog.PropertyBag.PropertyBagBuilder(ruleset=" + this.ruleset + ", priority=" + this.priority + ")";
+                return "SarifLog.PropertyBag.PropertyBagBuilder(ruleset=" + this.ruleset + ", priority=" + this.priority + ", tags=" + this.tags + ")";
             }
         }
 
@@ -622,6 +639,14 @@ public class SarifLog {
         }
 
         /**
+         * A set of distinct strings that provide additional information. This is SARIF 2.1.0 Schema.
+         */
+        @java.lang.SuppressWarnings("all")
+        public String[] getTags() {
+            return this.tags;
+        }
+
+        /**
          * The name of the rule set.
          * @return {@code this}.
          */
@@ -638,6 +663,16 @@ public class SarifLog {
         @java.lang.SuppressWarnings("all")
         public SarifLog.PropertyBag setPriority(final Integer priority) {
             this.priority = priority;
+            return this;
+        }
+
+        /**
+         * The set of distinct strings that provide additional information. This is SARIF 2.1.0 Schema.
+         * @return {@code this}.
+         */
+        @java.lang.SuppressWarnings("all")
+        public SarifLog.PropertyBag setTags(final String[] tags) {
+            this.tags = tags;
             return this;
         }
 
@@ -664,6 +699,11 @@ public class SarifLog {
             if (this$priority == null ? other$priority != null : !this$priority.equals(other$priority)) {
                 return false;
             }
+            final java.lang.Object this$tags = this.getTags();
+            final java.lang.Object other$tags = other.getTags();
+            if (this$tags == null ? other$tags != null : !this$tags.equals(other$tags)) {
+                return false;
+            }
             return true;
         }
 
@@ -681,13 +721,15 @@ public class SarifLog {
             result = result * PRIME + ($ruleset == null ? 43 : $ruleset.hashCode());
             final java.lang.Object $priority = this.getPriority();
             result = result * PRIME + ($priority == null ? 43 : $priority.hashCode());
+            final java.lang.Object $tags = this.getTags();
+            result = result * PRIME + ($tags == null ? 43 : $tags.hashCode());
             return result;
         }
 
         @java.lang.Override
         @java.lang.SuppressWarnings("all")
         public java.lang.String toString() {
-            return "SarifLog.PropertyBag(ruleset=" + this.getRuleset() + ", priority=" + this.getPriority() + ")";
+            return "SarifLog.PropertyBag(ruleset=" + this.getRuleset() + ", priority=" + this.getPriority() + ", tags=" + this.getTags() + ")";
         }
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/internal/sarif/SarifLogBuilder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/internal/sarif/SarifLogBuilder.java
@@ -176,6 +176,7 @@ public class SarifLogBuilder {
         return ReportingDescriptor.builder()
             .id(rv.getRule().getName())
             .shortDescription(new MultiformatMessage(rv.getDescription()))
+            .fullDescription(new MultiformatMessage(rv.getRule().getDescription()))
             .helpUri(rv.getRule().getExternalInfoUrl())
             .properties(getRuleProperties(rv))
             .build();
@@ -185,6 +186,7 @@ public class SarifLogBuilder {
         return PropertyBag.builder()
                 .ruleset(rv.getRule().getRuleSetName())
                 .priority(rv.getRule().getPriority().getPriority())
+                .tags(new String[] { rv.getRule().getRuleSetName() })
                 .build();
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/internal/sarif/SarifLogBuilder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/internal/sarif/SarifLogBuilder.java
@@ -180,6 +180,7 @@ public class SarifLogBuilder {
             .shortDescription(new MultiformatMessage(rv.getDescription()))
             .fullDescription(new MultiformatMessage(rv.getRule().getDescription()))
             .helpUri(rv.getRule().getExternalInfoUrl())
+            .help(new MultiformatMessage(rv.getRule().getDescription()))
             .properties(getRuleProperties(rv))
             .build();
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/internal/sarif/SarifLogBuilder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/internal/sarif/SarifLogBuilder.java
@@ -23,8 +23,10 @@ import static net.sourceforge.pmd.renderers.internal.sarif.SarifLog.ToolConfigur
 import static net.sourceforge.pmd.renderers.internal.sarif.SarifLog.ToolExecutionNotification;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
@@ -186,7 +188,7 @@ public class SarifLogBuilder {
         return PropertyBag.builder()
                 .ruleset(rv.getRule().getRuleSetName())
                 .priority(rv.getRule().getPriority().getPriority())
-                .tags(new String[] { rv.getRule().getRuleSetName() })
+                .tags(new HashSet<String>(Arrays.asList(rv.getRule().getRuleSetName())))
                 .build();
     }
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/SarifRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/SarifRendererTest.java
@@ -4,7 +4,8 @@
 
 package net.sourceforge.pmd.renderers;
 
-import static org.junit.Assert.assertEquals;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -85,8 +86,13 @@ public class SarifRendererTest extends AbstractRendererTest {
         // Exercise
         String actual = ReportTest.render(getRenderer(), rep);
 
-        // Verify
-        assertEquals(filter(getExpectedMultiple()), filter(actual));
+        // Verify that both rules are and rule ids are linked in the results 
+        // Initially was comparing whole files but order of rules rendered can't be guaranteed when the report is being rendered
+        // Refer to pmd-core/src/test/resources/net/sourceforge/pmd/renderers/sarif/expected-multiple.sarif.json to see an example data structure
+        assertThat(filter(actual), containsString("\"ruleId\": \"Foo\""));
+        assertThat(filter(actual), containsString("\"ruleId\": \"Boo\""));
+        assertThat(filter(actual), containsString("\"id\": \"Foo\""));
+        assertThat(filter(actual), containsString("\"id\": \"Boo\""));
     }
 
     private Report reportTwoViolations() {

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/sarif/expected-multiple.sarif.json
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/sarif/expected-multiple.sarif.json
@@ -14,9 +14,15 @@
               "shortDescription": {
                 "text": "blah"
               },
+              "fullDescription": {
+                "text": "desc"
+              },
               "properties": {
                 "ruleset": "RuleSet",
-                "priority": 1
+                "priority": 1,
+                "tags": [
+                  "RuleSet"
+                ]
               }
             },
             {
@@ -24,9 +30,15 @@
               "shortDescription": {
                 "text": "blah"
               },
+              "fullDescription": {
+                "text": "desc"
+              },
               "properties": {
                 "ruleset": "RuleSet",
-                "priority": 5
+                "priority": 5,
+                "tags": [
+                  "RuleSet"
+                ]
               }
             }
           ]

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/sarif/expected-multiple.sarif.json
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/sarif/expected-multiple.sarif.json
@@ -17,6 +17,9 @@
               "fullDescription": {
                 "text": "desc"
               },
+              "help": {
+                "text": "desc"
+              },
               "properties": {
                 "ruleset": "RuleSet",
                 "priority": 1,
@@ -31,6 +34,9 @@
                 "text": "blah"
               },
               "fullDescription": {
+                "text": "desc"
+              },
+              "help": {
                 "text": "desc"
               },
               "properties": {

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/sarif/expected.sarif.json
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/sarif/expected.sarif.json
@@ -17,6 +17,9 @@
               "fullDescription": {
                 "text": "desc"
               },
+              "help": {
+                "text": "desc"
+              },
               "properties": {
                 "ruleset": "RuleSet",
                 "priority": 5,

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/sarif/expected.sarif.json
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/sarif/expected.sarif.json
@@ -14,9 +14,15 @@
               "shortDescription": {
                 "text": "blah"
               },
+              "fullDescription": {
+                "text": "desc"
+              },
               "properties": {
                 "ruleset": "RuleSet",
-                "priority": 5
+                "priority": 5,
+                "tags": [
+                  "RuleSet"
+                ]
               }
             }
           ]


### PR DESCRIPTION
## Describe the PR

First time contributor (long time fan) so please go easy on me 😄 this adds the fullDescription, help and tags attributes into the SARIF report being produced (both compliant in the [SARIF 2.1.0 schema](https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json)). These fields also have support in [GitHub](https://docs.github.com/en/code-security/secure-coding/integrating-with-code-scanning/sarif-support-for-code-scanning#reportingdescriptor-object) and was hoping that by adding them into the SARIF report produced I could make use of it in the [PMD Analyser GitHub Action](https://github.com/synergy-au/pmd-analyser-action) I was working on.

I didn't try the complete build as was trying to make the change in GitHub Codespaces (so was unsure if it was something to do with my container config). If there's any issues or things that need doing please let me know. Thanks!

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- SARIF was introduced first with #2953 
- This fix is required for #2954 / https://github.com/synergy-au/pmd-analyser-action

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

