### PR TITLE
[core] Internalize cpd.TokenEntry.State

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -25,6 +25,14 @@ This is a {{ site.pmd.release_type }} release.
 
 ### API Changes
 
+#### Internal API
+
+Those APIs are not intended to be used by clients, and will be hidden or removed with PMD 7.0.0.
+You can identify them with the `@InternalApi` annotation. You'll also get a deprecation warning.
+
+*   The inner class {% jdoc !!core::cpd.TokenEntry.State %} is considered to be internal API.
+    It will probably be moved away with PMD 7.
+
 ### External Contributions
 
 *   [#3367](https://github.com/pmd/pmd/pull/3367): \[apex] Check SOQL CRUD on for loops - [Jonathan Wiesel](https://github.com/jonathanwiesel)

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPD.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPD.java
@@ -147,12 +147,12 @@ public class CPD {
     }
 
     private void addAndSkipLexicalErrors(SourceCode sourceCode) throws IOException {
-        final TokenEntry.State savedState = tokens.snapshot();
+        final TokenEntry.State savedState = new TokenEntry.State();
         try {
             addAndThrowLexicalError(sourceCode);
         } catch (TokenMgrError e) {
             System.err.println("Skipping " + sourceCode.getFileName() + ". Reason: " + e.getMessage());
-            tokens.restore(savedState);
+            savedState.restore(tokens);
         }
     }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/TokenEntry.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/TokenEntry.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import net.sourceforge.pmd.annotation.InternalApi;
+
 public class TokenEntry implements Comparable<TokenEntry> {
 
     public static final TokenEntry EOF = new TokenEntry();
@@ -92,7 +94,11 @@ public class TokenEntry implements Comparable<TokenEntry> {
     /**
      * Helper class to preserve and restore the current state of the token
      * entries.
+     * 
+     * @deprecated This is internal API.
      */
+    @InternalApi
+    @Deprecated
     public static class State {
         private final int tokenCount;
         private final int tokensMapSize;
@@ -102,7 +108,8 @@ public class TokenEntry implements Comparable<TokenEntry> {
             this.tokensMapSize = TokenEntry.TOKENS.get().size();
         }
 
-        public void restore(final List<TokenEntry> entries) {
+        public void restore(Tokens tokens) {
+            final List<TokenEntry> entries = tokens.getTokens();
             TokenEntry.TOKEN_COUNT.get().set(tokenCount);
             final Iterator<Map.Entry<String, Integer>> it = TOKENS.get().entrySet().iterator();
             while (it.hasNext()) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/Tokens.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/Tokens.java
@@ -8,8 +8,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import net.sourceforge.pmd.cpd.TokenEntry.State;
-
 public class Tokens {
 
     private List<TokenEntry> tokens = new ArrayList<>();
@@ -45,13 +43,4 @@ public class Tokens {
     public List<TokenEntry> getTokens() {
         return tokens;
     }
-
-    public State snapshot() {
-        return new State();
-    }
-
-    public void restore(final State savedState) {
-        savedState.restore(tokens);
-    }
-
 }


### PR DESCRIPTION
## Describe the PR

Follow up on https://github.com/pmd/pmd/pull/3385/files#r665984073

@jsotuyod I needed to undo a bit your changes as otherwise we would expose "State" in our API in Tokens.

Instead of adding the old methods  back as deprecated I simply internalized the inner class as suggested by @oowekyala .

## Related issues

- Refs #3385 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

