### PR TITLE
[visualforce] Updated DataType.java

### DIFF
--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/DataType.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/DataType.java
@@ -121,7 +121,7 @@ public enum DataType {
         this(requiresEscaping, null);
     }
 
-    DataType(boolean requiresEscaping, BasicType...basicTypes) {
+    DataType(boolean requiresEscaping, BasicType... basicTypes) {
         this.requiresEscaping = requiresEscaping;
         this.basicTypes = new HashSet<>();
         if (basicTypes != null) {


### PR DESCRIPTION
Varargs support was added to `NoWhitespaceAfterCheck`, wercker was failing on PMD.
CS PR: https://github.com/checkstyle/checkstyle/pull/11198
```
INFO] --- maven-checkstyle-plugin:3.1.2:check (checkstyle-check) @ pmd-visualforce ---
[INFO] There is 1 error reported by Checkstyle 9.3-SNAPSHOT with /net/sourceforge/pmd/pmd-checkstyle-config.xml ruleset.
[ERROR] src/main/java/net/sourceforge/pmd/lang/vf/DataType.java:[124,49] (whitespace) WhitespaceAfter: '...' is not followed by whitespace.
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for PMD 6.42.0-SNAPSHOT:
[INFO] 
[INFO] PMD ................................................ SUCCESS [  2.490 s]
[INFO] PMD

```