### PR TITLE
[java] ClassNamingConventions: Disable utilityClassPattern by default

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -108,6 +108,29 @@ This is a {{ site.pmd.release_type }} release.
     }
     ```
 
+*   The Java rule {% rule java/codestyle/ClassNamingConventions %} uses a different default value of the
+    property `utilityClassPattern`: This rule was detecting utility classes by default since PMD 6.3.0
+    and enforcing the naming convention that utility classes has to be suffixed with Util or Helper or Constants.
+    However this turned out to be not so useful as a default configuration, as there is no standard
+    naming convention for utility classes.
+    
+    With PMD 6.40.0, the default value of this property has been changed to `[A-Z][a-zA-Z0-9]*`
+    (Pascal case), effectively disabling the special handling of utility classes. This is the same default
+    pattern used for concrete classes.
+    
+    This means, that the feature to enforce a naming convention for utility classes is now a opt-in
+    feature and can be enabled on demand.
+    
+    To use the old behaviour, the property needs to be configured as follows:
+    
+    ```xml
+    <rule ref="category/java/codestyle.xml/ClassNamingConventions">
+        <properties>
+            <property name="utilityClassPattern" value="[A-Z][a-zA-Z0-9]+(Utils?|Helper|Constants)" />
+        </properties>
+    </rule>
+
+
 ### Fixed Issues
 
 *   apex
@@ -120,6 +143,9 @@ This is a {{ site.pmd.release_type }} release.
     *   [#3570](https://github.com/pmd/pmd/issues/3570): \[apex] OneDeclarationPerLine: should provide an option to ignore multiple declarations in a for loop initializer
     *   [#3576](https://github.com/pmd/pmd/issues/3576): \[apex] ApexCRUDViolation should provide an option to specify additional patterns for methods that encapsulate authorization checks
     *   [#3579](https://github.com/pmd/pmd/issues/3579): \[apex] ApexCRUDViolation: false negative with undelete
+*   java-codestyle
+    *   [#1595](https://github.com/pmd/pmd/issues/1595): \[java] Discuss default for utility classes in ClassNamingConventions
+    *   [#3563](https://github.com/pmd/pmd/issues/3563): \[java] The ClassNamingConventionsRule false-positive's on the class name "Constants"
 *   java-errorprone
     *   [#3560](https://github.com/pmd/pmd/issues/3560): \[java] InvalidLogMessageFormat: False positive with message and exception in a block inside a lambda
 *   java-performance

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ClassNamingConventionsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ClassNamingConventionsRule.java
@@ -30,7 +30,7 @@ public class ClassNamingConventionsRule extends AbstractNamingConventionRule<AST
     private final PropertyDescriptor<Pattern> interfaceRegex = defaultProp("interface").build();
     private final PropertyDescriptor<Pattern> enumerationRegex = defaultProp("enum").build();
     private final PropertyDescriptor<Pattern> annotationRegex = defaultProp("annotation").build();
-    private final PropertyDescriptor<Pattern> utilityClassRegex = defaultProp("utility class").defaultValue("[A-Z][a-zA-Z0-9]+(Utils?|Helper|Constants)").build();
+    private final PropertyDescriptor<Pattern> utilityClassRegex = defaultProp("utility class").build();
 
 
     public ClassNamingConventionsRule() {

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -398,8 +398,16 @@ public class Foo extends Bar{
             specific kind (e.g. enum or interface). Each regex can be configured through
             properties.
 
-            By default this rule uses the standard Java naming convention (Pascal case),
-            and reports utility class names not ending with 'Util'.
+            By default this rule uses the standard Java naming convention (Pascal case).
+            
+            The rule can detect utility classes and enforce a different naming convention
+            on those. E.g. setting the property `utilityClassPattern` to
+            `[A-Z][a-zA-Z0-9]+(Utils?|Helper|Constants)` reports any utility class, whose name
+            does not end in "Util(s)", "Helper" or "Constants".
+            
+            For this rule, a utility class is defined as: a concrete class that does not
+            inherit from a super class or implement any interface and only has static fields
+            or methods.
         </description>
         <priority>1</priority>
         <example>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ClassNamingConventions.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ClassNamingConventions.xml
@@ -47,13 +47,7 @@ public class foo {
         ]]></code>
     </test-code>
 
-    <test-code>
-        <description>Utility class convention</description>
-        <expected-problems>1</expected-problems>
-        <expected-messages>
-            <message>The utility class name 'Foo' doesn't match '[A-Z][a-zA-Z0-9]+(Utils?|Helper|Constants)'</message>
-        </expected-messages>
-        <code><![CDATA[
+    <code-fragment id="utility-class"><![CDATA[
 public class Foo {
 
     static final int ZERO = 0;
@@ -68,11 +62,28 @@ public class Foo {
 
     }
 }
-        ]]></code>
+    ]]></code-fragment>
+
+    <test-code>
+        <description>Utility class convention (default) - #3563</description>
+        <expected-problems>0</expected-problems>
+        <code-ref id="utility-class"/>
+    </test-code>
+
+    <test-code>
+        <description>Utility class convention</description>
+        <rule-property name="utilityClassPattern">[A-Z][a-zA-Z0-9]+(Utils?|Helper|Constants)</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>1</expected-linenumbers>
+        <expected-messages>
+            <message>The utility class name 'Foo' doesn't match '[A-Z][a-zA-Z0-9]+(Utils?|Helper|Constants)'</message>
+        </expected-messages>
+        <code-ref id="utility-class"/>
     </test-code>
 
     <test-code>
         <description>Class with only empty decls should not be a utility class</description>
+        <rule-property name="utilityClassPattern">[A-Z][a-zA-Z0-9]+(Utils?|Helper|Constants)</rule-property>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -83,6 +94,7 @@ public class Foo {
 
     <test-code>
         <description>Class with some instance fields should not be a utility class</description>
+        <rule-property name="utilityClassPattern">[A-Z][a-zA-Z0-9]+(Utils?|Helper|Constants)</rule-property>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Position {
@@ -105,6 +117,7 @@ public class Position {
 
     <test-code>
         <description>Class with static initializer alone should not be a utility class</description>
+        <rule-property name="utilityClassPattern">[A-Z][a-zA-Z0-9]+(Utils?|Helper|Constants)</rule-property>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -119,6 +132,7 @@ public class Foo {
 
     <test-code>
         <description>Class with instance initializer should not be a utility class</description>
+        <rule-property name="utilityClassPattern">[A-Z][a-zA-Z0-9]+(Utils?|Helper|Constants)</rule-property>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -140,6 +154,7 @@ public class Foo {
 
     <test-code>
         <description>Class with only static members except constructors should be a utility class</description>
+        <rule-property name="utilityClassPattern">[A-Z][a-zA-Z0-9]+(Utils?|Helper|Constants)</rule-property>
         <expected-problems>1</expected-problems>
         <expected-messages>
             <message>The utility class name 'Foo' doesn't match '[A-Z][a-zA-Z0-9]+(Utils?|Helper|Constants)'</message>
@@ -168,6 +183,7 @@ public class Foo {
 
     <test-code>
         <description>Class with only constructors should not be a utility class</description>
+        <rule-property name="utilityClassPattern">[A-Z][a-zA-Z0-9]+(Utils?|Helper|Constants)</rule-property>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -190,6 +206,7 @@ public class Md5Checksum {
 
     <test-code>
         <description>Class extending another class should not be utility class</description>
+        <rule-property name="utilityClassPattern">[A-Z][a-zA-Z0-9]+(Utils?|Helper|Constants)</rule-property>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class StringList extends ArrayList<String> {
@@ -202,6 +219,7 @@ public class StringList extends ArrayList<String> {
 
     <test-code>
         <description>Class extending another class should not be utility class 2</description>
+        <rule-property name="utilityClassPattern">[A-Z][a-zA-Z0-9]+(Utils?|Helper|Constants)</rule-property>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 // I couldn't reproduce the original failure, but we can use another regression test.
@@ -215,6 +233,7 @@ public class MyException extends RuntimeException {
 
     <test-code>
         <description>Class with only main method should not be utility class</description>
+        <rule-property name="utilityClassPattern">[A-Z][a-zA-Z0-9]+(Utils?|Helper|Constants)</rule-property>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class MyException {
@@ -228,6 +247,7 @@ public class MyException {
 
     <test-code>
         <description>Class with only main method should not be utility class - varargs case</description>
+        <rule-property name="utilityClassPattern">[A-Z][a-zA-Z0-9]+(Utils?|Helper|Constants)</rule-property>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class MyException {
@@ -241,6 +261,7 @@ public class MyException {
 
     <test-code>
         <description>Class with main method and private static fields should not be utility class</description>
+        <rule-property name="utilityClassPattern">[A-Z][a-zA-Z0-9]+(Utils?|Helper|Constants)</rule-property>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class MyException {
@@ -255,6 +276,7 @@ public class MyException {
 
     <test-code>
         <description>Utility class can have name constants</description>
+        <rule-property name="utilityClassPattern">[A-Z][a-zA-Z0-9]+(Utils?|Helper|Constants)</rule-property>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class MyConstants {


### PR DESCRIPTION
## Describe the PR

Changes the default value for `utilityClassPattern` to effectively disable this feature, but keep it as a opt-in.

## Related issues

- Fixes #1595
- Fixes #3563

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

