### PR TITLE
[doc] Document Ant Task parameter `threads`

### DIFF
--- a/docs/pages/pmd/userdocs/tools/ant.md
+++ b/docs/pages/pmd/userdocs/tools/ant.md
@@ -122,6 +122,14 @@ The examples below won't repeat this taskdef element, as this is always required
       </td>
       <td>No</td>
     </tr>
+    <tr>
+      <td>threads</td>
+      <td>
+        Sets the number of threads used by PMD. Set threads to <code>0</code> to disable multi-threading processing.
+        Default: 1
+      </td>
+      <td>No</td>
+    </tr>
 </table>
 
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -20,6 +20,7 @@ This is a {{ site.pmd.release_type }} release.
     *   [#3427](https://github.com/pmd/pmd/issues/3427): \[core] Stop printing CLI usage text when exiting due to invalid parameters
 *   doc
     *   [#2502](https://github.com/pmd/pmd/issues/2502): \[doc] Add floating table-of-contents (toc) on the right
+    *   [#3807](https://github.com/pmd/pmd/pull/3807): \[doc] Document Ant Task parameter `threads`
 *   java
     *   [#3698](https://github.com/pmd/pmd/issues/3697): \[java] Parsing error with try-with-resources and qualified resource
 *   java-codestyle

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/PMDTask.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/PMDTask.java
@@ -30,7 +30,7 @@ public class PMDTask extends Task {
     private String rulesetFiles;
     private boolean noRuleSetCompatibility;
     private String encoding;
-    private int threads;
+    private int threads = 1; // same default as in PMDParameters (CLI)
     private int minimumPriority;
     private int maxRuleViolations = 0;
     private String failuresPropertyName;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cli/PMDParameters.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cli/PMDParameters.java
@@ -60,7 +60,7 @@ public class PMDParameters {
 
     @Parameter(names = { "--threads", "-threads", "-t" }, description = "Sets the number of threads used by PMD.",
             validateWith = PositiveInteger.class)
-    private int threads = 1;
+    private int threads = 1; // see also default in PMDTask (Ant)
 
     @Parameter(names = { "--benchmark", "-benchmark", "-b" },
             description = "Benchmark mode - output a benchmark report upon completion; default to System.err.")


### PR DESCRIPTION
Also change the default to "1" to be consistent with
CLI `--threads` parameter.

See also #3806
