### PR TITLE
[java] Bump log4j to 2.16.0

### DIFF
--- a/pmd-java/pom.xml
+++ b/pmd-java/pom.xml
@@ -12,7 +12,7 @@
     </parent>
 
     <properties>
-        <log4j.version>2.15.0</log4j.version>
+        <log4j.version>2.16.0</log4j.version>
     </properties>
 
     <build>


### PR DESCRIPTION


## Describe the PR

Update log4 to 2.16.0 to harden defaults.
 Based on CVE-2021-45046 the fix to address CVE-2021-44228 in Apache Log4j 2.15.0 was incomplete in certain non-default configurations.
for more details CVE-2021-45046 (https://nvd.nist.gov/vuln/detail/CVE-2021-45046)



