### PR TITLE
[doc] Rename Code Inspector to Codiga

### DIFF
--- a/docs/pages/pmd/userdocs/tools/tools.md
+++ b/docs/pages/pmd/userdocs/tools/tools.md
@@ -20,16 +20,16 @@ With Codacy you have PMDJava analysis out-of-the-box, and it is free for open so
 * Source code: [https://github.com/codacy/codacy-pmdjava](https://github.com/codacy/codacy-pmdjava)
 * Maintainer: Codacy
 
-### Code Inspector
+### Codiga
 
-[Code Inspector](https://www.code-inspector.com) automates code review, check your code quality and helps you manage your technical debt.
+[Codiga](https://www.codiga.io) automates code review, check your code quality and helps you manage your technical debt.
 It is integrated with GitHub, GitLab and Bitbucket. The platform also analyzes code directly in your IDE using its integration
 plugins for VS Code and IntelliJ, providing a consistent analysis along your development cycle (from the IDE to the CI/CD pipeline).
 
-Code Inspector uses PMD to check Java and Apex code.
+Codiga uses PMD to check Java and Apex code.
 
-* Homepage: [https://www.code-inspector.com](https://www.code-inspector.com)
-* Documentation: [https://doc.code-inspector.com](https://doc.code-inspector.com)
+* Homepage: [https://www.codiga.io](https://www.codiga.io)
+* Documentation: [https://doc.codiga.io](https://doc.codiga.io)
 
 
 ## IDE Integrations


### PR DESCRIPTION
## Describe the PR

[Code Inspector](https://www.code-inspector.com) is rebranding as [Codiga](https://www.codiga.io). Therefore, we are changing our references in the PMD documentation and making sure references are up to date.
