### PR TITLE
[apex] #3569 - Requested changes for code review feedback

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexCommentContainerNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexCommentContainerNode.java
@@ -11,7 +11,7 @@ import apex.jorje.semantic.ast.AstNode;
  *
  * @param <T> the node type
  */
-public abstract class AbstractApexCommentContainerNode<T extends AstNode> extends AbstractApexNode<T> implements ASTCommentContainer<T> {
+abstract class AbstractApexCommentContainerNode<T extends AstNode> extends AbstractApexNode<T> implements ASTCommentContainer<T> {
 
     private boolean containsComment = false;
 


### PR DESCRIPTION
Addressed the final two code review feedback items requested by @oowekyala from PR #3574 for issue #3569. That PR was already merged, so creating a new PR for these.

## Describe the PR

Made the check for whether a node contains comments more efficient. Instead of having to inspect all commented lines in the file for each comment container, we now pre-calculate an index of which lines were comments, and then we see whether any of the lines in a comment container's range are flagged in that index. Given that we're currently only going to perform this logic for `ASTCatchBlockStatement` nodes, hopefully this should be very efficient. If/when this logic is expanded to include other node types, we can revisit and determine whether another approach such as a binary search for lines in a given range is a better fit.

Made `AbstractApexCommentContainerNode` package-private.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #3569 #3574 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

