### PR TITLE
[ci] Run PMD on PMD with the latest snapshot

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -85,6 +85,18 @@ function build() {
     pmd_ci_log_group_end
 
     if pmd_ci_maven_isSnapshotBuild; then
+    pmd_ci_log_group_start "Executing PMD dogfood test"
+        ./mvnw versions:set -DnewVersion=${PMD_CI_MAVEN_PROJECT_VERSION}-dogfood -DgenerateBackupPoms=false
+        ./mvnw verify --show-version --errors --batch-mode --no-transfer-progress "${PMD_MAVEN_EXTRA_OPTS[@]}" \
+            -DskipTests \
+            -Dmaven.javadoc.skip=true \
+            -Dmaven.source.skip=true \
+            -Dcheckstyle.skip=true \
+            -Ppmd-dogfood \
+            -Dpmd.dogfood.version=${PMD_CI_MAVEN_PROJECT_VERSION}
+        ./mvnw versions:set -DnewVersion=${PMD_CI_MAVEN_PROJECT_VERSION} -DgenerateBackupPoms=false
+    pmd_ci_log_group_end
+
     pmd_ci_log_group_start "Executing build with sonar"
         # Note: Sonar also needs GITHUB_TOKEN (!)
         ./mvnw \

--- a/pom.xml
+++ b/pom.xml
@@ -1048,6 +1048,33 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>pmd-dogfood</id>
+            <properties>
+                <pmd.dogfood.version>${project.version}</pmd.dogfood.version>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-pmd-plugin</artifactId>
+                        <dependencies>
+                            <dependency>
+                                <groupId>net.sourceforge.pmd</groupId>
+                                <artifactId>pmd-core</artifactId>
+                                <version>${pmd.dogfood.version}</version>
+                            </dependency>
+                            <dependency>
+                                <groupId>net.sourceforge.pmd</groupId>
+                                <artifactId>pmd-java</artifactId>
+                                <version>${pmd.dogfood.version}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <modules>


### PR DESCRIPTION
## Describe the PR

This is only executed on push builds. In order to do this,
we must change the version temporarily to avoid a circular
dependency to ourselves.

The latest version is brought in via the maven profile "pmd-dogfood"
and the property "pmd.dogfood.version".

That way we hopefully see potential problems earlier.
