### PR TITLE
[java] NullPointerException applying rule GuardLogStatement

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -46,6 +46,8 @@ This is a {{ site.pmd.release_type }} release.
     *   [#3321](https://github.com/pmd/pmd/issues/3321): \[apex] New rule to detect inaccessible AuraEnabled getters (summer '21 security update)
 *   core
     *   [#3323](https://github.com/pmd/pmd/pull/3323): \[core] Adds fullDescription and tags in SARIF report
+*   java-bestpractices
+    *   [#3340](https://github.com/pmd/pmd/issues/3340): \[java] NullPointerException applying rule GuardLogStatement
 *   java-codestyle
     *   [#3317](https://github.com/pmd/pmd/pull/3317): \[java] Update UnnecessaryImport to recognize usage of imported types in javadoc's `@exception` tag
 *   java-errorprone

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
@@ -129,7 +129,7 @@ public class GuardLogStatementRule extends AbstractJavaRule implements Rule {
     }
 
     private boolean hasArgumentWithMethodCall(ASTPrimarySuffix node) {
-        if (!node.isArguments()) {
+        if (!node.isArguments() || node.getArgumentCount() <= 0) {
             return false;
         }
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
@@ -462,4 +462,18 @@ public class Logger {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>NullPointerException applying rule GuardLogStatement (#3340)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Logger {
+    private static final Logger LOGGER = new Logger();
+
+    public void bar() {
+        LOGGER.debug();
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Ignores now log calls without any arguments

## Related issues

- Fixes #3340

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

