### PR TITLE
[java] Fix #3712: InsufficientStringBufferDeclaration setLength false positive

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -46,6 +46,7 @@ This is a {{ site.pmd.release_type }} release.
     *   [#3701](https://github.com/pmd/pmd/issues/3701): \[java] MissingStaticMethodInNonInstantiatableClass false positive with method inner classes
 *   java-performance
     *   [#3492](https://github.com/pmd/pmd/issues/3492): \[java] UselessStringValueOf: False positive when there is no initial String to append to
+    *   [#3712](https://github.com/pmd/pmd/issues/3712): \[java] InsufficientStringBufferDeclaration false positive with StringBuilder.setLength(0)
 
 ### API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
@@ -97,7 +97,7 @@ public class InsufficientStringBufferDeclarationRule extends AbstractJavaRule {
 
                 if (n.getImage().endsWith("setLength")) {
                     int newLength = getConstructorLength(n, 0);
-                    if (newLength > constructorLength) {
+                    if (constructorLength != -1 && newLength > constructorLength) {
                         constructorLength = newLength; // a bigger setLength increases capacity
                         rootNode = n;
                     }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/InsufficientStringBufferDeclaration.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/InsufficientStringBufferDeclaration.xml
@@ -1220,13 +1220,14 @@ public class FalsePositive {
 
     <test-code>
         <description>Calculated initial size in constructor</description>
-        <expected-problems>4</expected-problems>
-        <expected-linenumbers>10,34,44,61</expected-linenumbers>
+        <expected-problems>5</expected-problems>
+        <expected-linenumbers>10,34,44,61,88</expected-linenumbers>
         <expected-messages>
             <message>StringBuilder has been initialized with size 4, but has at least 5 characters appended.</message>
             <message>StringBuilder has been initialized with size 5, but has at least 6 characters appended.</message>
             <message>StringBuilder has been initialized with size 8, but has at least 10 characters appended.</message>
             <message>StringBuilder has been initialized with size 8, but has at least 9 characters appended.</message>
+            <message>StringBuilder has been initialized with size 7, but has at least 8 characters appended.</message>
         </expected-messages>
         <code><![CDATA[
 public class InsufficientStringBufferDeclaration {
@@ -1294,6 +1295,30 @@ public class InsufficientStringBufferDeclaration {
         sb.append("bb"); // length is 6
         sb.append("cc"); // length is 8
         sb.append('d'); // length is now 9
+        return sb.toString();
+    }
+
+    public String case9_sufficient_setLength() {
+        StringBuilder sb = new StringBuilder(4);
+        sb.append("xxxx");
+        sb.setLength(0); // length is 0, capacity is still 4
+        sb.append("aaaa");
+        return sb.toString();
+    }
+
+    public String case10_unknown_setLength(String in) {
+        StringBuilder sb = new StringBuilder(in.length()); // unknown
+        sb.append("xxxx");
+        sb.setLength(0); // length is 0, capacity is still unknown
+        sb.append("aaaa");
+        return sb.toString();
+    }
+
+    public String case11_unknown_ensureCapacity(String in) {
+        StringBuilder sb = new StringBuilder(in.length()); // unknown
+        sb.append("xxxx"); // length is 4
+        sb.ensureCapacity(7); // line 88 - length is still 4, new capacity now at least 7 -> violation here
+        sb.append("aaaa"); // length is 8
         return sb.toString();
     }
 }


### PR DESCRIPTION
## Describe the PR

Fix bug #3712 where StringBuilder.setLength(int) is incorrectly flagged when the initial constructor capacity cannot be determined.

## Related issues

- Fixes #3712

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)
