### PR TITLE
[java] JUnitTestsShouldIncludeAssert Tweak assertion definition to avoid false positive with modern JUnit5

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitTestsShouldIncludeAssertRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/JUnitTestsShouldIncludeAssertRule.java
@@ -162,7 +162,8 @@ public class JUnitTestsShouldIncludeAssertRule extends AbstractJUnitRule {
     private boolean isAssertOrFailStatement(ASTStatementExpression expression) {
         String img = getMethodCallNameOrNull(expression);
         return img != null && (img.startsWith("assert") || img.startsWith("fail")
-                || img.startsWith("Assert.assert") || img.startsWith("Assert.fail"));
+                || img.startsWith("Assert.assert") || img.startsWith("Assert.fail")
+                || img.startsWith("Assertions.assert") || img.startsWith("Assertions.fail"));
     }
 
     /**

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnitTestsShouldIncludeAssert.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnitTestsShouldIncludeAssert.xml
@@ -534,7 +534,7 @@ public class FooTest extends TestCase {
     </test-code>
 
     <test-code>
-        <description>AssertJ and JUnit5 ?</description>
+        <description>AssertJ and JUnit5</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 import org.assertj.core.api.Assertions;
@@ -545,6 +545,23 @@ class JUnit5AssertJTest {
   @Test
   void check() {
     Assertions.assertThat("FOO").isNotNull();
+  }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>JUnit5</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class JUnit5Test {
+
+  @Test
+  void check() {
+    Assertions.assertNotNull("FOO");
   }
 }
         ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnitTestsShouldIncludeAssert.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/JUnitTestsShouldIncludeAssert.xml
@@ -532,4 +532,21 @@ public class FooTest extends TestCase {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>AssertJ and JUnit5 ?</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class JUnit5AssertJTest {
+
+  @Test
+  void check() {
+    Assertions.assertThat("FOO").isNotNull();
+  }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

As described in https://github.com/pmd/pmd/issues/1455#issuecomment-851667408, JUnit5 and AssertJ do assertions with the pattern `Assertions.assert*`

This pattern is not recognized by rule [JUnitTestsShouldIncludeAssert](https://pmd.github.io/latest/pmd_rules_java_bestpractices.html#junittestsshouldincludeassert)

Add this pattern to the existing patterns to avoid the false positive

Also add a test case.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Refs #1455 ~Partially fixes it~
- Fixes #3341 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

