### PR TITLE
[core] Add Rule.getPostProcessors() method to support per-rule global post-processing steps

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/Rule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/Rule.java
@@ -12,6 +12,7 @@ import net.sourceforge.pmd.lang.ParserOptions;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.properties.PropertySource;
 import net.sourceforge.pmd.properties.StringProperty;
+import net.sourceforge.pmd.renderers.Renderer;
 
 /**
  * This is the basic Rule interface for PMD rules.
@@ -437,4 +438,12 @@ public interface Rule extends PropertySource {
      * @return A new exact copy of this rule
      */
     Rule deepCopy();
+
+    /**
+     * Return any (additional) post-processing tasks to enable with this rule.
+     * These will run before the configured Renderer.
+     *
+     * @return A list of renderers
+     */
+    List<Renderer> getPostProcessors();
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractDelegateRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractDelegateRule.java
@@ -18,6 +18,7 @@ import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.properties.MultiValuePropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertySource;
+import net.sourceforge.pmd.renderers.Renderer;
 
 /**
  * Base class for Rule implementations which delegate to another Rule instance.
@@ -347,5 +348,10 @@ public abstract class AbstractDelegateRule implements Rule {
     @Override
     public boolean hasDescriptor(PropertyDescriptor<?> descriptor) {
         return rule.hasDescriptor(descriptor);
+    }
+
+    @Override
+    public List<Renderer> getPostProcessors() {
+        return java.util.Collections.emptyList();
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.rule;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import net.sourceforge.pmd.Rule;
@@ -16,6 +17,7 @@ import net.sourceforge.pmd.lang.ParserOptions;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.properties.AbstractPropertySource;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.renderers.Renderer;
 
 /**
  * Basic abstract implementation of all parser-independent methods of the Rule
@@ -475,5 +477,10 @@ public abstract class AbstractRule extends AbstractPropertySource implements Rul
             }
         }
         return rule;
+    }
+
+    @Override
+    public List<Renderer> getPostProcessors() {
+        return java.util.Collections.emptyList();
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/AbstractRuleTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/AbstractRuleTest.java
@@ -25,6 +25,8 @@ import net.sourceforge.pmd.lang.rule.ParametricRuleViolation;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
 import net.sourceforge.pmd.properties.StringProperty;
+import net.sourceforge.pmd.renderers.EmptyRenderer;
+import net.sourceforge.pmd.renderers.Renderer;
 
 
 public class AbstractRuleTest {
@@ -50,6 +52,11 @@ public class AbstractRuleTest {
 
         @Override
         public void apply(List<? extends Node> nodes, RuleContext ctx) {
+        }
+
+        @Override
+        public List<Renderer> getPostProcessors() {
+            return java.util.Collections.singletonList((Renderer)new EmptyRenderer());
         }
     }
 
@@ -232,5 +239,13 @@ public class AbstractRuleTest {
 
         assertEquals(r1.isPropertyOverridden(MyRule.FOO_DEFAULT_PROPERTY),
                 r2.isPropertyOverridden(MyRule.FOO_DEFAULT_PROPERTY));
+    }
+
+    @Test
+    public void testPostProcessors() {
+        MyRule myRule = new MyRule();
+        assertEquals("Didn't return post-processor!", 1, myRule.getPostProcessors().size());
+        MyOtherRule myOtherRule = new MyOtherRule();
+        assertEquals("Returned spurious post-processor!", 0, myOtherRule.getPostProcessors().size());
     }
 }


### PR DESCRIPTION
Add Rule.getPostProcessors() abstract method to allow a rule to specify extra rendering steps after analyzing all files.
Add default implementation for existing rules to do nothing.
Update PMD.doPMD to collect these in the list of renderers and to call the start, end, and flush lifecycle methods.
Unit test the new method.

Change-Id: I92327fada337feca74967bb3bb4e6187b3a0d1fd

## Describe the PR

Our org is building some custom PMD rules that require gathering and then post-processing global data.  This pull request supports with the latter aspect.  I think it would be very useful to others.

Architecturally, the Renderer is a natural "post-processor" because it already has the necessary data access and workflow callback (i.e. end) to process cross-file data.  We did consider just adding a new top-level renderer... but we want this post-processing to run in addition to the existing renderers that output the violations.

A possible factoring would be to split the workflow methods (start, end, renderFile, ...) out of Renderer and create a new PostProcessor parent interface, leaving behind the output-related methods (setWriter, defaultFileExtension, ...) in Renderer.   I'm happy to do this, but it would change a fair number of parameter types, and I can just easily ignore the output-related methods in my custom classes.  PLMK.
