### PR TITLE
[java] Local records are a find boundary

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTRecordDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTRecordDeclaration.java
@@ -52,7 +52,7 @@ public final class ASTRecordDeclaration extends AbstractAnyTypeDeclaration {
 
     @Override
     public boolean isFindBoundary() {
-        return isNested();
+        return isNested() || isLocal();
     }
 
     @Override

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
@@ -1680,4 +1680,18 @@ public class FalsePositive {
             }
             ]]></code>
     </test-code>
+
+    <test-code>
+        <description>ClassCastException with local record</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public record MyRecord(boolean a) {
+    public void foo () {
+        record TestInnerRecord() {
+            private static Object test;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
This fixes a ClassCastException in CloseResource

This was found when updating the regression tester projects (#3640).

<details>
  <summary>original stack trace</summary>
  <pre>
java.lang.ClassCastException: class net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration cannot be cast to class net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration (net.sourceforge.pmd.lang.
java.ast.ASTFieldDeclaration and net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration are in unnamed module of loader 'app')
        at net.sourceforge.pmd.lang.java.rule.errorprone.CloseResourceRule.getDeclaredTypeOfVariable(CloseResourceRule.java:209)
        at net.sourceforge.pmd.lang.java.rule.errorprone.CloseResourceRule.getTypeOfVariable(CloseResourceRule.java:205)
        at net.sourceforge.pmd.lang.java.rule.errorprone.CloseResourceRule.getResourceVariables(CloseResourceRule.java:195)
        at net.sourceforge.pmd.lang.java.rule.errorprone.CloseResourceRule.checkForResources(CloseResourceRule.java:167)
        at net.sourceforge.pmd.lang.java.rule.errorprone.CloseResourceRule.visit(CloseResourceRule.java:161)
        at net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration.jjtAccept(ASTMethodDeclaration.java:37)
        at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:222)
        at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:269)
        at net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBodyDeclaration.jjtAccept(ASTClassOrInterfaceBodyDeclaration.java:44)
        at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:222)
        at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:864)
        at net.sourceforge.pmd.lang.java.ast.ASTRecordBody.jjtAccept(ASTRecordBody.java:31)
        at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:222)
        at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:849)
        at net.sourceforge.pmd.lang.java.ast.ASTRecordDeclaration.jjtAccept(ASTRecordDeclaration.java:40)
        at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:222)
        at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:269)
        at net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBodyDeclaration.jjtAccept(ASTClassOrInterfaceBodyDeclaration.java:44)
        at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:222)
        at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:264)
        at net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBody.jjtAccept(ASTClassOrInterfaceBody.java:35)
        at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:222)
        at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:234)
        at net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration.jjtAccept(ASTClassOrInterfaceDeclaration.java:55)
        at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:222)
        at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:419)
        at net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration.jjtAccept(ASTTypeDeclaration.java:39)
        at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:222)
        at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:394)
        at net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit.jjtAccept(ASTCompilationUnit.java:44)
        at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visitAll(AbstractJavaRule.java:164)
        at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.apply(AbstractJavaRule.java:158)
        at net.sourceforge.pmd.lang.rule.AbstractDelegateRule.apply(AbstractDelegateRule.java:336)
        at net.sourceforge.pmd.RuleSet.apply(RuleSet.java:659)
        at net.sourceforge.pmd.RuleSets.apply(RuleSets.java:163)
        at net.sourceforge.pmd.SourceCodeProcessor.processSource(SourceCodeProcessor.java:209)
        at net.sourceforge.pmd.SourceCodeProcessor.processSourceCodeWithoutCache(SourceCodeProcessor.java:118)
        at net.sourceforge.pmd.SourceCodeProcessor.processSourceCode(SourceCodeProcessor.java:100)
        at net.sourceforge.pmd.SourceCodeProcessor.processSourceCode(SourceCodeProcessor.java:62)
        at net.sourceforge.pmd.processor.PmdRunnable.call(PmdRunnable.java:85)
        at net.sourceforge.pmd.processor.PmdRunnable.call(PmdRunnable.java:29)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
        at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
</pre>
</details>

File: https://github.com/checkstyle/checkstyle/blob/checkstyle-9.1/src/test/resources-noncompilable/com/puppycrawl/tools/checkstyle/checks/metrics/javancss/InputJavaNCSSRecordsAndCompactCtors.java

