### PR TITLE
[doc] Make TOC scrollable when too many subheadings

### DIFF
--- a/docs/css/customstyles.css
+++ b/docs/css/customstyles.css
@@ -29,6 +29,8 @@ body {
         margin-top: 60px;
         margin-left: -15px;
         margin-right: 15px;
+        height: 80%;
+        overflow: auto;
     }
     .container {
         margin-left: 15px;
@@ -49,6 +51,8 @@ body {
         margin-top: 60px;
         margin-left: -15px;
         margin-right: 15px;
+        height: 80%;
+        overflow: auto;
     }
     .container {
         margin-left: 15px;


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
Makes documentation website table of contents scrollable on pages with many subheadings. Leaves pages with small number of subheadings and the small screen view unchanged.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #3812

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

