### PR TITLE
[core] Extend the Report class to store custom data objects

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/MergeableData.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/MergeableData.java
@@ -1,0 +1,26 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd;
+
+/**
+ * A data object that can be merged with another of the same type.
+ *
+ */
+public interface MergeableData {
+
+    /**
+     * Creates an empty instance of the same type as this one.
+     *
+     * @return A new MergeableData object
+     */
+    MergeableData create();
+
+    /**
+     * Merge another data object of the same type into this.
+     *
+     * @param other The other data object.
+     */
+    void merge(MergeableData other);
+}

--- a/pmd-core/src/test/java/net/sourceforge/pmd/ReportTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/ReportTest.java
@@ -196,4 +196,37 @@ public class ReportTest implements ThreadSafeReportListener {
         renderer.end();
         return writer.toString();
     }
+
+    public static class MyMergeableData implements MergeableData {
+        public int count = 0;
+
+        @Override
+        public MergeableData create() {
+            return new MyMergeableData();
+        }
+
+        @Override
+        public void merge(MergeableData other) {
+            this.count += ((MyMergeableData)other).count;
+        }
+    }
+
+    @Test
+    public void testCustomData() {
+        Report r = new Report();
+
+        MyMergeableData d0 = new MyMergeableData();
+        d0.count = 10;
+
+        MyMergeableData d1 = r.getCustomData(d0);
+        assertEquals(0, d1.count);
+        d1.count += 1;
+
+        MyMergeableData d2 = r.getCustomData(new MyMergeableData());
+        assertEquals(d1, d2); // same instance
+        assertEquals(1, d2.count);
+
+        d2.merge(d0);
+        assertEquals(11, d2.count);
+    }
 }


### PR DESCRIPTION
Extend the Report class to store custom MergeableData objects, one per runtime type.

## Describe the PR

Our org is building some custom PMD rules that require gathering and then post-processing global data. This pull request supports with the former aspect. I think it would be very useful to others.

The MergeableData defines the minimum interface of the stored data, which needs to be merged as the containing Report   objects are merged.   Our custom Rules add these to the Report (e.g. as method summaries, conditional violations.)  They are later consumed by a Renderer, in order to output additional custom information.  For example, one of our use cases is to extract properties about test code.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

