### PR TITLE
[javascript] NPE while creating rule violation when specifying explicit line numbers

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/ParametricRuleViolation.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/ParametricRuleViolation.java
@@ -66,13 +66,6 @@ public class ParametricRuleViolation<T extends Node> implements RuleViolation {
 
     }
 
-    public ParametricRuleViolation(Rule theRule, RuleContext ctx, T node, String message,
-            int beginLine, int endLine) {
-        this(theRule, ctx, node, message);
-        this.beginLine = beginLine;
-        this.endLine = endLine;
-    }
-
     private void setSuppression(Rule rule, T node) {
 
         String regex = rule.getProperty(Rule.VIOLATION_SUPPRESS_REGEX_DESCRIPTOR); // Regex

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/ParametricRuleViolation.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/ParametricRuleViolation.java
@@ -66,6 +66,13 @@ public class ParametricRuleViolation<T extends Node> implements RuleViolation {
 
     }
 
+    public ParametricRuleViolation(Rule theRule, RuleContext ctx, T node, String message,
+            int beginLine, int endLine) {
+        this(theRule, ctx, node, message);
+        this.beginLine = beginLine;
+        this.endLine = endLine;
+    }
+
     private void setSuppression(Rule rule, T node) {
 
         String regex = rule.getProperty(Rule.VIOLATION_SUPPRESS_REGEX_DESCRIPTOR); // Regex

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/rule/EcmascriptRuleViolationFactory.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/rule/EcmascriptRuleViolationFactory.java
@@ -35,6 +35,6 @@ public final class EcmascriptRuleViolationFactory extends AbstractRuleViolationF
     @Override
     protected RuleViolation createRuleViolation(Rule rule, RuleContext ruleContext, Node node, String message,
                                                 int beginLine, int endLine) {
-        return null; // FIXME
+        return new ParametricRuleViolation<>(rule, ruleContext, (EcmascriptNode) node, message, beginLine, endLine);
     }
 }

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/rule/EcmascriptRuleViolationFactory.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/rule/EcmascriptRuleViolationFactory.java
@@ -26,15 +26,16 @@ public final class EcmascriptRuleViolationFactory extends AbstractRuleViolationF
     private EcmascriptRuleViolationFactory() {
     }
 
-    @SuppressWarnings("rawtypes")
     @Override
     protected RuleViolation createRuleViolation(Rule rule, RuleContext ruleContext, Node node, String message) {
-        return new ParametricRuleViolation<>(rule, ruleContext, (EcmascriptNode) node, message);
+        return new ParametricRuleViolation<>(rule, ruleContext, (EcmascriptNode<?>) node, message);
     }
 
     @Override
     protected RuleViolation createRuleViolation(Rule rule, RuleContext ruleContext, Node node, String message,
                                                 int beginLine, int endLine) {
-        return new ParametricRuleViolation<>(rule, ruleContext, (EcmascriptNode) node, message, beginLine, endLine);
+        ParametricRuleViolation<EcmascriptNode<?>> ruleViolation = new ParametricRuleViolation<>(rule, ruleContext, (EcmascriptNode<?>) node, message);
+        ruleViolation.setLines(beginLine, endLine);
+        return ruleViolation;
     }
 }

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/EcmasccriptLanguageModuleTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/EcmasccriptLanguageModuleTest.java
@@ -1,0 +1,46 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.ecmascript;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.RuleContext;
+import net.sourceforge.pmd.RuleViolation;
+import net.sourceforge.pmd.lang.LanguageRegistry;
+import net.sourceforge.pmd.lang.LanguageVersion;
+import net.sourceforge.pmd.lang.LanguageVersionHandler;
+import net.sourceforge.pmd.lang.ecmascript.ast.ASTAstRoot;
+import net.sourceforge.pmd.lang.ecmascript.ast.JsParsingHelper;
+import net.sourceforge.pmd.lang.ecmascript.rule.AbstractEcmascriptRule;
+import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
+
+public class EcmasccriptLanguageModuleTest {
+    private Rule rule = new AbstractEcmascriptRule() { };
+    private ASTAstRoot node = JsParsingHelper.DEFAULT.parse("function a() {}");
+    private LanguageVersion js = LanguageRegistry.getLanguage(EcmascriptLanguageModule.NAME).getDefaultVersion();
+    private LanguageVersionHandler languageVersionHandler = js.getLanguageVersionHandler();
+    private RuleViolationFactory ruleViolationFactory = languageVersionHandler.getRuleViolationFactory();
+
+    @Test
+    public void canCreateRuleViolation() {
+        RuleContext context = new RuleContext();
+        ruleViolationFactory.addViolation(context, rule, node, "the message", new Object[0]);
+        Assert.assertEquals(1, context.getReport().getViolations().size());
+        RuleViolation ruleViolation = context.getReport().getViolations().get(0);
+        Assert.assertEquals(1, ruleViolation.getBeginLine());
+    }
+
+    @Test
+    public void canCreateRuleViolationWithLineNumbers() {
+        RuleContext context = new RuleContext();
+        ruleViolationFactory.addViolation(context, rule, node, "the message", 5, 7, new Object[0]);
+        Assert.assertEquals(1, context.getReport().getViolations().size());
+        RuleViolation ruleViolation = context.getReport().getViolations().get(0);
+        Assert.assertEquals(5, ruleViolation.getBeginLine());
+        Assert.assertEquals(7, ruleViolation.getEndLine());
+    }
+}


### PR DESCRIPTION
## Describe the PR

AbstractEcmascriptRule has a function that takes begin and end lines as parameters. However when using, it produces a null pointer exception. This solution adds the call to the constructor for ParametricRuleViolation in which it was added support for those two line parameters. The new constructor calls the default constructor and then sets the line parameters. 

## Related issues

- Fixes #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

