### PR TITLE
[core] Fix #3427 - Stop printing usage text on error

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/cli/internal/CliMessages.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cli/internal/CliMessages.java
@@ -1,0 +1,29 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.cli.internal;
+
+/**
+ * @author Clément Fournier
+ */
+public final class CliMessages {
+
+    private CliMessages() {
+        // utility class
+    }
+
+    public static String errorDetectedMessage(int errors, String program) {
+        String anError = errors == 1 ? "An error" : errors + " errors";
+        return anError + " occurred while executing " + program + ".\n"
+            + "Run with --debug to see a stack-trace.\n"
+            + "If you think this is a bug in " + program
+            + ", please report this issue at https://github.com/pmd/pmd/issues/new/choose\n"
+            + "If you do so, please include a stack-trace, the code sample\n"
+            + " causing the issue, and details about your run configuration.";
+    }
+
+    public static String runWithHelpFlagMessage() {
+        return "Run with --help for command line help.";
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDCommandLineInterface.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDCommandLineInterface.java
@@ -22,6 +22,7 @@ import java.util.logging.Logger;
 
 import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.PMDVersion;
+import net.sourceforge.pmd.cli.internal.CliMessages;
 import net.sourceforge.pmd.util.FileUtil;
 import net.sourceforge.pmd.util.database.DBURI;
 
@@ -76,9 +77,8 @@ public final class CPDCommandLineInterface {
                 return;
             }
         } catch (ParameterException e) {
-            jcommander.usage();
-            System.out.println(buildUsageText());
-            System.err.println(" " + e.getMessage());
+            System.err.println(e.getMessage());
+            System.err.println(CliMessages.runWithHelpFlagMessage());
             setStatusCodeOrExit(ERROR_STATUS);
             return;
         }
@@ -117,6 +117,7 @@ public final class CPDCommandLineInterface {
             }
         } catch (IOException | RuntimeException e) {
             e.printStackTrace();
+            LOGGER.severe(CliMessages.errorDetectedMessage(1, "CPD"));
             setStatusCodeOrExit(ERROR_STATUS);
         }
     }

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistributionIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistributionIT.java
@@ -18,6 +18,7 @@ import java.util.zip.ZipFile;
 import org.junit.Test;
 
 import net.sourceforge.pmd.PMDVersion;
+import net.sourceforge.pmd.cli.internal.CliMessages;
 
 public class BinaryDistributionIT extends AbstractBinaryDistributionTest {
 
@@ -80,7 +81,7 @@ public class BinaryDistributionIT extends AbstractBinaryDistributionTest {
         ExecutionResult result;
 
         result = PMDExecutor.runPMD(tempDir); // without any argument, display usage help and error
-        result.assertExecutionResult(1, SUPPORTED_LANGUAGES_PMD);
+        result.assertExecutionResultErrOutput(1, CliMessages.runWithHelpFlagMessage());
 
         result = PMDExecutor.runPMD(tempDir, "-h");
         result.assertExecutionResult(0, SUPPORTED_LANGUAGES_PMD);
@@ -98,13 +99,21 @@ public class BinaryDistributionIT extends AbstractBinaryDistributionTest {
     }
 
     @Test
+    public void runPMDWithError() throws Exception {
+        String srcDir = new File(".", "src/test/resources/sample-source/unparsable/").getAbsolutePath();
+
+        ExecutionResult result = PMDExecutor.runPMDRules(folder.newFile().toPath(), tempDir, srcDir, "src/test/resources/rulesets/sample-ruleset.xml");
+        result.assertExecutionResultErrOutput(0, "Run with --debug to see a stack-trace.");
+    }
+
+    @Test
     public void runCPD() throws Exception {
         String srcDir = new File(".", "src/test/resources/sample-source-cpd/").getAbsolutePath();
 
         ExecutionResult result;
 
         result = CpdExecutor.runCpd(tempDir); // without any argument, display usage help and error
-        result.assertExecutionResult(1, SUPPORTED_LANGUAGES_CPD);
+        result.assertExecutionResultErrOutput(1, CliMessages.runWithHelpFlagMessage());
 
         result = CpdExecutor.runCpd(tempDir, "-h");
         result.assertExecutionResult(0, SUPPORTED_LANGUAGES_CPD);

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/CpdExecutor.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/CpdExecutor.java
@@ -4,11 +4,12 @@
 
 package net.sourceforge.pmd.it;
 
-import java.nio.charset.StandardCharsets;
+import static net.sourceforge.pmd.util.CollectionUtil.listOf;
+
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.List;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.SystemUtils;
 
 import net.sourceforge.pmd.PMDVersion;
@@ -25,30 +26,6 @@ public class CpdExecutor {
         // this is a helper class only
     }
 
-    private static ExecutionResult runCpdUnix(Path tempDir, String... arguments) throws Exception {
-        String cmd = tempDir.resolve(PMD_BIN_PREFIX + PMDVersion.VERSION + "/bin/run.sh").toAbsolutePath().toString();
-        ProcessBuilder pb = new ProcessBuilder(cmd, "cpd");
-        pb.command().addAll(Arrays.asList(arguments));
-        pb.redirectErrorStream(true);
-        Process process = pb.start();
-        String output = IOUtils.toString(process.getInputStream(), StandardCharsets.UTF_8);
-
-        int result = process.waitFor();
-        return new ExecutionResult(result, output, null, null);
-    }
-
-    private static ExecutionResult runCpdWindows(Path tempDir, String... arguments) throws Exception {
-        String cmd = tempDir.resolve(PMD_BIN_PREFIX + PMDVersion.VERSION + "/bin/cpd.bat").toAbsolutePath().toString();
-        ProcessBuilder pb = new ProcessBuilder(cmd);
-        pb.command().addAll(Arrays.asList(arguments));
-        pb.redirectErrorStream(true);
-        Process process = pb.start();
-        String output = IOUtils.toString(process.getInputStream(), StandardCharsets.UTF_8);
-
-        int result = process.waitFor();
-        return new ExecutionResult(result, output, null, null);
-    }
-
     /**
      * Executes CPD found in tempDir with the given command line arguments.
      * @param tempDir the directory, to which the binary distribution has been extracted
@@ -57,10 +34,16 @@ public class CpdExecutor {
      * @throws Exception if the execution fails for any reason (executable not found, ...)
      */
     public static ExecutionResult runCpd(Path tempDir, String... arguments) throws Exception {
+        String cmd;
+        List<String> args;
         if (SystemUtils.IS_OS_WINDOWS) {
-            return runCpdWindows(tempDir, arguments);
+            cmd = "/bin/cpd.bat";
+            args = Arrays.asList(arguments);
         } else {
-            return runCpdUnix(tempDir, arguments);
+            cmd = "/bin/run.sh";
+            args = listOf("cpd", arguments);
         }
+        cmd = tempDir.resolve(PMD_BIN_PREFIX + PMDVersion.VERSION + cmd).toAbsolutePath().toString();
+        return PMDExecutor.runCommand(cmd, args, null);
     }
 }

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/ExecutionResult.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/ExecutionResult.java
@@ -68,10 +68,38 @@ public class ExecutionResult {
      * generated report.
      *
      * @param expectedExitCode the exit code, e.g. 0 if no rule violations are expected, or 4 if violations are found
-     * @param expectedOutput the output to search for
-     * @param expectedReport the string to search for tin the report
+     * @param expectedOutput   the output to search for
+     * @param expectedReport   the string to search for tin the report
      */
     public void assertExecutionResult(int expectedExitCode, String expectedOutput, String expectedReport) {
+        assertExecResultImpl(expectedExitCode, output, expectedOutput, expectedReport);
+    }
+
+    /**
+     * Asserts that the command exited with the expected exit code and that the given expected
+     * output is contained in the actual command ERROR output, and the given expected report is in the
+     * generated report.
+     *
+     * @param expectedExitCode    the exit code, e.g. 0 if no rule violations are expected, or 4 if violations are found
+     * @param expectedErrorOutput the output to search for in stderr
+     * @param expectedReport      the string to search for tin the report
+     */
+    public void assertExecutionResultErrOutput(int expectedExitCode, String expectedErrorOutput, String expectedReport) {
+        assertExecResultImpl(expectedExitCode, errorOutput, expectedErrorOutput, expectedReport);
+    }
+
+    /**
+     * Asserts that the command exited with the expected exit code and that the given expected
+     * output is contained in the actual command ERROR output.
+     *
+     * @param expectedExitCode    the exit code, e.g. 0 if no rule violations are expected, or 4 if violations are found
+     * @param expectedErrorOutput the output to search for in stderr
+     */
+    public void assertExecutionResultErrOutput(int expectedExitCode, String expectedErrorOutput) {
+        assertExecResultImpl(expectedExitCode, errorOutput, expectedErrorOutput, null);
+    }
+
+    private void assertExecResultImpl(int expectedExitCode, String output, String expectedOutput, String expectedReport) {
         assertEquals("Command exited with wrong code.\nComplete result:\n\n" + this, expectedExitCode, exitCode);
         assertNotNull("No output found", output);
         if (expectedOutput != null && !expectedOutput.isEmpty()) {
@@ -83,7 +111,7 @@ public class ExecutionResult {
         }
         if (expectedReport != null && !expectedReport.isEmpty()) {
             assertTrue("Expected report '" + expectedReport + "'.\nComplete result:\n\n" + this,
-                    report.contains(expectedReport));
+                       report.contains(expectedReport));
         }
     }
 

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/PMDExecutor.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/PMDExecutor.java
@@ -39,15 +39,15 @@ public class PMDExecutor {
         List<String> args = new ArrayList<>();
         args.add("pmd");
         args.addAll(Arrays.asList(arguments));
-        return runPMD(cmd, args, reportFile);
+        return runCommand(cmd, args, reportFile);
     }
 
     private static ExecutionResult runPMDWindows(Path tempDir, Path reportFile, String... arguments) throws Exception {
         String cmd = tempDir.resolve(AbstractBinaryDistributionTest.PMD_BIN_PREFIX + PMDVersion.VERSION + "/bin/pmd.bat").toAbsolutePath().toString();
-        return runPMD(cmd, Arrays.asList(arguments), reportFile);
+        return runCommand(cmd, Arrays.asList(arguments), reportFile);
     }
 
-    private static ExecutionResult runPMD(String cmd, List<String> arguments, Path reportFile) throws Exception {
+    static ExecutionResult runCommand(String cmd, List<String> arguments, Path reportFile) throws Exception {
         ProcessBuilder pb = new ProcessBuilder(cmd);
         pb.command().addAll(arguments);
         pb.redirectErrorStream(false);

--- a/pmd-dist/src/test/resources/sample-source/unparsable/cannot_be_parsed.java
+++ b/pmd-dist/src/test/resources/sample-source/unparsable/cannot_be_parsed.java
@@ -1,0 +1,3 @@
+
+
+{} // not a valid file


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #3427, also for CPD

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

