### PR TITLE
[java] Fix #3403 about MethodNamingConventions and JUnit5 parameterized tests

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/MethodNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/MethodNamingConventionsRule.java
@@ -49,7 +49,7 @@ public class MethodNamingConventionsRule extends AbstractNamingConventionRule<AS
     }
 
     private boolean isJunit5Test(ASTMethodDeclaration node) {
-        return node.isAnnotationPresent("org.junit.jupiter.api.Test");
+        return node.isAnnotationPresent("org.junit.jupiter.api.Test") || node.isAnnotationPresent("org.junit.jupiter.params.ParameterizedTest");
     }
 
     private boolean isJunit4Test(ASTMethodDeclaration node) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/MethodNamingConventions.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/MethodNamingConventions.xml
@@ -212,9 +212,11 @@ public class TournamentTest {
         <expected-messages>
             <message>The JUnit 5 test method name 'testGetBestTeam' doesn't match '[a-z][A-Za-z]*Test'</message>
             <message>The JUnit 5 test method name 'getBestTeam' doesn't match '[a-z][A-Za-z]*Test'</message>
+            <message>The JUnit 5 test method name 'getWorstTeam' doesn't match '[a-z][A-Za-z]*Test'</message>
         </expected-messages>
         <code><![CDATA[
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
 
 public class TournamentTest {
     @Test // note that this is also a junit 3 test, but the junit 5 rule applies
@@ -223,6 +225,10 @@ public class TournamentTest {
 
     @Test // this is just a junit 5 test
     public void getBestTeam() {
+    }
+
+    @ParameterizedTest // this is a paramterized junit 5 test
+    public void getWorstTeam(String param) {
     }
 
     // this is ok

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/MethodNamingConventions.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/MethodNamingConventions.xml
@@ -207,8 +207,8 @@ public class TournamentTest {
     <test-code>
         <description>JUnit 5 test detection</description>
         <rule-property name="junit5TestPattern">[a-z][A-Za-z]*Test</rule-property>
-        <expected-problems>2</expected-problems>
-        <expected-linenumbers>5,9</expected-linenumbers>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>6,10,14</expected-linenumbers>
         <expected-messages>
             <message>The JUnit 5 test method name 'testGetBestTeam' doesn't match '[a-z][A-Za-z]*Test'</message>
             <message>The JUnit 5 test method name 'getBestTeam' doesn't match '[a-z][A-Za-z]*Test'</message>


### PR DESCRIPTION
## Describe the PR

- Consider parameterized JUnit5 tests for methodNaming Conventions ;
- Already fixed for PMD 7.0.0 but with no release date, I hope that this can be useful for PMD 6.x.x ;)

## Related issues

- Fixes #3403 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

