### PR TITLE
[apex] Add designer bindings to display main attributes

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ApexHandler.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ApexHandler.java
@@ -17,6 +17,7 @@ import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClassOrInterface;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.ast.DumpFacade;
+import net.sourceforge.pmd.lang.apex.internal.ApexDesignerBindings;
 import net.sourceforge.pmd.lang.apex.metrics.ApexMetrics;
 import net.sourceforge.pmd.lang.apex.metrics.api.ApexClassMetricKey;
 import net.sourceforge.pmd.lang.apex.metrics.api.ApexOperationMetricKey;
@@ -25,6 +26,7 @@ import net.sourceforge.pmd.lang.apex.rule.ApexRuleViolationFactory;
 import net.sourceforge.pmd.lang.metrics.LanguageMetricsProvider;
 import net.sourceforge.pmd.lang.metrics.internal.AbstractLanguageMetricsProvider;
 import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
+import net.sourceforge.pmd.util.designerbindings.DesignerBindings;
 
 
 /**
@@ -67,6 +69,11 @@ public class ApexHandler extends AbstractLanguageVersionHandler {
     @Override
     public LanguageMetricsProvider<ASTUserClassOrInterface<?>, ASTMethod> getLanguageMetricsProvider() {
         return myMetricsProvider;
+    }
+
+    @Override
+    public DesignerBindings getDesignerBindings() {
+        return ApexDesignerBindings.INSTANCE;
     }
 
     private static class ApexMetricsProvider extends AbstractLanguageMetricsProvider<ASTUserClassOrInterface<?>, ASTMethod> {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/internal/ApexDesignerBindings.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/internal/ApexDesignerBindings.java
@@ -1,0 +1,64 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.internal;
+
+import net.sourceforge.pmd.lang.apex.ast.ASTFieldDeclaration;
+import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
+import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
+import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration;
+import net.sourceforge.pmd.lang.apex.ast.ApexNode;
+import net.sourceforge.pmd.lang.apex.ast.ApexParserVisitorAdapter;
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.ast.xpath.Attribute;
+import net.sourceforge.pmd.util.designerbindings.DesignerBindings.DefaultDesignerBindings;
+
+public class ApexDesignerBindings extends DefaultDesignerBindings {
+
+    public static final ApexDesignerBindings INSTANCE = new ApexDesignerBindings();
+
+    @Override
+    public Attribute getMainAttribute(Node node) {
+        if (node instanceof ApexNode) {
+            Attribute attr = (Attribute) ((ApexNode<?>) node).jjtAccept(MainAttrVisitor.INSTANCE, null);
+            if (attr != null) {
+                return attr;
+            }
+        }
+
+        return super.getMainAttribute(node);
+    }
+
+    @Override
+    public TreeIconId getIcon(Node node) {
+        if (node instanceof ASTFieldDeclaration) {
+            return TreeIconId.FIELD;
+        } else if (node instanceof ASTUserClass) {
+            return TreeIconId.CLASS;
+        } else if (node instanceof ASTMethod) {
+            return TreeIconId.METHOD;
+        } else if (node instanceof ASTVariableDeclaration) {
+            return TreeIconId.VARIABLE;
+        }
+        return super.getIcon(node);
+    }
+
+
+    private static final class MainAttrVisitor extends ApexParserVisitorAdapter {
+
+        private static final MainAttrVisitor INSTANCE = new MainAttrVisitor();
+
+        @Override
+        public Object visit(ApexNode<?> node, Object data) {
+            return null; // don't recurse
+        }
+
+        @Override
+        public Object visit(ASTMethodCallExpression node, Object data) {
+            return new Attribute(node, "MethodName", node.getMethodName());
+        }
+    }
+
+}


### PR DESCRIPTION
## Describe the PR

Small enhancement for Apex + Designer - now the name of the called method is displayed:

![grafik](https://user-images.githubusercontent.com/1573684/156625024-fa10784c-51f7-4906-94c1-92586b112bb3.png)

## Related issues
- none

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

