### PR TITLE
[java] InefficientEmptyStringCheck FN with trim.length on method call

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -42,7 +42,7 @@ This is a {{ site.pmd.release_type }} release.
     *   [#2895](https://github.com/pmd/pmd/issues/2895): \[java] Improve BadComparison and rename to ComparisonWithNaN
     *   [#3304](https://github.com/pmd/pmd/issues/3304): \[java] NPE in MoreThanOneLoggerRule on a java 16 record
 *   java-performance
-    *   [#3334](https://github.com/pmd/pmd/pull/3344): \[java] InefficientEmptyStringCheck FN with trim.length on method call
+    *   [#3344](https://github.com/pmd/pmd/pull/3344): \[java] InefficientEmptyStringCheck FN with trim.length on method call
 
 ### API Changes
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -41,6 +41,8 @@ This is a {{ site.pmd.release_type }} release.
 *   java-errorprone
     *   [#2895](https://github.com/pmd/pmd/issues/2895): \[java] Improve BadComparison and rename to ComparisonWithNaN
     *   [#3304](https://github.com/pmd/pmd/issues/3304): \[java] NPE in MoreThanOneLoggerRule on a java 16 record
+*   java-performance
+    *   [#3334](https://github.com/pmd/pmd/pull/3344): \[java] InefficientEmptyStringCheck FN with trim.length on method call
 
 ### API Changes
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/inefficientemptystringcheck/StringTrimIsEmpty.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/inefficientemptystringcheck/StringTrimIsEmpty.java
@@ -1,0 +1,28 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.performance.inefficientemptystringcheck;
+
+public class StringTrimIsEmpty {
+    String get() {
+        return "foo";
+    }
+
+    void bar() {
+        if (get().trim().isEmpty()) {
+            // violation
+        }
+        if (this.get().trim().isEmpty()) {
+            // violation
+        }
+
+        String bar = get();
+        if (bar.trim().isEmpty()) {
+            // violation
+        }
+        if (bar.toString().trim().isEmpty()) {
+            // violation
+        }
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/inefficientemptystringcheck/StringTrimLength.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/inefficientemptystringcheck/StringTrimLength.java
@@ -1,0 +1,28 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.performance.inefficientemptystringcheck;
+
+public class StringTrimLength {
+    String get() {
+        return "foo";
+    }
+
+    void bar() {
+        if (get().trim().length() == 0) {
+            // violation
+        }
+        if (this.get().trim().length() == 0) {
+            // violation
+        }
+
+        String bar = get();
+        if (bar.trim().length() == 0) {
+            // violation
+        }
+        if (bar.toString().trim().length() == 0) {
+            // violation
+        }
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/inefficientemptystringcheck/StringTrimMethodArgument.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/inefficientemptystringcheck/StringTrimMethodArgument.java
@@ -1,0 +1,21 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.performance.inefficientemptystringcheck;
+
+public class StringTrimMethodArgument {
+    public String get() {
+        return "foo";
+    }
+
+    public void bar() {
+        String bar = "foo";
+        System.out.println(bar.trim().isEmpty()); // violation missing
+        System.out.println(bar.trim().length() == 0);
+        System.out.println(get().trim().isEmpty());
+        System.out.println(get().trim().length() == 0);
+        System.out.println(this.get().trim().isEmpty());
+        System.out.println(this.get().trim().length() == 0);
+    }
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/InefficientEmptyStringCheck.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/InefficientEmptyStringCheck.xml
@@ -143,7 +143,9 @@ public class Foo {
     <test-code>
         <description>String.trim().isEmpty() is called after a chain call, should have failed</description>
         <expected-problems>2</expected-problems>
+        <expected-linenumbers>5,7</expected-linenumbers>
         <code><![CDATA[
+import java.util.Arrays;
 public class Foo {
     void bar() {
         String foo = "foo";
@@ -158,7 +160,9 @@ public class Foo {
     <test-code>
         <description>String.trim().isEmpty() is called after a chain call, should have failed twice</description>
         <expected-problems>2</expected-problems>
+        <expected-linenumbers>5,6</expected-linenumbers>
         <code><![CDATA[
+import java.util.Arrays;
 public class Foo {
     void bar() {
         String foo = "foo";
@@ -199,5 +203,88 @@ public class PatternMatchingInstanceof {
 }
         ]]></code>
         <source-type>java 16</source-type>
+    </test-code>
+
+    <test-code>
+        <description>String.trim.isEmpty is called on method result, should have failed</description>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>7,10,15,18</expected-linenumbers>
+        <code><![CDATA[
+package net.sourceforge.pmd.lang.java.rule.performance.inefficientemptystringcheck;
+public class StringTrimIsEmpty {
+    String get() {
+        return "foo";
+    }
+    void bar() {
+        if (get().trim().isEmpty()) {
+            // violation
+        }
+        if (this.get().trim().isEmpty()) {
+            // violation
+        }
+
+        String bar = get();
+        if (bar.trim().isEmpty()) {
+            // violation
+        }
+        if (bar.toString().trim().isEmpty()) {
+            // violation
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>String.trim.length is called on method result, should have failed</description>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>7,10,15,18</expected-linenumbers>
+        <code><![CDATA[
+package net.sourceforge.pmd.lang.java.rule.performance.inefficientemptystringcheck;
+public class StringTrimLength {
+    String get() {
+        return "foo";
+    }
+    void bar() {
+        if (get().trim().length() == 0) {
+            // violation missing
+        }
+        if (this.get().trim().length() == 0) {
+            // violation missing
+        }
+
+        String bar = get();
+        if (bar.trim().length() == 0) {
+            // violation already detected
+        }
+        if (bar.toString().trim().length() == 0) {
+            // violation missing
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>String.trim.isEmpty and length called in method argument</description>
+        <expected-problems>6</expected-problems>
+        <expected-linenumbers>8,9,10,11,12,13</expected-linenumbers>
+        <code><![CDATA[
+package net.sourceforge.pmd.lang.java.rule.performance.inefficientemptystringcheck;
+public class StringTrimMethodArgument {
+    public String get() {
+        return "foo";
+    }
+    public void bar() {
+        String bar = "foo";
+        System.out.println(bar.trim().isEmpty()); // violation missing
+        System.out.println(bar.trim().length() == 0);
+        System.out.println(get().trim().isEmpty()); // violation missing
+        System.out.println(get().trim().length() == 0); // violation missing
+        System.out.println(this.get().trim().isEmpty()); // violation missing
+        System.out.println(this.get().trim().length() == 0); // violating missing
+    }
+}
+        ]]></code>
     </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

**Rule:** [InefficientEmptyStringCheck](https://pmd.github.io/latest/pmd_rules_java_performance.html#inefficientemptystringcheck)

**Description:**

This PR fixes a false negative for calls to trim().length() and trim().isEmpty() when used as method arguments

**Code Sample demonstrating the issue:**

```java
public class StringTrimLength {
    String get() {
        return "foo";
    }
    void bar() {
        if (get().trim().length() == 0) {
            // violation missing
        }
        if (this.get().trim().length() == 0) {
            // violation missing
        }

        String bar = get();
        if (bar.trim().length() == 0) {
            // violation already detected
        }
        if (bar.toString().trim().length() == 0) {
            // violation missing
        }
    }
}
```

```java
package net.sourceforge.pmd.lang.java.rule.performance.inefficientemptystringcheck;
public class StringTrimMethodArgument {
    public String get() {
        return "foo";
    }
    public void bar() {
        String bar = "foo";
        System.out.println(bar.trim().isEmpty()); // violation missing
        System.out.println(bar.trim().length() == 0);
        System.out.println(get().trim().isEmpty()); // violation missing
        System.out.println(get().trim().length() == 0); // violation missing
        System.out.println(this.get().trim().isEmpty()); // violation missing
        System.out.println(this.get().trim().length() == 0); // violating missing
    }
}
```

Original occurrences:
* https://github.com/checkstyle/checkstyle/blob/checkstyle-8.10/src/main/java/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocTagContinuationIndentationCheck.java#L90
* https://github.com/checkstyle/checkstyle/blob/checkstyle-8.10/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllChecksTest.java#L533
* https://github.com/checkstyle/checkstyle/blob/checkstyle-8.10/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsPagesTest.java#L593

**Expected outcome:**

PMD should report a violations at line 7,10,18 in StringTrimLength and 8,10,11,12,13 in StringTrimMethodArgument, but doesn't. This is a false-negative.

## Related issues

- Ref #2687

## Note

This rule has already been updated on pmd/7.0.x - might be already fixed there or not. Be careful when merging this into pmd/7.0.x.

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

