### PR TITLE
[core] CPD: Optimize --skip-lexical-errors option

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPD.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPD.java
@@ -147,13 +147,12 @@ public class CPD {
     }
 
     private void addAndSkipLexicalErrors(SourceCode sourceCode) throws IOException {
-        TokenEntry.State savedTokenEntry = new TokenEntry.State(tokens.getTokens());
+        TokenEntry.State savedTokenEntry = new TokenEntry.State();
         try {
             addAndThrowLexicalError(sourceCode);
         } catch (TokenMgrError e) {
             System.err.println("Skipping " + sourceCode.getFileName() + ". Reason: " + e.getMessage());
-            tokens.getTokens().clear();
-            tokens.getTokens().addAll(savedTokenEntry.restore());
+            savedTokenEntry.restore(tokens.getTokens());
         }
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/TokenEntry.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/TokenEntry.java
@@ -4,8 +4,8 @@
 
 package net.sourceforge.pmd.cpd;
 
-import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -95,20 +95,22 @@ public class TokenEntry implements Comparable<TokenEntry> {
      */
     public static class State {
         private int tokenCount;
-        private Map<String, Integer> tokens;
-        private List<TokenEntry> entries;
+        private int tokensMapSize;
 
-        public State(List<TokenEntry> entries) {
+        public State() {
             this.tokenCount = TokenEntry.TOKEN_COUNT.get().intValue();
-            this.tokens = new HashMap<>(TokenEntry.TOKENS.get());
-            this.entries = new ArrayList<>(entries);
+            this.tokensMapSize = TokenEntry.TOKENS.get().size();
         }
 
-        public List<TokenEntry> restore() {
+        public void restore(List<TokenEntry> entries) {
             TokenEntry.TOKEN_COUNT.get().set(tokenCount);
-            TOKENS.get().clear();
-            TOKENS.get().putAll(tokens);
-            return entries;
+            Iterator<Map.Entry<String, Integer>> it = TOKENS.get().entrySet().iterator();
+            while (it.hasNext()) {
+                if (it.next().getValue() > tokensMapSize) {
+                    it.remove();
+                }
+            }
+            entries.subList(tokenCount, entries.size()).clear();
         }
     }
 


### PR DESCRIPTION
## Describe the PR

This PR optimizes the state saving mechanism for --skip-lexical-errors option:

1. Instead of copying the `tokens` array for all files processed so far, just save the array index and remove entries after the index when doing the recovery. This is appropriate because tokenizing the current file can't affect the tokens of previous files even when a lexical error occurs.
2. Similarly, instead of copying the "token content to unique integer" map, save the current map size and remove entries added afterwards when doing the recovery. The added entries can be easily identified because the unique integer is assigned as "current map size + 1".

I did some benchmarking and it shows that the performance gain is substantial for large projects:

- Project: https://github.com/pmd/pmd/ (Java / 2,871 files / 225,752 lines)
  - Before: 5.3 sec
  - After: 1.8 sec
- Project: https://github.com/Automattic/wp-calypso (JavaScript / 5,348 files / 584,286 lines)
  - Before: 22.6 sec
  - After: 2.8 sec
- Project: https://github.com/SAP/openui5 (JavaScript / 11,746 files / 2,819,699 lines)
  - Before: 450.7 sec
  - After: 28.1 sec

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

