### PR TITLE
[java] Fix unused variable/field detection with unary expressions

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
@@ -42,6 +42,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceType;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTExpressionStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldAccess;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTForStatement;
@@ -467,9 +468,9 @@ public final class JavaRuleUtil {
 
     private static boolean isReadUsage(ASTNamedReferenceExpr expr) {
         return expr.getAccessType() == AccessType.READ
-            // foo(x++)
+            // x++ as a method argument or used in other expression
             || expr.getParent() instanceof ASTUnaryExpression
-            && expr.getParent().getParent() instanceof ASTArgumentList;
+            && !(expr.getParent().getParent() instanceof ASTExpressionStatement);
     }
 
     /**

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedLocalVariable.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedLocalVariable.xml
@@ -420,4 +420,27 @@ public class UnusedLocalVariable {
             }
             ]]></code>
     </test-code>
+
+    <test-code>
+        <description>False positive with variable used in unary expression</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void run1(String ...args) {
+        int i;
+        for (String a : args) {
+            String id = a + " -> " + i++;
+            System.out.println(id);
+        }
+    }
+    public void run2(String ...args) {
+        int x;
+        for (String a : args) {
+            String id = a + " -> " + (++x);
+            System.out.println(id);
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedLocalVariable.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedLocalVariable.xml
@@ -422,7 +422,7 @@ public class UnusedLocalVariable {
     </test-code>
 
     <test-code>
-        <description>False positive with variable used in unary expression</description>
+        <description>False positive with variable used in unary expression #3671</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateField.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateField.xml
@@ -659,7 +659,7 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>False positive with field used in unary expression</description>
+        <description>False positive with field used in unary expression #3671</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateField.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateField.xml
@@ -657,4 +657,19 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>False positive with field used in unary expression</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    private int counter;
+    public void skip(int n) {
+        while (counter++ < n) {
+            System.out.println("Skipping");
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
This affects at least UnusedLocalVariable and UnusedPrivateField.
I found this while trying to run PMD 7 on PMD 7 sources (dogfood).

Sample false positives:
*   `[INFO] PMD Failure: net.sourceforge.pmd.internal.GraphUtils:45 Rule:UnusedLocalVariable Priority:1 Avoid unused local variables such as 'i'..`
https://github.com/pmd/pmd/blob/f36b99fbd755fbe2f6f4f8b35a4299a936305e26/pmd-core/src/main/java/net/sourceforge/pmd/internal/GraphUtils.java#L45

    i++ or ++i is not considered a usage...
    or String id = "n" + i++; is not considered a usage
*   `[INFO] PMD Failure: net.sourceforge.pmd.internal.util.IteratorUtil$11:369 Rule:UnusedPrivateField Priority:1 Avoid unused private fields such as 'yielded'..`
https://github.com/pmd/pmd/blob/f36b99fbd755fbe2f6f4f8b35a4299a936305e26/pmd-core/src/main/java/net/sourceforge/pmd/internal/util/IteratorUtil.java#L369
    same for fields

