### PR TITLE
[core] Deprecations for analysis listeners

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -35,6 +35,9 @@ It is now forbidden to report a violation:
 - With a `null` message
 - With a `null` set of format arguments (prefer a zero-length array)
 
+Note that the message is set from the XML rule declaration, so this is only relevant
+if you instantiate rules manually.
+
 {% jdoc core::RuleContext %} now requires setting the current rule before calling
 {% jdoc core::lang.rule.Rule#apply(java.util.List, core::RuleContext)}. This is
 done automatically by `RuleSet#apply` and such. Creating and configuring a

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -18,6 +18,29 @@ This is a {{ site.pmd.release_type }} release.
 
 ### API Changes
 
+#### Deprecated API
+
+Some API deprecations were performed in core PMD classes, to improve compatibility with PMD 7.
+- {% jdoc core::Report %}: construction methods like addViolation or createReport
+- {% jdoc core::RuleContext %}: all constructors, getters and setters. A new set
+of stable methods, matching those in PMD 7, was added to replace the `addViolation`
+overloads of {% jdoc core::lang.rule.AbstractRule %}. In PMD 7, `RuleContext` will
+be the API to report violations, and it can already be used as such in PMD 6.
+- {% jdoc core::RuleSet %}: methods that serve to apply rules, including `apply`, `start`, `end`, `removeDysfunctionalRules`
+
+#### Changed API
+
+It is now forbidden to report a violation:
+- With a `null` node
+- With a `null` message
+- With a `null` set of format arguments (prefer a zero-length array)
+
+{% jdoc core::RuleContext %} now requires setting the current rule before calling
+{% jdoc core::lang.rule.Rule#apply(java.util.List, core::RuleContext)}. This is
+done automatically by `RuleSet#apply` and such. Creating and configuring a
+`RuleContext` manually is strongly advised against, as the lifecycle of `RuleContext`
+will change drastically in PMD 7.
+
 ### External Contributions
 
 {% endtocmaker %}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/documentation/ApexDocRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/documentation/ApexDocRule.java
@@ -86,20 +86,20 @@ public class ApexDocRule extends AbstractApexRule {
         ApexDocComment comment = getApexDocComment(node);
         if (comment == null) {
             if (shouldHaveApexDocs(node)) {
-                addViolationWithMessage(data, node, MISSING_COMMENT_MESSAGE);
+                asCtx(data).addViolationWithMessage(node, MISSING_COMMENT_MESSAGE);
             }
         } else {
             if (getProperty(REPORT_MISSING_DESCRIPTION_DESCRIPTOR) && !comment.hasDescription) {
-                addViolationWithMessage(data, node, MISSING_DESCRIPTION_MESSAGE);
+                asCtx(data).addViolationWithMessage(node, MISSING_DESCRIPTION_MESSAGE);
             }
 
             String returnType = node.getReturnType();
             boolean shouldHaveReturn = !(returnType.isEmpty() || "void".equalsIgnoreCase(returnType));
             if (comment.hasReturn != shouldHaveReturn) {
                 if (shouldHaveReturn) {
-                    addViolationWithMessage(data, node, MISSING_RETURN_MESSAGE);
+                    asCtx(data).addViolationWithMessage(node, MISSING_RETURN_MESSAGE);
                 } else {
-                    addViolationWithMessage(data, node, UNEXPECTED_RETURN_MESSAGE);
+                    asCtx(data).addViolationWithMessage(node, UNEXPECTED_RETURN_MESSAGE);
                 }
             }
 
@@ -108,7 +108,7 @@ public class ApexDocRule extends AbstractApexRule {
                     .stream().map(p -> p.getImage()).collect(Collectors.toList());
 
             if (!comment.params.equals(params)) {
-                addViolationWithMessage(data, node, MISMATCHED_PARAM_MESSAGE);
+                asCtx(data).addViolationWithMessage(node, MISMATCHED_PARAM_MESSAGE);
             }
         }
 
@@ -121,11 +121,11 @@ public class ApexDocRule extends AbstractApexRule {
 
         if (comment == null) {
             if (shouldHaveApexDocs(node)) {
-                addViolationWithMessage(data, node, MISSING_COMMENT_MESSAGE);
+                asCtx(data).addViolationWithMessage(node, MISSING_COMMENT_MESSAGE);
             }
         } else {
             if (getProperty(REPORT_MISSING_DESCRIPTION_DESCRIPTOR) && !comment.hasDescription) {
-                addViolationWithMessage(data, node, MISSING_DESCRIPTION_MESSAGE);
+                asCtx(data).addViolationWithMessage(node, MISSING_DESCRIPTION_MESSAGE);
             }
         }
 
@@ -136,11 +136,11 @@ public class ApexDocRule extends AbstractApexRule {
         ApexDocComment comment = getApexDocComment(node);
         if (comment == null) {
             if (shouldHaveApexDocs(node)) {
-                addViolationWithMessage(data, node, MISSING_COMMENT_MESSAGE);
+                asCtx(data).addViolationWithMessage(node, MISSING_COMMENT_MESSAGE);
             }
         } else {
             if (getProperty(REPORT_MISSING_DESCRIPTION_DESCRIPTOR) && !comment.hasDescription) {
-                addViolationWithMessage(data, node, MISSING_DESCRIPTION_MESSAGE);
+                asCtx(data).addViolationWithMessage(node, MISSING_DESCRIPTION_MESSAGE);
             }
         }
     }

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/SuppressWarningsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/SuppressWarningsTest.java
@@ -21,6 +21,12 @@ import net.sourceforge.pmd.testframework.RuleTst;
 public class SuppressWarningsTest extends RuleTst {
 
     private static class BarRule extends AbstractApexRule {
+
+        @Override
+        public String getMessage() {
+            return "a message";
+        }
+
         @Override
         public Object visit(ASTUserClass clazz, Object ctx) {
             if (clazz.getImage().equalsIgnoreCase("bar")) {

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexRuleTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexRuleTest.java
@@ -45,14 +45,21 @@ public class AbstractApexRuleTest extends ApexParserTestBase {
 
     private void run(String code) {
         ApexNode<Compilation> node = parse(code);
+        TopLevelRule rule = new TopLevelRule();
         RuleContext ctx = new RuleContext();
         ctx.setLanguageVersion(apex.getDefaultVersion());
-        TopLevelRule rule = new TopLevelRule();
+        ctx.setCurrentRule(rule);
         rule.apply(Collections.singletonList(node), ctx);
         assertEquals(1, ctx.getReport().size());
     }
 
     private static class TopLevelRule extends AbstractApexRule {
+
+        @Override
+        public String getMessage() {
+            return "a message";
+        }
+
         @Override
         public Object visit(ASTUserClass node, Object data) {
             addViolation(data, node);

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSharingViolationsNestedClassTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSharingViolationsNestedClassTest.java
@@ -86,8 +86,10 @@ public class ApexSharingViolationsNestedClassTest extends RuleTst {
     public void testSharingPermutation() {
         String apexClass = generateClass(outerSharingDeclared, outerOperation, innerSharingDeclared, innerOperation);
         Report rpt = new Report();
-        runTestFromString(apexClass, new ApexSharingViolationsRule(), rpt,
-                LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
+        ApexSharingViolationsRule rule = new ApexSharingViolationsRule();
+        rule.setMessage("a message");
+        runTestFromString(apexClass, rule, rpt,
+                          LanguageRegistry.getLanguage(ApexLanguageModule.NAME).getDefaultVersion());
         List<RuleViolation> violations = rpt.getViolations();
         assertEquals("Unexpected Violation Size\n" + apexClass, expectedViolations, violations.size());
         List<Integer> lineNumbers = violations.stream().map(v -> v.getBeginLine()).collect(Collectors.toList());

--- a/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -19,6 +20,7 @@ import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 
+import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.dfa.report.ReportTree;
 import net.sourceforge.pmd.lang.rule.stat.StatisticalRule;
 import net.sourceforge.pmd.renderers.AbstractAccumulatingRenderer;
@@ -27,9 +29,12 @@ import net.sourceforge.pmd.util.DateTimeUtil;
 import net.sourceforge.pmd.util.NumericConstants;
 
 /**
- * A {@link Report} collects all informations during a PMD execution. This
- * includes violations, suppressed violations, metrics, error during processing
- * and configuration errors.
+ * A {@link Report} is the output of a PMD execution. This
+ * includes violations, suppressed violations, metrics, error
+ * during processing and configuration errors. PMD's entry point creates
+ * a report (see {@link PMD#processFiles(PMDConfiguration, List, Collection, List)}).
+ * The mutation methods on this class are deprecated, as they will be
+ * internalized in PMD 7.
  */
 public class Report implements Iterable<RuleViolation> {
 
@@ -56,12 +61,15 @@ public class Report implements Iterable<RuleViolation> {
     /**
      * Creates a new, initialized, empty report for the given file name.
      *
-     * @param ctx
-     *            The context to use to connect to the report
-     * @param fileName
-     *            the filename used to report any violations
+     * @param ctx      The context to use to connect to the report
+     * @param fileName the filename used to report any violations
+     *
      * @return the new report
+     *
+     * @deprecated Is internal API
      */
+    @Deprecated
+    @InternalApi
     public static Report createReport(RuleContext ctx, String fileName) {
         Report report = new Report();
 
@@ -330,9 +338,12 @@ public class Report implements Iterable<RuleViolation> {
     /**
      * Adds a new rule violation to the report and notify the listeners.
      *
-     * @param violation
-     *            the violation to add
+     * @param violation the violation to add
+     *
+     * @deprecated PMD's way of creating a report is internal and may be changed in pmd 7.
      */
+    @Deprecated
+    @InternalApi
     public void addRuleViolation(RuleViolation violation) {
 
         // NOPMD suppress
@@ -376,7 +387,11 @@ public class Report implements Iterable<RuleViolation> {
      *
      * @param error
      *            the error to add
+     *
+     * @deprecated PMD's way of creating a report is internal and may be changed in pmd 7.
      */
+    @Deprecated
+    @InternalApi
     public void addConfigError(ConfigurationError error) {
         configErrors.add(error);
     }
@@ -386,7 +401,10 @@ public class Report implements Iterable<RuleViolation> {
      *
      * @param error
      *            the error to add
+     * @deprecated PMD's way of creating a report is internal and may be changed in pmd 7.
      */
+    @Deprecated
+    @InternalApi
     public void addError(ProcessingError error) {
         errors.add(error);
     }
@@ -402,7 +420,11 @@ public class Report implements Iterable<RuleViolation> {
      * @param r the report to be merged into this.
      *
      * @see AbstractAccumulatingRenderer
+     *
+     * @deprecated Internal API
      */
+    @Deprecated
+    @InternalApi
     public void merge(Report r) {
         synchronized (lock) {
             errors.addAll(r.errors);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleContext.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleContext.java
@@ -11,13 +11,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Logger;
 
-import org.apache.commons.lang3.StringUtils;
-
-import net.sourceforge.pmd.Report.SuppressedViolation;
 import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.rule.ParametricRuleViolation;
 import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
 
 /**
@@ -170,7 +166,11 @@ public class RuleContext {
         Objects.requireNonNull(formatArgs, "Format arguments were null, use an empty array");
 
         RuleViolationFactory fact = getLanguageVersion().getLanguageVersionHandler().getRuleViolationFactory();
-        fact.addViolation(this, getCurrentRule(), location,message, beginLine, endLine, formatArgs);
+        if (beginLine != -1 && endLine != -1) {
+            fact.addViolation(this, getCurrentRule(), location, message, beginLine, endLine, formatArgs);
+        } else {
+            fact.addViolation(this, getCurrentRule(), location, message, formatArgs);
+        }
     }
 
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleContext.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleContext.java
@@ -9,7 +9,9 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Logger;
 
+import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.LanguageVersion;
+import net.sourceforge.pmd.lang.ast.Node;
 
 /**
  * The RuleContext provides access to Rule processing state. This information
@@ -39,7 +41,11 @@ public class RuleContext {
 
     /**
      * Default constructor.
+     *
+     * @deprecated Internal API, removed in PMD 7
      */
+    @Deprecated
+    @InternalApi
     public RuleContext() {
         attributes = new ConcurrentHashMap<>();
     }
@@ -48,9 +54,12 @@ public class RuleContext {
      * Constructor which shares attributes and report listeners with the given
      * RuleContext.
      *
-     * @param ruleContext
-     *            the context from which the values are shared
+     * @param ruleContext the context from which the values are shared
+     *
+     * @deprecated Internal API, removed in PMD 7
      */
+    @Deprecated
+    @InternalApi
     public RuleContext(RuleContext ruleContext) {
         this.attributes = ruleContext.attributes;
         this.report.addListeners(ruleContext.getReport().getListeners());
@@ -60,7 +69,11 @@ public class RuleContext {
      * Get the Report to which Rule Violations are sent.
      *
      * @return The Report.
+     *
+     * @deprecated Internal API, removed in PMD 7
      */
+    @Deprecated
+    @InternalApi
     public Report getReport() {
         return report;
     }
@@ -68,9 +81,12 @@ public class RuleContext {
     /**
      * Set the Report to which Rule Violations are sent.
      *
-     * @param report
-     *            The Report.
+     * @param report The Report.
+     *
+     * @deprecated Internal API, removed in PMD 7
      */
+    @Deprecated
+    @InternalApi
     public void setReport(Report report) {
         this.report = report;
     }
@@ -79,7 +95,11 @@ public class RuleContext {
      * Get the File associated with the current source file.
      *
      * @return The File.
+     *
+     * @deprecated Internal API, removed in PMD 7
      */
+    @Deprecated
+    @InternalApi
     public File getSourceCodeFile() {
         return sourceCodeFile;
     }
@@ -89,9 +109,12 @@ public class RuleContext {
      * set to <code>null</code>, the exclude/include facilities will not work
      * properly without a File.
      *
-     * @param sourceCodeFile
-     *            The File.
+     * @param sourceCodeFile The File.
+     *
+     * @deprecated Internal API, removed in PMD 7
      */
+    @Deprecated
+    @InternalApi
     public void setSourceCodeFile(File sourceCodeFile) {
         this.sourceCodeFile = sourceCodeFile;
     }
@@ -101,7 +124,11 @@ public class RuleContext {
      * If there is no source file, then an empty string is returned.
      *
      * @return The file name.
+     *
+     * @deprecated Internal API, removed in PMD 7
      */
+    @Deprecated
+    @InternalApi
     public String getSourceCodeFilename() {
         if (sourceCodeFile != null) {
             return sourceCodeFile.getName();
@@ -129,7 +156,14 @@ public class RuleContext {
      * Get the LanguageVersion associated with the current source file.
      *
      * @return The LanguageVersion, <code>null</code> if unknown.
+     *
+     * @deprecated Will be removed in PMD 7, as the nodes have access
+     *     to their language version. In PMD 6, this is still the only way
+     *     to access the language version within a rule, and cannot be replaced.
+     *     The deprecation warning hints that the method should be replaced
+     *     in PMD 7.
      */
+    @Deprecated
     public LanguageVersion getLanguageVersion() {
         return this.languageVersion;
     }
@@ -139,9 +173,12 @@ public class RuleContext {
      * be set to <code>null</code> to indicate the version is unknown and should
      * be automatically determined.
      *
-     * @param languageVersion
-     *            The LanguageVersion.
+     * @param languageVersion The LanguageVersion.
+     *
+     * @deprecated Internal API, removed in PMD 7
      */
+    @Deprecated
+    @InternalApi
     public void setLanguageVersion(LanguageVersion languageVersion) {
         this.languageVersion = languageVersion;
     }
@@ -241,9 +278,12 @@ public class RuleContext {
      * exception. This is especially useful during unit tests, in order to not
      * oversee any exceptions.
      *
-     * @param ignoreExceptions
-     *            if <code>true</code> simply skip failing rules (default).
+     * @param ignoreExceptions if <code>true</code> simply skip failing rules (default).
+     *
+     * @deprecated Internal API, removed in PMD 7
      */
+    @Deprecated
+    @InternalApi
     public void setIgnoreExceptions(boolean ignoreExceptions) {
         this.ignoreExceptions = ignoreExceptions;
     }
@@ -254,8 +294,12 @@ public class RuleContext {
      * first failing rule.
      *
      * @return <code>true</code> when failing rules are skipped,
-     *         <code>false</code> otherwise.
+     *     <code>false</code> otherwise.
+     *
+     * @deprecated Internal API, removed in PMD 7
      */
+    @Deprecated
+    @InternalApi
     public boolean isIgnoreExceptions() {
         return ignoreExceptions;
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
@@ -20,6 +20,7 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.lang3.StringUtils;
 
+import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.benchmark.TimeTracker;
 import net.sourceforge.pmd.benchmark.TimedOperation;
 import net.sourceforge.pmd.benchmark.TimedOperationCategory;
@@ -633,9 +634,13 @@ public class RuleSet implements ChecksumAware {
      * Triggers that start lifecycle event on each rule in this ruleset. Some
      * rules perform initialization tasks on start.
      *
-     * @param ctx
-     *            the current context
+     * @param ctx the current context
+     *
+     * @deprecated This is internal API, removed in PMD 7. You should
+     *     not use a ruleset directly.
      */
+    @Deprecated
+    @InternalApi
     public void start(RuleContext ctx) {
         for (Rule rule : rules) {
             rule.start(ctx);
@@ -649,7 +654,12 @@ public class RuleSet implements ChecksumAware {
      *            the node list, usually the root nodes like compilation units
      * @param ctx
      *            the current context
+     *
+     * @deprecated This is internal API, removed in PMD 7. You should
+     * not use a ruleset directly.
      */
+    @Deprecated
+    @InternalApi
     public void apply(List<? extends Node> acuList, RuleContext ctx) {
         try (TimedOperation to = TimeTracker.startOperation(TimedOperationCategory.RULE)) {
             for (Rule rule : rules) {
@@ -689,7 +699,12 @@ public class RuleSet implements ChecksumAware {
      *
      * @return <code>true</code> if the given rule matches the given language,
      *         which means, that the rule would be executed.
+     *
+     * @deprecated This is internal API, removed in PMD 7. You should
+     * not use a ruleset directly.
      */
+    @Deprecated
+    @InternalApi
     public static boolean applies(Rule rule, LanguageVersion languageVersion) {
         final LanguageVersion min = rule.getMinimumLanguageVersion();
         final LanguageVersion max = rule.getMaximumLanguageVersion();
@@ -704,7 +719,11 @@ public class RuleSet implements ChecksumAware {
      *
      * @param ctx
      *            the current context
+     * @deprecated This is internal API, removed in PMD 7. You should
+     * not use a ruleset directly.
      */
+    @Deprecated
+    @InternalApi
     public void end(RuleContext ctx) {
         for (Rule rule : rules) {
             rule.end(ctx);
@@ -841,7 +860,12 @@ public class RuleSet implements ChecksumAware {
      *
      * @param collector
      *            the removed rules will be added to this collection
+     *
+     * @deprecated This is internal API, removed in PMD 7. You should
+     * not use a ruleset directly.
      */
+    @Deprecated
+    @InternalApi
     public void removeDysfunctionalRules(Collection<Rule> collector) {
         Iterator<Rule> iter = rules.iterator();
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSet.java
@@ -656,6 +656,7 @@ public class RuleSet implements ChecksumAware {
                 if (!rule.isRuleChain() && applies(rule, ctx.getLanguageVersion())) {
 
                     try (TimedOperation rto = TimeTracker.startOperation(TimedOperationCategory.RULE, rule.getName())) {
+                        ctx.setCurrentRule(rule);
                         rule.apply(acuList, ctx);
                     } catch (RuntimeException e) {
                         if (ctx.isIgnoreExceptions()) {
@@ -668,6 +669,8 @@ public class RuleSet implements ChecksumAware {
                         } else {
                             throw e;
                         }
+                    } finally {
+                        ctx.setCurrentRule(null);
                     }
                 }
             }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ThreadSafeReportListener.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ThreadSafeReportListener.java
@@ -14,7 +14,8 @@ import net.sourceforge.pmd.stat.Metric;
  * Same file violations are guaranteed to be reported serially.
  *
  * @deprecated All entry points of PMD that allowed usage of this are now deprecated.
- *     This will be replaced by another TBD mechanism in PMD 7.
+ *     This will be replaced by analysis listeners in PMD 7, a more general event
+ *     handling mechanism (see <a href="https://github.com/pmd/pmd/pull/3692">#3692</a>)
  */
 @Deprecated
 public interface ThreadSafeReportListener {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
@@ -355,7 +355,7 @@ public abstract class AbstractRule extends AbstractPropertySource implements Rul
      */
     protected final RuleContext asCtx(Object ctx) {
         if (ctx instanceof RuleContext) {
-            assert ((RuleContext) ctx).getCurrentRule() == this // NOPMD CompareObjectsWithEquals
+            assert isThisRule(((RuleContext) ctx).getCurrentRule())
                 : "not an appropriate rule context!";
             return (RuleContext) ctx;
         } else {
@@ -363,9 +363,13 @@ public abstract class AbstractRule extends AbstractPropertySource implements Rul
         }
     }
 
+    private boolean isThisRule(Rule rule) {
+        return rule == this // NOPMD CompareObjectsWithEquals
+            || rule instanceof AbstractDelegateRule && this.isThisRule(((AbstractDelegateRule) rule).getRule());
+    }
+
     /**
      * @see RuleContext#addViolation(Node)
-     *
      * @deprecated Replace with {@code asCtx(data).addViolation(node)}.
      */
     public void addViolation(Object data, Node node) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
@@ -374,6 +374,15 @@ public abstract class AbstractRule extends AbstractPropertySource implements Rul
     /**
      * @see RuleContext#addViolation(Node, Object[])
      *
+     * @deprecated Replace with {@code asCtx(data).addViolation(node, arg)}.
+     */
+    public void addViolation(Object data, Node node, String arg) {
+        asCtx(data).addViolation(node, arg);
+    }
+
+    /**
+     * @see RuleContext#addViolation(Node, Object[])
+     *
      * @deprecated Replace with {@code asCtx(data).addViolation(node, arg1, arg2)}.
      */
     public void addViolation(Object data, Node node, Object... args) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
@@ -355,7 +355,8 @@ public abstract class AbstractRule extends AbstractPropertySource implements Rul
      */
     protected final RuleContext asCtx(Object ctx) {
         if (ctx instanceof RuleContext) {
-            assert ((RuleContext) ctx).getCurrentRule() == this: "not an appropriate rule context!";
+            assert ((RuleContext) ctx).getCurrentRule() == this // NOPMD CompareObjectsWithEquals
+                : "not an appropriate rule context!";
             return (RuleContext) ctx;
         } else {
             throw new ClassCastException("Unexpected context object! " + ctx);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
@@ -342,63 +342,66 @@ public abstract class AbstractRule extends AbstractPropertySource implements Rul
     }
 
     /**
-     * @see RuleViolationFactory#addViolation(RuleContext, Rule, Node, String,
-     * Object[])
+     * Cast the argument to a {@link RuleContext}. Use it to report violations:
+     * <pre>{@code
+     *  asCtx(data).addViolation(node);
+     *  asCtx(data).addViolationWithMessage(node, "Some message");
+     * }</pre>
+     *
+     * In PMD 7, rules will have type-safe access to a RuleContext, and
+     * this will be deprecated as useless. In PMD 6, you can use this to
+     * stop using the deprecated {@link #addViolation(Object, Node)} overloads
+     * of this class.
+     */
+    protected final RuleContext asCtx(Object ctx) {
+        if (ctx instanceof RuleContext) {
+            assert ((RuleContext) ctx).getCurrentRule() == this: "not an appropriate rule context!";
+            return (RuleContext) ctx;
+        } else {
+            throw new ClassCastException("Unexpected context object! " + ctx);
+        }
+    }
+
+    /**
+     * @see RuleContext#addViolation(Node)
+     *
+     * @deprecated Replace with {@code asCtx(data).addViolation(node)}.
      */
     public void addViolation(Object data, Node node) {
-        RuleContext ruleContext = (RuleContext) data;
-        ruleContext.getLanguageVersion().getLanguageVersionHandler().getRuleViolationFactory().addViolation(ruleContext,
-                this, node, this.getMessage(), null);
+        asCtx(data).addViolation(node);
     }
 
     /**
-     * @see RuleViolationFactory#addViolation(RuleContext, Rule, Node, String,
-     * Object[])
+     * @see RuleContext#addViolation(Node, Object[])
+     *
+     * @deprecated Replace with {@code asCtx(data).addViolation(node, arg1, arg2)}.
      */
-    public void addViolation(Object data, Node node, String arg) {
-        RuleContext ruleContext = (RuleContext) data;
-        ruleContext.getLanguageVersion().getLanguageVersionHandler().getRuleViolationFactory().addViolation(ruleContext,
-                this, node, this.getMessage(), new Object[]{arg});
+    public void addViolation(Object data, Node node, Object... args) {
+        asCtx(data).addViolation(node, args);
     }
 
     /**
-     * @see RuleViolationFactory#addViolation(RuleContext, Rule, Node, String,
-     * Object[])
-     */
-    public void addViolation(Object data, Node node, Object[] args) {
-        RuleContext ruleContext = (RuleContext) data;
-        ruleContext.getLanguageVersion().getLanguageVersionHandler().getRuleViolationFactory().addViolation(ruleContext,
-                this, node, this.getMessage(), args);
-    }
-
-    /**
-     * @see RuleViolationFactory#addViolation(RuleContext, Rule, Node, String,
-     * Object[])
+     * @see RuleContext#addViolationWithMessage(Node, String)
+     * @deprecated Replace with {@code asCtx(data).addViolationWithMessage(node, message)}.
      */
     public void addViolationWithMessage(Object data, Node node, String message) {
-        RuleContext ruleContext = (RuleContext) data;
-        ruleContext.getLanguageVersion().getLanguageVersionHandler().getRuleViolationFactory().addViolation(ruleContext,
-                this, node, message, null);
+        asCtx(data).addViolationWithMessage(node, message);
     }
 
     /**
-     * @see RuleViolationFactory#addViolation(RuleContext, Rule, Node, String,
-     * Object[])
+     * @see RuleContext#addViolationWithPosition(Node, int, int, String, Object...)
+     * @deprecated Replace with {@code asCtx(data).addViolationWithPosition(node, beginLine, endLine, message)}.
      */
     public void addViolationWithMessage(Object data, Node node, String message, int beginLine, int endLine) {
-        RuleContext ruleContext = (RuleContext) data;
-        ruleContext.getLanguageVersion().getLanguageVersionHandler().getRuleViolationFactory().addViolation(ruleContext,
-                this, node, message, beginLine, endLine, null);
+        asCtx(data).addViolationWithPosition(node, beginLine, endLine, message);
     }
 
     /**
-     * @see RuleViolationFactory#addViolation(RuleContext, Rule, Node, String,
-     * Object[])
+     * @see RuleContext#addViolationWithMessage(Node, String, Object...)
+     * @deprecated Replace with {@code asCtx(data).addViolationWithMessage(node, message, args)}.
      */
     public void addViolationWithMessage(Object data, Node node, String message, Object[] args) {
-        RuleContext ruleContext = (RuleContext) data;
-        ruleContext.getLanguageVersion().getLanguageVersionHandler().getRuleViolationFactory().addViolation(ruleContext,
-                this, node, message, args);
+        asCtx(data).addViolationWithMessage(node, message, args);
     }
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRuleChainVisitor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRuleChainVisitor.java
@@ -86,7 +86,9 @@ public abstract class AbstractRuleChainVisitor implements RuleChainVisitor {
                     if (!RuleSet.applies(rule, ctx.getLanguageVersion())) {
                         continue;
                     }
+                    // CPD-OFF
                     try (TimedOperation rcto = TimeTracker.startOperation(TimedOperationCategory.RULECHAIN_RULE, rule.getName())) {
+                        ctx.setCurrentRule(rule);
                         final List<String> nodeNames = rule.getRuleChainVisits();
                         for (int j = 0; j < nodeNames.size(); j++) {
                             List<Node> ns = nodeNameToNodes.get(nodeNames.get(j));
@@ -112,7 +114,10 @@ public abstract class AbstractRuleChainVisitor implements RuleChainVisitor {
                         } else {
                             throw e;
                         }
+                    } finally {
+                        ctx.setCurrentRule(null);
                     }
+                    // CPD-ON
                 }
             }
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleViolationFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleViolationFactory.java
@@ -16,6 +16,10 @@ import net.sourceforge.pmd.lang.ast.Node;
  * <p>Since PMD 6.21.0, implementations of this interface are considered internal
  * API and hence deprecated. Clients should exclusively use this interface and obtain
  * instances through {@link LanguageVersionHandler#getRuleViolationFactory()}.
+ *
+ * <p>Since PMD 6.43.0, {@link RuleContext} has been enriched with methods that should
+ * be strongly preferred to using this interface directly. The interface will change a
+ * lot in PMD 7.
  */
 public interface RuleViolationFactory {
     /**

--- a/pmd-core/src/test/java/net/sourceforge/pmd/AbstractRuleTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/AbstractRuleTest.java
@@ -110,6 +110,7 @@ public class AbstractRuleTest {
         ctx.setLanguageVersion(LanguageRegistry.getLanguage(DummyLanguageModule.NAME).getDefaultVersion());
         ctx.setReport(new Report());
         ctx.setSourceCodeFile(new File("filename"));
+        ctx.setCurrentRule(r);
         DummyNode s = new DummyNode(1);
         s.testingOnlySetBeginColumn(5);
         s.testingOnlySetBeginLine(5);

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/XPathRuleTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/XPathRuleTest.java
@@ -155,7 +155,9 @@ public class XPathRuleTest {
     }
 
     public void eval(RuleContext ctx, net.sourceforge.pmd.Rule rule, DummyNode node) {
+        ctx.setCurrentRule(rule);
         rule.apply(singletonList(node), ctx);
+        ctx.setCurrentRule(null);
     }
 
     public DummyNode newNode() {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/stat/MockStatisticalRule.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/stat/MockStatisticalRule.java
@@ -60,6 +60,6 @@ public class MockStatisticalRule extends FooRule implements StatisticalRule {
 
     @Override
     public Object[] getViolationParameters(DataPoint point) {
-        return null;
+        return new Object[0];
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/stat/StatisticalRuleTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/stat/StatisticalRuleTest.java
@@ -860,6 +860,7 @@ public class StatisticalRuleTest {
         ctx.setReport(report);
         ctx.setSourceCodeFile(new File(testName));
         ctx.setLanguageVersion(LanguageRegistry.getLanguage(DummyLanguageModule.NAME).getDefaultVersion());
+        ctx.setCurrentRule(rule);
 
         rule.apply(list, ctx);
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/SuppressWarningsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/SuppressWarningsTest.java
@@ -19,6 +19,12 @@ import net.sourceforge.pmd.testframework.RuleTst;
 public class SuppressWarningsTest extends RuleTst {
 
     private static class BarRule extends AbstractJavaRule {
+
+        @Override
+        public String getMessage() {
+            return "a message";
+        }
+
         @Override
         public Object visit(ASTCompilationUnit cu, Object ctx) {
             // Convoluted rule to make sure the violation is reported for the

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/AvoidTabCharacterRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/AvoidTabCharacterRule.java
@@ -35,7 +35,7 @@ public class AvoidTabCharacterRule extends AbstractPLSQLRule {
             while ((line = in.readLine()) != null) {
                 lineNumber++;
                 if (line.indexOf('\t') != -1) {
-                    addViolationWithMessage(data, null, "Tab characters are not allowed. Use spaces for indentation",
+                    addViolationWithMessage(data, node, "Tab characters are not allowed. Use spaces for indentation",
                             lineNumber, lineNumber);
 
                     if (!eachLine) {

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/LineLengthRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/codestyle/LineLengthRule.java
@@ -43,7 +43,7 @@ public class LineLengthRule extends AbstractPLSQLRule {
             while ((line = in.readLine()) != null) {
                 lineNumber++;
                 if (line.length() > maxLineLength) {
-                    addViolationWithMessage(data, null, "The line is too long. Only " + maxLineLength + " characters are allowed.",
+                    addViolationWithMessage(data, node, "The line is too long. Only " + maxLineLength + " characters are allowed.",
                             lineNumber, lineNumber);
 
                     if (!eachLine) {

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/PLSQLXPathRuleTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/PLSQLXPathRuleTest.java
@@ -59,6 +59,7 @@ public class PLSQLXPathRuleTest extends AbstractPLSQLParserTst {
         rule.setMessage("Test Violation");
 
         RuleContext ctx = new RuleContext();
+        ctx.setCurrentRule(rule);
         ctx.setLanguageVersion(plsql.getDefaultVersion());
 
         rule.apply(singletonList(node), ctx);

--- a/pmd-scala-modules/pmd-scala-common/src/test/java/net/sourceforge/pmd/lang/scala/rule/ScalaRuleTest.java
+++ b/pmd-scala-modules/pmd-scala-common/src/test/java/net/sourceforge/pmd/lang/scala/rule/ScalaRuleTest.java
@@ -43,6 +43,11 @@ public class ScalaRuleTest extends BaseScalaTest {
     public void testDummyRule() {
         ScalaRule rule = new ScalaRule() {
             @Override
+            public String getMessage() {
+                return "a message";
+            }
+
+            @Override
             public RuleContext visit(ASTTermApply node, RuleContext data) {
                 ASTTermName child = node.getFirstChildOfType(ASTTermName.class);
                 if (child != null && child.hasImageEqualTo("println")) {


### PR DESCRIPTION
## Describe the PR

Deprecations for #3692 

Unresolved points:
- [ ] RuleContext now has the new methods of PMD 7. Maybe we should deprecate the old AbstractRule#addViolation, but the new way to do this doesn't feel great, and is also transitional anyway (`asCtx(data).addViolation(node)`). I think it makes sense to keep those methods around for transition. We can mark them as `@DeprecatedUntil700` in PMD 7.
- [ ] @adangel [Your comment](https://github.com/pmd/pmd/pull/3692#pullrequestreview-872768952) talks about internalizing some members of the ant Formatter class. What about making the entire class internal in PMD 6? -> #3787 
- [ ] Maybe other things should be deprecated, like in Renderers, though I'm inclined not to do this before we're clearer about #3753 

I looked into the designer sources and don't think the designer needs an update.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

-  #3692

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

