### PR TITLE
[apex] ApexDoc: Add reportProperty property

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/documentation/ApexDocRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/documentation/ApexDocRule.java
@@ -48,10 +48,15 @@ public class ApexDocRule extends AbstractApexRule {
             booleanProperty("reportMissingDescription")
                 .desc("Report missing @description").defaultValue(true).build();
 
+    private static final PropertyDescriptor<Boolean> REPORT_MISSING_PROPERTY_DESCRIPTOR =
+            booleanProperty("reportMissingProperty")
+                .desc("Report missing properties").defaultValue(true).build();
+
     public ApexDocRule() {
         definePropertyDescriptor(REPORT_PRIVATE_DESCRIPTOR);
         definePropertyDescriptor(REPORT_PROTECTED_DESCRIPTOR);
         definePropertyDescriptor(REPORT_MISSING_DESCRIPTION_DESCRIPTOR);
+        definePropertyDescriptor(REPORT_MISSING_PROPERTY_DESCRIPTOR);
 
         addRuleChainVisit(ASTUserClass.class);
         addRuleChainVisit(ASTUserInterface.class);
@@ -113,13 +118,16 @@ public class ApexDocRule extends AbstractApexRule {
     @Override
     public Object visit(ASTProperty node, Object data) {
         ApexDocComment comment = getApexDocComment(node);
-        if (comment == null) {
-            if (shouldHaveApexDocs(node)) {
-                addViolationWithMessage(data, node, MISSING_COMMENT_MESSAGE);
-            }
-        } else {
-            if (getProperty(REPORT_MISSING_DESCRIPTION_DESCRIPTOR) && !comment.hasDescription) {
-                addViolationWithMessage(data, node, MISSING_DESCRIPTION_MESSAGE);
+
+        if (getProperty(REPORT_MISSING_PROPERTY_DESCRIPTOR)) {
+            if (comment == null) {
+                if (shouldHaveApexDocs(node)) {
+                    addViolationWithMessage(data, node, MISSING_COMMENT_MESSAGE);
+                }
+            } else {
+                if (getProperty(REPORT_MISSING_DESCRIPTION_DESCRIPTOR) && !comment.hasDescription) {
+                    addViolationWithMessage(data, node, MISSING_DESCRIPTION_MESSAGE);
+                }
             }
         }
 

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/documentation/xml/ApexDoc.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/documentation/xml/ApexDoc.xml
@@ -631,4 +631,32 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>property should have comment</description>
+        <rule-property name="reportMissingProperty">true</rule-property>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+/**
+ * @description Foo
+ */
+public class Foo {
+    global Object Bar { get; set; }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>property does not need comment</description>
+        <rule-property name="reportMissingProperty">false</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+/**
+ * @description Foo
+ */
+public class Foo {
+    global Object Bar { get; set; }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Adds a new 'reportProperty' property to the Apex Documentation rule which is enabled by default. When disabled, properties are not evaluated for ApexDoc comments regardless of access level.

## Related issues

This solves a request I had personally. While I appreciate ApexDoc comments for classes and methods, they become unwieldy for properties since they require 3 lines of comment for each property. Adding this new property allows you to enforce ApexDoc comments for classes and methods without requiring them for properties.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

