### PR TITLE
[ci] Stop autogenerating ruleset from branch differences

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -12,7 +12,7 @@ def get_args(base_branch, autogen = TRUE, patch_config = './pmd/.ci/files/all-ja
    '--patch-branch', 'HEAD',
    '--patch-config', patch_config,
    '--mode', 'online',
-   autogen ? '--auto-gen-config' : '--filter-with-patch-config',
+   # autogen ? '--auto-gen-config' : '--filter-with-patch-config',
    '--keep-reports',
    '--error-recovery',
    '--baseline-download-url', 'https://pmd-code.org/pmd-regression-tester/',


### PR DESCRIPTION
## Describe the PR

This prevents failing rules in pmd 7 to make the regression tester fail entirely. This is a stopgap, that we can revert when all rules have been ported (#2701)



## Related issues

<!-- PR relates to issues in the `pmd` repo: -->
The following PRs have recently had problems in CI that this should "solve":

- #3384
- #3389
- #3396
- #3397 
- 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

