### PR TITLE
[java] Update BigIntegerInstantiation

### DIFF
--- a/.ci/files/all-java.xml
+++ b/.ci/files/all-java.xml
@@ -291,7 +291,7 @@
     <rule ref="category/java/performance.xml/AvoidFileStream"/>
     <!-- <rule ref="category/java/performance.xml/AvoidInstantiatingObjectsInLoops"/> -->
     <rule ref="category/java/performance.xml/AvoidUsingShortType"/>
-    <!-- <rule ref="category/java/performance.xml/BigIntegerInstantiation"/> -->
+    <rule ref="category/java/performance.xml/BigIntegerInstantiation"/>
     <!-- <rule ref="category/java/performance.xml/BooleanInstantiation"/> -->
     <rule ref="category/java/performance.xml/ByteInstantiation"/>
     <rule ref="category/java/performance.xml/ConsecutiveAppendsShouldReuse"/>

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/BigIntegerInstantiationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/BigIntegerInstantiationRule.java
@@ -11,6 +11,7 @@ import java.util.Set;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import net.sourceforge.pmd.lang.LanguageRegistry;
+import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.lang.java.JavaLanguageModule;
 import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
@@ -37,8 +38,11 @@ public class BigIntegerInstantiationRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTConstructorCall node, Object data) {
-        boolean jdk15 = node.getAstInfo().getLanguageVersion()
+        LanguageVersion languageVersion = node.getAstInfo().getLanguageVersion();
+        boolean jdk15 = languageVersion
                 .compareTo(LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5")) >= 0;
+        boolean jdk9 = languageVersion
+                .compareTo(LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("9")) >= 0;
 
         if (TypeTestUtil.isA(BigInteger.class, node) || jdk15 && TypeTestUtil.isA(BigDecimal.class, node)) {
 
@@ -48,7 +52,8 @@ public class BigIntegerInstantiationRule extends AbstractJavaRulechainRule {
                 ASTExpression firstArg = arguments.get(0);
                 if (firstArg instanceof ASTStringLiteral) {
                     String img = ((ASTStringLiteral) firstArg).getConstValue();
-                    if (CONSTANTS.contains(img) || jdk15 && "10".equals(img)) {
+                    if (CONSTANTS.contains(img) || jdk15 && "10".equals(img)
+                            || jdk9 && "2".equals(img)) {
                         addViolation(data, node);
                     }
                 } else if (firstArg instanceof ASTNumericLiteral) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/BigIntegerInstantiationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/BigIntegerInstantiationRule.java
@@ -14,8 +14,6 @@ import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTNumericLiteral;
-import net.sourceforge.pmd.lang.java.ast.ASTStringLiteral;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.util.CollectionUtil;
@@ -46,19 +44,16 @@ public class BigIntegerInstantiationRule extends AbstractJavaRulechainRule {
             ASTArgumentList arguments = node.getArguments();
             if (arguments.size() == 1) {
                 ASTExpression firstArg = arguments.get(0);
-                if (firstArg instanceof ASTStringLiteral) {
-                    String img = ((ASTStringLiteral) firstArg).getConstValue();
-                    if (CONSTANTS.contains(img) || jdk15 && "10".equals(img)
-                            || jdk9 && "2".equals(img)) {
-                        addViolation(data, node);
-                    }
-                } else if (firstArg instanceof ASTNumericLiteral) {
-                    Number val = ((ASTNumericLiteral) firstArg).getConstValue();
-                    if (val.equals(0) || val.equals(1) || jdk15 && val.equals(10)) {
-                        addViolation(data, node);
-                    }
-                }
 
+                Object constValue = firstArg.getConstValue();
+                if (CONSTANTS.contains(constValue)
+                        || jdk15 && "10".equals(constValue)
+                        || jdk9 && "2".equals(constValue)
+                        || Integer.valueOf(0).equals(constValue)
+                        || Integer.valueOf(1).equals(constValue)
+                        || jdk15 && Integer.valueOf(10).equals(constValue)) {
+                    addViolation(data, node);
+                }
             }
         }
         return data;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/BigIntegerInstantiationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/BigIntegerInstantiationRule.java
@@ -10,9 +10,7 @@ import java.util.Set;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 
-import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersion;
-import net.sourceforge.pmd.lang.java.JavaLanguageModule;
 import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
@@ -39,10 +37,8 @@ public class BigIntegerInstantiationRule extends AbstractJavaRulechainRule {
     @Override
     public Object visit(ASTConstructorCall node, Object data) {
         LanguageVersion languageVersion = node.getAstInfo().getLanguageVersion();
-        boolean jdk15 = languageVersion
-                .compareTo(LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5")) >= 0;
-        boolean jdk9 = languageVersion
-                .compareTo(LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("9")) >= 0;
+        boolean jdk15 = languageVersion.compareToVersion("1.5") >= 0;
+        boolean jdk9 = languageVersion.compareToVersion("9") >= 0;
 
         if (TypeTestUtil.isA(BigInteger.class, node) || jdk15 && TypeTestUtil.isA(BigDecimal.class, node)) {
 

--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -313,7 +313,7 @@ public class UsingShort {
     <rule name="BigIntegerInstantiation"
           language="java"
           since="3.9"
-          message="Don't create instances of already existing BigInteger and BigDecimal (ZERO, ONE, TEN)"
+          message="Don''t create instances of already existing BigInteger and BigDecimal (ZERO, ONE, TEN)"
           class="net.sourceforge.pmd.lang.java.rule.performance.BigIntegerInstantiationRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_performance.html#bigintegerinstantiation">
         <description>
@@ -323,11 +323,14 @@ for Java 1.5 onwards, BigInteger.TEN and BigDecimal (BigDecimal.ZERO, BigDecimal
         <priority>3</priority>
         <example>
 <![CDATA[
-BigInteger bi = new BigInteger(1);       // reference BigInteger.ONE instead
+BigInteger bi1 = new BigInteger("1");    // reference BigInteger.ONE instead
 BigInteger bi2 = new BigInteger("0");    // reference BigInteger.ZERO instead
-BigInteger bi3 = new BigInteger(0.0);    // reference BigInteger.ZERO instead
-BigInteger bi4;
-bi4 = new BigInteger(0);                 // reference BigInteger.ZERO instead
+BigInteger bi3;
+bi3 = new BigInteger("0");               // reference BigInteger.ZERO instead
+
+BigDecimal bd1 = new BigDecimal(0);      // reference BigDecimal.ZERO instead
+BigDecimal bd2 = new BigDecimal("0.") ;  // reference BigDecimal.ZERO instead
+BigDecimal bd3 = new BigDecimal(10);     // reference BigDecimal.TEN instead
 ]]>
         </example>
     </rule>

--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -317,8 +317,9 @@ public class UsingShort {
           class="net.sourceforge.pmd.lang.java.rule.performance.BigIntegerInstantiationRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_performance.html#bigintegerinstantiation">
         <description>
-Don't create instances of already existing BigInteger (BigInteger.ZERO, BigInteger.ONE) and
-for Java 1.5 onwards, BigInteger.TEN and BigDecimal (BigDecimal.ZERO, BigDecimal.ONE, BigDecimal.TEN)
+Don't create instances of already existing BigInteger (`BigInteger.ZERO`, `BigInteger.ONE`),
+for Java 1.5 onwards, BigInteger.TEN and BigDecimal (`BigDecimal.ZERO`, `BigDecimal.ONE`, `BigDecimal.TEN`) and
+for Java 9 onwards `BigInteger.TWO`.
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/BigIntegerInstantiationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/BigIntegerInstantiationTest.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.lang.java.rule.performance;
 
 import net.sourceforge.pmd.testframework.PmdRuleTst;
 
-@org.junit.Ignore("Rule has not been updated yet")
 public class BigIntegerInstantiationTest extends PmdRuleTst {
     // no additional unit tests
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/BigIntegerInstantiation.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/BigIntegerInstantiation.xml
@@ -142,4 +142,18 @@ public class Foo {
         ]]></code>
         <source-type>java 1.5</source-type>
     </test-code>
+
+    <test-code>
+        <description>Fail, BigInteger(2) with Java9</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <code><![CDATA[
+import java.math.BigInteger;
+
+public class Foo {
+    BigInteger b = new BigInteger("2"); // Use BigInteger.TWO instead
+}
+        ]]></code>
+        <source-type>java 9</source-type>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/BigIntegerInstantiation.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/BigIntegerInstantiation.xml
@@ -156,4 +156,22 @@ public class Foo {
         ]]></code>
         <source-type>java 9</source-type>
     </test-code>
+
+    <test-code>
+        <description>False negative with indirect const string</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+import java.math.BigInteger;
+
+class Foo {
+    static final String Z = "0";
+    static { new BigInteger(Z); }
+
+    public void test(String a) {
+        new BigInteger(a); // not a const value
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/BigIntegerInstantiation.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/BigIntegerInstantiation.xml
@@ -7,6 +7,7 @@
     <test-code>
         <description>Fail, BigInteger(1)</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
         <code><![CDATA[
 import java.math.BigInteger;
 
@@ -33,6 +34,7 @@ public class Foo {
     <test-code>
         <description>Fail, BigInteger(0)</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
         <code><![CDATA[
 import java.math.BigInteger;
 
@@ -83,6 +85,7 @@ public class Foo {
     <test-code>
         <description>Fail, BigInteger(10) 1.5 mode</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
         <code><![CDATA[
 import java.math.BigInteger;
 
@@ -95,12 +98,14 @@ public class Foo {
 
     <test-code>
         <description>Fail, BigDecimal(1)</description>
-        <expected-problems>1</expected-problems>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>4,5</expected-linenumbers>
         <code><![CDATA[
 import java.math.BigDecimal;
 
 public class Foo {
-    BigDecimal b = new BigDecimal(1);
+    BigDecimal b1 = new BigDecimal(1);
+    BigDecimal b2 = new BigDecimal("1");
 }
         ]]></code>
         <source-type>java 1.5</source-type>
@@ -108,12 +113,14 @@ public class Foo {
 
     <test-code>
         <description>Fail, BigDecimal(10)</description>
-        <expected-problems>1</expected-problems>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>4,5</expected-linenumbers>
         <code><![CDATA[
 import java.math.BigDecimal;
 
 public class Foo {
-    BigDecimal b = new BigDecimal(10);
+    BigDecimal b1 = new BigDecimal(10);
+    BigDecimal b2 = new BigDecimal("10");
 }
         ]]></code>
         <source-type>java 1.5</source-type>
@@ -121,12 +128,16 @@ public class Foo {
 
     <test-code>
         <description>Fail, BigDecimal(0)</description>
-        <expected-problems>1</expected-problems>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>4,5,6</expected-linenumbers>
         <code><![CDATA[
 import java.math.BigDecimal;
 
 public class Foo {
-    BigDecimal b = new BigDecimal(0);
+    BigDecimal b1 = new BigDecimal(0);
+    BigDecimal b2 = new BigDecimal("0");
+    BigDecimal b3 = new BigDecimal("0.");
+    BigDecimal b4 = new BigDecimal("0.0"); // that's not ZERO - ZERO has no decimals, this has 1 decimal (scale)
 }
         ]]></code>
         <source-type>java 1.5</source-type>


### PR DESCRIPTION
## Describe the PR

Part of #2701 

It also adds support for BigInteger.TWO, which was added with Java9.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

