### PR TITLE
[ci] Regression Tester Test - do not merge

### DIFF
--- a/.ci/files/all-java.xml
+++ b/.ci/files/all-java.xml
@@ -295,7 +295,7 @@
     <!-- <rule ref="category/java/performance.xml/BooleanInstantiation"/> -->
     <rule ref="category/java/performance.xml/ByteInstantiation"/>
     <rule ref="category/java/performance.xml/ConsecutiveAppendsShouldReuse"/>
-    <!-- <rule ref="category/java/performance.xml/ConsecutiveLiteralAppends"/> -->
+    <rule ref="category/java/performance.xml/ConsecutiveLiteralAppends"/>
     <rule ref="category/java/performance.xml/InefficientEmptyStringCheck"/>
     <rule ref="category/java/performance.xml/InefficientStringBuffering"/>
     <!-- <rule ref="category/java/performance.xml/InsufficientStringBufferDeclaration"/> -->

--- a/Dangerfile
+++ b/Dangerfile
@@ -5,19 +5,19 @@ require 'fileutils'
 
 @logger = Logger.new(STDOUT)
 
-def get_args(base_branch)
+def get_args(base_branch, autogen = TRUE, patch_config = './pmd/.ci/files/all-java.xml')
   ['--local-git-repo', './pmd',
    '--list-of-project', './pmd/.ci/files/project-list.xml',
    '--base-branch', base_branch,
    '--patch-branch', 'HEAD',
-   '--patch-config', './pmd/.ci/files/all-java.xml',
+   '--patch-config', patch_config,
    '--mode', 'online',
-   '--auto-gen-config',
+   autogen ? '--auto-gen-config' : '',
    '--keep-reports',
    '--error-recovery',
    '--baseline-download-url', 'https://pmd-code.org/pmd-regression-tester/',
    # '--debug',
-   ]
+   ].reject { |c| c.empty? }
 end
 
 def run_pmdtester
@@ -39,8 +39,9 @@ def run_pmdtester
       # run against master branch (if the PR is not already against master)
       unless ENV['PMD_CI_BRANCH'] == 'master'
         @base_branch = 'master'
+        @logger.info "--------------------------------------"
         @logger.info "Run against #{@base_branch}"
-        @summary = PmdTester::Runner.new(get_args(@base_branch)).run
+        @summary = PmdTester::Runner.new(get_args(@base_branch, FALSE, 'target/diff1/patch_config.xml')).run
 
         # move the generated report out of the way
         FileUtils.mv 'target/reports/diff', 'target/diff2'
@@ -85,6 +86,7 @@ def upload_report
     tar_filename = "pr-#{ENV['PMD_CI_PULL_REQUEST_NUMBER']}-diff-report-#{Time.now.strftime("%Y-%m-%dT%H-%M-%SZ")}.tar"
 
     `tar -cf #{tar_filename} diff1/ diff2/`
+    @logger.info "Uploading file #{tar_filename} now..."
     report_url = `curl -u #{ENV['PMD_CI_CHUNK_TOKEN']} -T #{tar_filename} https://chunk.io`
     if $?.success?
       report_url.chomp!

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveLiteralAppendsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveLiteralAppendsRule.java
@@ -7,13 +7,9 @@ package net.sourceforge.pmd.lang.java.rule.performance;
 import static net.sourceforge.pmd.properties.constraints.NumericConstraints.inRange;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
-
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignableExpr.ASTNamedReferenceExpr;
 import net.sourceforge.pmd.lang.java.ast.ASTCatchClause;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
@@ -21,6 +17,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTDoStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTFinallyClause;
 import net.sourceforge.pmd.lang.java.ast.ASTForStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTForeachStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTInfixExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTLambdaExpression;
@@ -29,11 +26,10 @@ import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTStringLiteral;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchArrowBranch;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchFallthroughBranch;
-import net.sourceforge.pmd.lang.java.ast.ASTSwitchLabel;
 import net.sourceforge.pmd.lang.java.ast.ASTSwitchStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 import net.sourceforge.pmd.lang.java.ast.ASTWhileStatement;
-import net.sourceforge.pmd.lang.java.ast.JavaNode;
+import net.sourceforge.pmd.lang.java.ast.InvocationNode;
 import net.sourceforge.pmd.lang.java.ast.TypeNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
@@ -44,8 +40,8 @@ import net.sourceforge.pmd.properties.PropertyFactory;
 
 /**
  * This rule finds concurrent calls to StringBuffer/Builder.append where String
- * literals are used It would be much better to make these calls using one call
- * to <code>.append</code>
+ * literals are used. It would be much better to make these calls using one call
+ * to <code>.append</code>.
  *
  * <p>Example:</p>
  *
@@ -72,6 +68,7 @@ public class ConsecutiveLiteralAppendsRule extends AbstractJavaRulechainRule {
     static {
         BLOCK_PARENTS = new HashSet<>();
         BLOCK_PARENTS.add(ASTForStatement.class);
+        BLOCK_PARENTS.add(ASTForeachStatement.class);
         BLOCK_PARENTS.add(ASTWhileStatement.class);
         BLOCK_PARENTS.add(ASTDoStatement.class);
         BLOCK_PARENTS.add(ASTIfStatement.class);
@@ -89,7 +86,7 @@ public class ConsecutiveLiteralAppendsRule extends AbstractJavaRulechainRule {
                              .desc("Max consecutive appends")
                              .require(inRange(1, 10)).defaultValue(1).build();
 
-    private int threshold = 1;
+    private ConsecutiveCounter counter = new ConsecutiveCounter();
 
     public ConsecutiveLiteralAppendsRule() {
         super(ASTVariableDeclaratorId.class);
@@ -98,32 +95,26 @@ public class ConsecutiveLiteralAppendsRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTVariableDeclaratorId node, Object data) {
-
         if (!isStringBuilderOrBuffer(node)) {
             return data;
         }
-        threshold = getProperty(THRESHOLD_DESCRIPTOR);
 
-        int concurrentCount = checkConstructor(node);
-        concurrentCount += checkInitializerExpressions(node.getInitializer());
+        counter.initThreshold(getProperty(THRESHOLD_DESCRIPTOR));
+        counter.reset();
+        checkConstructor(data, node);
+
         Node lastBlock = getFirstParentBlock(node);
         Node currentBlock = lastBlock;
-        Node rootNode = null;
-        // only want the constructor flagged if it's really containing strings
-        if (concurrentCount >= 1) {
-            rootNode = node;
-        }
 
-        List<ASTNamedReferenceExpr> usages = node.getLocalUsages();
+        for (ASTNamedReferenceExpr namedReference : node.getLocalUsages()) {
+            currentBlock = getFirstParentBlock(namedReference);
 
-        for (ASTNamedReferenceExpr namedReference : usages) {
-            Node current = namedReference;
             // loop through method call chain
+            Node current = namedReference;
             while (current.getParent() instanceof ASTMethodCall) {
                 ASTMethodCall methodCall = (ASTMethodCall) current.getParent();
                 current = methodCall;
 
-                currentBlock = getFirstParentBlock(namedReference);
 
                 if (JavaRuleUtil.isStringBuilderCtorOrAppend(methodCall)) {
                     // append method call detected
@@ -131,136 +122,95 @@ public class ConsecutiveLiteralAppendsRule extends AbstractJavaRulechainRule {
                     // see if it changed blocks
                     if (currentBlock != null && lastBlock != null && !currentBlock.equals(lastBlock)
                             || currentBlock == null ^ lastBlock == null) {
-                        checkForViolation(rootNode, data, concurrentCount);
-                        concurrentCount = 0;
+                        checkForViolation(data);
+                        counter.reset();
                     }
 
-                    // if concurrent is 0 then we reset the root to report from
-                    // here
-                    if (concurrentCount == 0) {
-                        rootNode = methodCall;
-                    }
-                    if (isAdditive(methodCall)) {
-                        concurrentCount = processAdditive(data, concurrentCount, methodCall, rootNode);
-                        if (concurrentCount != 0) {
-                            rootNode = methodCall;
-                        }
-                    } else if (isAppendingVariablesOrFields(methodCall) || isAppendingMethodResult(methodCall)) {
-                        checkForViolation(rootNode, data, concurrentCount);
-                        concurrentCount = 0;
-                    } else {
-                        concurrentCount++;
-                    }
+                    analyzeInvocation(data, methodCall);
                     lastBlock = currentBlock;
-                } else if ("length".equals(methodCall.getMethodName())) {
-                    // ignore length, they do not change affect the content of the sb
-                    // note: while toString doesn't change the content, it depends on the content.
-                    // changing/merging appends call would change the result of toString
                 } else {
-                    // other method calls the stringbuilder variable, e.g. calling delete
-                    checkForViolation(rootNode, data, concurrentCount);
-                    concurrentCount = 0;
+                    // other method calls the stringbuilder variable, e.g. calling delete, toString, etc.
+                    checkForViolation(data);
+                    counter.reset();
                 }
             }
             if (!(namedReference.getParent() instanceof ASTMethodCall)) {
                 // usage of the stringbuilder variable for any other purpose, e.g. as a argument for
                 // a different method call
-                checkForViolation(rootNode, data, concurrentCount);
-                concurrentCount = 0;
+                checkForViolation(data);
+                counter.reset();
             }
         }
-        checkForViolation(rootNode, data, concurrentCount);
+        checkForViolation(data);
         return data;
     }
 
     /**
-     * Determine if the constructor contains (or ends with) a String Literal
+     * Determine if the constructor contains (or ends with) a String Literal.
+     * Also analyzes a possible method call chain for append calls.
      *
      * @param node
-     * @return 1 if the constructor contains string argument, else 0
      */
-    private int checkConstructor(ASTVariableDeclaratorId node) {
+    private void checkConstructor(Object data, ASTVariableDeclaratorId node) {
         ASTExpression initializer = node.getInitializer();
-        ASTConstructorCall constructorCall = null;
-        if (initializer != null) {
-            constructorCall = initializer.descendantsOrSelf().filterIs(ASTConstructorCall.class).first();
-        }
-        
-        if (constructorCall != null) {
-            ASTArgumentList list = constructorCall.getArguments();
-            
-            @Nullable
-            ASTExpression firstArgument = list.children().first();
-            if (firstArgument instanceof ASTStringLiteral) {
-                return 1;
-            } else if (JavaRuleUtil.isStringConcatExpr(firstArgument)) {
-                
-                if (firstArgument instanceof ASTInfixExpression) {
-                    if (((ASTInfixExpression) firstArgument).getRightOperand() instanceof ASTStringLiteral) {
-                        return 1;
-                    } else {
-                        return 0;
-                    }
-                }
-            }
-        }
-        return 0;
-    }
-
-    /**
-     * Determine if during the variable initializer calls to ".append" are done (call chains).
-     *
-     * @param node
-     * @return
-     */
-    private int checkInitializerExpressions(ASTExpression initializer) {
         if (initializer == null) {
-            return 0;
-        }
-        
-        if (initializer instanceof ASTConstructorCall) {
-            return 0;
-        }
-        
-        if (initializer instanceof ASTMethodCall && JavaRuleUtil.isStringBuilderCtorOrAppend(initializer)) {
-            int count = 1;
-            @Nullable
-            JavaNode child = initializer.getFirstChild();
-            while (child instanceof ASTMethodCall) {
-                ASTMethodCall call = (ASTMethodCall) child;
-                if (call.getArguments().descendants(ASTNamedReferenceExpr.class).count() > 0) {
-                    // at least one variable/field access found - can't combine appends
-                    count = 0;
-                    break;
-                }
-                if (JavaRuleUtil.isStringBuilderCtorOrAppend(call)) {
-                    count++;
-                }
-                child = child.getFirstChild();
-            }
-            return count;
+            return;
         }
 
-        return 0;
+        ASTConstructorCall constructorCall = initializer.descendantsOrSelf().filterIs(ASTConstructorCall.class).first();
+        if (constructorCall == null) {
+            return;
+        }
+
+        analyzeInvocation(data, constructorCall);
+
+        // analyze chained calls to append
+        Node parent = constructorCall.getParent();
+        while (parent instanceof ASTMethodCall) {
+            analyzeInvocation(data, (ASTMethodCall) parent);
+            parent = parent.getParent();
+        }
     }
 
-    private int processAdditive(Object data, int concurrentCount, ASTMethodCall methodCall, Node rootNode) {
-        ASTExpression firstArg = methodCall.getArguments().children().first();
-        if (firstArg == null) {
-            // no arg found, this doesn't count
-            return 0;
+    private void analyzeInvocation(Object data, InvocationNode invocation) {
+        if (!(invocation instanceof ASTExpression)) {
+            return;
         }
-        
+        if (!JavaRuleUtil.isStringBuilderCtorOrAppend((ASTExpression) invocation)) {
+            return;
+        }
+
+        if (isAdditive(invocation)) {
+            processAdditive(data, invocation);
+        } else if (isAppendingVariablesOrFields(invocation) || isAppendingInvocationResult(invocation)) {
+            checkForViolation(data);
+            counter.reset();
+        } else if (invocation.getArguments().getFirstChild() instanceof ASTStringLiteral
+                || invocation instanceof ASTMethodCall) {
+            counter.count(invocation);
+        }
+    }
+
+    private void processAdditive(Object data, InvocationNode invocation) {
+        ASTExpression firstArg = invocation.getArguments().getFirstChild();
         if (firstArg.descendants(ASTNamedReferenceExpr.class).count() > 0) {
             // at least one variable/field access found
-            checkForViolation(rootNode, data, concurrentCount);
-            // continue with a fresh round
-            return 0;
+            checkForViolation(data);
+
+            if (firstArg instanceof ASTInfixExpression) {
+                if (((ASTInfixExpression) firstArg).getRightOperand() instanceof ASTStringLiteral) {
+                    // argument ends with ... + "some string"
+                    counter.count(invocation);
+                }
+            } else {
+                // continue with a fresh round
+                counter.reset();
+            }
+        } else {
+            // no variables appended, compiler will take care of merging all the
+            // string concats, we really only have 1 then
+            counter.count(invocation);
         }
-        
-        // no variables appended, compiler will take care of merging all the
-        // string concats, we really only have 1 then
-        return 1;
     }
 
     /**
@@ -274,18 +224,15 @@ public class ConsecutiveLiteralAppendsRule extends AbstractJavaRulechainRule {
      * @return true if the node has an additive expression (i.e. "Hello " +
      *         Const.WORLD)
      */
-    private boolean isAdditive(ASTMethodCall n) {
-        ASTExpression firstArg = n.getArguments().children().first();
-        return JavaRuleUtil.isStringConcatExpr(firstArg);
+    private boolean isAdditive(InvocationNode n) {
+        return JavaRuleUtil.isStringConcatExpr(n.getArguments().getFirstChild());
     }
 
     /**
      * Get the first parent. Keep track of the last node though. For If
      * statements it's the only way we can differentiate between if's and else's
-     * For switches it's the only way we can differentiate between switches
      *
-     * @param node
-     *            The node to check
+     * @param node The node to check
      * @return The first parent block
      */
     private Node getFirstParentBlock(Node node) {
@@ -298,58 +245,72 @@ public class ConsecutiveLiteralAppendsRule extends AbstractJavaRulechainRule {
         }
         if (parentNode instanceof ASTIfStatement) {
             parentNode = lastNode;
-        } else if (parentNode instanceof ASTSwitchStatement) {
-            parentNode = getSwitchParent(parentNode, lastNode);
         }
         return parentNode;
-    }
-
-    /**
-     * Determine which SwitchLabel we belong to inside a switch
-     *
-     * @param parentNode
-     *            The parent node we're looking at
-     * @param lastNode
-     *            The last node processed
-     * @return The parent node for the switch statement
-     */
-    private Node getSwitchParent(Node parentNode, Node lastNode) {
-        int allChildren = parentNode.getNumChildren();
-        Node result = parentNode;
-        ASTSwitchLabel label = null;
-        for (int ix = 0; ix < allChildren; ix++) {
-            Node n = result.getChild(ix);
-            if (n instanceof ASTSwitchLabel) {
-                label = (ASTSwitchLabel) n;
-            } else if (n.equals(lastNode)) {
-                result = label;
-                break;
-            }
-        }
-        return result;
     }
 
     /**
      * Helper method checks to see if a violation occurred, and adds a
      * RuleViolation if it did
      */
-    private void checkForViolation(Node node, Object data, int concurrentCount) {
-        if (concurrentCount > threshold) {
-            String[] param = { String.valueOf(concurrentCount) };
-            addViolation(data, node, param);
+    private void checkForViolation(Object data) {
+        if (counter.isViolation()) {
+            assert counter.getReportNode() != null;
+            String[] param = { String.valueOf(counter.getCounter()) };
+            addViolation(data, counter.getReportNode(), param);
         }
     }
 
-    private boolean isAppendingVariablesOrFields(ASTMethodCall node) {
+    private boolean isAppendingVariablesOrFields(InvocationNode node) {
         return node.getArguments().descendants(ASTNamedReferenceExpr.class).count() > 0;
     }
 
-    private boolean isAppendingMethodResult(ASTMethodCall node) {
-        return node.getArguments().getFirstChild() instanceof ASTMethodCall;
+    private boolean isAppendingInvocationResult(InvocationNode node) {
+        return node.getArguments().getFirstChild() instanceof ASTMethodCall
+                || node.getArguments().getFirstChild() instanceof ASTConstructorCall;
     }
 
     static boolean isStringBuilderOrBuffer(TypeNode node) {
         return TypeTestUtil.isA(StringBuffer.class, node)
             || TypeTestUtil.isA(StringBuilder.class, node);
+    }
+
+    private static class ConsecutiveCounter {
+        private int threshold;
+        private int counter;
+        private Node reportNode;
+
+        public void initThreshold(int threshold) {
+            this.threshold = threshold;
+        }
+
+        public void count(Node node) {
+            if (counter == 0) {
+                reportNode = node;
+            }
+            counter++;
+        }
+
+        public void reset() {
+            counter = 0;
+            reportNode = null;
+        }
+
+        public boolean isViolation() {
+            return counter > threshold;
+        }
+
+        public int getCounter() {
+            return counter;
+        }
+
+        public Node getReportNode() {
+            return reportNode;
+        }
+
+        @Override
+        public String toString() {
+            return "counter=" + counter + ",threshold=" + threshold + ",node=" + reportNode;
+        }
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveLiteralAppendsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveLiteralAppendsRule.java
@@ -187,7 +187,7 @@ public class ConsecutiveLiteralAppendsRule extends AbstractJavaRulechainRule {
             counter.reset();
         } else if (invocation.getArguments().getFirstChild() instanceof ASTStringLiteral
                 || invocation instanceof ASTMethodCall) {
-            counter.count(invocation);
+            counter.count(invocation.getArguments().getFirstChild());
         }
     }
 
@@ -198,9 +198,10 @@ public class ConsecutiveLiteralAppendsRule extends AbstractJavaRulechainRule {
             checkForViolation(data);
 
             if (firstArg instanceof ASTInfixExpression) {
-                if (((ASTInfixExpression) firstArg).getRightOperand() instanceof ASTStringLiteral) {
+                ASTExpression rightOperand = ((ASTInfixExpression) firstArg).getRightOperand();
+                if (rightOperand instanceof ASTStringLiteral) {
                     // argument ends with ... + "some string"
-                    counter.count(invocation);
+                    counter.count(rightOperand);
                 }
             } else {
                 // continue with a fresh round
@@ -209,7 +210,7 @@ public class ConsecutiveLiteralAppendsRule extends AbstractJavaRulechainRule {
         } else {
             // no variables appended, compiler will take care of merging all the
             // string concats, we really only have 1 then
-            counter.count(invocation);
+            counter.count(invocation.getArguments().getFirstChild());
         }
     }
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveLiteralAppendsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveLiteralAppendsTest.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.lang.java.rule.performance;
 
 import net.sourceforge.pmd.testframework.PmdRuleTst;
 
-@org.junit.Ignore("Rule has not been updated yet")
 public class ConsecutiveLiteralAppendsTest extends PmdRuleTst {
     // no additional unit tests
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/ConsecutiveLiteralAppends.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/ConsecutiveLiteralAppends.xml
@@ -56,6 +56,8 @@ public class Foo {
         <description>3, Appends broken up by variable</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+import java.util.Date;
+
 public class Foo {
     public void bar() {
         StringBuffer sb = new StringBuffer();
@@ -70,6 +72,14 @@ public class Foo {
         String foo = "Hello";
         sb.append("Hello");
         sb.append(foo);
+        sb.append("World");
+    }
+
+    public void bar2() {
+        StringBuilder sb = new StringBuilder();
+        String foo = "Hello";
+        sb.append("Hello");
+        sb.append(new Date());
         sb.append("World");
     }
 }
@@ -285,7 +295,7 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>12, Two loops, not concurrent appends though</description>
+        <description>12, Two loops, not consecutive appends though</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -317,7 +327,7 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>13, A bunch of loops, but nothing concurrent</description>
+        <description>13, A bunch of loops, but nothing consecutive</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 import java.util.Iterator;
@@ -363,7 +373,7 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>14, A bunch of loops, one concurrent</description>
+        <description>14, A bunch of loops, one consecutive</description>
         <expected-problems>2</expected-problems>
         <expected-linenumbers>15,34</expected-linenumbers>
         <code><![CDATA[
@@ -412,7 +422,7 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>15, A bunch of loops, none concurrent, separated by else</description>
+        <description>15, A bunch of loops, none consecutive, separated by else</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 import java.util.Iterator;
@@ -478,7 +488,7 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>17, Additive Expression 2</description>
+        <description>17a, Additive Expression 2</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -493,6 +503,29 @@ public class Foo {
         StringBuilder sb = new StringBuilder();
         String foo = "World";
         sb.append("Hello" + foo);
+        sb.append("World");
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>17b, Additive Expression 3</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>5,12</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public void bar() {
+        StringBuffer sb = new StringBuffer();
+        String foo = "Hello";
+        sb.append(foo + " ");
+        sb.append("World");
+    }
+
+    public void bar2() {
+        StringBuilder sb = new StringBuilder();
+        String foo = "Hello";
+        sb.append(foo + " ");
         sb.append("World");
     }
 }
@@ -544,7 +577,7 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>20, Suffix append follwed by real append</description>
+        <description>20, Suffix append followed by real append</description>
         <expected-problems>2</expected-problems>
         <expected-linenumbers>5,12</expected-linenumbers>
         <code><![CDATA[
@@ -919,8 +952,8 @@ public class Foo {
 
     <test-code>
         <description>32, Including the constructor's string</description>
-        <expected-problems>2</expected-problems>
-        <expected-linenumbers>3,8</expected-linenumbers>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>3,8,15,26</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     public void bar() {
@@ -931,6 +964,26 @@ public class Foo {
     public void bar2() {
         StringBuilder sb = new StringBuilder("CCC");
         sb.append("CCC");
+    }
+
+    private String getName() { return "foo"; }
+    public void bar3() {
+        StringBuilder sb = new StringBuilder(getName());
+        sb.append("first");
+        sb.append("second");
+    }
+
+    private String field = "f";
+    public void bar4() {
+        StringBuilder sb = new StringBuilder("CCC").append(this.field);
+        sb.append("CCC");
+    }
+
+    public void bar5(String desc) {
+        StringBuilder sb = new StringBuilder(desc)
+            .append("\n")
+            .append("CCC")
+            .append("DDD");
     }
 }
         ]]></code>
@@ -1276,7 +1329,13 @@ public class Foo {
     public String foo(final String value)
     {
         StringBuilder s = new StringBuilder("start:").append(value).append(":end");
+        return s.toString();
+    }
 
+    public String foo2(final String value)
+    {
+        StringBuilder s = new StringBuilder("start:").append(value);
+        s.append(":end");
         return s.toString();
     }
 }
@@ -1300,8 +1359,8 @@ public class Foo {
 
     <test-code>
         <description>Consecutive append of literals other than string: chars</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>4</expected-linenumbers>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>4,13</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     public void bar() {
@@ -1311,6 +1370,15 @@ public class Foo {
         s.append('l');
         s.append('l');
         s.append('o');
+    }
+
+    public void bar2(int i, String[] arr) {
+        StringBuilder s = new StringBuilder();
+        s.append('\n')
+         .append("Some string")
+         .append(i + 1)
+         .append("another")
+         .append(arr[i]);
     }
 }
         ]]></code>
@@ -1586,6 +1654,22 @@ public class FalsePositive {
 
     private static int findHTMLReservedChar(String text) {
         return 0;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>For-each loop, not consecutive appends</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class ConsecutiveLiteralAppendsForEach {
+    public void foo(String[] arr) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("array:\n");
+        for (String s : arr) {
+            sb.append('\t').append(s).append('\n');
+        }
     }
 }
         ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/ConsecutiveLiteralAppends.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/ConsecutiveLiteralAppends.xml
@@ -953,7 +953,7 @@ public class Foo {
     <test-code>
         <description>32, Including the constructor's string</description>
         <expected-problems>4</expected-problems>
-        <expected-linenumbers>3,8,15,26</expected-linenumbers>
+        <expected-linenumbers>3,8,15,27</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     public void bar() {
@@ -1671,6 +1671,34 @@ public class ConsecutiveLiteralAppendsForEach {
             sb.append('\t').append(s).append('\n');
         }
     }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Wrong count of appends - should be 3</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>4,8</expected-linenumbers>
+        <expected-messages>
+            <message>StringBuffer (or StringBuilder).append is called 3 consecutive times with literals. Use a single append with a single combined String.</message>
+            <message>StringBuffer (or StringBuilder).append is called 2 consecutive times with literals. Use a single append with a single combined String.</message>
+        </expected-messages>
+        <code><![CDATA[
+public class ConsecutiveLiteralAppends3 {
+    public String createMessage(String description) {
+        StringBuilder sb = new StringBuilder(description)
+                .append("\n")                       // <--- here
+                .append("Endpoint handler details:\n")
+                .append("Method [")
+                .append(this.getMethod())
+                .append("]\n")                      // <--- here
+                .append("Bean [")
+                .append(this.getBean())
+                .append("]\n");
+        return sb.toString();
+    }
+    public String getMethod() { return "method"; }
+    public String getBean() { return "bean"; }
 }
         ]]></code>
     </test-code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/ConsecutiveLiteralAppends.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/ConsecutiveLiteralAppends.xml
@@ -9,7 +9,6 @@
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
-    private static org.apache.log4j.Logger logger = org.apache.log4j.Logger.getLogger(Foo.class);
     public void bar() {
         StringBuffer sb = new StringBuffer(15);
         sb.append("foo");
@@ -42,6 +41,7 @@ public class Foo {
     <test-code>
         <description>2, Back to back append, not ok</description>
         <expected-problems>2</expected-problems>
+        <expected-linenumbers>4,10</expected-linenumbers>
         <code-ref id="back-to-back-append"/>
     </test-code>
 
@@ -79,6 +79,7 @@ public class Foo {
     <test-code>
         <description>4, Appends with literal appends</description>
         <expected-problems>2</expected-problems>
+        <expected-linenumbers>4,9</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     public void bar() {
@@ -97,6 +98,7 @@ public class Foo {
     <test-code>
         <description>5, Appends broken up by while loop</description>
         <expected-problems>2</expected-problems>
+        <expected-linenumbers>4,12</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     public void bar() {
@@ -121,6 +123,7 @@ public class Foo {
     <test-code>
         <description>6, Appends, then a variable</description>
         <expected-problems>2</expected-problems>
+        <expected-linenumbers>5,14</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     public void bar() {
@@ -199,6 +202,7 @@ public class Foo {
     <test-code>
         <description>9, Multiple appends in same while</description>
         <expected-problems>2</expected-problems>
+        <expected-linenumbers>6,16</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     public void bar() {
@@ -227,6 +231,7 @@ public class Foo {
     <test-code>
         <description>10, Multiple appends in same while, with multiple outside that while</description>
         <expected-problems>4</expected-problems>
+        <expected-linenumbers>4,7,15,18</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     public void bar() {
@@ -257,6 +262,7 @@ public class Foo {
     <test-code>
         <description>11, Multiple appends in same while, none outside the loop</description>
         <expected-problems>2</expected-problems>
+        <expected-linenumbers>5,13</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     public void bar() {
@@ -314,6 +320,8 @@ public class Foo {
         <description>13, A bunch of loops, but nothing concurrent</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+import java.util.Iterator;
+import java.util.List;
 public class Foo {
     public void bar(List l) {
         StringBuffer sb = new StringBuffer();
@@ -357,7 +365,10 @@ public class Foo {
     <test-code>
         <description>14, A bunch of loops, one concurrent</description>
         <expected-problems>2</expected-problems>
+        <expected-linenumbers>15,34</expected-linenumbers>
         <code><![CDATA[
+import java.util.Iterator;
+import java.util.List;
 public class Foo {
     public void bar(List l) {
         StringBuffer sb = new StringBuffer();
@@ -404,6 +415,8 @@ public class Foo {
         <description>15, A bunch of loops, none concurrent, separated by else</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+import java.util.Iterator;
+import java.util.List;
 public class Foo {
     public void bar(List l) {
         StringBuffer sb = new StringBuffer();
@@ -533,6 +546,7 @@ public class Foo {
     <test-code>
         <description>20, Suffix append follwed by real append</description>
         <expected-problems>2</expected-problems>
+        <expected-linenumbers>5,12</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     public void bar() {
@@ -623,6 +637,7 @@ public class Foo {
     <test-code>
         <description>23, force 2 failures on 3 lines</description>
         <expected-problems>4</expected-problems>
+        <expected-linenumbers>5,6,14,15</expected-linenumbers>
         <code-ref id="three-appends-on-one-line"/>
     </test-code>
 
@@ -630,6 +645,7 @@ public class Foo {
         <description>23, re-running with threshold</description>
         <rule-property name="threshold">2</rule-property>
         <expected-problems>2</expected-problems>
+        <expected-linenumbers>6,15</expected-linenumbers>
         <code-ref id="three-appends-on-one-line"/>
     </test-code>
 
@@ -756,6 +772,7 @@ public class Foo {
     <test-code>
         <description>27, Concurrent Appends from within switch statement</description>
         <expected-problems>4</expected-problems>
+        <expected-linenumbers>12,19,37,44</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     public String foo(int in) {
@@ -882,6 +899,7 @@ public class Foo {
     <test-code>
         <description>31, Adding two strings together then another append</description>
         <expected-problems>2</expected-problems>
+        <expected-linenumbers>4,10</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     public void bar() {
@@ -902,6 +920,7 @@ public class Foo {
     <test-code>
         <description>32, Including the constructor's string</description>
         <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,8</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     public void bar() {
@@ -920,6 +939,7 @@ public class Foo {
     <test-code>
         <description>33, Additive in the constructor</description>
         <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,8</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     public void bar() {
@@ -1002,20 +1022,20 @@ public class Foo {
 
     <test-code>
         <description>37, Intervening method call not related to append</description>
-        <expected-problems>2</expected-problems>
+        <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
     public void bar() {
         StringBuffer sb = new StringBuffer();
         sb.append("World");
-        sb.toString();
-        sb.append("World");
+        System.out.println(sb.toString());
+        sb.append("World"); // merging this append in the previous would change the result of toString()
     }
 
     public void bar2() {
         StringBuilder sb = new StringBuilder();
         sb.append("World");
-        sb.toString();
+        System.out.println(sb.toString());
         sb.append("World");
     }
 }
@@ -1024,7 +1044,7 @@ public class Foo {
 
     <test-code>
         <description>38, Intervening method call not related to append</description>
-        <expected-problems>2</expected-problems>
+        <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
     public void bar() {
@@ -1130,7 +1150,7 @@ public class Foo {
         ]]></code>
     </test-code>
 
-    <test-code regressionTest="false">
+    <test-code>
         <description>43, Using variable char array</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
@@ -1213,14 +1233,14 @@ public class StringBufferTest {
         // This lint is reported as ConsecutiveLiteralAppends, but says ".append is called **5** consecutive times"
         final StringBuffer stringBuffer = new StringBuffer().append("agrego ").append("un ");
         stringBuffer.append("string "); // and in this line says ".append is called **4** consecutive times"
-        Log.i(TAG, stringBuffer.toString());
+        System.out.println(stringBuffer.toString());
 
         final StringBuffer stringBuffer2 = new StringBuffer();
         // ConsecutiveLiteralAppends is not reported on any of these lines
         stringBuffer2.append("agrego ");
         stringBuffer2.append("un ");
         stringBuffer2.append("string ");
-        Log.i(TAG, stringBuffer2.toString());
+        System.out.println(stringBuffer2.toString());
     }
 }
         ]]></code>
@@ -1266,6 +1286,7 @@ public class Foo {
     <test-code>
         <description>Consecutive append of literals other than string: integer</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     public void bar() {
@@ -1280,6 +1301,7 @@ public class Foo {
     <test-code>
         <description>Consecutive append of literals other than string: chars</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     public void bar() {
@@ -1297,6 +1319,7 @@ public class Foo {
     <test-code>
         <description>Consecutive append of literals other than string: mix chars and strings</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     public void bar() {
@@ -1312,7 +1335,12 @@ public class Foo {
         <description>#1325 [java] False positive in ConsecutiveLiteralAppends</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+import java.util.List;
+import java.util.function.Function;
+
 public class ConsecutiveLiteralAppendsFP {
+    private Function<Object, String> valueToStringFunction = String::valueOf;
+    private List nodes;
     public String test() {
         StringBuilder builder = new StringBuilder("[");
         nodes.forEach((k, v) -> builder
@@ -1393,7 +1421,7 @@ public final class Test {
             sb.append("literal2");
         } catch (ArithmeticException e) {
             sb.append("literal3");
-        } catch (ArrayIndexOutOfBoundException e) {
+        } catch (ArrayIndexOutOfBoundsException e) {
             sb.append("literal4");
         } catch (Exception e) {
             sb.append("literal5");
@@ -1413,8 +1441,10 @@ public final class Test {
     <test-code>
         <description>Consecutive literal append over try</description>
         <expected-problems>1</expected-problems>
-        <expected-linenumbers>4</expected-linenumbers>
+        <expected-linenumbers>6</expected-linenumbers>
         <code><![CDATA[
+import java.io.IOException;
+
 public final class Test {
     public String foo() {
         final StringBuilder sb = new StringBuilder();
@@ -1470,6 +1500,7 @@ public class Foo {
     <test-code>
         <description>[java] StringBuilder/Buffer false negatives with typeres #2881</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
         <code><![CDATA[
             package net.sourceforge.pmd.lang.java.types.testdata;
 
@@ -1486,6 +1517,7 @@ public class Foo {
     <test-code>
         <description>[java] StringBuilder/Buffer false negatives with typeres #2881 (countertest, no classpath)</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
         <code><![CDATA[
             public class NoCompiledClass {
                 public String toString() {


### PR DESCRIPTION
## Describe the PR

This is just a PR to test a small improvement for the regression tester integration.
See last commit:

> When executing regression tester against master, we
> don't actually run PMD again, but we use the result from
> the previous run. There only the modified rules have been
> executed, so we should use the same rules for comparison
> against master.
> This should result in smaller reports, since the comparison
> on master reported all the not executed rules as missing
> violations.

This allows to compare the regression report from this PR against #3335 
E.g. #3335 "removes 304748" violations - but these are just the violations from the rules, that just did not have been executed...

If the report looks better here, that we can apply the last commit to pmd/7.0.x branch.
