### PR TITLE
[apex] added fix to not tag single block for two error statements

### DIFF
--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/EmptyIfStmtTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/EmptyIfStmtTest.java
@@ -4,8 +4,46 @@
 
 package net.sourceforge.pmd.lang.apex.rule.errorprone;
 
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import net.sourceforge.pmd.PMD;
+import net.sourceforge.pmd.Report;
+import net.sourceforge.pmd.RuleSet;
+import net.sourceforge.pmd.RuleSetFactory;
+import net.sourceforge.pmd.RuleSetLoader;
+import net.sourceforge.pmd.lang.LanguageRegistry;
+import net.sourceforge.pmd.lang.apex.ApexLanguageModule;
 import net.sourceforge.pmd.testframework.PmdRuleTst;
 
+
 public class EmptyIfStmtTest extends PmdRuleTst {
-    // no additional unit tests
+
+    private RuleSetFactory factory = new RuleSetLoader().enableCompatibility(false).toFactory();
+
+    @Test
+    public void testEmptyRuleSetIfEmpty() throws Exception {
+        RuleSet ruleSet = factory.createRuleSet("rulesets/apex/empty.xml");
+        Report rpt = new Report();
+        runTestFromString(TESTIF, ruleSet, rpt,
+                LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion(), true);
+        assertEquals(1, rpt.size());
+    }
+
+    @Test
+    public void testEmptyRuleSetBlockEmpty() throws Exception {
+        RuleSet ruleSet = factory.createRuleSet("rulesets/apex/empty.xml");
+        Report rpt = new Report();
+        runTestFromString(TESTBLOCK, ruleSet, rpt,
+                LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion(), true);
+        assertEquals(1, rpt.size());
+    }
+
+    private static final String TESTIF = "public class BlockWithEmptyIf {" + PMD.EOL + "public void methodEmpty() {"
+             + PMD.EOL + "int i = 0;" + PMD.EOL
+             + PMD.EOL + "if (i<5) {" + PMD.EOL + "}" + PMD.EOL + "}" + PMD.EOL + "}";
+
+    private static final String TESTBLOCK = "public class BlockEmpty {" + PMD.EOL + "public void methodEmpty() {"
+            + PMD.EOL + "}" + PMD.EOL + "}";
 }

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/EmptyIfStmtTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/EmptyIfStmtTest.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.apex.rule.errorprone;
 
 import static org.junit.Assert.assertEquals;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import net.sourceforge.pmd.PMD;
@@ -14,36 +15,132 @@ import net.sourceforge.pmd.RuleSet;
 import net.sourceforge.pmd.RuleSetFactory;
 import net.sourceforge.pmd.RuleSetLoader;
 import net.sourceforge.pmd.lang.LanguageRegistry;
+import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.lang.apex.ApexLanguageModule;
 import net.sourceforge.pmd.testframework.PmdRuleTst;
 
-
+/**
+ * Test class to test if empty if statements are captured
+ * and no empty block statement error is thrown
+ *
+ */
 public class EmptyIfStmtTest extends PmdRuleTst {
-
-    private RuleSetFactory factory = new RuleSetLoader().enableCompatibility(false).toFactory();
-
-    @Test
-    public void testEmptyRuleSetIfEmpty() throws Exception {
-        RuleSet ruleSet = factory.createRuleSet("rulesets/apex/empty.xml");
-        Report rpt = new Report();
-        runTestFromString(TESTIF, ruleSet, rpt,
-                LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion(), true);
-        assertEquals(1, rpt.size());
-    }
-
-    @Test
-    public void testEmptyRuleSetBlockEmpty() throws Exception {
-        RuleSet ruleSet = factory.createRuleSet("rulesets/apex/empty.xml");
-        Report rpt = new Report();
-        runTestFromString(TESTBLOCK, ruleSet, rpt,
-                LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion(), true);
-        assertEquals(1, rpt.size());
-    }
-
+    /**
+     * Assert error string, in case of failures
+     */
+    private static final String MATCH_ERROR = "Expected Violation count do not match";
+    /**
+     * Rule set factory initialization
+     */
+    private static RuleSetFactory factory = new RuleSetLoader().enableCompatibility(false).toFactory();
+    /**
+     * language variable to hold apex language configuration
+     */
+    private static final LanguageVersion LANGUAGE_VERSION = LanguageRegistry
+                                                                .getLanguage(ApexLanguageModule.NAME)
+                                                                .getDefaultVersion();
+    /**
+     * boolean to control unit test run class path
+     */
+    private static final boolean USE_CLASS_PATH = true;
+    /**
+     * variable to hold ruleset
+     */
+    private static RuleSet ruleSet;
+    /**
+     * variable to hold report of violations
+     */
+    private static Report rpt;
+    /**
+     * variable to hold error logs
+     */
+    private static String errorLog;
+    /**empty if block created
+     * for testing if block error scenario
+     */
     private static final String TESTIF = "public class BlockWithEmptyIf {" + PMD.EOL + "public void methodEmpty() {"
-             + PMD.EOL + "int i = 0;" + PMD.EOL
-             + PMD.EOL + "if (i<5) {" + PMD.EOL + "}" + PMD.EOL + "}" + PMD.EOL + "}";
-
+            + PMD.EOL + "int i = 0;" + PMD.EOL
+            + PMD.EOL + "if (i<5) {" + PMD.EOL + "}" + PMD.EOL + "}" + PMD.EOL + "}";
+    /**non-empty if block created
+     * for testing if block no error scenario
+     */
+    private static final String TESTIFWITHDATA = "public class BlockWithNotEmptyIf {" + PMD.EOL + "public void methodNotEmpty() {"
+            + PMD.EOL + "int i = 0;" + PMD.EOL
+            + PMD.EOL + "if (i<5) {" + PMD.EOL
+            + PMD.EOL + "i++;" + PMD.EOL
+            + "}" + PMD.EOL + "}" + PMD.EOL + "}";
+    /**empty method block created
+     * for testing Block error scenario
+     */
     private static final String TESTBLOCK = "public class BlockEmpty {" + PMD.EOL + "public void methodEmpty() {"
             + PMD.EOL + "}" + PMD.EOL + "}";
+    /**non-empty method block created
+     * for testing no block error scenario
+     */
+    private static final String TESTBLOCKWITHDATA = "public class BlockNotEmpty {" + PMD.EOL + "public void methodNotEmpty() {"
+            + PMD.EOL + "int i = 0;" + PMD.EOL
+            + PMD.EOL + "}" + PMD.EOL + "}";
+
+    /**
+     * method to initialize ruleset
+     * and report before every new test method execution
+     **/
+    @Before
+    public void initialize() {
+        initializeRuleSet();
+        rpt = new Report();
+    }
+
+    private static void initializeRuleSet() {
+        try {
+            ruleSet = factory.createRuleSet("rulesets/apex/empty.xml");
+        } catch (Exception exception) {
+            errorLog = errorLog + exception.getMessage();
+        }
+    }
+
+    /**
+     * Test method to test if error is reported if the
+     * incoming "if block" has no statements
+     **/
+    @Test
+    public void testEmptyRuleSetIfEmpty() {
+        runTestFromString(TESTIF, ruleSet, rpt,
+                LANGUAGE_VERSION, USE_CLASS_PATH);
+        assertEquals(MATCH_ERROR, 1, rpt.size());
+    }
+
+    /**
+     * Test method to test if no error is reported
+     * if the incoming "if block" has statements
+     **/
+    @Test
+    public void testEmptyRuleSetIfWithData() {
+        runTestFromString(TESTIFWITHDATA, ruleSet, rpt,
+                LANGUAGE_VERSION, USE_CLASS_PATH);
+        assertEquals(MATCH_ERROR, 0, rpt.size());
+    }
+
+    /**
+     * Test method to test if error is reported
+     * if the incoming block has no statements
+     * and no if or while or catch block
+     **/
+    @Test
+    public void testEmptyRuleSetBlockEmpty() {
+        runTestFromString(TESTBLOCK, ruleSet, rpt,
+                LANGUAGE_VERSION, USE_CLASS_PATH);
+        assertEquals(MATCH_ERROR, 1, rpt.size());
+    }
+
+    /**
+    * Test method to test if no errors are reported
+     * if the incoming block has statements
+     **/
+    @Test
+    public void testEmptyRuleSetBlockNotEmpty() {
+        runTestFromString(TESTBLOCKWITHDATA, ruleSet, rpt,
+                LANGUAGE_VERSION, USE_CLASS_PATH);
+        assertEquals(MATCH_ERROR, 0, rpt.size());
+    }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
@@ -52,6 +52,22 @@ public class Report implements Iterable<RuleViolation> {
     private long start;
     private long end;
     private final List<SuppressedViolation> suppressedRuleViolations = new ArrayList<>();
+    /**
+     * Variable for empty If rule
+    **/
+    private static final String EMPTY_IF_RULE = "EmptyIfStmt";
+    /**
+     * Variable for empty If rule
+     **/
+    private static final String EMPTY_WHILE_RULE = "EmptyWhileStmt";
+    /**
+     * Variable for empty If rule
+     **/
+    private static final String EMPTY_CATCH_RULE = "EmptyCatchBlock";
+    /**
+     * Variable for empty If rule
+     **/
+    private static final String EMPTY_BLOCK_RULE = "EmptyStatementBlock";
 
     /**
      * Creates a new, initialized, empty report for the given file name.
@@ -356,33 +372,33 @@ public class Report implements Iterable<RuleViolation> {
         }
     }
 
-    public boolean isDuplicateViolation(RuleViolation violation) {
-        boolean isDuplicate = false;
-        for (RuleViolation existingViolation : violations) {
+    private boolean isDuplicateViolation(final RuleViolation violation) {
+        boolean isDuplicateBlockType = false;
+        for (final RuleViolation existingViolation : violations) {
             if (isCheckDuplicate(existingViolation, violation)) {
-                isDuplicate = true;
+                isDuplicateBlockType = true;
                 break;
             }
         }
-        return isDuplicate;
+        return isDuplicateBlockType;
     }
 
-    public boolean isCheckDuplicate(RuleViolation existingViolation, RuleViolation violation) {
-        boolean isDuplicate = false;
+    private boolean isCheckDuplicate(final RuleViolation existingViolation, final RuleViolation violation) {
+        boolean isDuplicateViolation = false;
         if (isSameCodeBlockViolation(existingViolation, violation)) {
             if (isEmptyBock(existingViolation)
                     && isEmptyIfWhileCatch(violation)) {
                 violations.remove(existingViolation);
-                isDuplicate = false;
+                isDuplicateViolation = false;
             } else if (isEmptyIfWhileCatch(existingViolation)
                     && isEmptyBock(violation)) {
-                isDuplicate = true;
+                isDuplicateViolation = true;
             }
         }
-        return isDuplicate;
+        return isDuplicateViolation;
     }
 
-    public boolean isSameCodeBlockViolation(RuleViolation existingViolation, RuleViolation violation) {
+    private boolean isSameCodeBlockViolation(final RuleViolation existingViolation, final RuleViolation violation) {
         return existingViolation != null
                 && violation != null
                 && existingViolation.getBeginLine() == violation.getBeginLine()
@@ -392,22 +408,28 @@ public class Report implements Iterable<RuleViolation> {
                 && existingViolation.getPackageName() != null && existingViolation.getPackageName().equals(violation.getPackageName());
     }
 
-    public boolean isEmptyIfWhileCatch(RuleViolation violation) {
-        return isCheckValidViolation(violation)
-                && (violation.getRule().getName().equals(new String("EmptyIfStmt"))
-                || violation.getRule().getName().equals(new String("EmptyWhileStmt"))
-                || violation.getRule().getName().equals(new String("EmptyCatchBlock")));
+    private boolean isEmptyIfWhileCatch(final RuleViolation violation) {
+        boolean isMatch = false;
+        if (isCheckValidViolation(violation)) {
+            String currentRuleName = violation.getRule().getName();
+            if (EMPTY_IF_RULE.equals(currentRuleName)
+                    || EMPTY_WHILE_RULE.equals(currentRuleName)
+                    || EMPTY_CATCH_RULE.equals(currentRuleName)) {
+                isMatch = true;
+            }
+        }
+        return isMatch;
     }
 
-    public boolean isCheckValidViolation(RuleViolation violation) {
+    private boolean isCheckValidViolation(final RuleViolation violation) {
         return violation != null
                 && violation.getRule() != null
                 && violation.getRule().getName() != null;
     }
 
-    public boolean isEmptyBock(RuleViolation violation) {
+    private boolean isEmptyBock(final RuleViolation violation) {
         return isCheckValidViolation(violation)
-                && violation.getRule().getName().equals(new String("EmptyStatementBlock"));
+                && EMPTY_BLOCK_RULE.equals(violation.getRule().getName());
     }
 
     /**

--- a/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
@@ -267,6 +267,12 @@ public abstract class RuleTst {
 
     public void runTestFromString(String code, Rule rule, Report report, LanguageVersion languageVersion,
             boolean isUseAuxClasspath) {
+        RuleSet rules = RuleSet.forSingleRule(rule);
+        runTestFromString(code, rules, report, languageVersion, isUseAuxClasspath);
+    }
+
+    public void runTestFromString(String code, RuleSet rules, Report report, LanguageVersion languageVersion,
+                                  boolean isUseAuxClasspath) {
         try {
             PMD p = new PMD();
             p.getConfiguration().setDefaultLanguageVersion(languageVersion);
@@ -294,7 +300,7 @@ public abstract class RuleTst {
             ctx.setSourceCodeFile(new File("n/a"));
             ctx.setLanguageVersion(languageVersion);
             ctx.setIgnoreExceptions(false);
-            RuleSet rules = RuleSet.forSingleRule(rule);
+            //RuleSet rules = RuleSet.forSingleRule(rule);
             p.getSourceCodeProcessor().processSourceCode(new StringReader(code), new RuleSets(rules), ctx);
         } catch (Exception e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
Added check to see if a violation of type EmptyIfStmt or EmptyWhileStmt or EmptyCatchBlock is already present not to add EmptyStatementBlock. Also handled the other scenario, if EmptyStatementBlock is already part of violation remove the violation and add the new violation of type EmptyIfStmt or EmptyWhileStmt or EmptyCatchBlock to the list.

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues
https://github.com/pmd/pmd/issues/3164

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #

## Ready?
Yes, wrote unit test and all unit tests passed also build and successfully tested in local.

