### PR TITLE
[apex] Fix for #3566 - Added new configuration property reportMissingDescription to ApexDocRule

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/documentation/ApexDocRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/documentation/ApexDocRule.java
@@ -44,9 +44,14 @@ public class ApexDocRule extends AbstractApexRule {
             booleanProperty("reportProtected")
                 .desc("Report protected methods").defaultValue(false).build();
 
+    private static final PropertyDescriptor<Boolean> REPORT_MISSING_DESCRIPTION_DESCRIPTOR =
+            booleanProperty("reportMissingDescription")
+                .desc("Report missing @description").defaultValue(true).build();
+
     public ApexDocRule() {
         definePropertyDescriptor(REPORT_PRIVATE_DESCRIPTOR);
         definePropertyDescriptor(REPORT_PROTECTED_DESCRIPTOR);
+        definePropertyDescriptor(REPORT_MISSING_DESCRIPTION_DESCRIPTOR);
 
         addRuleChainVisit(ASTUserClass.class);
         addRuleChainVisit(ASTUserInterface.class);
@@ -79,7 +84,7 @@ public class ApexDocRule extends AbstractApexRule {
                 addViolationWithMessage(data, node, MISSING_COMMENT_MESSAGE);
             }
         } else {
-            if (!comment.hasDescription) {
+            if (getProperty(REPORT_MISSING_DESCRIPTION_DESCRIPTOR) && !comment.hasDescription) {
                 addViolationWithMessage(data, node, MISSING_DESCRIPTION_MESSAGE);
             }
 
@@ -113,7 +118,7 @@ public class ApexDocRule extends AbstractApexRule {
                 addViolationWithMessage(data, node, MISSING_COMMENT_MESSAGE);
             }
         } else {
-            if (!comment.hasDescription) {
+            if (getProperty(REPORT_MISSING_DESCRIPTION_DESCRIPTOR) && !comment.hasDescription) {
                 addViolationWithMessage(data, node, MISSING_DESCRIPTION_MESSAGE);
             }
         }
@@ -128,7 +133,7 @@ public class ApexDocRule extends AbstractApexRule {
                 addViolationWithMessage(data, node, MISSING_COMMENT_MESSAGE);
             }
         } else {
-            if (!comment.hasDescription) {
+            if (getProperty(REPORT_MISSING_DESCRIPTION_DESCRIPTOR) && !comment.hasDescription) {
                 addViolationWithMessage(data, node, MISSING_DESCRIPTION_MESSAGE);
             }
         }

--- a/pmd-apex/src/main/resources/category/apex/documentation.xml
+++ b/pmd-apex/src/main/resources/category/apex/documentation.xml
@@ -22,7 +22,7 @@ This rule validates that:
     overrides and test classes (as well as the contents of test classes).
 *   ApexDoc comments are present for classes, methods, and properties that are protected or private, depending
     on the properties `reportPrivate` and `reportProtected`.
-*   ApexDoc comments should contain @description.
+*   ApexDoc comments should contain @description depending on the property 'reportMissingDescription'.
 *   ApexDoc comments on non-void, non-constructor methods should contain @return.
 *   ApexDoc comments on void or constructor methods should not contain @return.
 *   ApexDoc comments on methods with parameters should contain @param for each parameter, in the same

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/documentation/xml/ApexDoc.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/documentation/xml/ApexDoc.xml
@@ -574,4 +574,61 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#3566 [apex] ApexDoc: Verify use of reportMissingDescription, negative test unspecified/default</description>
+        <!-- reportMissingDescription unspecified; should default to true -->
+        <expected-problems>2</expected-problems>
+        <code><![CDATA[
+/**
+ * No at-description tag provided.
+ */
+public class Foo {
+
+    /**
+     * No at-description tag provided.
+     */
+    public Foo() {
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#3566 [apex] ApexDoc: Verify use of reportMissingDescription, negative test specified</description>
+        <rule-property name="reportMissingDescription">true</rule-property>
+        <expected-problems>2</expected-problems>
+        <code><![CDATA[
+/**
+ * No at-description tag provided.
+ */
+public class Foo {
+
+    /**
+     * No at-description tag provided.
+     */
+    public Foo() {
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#3566 [apex] ApexDoc: Verify use of reportMissingDescription, positive test</description>
+        <rule-property name="reportMissingDescription">false</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+/**
+ * No at-description tag provided.
+ */
+public class Foo {
+
+    /**
+     * No at-description tag provided.
+     */
+    public Foo() {
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Added a new configuration property to `ApexDocRule`, `reportMissingDescription`, that if set to `false` (default is `true` if unspecified) doesn't report an issue if the `@description` tag is missing. This is consistent with the ApexDoc dialect supported by derivatives such as [SfApexDoc](https://gitlab.com/StevenWCox/sfapexdoc) and also with analogous documentation tools for other languages, e.g., JavaDoc, ESDoc/JSDoc, etc.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #3566

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)
