### PR TITLE
[java] LooseCoupling - fix false positive with generics

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LooseCouplingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LooseCouplingRule.java
@@ -7,6 +7,8 @@ package net.sourceforge.pmd.lang.java.rule.bestpractices;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import net.sourceforge.pmd.lang.ast.NodeStream;
 import net.sourceforge.pmd.lang.java.ast.ASTArrayAllocation;
@@ -21,6 +23,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTSuperExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTThisExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTTypeExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTTypeParameter;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
@@ -45,7 +48,8 @@ public class LooseCouplingRule extends AbstractJavaRulechainRule {
         if (isConcreteCollectionType(node)
             && !isInOverriddenMethodSignature(node)
             && !isInAllowedSyntacticCtx(node)
-            && !isAllowedType(node)) {
+            && !isAllowedType(node)
+            && !isTypeParameter(node)) {
             addViolation(data, node, node.getSimpleName());
         }
         return null;
@@ -86,5 +90,14 @@ public class LooseCouplingRule extends AbstractJavaRulechainRule {
             return ((ASTMethodDeclaration) ancestor).isOverridden();
         }
         return false;
+    }
+
+    private boolean isTypeParameter(ASTClassOrInterfaceType node) {
+        Set<String> typeParameters = node.getRoot()
+                .descendants(ASTTypeParameter.class)
+                .toStream()
+                .map(ASTTypeParameter::getName)
+                .collect(Collectors.toSet());
+        return typeParameters.contains(node.getSimpleName());
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LooseCouplingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LooseCouplingRule.java
@@ -7,8 +7,6 @@ package net.sourceforge.pmd.lang.java.rule.bestpractices;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import net.sourceforge.pmd.lang.ast.NodeStream;
 import net.sourceforge.pmd.lang.java.ast.ASTArrayAllocation;
@@ -23,7 +21,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTSuperExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTThisExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTTypeExpression;
-import net.sourceforge.pmd.lang.java.ast.ASTTypeParameter;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LooseCouplingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LooseCouplingRule.java
@@ -93,11 +93,6 @@ public class LooseCouplingRule extends AbstractJavaRulechainRule {
     }
 
     private boolean isTypeParameter(ASTClassOrInterfaceType node) {
-        Set<String> typeParameters = node.getRoot()
-                .descendants(ASTTypeParameter.class)
-                .toStream()
-                .map(ASTTypeParameter::getName)
-                .collect(Collectors.toSet());
-        return typeParameters.contains(node.getSimpleName());
+        return node.getTypeMirror().isTypeVariable();
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LooseCoupling.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LooseCoupling.xml
@@ -315,4 +315,16 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>False positive with generics</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.Collection;
+import java.util.Set;
+public final class Foo<A, B extends Collection<A>> {
+    private final Set<? super B> things;
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LooseCoupling.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LooseCoupling.xml
@@ -317,7 +317,7 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>False positive with generics</description>
+        <description>False positive with generics #3672</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 import java.util.Collection;


### PR DESCRIPTION
I found this while trying to run PMD 7 on PMD 7 sources (dogfood).

It addresses the following false positive:

*   `[INFO] PMD Failure: net.sourceforge.pmd.properties.GenericMultiValuePropertyDescriptor:26 Rule:LooseCoupling Priority:1 Avoid using implementation types like 'C'; use the interface instead.`
    with generics...
    https://github.com/pmd/pmd/blob/f36b99fbd755fbe2f6f4f8b35a4299a936305e26/pmd-core/src/main/java/net/sourceforge/pmd/properties/GenericMultiValuePropertyDescriptor.java#L26
