### PR TITLE
[java] Fix for #3686 - Fix ReturnEmptyCollectionRatherThanNull

### DIFF
--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2925,10 +2925,12 @@ See Effective Java, 3rd Edition, Item 54: Return empty collections or arrays ins
 <![CDATA[
 //MethodDeclaration
 [
-(./ResultType/Type[pmd-java:typeIs('java.util.Collection') or pmd-java:typeIs('java.util.Map') or @ArrayType=true()])
-and
-(./Block/BlockStatement/Statement/ReturnStatement/Expression/PrimaryExpression/PrimaryPrefix/Literal/NullLiteral)
+    (./ResultType/Type[pmd-java:typeIs('java.util.Collection')
+    or pmd-java:typeIs('java.util.Map')
+    or @ArrayType=true()])
 ]
+//ReturnStatement/Expression/PrimaryExpression/PrimaryPrefix/Literal/NullLiteral
+[not(./ancestor::StatementExpression)]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReturnEmptyCollectionRatherThanNull.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReturnEmptyCollectionRatherThanNull.xml
@@ -157,7 +157,8 @@ public class Foo {
 
   <test-code>
     <description>Null is returned from a loop</description>
-    <expected-problems>0</expected-problems>
+    <expected-problems>1</expected-problems>
+    <expected-linenumbers>7</expected-linenumbers>
     <code><![CDATA[
   import java.util.List;
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReturnEmptyCollectionRatherThanNull.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ReturnEmptyCollectionRatherThanNull.xml
@@ -33,7 +33,7 @@ public class Foo {
    <test-code>
       <description>Returning null instead of collection (List)</description>
       <expected-problems>1</expected-problems>
-      <expected-linenumbers>5</expected-linenumbers>
+      <expected-linenumbers>8</expected-linenumbers>
       <code><![CDATA[
 import java.util.List;
 
@@ -67,7 +67,7 @@ public class Foo {
    <test-code>
       <description>Returning null instead of collection (Set)</description>
       <expected-problems>1</expected-problems>
-      <expected-linenumbers>5</expected-linenumbers>
+      <expected-linenumbers>8</expected-linenumbers>
       <code><![CDATA[
 import java.util.Set;
 
@@ -84,7 +84,7 @@ public class Foo {
    <test-code>
       <description>Returning null instead of collection (Map)</description>
       <expected-problems>1</expected-problems>
-      <expected-linenumbers>5</expected-linenumbers>
+      <expected-linenumbers>8</expected-linenumbers>
       <code><![CDATA[
 import java.util.Map;
 
@@ -98,4 +98,79 @@ public class Foo {
 }
         ]]></code>
    </test-code>
+
+  <test-code>
+    <description>False negative case #3686</description>
+    <expected-problems>2</expected-problems>
+    <expected-linenumbers>4, 6</expected-linenumbers>
+    <code><![CDATA[
+public class Foo {
+    public int[] foo() {
+     if(true) {
+         return null;   //violation
+     } else {
+         return null;   //violation
+     }
+   }
+}
+    ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>Null is returned from an internal statement, not from the method</description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+public class Foo {
+
+    private int[] foo() {
+        bar(new SomeInterface() {
+            @Override
+            public Object run() {
+                baz();
+                return null;
+            }
+        });
+
+        return new int[0];
+    }
+}
+    ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>Null is returned from an internal statement, not from the method</description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+public class Foo {
+
+    private int[] foo() {
+        bar(() -> {
+            baz();
+            return null;
+        });
+
+        return new int[0];
+    }
+}
+    ]]></code>
+  </test-code>
+
+  <test-code>
+    <description>Null is returned from a loop</description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+  import java.util.List;
+
+  public class Foo {
+      private List<Integer> foo(List<Integer> list) {
+          for(Integer i : list) {
+              if(condition) {
+                  return null;
+              }
+          }
+          return list;
+      }
+  }
+    ]]></code>
+  </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Fixed XPath for the [ReturnEmptyCollectionRatherThanNull](https://pmd.github.io/latest/pmd_rules_java_errorprone.html#returnemptycollectionratherthannull) rule.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #3686

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

