### PR TITLE
[java] Fix #3305 - ConstructorCallsOverridableMethod NPE with records

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConstructorCallsOverridableMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConstructorCallsOverridableMethodRule.java
@@ -33,6 +33,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimarySuffix;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimitiveType;
+import net.sourceforge.pmd.lang.java.ast.ASTRecordDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTReferenceType;
 import net.sourceforge.pmd.lang.java.ast.ASTType;
 import net.sourceforge.pmd.lang.java.ast.AccessNode;
@@ -884,6 +885,15 @@ public final class ConstructorCallsOverridableMethodRule extends AbstractJavaRul
             removeCurrentEvalPackage();
             return o;
         }
+    }
+
+    @Override
+    public Object visit(ASTRecordDeclaration node, Object data) {
+        // records are final
+        putEvalPackage(NULL_EVAL_PACKAGE);
+        super.visit(node, data);
+        removeCurrentEvalPackage();
+        return null;
     }
 
     /**

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ConstructorCallsOverridableMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ConstructorCallsOverridableMethod.xml
@@ -304,4 +304,20 @@ import java.lang.annotation.*;
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>Record creates an IndexOutOfBounds exception</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            record HelloMsg(String msg) {
+
+                    HelloMsg toTheWorld() {
+                       return new HelloMsg("World");
+                    }
+
+                    String hello() {
+                    return "Hello " + msg;
+                    }
+            }
+            ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #3305

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

