### PR TITLE
[ci] Fix project-list for spring

### DIFF
--- a/.ci/files/project-list.xml
+++ b/.ci/files/project-list.xml
@@ -39,10 +39,6 @@ mvn dependency:build-classpath -DincludeScope=test -Dmdep.outputFile=classpath.t
     <exclude-pattern>.*/build/generated-sources/.*</exclude-pattern>
 
     <build-command><![CDATA[#!/usr/bin/env bash
-if test -e classpath.txt; then
-  exit
-fi
-
 set -e
 
 # Make sure to use java11. This is already installed by build.sh
@@ -131,6 +127,11 @@ index 6021fa574d..15d29ed699 100644
 +}
 EOF
 ) | patch --strip=1
+
+## Skip gradle execution
+if test -e classpath.txt; then
+  exit
+fi
 
 ./gradlew --console=plain --build-cache --no-daemon --max-workers=4 build testClasses -x test -x javadoc -x api -x asciidoctor -x asciidoctorPdf
 ./gradlew --console=plain --build-cache --no-daemon --max-workers=4 createSquishClasspath -q > classpath.txt


### PR DESCRIPTION
## Describe the PR

We modify (among other files) AutowiredAnnotationBeanPostProcessor.java
but only, when we intend to build the project. This leads to
the situation, that the baseline was created against the
modified file, but PRs use the unmodified file. This is because
the regression-tester does a "git reset --hard" before running
PMD.

Now we patch spring always and only skip the gradle calls.

This should fix Regression Reports like this one (from #3807):

![grafik](https://user-images.githubusercontent.com/1573684/158799884-bf91cd85-5c19-4c16-96c1-f182a34476c5.png)

