### PR TITLE
[java] #3724 - fix FinalFieldCouldBeStatic: triggers only if the referenced name is static

### DIFF
--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -804,12 +804,18 @@ in each object at runtime.
                 <value>
 <![CDATA[
 //FieldDeclaration
- [@Final= true() and @Static= false()]
+ [@Final=true() and @Static=false()]
  [not(preceding-sibling::Annotation/MarkerAnnotation/Name[@Image="Builder.Default"]
     and //ImportDeclaration/Name[@Image="lombok.Builder"])]
 /VariableDeclarator
  [VariableInitializer/Expression/PrimaryExpression[not(PrimarySuffix)]
-  /PrimaryPrefix/*[self::Literal or self::Name]
+  /PrimaryPrefix/*
+    [
+        self::Literal (: literal :)
+        or
+        (: another static field :)
+        self::Name[@Image=//FieldDeclaration[@Static=true()]/VariableDeclarator/@Name]
+    ]
  ]
 /VariableDeclaratorId
 ]]>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/FinalFieldCouldBeStatic.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/FinalFieldCouldBeStatic.xml
@@ -174,4 +174,22 @@ class Clazz {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>
+            #3724 - the rule should be triggered only if the referenced name is static
+        </description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    private int nonStaticPrivate = 1;                   //no violation cause non-final
+    private final int nonStatic = nonStaticPrivate;     //no violation cause referenced name is non-static
+
+    //private static final int staticFinal = nonStatic; //noncompliant: Non-static field 'nonStatic' cannot be referenced from a static context
+    private static int staticNonFinal = 1;              //no violation cause non-final
+    private final int nonStatic2 = staticNonFinal;      //violation because it could be static
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR
Improved previous fix for the [FinalFieldCouldBeStatic](https://pmd.github.io/latest/pmd_rules_java_design.html#finalfieldcouldbestatic) rule - #3724.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #3679

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

