### PR TITLE
[java] InsufficientStringBufferDeclaration: Fix NPE

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
@@ -187,7 +187,7 @@ public class InsufficientStringBufferDeclarationRule extends AbstractJavaRulecha
             if (ifStatement != null) {
                 if (ifStatement.getThenBranch().descendants().any(n -> n == methodCall)) {
                     state.addBranch(ifStatement.getThenBranch(), counter);
-                } else {
+                } else if (ifStatement.getElseBranch() != null) {
                     state.addBranch(ifStatement.getElseBranch(), counter);
                 }
             } else if (switchStatement != null) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/InsufficientStringBufferDeclaration.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/InsufficientStringBufferDeclaration.xml
@@ -1312,4 +1312,27 @@ public class InsufficientStringBufferDeclaration {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>NPE when StringBuilder is used in lambda and if without else</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public class InsufficientStringBufferDeclarationNPE {
+    public void perform() {
+        boolean added;
+        String mode;
+        if (added) {
+            String msg = "";
+            Set<String> altns = new LinkedHashSet<>();
+            StringBuilder sb = new StringBuilder();
+            altns.forEach(s -> sb.append(System.lineSeparator()).append("\tat " + "foo"));
+            msg = sb.toString();
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
... when StringBuilder is used in lambda and if without else

Found this in one of the regression reports, e.g. https://chunk.io/pmd/6ba1372f8806483e8fe17a4901bc6823/diff2/openjdk-11/index.html#section-errors
In Patterns.java and IllegalAccessLogger.java
