### PR TITLE
[java] CloneMethodMustImplementCloneable: FN with local classes

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -41,6 +41,7 @@ This is a {{ site.pmd.release_type }} release.
 *   java-errorprone
     *   [#2895](https://github.com/pmd/pmd/issues/2895): \[java] Improve BadComparison and rename to ComparisonWithNaN
     *   [#3304](https://github.com/pmd/pmd/issues/3304): \[java] NPE in MoreThanOneLoggerRule on a java 16 record
+    *   [#3343](https://github.com/pmd/pmd/pull/3343): \[java] CloneMethodMustImplementCloneable: FN with local classes
 
 ### API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloneMethodMustImplementCloneableRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloneMethodMustImplementCloneableRule.java
@@ -18,7 +18,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTExtendsList;
 import net.sourceforge.pmd.lang.java.ast.ASTImplementsList;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclarator;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 
 /**
@@ -83,9 +82,10 @@ public class CloneMethodMustImplementCloneableRule extends AbstractJavaRule {
 
     @Override
     public Object visit(final ASTMethodDeclaration node, final Object data) {
+        super.visit(node, data);
+
         // Is this a clone method?
-        final ASTMethodDeclarator methodDeclarator = node.getFirstChildOfType(ASTMethodDeclarator.class);
-        if (!isCloneMethod(methodDeclarator)) {
+        if (!isCloneMethod(node)) {
             return data;
         }
 
@@ -159,10 +159,10 @@ public class CloneMethodMustImplementCloneableRule extends AbstractJavaRule {
         return classesNames;
     }
 
-    public boolean isCloneMethod(final ASTMethodDeclarator method) {
-        if (!"clone".equals(method.getImage())) {
+    public boolean isCloneMethod(final ASTMethodDeclaration method) {
+        if (!"clone".equals(method.getName())) {
             return false;
         }
-        return method.getParameterCount() == 0;
+        return method.getArity() == 0;
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloneMethodMustImplementCloneable.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloneMethodMustImplementCloneable.xml
@@ -186,4 +186,26 @@ class CloneableClass implements TestInterface {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[java] CloneMethodMustImplementCloneable: False negative with local classes</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>3,9</expected-linenumbers>
+        <code><![CDATA[
+public class Outer {
+    public static class Inner {
+        public Object clone() throws CloneNotSupportedException {
+            return super.clone();
+        }
+    }
+    public void foo() {
+        class Local {
+            public Object clone() throws CloneNotSupportedException {
+                return super.clone();
+            }
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloneMethodMustImplementCloneable.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloneMethodMustImplementCloneable.xml
@@ -188,7 +188,7 @@ class CloneableClass implements TestInterface {
     </test-code>
 
     <test-code>
-        <description>[java] CloneMethodMustImplementCloneable: False negative with local classes</description>
+        <description>[java] CloneMethodMustImplementCloneable: False negative with local classes #3343</description>
         <expected-problems>2</expected-problems>
         <expected-linenumbers>3,9</expected-linenumbers>
         <code><![CDATA[


### PR DESCRIPTION
## Describe the PR

**Rule:** [CloneMethodMustImplementCloneable](https://pmd.github.io/latest/pmd_rules_java_errorprone.html#clonemethodmustimplementcloneable)

**Description:**

This PR fixes a false negative for local classes defined inside methods.

**Code Sample demonstrating the issue:**

```java
public class Outer {
    public static class Inner {
        public Object clone() throws CloneNotSupportedException {
            return super.clone();
        }
    }
    public void foo() {
        class Local {
            public Object clone() throws CloneNotSupportedException {      // <---- missing violation
                return super.clone();
            }
        }
    }
}

```

Original occurrences:
* https://github.com/checkstyle/checkstyle/blob/checkstyle-8.10/src/it/resources/com/google/checkstyle/test/chapter3filestructure/rule341onetoplevel/InputOneTopLevelClassBasic.java#L39
* https://github.com/checkstyle/checkstyle/blob/checkstyle-8.10/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/noclone/InputNoClone.java#L39
* https://github.com/checkstyle/checkstyle/blob/checkstyle-8.10/src/test/resources/com/puppycrawl/tools/checkstyle/checks/coding/superclone/InputSuperCloneInnerAndWithArguments.java#L39

**Expected outcome:**

PMD should report a violation at line 9, but doesn't. This is a false-negative.

## Related issues

- Ref #2687

## Note

This rule has already been updated on pmd/7.0.x - might be already fixed there or not. Be careful when merging this into pmd/7.0.x.

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

