### PR TITLE
[java] InvalidLogMessageFormat: False positive with message and exception in a block inside a lambda

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidLogMessageFormatRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/InvalidLogMessageFormatRule.java
@@ -35,6 +35,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.lang.symboltable.NameDeclaration;
+import net.sourceforge.pmd.lang.symboltable.Scope;
 
 public class InvalidLogMessageFormatRule extends AbstractJavaRule {
 
@@ -217,14 +218,17 @@ public class InvalidLogMessageFormatRule extends AbstractJavaRule {
                 varName = name.getImage();
             }
         }
-        for (NameDeclaration decl : prefix.getScope().getDeclarations().keySet()) {
-            if (decl.getName().equals(varName)) {
-                if (decl.getNode().getParent() instanceof ASTLambdaExpression) {
+        Scope scope = prefix == null ? null : prefix.getScope();
+        while (scope != null) {
+            // Try recursively to find the expected NameDeclaration
+            for (NameDeclaration decl : scope.getDeclarations().keySet()) {
+                if (decl.getName().equals(varName)) {
                     // If the last parameter is a lambda parameter, then we also ignore it - regardless of the type.
                     // This is actually a workaround, since type resolution doesn't resolve the types of lambda parameters.
-                    return true;
+                    return decl.getNode().getParent() instanceof ASTLambdaExpression;
                 }
             }
+            scope = scope.getParent();
         }
         return false;
     }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidLogMessageFormat.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/InvalidLogMessageFormat.xml
@@ -175,6 +175,27 @@ public class InvalidSl4jExceptionBug1541 {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>#3560 [java] InvalidLogMessageFormat: False positive with message and exception in a block inside a lambda</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.function.Consumer;
+
+public class InvalidSl4jExceptionBug3560 {
+    private static final Logger LOGGER = LoggerFactory.getLogger(InvalidSl4jExceptionBug3560.class);
+
+    public static Consumer<Throwable> build() {
+        return e -> {
+            if (e instanceof RuntimeException) {
+                LOGGER.warn("Unexpected RuntimeException", e);
+            }
+        };
+    }
+}
+        ]]></code>
+    </test-code>
 
     <test-code>
         <description>#1551 [java] InvalidSlf4jMessageFormat: fails with NPE</description>
@@ -868,7 +889,7 @@ class InvalidLogMessageFormatTest {
 }
         ]]></code>
     </test-code>
-    
+
     <test-code>
         <description>#2431 IndexOutOfBoundsException when only logging exception message</description>
         <expected-problems>0</expected-problems>


### PR DESCRIPTION
## Describe the PR

PMD cannot properly validate the rule `InvalidLogMessageFormat` when the code is inside a block in a lambda as it only checks the scope of the current block instead of iterating until it finds the scope with the corresponding variable.

## Related issues

- Fixes #3560

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

