### PR TITLE
[java] UnusedLocalVariable - fix false positive with try-with-resources

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedLocalVariableRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedLocalVariableRule.java
@@ -4,26 +4,24 @@
 
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-
 import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTResource;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
-import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
-import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
 
-public class UnusedLocalVariableRule extends AbstractJavaRule {
+public class UnusedLocalVariableRule extends AbstractJavaRulechainRule {
 
-    @Override
-    protected @NonNull RuleTargetSelector buildTargetSelector() {
-        return RuleTargetSelector.forTypes(ASTLocalVariableDeclaration.class);
+    public UnusedLocalVariableRule() {
+        super(ASTLocalVariableDeclaration.class);
     }
 
     @Override
     public Object visit(ASTLocalVariableDeclaration decl, Object data) {
         for (ASTVariableDeclaratorId varId : decl.getVarIds()) {
             if (JavaRuleUtil.isNeverUsed(varId)
-                && !JavaRuleUtil.isExplicitUnusedVarName(varId.getName())) {
+                && !JavaRuleUtil.isExplicitUnusedVarName(varId.getName())
+                && !(varId.ancestors().get(2) instanceof ASTResource)) {
                 addViolation(data, varId, varId.getName());
             }
         }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedLocalVariable.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedLocalVariable.xml
@@ -420,4 +420,22 @@ public class UnusedLocalVariable {
             }
             ]]></code>
     </test-code>
+
+    <test-code>
+        <description>False positive with try-with-resources</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.InputStream;
+public class UsedLocalVar {
+    public boolean run() {
+        boolean canRead = false;
+        try(InputStream resource = open()) {
+            canRead = true;
+        } catch (Throwable ignore) {}
+        return canRead;
+    }
+    private InputStream open() { return null; }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
I found this while trying to run PMD 7 on PMD 7 sources (dogfood).

At least two occurrences, e.g.
* https://github.com/pmd/pmd/blob/f36b99fbd755fbe2f6f4f8b35a4299a936305e26/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java#L208
* https://github.com/pmd/pmd/blob/f36b99fbd755fbe2f6f4f8b35a4299a936305e26/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetReferenceId.java#L235
