### PR TITLE
[java] AvoidAccessibilityAlteration: add tests and fix rule

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -16,6 +16,9 @@ This is a {{ site.pmd.release_type }} release.
 
 ### Fixed Issues
 
+*   java-errorprone
+    *   [#3493](https://github.com/pmd/pmd/pull/3493): \[java] AvoidAccessibilityAlteration: add tests and fix rule
+
 ### API Changes
 
 ### External Contributions

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQueryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQueryTest.java
@@ -193,6 +193,16 @@ public class SaxonXPathRuleQueryTest {
         assertExpression("DocumentSorter((LetExpression(LazyExpression(CardinalityChecker(ItemChecker(UntypedAtomicConverter(Atomizer($testClassPattern))))), (((/)/descendant::element(dummyNode, xs:anyType))[matches(CardinalityChecker(ItemChecker(UntypedAtomicConverter(Atomizer(attribute::attribute(SimpleName, xs:anyAtomicType))))), $zz:zz952562199)]))/child::element(foo, xs:anyType)))", query.nodeNameToXPaths.get(SaxonXPathRuleQuery.AST_ROOT).get(0));
     }
 
+    @Test
+    public void ruleChainVisitWithTwoFunctions() {
+        SaxonXPathRuleQuery query = createQuery("//dummyNode[ends-with(@Image, 'foo')][pmd-dummy:typeIs('bar')]");
+        List<String> ruleChainVisits = query.getRuleChainVisits();
+        Assert.assertEquals(1, ruleChainVisits.size());
+        Assert.assertTrue(ruleChainVisits.contains("dummyNode"));
+        Assert.assertEquals(2, query.nodeNameToXPaths.size());
+        assertExpression("((self::node()[ends-with(CardinalityChecker(ItemChecker(UntypedAtomicConverter(Atomizer(attribute::attribute(Image, xs:anyAtomicType))))), \"foo\")])[pmd-dummy:typeIs(\"bar\")])", query.nodeNameToXPaths.get("dummyNode").get(0));
+    }
+
     private static void assertExpression(String expected, Expression actual) {
         Assert.assertEquals(normalizeExprDump(expected),
                             normalizeExprDump(actual.toString()));

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -56,7 +56,7 @@ public class StaticField {
     <rule name="AvoidAccessibilityAlteration"
           language="java"
           since="4.1"
-          message="You should not modify visibility of class or methods using getDeclaredConstructors(), getDeclaredConstructor(Class[]), setAccessible() or PrivilegedAction."
+          message="You should not modify visibility of constructors, methods or fields using setAccessible()"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#avoidaccessibilityalteration">
         <description>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -67,6 +67,11 @@ This gives access to normally protected data which violates the principle of enc
 This rule detects calls to `setAccessible` and finds possible accessibility alterations.
 If the call to `setAccessible` is wrapped within a `PrivilegedAction`, then the access alteration
 is assumed to be deliberate and is not reported.
+
+Note that with Java 17 the Security Manager, which is used for `PrivilegedAction` execution,
+is deprecated: [JEP 411: Deprecate the Security Manager for Removal](https://openjdk.java.net/jeps/411).
+For future-proof code, deliberate access alteration should be suppressed using the usual
+suppression methods (e.g. by using `@SuppressWarnings` annotation).
         </description>
         <priority>3</priority>
         <properties>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -60,9 +60,13 @@ public class StaticField {
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#avoidaccessibilityalteration">
         <description>
-Methods such as getDeclaredConstructors(), getDeclaredConstructor(Class[]) and setAccessible(),
-as the interface PrivilegedAction, allow for the runtime alteration of variable, class, or
-method visibility, even if they are private. This violates the principle of encapsulation.
+Methods such as `getDeclaredConstructors()`, `getDeclaredMethods()`, and `getDeclaredFields()` also
+return private constructors, methods and fields. These can be made accessible by calling `setAccessible(true)`.
+This gives access to normally protected data which violates the principle of encapsulation.
+
+This rule detects calls to `setAccessible` and finds possible accessibility alterations.
+If the call to `setAccessible` is wrapped within a `PrivilegedAction`, then the access alteration
+is assumed to be deliberate and is not reported.
         </description>
         <priority>3</priority>
         <properties>
@@ -70,60 +74,49 @@ method visibility, even if they are private. This violates the principle of enca
             <property name="xpath">
                 <value>
 <![CDATA[
-//PrimaryExpression[
-(
-(PrimarySuffix[
-        ends-with(@Image,'getDeclaredConstructors')
-                or
-        ends-with(@Image,'getDeclaredConstructor')
-                or
-        ends-with(@Image,'setAccessible')
-        ])
-or
-(PrimaryPrefix/Name[
-        ends-with(@Image,'getDeclaredConstructor')
-        or
-        ends-with(@Image,'getDeclaredConstructors')
-        or
-        starts-with(@Image,'AccessibleObject.setAccessible')
-        ])
-)
-and
-(//ImportDeclaration/Name[
-        contains(@Image,'java.security.PrivilegedAction')])
-]
+//PrimaryPrefix
+    [Name[ends-with(@Image, '.setAccessible')]]
+    [pmd-java:typeIs('java.lang.reflect.AccessibleObject')]
+    (: exclude anonymous privileged action classes :)
+    [not(ancestor::AllocationExpression[pmd-java:typeIs('java.security.PrivilegedAction')])]
+    (: exclude inner privileged action classes :)
+    [not(ancestor::ClassOrInterfaceDeclaration[1][pmd-java:typeIs('java.security.PrivilegedAction')])]
 ]]>
                 </value>
             </property>
         </properties>
         <example>
 <![CDATA[
-import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.Method;
+import java.security.AccessController;
 import java.security.PrivilegedAction;
 
 public class Violation {
-  public void invalidCallsInMethod() throws SecurityException, NoSuchMethodException {
-    // Possible call to forbidden getDeclaredConstructors
-    Class[] arrayOfClass = new Class[1];
-    this.getClass().getDeclaredConstructors();
-    this.getClass().getDeclaredConstructor(arrayOfClass);
-    Class clazz = this.getClass();
-    clazz.getDeclaredConstructor(arrayOfClass);
-    clazz.getDeclaredConstructors();
-      // Possible call to forbidden setAccessible
-    clazz.getMethod("", arrayOfClass).setAccessible(false);
-    AccessibleObject.setAccessible(null, false);
-    Method.setAccessible(null, false);
-    Method[] methodsArray = clazz.getMethods();
-    int nbMethod;
-    for ( nbMethod = 0; nbMethod < methodsArray.length; nbMethod++ ) {
-      methodsArray[nbMethod].setAccessible(false);
-    }
+    private void invalidSetAccessCalls() throws NoSuchMethodException, SecurityException {
+        Constructor<?> constructor = this.getClass().getDeclaredConstructor(String.class);
+        // call to forbidden setAccessible
+        constructor.setAccessible(true);
 
-      // Possible call to forbidden PrivilegedAction
-    PrivilegedAction priv = (PrivilegedAction) new Object(); priv.run();
-  }
+        Method privateMethod = this.getClass().getDeclaredMethod("aPrivateMethod");
+        // call to forbidden setAccessible
+        privateMethod.setAccessible(true);
+
+        // deliberate accessibility alteration
+        String privateField = AccessController.doPrivileged(new PrivilegedAction<String>() {
+            @Override
+            public String run() {
+                try {
+                    Field field = Violation.class.getDeclaredField("aPrivateField");
+                    field.setAccessible(true);
+                    return (String) field.get(null);
+                } catch (ReflectiveOperationException | SecurityException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+    }
 }
 ]]>
         </example>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -76,6 +76,7 @@ is assumed to be deliberate and is not reported.
 <![CDATA[
 //PrimaryPrefix
     [Name[ends-with(@Image, '.setAccessible')]]
+    [not(following-sibling::PrimarySuffix/Arguments//BooleanLiteral[@True = false()])]
     [pmd-java:typeIs('java.lang.reflect.AccessibleObject')]
     (: exclude anonymous privileged action classes :)
     [not(ancestor::AllocationExpression[pmd-java:typeIs('java.security.PrivilegedAction')])]

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidAccessibilityAlterationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidAccessibilityAlterationTest.java
@@ -1,0 +1,11 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.errorprone;
+
+import net.sourceforge.pmd.testframework.PmdRuleTst;
+
+public class AvoidAccessibilityAlterationTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidAccessibilityAlteration.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidAccessibilityAlteration.xml
@@ -165,4 +165,20 @@ public class NoViolation { {
 } }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>setAccessible(false) is ok</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.lang.reflect.Constructor;
+
+public class Violation {
+    private void invalidSetAccessCalls() throws NoSuchMethodException, SecurityException {
+        Constructor<?> constructor = this.getClass().getDeclaredConstructor(String.class);
+        // call to setAccessible with false - that's ok
+        constructor.setAccessible(false);
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidAccessibilityAlteration.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidAccessibilityAlteration.xml
@@ -170,6 +170,7 @@ public class NoViolation { {
         <description>setAccessible(false) is ok</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Constructor;
 
 public class Violation {
@@ -177,6 +178,10 @@ public class Violation {
         Constructor<?> constructor = this.getClass().getDeclaredConstructor(String.class);
         // call to setAccessible with false - that's ok
         constructor.setAccessible(false);
+
+        Constructor<?>[] constructors = this.getClass().getConstructors();
+        AccessibleObject.setAccessible(constructors, false);
+        Constructor.setAccessible(constructors, false);
     }
 }
         ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidAccessibilityAlteration.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidAccessibilityAlteration.xml
@@ -150,4 +150,19 @@ public class Violation {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>false positive when accessible object is used as primary prefix</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.lang.reflect.Constructor;
+import java.util.List;
+
+public class NoViolation { {
+    List<Constructor<?>> list = new ArrayList<>();
+    Constructor<?> ctor = NoViolation.class.getConstructor();
+    list.add(ctor);
+} }
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidAccessibilityAlteration.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidAccessibilityAlteration.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+    <test-code>
+        <description>Example code snippet</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>11,15</expected-linenumbers>
+        <code><![CDATA[
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+public class Violation {
+    private void invalidSetAccessCalls() throws NoSuchMethodException, SecurityException {
+        Constructor<?> constructor = this.getClass().getDeclaredConstructor(String.class);
+        // call to forbidden setAccessible
+        constructor.setAccessible(true);
+
+        Method privateMethod = this.getClass().getDeclaredMethod("aPrivateMethod");
+        // call to forbidden setAccessible
+        privateMethod.setAccessible(true);
+
+        // deliberate accessibility alteration
+        String privateField = AccessController.doPrivileged(new PrivilegedAction<String>() {
+            @Override
+            public String run() {
+                try {
+                    Field field = Violation.class.getDeclaredField("aPrivateField");
+                    field.setAccessible(true);
+                    return (String) field.get(null);
+                } catch (ReflectiveOperationException | SecurityException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Detect calls to setAccessible</description>
+        <expected-problems>9</expected-problems>
+        <expected-linenumbers>9,12,13,16,19,20,23,26,27</expected-linenumbers>
+        <code><![CDATA[
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+
+public class Violation {
+    public void invalidSetAccessibleCalls() {
+        for (Constructor<?> constructor : this.getClass().getConstructors()) {
+            constructor.setAccessible(true);
+        }
+        Constructor<?>[] constructors = this.getClass().getConstructors();
+        AccessibleObject.setAccessible(constructors, true);
+        Constructor.setAccessible(constructors, true);
+
+        for (Method method : this.getClass().getMethods()) {
+            method.setAccessible(true);
+        }
+        Method[] methods = this.getClass().getMethods();
+        AccessibleObject.setAccessible(methods, true);
+        Method.setAccessible(methods, true);
+
+        for (Field field : this.getClass().getFields()) {
+            field.setAccessible(true);
+        }
+        Field[] fields = this.getClass().getFields();
+        AccessibleObject.setAccessible(fields, true);
+        Field.setAccessible(fields, true);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code regressionTest="false">
+        <!-- Note: type res doesn't work well on method call chains in PMD 6, so none
+             of these are detected. -->
+        <description>Make sure to detect method call chains</description>
+        <expected-problems>6</expected-problems>
+        <expected-linenumbers>3,4,5,6,7,8</expected-linenumbers>
+        <code><![CDATA[
+public class Violation {
+    public void invalidSetAccessibleCalls() {
+        this.getClass().getDeclaredConstructor(String.class).setAccessible(true);
+        this.getClass().getDeclaredMethod("aPrivateMethod").setAccessible(true);
+        this.getClass().getDeclaredField("aPrivateField").setAccessible(true);
+
+        Violation.class.getDeclaredConstructor(String.class).setAccessible(true);
+        Violation.class.getDeclaredMethod("aPrivateMethod").setAccessible(true);
+        Violation.class.getDeclaredField("aPrivateField").setAccessible(true);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Anonymous privileged action is OK</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Method;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+public class NoViolation {
+    public void explicitAccessibilityAlteration() {
+        Method[] methods = AccessController.doPrivileged(new PrivilegedAction<Method[]>() {
+            @Override
+            public Method[] run() {
+                Method[] declaredMethods = Violation.class.getDeclaredMethods();
+                AccessibleObject.setAccessible(declaredMethods, true);
+                return declaredMethods;
+            }
+        });
+        try {
+            methods[0].invoke(null);
+        } catch (ReflectiveOperationException e) {
+            e.printStackTrace();
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Inner class privileged action is OK</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.lang.reflect.AccessibleObject;
+import java.lang.reflect.Field;
+import java.security.PrivilegedAction;
+
+public class Violation {
+    private static class MyPrivilegedAction implements PrivilegedAction<Field[]> {
+        @Override
+        public Field[] run() {
+            Field[] declaredFields = Violation.class.getDeclaredFields();
+            AccessibleObject.setAccessible(declaredFields, true);
+            return declaredFields;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+</test-data>


### PR DESCRIPTION
## Describe the PR

This adds tests for the rule - they were completely missing.
It also changes the rule to be less surprising (at least for me).

**Main changes:**

* only calls to `setAccessible(true)` are now detected.
* a call to `setAccessible(false)` is now explicitly allowed (this would restore the Java language access controls, so that private member can't be accessed anymore from outside)
* previously calls to `getDeclaredContructors()` (etc..) were detected, but just getting these reflected objects doesn't do any harm yet. So, these calls are not reported anymore. This results in maybe different line numbers.
* When the call to `setAccessible(true)` is within a `PrivilegedAction`, then it is considered deliberate and ignored.

## Related issues

- See also #3010

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

