### PR TITLE
Update GUI.java

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/GUI.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/GUI.java
@@ -170,7 +170,7 @@ public class GUI implements CPDListener {
                     if (terseName == null) {
                         return false;
                     }
-                    switch(terseName) {
+                    switch (terseName) {
                         case "cpp":
                         case "cs":
                             return true;


### PR DESCRIPTION
`switch` support was added to `WhitespaceAfterCheck`, wercker was failing on PMD.
Checkstyle PR: https://github.com/checkstyle/checkstyle/pull/11299
```
[INFO] --- maven-checkstyle-plugin:3.1.2:check (checkstyle-check) @ pmd-core ---
[INFO] There is 1 error reported by Checkstyle 10.0-SNAPSHOT with /net/sourceforge/pmd/pmd-checkstyle-config.xml ruleset.
[ERROR] src/main/java/net/sourceforge/pmd/cpd/GUI.java:[173,21] (whitespace) WhitespaceAfter: 'switch' is not followed by whitespace.
```