### PR TITLE
[java] MissingOverride - fix false positive with mixing type vars

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
@@ -125,7 +125,7 @@ public class MissingOverrideRule extends AbstractJavaRulechainRule {
                                     JMethodSig superSig) {
             ASTMethodDeclaration subSig = null;
             for (ASTMethodDeclaration it : tracked) {
-                if (TypeOps.overrides(it.getGenericSignature(), superSig, site)) {
+                if (TypeOps.isSubSignature(it.getGenericSignature(), superSig)) {
                     subSig = it;
                     // we assume there is a single relevant method that may match,
                     // otherwise it would be a compile-time error

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
@@ -125,6 +125,11 @@ public class MissingOverrideRule extends AbstractJavaRulechainRule {
                                     JMethodSig superSig) {
             ASTMethodDeclaration subSig = null;
             for (ASTMethodDeclaration it : tracked) {
+                // note: we don't use override-equivalence, the definition
+                // of an override uses the concept of sub-signature instead,
+                // which is slightly different. We could also use TypeOps.overrides
+                // but at this point we already know much of what that method checks.
+                // https://docs.oracle.com/javase/specs/jls/se15/html/jls-8.html#jls-8.4.8.1
                 if (TypeOps.isSubSignature(it.getGenericSignature(), superSig)) {
                     subSig = it;
                     // we assume there is a single relevant method that may match,

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/MissingOverrideRule.java
@@ -12,21 +12,18 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collector;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.JModifier;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
-import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JMethodSymbol;
 import net.sourceforge.pmd.lang.java.symbols.table.internal.SuperTypesEnumerator;
 import net.sourceforge.pmd.lang.java.types.JMethodSig;
 import net.sourceforge.pmd.lang.java.types.TypeOps;
-import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
 
 
 /**
@@ -35,11 +32,10 @@ import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
  * @author Clément Fournier
  * @since 6.2.0
  */
-public class MissingOverrideRule extends AbstractJavaRule {
+public class MissingOverrideRule extends AbstractJavaRulechainRule {
 
-    @Override
-    protected @NonNull RuleTargetSelector buildTargetSelector() {
-        return RuleTargetSelector.forTypes(ASTAnyTypeDeclaration.class);
+    public MissingOverrideRule() {
+        super(ASTAnyTypeDeclaration.class);
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
@@ -1249,7 +1249,11 @@ public final class TypeOps {
             JTypeMirror fi1 = formals1.get(i);
             JTypeMirror fi2 = formals2.get(i);
 
-            if (!isSameType(fi1.getErasure(), fi2.getErasure())) {
+            // Mixing type vars with concrete types while overriding
+            // leads to non equivalent parameters.
+            boolean mixedTypeVars = fi1 instanceof JTypeVar ^ fi2 instanceof JTypeVar;
+
+            if (!isSameType(fi1.getErasure(), fi2.getErasure()) || mixedTypeVars) {
                 return false;
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
@@ -1265,7 +1265,7 @@ public final class TypeOps {
      * - m2 has the same signature as m1, or
      * - the signature of m1 is the same as the erasure (§4.6) of the signature of m2.
      */
-    private static boolean isSubSignature(JMethodSig m1, JMethodSig m2) {
+    public static boolean isSubSignature(JMethodSig m1, JMethodSig m2) {
         // prune easy cases
         if (m1.getArity() != m2.getArity() || !m1.getName().equals(m2.getName())) {
             return false;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
@@ -1249,11 +1249,7 @@ public final class TypeOps {
             JTypeMirror fi1 = formals1.get(i);
             JTypeMirror fi2 = formals2.get(i);
 
-            // Mixing type vars with concrete types while overriding
-            // leads to non equivalent parameters.
-            boolean mixedTypeVars = fi1 instanceof JTypeVar ^ fi2 instanceof JTypeVar;
-
-            if (!isSameType(fi1.getErasure(), fi2.getErasure()) || mixedTypeVars) {
+            if (!isSameType(fi1.getErasure(), fi2.getErasure())) {
                 return false;
             }
         }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AbstractBuilderMixedTypeVarOverride.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AbstractBuilderMixedTypeVarOverride.java
@@ -1,0 +1,31 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+import java.util.Collection;
+
+public abstract class AbstractBuilderMixedTypeVarOverride<B extends AbstractBuilderMixedTypeVarOverride<B, T>, T> {
+    @SuppressWarnings("unchecked")
+    public B defaultValue(T val) {
+        return (B) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public B defaultValue2(T val) {
+        return (B) this;
+    }
+
+    public static final class ConcreteBuilder<V, C extends Collection<V>> extends AbstractBuilderMixedTypeVarOverride<ConcreteBuilder<V, C>, C> {
+        //@Override is wrong here: method does not override or implement a method from a supertype
+        public ConcreteBuilder<V, C> defaultValue(Collection<? extends V> val) {
+            return this;
+        }
+
+        @Override
+        public ConcreteBuilder<V, C> defaultValue2(C val) {
+            return this;
+        }
+    }
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
@@ -617,4 +617,39 @@ public enum EnumToString {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>False positive with generic erasure</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>23</expected-linenumbers>
+        <code><![CDATA[
+package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+
+import java.util.Collection;
+
+public abstract class AbstractBuilderMixedTypeVarOverride<B extends AbstractBuilderMixedTypeVarOverride<B, T>, T> {
+    @SuppressWarnings("unchecked")
+    public B defaultValue(T val) {
+        return (B) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public B defaultValue2(T val) {
+        return (B) this;
+    }
+
+    public static final class ConcreteBuilder<V, C extends Collection<V>> extends AbstractBuilderMixedTypeVarOverride<ConcreteBuilder<V, C>, C> {
+        //@Override is wrong here: method does not override or implement a method from a supertype
+        public ConcreteBuilder<V, C> defaultValue(Collection<? extends V> val) {
+            return this;
+        }
+
+        //@Override is indeed missing here
+        public ConcreteBuilder<V, C> defaultValue2(C val) {
+            return this;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
@@ -623,7 +623,7 @@ public enum EnumToString {
         <expected-problems>1</expected-problems>
         <expected-linenumbers>23</expected-linenumbers>
         <code><![CDATA[
-package net.sourceforge.pmd.lang.java.rule.bestpractices.missingoverride;
+package test;
 
 import java.util.Collection;
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/MissingOverride.xml
@@ -619,7 +619,7 @@ public enum EnumToString {
     </test-code>
 
     <test-code>
-        <description>False positive with generic erasure</description>
+        <description>False positive with generic erasure #3675</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>23</expected-linenumbers>
         <code><![CDATA[


### PR DESCRIPTION
I found this while trying to run PMD 7 on PMD 7 sources (dogfood).

It addresses the following false positive:

*   `[INFO] PMD Failure: net.sourceforge.pmd.properties.PropertyBuilder$GenericCollectionPropertyBuilder:402 Rule:MissingOverride Priority:1 The method 'defaultValue(Collection<? extends V>)' is missing an @Override annotation..`
https://github.com/pmd/pmd/blob/f36b99fbd755fbe2f6f4f8b35a4299a936305e26/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyBuilder.java#L402

The java compiler doesn't allow here an `@Override`. We would need to use `C val` instead of `Collection<? extends V> val`.
While this erased type for both is `Collection`, the java compiler doesn't see it that way...
