### PR TITLE
[java] BrokenNullCheck - false positive test

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/BrokenNullCheckRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/BrokenNullCheckRule.java
@@ -76,7 +76,6 @@ public class BrokenNullCheckRule extends AbstractJavaRule {
             return; // No good null check
         }
 
-        // TODO: fix #3430
         // Now we find the expression to compare to and do the comparison
         for (int i = 0; i < conditionalExpression.getNumChildren(); i++) {
             Node conditionalSubnode = conditionalExpression.getChild(i);
@@ -177,8 +176,6 @@ public class BrokenNullCheckRule extends AbstractJavaRule {
             for (ASTPrimaryPrefix primaryPrefix : primaryPrefixes) {
                 if (primaryPrefix.hasDescendantOfType(ASTName.class)) {
                     // We found the variable that is compared to null
-
-                    // TODO: fix #3430
                     return primaryExpression;
                 }
             }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/BrokenNullCheckRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/BrokenNullCheckRule.java
@@ -76,6 +76,7 @@ public class BrokenNullCheckRule extends AbstractJavaRule {
             return; // No good null check
         }
 
+        // TODO: fix #3430
         // Now we find the expression to compare to and do the comparison
         for (int i = 0; i < conditionalExpression.getNumChildren(); i++) {
             Node conditionalSubnode = conditionalExpression.getChild(i);
@@ -176,6 +177,8 @@ public class BrokenNullCheckRule extends AbstractJavaRule {
             for (ASTPrimaryPrefix primaryPrefix : primaryPrefixes) {
                 if (primaryPrefix.hasDescendantOfType(ASTName.class)) {
                     // We found the variable that is compared to null
+
+                    // TODO: fix #3430
                     return primaryExpression;
                 }
             }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/BrokenNullCheck.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/BrokenNullCheck.xml
@@ -186,4 +186,17 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+
+    <test-code>
+        <description>#3430 False positive for BrokenNullCheck when the object variable is in the then branch of a conditional expression</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class BrokenNullCheck{
+        void test(){
+                if (index < 0 || (replacement != null ? properties.set(index, replacement) : properties.remove(index)) != old); //detected
+        }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/BrokenNullCheck.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/BrokenNullCheck.xml
@@ -187,14 +187,26 @@ public class Foo {
         ]]></code>
     </test-code>
 
-
     <test-code>
-        <description>#3430 False positive for BrokenNullCheck when the object variable is in the then branch of a conditional expression</description>
-        <expected-problems>0</expected-problems>
+        <description>#3430 Correct analyzation for BrokenNullCheck when the object variable may be null</description>
+        <expected-problems>1</expected-problems>
         <code><![CDATA[
 class BrokenNullCheck{
         void test(){
                 if (index < 0 || (replacement != null ? properties.set(index, replacement) : properties.remove(index)) != old); //detected
+        }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#3430 Correct analyzation for BrokenNullCheck when the object variable may be null</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+class BrokenNullCheck{
+        void test(){
+                if (index < 0       //detected
+                || (replacement != null ? properties.set(index, replacement) : properties.remove(index)) != old);
         }
 }
         ]]></code>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
This PR introduces two tests to reproduce #3430 and show #3430 is not a false positive, so the PMD rule BrokenNullCheck is correct. This is because the object variable `index` may be null rather than the object variable `replacement` that Noah0120 guessed.

In addition to using XML tests, I have written a text file and used a JUnit test to locally run it with the args "-d src/test/java/net/sourceforge/pmd/3430.txt -R category/java/errorprone.xml/BrokenNullCheck -f text", which I have not committed, but it also suggests the issue #3430 is not a false positive and the output of PMD is actually correct.


## Related issues
- Refs #3430

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

