### PR TITLE
[java] LiteralsFirstInComparisons false positive with two constants

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -36,6 +36,8 @@ This is a {{ site.pmd.release_type }} release.
     *   [#3321](https://github.com/pmd/pmd/issues/3321): \[apex] New rule to detect inaccessible AuraEnabled getters (summer '21 security update)
 *   core
     *   [#3323](https://github.com/pmd/pmd/pull/3323): \[core] Adds fullDescription and tags in SARIF report
+*   java-bestpractices
+    *   [#3315](https://github.com/pmd/pmd/issues/3315): \[java] LiteralsFirstInComparisons false positive with two constants
 *   java-codestyle
     *   [#3317](https://github.com/pmd/pmd/pull/3317): \[java] Update UnnecessaryImport to recognize usage of imported types in javadoc's `@exception` tag
 *   java-errorprone

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
@@ -33,6 +33,7 @@ import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
 import net.sourceforge.pmd.lang.java.typeresolution.ClassTypeResolver;
+import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.lang.symboltable.NameDeclaration;
 
 public class LiteralsFirstInComparisonsRule extends AbstractJavaRule {
@@ -161,8 +162,8 @@ public class LiteralsFirstInComparisonsRule extends AbstractJavaRule {
     }
 
     private boolean isStringLiteralFirstArgumentOfSuffix(ASTPrimarySuffix primarySuffix) {
-        JavaNode argumentPrimaryPrefix = getArgumentPrimaryPrefix(primarySuffix);
-        if (argumentPrimaryPrefix == null) {
+        ASTPrimaryPrefix argumentPrimaryPrefix = getArgumentPrimaryPrefix(primarySuffix);
+        if (argumentPrimaryPrefix == null || !TypeTestUtil.isA(String.class, argumentPrimaryPrefix)) {
             return false;
         }
         JavaNode firstLiteralArg = argumentPrimaryPrefix.getFirstChildOfType(ASTLiteral.class);
@@ -170,7 +171,7 @@ public class LiteralsFirstInComparisonsRule extends AbstractJavaRule {
         return isStringLiteral(firstLiteralArg) || isConstantString(firstNameArg);
     }
 
-    private JavaNode getArgumentPrimaryPrefix(ASTPrimarySuffix primarySuffix) {
+    private ASTPrimaryPrefix getArgumentPrimaryPrefix(ASTPrimarySuffix primarySuffix) {
         ASTExpression expression = primarySuffix.getFirstChildOfType(ASTArguments.class)
                                                 .getFirstChildOfType(ASTArgumentList.class)
                                                 .getFirstChildOfType(ASTExpression.class);
@@ -179,7 +180,7 @@ public class LiteralsFirstInComparisonsRule extends AbstractJavaRule {
 
         ASTPrimaryExpression primaryExpression = expression.getFirstChildOfType(ASTPrimaryExpression.class);
         if (primaryExpression != null) {
-            return primaryExpression.getChild(0);
+            return (ASTPrimaryPrefix) primaryExpression.getChild(0);
         }
         return null;
     }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LiteralsFirstInComparisons.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LiteralsFirstInComparisons.xml
@@ -441,4 +441,21 @@ public class LiteralsFirstInComparisonCase {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>False positive with non-String constants</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.math.BigInteger;
+
+public class LiteralsFirstInComparisonBigInteger {
+    public void foo() {
+        BigInteger value = new BigInteger("1");
+        if (value.equals(BigInteger.ZERO)) {
+            System.out.println("1==0!!");
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LiteralsFirstInComparisons.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LiteralsFirstInComparisons.xml
@@ -409,4 +409,36 @@ public class Foo {
             }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[java] LiteralsFirstInComparisons with two constants #3315</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import net.sourceforge.pmd.PMDVersion;
+public class LiteralsFirstInComparisonCase {
+    private static final String S1 = "s1";
+    private static final String S2 = "s2";
+    public static boolean compare() {
+        return S1.equals(S2);
+    }
+    public static boolean isUnkown() {
+        return PMDVersion.VERSION.equals(S2);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] LiteralsFirstInComparisons with two constants #3315 - with on demand import</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import net.sourceforge.pmd.*;
+public class LiteralsFirstInComparisonCase {
+    private static final String S2 = "s2";
+    public static boolean isUnkown() {
+        return PMDVersion.VERSION.equals(S2);
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Now we also consider the left hand side of the method call. The easy cases are supported:
* referencing a field in the local class
* referencing a static field in a different class

This basically does some reimplementation of the type res in the rule, so that we know the type and field on which the method is called. The current type res just gives as the type of the method result.
The solution here is not nice, but maybe good enough for PMD 6. I'm sure that the solution in PMD 7 will be much easier.

Note: This rule has already been converted  in PMD 7 - so we should expect some merge conflicts when merging master->pmd/7.0.x later.

## Related issues

- Fixes #3315

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

