### PR TITLE
[apex] Add ApexCRUDViolation support for database class, inline no-arg object construction DML and inline list initialization DML

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/internal/Helper.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/internal/Helper.java
@@ -20,6 +20,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTModifierNode;
 import net.sourceforge.pmd.lang.apex.ast.ASTNewKeyValueObjectExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTNewObjectExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTParameter;
 import net.sourceforge.pmd.lang.apex.ast.ASTReferenceExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTSoqlExpression;
@@ -158,6 +159,13 @@ public final class Helper {
     }
 
     public static String getFQVariableName(final ASTNewKeyValueObjectExpression variable) {
+        StringBuilder sb = new StringBuilder()
+                .append(variable.getDefiningType()).append(":")
+                .append(variable.getType());
+        return sb.toString();
+    }
+
+    public static String getFQVariableName(final ASTNewObjectExpression variable) {
         StringBuilder sb = new StringBuilder()
                 .append(variable.getDefiningType()).append(":")
                 .append(variable.getType());

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
@@ -114,7 +114,33 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
 
     @Override
     public Object visit(ASTMethodCallExpression node, Object data) {
-        collectCRUDMethodLevelChecks(node);
+        if (Helper.isAnyDatabaseMethodCall(node)) {
+
+            switch (node.getMethodName().toLowerCase(Locale.ROOT)) {
+            case "insert":
+                checkForCRUD(node, data, IS_CREATEABLE);
+                break;
+            case "update":
+                checkForCRUD(node, data, IS_UPDATEABLE);
+                break;
+            case "delete":
+                checkForCRUD(node, data, IS_DELETABLE);
+                break;
+            case "upsert":
+                checkForCRUD(node, data, IS_CREATEABLE);
+                checkForCRUD(node, data, IS_UPDATEABLE);
+                break;
+            case "merge":
+                checkForCRUD(node, data, IS_MERGEABLE);
+                break;
+            default:
+                break;
+            }
+             
+        } else {
+            collectCRUDMethodLevelChecks(node);
+        }
+        
         return data;
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexCRUDViolationRule.java
@@ -33,6 +33,9 @@ import net.sourceforge.pmd.lang.apex.ast.ASTIfElseBlockStatement;
 import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
 import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTNewKeyValueObjectExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTNewListInitExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTNewListLiteralExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTNewObjectExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTProperty;
 import net.sourceforge.pmd.lang.apex.ast.ASTReferenceExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTReturnStatement;
@@ -379,11 +382,8 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
             return;
         }
 
-        final ASTNewKeyValueObjectExpression newObj = node.getFirstChildOfType(ASTNewKeyValueObjectExpression.class);
-        if (newObj != null) {
-            final String type = Helper.getFQVariableName(newObj);
-            validateCRUDCheckPresent(node, data, crudMethod, type);
-        }
+        checkInlineObject(node, data, crudMethod);
+        checkInlineNonArgsObject(node, data, crudMethod);
 
         final ASTVariableExpression variable = node.getFirstChildOfType(ASTVariableExpression.class);
         if (variable != null) {
@@ -394,6 +394,36 @@ public class ApexCRUDViolationRule extends AbstractApexRule {
 
                 validateCRUDCheckPresent(node, data, crudMethod, typeCheck.toString());
             }
+        }
+
+        final ASTNewListLiteralExpression inlineListLiteral = node.getFirstChildOfType(ASTNewListLiteralExpression.class);
+        if (inlineListLiteral != null) {
+            checkInlineObject(inlineListLiteral, data, crudMethod);
+            checkInlineNonArgsObject(inlineListLiteral, data, crudMethod);
+        }
+
+        final ASTNewListInitExpression inlineListInit = node.getFirstChildOfType(ASTNewListInitExpression.class);
+        if (inlineListInit != null) {
+            checkInlineObject(inlineListInit, data, crudMethod);
+            checkInlineNonArgsObject(inlineListInit, data, crudMethod);
+        }
+    }
+
+    private void checkInlineObject(final ApexNode<?> node, final Object data, final String crudMethod) {
+
+        final ASTNewKeyValueObjectExpression newObj = node.getFirstChildOfType(ASTNewKeyValueObjectExpression.class);
+        if (newObj != null) {
+            final String type = Helper.getFQVariableName(newObj);
+            validateCRUDCheckPresent(node, data, crudMethod, type);
+        }
+    }
+
+    private void checkInlineNonArgsObject(final ApexNode<?> node, final Object data, final String crudMethod) {
+        
+        final ASTNewObjectExpression newEmptyObj = node.getFirstChildOfType(ASTNewObjectExpression.class);
+        if (newEmptyObj != null) {
+            final String type = Helper.getFQVariableName(newEmptyObj);
+            validateCRUDCheckPresent(node, data, crudMethod, type);
         }
     }
 

--- a/pmd-apex/src/main/resources/category/apex/security.xml
+++ b/pmd-apex/src/main/resources/category/apex/security.xml
@@ -58,7 +58,7 @@ public class Foo {
         Contact c = [SELECT Status__c FROM Contact WHERE Id=:ID WITH SECURITY_ENFORCED];
 
         // Make sure we can update the database before even trying
-        if (!Schema.sObjectType.Contact.fields.Name.isUpdateable()) {
+        if (!Schema.sObjectType.Contact.fields.Status__c.isUpdateable()) {
             return null;
         }
 

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
@@ -135,6 +135,32 @@ public class Foo {
     </test-code>
 
     <test-code>
+        <description>Proper CRUD,FLS via upsert with database class</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void foo(String newName, String tempID) {
+        if (Contact.sObjectType.getDescribe().isCreateable() && Contact.sObjectType.getDescribe().isUpdateable()) {
+            Database.upsert(new Contact(FirstName = 'First', LastName = 'Last', Phone = '414-414-4414'));
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>No CRUD check for inline upsert with database class</description>
+        <expected-problems>2</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void foo() {
+        Database.upsert(new Contact(FirstName = 'First', LastName = 'Last', Phone = '414-414-4414'));
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>VF built-in CRUD checks via getter, but cannot determine if is really VF</description>
         <expected-problems>2</expected-problems>
         <code><![CDATA[
@@ -601,6 +627,40 @@ public class Foo {
     </test-code>
 
     <test-code>
+        <description>No CRUD,FLS check for update with database class</description>
+        <expected-problems>2</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void foo(String newName, String tempID) {
+        Contact c = [SELECT Name FROM Contact WHERE Id=:tempID];
+        c.Name = newName;
+        Database.update(c);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Proper CRUD,FLS check for update with database class</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public Contact foo(String newName, String tempID) {
+        if (Contact.sObjectType.getDescribe().isAccessible()) {
+            Contact c = [SELECT Name FROM Contact WHERE Id=:tempID];
+            if (!Schema.sObjectType.Contact.fields.Name.isUpdateable()){
+                return null;
+            }
+            c.Name = newName;
+        }
+        Database.update(c);
+        return c;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>No CRUD check for insert</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
@@ -622,6 +682,34 @@ public class Foo {
         if (Contact.sObjectType.getDescribe().isCreateable()) {
             Contact myCon = new Contact(FirstName = 'First', LastName = 'Last', Phone = '414-414-4414');
             insert myCon;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>No CRUD check for insert with database class</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void foo() {
+        Contact myCon = new Contact(FirstName = 'First', LastName = 'Last', Phone = '414-414-4414');
+        Database.insert(myCon);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Proper CRUD check for insert with database class</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void foo() {
+        if (Contact.sObjectType.getDescribe().isCreateable()) {
+            Contact myCon = new Contact(FirstName = 'First', LastName = 'Last', Phone = '414-414-4414');
+            Database.insert(myCon);
         }
     }
 }
@@ -651,6 +739,36 @@ public class Foo {
             Contact toDelete = [SELECT Id FROM Contact WHERE Id=: contactId];
             if (Contact.sObjectType.getDescribe().isDeletable()) {
                 delete toDelete;
+            }
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>No CRUD check for delete with database class</description>
+        <expected-problems>2</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void bar(String contactId) {
+            Contact toDelete = [SELECT Id FROM Contact WHERE Id=: contactId];
+            Database.delete(toDelete);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Proper CRUD check for delete with database class</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void bar(String contactId) {
+        if (Contact.sObjectType.getDescribe().isAccessible()) {
+            Contact toDelete = [SELECT Id FROM Contact WHERE Id=: contactId];
+            if (Contact.sObjectType.getDescribe().isDeletable()) {
+                Database.delete(toDelete);
             }
         }
     }

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexCRUDViolation.xml
@@ -1042,7 +1042,7 @@ public class Foo {
 public class Foo {
     void bar() {
         for (Account a : [SELECT Id FROM Account]) {
-
+        
         }
     }
 }
@@ -1073,6 +1073,84 @@ public class Foo {
             for (Account a : [SELECT Id FROM Account]) {
                 
             }
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>No CRUD,FLS for inline no-args object</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void foo() {
+        insert new Account();
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Proper CRUD,FLS for inline no-args object</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void foo(String newName, String tempID) {
+        if(Account.sObjectType.getDescribe().isCreateable()) {
+            insert new Account();
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>No CRUD,FLS for inline literal list</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void foo() {
+        insert new Account[]{new Account(Name = 'X')};
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Proper CRUD,FLS for inline literal list</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void foo(String newName, String tempID) {
+        if(Account.sObjectType.getDescribe().isCreateable()) {
+            insert new Account[]{new Account(Name = 'X')};
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>No CRUD,FLS for inline initialized list</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void foo() {
+        insert new List<Account>(new Account(Name = 'X'));
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Proper CRUD,FLS for inline initialized list</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void foo(String newName, String tempID) {
+        if(Account.sObjectType.getDescribe().isCreateable()) {
+            insert new List<Account>(new Account(Name = 'X'));
         }
     }
 }


### PR DESCRIPTION
## Describe the PR

Until now `ApexCRUDViolation` didn't support checks when using the `Database` class DML methods, only the inline DML statements.

Also when a DML statement was issued with an inline instantiation of an SObject without any arguments it was not checked. Similarly with an inline instantiation of an SObject list with inline item adding.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->


- Fixes #3201

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

