### PR TITLE
[core] Better classpath fingerprinting

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -14,6 +14,18 @@ This is a {{ site.pmd.release_type }} release.
 
 ### New and noteworthy
 
+#### Improved Incremental Analysis
+
+[Incremental Analysis](https://pmd.github.io/pmd-6.36.0/pmd_userdocs_incremental_analysis.html) has long helped our users obtain faster analysis results,
+however, it's implementation tended to be too cautious in detecting changes to the runtime and type resolution classpaths, producing more cache invalidations than were necessary.
+We have now improved the heuristics to remove several bogus invalidations, and slightly sped up the cache usage along the way.
+
+PMD will now ignore:
+
+*   Non class files in classpath and jar / zip files being referenced.
+*   Changes to the order of file entries within a jar / zip
+*   Changes to file metadata within jar / zip (ie: creation and modification time, significant in multi-mmodule / composite build projects where lateral artifacts are frequently recreated)
+
 ### Fixed Issues
 
 ### API Changes

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimedOperationCategory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimedOperationCategory.java
@@ -25,6 +25,7 @@ public enum TimedOperationCategory {
     MULTIFILE_ANALYSIS,
     REPORTING,
     FILE_PROCESSING,
+    ANALYSIS_CACHE,
     UNACCOUNTED;
 
     public String displayName() {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/AbstractAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/AbstractAnalysisCache.java
@@ -215,7 +215,7 @@ public abstract class AbstractAnalysisCache implements AnalysisCache {
             throw new RuntimeException(e);
         }
 
-        return entries.toArray(new URL[entries.size()]);
+        return entries.toArray(new URL[0]);
     }
 
     @Override

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/AbstractAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/AbstractAnalysisCache.java
@@ -5,7 +5,6 @@
 package net.sourceforge.pmd.cache;
 
 import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -23,17 +22,18 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.zip.Adler32;
-import java.util.zip.CheckedInputStream;
 
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.io.IOUtils;
 
 import net.sourceforge.pmd.PMDVersion;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleSets;
 import net.sourceforge.pmd.RuleViolation;
 import net.sourceforge.pmd.annotation.InternalApi;
+import net.sourceforge.pmd.benchmark.TimeTracker;
+import net.sourceforge.pmd.benchmark.TimedOperation;
+import net.sourceforge.pmd.benchmark.TimedOperationCategory;
+import net.sourceforge.pmd.cache.internal.ClasspathFingerprinter;
 import net.sourceforge.pmd.stat.Metric;
 
 /**
@@ -46,6 +46,7 @@ import net.sourceforge.pmd.stat.Metric;
 public abstract class AbstractAnalysisCache implements AnalysisCache {
 
     protected static final Logger LOG = Logger.getLogger(AbstractAnalysisCache.class.getName());
+    protected static final ClasspathFingerprinter FINGERPRINTER = new ClasspathFingerprinter();
     protected final String pmdVersion;
     protected final ConcurrentMap<String, AnalysisResult> fileResultsCache;
     protected final ConcurrentMap<String, AnalysisResult> updatedResultsCache;
@@ -65,27 +66,29 @@ public abstract class AbstractAnalysisCache implements AnalysisCache {
 
     @Override
     public boolean isUpToDate(final File sourceFile) {
-        // There is a new file being analyzed, prepare entry in updated cache
-        final AnalysisResult updatedResult = new AnalysisResult(sourceFile);
-        updatedResultsCache.put(sourceFile.getPath(), updatedResult);
+        try (TimedOperation to = TimeTracker.startOperation(TimedOperationCategory.ANALYSIS_CACHE, "up-to-date check")) {
+            // There is a new file being analyzed, prepare entry in updated cache
+            final AnalysisResult updatedResult = new AnalysisResult(sourceFile);
+            updatedResultsCache.put(sourceFile.getPath(), updatedResult);
 
-        // Now check the old cache
-        final AnalysisResult analysisResult = fileResultsCache.get(sourceFile.getPath());
+            // Now check the old cache
+            final AnalysisResult analysisResult = fileResultsCache.get(sourceFile.getPath());
 
-        // is this a known file? has it changed?
-        final boolean result = analysisResult != null
-                && analysisResult.getFileChecksum() == updatedResult.getFileChecksum();
+            // is this a known file? has it changed?
+            final boolean result = analysisResult != null
+                    && analysisResult.getFileChecksum() == updatedResult.getFileChecksum();
 
-        if (LOG.isLoggable(Level.FINE)) {
-            if (result) {
-                LOG.fine("Incremental Analysis cache HIT");
-            } else {
-                LOG.fine("Incremental Analysis cache MISS - "
-                        + (analysisResult != null ? "file changed" : "no previous result found"));
+            if (LOG.isLoggable(Level.FINE)) {
+                if (result) {
+                    LOG.fine("Incremental Analysis cache HIT");
+                } else {
+                    LOG.fine("Incremental Analysis cache MISS - "
+                            + (analysisResult != null ? "file changed" : "no previous result found"));
+                }
             }
-        }
 
-        return result;
+            return result;
+        }
     }
 
     @Override
@@ -115,50 +118,52 @@ public abstract class AbstractAnalysisCache implements AnalysisCache {
 
     @Override
     public void checkValidity(final RuleSets ruleSets, final ClassLoader auxclassPathClassLoader) {
-        boolean cacheIsValid = cacheExists();
+        try (TimedOperation to = TimeTracker.startOperation(TimedOperationCategory.ANALYSIS_CACHE, "validity check")) {
+            boolean cacheIsValid = cacheExists();
 
-        if (cacheIsValid && ruleSets.getChecksum() != rulesetChecksum) {
-            LOG.info("Analysis cache invalidated, rulesets changed.");
-            cacheIsValid = false;
-        }
+            if (cacheIsValid && ruleSets.getChecksum() != rulesetChecksum) {
+                LOG.info("Analysis cache invalidated, rulesets changed.");
+                cacheIsValid = false;
+            }
 
-        final long currentAuxClassPathChecksum;
-        if (auxclassPathClassLoader instanceof URLClassLoader) {
-            // we don't want to close our aux classpath loader - we still need it...
-            @SuppressWarnings("PMD.CloseResource")
-            final URLClassLoader urlClassLoader = (URLClassLoader) auxclassPathClassLoader;
-            currentAuxClassPathChecksum = computeClassPathHash(urlClassLoader.getURLs());
+            final long currentAuxClassPathChecksum;
+            if (auxclassPathClassLoader instanceof URLClassLoader) {
+                // we don't want to close our aux classpath loader - we still need it...
+                @SuppressWarnings("PMD.CloseResource")
+                final URLClassLoader urlClassLoader = (URLClassLoader) auxclassPathClassLoader;
+                currentAuxClassPathChecksum = FINGERPRINTER.fingerprint(urlClassLoader.getURLs());
 
-            if (cacheIsValid && currentAuxClassPathChecksum != auxClassPathChecksum) {
-                // Do we even care?
-                for (final Rule r : ruleSets.getAllRules()) {
-                    if (r.isDfa() || r.isTypeResolution()) {
-                        LOG.info("Analysis cache invalidated, auxclasspath changed.");
-                        cacheIsValid = false;
-                        break;
+                if (cacheIsValid && currentAuxClassPathChecksum != auxClassPathChecksum) {
+                    // Do we even care?
+                    for (final Rule r : ruleSets.getAllRules()) {
+                        if (r.isDfa() || r.isTypeResolution()) {
+                            LOG.info("Analysis cache invalidated, auxclasspath changed.");
+                            cacheIsValid = false;
+                            break;
+                        }
                     }
                 }
+            } else {
+                currentAuxClassPathChecksum = 0;
             }
-        } else {
-            currentAuxClassPathChecksum = 0;
-        }
 
-        final long currentExecutionClassPathChecksum = computeClassPathHash(getClassPathEntries());
-        if (cacheIsValid && currentExecutionClassPathChecksum != executionClassPathChecksum) {
-            LOG.info("Analysis cache invalidated, execution classpath changed.");
-            cacheIsValid = false;
-        }
+            final long currentExecutionClassPathChecksum = FINGERPRINTER.fingerprint(getClassPathEntries());
+            if (cacheIsValid && currentExecutionClassPathChecksum != executionClassPathChecksum) {
+                LOG.info("Analysis cache invalidated, execution classpath changed.");
+                cacheIsValid = false;
+            }
 
-        if (!cacheIsValid) {
-            // Clear the cache
-            fileResultsCache.clear();
-        }
+            if (!cacheIsValid) {
+                // Clear the cache
+                fileResultsCache.clear();
+            }
 
-        // Update the local checksums
-        rulesetChecksum = ruleSets.getChecksum();
-        auxClassPathChecksum = currentAuxClassPathChecksum;
-        executionClassPathChecksum = currentExecutionClassPathChecksum;
-        ruleMapper.initialize(ruleSets);
+            // Update the local checksums
+            rulesetChecksum = ruleSets.getChecksum();
+            auxClassPathChecksum = currentAuxClassPathChecksum;
+            executionClassPathChecksum = currentExecutionClassPathChecksum;
+            ruleMapper.initialize(ruleSets);
+        }
     }
 
     private static boolean isClassPathWildcard(String entry) {
@@ -210,26 +215,7 @@ public abstract class AbstractAnalysisCache implements AnalysisCache {
             throw new RuntimeException(e);
         }
 
-        return entries.toArray(new URL[0]);
-    }
-
-    private long computeClassPathHash(final URL... classpathEntry) {
-        final Adler32 adler32 = new Adler32();
-        for (final URL url : classpathEntry) {
-            try (CheckedInputStream inputStream = new CheckedInputStream(url.openStream(), adler32)) {
-                // Just read it, the CheckedInputStream will update the checksum on it's own
-                while (IOUtils.skip(inputStream, Long.MAX_VALUE) == Long.MAX_VALUE) {
-                    // just loop
-                }
-            } catch (final FileNotFoundException ignored) {
-                LOG.warning("Auxclasspath entry " + url.toString() + " doesn't exist, ignoring it");
-            } catch (final IOException e) {
-                // Can this even happen?
-                LOG.log(Level.SEVERE, "Incremental analysis can't check auxclasspath contents", e);
-                throw new RuntimeException(e);
-            }
-        }
-        return adler32.getValue();
+        return entries.toArray(new URL[entries.size()]);
     }
 
     @Override

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/FileAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/FileAnalysisCache.java
@@ -17,8 +17,12 @@ import java.util.List;
 import java.util.Map;
 
 import net.sourceforge.pmd.PMDVersion;
+import net.sourceforge.pmd.RuleSets;
 import net.sourceforge.pmd.RuleViolation;
 import net.sourceforge.pmd.annotation.InternalApi;
+import net.sourceforge.pmd.benchmark.TimeTracker;
+import net.sourceforge.pmd.benchmark.TimedOperation;
+import net.sourceforge.pmd.benchmark.TimedOperationCategory;
 
 /**
  * An analysis cache backed by a regular file.
@@ -32,14 +36,19 @@ public class FileAnalysisCache extends AbstractAnalysisCache {
     private final File cacheFile;
 
     /**
-     * Creates a new cache backed by the given file, and attempts to load pre-existing data from it.
+     * Creates a new cache backed by the given file.
      * @param cache The file on which to store analysis cache
      */
     public FileAnalysisCache(final File cache) {
         super();
         this.cacheFile = cache;
+    }
 
-        loadFromFile(cache);
+    @Override
+    public void checkValidity(RuleSets ruleSets, ClassLoader auxclassPathClassLoader) {
+        // load cached data before checking for validity
+        loadFromFile(cacheFile);
+        super.checkValidity(ruleSets, auxclassPathClassLoader);
     }
 
     /**
@@ -47,95 +56,98 @@ public class FileAnalysisCache extends AbstractAnalysisCache {
      * @param cacheFile The file which backs the file analysis cache.
      */
     private void loadFromFile(final File cacheFile) {
-        if (cacheExists()) {
-            try (
-                DataInputStream inputStream = new DataInputStream(
-                    new BufferedInputStream(Files.newInputStream(cacheFile.toPath())));
-            ) {
-                final String cacheVersion = inputStream.readUTF();
+        try (TimedOperation to = TimeTracker.startOperation(TimedOperationCategory.ANALYSIS_CACHE, "load")) {
+            if (cacheExists()) {
+                try (
+                    DataInputStream inputStream = new DataInputStream(
+                        new BufferedInputStream(Files.newInputStream(cacheFile.toPath())));
+                ) {
+                    final String cacheVersion = inputStream.readUTF();
 
-                if (PMDVersion.VERSION.equals(cacheVersion)) {
-                    // Cache seems valid, load the rest
+                    if (PMDVersion.VERSION.equals(cacheVersion)) {
+                        // Cache seems valid, load the rest
 
-                    // Get checksums
-                    rulesetChecksum = inputStream.readLong();
-                    auxClassPathChecksum = inputStream.readLong();
-                    executionClassPathChecksum = inputStream.readLong();
+                        // Get checksums
+                        rulesetChecksum = inputStream.readLong();
+                        auxClassPathChecksum = inputStream.readLong();
+                        executionClassPathChecksum = inputStream.readLong();
 
-                    // Cached results
-                    while (inputStream.available() > 0) {
-                        final String fileName = inputStream.readUTF();
-                        final long checksum = inputStream.readLong();
+                        // Cached results
+                        while (inputStream.available() > 0) {
+                            final String fileName = inputStream.readUTF();
+                            final long checksum = inputStream.readLong();
 
-                        final int countViolations = inputStream.readInt();
-                        final List<RuleViolation> violations = new ArrayList<>(countViolations);
-                        for (int i = 0; i < countViolations; i++) {
-                            violations.add(CachedRuleViolation.loadFromStream(inputStream, fileName, ruleMapper));
+                            final int countViolations = inputStream.readInt();
+                            final List<RuleViolation> violations = new ArrayList<>(countViolations);
+                            for (int i = 0; i < countViolations; i++) {
+                                violations.add(CachedRuleViolation.loadFromStream(inputStream, fileName, ruleMapper));
+                            }
+
+                            fileResultsCache.put(fileName, new AnalysisResult(checksum, violations));
                         }
 
-                        fileResultsCache.put(fileName, new AnalysisResult(checksum, violations));
+                        LOG.info("Analysis cache loaded");
+                    } else {
+                        LOG.info("Analysis cache invalidated, PMD version changed.");
                     }
-
-                    LOG.info("Analysis cache loaded");
-                } else {
-                    LOG.info("Analysis cache invalidated, PMD version changed.");
+                } catch (final EOFException e) {
+                    LOG.warning("Cache file " + cacheFile.getPath() + " is malformed, will not be used for current analysis");
+                } catch (final IOException e) {
+                    LOG.severe("Could not load analysis cache from file. " + e.getMessage());
                 }
-            } catch (final EOFException e) {
-                LOG.warning("Cache file " + cacheFile.getPath() + " is malformed, will not be used for current analysis");
-            } catch (final IOException e) {
-                LOG.severe("Could not load analysis cache from file. " + e.getMessage());
+            } else if (cacheFile.isDirectory()) {
+                LOG.severe("The configured cache location must be the path to a file, but is a directory.");
             }
-        } else if (cacheFile.isDirectory()) {
-            LOG.severe("The configured cache location must be the path to a file, but is a directory.");
         }
     }
 
     @Override
     public void persist() {
-
-        if (cacheFile.isDirectory()) {
-            LOG.severe("Cannot persist the cache, the given path points to a directory.");
-            return;
-        }
-
-        boolean cacheFileShouldBeCreated = !cacheFile.exists();
-
-        // Create directories missing along the way
-        if (cacheFileShouldBeCreated) {
-            final File parentFile = cacheFile.getAbsoluteFile().getParentFile();
-            if (parentFile != null && !parentFile.exists()) {
-                parentFile.mkdirs();
+        try (TimedOperation to = TimeTracker.startOperation(TimedOperationCategory.ANALYSIS_CACHE, "persist")) {
+            if (cacheFile.isDirectory()) {
+                LOG.severe("Cannot persist the cache, the given path points to a directory.");
+                return;
             }
-        }
 
-        try (
-            DataOutputStream outputStream = new DataOutputStream(
-                new BufferedOutputStream(Files.newOutputStream(cacheFile.toPath())))
-        ) {
-            outputStream.writeUTF(pmdVersion);
+            boolean cacheFileShouldBeCreated = !cacheFile.exists();
 
-            outputStream.writeLong(rulesetChecksum);
-            outputStream.writeLong(auxClassPathChecksum);
-            outputStream.writeLong(executionClassPathChecksum);
-
-            for (final Map.Entry<String, AnalysisResult> resultEntry : updatedResultsCache.entrySet()) {
-                final List<RuleViolation> violations = resultEntry.getValue().getViolations();
-
-                outputStream.writeUTF(resultEntry.getKey()); // the full filename
-                outputStream.writeLong(resultEntry.getValue().getFileChecksum());
-
-                outputStream.writeInt(violations.size());
-                for (final RuleViolation rv : violations) {
-                    CachedRuleViolation.storeToStream(outputStream, rv);
+            // Create directories missing along the way
+            if (cacheFileShouldBeCreated) {
+                final File parentFile = cacheFile.getAbsoluteFile().getParentFile();
+                if (parentFile != null && !parentFile.exists()) {
+                    parentFile.mkdirs();
                 }
             }
-            if (cacheFileShouldBeCreated) {
-                LOG.info("Analysis cache created");
-            } else {
-                LOG.info("Analysis cache updated");
+
+            try (
+                DataOutputStream outputStream = new DataOutputStream(
+                    new BufferedOutputStream(Files.newOutputStream(cacheFile.toPath())))
+            ) {
+                outputStream.writeUTF(pmdVersion);
+
+                outputStream.writeLong(rulesetChecksum);
+                outputStream.writeLong(auxClassPathChecksum);
+                outputStream.writeLong(executionClassPathChecksum);
+
+                for (final Map.Entry<String, AnalysisResult> resultEntry : updatedResultsCache.entrySet()) {
+                    final List<RuleViolation> violations = resultEntry.getValue().getViolations();
+
+                    outputStream.writeUTF(resultEntry.getKey()); // the full filename
+                    outputStream.writeLong(resultEntry.getValue().getFileChecksum());
+
+                    outputStream.writeInt(violations.size());
+                    for (final RuleViolation rv : violations) {
+                        CachedRuleViolation.storeToStream(outputStream, rv);
+                    }
+                }
+                if (cacheFileShouldBeCreated) {
+                    LOG.info("Analysis cache created");
+                } else {
+                    LOG.info("Analysis cache updated");
+                }
+            } catch (final IOException e) {
+                LOG.severe("Could not persist analysis cache to file. " + e.getMessage());
             }
-        } catch (final IOException e) {
-            LOG.severe("Could not persist analysis cache to file. " + e.getMessage());
         }
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/ClasspathEntryFingerprinter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/ClasspathEntryFingerprinter.java
@@ -1,0 +1,32 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.cache.internal;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.zip.Checksum;
+
+/**
+ * A strategy to fingerprint a given classpath entry.
+ */
+public interface ClasspathEntryFingerprinter {
+
+    /**
+     * Checks if the fingerprinter applies to a particular file extension
+     * 
+     * @param fileExtension The extension of the classpath entry to check
+     * @return True if this fingerprinter applies, false otherwise
+     */
+    boolean appliesTo(String fileExtension);
+    
+    /**
+     * Adds the given entry fingerprint to the current checksum.
+     * 
+     * @param entry The entry to be fingerprinted
+     * @param checksum The {@link Checksum} in which to accumulate fingerprints
+     * @throws IOException
+     */
+    void fingerprint(URL entry, Checksum checksum) throws IOException;
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/ClasspathFingerprinter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/ClasspathFingerprinter.java
@@ -15,21 +15,21 @@ import java.util.zip.Adler32;
 
 public class ClasspathFingerprinter {
     private static final Logger LOG = Logger.getLogger(ClasspathFingerprinter.class.getName());
-    
+
     // TODO : With Java 9 we could use List.of()…
     private static final List<ClasspathEntryFingerprinter> FINGERPRINTERS = Collections.unmodifiableList(Arrays.asList(
             new ZipFileFingerprinter(),
             new RawFileFingerprinter(),
             new NoopFingerprinter() // catch-all fingerprinter, MUST be last
         ));
-    
+
     public long fingerprint(final URL... classpathEntry) {
         final Adler32 adler32 = new Adler32();
-        
+
         try {
             for (final URL url : classpathEntry) {
                 final String extension = getExtension(url);
-                
+
                 for (ClasspathEntryFingerprinter f : FINGERPRINTERS) {
                     if (f.appliesTo(extension)) {
                         f.fingerprint(url, adler32);
@@ -42,18 +42,18 @@ public class ClasspathFingerprinter {
             LOG.log(Level.SEVERE, "Incremental analysis can't fingerprint classpath contents", e);
             throw new RuntimeException(e);
         }
-        
+
         return adler32.getValue();
     }
 
     private String getExtension(final URL url) {
         final String file = url.getFile();
         final int lastDot = file.lastIndexOf('.');
-        
+
         if (lastDot == -1) {
-            return  "";
+            return "";
         }
-        
+
         return file.substring(lastDot + 1);
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/ClasspathFingerprinter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/ClasspathFingerprinter.java
@@ -1,0 +1,59 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.cache.internal;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.zip.Adler32;
+
+public class ClasspathFingerprinter {
+    private static final Logger LOG = Logger.getLogger(ClasspathFingerprinter.class.getName());
+    
+    // TODO : With Java 9 we could use List.of()…
+    private static final List<ClasspathEntryFingerprinter> FINGERPRINTERS = Collections.unmodifiableList(Arrays.asList(
+            new ZipFileFingerprinter(),
+            new RawFileFingerprinter(),
+            new NoopFingerprinter() // catch-all fingerprinter, MUST be last
+        ));
+    
+    public long fingerprint(final URL... classpathEntry) {
+        final Adler32 adler32 = new Adler32();
+        
+        try {
+            for (final URL url : classpathEntry) {
+                final String extension = getExtension(url);
+                
+                for (ClasspathEntryFingerprinter f : FINGERPRINTERS) {
+                    if (f.appliesTo(extension)) {
+                        f.fingerprint(url, adler32);
+                        break;
+                    }
+                }
+            }
+        } catch (final IOException e) {
+            // Can this even happen?
+            LOG.log(Level.SEVERE, "Incremental analysis can't fingerprint classpath contents", e);
+            throw new RuntimeException(e);
+        }
+        
+        return adler32.getValue();
+    }
+
+    private String getExtension(final URL url) {
+        final String file = url.getFile();
+        final int lastDot = file.lastIndexOf('.');
+        
+        if (lastDot == -1) {
+            return  "";
+        }
+        
+        return file.substring(lastDot + 1);
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/NoopFingerprinter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/NoopFingerprinter.java
@@ -1,0 +1,31 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.cache.internal;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.zip.Checksum;
+
+/**
+ * Catch-all {@link ClasspathEntryFingerprinter} that ignores all files.
+ */
+public class NoopFingerprinter implements ClasspathEntryFingerprinter {
+    private static final Logger LOG = Logger.getLogger(NoopFingerprinter.class.getName());
+
+    @Override
+    public boolean appliesTo(String fileExtension) {
+        return true;
+    }
+
+    @Override
+    public void fingerprint(URL entry, Checksum checksum) throws IOException {
+        // noop
+        if (LOG.isLoggable(Level.FINE)) {
+            LOG.fine("Ignoring classpath entry " + entry);
+        }
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/RawFileFingerprinter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/RawFileFingerprinter.java
@@ -1,0 +1,51 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.cache.internal;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.logging.Logger;
+import java.util.zip.CheckedInputStream;
+import java.util.zip.Checksum;
+
+import org.apache.commons.io.IOUtils;
+
+/**
+ * Base fingerprinter for raw files.
+ */
+public class RawFileFingerprinter implements ClasspathEntryFingerprinter {
+    
+    private static final Logger LOG = Logger.getLogger(RawFileFingerprinter.class.getName());
+    
+    private static final Set<String> SUPPORTED_EXTENSIONS;
+    
+    static {
+        final Set<String> extensions = new HashSet<>();
+        extensions.add("class"); // Java class files
+        SUPPORTED_EXTENSIONS = Collections.unmodifiableSet(extensions);
+    }
+
+    @Override
+    public boolean appliesTo(String fileExtension) {
+        return SUPPORTED_EXTENSIONS.contains(fileExtension);
+    }
+
+    @Override
+    public void fingerprint(URL entry, Checksum checksum) throws IOException {
+        try (CheckedInputStream inputStream = new CheckedInputStream(entry.openStream(), checksum)) {
+            // Just read it, the CheckedInputStream will update the checksum on it's own
+            while (IOUtils.skip(inputStream, Long.MAX_VALUE) == Long.MAX_VALUE) {
+                // just loop
+            }
+        } catch (final FileNotFoundException ignored) {
+            LOG.warning("Classpath entry " + entry.toString() + " doesn't exist, ignoring it");
+        }
+    }
+
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/ZipFileFingerprinter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/ZipFileFingerprinter.java
@@ -30,10 +30,10 @@ import java.util.zip.ZipFile;
 public class ZipFileFingerprinter implements ClasspathEntryFingerprinter {
 
     private static final Logger LOG = Logger.getLogger(ZipFileFingerprinter.class.getName());
-    
+
     private static final Set<String> SUPPORTED_EXTENSIONS;
     private static final Set<String> SUPPORTED_ENTRY_EXTENSIONS;
-    
+
     private static final Comparator<ZipEntry> FILE_NAME_COMPARATOR = new Comparator<ZipEntry>() {
 
         @Override
@@ -41,18 +41,18 @@ public class ZipFileFingerprinter implements ClasspathEntryFingerprinter {
             return o1.getName().compareTo(o2.getName());
         }
     };
-    
+
     static {
         final Set<String> extensions = new HashSet<>();
         extensions.add("jar");
         extensions.add("zip");
         SUPPORTED_EXTENSIONS = Collections.unmodifiableSet(extensions);
-        
+
         final Set<String> entryExtensions = new HashSet<>();
         entryExtensions.add("class");
         SUPPORTED_ENTRY_EXTENSIONS = Collections.unmodifiableSet(entryExtensions);
     }
-    
+
     @Override
     public boolean appliesTo(String fileExtension) {
         return SUPPORTED_EXTENSIONS.contains(fileExtension);
@@ -62,15 +62,15 @@ public class ZipFileFingerprinter implements ClasspathEntryFingerprinter {
     public void fingerprint(URL entry, Checksum checksum) throws IOException {
         try (ZipFile zip = new ZipFile(new File(entry.toURI()))) {
             final List<ZipEntry> meaningfulEntries = getMeaningfulEntries(zip);
-            
+
             /*
              *  Make sure the order of entries in the zip do not matter.
              *  Duplicates are technically possible, but shouldn't exist in classpath entries
              */
             Collections.sort(meaningfulEntries, FILE_NAME_COMPARATOR);
-            
+
             final ByteBuffer buffer = ByteBuffer.allocate(4); // Size of an int
-            
+
             for (final ZipEntry zipEntry : meaningfulEntries) {
                 /*
                  * The CRC actually uses 4 bytes, but as it's unsigned Java uses a long…
@@ -95,15 +95,15 @@ public class ZipFileFingerprinter implements ClasspathEntryFingerprinter {
     private List<ZipEntry> getMeaningfulEntries(ZipFile zip) {
         final List<ZipEntry> meaningfulEntries = new ArrayList<>();
         final Enumeration<? extends ZipEntry> entries = zip.entries();
-        
+
         while (entries.hasMoreElements()) {
             final ZipEntry zipEntry = entries.nextElement();
-            
+
             if (SUPPORTED_ENTRY_EXTENSIONS.contains(getFileExtension(zipEntry))) {
                 meaningfulEntries.add(zipEntry);
             }
         }
-        
+
         return meaningfulEntries;
     }
 
@@ -111,14 +111,14 @@ public class ZipFileFingerprinter implements ClasspathEntryFingerprinter {
         if (entry.isDirectory()) {
             return null;
         }
-        
+
         final String file = entry.getName();
         final int lastDot = file.lastIndexOf('.');
-        
+
         if (lastDot == -1) {
-            return  "";
+            return "";
         }
-        
+
         return file.substring(lastDot + 1);
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/ZipFileFingerprinter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/ZipFileFingerprinter.java
@@ -1,0 +1,124 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.cache.internal;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.nio.file.NoSuchFileException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.zip.Checksum;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+
+/**
+ * Specialized fingerprinter for Zip files.
+ */
+public class ZipFileFingerprinter implements ClasspathEntryFingerprinter {
+
+    private static final Logger LOG = Logger.getLogger(ZipFileFingerprinter.class.getName());
+    
+    private static final Set<String> SUPPORTED_EXTENSIONS;
+    private static final Set<String> SUPPORTED_ENTRY_EXTENSIONS;
+    
+    private static final Comparator<ZipEntry> FILE_NAME_COMPARATOR = new Comparator<ZipEntry>() {
+
+        @Override
+        public int compare(ZipEntry o1, ZipEntry o2) {
+            return o1.getName().compareTo(o2.getName());
+        }
+    };
+    
+    static {
+        final Set<String> extensions = new HashSet<>();
+        extensions.add("jar");
+        extensions.add("zip");
+        SUPPORTED_EXTENSIONS = Collections.unmodifiableSet(extensions);
+        
+        final Set<String> entryExtensions = new HashSet<>();
+        entryExtensions.add("class");
+        SUPPORTED_ENTRY_EXTENSIONS = Collections.unmodifiableSet(entryExtensions);
+    }
+    
+    @Override
+    public boolean appliesTo(String fileExtension) {
+        return SUPPORTED_EXTENSIONS.contains(fileExtension);
+    }
+
+    @Override
+    public void fingerprint(URL entry, Checksum checksum) throws IOException {
+        try (ZipFile zip = new ZipFile(new File(entry.toURI()))) {
+            final List<ZipEntry> meaningfulEntries = getMeaningfulEntries(zip);
+            
+            /*
+             *  Make sure the order of entries in the zip do not matter.
+             *  Duplicates are technically possible, but shouldn't exist in classpath entries
+             */
+            Collections.sort(meaningfulEntries, FILE_NAME_COMPARATOR);
+            
+            final ByteBuffer buffer = ByteBuffer.allocate(4); // Size of an int
+            
+            for (final ZipEntry zipEntry : meaningfulEntries) {
+                /*
+                 * The CRC actually uses 4 bytes, but as it's unsigned Java uses a long…
+                 * the cast changes the sign, but not the underlying byte values themselves
+                 */
+                buffer.putInt(0, (int) zipEntry.getCrc());
+                checksum.update(buffer.array(), 0, 4);
+            }
+        } catch (final FileNotFoundException | NoSuchFileException ignored) {
+            LOG.warning("Classpath entry " + entry.toString() + " doesn't exist, ignoring it");
+        } catch (final URISyntaxException e) {
+            // Should never happen?
+            LOG.log(Level.WARNING, "Malformed classpath entry doesn't refer to zip in filesystem.", e);
+        }
+    }
+
+    /**
+     * Retrieve a filtered list of entries discarding those that do not matter for classpath computation
+     * @param zip The zip file whose entries to retrieve
+     * @return The filtered list of zip entries
+     */
+    private List<ZipEntry> getMeaningfulEntries(ZipFile zip) {
+        final List<ZipEntry> meaningfulEntries = new ArrayList<>();
+        final Enumeration<? extends ZipEntry> entries = zip.entries();
+        
+        while (entries.hasMoreElements()) {
+            final ZipEntry zipEntry = entries.nextElement();
+            
+            if (SUPPORTED_ENTRY_EXTENSIONS.contains(getFileExtension(zipEntry))) {
+                meaningfulEntries.add(zipEntry);
+            }
+        }
+        
+        return meaningfulEntries;
+    }
+
+    private String getFileExtension(final ZipEntry entry) {
+        if (entry.isDirectory()) {
+            return null;
+        }
+        
+        final String file = entry.getName();
+        final int lastDot = file.lastIndexOf('.');
+        
+        if (lastDot == -1) {
+            return  "";
+        }
+        
+        return file.substring(lastDot + 1);
+    }
+}

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cache/FileAnalysisCacheTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cache/FileAnalysisCacheTest.java
@@ -97,6 +97,7 @@ public class FileAnalysisCacheTest {
     @Test
     public void testStorePersistsFilesWithViolations() {
         final FileAnalysisCache cache = new FileAnalysisCache(newCacheFile);
+        cache.checkValidity(mock(RuleSets.class), mock(ClassLoader.class));
         cache.isUpToDate(sourceFile);
 
         final RuleViolation rv = mock(RuleViolation.class);
@@ -109,6 +110,7 @@ public class FileAnalysisCacheTest {
         cache.persist();
 
         final FileAnalysisCache reloadedCache = new FileAnalysisCache(newCacheFile);
+        reloadedCache.checkValidity(mock(RuleSets.class), mock(ClassLoader.class));
         assertTrue("Cache believes unmodified file with violations is not up to date",
                 reloadedCache.isUpToDate(sourceFile));
 
@@ -348,6 +350,7 @@ public class FileAnalysisCacheTest {
         setupCacheWithFiles(newCacheFile, mock(RuleSets.class), mock(ClassLoader.class), sourceFile);
 
         final FileAnalysisCache cache = new FileAnalysisCache(newCacheFile);
+        cache.checkValidity(mock(RuleSets.class), mock(ClassLoader.class));
         assertTrue("Cache believes a known, unchanged file is not up to date",
                 cache.isUpToDate(sourceFile));
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cache/FileAnalysisCacheTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cache/FileAnalysisCacheTest.java
@@ -13,7 +13,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -383,7 +382,7 @@ public class FileAnalysisCacheTest {
 
     private File createZipFile(String fileName, int numEntries) throws IOException {
         final File zipFile = tempFolder.newFile(fileName);
-        try (final ZipOutputStream zipOS = new ZipOutputStream(new FileOutputStream(zipFile))) {
+        try (ZipOutputStream zipOS = new ZipOutputStream(Files.newOutputStream(zipFile.toPath()))) {
             for (int i = 0; i < numEntries; i++) {
                 zipOS.putNextEntry(new ZipEntry("lib/foo" + i + ".class"));
                 zipOS.write(("content of " + fileName + " entry " + i).getBytes(StandardCharsets.UTF_8));

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cache/internal/AbstractClasspathEntryFingerprinterTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cache/internal/AbstractClasspathEntryFingerprinterTest.java
@@ -1,0 +1,79 @@
+
+package net.sourceforge.pmd.cache.internal;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.util.zip.Adler32;
+import java.util.zip.Checksum;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+@RunWith(JUnitParamsRunner.class)
+public abstract class AbstractClasspathEntryFingerprinterTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+    
+    protected ClasspathEntryFingerprinter fingerprinter = newFingerPrinter();
+    protected Checksum checksum = new Adler32();
+
+    @Before
+    public void setUp() {
+        checksum.reset();
+    }
+
+    protected abstract ClasspathEntryFingerprinter newFingerPrinter();
+    
+    protected abstract String[] getValidFileExtensions();
+    protected abstract String[] getInvalidFileExtensions();
+    
+    protected abstract File createValidNonEmptyFile() throws IOException;
+    
+    @Test
+    public void appliesToNullIsSafe() {
+        fingerprinter.appliesTo(null);
+    }
+
+    @Parameters(method = "getValidFileExtensions")
+    @Test
+    public void appliesToValidFile(final String extension) {
+        Assert.assertTrue(fingerprinter.appliesTo(extension));
+    }
+
+    @Parameters(method = "getInvalidFileExtensions")
+    @Test
+    public void doesNotApplyToInvalidFile(final String extension) {
+        Assert.assertFalse(fingerprinter.appliesTo(extension));
+    }
+
+    @Test
+    public void fingerprintNonExistingFile() throws MalformedURLException, IOException {
+        final long prevValue = checksum.getValue();
+        
+        fingerprinter.fingerprint(new File("non-existing").toURI().toURL(), checksum);
+        
+        Assert.assertEquals(prevValue, checksum.getValue());
+    }
+
+    @Test
+    public void fingerprintExistingValidFile() throws IOException {
+        final long prevValue = checksum.getValue();
+        final File file = createValidNonEmptyFile();
+        
+        Assert.assertNotEquals(prevValue, updateFingerprint(file));
+    }
+    
+    protected long updateFingerprint(final File file) throws MalformedURLException, IOException {
+        fingerprinter.fingerprint(file.toURI().toURL(), checksum);
+        return checksum.getValue();
+    }
+}

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cache/internal/AbstractClasspathEntryFingerprinterTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cache/internal/AbstractClasspathEntryFingerprinterTest.java
@@ -1,3 +1,6 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
 
 package net.sourceforge.pmd.cache.internal;
 
@@ -22,7 +25,7 @@ public abstract class AbstractClasspathEntryFingerprinterTest {
 
     @Rule
     public TemporaryFolder tempFolder = new TemporaryFolder();
-    
+
     protected ClasspathEntryFingerprinter fingerprinter = newFingerPrinter();
     protected Checksum checksum = new Adler32();
 
@@ -32,12 +35,13 @@ public abstract class AbstractClasspathEntryFingerprinterTest {
     }
 
     protected abstract ClasspathEntryFingerprinter newFingerPrinter();
-    
+
     protected abstract String[] getValidFileExtensions();
+
     protected abstract String[] getInvalidFileExtensions();
-    
+
     protected abstract File createValidNonEmptyFile() throws IOException;
-    
+
     @Test
     public void appliesToNullIsSafe() {
         fingerprinter.appliesTo(null);
@@ -58,9 +62,9 @@ public abstract class AbstractClasspathEntryFingerprinterTest {
     @Test
     public void fingerprintNonExistingFile() throws MalformedURLException, IOException {
         final long prevValue = checksum.getValue();
-        
+
         fingerprinter.fingerprint(new File("non-existing").toURI().toURL(), checksum);
-        
+
         Assert.assertEquals(prevValue, checksum.getValue());
     }
 
@@ -68,10 +72,10 @@ public abstract class AbstractClasspathEntryFingerprinterTest {
     public void fingerprintExistingValidFile() throws IOException {
         final long prevValue = checksum.getValue();
         final File file = createValidNonEmptyFile();
-        
+
         Assert.assertNotEquals(prevValue, updateFingerprint(file));
     }
-    
+
     protected long updateFingerprint(final File file) throws MalformedURLException, IOException {
         fingerprinter.fingerprint(file.toURI().toURL(), checksum);
         return checksum.getValue();

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cache/internal/RawFileFingerprinterTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cache/internal/RawFileFingerprinterTest.java
@@ -1,0 +1,34 @@
+
+package net.sourceforge.pmd.cache.internal;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+import com.google.common.io.Files;
+
+public class RawFileFingerprinterTest extends AbstractClasspathEntryFingerprinterTest {
+
+    @Override
+    protected ClasspathEntryFingerprinter newFingerPrinter() {
+        return new RawFileFingerprinter();
+    }
+
+    @Override
+    protected String[] getValidFileExtensions() {
+        return new String[] { "class" };
+    }
+
+    @Override
+    protected String[] getInvalidFileExtensions() {
+        return new String[] { "xml" };
+    }
+    
+    @Override
+    protected File createValidNonEmptyFile() throws IOException {
+        final File file = tempFolder.newFile("Foo.class");
+        
+        Files.write("some content", file, StandardCharsets.UTF_8);
+        return file;
+    }
+}

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cache/internal/RawFileFingerprinterTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cache/internal/RawFileFingerprinterTest.java
@@ -1,3 +1,6 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
 
 package net.sourceforge.pmd.cache.internal;
 
@@ -23,11 +26,11 @@ public class RawFileFingerprinterTest extends AbstractClasspathEntryFingerprinte
     protected String[] getInvalidFileExtensions() {
         return new String[] { "xml" };
     }
-    
+
     @Override
     protected File createValidNonEmptyFile() throws IOException {
         final File file = tempFolder.newFile("Foo.class");
-        
+
         Files.write("some content", file, StandardCharsets.UTF_8);
         return file;
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cache/internal/ZipFileFingerprinterTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cache/internal/ZipFileFingerprinterTest.java
@@ -1,3 +1,6 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
 
 package net.sourceforge.pmd.cache.internal;
 
@@ -24,7 +27,7 @@ public class ZipFileFingerprinterTest extends AbstractClasspathEntryFingerprinte
         final long originalFileSize = file.length();
 
         // Change zip entry's metadata
-        try (final ZipFile zip = new ZipFile(file)) {
+        try (ZipFile zip = new ZipFile(file)) {
             final ZipEntry zipEntry = zip.entries().nextElement();
             zipEntry.setComment("some comment");
             zipEntry.setTime(System.currentTimeMillis() + 1000);

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cache/internal/ZipFileFingerprinterTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cache/internal/ZipFileFingerprinterTest.java
@@ -1,0 +1,76 @@
+
+package net.sourceforge.pmd.cache.internal;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.Adler32;
+import java.util.zip.Checksum;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ZipFileFingerprinterTest extends AbstractClasspathEntryFingerprinterTest {
+
+    @Test
+    public void zipEntryMetadataDoesNotAffectFingerprint() throws IOException {
+        final File file = createValidNonEmptyFile();
+        final long baselineFingerprint = getBaseLineFingerprint(file);
+        final long originalFileSize = file.length();
+        
+        // Change zip entry's metadata
+        try (final ZipFile zip = new ZipFile(file)) {
+            final ZipEntry zipEntry = zip.entries().nextElement();
+            zipEntry.setComment("some comment");
+            zipEntry.setTime(System.currentTimeMillis() + 1000);
+            
+            overwriteZipFileContents(file, zipEntry);
+        }
+        
+        Assert.assertEquals(baselineFingerprint, updateFingerprint(file));
+        Assert.assertNotEquals(originalFileSize, file.length());
+    }
+    
+    @Override
+    protected ClasspathEntryFingerprinter newFingerPrinter() {
+        return new ZipFileFingerprinter();
+    }
+
+    @Override
+    protected String[] getValidFileExtensions() {
+        return new String[] { "zip", "jar" };
+    }
+
+    @Override
+    protected String[] getInvalidFileExtensions() {
+        return new String[] { "xml" };
+    }
+    
+    @Override
+    protected File createValidNonEmptyFile() throws IOException {
+        final File zipFile = tempFolder.newFile("foo.jar");
+        overwriteZipFileContents(zipFile, new ZipEntry("lib/Foo.class"));
+        return zipFile;
+    }
+    
+    private void overwriteZipFileContents(final File zipFile, final ZipEntry... zipEntries) throws IOException {
+        try (final ZipOutputStream zipOS = new ZipOutputStream(new FileOutputStream(zipFile))) {
+            for (final ZipEntry zipEntry : zipEntries) {
+                zipOS.putNextEntry(zipEntry);
+                zipOS.write(("content of zip entry").getBytes(StandardCharsets.UTF_8));
+                zipOS.closeEntry();
+            }
+        }
+    }
+    
+    private long getBaseLineFingerprint(final File file) throws MalformedURLException, IOException {
+        final Checksum checksum = new Adler32();
+        fingerprinter.fingerprint(file.toURI().toURL(), checksum);
+        return checksum.getValue();
+    }
+}


### PR DESCRIPTION
 As per #2704, we improve on the classpath checksum computation to detect changes.

While the old implementation performed full reads of all files in the classpath to compute an Adler32 checksum, we now introduce a series of fingerprinting strategies, specialized for different file formats:

 - For .class files, we still perform the same old whole-file checksum
 - For .jar / .zip files, we first tinker with the entries to:
     - Ignore non .class files
     - Sort all entries (order is irrelevant, well-formed jars don't include duplicates)
     - Focus on the archived file contents themselves (their checksum) rather than any metadata (ie: modification time)
 - For all other files, we ignore them (noop)

The ignoring of irrelevant changes both within jar / files and simply referenced in the classpath improves the likelihood of the cache remaining valid between runs, even with multi-module projects.

We take the chance to include time tracking to cache operations. They remain blazing fast on SSD. I've not been able to try it on a HDD, but given zip / jars now require to read only the central directory rather than the whole file I expect a positive improvement.