### PR TITLE
[ci] Run dogfood for PRs and PMD7

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -40,7 +40,9 @@ function build() {
             pmd_ci_log_group_end
 
             # also run dogfood for PRs (only on linux)
-            pmd_ci_dogfood
+            pmd_ci_log_group_start "Executing PMD dogfood test with ${PMD_CI_MAVEN_PROJECT_VERSION}"
+                pmd_ci_dogfood
+            pmd_ci_log_group_end
         fi
 
         exit 0
@@ -88,9 +90,13 @@ function build() {
         regression_tester_uploadBaseline
     pmd_ci_log_group_end
 
+    #
+    # everything from here runs only on snapshots, not on release builds
+    #
     if pmd_ci_maven_isSnapshotBuild; then
+    pmd_ci_log_group_start "Executing PMD dogfood test with ${PMD_CI_MAVEN_PROJECT_VERSION}"
         pmd_ci_dogfood
-    fi
+    pmd_ci_log_group_end
 
     pmd_ci_log_group_start "Executing build with sonar"
         # Note: Sonar also needs GITHUB_TOKEN (!)
@@ -238,20 +244,18 @@ ${rendered_release_notes}"
 # Runs the dogfood ruleset with the currently built pmd against itself
 #
 function pmd_ci_dogfood() {
-    pmd_ci_log_group_start "Executing PMD dogfood test with ${PMD_CI_MAVEN_PROJECT_VERSION}"
-        ./mvnw versions:set -DnewVersion="${PMD_CI_MAVEN_PROJECT_VERSION}-dogfood" -DgenerateBackupPoms=false
-        sed -i 's/<version>[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}.*<\/version>\( *<!-- pmd.dogfood.version -->\)/<version>'"${PMD_CI_MAVEN_PROJECT_VERSION}"'<\/version>\1/' pom.xml
-        if [ "${PMD_CI_MAVEN_PROJECT_VERSION}" = "7.0.0-SNAPSHOT" ]; then
-            sed -i 's/pmd-dogfood-config\.xml/pmd-dogfood-config7.xml/' pom.xml
-        fi
-        ./mvnw verify --show-version --errors --batch-mode --no-transfer-progress "${PMD_MAVEN_EXTRA_OPTS[@]}" \
-            -DskipTests \
-            -Dmaven.javadoc.skip=true \
-            -Dmaven.source.skip=true \
-            -Dcheckstyle.skip=true
-        ./mvnw versions:set -DnewVersion="${PMD_CI_MAVEN_PROJECT_VERSION}" -DgenerateBackupPoms=false
-        git checkout -- pom.xml
-    pmd_ci_log_group_end
+    ./mvnw versions:set -DnewVersion="${PMD_CI_MAVEN_PROJECT_VERSION}-dogfood" -DgenerateBackupPoms=false
+    sed -i 's/<version>[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}.*<\/version>\( *<!-- pmd.dogfood.version -->\)/<version>'"${PMD_CI_MAVEN_PROJECT_VERSION}"'<\/version>\1/' pom.xml
+    if [ "${PMD_CI_MAVEN_PROJECT_VERSION}" = "7.0.0-SNAPSHOT" ]; then
+        sed -i 's/pmd-dogfood-config\.xml/pmd-dogfood-config7.xml/' pom.xml
+    fi
+    ./mvnw verify --show-version --errors --batch-mode --no-transfer-progress "${PMD_MAVEN_EXTRA_OPTS[@]}" \
+        -DskipTests \
+        -Dmaven.javadoc.skip=true \
+        -Dmaven.source.skip=true \
+        -Dcheckstyle.skip=true
+    ./mvnw versions:set -DnewVersion="${PMD_CI_MAVEN_PROJECT_VERSION}" -DgenerateBackupPoms=false
+    git checkout -- pom.xml
 }
 
 build

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -29,7 +29,7 @@ function build() {
 
     if pmd_ci_utils_is_fork_or_pull_request; then
         pmd_ci_log_group_start "Build with mvnw"
-            ./mvnw clean verify --show-version --errors --batch-mode --no-transfer-progress "${PMD_MAVEN_EXTRA_OPTS[@]}"
+            ./mvnw clean install --show-version --errors --batch-mode --no-transfer-progress "${PMD_MAVEN_EXTRA_OPTS[@]}"
         pmd_ci_log_group_end
 
         # Danger is executed only on the linux runner
@@ -38,6 +38,9 @@ function build() {
                 regression_tester_setup_ci
                 regression_tester_executeDanger
             pmd_ci_log_group_end
+
+            # also run dogfood for PRs (only on linux)
+            pmd_ci_dogfood
         fi
 
         exit 0
@@ -86,21 +89,7 @@ function build() {
     pmd_ci_log_group_end
 
     if pmd_ci_maven_isSnapshotBuild; then
-    if [ "${PMD_CI_MAVEN_PROJECT_VERSION}" != "7.0.0-SNAPSHOT" ]; then
-        pmd_ci_log_group_start "Executing PMD dogfood test with ${PMD_CI_MAVEN_PROJECT_VERSION}"
-            ./mvnw versions:set -DnewVersion="${PMD_CI_MAVEN_PROJECT_VERSION}-dogfood" -DgenerateBackupPoms=false
-            sed -i 's/<version>[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}.*<\/version>\( *<!-- pmd.dogfood.version -->\)/<version>'"${PMD_CI_MAVEN_PROJECT_VERSION}"'<\/version>\1/' pom.xml
-            ./mvnw verify --show-version --errors --batch-mode --no-transfer-progress "${PMD_MAVEN_EXTRA_OPTS[@]}" \
-                -DskipTests \
-                -Dmaven.javadoc.skip=true \
-                -Dmaven.source.skip=true \
-                -Dcheckstyle.skip=true
-            ./mvnw versions:set -DnewVersion="${PMD_CI_MAVEN_PROJECT_VERSION}" -DgenerateBackupPoms=false
-            git checkout -- pom.xml
-        pmd_ci_log_group_end
-    else
-        # current maven-pmd-plugin is not compatible with PMD 7 yet.
-        pmd_ci_log_info "Skipping PMD dogfood test with ${PMD_CI_MAVEN_PROJECT_VERSION}"
+        pmd_ci_dogfood
     fi
 
     pmd_ci_log_group_start "Executing build with sonar"
@@ -243,6 +232,26 @@ ${rendered_release_notes}"
         publish_release_documentation_github
         pmd_ci_sourceforge_rsyncSnapshotDocumentation "${PMD_CI_MAVEN_PROJECT_VERSION}" "pmd-${PMD_CI_MAVEN_PROJECT_VERSION}"
     fi
+}
+
+#
+# Runs the dogfood ruleset with the currently built pmd against itself
+#
+function pmd_ci_dogfood() {
+    pmd_ci_log_group_start "Executing PMD dogfood test with ${PMD_CI_MAVEN_PROJECT_VERSION}"
+        ./mvnw versions:set -DnewVersion="${PMD_CI_MAVEN_PROJECT_VERSION}-dogfood" -DgenerateBackupPoms=false
+        sed -i 's/<version>[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}.*<\/version>\( *<!-- pmd.dogfood.version -->\)/<version>'"${PMD_CI_MAVEN_PROJECT_VERSION}"'<\/version>\1/' pom.xml
+        if [ "${PMD_CI_MAVEN_PROJECT_VERSION}" = "7.0.0-SNAPSHOT" ]; then
+            sed -i 's/pmd-dogfood-config\.xml/pmd-dogfood-config7.xml/' pom.xml
+        fi
+        ./mvnw verify --show-version --errors --batch-mode --no-transfer-progress "${PMD_MAVEN_EXTRA_OPTS[@]}" \
+            -DskipTests \
+            -Dmaven.javadoc.skip=true \
+            -Dmaven.source.skip=true \
+            -Dcheckstyle.skip=true
+        ./mvnw versions:set -DnewVersion="${PMD_CI_MAVEN_PROJECT_VERSION}" -DgenerateBackupPoms=false
+        git checkout -- pom.xml
+    pmd_ci_log_group_end
 }
 
 build


### PR DESCRIPTION
This unifies the build configuration. The dogfood build is now run also for PRs.

In future, we should probably split up the build into multiple jobs that can run in parallel (e.g. regression tester in parallel to dogfood). Then the build log would be better consumable.
This requires however to share files between the jobs to avoid rebuilding PMD over and over again (e.g. dogfood reuses the just now built PMD from the local maven repo and regression tester reuses the existing pmd-dist/target/pmd-bin-*.zip file).
