### PR TITLE
Add TCs UselessStringValueOf

### DIFF
--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/UselessStringValueOf.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/UselessStringValueOf.xml
@@ -125,4 +125,28 @@ public class Test {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>False positive UselessStringValueOfRule for sum of shorts</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Test {
+    private short getPrefix(long id) {
+        return 0;
+    }
+
+    private short getTimestamp(long id) {
+        return 0;
+    }
+
+    private short getCounter(long id) {
+        return 0;
+    }
+
+    public String toShortString(long id) {
+        return String.valueOf(getPrefix(id)) + getTimestamp(id) + getCounter(id);
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/UselessStringValueOf.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/UselessStringValueOf.xml
@@ -112,4 +112,17 @@ public class Test {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>False positive UselessStringValueOfRule for valueOf(char [], int, int)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Test {
+
+    public String test(char buf[], int offset, int len) {
+        print("XML Parser characters: " + String.valueOf(buf, offset, len));
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
```
2021-08-28T12:16:25.6393089Z [INFO] Results:
2021-08-28T12:16:25.6395375Z [INFO] 
2021-08-28T12:16:25.6397380Z [ERROR] Failures: 
2021-08-28T12:16:25.6401010Z [ERROR] net.sourceforge.pmd.lang.java.rule.performance.UselessStringValueOfTest.null
2021-08-28T12:16:25.6404768Z [INFO]   Run 1: PASS
2021-08-28T12:16:25.6406445Z [INFO]   Run 2: PASS
2021-08-28T12:16:25.6408088Z [INFO]   Run 3: PASS
2021-08-28T12:16:25.6409829Z [INFO]   Run 4: PASS
2021-08-28T12:16:25.6411407Z [INFO]   Run 5: PASS
2021-08-28T12:16:25.6413009Z [INFO]   Run 6: PASS
2021-08-28T12:16:25.6415049Z [INFO]   Run 7: PASS
2021-08-28T12:16:25.6416875Z [INFO]   Run 8: PASS
2021-08-28T12:16:25.6419763Z [ERROR]   Run 9: UselessStringValueOfTest>RuleTst.runTest:157 "False positive UselessStringValueOfRule for valueOf(char [], int, int)" resulted in wrong number of failures, expected:<0> but was:<1>
2021-08-28T12:16:25.6425909Z [ERROR]   Run 10: UselessStringValueOfTest>RuleTst.runTest:157 "False positive UselessStringValueOfRule for sum of shorts" resulted in wrong number of failures, expected:<0> but was:<1>
2021-08-28T12:16:25.6431483Z [INFO] 
2021-08-28T12:16:25.6434344Z [INFO] 
2021-08-28T12:16:25.6437345Z [ERROR] Tests run: 4710, Failures: 1, Errors: 0, Skipped: 4
```