### PR TITLE
[core] Updated SaxonXPathRuleQueryTest.java

### DIFF
--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQueryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQueryTest.java
@@ -237,7 +237,7 @@ public class SaxonXPathRuleQueryTest {
         return result;
     }
 
-    private static SaxonXPathRuleQuery createQuery(String xpath, PropertyDescriptor<?> ...descriptors) {
+    private static SaxonXPathRuleQuery createQuery(String xpath, PropertyDescriptor<?>... descriptors) {
         SaxonXPathRuleQuery query = new SaxonXPathRuleQuery();
         query.setVersion(XPathRuleQuery.XPATH_2_0);
         if (descriptors != null) {


### PR DESCRIPTION
Varargs support was added to `NoWhitespaceAfterCheck`, wercker was failing on PMD.
CS PR: https://github.com/checkstyle/checkstyle/pull/11198
```
[INFO] --- maven-checkstyle-plugin:3.1.2:check (checkstyle-check) @ pmd-core ---
[INFO] There is 1 error reported by Checkstyle 9.3-SNAPSHOT with
 /net/sourceforge/pmd/pmd-checkstyle-config.xml ruleset.
[ERROR] src/test/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQueryTest.java:[240,88] 
(whitespace) WhitespaceAfter: '...' is not followed by whitespace.
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for PMD 6.42.0-SNAPSHOT:

```