### PR TITLE
[apex] Fix for #3570 - Added new configuration property reportInForLoopInitializer to OneDeclarationPerLine

### DIFF
--- a/pmd-apex/src/main/resources/category/apex/codestyle.xml
+++ b/pmd-apex/src/main/resources/category/apex/codestyle.xml
@@ -282,11 +282,12 @@ can lead to quite messy code. This rule looks for several declarations on the sa
         <priority>1</priority>
         <properties>
             <property name="version" value="2.0"/>
+            <property name="reportInForLoopInitializer" type="Boolean" value="true" description="If false, multiple declarations in a for loop initializer are not flagged."/>
             <property name="xpath">
                 <value>
 <![CDATA[
 //VariableDeclarationStatements
-  [count(VariableDeclaration) > 1]
+  [count(VariableDeclaration) > 1 and ($reportInForLoopInitializer = true() or name(parent::*) != 'ForLoopStatement')]
   [$strictMode or count(distinct-values(VariableDeclaration/@BeginLine)) != count(VariableDeclaration)]
 |
 //FieldDeclarationStatements

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/OneDeclarationPerLine.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/codestyle/xml/OneDeclarationPerLine.xml
@@ -90,4 +90,45 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#3570 - Verify use of reportInForLoopInitializer, negative test unspecified/default</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void bar() {
+        for (Integer i = 0, maxValue = computeMaxValue(); i < maxValue; i++) {
+        }
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#3570 - Verify use of reportInForLoopInitializer, negative test specified</description>
+        <rule-property name="reportInForLoopInitializer">true</rule-property>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void bar() {
+        for (Integer i = 0, maxValue = computeMaxValue(); i < maxValue; i++) {
+        }
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#3570 - Verify use of reportInForLoopInitializer, positive test</description>
+        <rule-property name="reportInForLoopInitializer">false</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void bar() {
+        for (Integer i = 0, maxValue = computeMaxValue(); i < maxValue; i++) {
+        }
+    }
+}
+]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Added a new configuration property to the Apex `OneDeclarationPerLine` rule, `reportInForLoopInitializer`, that if set to `false` (default is `true` if unspecified) doesn't report an issue for multiple declarations in a `for` loop's initializer section. This is support the common idiom of one declaration for the loop variable and another for the loop bounds condition, e.g.,

```apex
for (Integer i = 0, numIterations = computeNumIterations(); i < numIterations; i++) {
}
```

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #3570

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)
