### PR TITLE
[core] Fix XPath rulechain with combined node tests

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -16,6 +16,9 @@ This is a {{ site.pmd.release_type }} release.
 
 ### Fixed Issues
 
+*   core
+    *   [#3499](https://github.com/pmd/pmd/pull/3499): \[core] Fix XPath rulechain with combined node tests
+
 ### API Changes
 
 ### External Contributions

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/RuleChainAnalyzer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/RuleChainAnalyzer.java
@@ -17,6 +17,7 @@ import net.sf.saxon.expr.LazyExpression;
 import net.sf.saxon.expr.PathExpression;
 import net.sf.saxon.expr.RootExpression;
 import net.sf.saxon.om.Axis;
+import net.sf.saxon.pattern.CombinedNodeTest;
 import net.sf.saxon.pattern.NameTest;
 import net.sf.saxon.sort.DocumentSorter;
 import net.sf.saxon.type.Type;
@@ -40,6 +41,7 @@ public class RuleChainAnalyzer extends SaxonExprVisitor {
     private boolean rootElementReplaced;
     private boolean insideLazyExpression;
     private boolean foundPathInsideLazy;
+    private boolean foundCombinedNodeTest;
 
     public RuleChainAnalyzer(Configuration currentConfiguration) {
         this.configuration = currentConfiguration;
@@ -93,13 +95,15 @@ public class RuleChainAnalyzer extends SaxonExprVisitor {
 
     @Override
     public Expression visit(AxisExpression e) {
-        if (rootElement == null && e.getNodeTest() instanceof NameTest) {
+        if (rootElement == null && e.getNodeTest() instanceof NameTest && !foundCombinedNodeTest) {
             NameTest test = (NameTest) e.getNodeTest();
             if (test.getPrimitiveType() == Type.ELEMENT && e.getAxis() == Axis.DESCENDANT) {
                 rootElement = configuration.getNamePool().getClarkName(test.getFingerprint());
             } else if (test.getPrimitiveType() == Type.ELEMENT && e.getAxis() == Axis.CHILD) {
                 rootElement = configuration.getNamePool().getClarkName(test.getFingerprint());
             }
+        } else if (e.getNodeTest() instanceof CombinedNodeTest) {
+            foundCombinedNodeTest = true;
         }
         return super.visit(e);
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQueryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQueryTest.java
@@ -256,4 +256,35 @@ public class SaxonXPathRuleQueryTest {
         List<String> ruleChainVisits = query.getRuleChainVisits();
         Assert.assertEquals(0, ruleChainVisits.size());
     }
+
+    @Test
+    public void ruleChainWithUnionsCustomFunctionsVariant1() {
+        SaxonXPathRuleQuery query = createQuery("(//ForStatement | //WhileStatement | //DoStatement)//dummyNode[pmd-dummy:typeIs(@Image)]");
+        List<String> ruleChainVisits = query.getRuleChainVisits();
+        Assert.assertEquals(0, ruleChainVisits.size());
+    }
+
+    @Test
+    public void ruleChainWithUnionsCustomFunctionsVariant2() {
+        SaxonXPathRuleQuery query = createQuery("//(ForStatement | WhileStatement | DoStatement)//dummyNode[pmd-dummy:typeIs(@Image)]");
+        List<String> ruleChainVisits = query.getRuleChainVisits();
+        Assert.assertEquals(0, ruleChainVisits.size());
+    }
+
+    @Test
+    public void ruleChainWithUnionsCustomFunctionsVariant3() {
+        SaxonXPathRuleQuery query = createQuery("//ForStatement//dummyNode[pmd-dummy:typeIs(@Image)]"
+                + " | //WhileStatement//dummyNode[pmd-dummy:typeIs(@Image)]"
+                + " | //DoStatement//dummyNode[pmd-dummy:typeIs(@Image)]");
+        List<String> ruleChainVisits = query.getRuleChainVisits();
+        Assert.assertEquals(3, ruleChainVisits.size());
+        Assert.assertTrue(ruleChainVisits.contains("ForStatement"));
+        Assert.assertTrue(ruleChainVisits.contains("WhileStatement"));
+        Assert.assertTrue(ruleChainVisits.contains("DoStatement"));
+
+        final String expectedSubexpression = "((self::node()/descendant-or-self::node())/(child::element(dummyNode, xs:anyType)[pmd-dummy:typeIs(CardinalityChecker(ItemChecker(UntypedAtomicConverter(Atomizer(attribute::attribute(Image, xs:anyAtomicType))))))]))";
+        assertExpression(expectedSubexpression, query.nodeNameToXPaths.get("ForStatement").get(0));
+        assertExpression(expectedSubexpression, query.nodeNameToXPaths.get("WhileStatement").get(0));
+        assertExpression(expectedSubexpression, query.nodeNameToXPaths.get("DoStatement").get(0));
+    }
 }


### PR DESCRIPTION
## Describe the PR

For now, we don't try to optimize the expression for
rulechain. Although it would be theoretically possible:
the manual optimization looks like variant3 in the
unit test.

The expression

```
//(NodeA | NodeB | NodeC)//NodeD[pmd:customFunction('foo')]
```

was not optimized correctly - the first part with the combined node test was ignored, so that all NodeD nodes have been found.

The equivalent expression

```
(//NodeA | //NodeB | //NodeC)//NodeD[pmd:customFunction('foo')]
```

suffered from the same problem.

The workaround is to expand the expression manually:

```
//NodeA//NodeD[pmd:customFunction('foo')]
|
//NodeB//NodeD[pmd:customFunction('foo')]
|
//NodeC//NodeD[pmd:customFunction('foo')]
```

## Related issues

- See https://stackoverflow.com/questions/69012708/how-do-i-create-a-custom-pmd-rule-to-check-if-an-instance-of-dslcontext-is-begin

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

