### PR TITLE
[java] New rule ReturnEmptyCollectionRatherThanNull

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -14,6 +14,23 @@ This is a {{ site.pmd.release_type }} release.
 
 ### New and noteworthy
 
+#### New rules
+
+This release ships with 1 new Java rule.
+
+*   {% rule java/errorprone/ReturnEmptyCollectionRatherThanNull %} suggests returning empty collections / arrays instead of null.
+```xml
+    <rule ref="category/java/errorprone.xml/ReturnEmptyCollectionRatherThanNull" />
+```
+
+   The rule is part of the quickstart.xml ruleset.
+
+#### Deprecated rules
+
+The following Java rules are deprecated and removed from the quickstart ruleset,
+ as the new rule {% rule java/errorprone.xml/ReturnEmptyCollectionRatherThanNull %} supersedes it:
+* {% rule java/errorprone.xml/ReturnEmptyArrayRatherThanNull %}
+
 ### Fixed Issues
 
 *   apex

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2852,16 +2852,65 @@ public class Foo {
         </example>
     </rule>
 
+	<rule name="ReturnEmptyCollectionRatherThanNull"
+          language="java"
+          since="6.37.0"
+          class="net.sourceforge.pmd.lang.rule.XPathRule"
+          message="Return an empty collection rather than 'null'."
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#returnemptycollectionratherthannull">
+        <description>
+For any method that returns an collection (such as an array, Collection or Map), it is a better to return an empty one rather than a
+null reference. This removes the need for null checking all results and avoids inadvertent
+NullPointerExceptions.
+        </description>
+        <priority>1</priority>
+        <properties>
+            <property name="version" value="2.0"/>
+            <property name="xpath">
+                <value>
+<![CDATA[
+//MethodDeclaration
+[
+(./ResultType/Type[pmd-java:typeIs('java.util.Collection') or pmd-java:typeIs('java.util.Map') or @ArrayType=true()])
+and
+(./Block/BlockStatement/Statement/ReturnStatement/Expression/PrimaryExpression/PrimaryPrefix/Literal/NullLiteral)
+]
+]]>
+                </value>
+            </property>
+        </properties>
+        <example>
+<![CDATA[
+public class Example {
+    // Not a good idea...
+    public int[] badBehavior() {
+        // ...
+        return null;
+    }
+
+    // Good behavior
+    public String[] bonnePratique() {
+        //...
+        return new String[0];
+    }
+}
+]]>
+        </example>
+    </rule>
+    
     <rule name="ReturnEmptyArrayRatherThanNull"
           language="java"
           since="4.2"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
+          deprecated="true"
           message="Return an empty array rather than 'null'."
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#returnemptyarrayratherthannull">
         <description>
 For any method that returns an array, it is a better to return an empty array rather than a
 null reference. This removes the need for null checking all results and avoids inadvertent
 NullPointerExceptions.
+
+Deprecated since PMD 6.37.0, use {% rule java/errorprone/ReturnEmptyCollectionRatherThanNull %} instead.
         </description>
         <priority>1</priority>
         <properties>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2862,6 +2862,8 @@ public class Foo {
 For any method that returns an collection (such as an array, Collection or Map), it is a better to return an empty one rather than a
 null reference. This removes the need for null checking all results and avoids inadvertent
 NullPointerExceptions.
+
+See Effective Java, 3rd Edition, Item 54: Return empty collections or arrays instead of null
         </description>
         <priority>1</priority>
         <properties>

--- a/pmd-java/src/main/resources/rulesets/java/quickstart.xml
+++ b/pmd-java/src/main/resources/rulesets/java/quickstart.xml
@@ -245,7 +245,7 @@
     <rule ref="category/java/errorprone.xml/OverrideBothEqualsAndHashcode"/>
     <rule ref="category/java/errorprone.xml/ProperCloneImplementation"/>
     <rule ref="category/java/errorprone.xml/ProperLogger"/>
-    <rule ref="category/java/errorprone.xml/ReturnEmptyArrayRatherThanNull"/>
+    <rule ref="category/java/errorprone.xml/ReturnEmptyCollectionRatherThanNull"/>
     <rule ref="category/java/errorprone.xml/ReturnFromFinallyBlock"/>
     <!-- <rule ref="category/java/errorprone.xml/SimpleDateFormatNeedsLocale" /> -->
     <rule ref="category/java/errorprone.xml/SingleMethodSingleton"/>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ReturnEmptyCollectionRatherThanNullTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/ReturnEmptyCollectionRatherThanNullTest.java
@@ -1,0 +1,12 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone;
+
+import net.sourceforge.pmd.testframework.PmdRuleTst;
+
+public class ReturnEmptyCollectionRatherThanNullTest extends PmdRuleTst {
+
+    // no additional unit tests
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReturnEmptyCollectionRatherThanNull.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReturnEmptyCollectionRatherThanNull.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data xmlns="http://pmd.sourceforge.net/rule-tests"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+   <test-code>
+      <description>Returning null array</description>
+      <expected-problems>1</expected-problems>
+      <code><![CDATA[
+public class Foo {
+    // Not a good idea...
+    public int []bar()
+    {
+        // ...
+        return null;
+    }
+}
+        ]]></code>
+   </test-code>
+   <test-code>
+      <description>Nonnull empty array</description>
+      <expected-problems>0</expected-problems>
+      <code><![CDATA[
+public class Foo {
+    // Good behavior
+    public String[] bar()
+    {
+        //...
+        return new String[0];
+    }
+}
+        ]]></code>
+   </test-code>
+   <test-code>
+      <description>Returning null instead of collection (List)</description>
+      <expected-problems>1</expected-problems>
+      <expected-linenumbers>5</expected-linenumbers>
+      <code><![CDATA[
+import java.util.List;
+
+public class Foo {
+    // Not a good idea...
+    public List<String> bar()
+    {
+        // ...
+        return null;
+    }
+}
+        ]]></code>
+   </test-code>
+   <test-code>
+      <description>Returning proper empty collection</description>
+      <expected-problems>0</expected-problems>
+      <code><![CDATA[
+import java.util.List;
+import java.util.Collections;
+
+public class Foo {
+    // Not a good idea...
+    public List<String> bar()
+    {
+        // ...
+        return Collections.emptyList();
+    }
+}
+        ]]></code>
+   </test-code>
+   <test-code>
+      <description>Returning null instead of collection (Set)</description>
+      <expected-problems>1</expected-problems>
+      <expected-linenumbers>5</expected-linenumbers>
+      <code><![CDATA[
+import java.util.Set;
+
+public class Foo {
+    // Not a good idea...
+    public Set<String> bar()
+    {
+        // ...
+        return null;
+    }
+}
+        ]]></code>
+   </test-code>
+   <test-code>
+      <description>Returning null instead of collection (Map)</description>
+      <expected-problems>1</expected-problems>
+      <expected-linenumbers>5</expected-linenumbers>
+      <code><![CDATA[
+import java.util.Map;
+
+public class Foo {
+    // Not a good idea...
+    public Map<String, String> bar()
+    {
+        // ...
+        return null;
+    }
+}
+        ]]></code>
+   </test-code>
+</test-data>


### PR DESCRIPTION
## Describe the PR

Create a new `ReturnEmptyCollectionRatherThanNull` to supersede the old `ReturnEmptyArrayRatherThanNull`.

The same principle applies not only to arrays, but to all collections (`java.util.Collections` even providing easy no-alloc methods to return empty maps, lists and sets).

I doubted if this should more generally look at any `java.lang.Iterable`, but I felt that was stretching it too much (and it would not on it's own consider maps).

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)
