### PR TITLE
[java] Fix #3701 - fix MissingStaticMethodInNonInstantiatableClass for method local classes

### DIFF
--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2547,7 +2547,7 @@ See the property `annotations`.
             <property name="xpath">
                 <value>
 <![CDATA[
-//ClassOrInterfaceDeclaration[@Nested= false()]
+//ClassOrInterfaceDeclaration[@Nested= false() and @Local= false()]
 [
   (
     (: at least one constructor :)

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/MissingStaticMethodInNonInstantiatableClass.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/MissingStaticMethodInNonInstantiatableClass.xml
@@ -349,4 +349,34 @@ public abstract class MyADT {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#3701 - false positive with method inner class</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Scratch {
+
+    public static void main(String[] args) {
+        Scratch scratch = new Scratch();
+
+        scratch.callMethod();
+    }
+
+    void callMethod() {
+
+        class InnerClass {
+            private InnerClass() {
+            }
+
+            void display() {
+                System.out.println("Works OK!");
+            }
+        }
+
+        InnerClass innerClass = new InnerClass();
+        innerClass.display();
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Fixed [MissingStaticMethodInNonInstantiatableClass](https://pmd.github.io/latest/pmd_rules_java_errorprone.html#missingstaticmethodinnoninstantiatableclass) for method local classes:
```java
public class Foo {
    void method() {

        class InnerClass {
            private InnerClass() {
            }
        }

        InnerClass innerClass = new InnerClass();
    }
}
```

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #3701

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

