### PR TITLE
[java] Fix #278 - ConfusingTernary should treat `!= null` as positive condition

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -16,6 +16,9 @@ This is a {{ site.pmd.release_type }} release.
 
 ### Fixed Issues
 
+*   java-codestyle
+    *   [#278](https://github.com/pmd/pmd/issues/278): \[java] ConfusingTernary should treat `!= null` as positive condition
+
 ### API Changes
 
 ### External Contributions

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ConfusingTernary.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ConfusingTernary.xml
@@ -29,6 +29,33 @@ public class Foo {
     </test-code>
 
     <test-code>
+        <description>null check, ok (if) - #278</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    String bar2(Object a) {
+        if (a != null)
+            return a.toString();
+        else
+            return null;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>null check, ok (ternary) - #278</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    String bar(Object a) {
+        return a != null ? a.toString() : null;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>!= inside if, bad</description>
         <expected-problems>2</expected-problems>
         <code><![CDATA[


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #278

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

