### PR TITLE
[core] Fix abstract ruleset factory test

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -65,6 +65,11 @@ The CLI itself remains compatible, if you run PMD via command-line, no action is
 * {% jdoc !!core::PMDConfiguration#prependClasspath(java.lang.String) %} is deprecated
   in favour of {% jdoc core::PMDConfiguration#prependAuxClasspath(java.lang.String) %}.
 
+* In modelica, the rule classes {% jdoc modelica::lang.modelica.rule.AmbiguousResolutionRule %}
+  and {% jdoc modelica::lang.modelica.rule.ConnectUsingNonConnector %} have been deprecated,
+  since they didn't comply to the usual rule class naming conventions yet.
+  The replacements are in the subpackage `bestpractices`.
+
 #### Experimental APIs
 
 *   Together with the [new programmatic API](#new-programmatic-api) the interface

--- a/pmd-modelica/pom.xml
+++ b/pmd-modelica/pom.xml
@@ -12,6 +12,12 @@
     </parent>
 
     <build>
+        <resources>
+            <resource>
+                <directory>${basedir}/src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <artifactId>maven-resources-plugin</artifactId>

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/AmbiguousResolutionRule.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/AmbiguousResolutionRule.java
@@ -1,26 +1,13 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
+
 package net.sourceforge.pmd.lang.modelica.rule;
 
-import net.sourceforge.pmd.lang.modelica.ast.ASTName;
-import net.sourceforge.pmd.lang.modelica.resolver.ResolutionResult;
-import net.sourceforge.pmd.lang.modelica.resolver.ResolvableEntity;
+/**
+ * @deprecated Use {@link net.sourceforge.pmd.lang.modelica.rule.bestpractices.AmbiguousResolutionRule}
+ */
+public class AmbiguousResolutionRule extends net.sourceforge.pmd.lang.modelica.rule.bestpractices.AmbiguousResolutionRule {
 
-public class AmbiguousResolutionRule extends AbstractModelicaRule {
-    @Override
-    public Object visit(ASTName node, Object data) {
-        ResolutionResult<ResolvableEntity> candidates = node.getResolutionCandidates();
-        if (candidates.isClashed()) {
-            StringBuilder sb = new StringBuilder();
-            sb.append("Candidate resolutions: ");
-            for (ResolvableEntity candidate: candidates.getBestCandidates()) {
-                sb.append(candidate.getDescriptiveName());
-                sb.append(", ");
-            }
-            addViolation(data, node, sb.substring(0, sb.length() - 2));
-        }
-        return super.visit(node, data);
-    }
 }

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/ConnectUsingNonConnector.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/ConnectUsingNonConnector.java
@@ -1,50 +1,16 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
+
 package net.sourceforge.pmd.lang.modelica.rule;
 
-import net.sourceforge.pmd.lang.modelica.ast.ASTComponentReference;
-import net.sourceforge.pmd.lang.modelica.ast.ASTConnectClause;
-import net.sourceforge.pmd.lang.modelica.resolver.ModelicaClassSpecialization;
-import net.sourceforge.pmd.lang.modelica.resolver.ModelicaClassType;
-import net.sourceforge.pmd.lang.modelica.resolver.ModelicaComponentDeclaration;
-import net.sourceforge.pmd.lang.modelica.resolver.ResolutionResult;
-import net.sourceforge.pmd.lang.modelica.resolver.ResolvableEntity;
+import net.sourceforge.pmd.lang.modelica.rule.bestpractices.ConnectUsingNonConnectorRule;
 
-public class ConnectUsingNonConnector extends AbstractModelicaRule {
-    private void reportIfViolated(ASTComponentReference ref, Object data) {
-        ResolutionResult<ResolvableEntity> resolution = ref.getResolutionCandidates();
-        if (!resolution.isUnresolved()) { // no false positive if not resolved at all
-            ResolvableEntity firstDecl = resolution.getBestCandidates().get(0);
-            if (firstDecl instanceof ModelicaComponentDeclaration) {
-                ModelicaComponentDeclaration componentDecl = (ModelicaComponentDeclaration) firstDecl;
-                ResolutionResult componentTypes = componentDecl.getTypeCandidates();
-                if (!componentTypes.isUnresolved()) {
-                    if (componentTypes.getBestCandidates().get(0) instanceof ModelicaClassType) {
-                        ModelicaClassType classDecl = (ModelicaClassType) componentTypes.getBestCandidates().get(0);
-                        ModelicaClassSpecialization restriction = classDecl.getSpecialization();
-                        if (!classDecl.isConnectorLike()) {
-                            addViolation(data, ref, restriction.toString());
-                        }
-                    } else {
-                        addViolation(data, ref, firstDecl.getDescriptiveName());
-                    }
-                }
-            } else {
-                addViolation(data, ref, firstDecl.getDescriptiveName());
-            }
-        }
-    }
+/**
+ * @deprecated Use {@link ConnectUsingNonConnectorRule}
+ */
+@Deprecated
+public class ConnectUsingNonConnector extends ConnectUsingNonConnectorRule {
 
-    @Override
-    public Object visit(ASTConnectClause node, Object data) {
-        ASTComponentReference lhs = (ASTComponentReference) node.getChild(0);
-        ASTComponentReference rhs = (ASTComponentReference) node.getChild(1);
-
-        reportIfViolated(lhs, data);
-        reportIfViolated(rhs, data);
-
-        return super.visit(node, data);
-    }
 }

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/bestpractices/AmbiguousResolutionRule.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/bestpractices/AmbiguousResolutionRule.java
@@ -1,0 +1,27 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.modelica.rule.bestpractices;
+
+import net.sourceforge.pmd.lang.modelica.ast.ASTName;
+import net.sourceforge.pmd.lang.modelica.resolver.ResolutionResult;
+import net.sourceforge.pmd.lang.modelica.resolver.ResolvableEntity;
+import net.sourceforge.pmd.lang.modelica.rule.AbstractModelicaRule;
+
+public class AmbiguousResolutionRule extends AbstractModelicaRule {
+    @Override
+    public Object visit(ASTName node, Object data) {
+        ResolutionResult<ResolvableEntity> candidates = node.getResolutionCandidates();
+        if (candidates.isClashed()) {
+            StringBuilder sb = new StringBuilder();
+            sb.append("Candidate resolutions: ");
+            for (ResolvableEntity candidate: candidates.getBestCandidates()) {
+                sb.append(candidate.getDescriptiveName());
+                sb.append(", ");
+            }
+            addViolation(data, node, sb.substring(0, sb.length() - 2));
+        }
+        return super.visit(node, data);
+    }
+}

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/bestpractices/ConnectUsingNonConnectorRule.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/bestpractices/ConnectUsingNonConnectorRule.java
@@ -1,0 +1,51 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.modelica.rule.bestpractices;
+
+import net.sourceforge.pmd.lang.modelica.ast.ASTComponentReference;
+import net.sourceforge.pmd.lang.modelica.ast.ASTConnectClause;
+import net.sourceforge.pmd.lang.modelica.resolver.ModelicaClassSpecialization;
+import net.sourceforge.pmd.lang.modelica.resolver.ModelicaClassType;
+import net.sourceforge.pmd.lang.modelica.resolver.ModelicaComponentDeclaration;
+import net.sourceforge.pmd.lang.modelica.resolver.ResolutionResult;
+import net.sourceforge.pmd.lang.modelica.resolver.ResolvableEntity;
+import net.sourceforge.pmd.lang.modelica.rule.AbstractModelicaRule;
+
+public class ConnectUsingNonConnectorRule extends AbstractModelicaRule {
+    private void reportIfViolated(ASTComponentReference ref, Object data) {
+        ResolutionResult<ResolvableEntity> resolution = ref.getResolutionCandidates();
+        if (!resolution.isUnresolved()) { // no false positive if not resolved at all
+            ResolvableEntity firstDecl = resolution.getBestCandidates().get(0);
+            if (firstDecl instanceof ModelicaComponentDeclaration) {
+                ModelicaComponentDeclaration componentDecl = (ModelicaComponentDeclaration) firstDecl;
+                ResolutionResult componentTypes = componentDecl.getTypeCandidates();
+                if (!componentTypes.isUnresolved()) {
+                    if (componentTypes.getBestCandidates().get(0) instanceof ModelicaClassType) {
+                        ModelicaClassType classDecl = (ModelicaClassType) componentTypes.getBestCandidates().get(0);
+                        ModelicaClassSpecialization restriction = classDecl.getSpecialization();
+                        if (!classDecl.isConnectorLike()) {
+                            addViolation(data, ref, restriction.toString());
+                        }
+                    } else {
+                        addViolation(data, ref, firstDecl.getDescriptiveName());
+                    }
+                }
+            } else {
+                addViolation(data, ref, firstDecl.getDescriptiveName());
+            }
+        }
+    }
+
+    @Override
+    public Object visit(ASTConnectClause node, Object data) {
+        ASTComponentReference lhs = (ASTComponentReference) node.getChild(0);
+        ASTComponentReference rhs = (ASTComponentReference) node.getChild(1);
+
+        reportIfViolated(lhs, data);
+        reportIfViolated(rhs, data);
+
+        return super.visit(node, data);
+    }
+}

--- a/pmd-modelica/src/main/resources/category/modelica/bestpractices.xml
+++ b/pmd-modelica/src/main/resources/category/modelica/bestpractices.xml
@@ -10,6 +10,7 @@ Rules which enforce generally accepted best practices.
 
     <rule name="ClassStartNameEqualsEndName"
           language="modelica"
+          since="6.21.0"
           message="Class ends with an end clause with a different name"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_modelica_bestpractices.html#classstartnameequalsendname"
           class="net.sourceforge.pmd.lang.rule.XPathRule">
@@ -41,9 +42,10 @@ end SomeOtherName /* should be SomeName */;
 
     <rule name="ConnectUsingNonConnector"
           language="modelica"
+          since="6.21.0"
           message="Arguments passed to `connect` should be connectors, not `{0}`"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_modelica_bestpractices.html#connectusingnonconnector"
-          class="net.sourceforge.pmd.lang.modelica.rule.ConnectUsingNonConnector">
+          class="net.sourceforge.pmd.lang.modelica.rule.bestpractices.ConnectUsingNonConnectorRule">
         <description>
             Modelica specification requires passing connectors to the `connect` clause,
             while some implementations tolerate using it on plain variables, etc..
@@ -75,8 +77,9 @@ end Example;
     <rule name="AmbiguousResolution"
           language="modelica"
           message="Type resolution is ambiguous: {0}"
+          since="6.21.0"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_modelica_bestpractices.html#ambiguousresolution"
-          class="net.sourceforge.pmd.lang.modelica.rule.AmbiguousResolutionRule">
+          class="net.sourceforge.pmd.lang.modelica.rule.bestpractices.AmbiguousResolutionRule">
         <description>
             There is multiple candidates for this type resolution. While generally this is not an error,
             this may indicate a bug.

--- a/pmd-test/src/main/java/net/sourceforge/pmd/AbstractRuleSetFactoryTest.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/AbstractRuleSetFactoryTest.java
@@ -287,9 +287,16 @@ public abstract class AbstractRuleSetFactoryTest {
 
     private List<String> getRuleSetFileNames(String language) throws IOException, RuleSetNotFoundException {
         List<String> ruleSetFileNames = new ArrayList<>();
+        ruleSetFileNames.addAll(getRuleSetFileNames(language, "rulesets/" + language + "/rulesets.properties"));
+        ruleSetFileNames.addAll(getRuleSetFileNames(language, "category/" + language + "/categories.properties"));
+        return ruleSetFileNames;
+    }
+
+    private List<String> getRuleSetFileNames(String language, String propertiesPath) throws IOException, RuleSetNotFoundException {
+        List<String> ruleSetFileNames = new ArrayList<>();
         try {
             Properties properties = new Properties();
-            try (InputStream is = new ResourceLoader().loadClassPathResourceAsStreamOrThrow("rulesets/" + language + "/rulesets.properties")) {
+            try (InputStream is = new ResourceLoader().loadClassPathResourceAsStreamOrThrow(propertiesPath)) {
                 properties.load(is);
             }
             String fileNames = properties.getProperty("rulesets.filenames");
@@ -304,6 +311,8 @@ public abstract class AbstractRuleSetFactoryTest {
         }
         return ruleSetFileNames;
     }
+    
+    
 
     private RuleSet loadRuleSetByFileName(String ruleSetFileName) throws RuleSetNotFoundException {
         RuleSetFactory rsf = RulesetsFactoryUtils.defaultFactory();


### PR DESCRIPTION
Found this, while working on the Kotlin branch. We stopped checking for our rulesets since we moved from rulesets to categories.


- [x] verify, that every PMD language uses the test - Ok, all other languages had already a RuleSetFactoryTest
