### PR TITLE
enable debug for regression tester

### DIFF
--- a/.ci/files/project-list.xml
+++ b/.ci/files/project-list.xml
@@ -39,6 +39,13 @@ mvn dependency:build-classpath -DincludeScope=test -Dmdep.outputFile=classpath.t
     <exclude-pattern>.*/build/generated-sources/.*</exclude-pattern>
 
     <build-command><![CDATA[#!/usr/bin/env bash
+echo "----------------------------------------------------"
+echo "current git status"
+git status
+echo "current changes"
+git diff
+echo "----------------------------------------------------"
+
 if test -e classpath.txt; then
   exit
 fi

--- a/Dangerfile
+++ b/Dangerfile
@@ -16,7 +16,7 @@ def run_pmdtester
             '--auto-gen-config',
             '--error-recovery',
             '--baseline-download-url', 'https://pmd-code.org/pmd-regression-tester/',
-            #'--debug',
+            '--debug',
             ]
     begin
       @summary = PmdTester::Runner.new(argv).run

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
@@ -63,6 +63,7 @@ import net.sourceforge.pmd.util.log.internal.SimpleMessageReporter;
  */
 public class PMD {
 
+
     private static final Logger LOG = Logger.getLogger(PMD.class.getName());
 
     /**


### PR DESCRIPTION
We are patching AutowiredAnnotationBeanPostProcessor
but it seems to look different for the baseline than
for pull requests...

