### PR TITLE
[java] Fix #3697 - lookahead error in concise resource spec

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -16,6 +16,9 @@ This is a {{ site.pmd.release_type }} release.
 
 ### Fixed Issues
 
+*   java
+    *   [#3698](https://github.com/pmd/pmd/issues/3697): \[java] Parsing error with try-with-resources and qualified resource
+
 ### API Changes
 
 ### External Contributions

--- a/pmd-java/etc/grammar/Java.jjt
+++ b/pmd-java/etc/grammar/Java.jjt
@@ -2406,7 +2406,7 @@ void Resources() :
 void Resource() :
 {}
 {
-   LOOKAHEAD("this" | Name() ")") (
+   LOOKAHEAD("this" | Name() (")" | ";")) (
        {checkForBadConciseTryWithResourcesUsage();}
        Name()
        // replaced with Expression in PMD 7, do the bare minimum

--- a/pmd-java/etc/grammar/Java.jjt
+++ b/pmd-java/etc/grammar/Java.jjt
@@ -2406,9 +2406,15 @@ void Resources() :
 void Resource() :
 {}
 {
-   LOOKAHEAD(2) ( ( "final" {jjtThis.setFinal(true);} | Annotation() )* LocalVariableType() VariableDeclaratorId() "=" Expression() )
-   |
-   Name() {checkForBadConciseTryWithResourcesUsage();}
+   LOOKAHEAD("this" | Name() ")") (
+       {checkForBadConciseTryWithResourcesUsage();}
+       Name()
+       // replaced with Expression in PMD 7, do the bare minimum
+       | "this" "." Name() // possible pmd6 improvement: add a isThisModifier() or so
+   )
+   | ( "final" {jjtThis.setFinal(true);} | Annotation() )*
+     LocalVariableType() VariableDeclaratorId() "=" Expression()
+
 }
 
 void CatchStatement() :

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ParserCornersTest.java
@@ -25,6 +25,7 @@ public class ParserCornersTest {
     private static final String MULTICATCH = "public class Foo { public void bar() { "
         + "try { System.out.println(); } catch (RuntimeException | IOException e) {} } }";
     private final JavaParsingHelper java = JavaParsingHelper.WITH_PROCESSING.withResourceContext(ParserCornersTest.class);
+    private final JavaParsingHelper java9 = java.withDefaultVersion("9");
     private final JavaParsingHelper java8 = java.withDefaultVersion("1.8");
     private final JavaParsingHelper java4 = java.withDefaultVersion("1.4");
     private final JavaParsingHelper java5 = java.withDefaultVersion("1.5");
@@ -88,6 +89,33 @@ public class ParserCornersTest {
     @Test
     public final void testCastLookaheadProblem() {
         java4.parse(CAST_LOOKAHEAD_PROBLEM);
+    }
+
+    @Test
+    public final void testTryWithResourcesConcise() {
+        // https://github.com/pmd/pmd/issues/3697
+        java9.parse("import java.io.InputStream;\n"
+                        + "public class Foo {\n"
+                        + "    public InputStream in;\n"
+                        + "    public void bar() {\n"
+                        + "        Foo f = this;\n"
+                        + "        try (f.in) {\n"
+                        + "        }\n"
+                        + "    }\n"
+                        + "}");
+    }
+
+    @Test
+    public final void testTryWithResourcesThis() {
+        // https://github.com/pmd/pmd/issues/3697
+        java9.parse("import java.io.InputStream;\n"
+                        + "public class Foo {\n"
+                        + "    public InputStream in;\n"
+                        + "    public void bar() {\n"
+                        + "        try (this.in) {\n"
+                        + "        }\n"
+                        + "    }\n"
+                        + "}");
     }
 
     /**

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/jdkversiontests/jdk9_try_with_resources.java
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/jdkversiontests/jdk9_try_with_resources.java
@@ -2,6 +2,13 @@ public class InputJava9TryWithResources {
  public static void main() {
   MyResource resource1 = new MyResource();
   MyResource resource2 = new MyResource();
+  try (resource1) { }
+  try (resource1;) { }
   try (resource1; resource2) { }
+  try (resource1.foo) { }
+  try (resource1.foo.a) { }
+  try (resource1.foo.Type v = null) { }
+  try (this.foo.aa) { }
+  try (this.foo) { }
  }
 }


### PR DESCRIPTION
## Describe the PR

The LOOKAHEAD(2) was not enough as `f.in` may begin a qualified type of a local var-ish resource, or a concise resource.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #3697

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

