### PR TITLE
[core] Fix LanguageVersion compareTo

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -48,6 +48,7 @@ supersedes it.
     *   [#3201](https://github.com/pmd/pmd/issues/3201): \[apex] ApexCRUDViolation doesn't report Database class DMLs, inline no-arg object instantiations and inline list initialization
     *   [#3329](https://github.com/pmd/pmd/issues/3329): \[apex] ApexCRUDViolation doesn't report SOQL for loops
 *   core
+    *   [#1603](https://github.com/pmd/pmd/issues/1603): \[core] Language version comparison
     *   [#3377](https://github.com/pmd/pmd/issues/3377): \[core] NPE when specifying report file in current directory in PMD CLI
     *   [#3387](https://github.com/pmd/pmd/issues/3387): \[core] CPD should avoid unnecessary copies when running with --skip-lexical-errors
 *   java-errorprone

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageVersion.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageVersion.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang;
 
+import java.util.List;
+
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.annotation.InternalApi;
 
@@ -102,27 +104,28 @@ public class LanguageVersion implements Comparable<LanguageVersion> {
 
     @Override
     public int compareTo(LanguageVersion o) {
-        if (o == null) {
-            return 1;
-        }
+        List<LanguageVersion> versions = language.getVersions();
+        int thisPosition = versions.indexOf(this);
+        int otherPosition = versions.indexOf(o);
+        return Integer.compare(thisPosition, otherPosition);
+    }
 
-        int comp = getName().compareTo(o.getName());
-        if (comp != 0) {
-            return comp;
+    /**
+     * Compare this version to another version of the same language identified
+     * by the given version string.
+     *
+     * @param versionString The version with which to compare
+     *
+     * @throws IllegalArgumentException If the argument is not a valid version
+     *                                  string for the parent language
+     */
+    public int compareToVersion(String versionString) {
+        LanguageVersion otherVersion = language.getVersion(versionString);
+        if (otherVersion == null) {
+            throw new IllegalArgumentException(
+                "No such version '" + versionString + "' for language " + language.getName());
         }
-
-        String[] vals1 = getName().split("\\.");
-        String[] vals2 = o.getName().split("\\.");
-        int i = 0;
-        while (i < vals1.length && i < vals2.length && vals1[i].equals(vals2[i])) {
-            i++;
-        }
-        if (i < vals1.length && i < vals2.length) {
-            int diff = Integer.valueOf(vals1[i]).compareTo(Integer.valueOf(vals2[i]));
-            return Integer.signum(diff);
-        } else {
-            return Integer.signum(vals1.length - vals2.length);
-        }
+        return this.compareTo(otherVersion);
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/BigIntegerInstantiationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/BigIntegerInstantiationRule.java
@@ -8,9 +8,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 
 import net.sourceforge.pmd.RuleContext;
-import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.java.JavaLanguageModule;
 import net.sourceforge.pmd.lang.java.ast.ASTAllocationExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTArguments;
 import net.sourceforge.pmd.lang.java.ast.ASTArrayDimsAndInits;
@@ -34,8 +32,7 @@ public class BigIntegerInstantiationRule extends AbstractJavaRule {
             return super.visit(node, data);
         }
 
-        boolean jdk15 = ((RuleContext) data).getLanguageVersion()
-                .compareTo(LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5")) >= 0;
+        boolean jdk15 = ((RuleContext) data).getLanguageVersion().compareToVersion("1.5") >= 0;
         if ((TypeTestUtil.isA(BigInteger.class, (ASTClassOrInterfaceType) type)
                 || jdk15 && TypeTestUtil.isA(BigDecimal.class, (ASTClassOrInterfaceType) type))
                 && !node.hasDescendantOfType(ASTArrayDimsAndInits.class)) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/UnnecessaryWrapperObjectCreationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/UnnecessaryWrapperObjectCreationRule.java
@@ -7,9 +7,7 @@ package net.sourceforge.pmd.lang.java.rule.performance;
 import java.util.Set;
 
 import net.sourceforge.pmd.RuleContext;
-import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.java.JavaLanguageModule;
 import net.sourceforge.pmd.lang.java.ast.ASTName;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryPrefix;
@@ -36,8 +34,7 @@ public class UnnecessaryWrapperObjectCreationRule extends AbstractJavaRule {
             image = image.substring(10);
         }
 
-        boolean checkBoolean = ((RuleContext) data).getLanguageVersion()
-                .compareTo(LanguageRegistry.getLanguage(JavaLanguageModule.NAME).getVersion("1.5")) >= 0;
+        boolean checkBoolean = ((RuleContext) data).getLanguageVersion().compareToVersion("1.5") >= 0;
 
         if (PREFIX_SET.contains(image) || checkBoolean && "Boolean.valueOf".equals(image)) {
             ASTPrimaryExpression parent = (ASTPrimaryExpression) node.getParent();

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/JavaLanguageModuleTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/JavaLanguageModuleTest.java
@@ -1,0 +1,51 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.sourceforge.pmd.lang.Language;
+import net.sourceforge.pmd.lang.LanguageRegistry;
+import net.sourceforge.pmd.lang.LanguageVersion;
+
+public class JavaLanguageModuleTest {
+    private Language javaLanguage = LanguageRegistry.getLanguage(JavaLanguageModule.NAME);
+
+    @Test
+    public void java9IsSmallerThanJava10() {
+        LanguageVersion java9 = javaLanguage.getVersion("9");
+        LanguageVersion java10 = javaLanguage.getVersion("10");
+
+        Assert.assertTrue("java9 should be smaller than java10", java9.compareTo(java10) < 0);
+    }
+
+    @Test
+    public void previewVersionShouldBeGreaterThanNonPreview() {
+        LanguageVersion java16 = javaLanguage.getVersion("16");
+        LanguageVersion java16p = javaLanguage.getVersion("16-preview");
+
+        Assert.assertTrue("java16-preview should be greater than java16", java16p.compareTo(java16) > 0);
+    }
+
+    @Test
+    public void testCompareToVersion() {
+        LanguageVersion java9 = javaLanguage.getVersion("9");
+        Assert.assertTrue("java9 should be smaller than java10", java9.compareToVersion("10") < 0);
+    }
+
+    @Test
+    public void allVersions() {
+        List<LanguageVersion> versions = javaLanguage.getVersions();
+        for (int i = 1; i < versions.size(); i++) {
+            LanguageVersion previous = versions.get(i - 1);
+            LanguageVersion current = versions.get(i);
+            Assert.assertTrue("Version " + previous + " should be smaller than " + current,
+                    previous.compareTo(current) < 0);
+        }
+    }
+}


### PR DESCRIPTION
## Describe the PR

This didn't work with java 9 compared to java 10,
as the full name was compared ("Java 9" vs. "Java 10")
as a string rather than using version numbers.

Now the logic is much simpler: The versions defined
for a language are ordered, new versions are always added
at the end.

Also backports the useful method "compareToVersion" from pmd 7
and use this in the rules BigIntegerInstatiation and
UnnecessaryWrapperObjectCreation.

## Related issues

- I found this problem while fixing #3393 . So after this is merged, that can be simplified.
- Fixes #1603

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

