### PR TITLE
[java] Fix for #3686 - fix FinalFieldCouldBeStatic

### DIFF
--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -808,7 +808,9 @@ in each object at runtime.
  [not(preceding-sibling::Annotation/MarkerAnnotation/Name[@Image="Builder.Default"]
     and //ImportDeclaration/Name[@Image="lombok.Builder"])]
 /VariableDeclarator
- [VariableInitializer/Expression/PrimaryExpression[not(PrimarySuffix)]/PrimaryPrefix/Literal]
+ [VariableInitializer/Expression/PrimaryExpression[not(PrimarySuffix)]
+  /PrimaryPrefix/*[self::Literal or self::Name]
+ ]
 /VariableDeclaratorId
 ]]>
                 </value>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/FinalFieldCouldBeStatic.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/FinalFieldCouldBeStatic.xml
@@ -152,4 +152,26 @@ public class ExampleClass {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#3679 - False-negative on initializing with another object</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
+        <code><![CDATA[
+class Clazz {
+  public static final int a = 10;
+  public final int b = a;  // should report a warning here
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[OK] initializing with a method invocation</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+class Clazz {
+  public final int a = getValue();
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR
Fixed XPath for the [FinalFieldCouldBeStatic](https://pmd.github.io/latest/pmd_rules_java_design.html#finalfieldcouldbestatic) rule.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #3679 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

