### PR TITLE
[xml] Add new XPath rule for xml

### DIFF
--- a/docs/_data/sidebars/pmd_sidebar.yml
+++ b/docs/_data/sidebars/pmd_sidebar.yml
@@ -355,7 +355,7 @@ entries:
     - title: Visualforce
       url: /pmd_languages_visualforce.html
       output: web, pdf
-    - title: XML and derived languages
+    - title: XML and XML dialects
       url: /pmd_languages_xml.html
       output: web, pdf
   - title: Developer Documentation

--- a/docs/_data/sidebars/pmd_sidebar.yml
+++ b/docs/_data/sidebars/pmd_sidebar.yml
@@ -355,6 +355,9 @@ entries:
     - title: Visualforce
       url: /pmd_languages_visualforce.html
       output: web, pdf
+    - title: XML and derived languages
+      url: /pmd_languages_xml.html
+      output: web, pdf
   - title: Developer Documentation
     output: web, pdf
     folderitems:

--- a/docs/_data/xpath_funs.yml
+++ b/docs/_data/xpath_funs.yml
@@ -12,7 +12,9 @@ aliases:
     type: "xs:element"
     description: "Any element node"
   - &needs_typenode "The context node must be a {% jdoc jast::TypeNode %}"
-  - &not_ctx_dependent "The function is not context-dependent, but takes a node as its first parameter."
+  - &coord_fun_note |
+      The function is not context-dependent, but takes a node as its first parameter.
+      The function is only available in XPath 2.0.
   - &needs_node_ctx "The requires the context node to be an element"
 
 langs:
@@ -32,19 +34,19 @@ langs:
           - code: "//b[pmd:fileName() = 'Foo.xml']"
             outcome: "Matches any `&lt;b&gt;` tags in files called `Foo.xml`."
 
-      - name: beginLine
+      - name: startLine
         returnType: "xs:int"
         parameters:
           - *node_param
-        shortDescription: "Returns the begin line of the given node"
+        shortDescription: "Returns the start line of the given node"
         description: |
           Returns the line where the node starts in the source file.
           Line numbers are 1-based.
 
         since: 6.44.0
-        notes: *not_ctx_dependent
+        notes: *coord_fun_note
         examples:
-          - code: "//b[pmd:beginLine(.) > 5]"
+          - code: "//b[pmd:startLine(.) > 5]"
             outcome: "Matches any `&lt;b&gt;` node which starts after the fifth line."
 
       - name: endLine
@@ -57,11 +59,40 @@ langs:
           Line numbers are 1-based.
 
         since: 6.44.0
-        notes: *not_ctx_dependent
+        notes: *coord_fun_note
         examples:
-          - code: "//b[pmd:endLine(.) == pmd:beginLine(.)]"
+          - code: "//b[pmd:endLine(.) == pmd:startLine(.)]"
             outcome: "Matches any `&lt;b&gt;` node which doesn't span more than one line."
 
+      - name: startColumn
+        returnType: "xs:int"
+        parameters:
+          - *node_param
+        shortDescription: "Returns the start column of the given node (inclusive)"
+        description: |
+          Returns the column number where the node starts in the source file.
+          Column numbers are 1-based. The start column is inclusive.
+
+        since: 6.44.0
+        notes: *coord_fun_note
+        examples:
+          - code: "//b[pmd:startColumn(.) = 1]"
+            outcome: "Matches any `&lt;b&gt;` node which starts on the first column of a line"
+
+      - name: endColumn
+        returnType: "xs:int"
+        parameters:
+          - *node_param
+        shortDescription: "Returns the end column of the given node (exclusive)"
+        description: |
+          Returns the column number where the node ends in the source file.
+          Column numbers are 1-based. The end column is exclusive.
+
+        since: 6.44.0
+        notes: *coord_fun_note
+        examples:
+          - code: "//b[pmd:startLine(.) = pmd:endLine(.) and pmd:endColumn(.) - pmd:startColumn(.) = 1]"
+            outcome: "Matches any `&lt;b&gt;` node which spans exactly one character"
 
   - name: "Java"
     ns: "pmd-java"

--- a/docs/_data/xpath_funs.yml
+++ b/docs/_data/xpath_funs.yml
@@ -18,8 +18,9 @@ aliases:
   - &needs_node_ctx "The requires the context node to be an element"
 
 langs:
-  - name: "Any language"
+  - name: "All languages"
     ns: "pmd"
+    header: "Functions available to all languages are in the namespace `pmd`."
     funs:
       - name: fileName
         returnType: "xs:string"

--- a/docs/_data/xpath_funs.yml
+++ b/docs/_data/xpath_funs.yml
@@ -13,6 +13,7 @@ aliases:
     description: "Any element node"
   - &needs_typenode "The context node must be a {% jdoc jast::TypeNode %}"
   - &not_ctx_dependent "The function is not context-dependent, but takes a node as its first parameter."
+  - &needs_node_ctx "The requires the context node to be an element"
 
 langs:
   - name: "Any language"
@@ -21,11 +22,12 @@ langs:
       - name: fileName
         returnType: "xs:string"
         shortDescription: "Returns the simple name of the current file"
-        description: "Returns the current simple filename without path but including the extension.
-                      This can be used to write rules that check filename naming conventions.
+        description: |
+          Returns the current simple file name, without path but including the extension.
+          This can be used to write rules that check file naming conventions.
 
-                      <p>This function is available since PMD 6.38.0.</p>"
-        notes: "The function can be called on any node."
+        since: 6.38.0
+        notes: *needs_node_ctx
         examples:
           - code: "//b[pmd:fileName() = 'Foo.xml']"
             outcome: "Matches any `&lt;b&gt;` tags in files called `Foo.xml`."
@@ -35,10 +37,11 @@ langs:
         parameters:
           - *node_param
         shortDescription: "Returns the begin line of the given node"
-        description: "Returns the begin line of the given node in the source text.
-                      Line numbers are 1-based.
+        description: |
+          Returns the line where the node starts in the source file.
+          Line numbers are 1-based.
 
-                      <p>This function is available since PMD 6.44.0.</p>"
+        since: 6.44.0
         notes: *not_ctx_dependent
         examples:
           - code: "//b[pmd:beginLine(.) > 5]"
@@ -49,10 +52,11 @@ langs:
         parameters:
           - *node_param
         shortDescription: "Returns the end line of the given node"
-        description: "Returns the end line of the given node in the source text.
-                      Line numbers are 1-based.
+        description: |
+          Returns the line where the node ends in the source file.
+          Line numbers are 1-based.
 
-                      <p>This function is available since PMD 6.44.0.</p>"
+        since: 6.44.0
         notes: *not_ctx_dependent
         examples:
           - code: "//b[pmd:endLine(.) == pmd:beginLine(.)]"

--- a/docs/_data/xpath_funs.yml
+++ b/docs/_data/xpath_funs.yml
@@ -7,7 +7,12 @@ aliases:
     type: "xs:string"
     description: "The qualified name of a Java class, possibly with pairs of brackets to indicate an array type.
                   Can also be a primitive type name."
+  - &node_param
+    name: element
+    type: "xs:element"
+    description: "Any element node"
   - &needs_typenode "The context node must be a {% jdoc jast::TypeNode %}"
+  - &not_ctx_dependent "The function is not context-dependent, but takes a node as its first parameter."
 
 langs:
   - name: "Any language"
@@ -15,15 +20,43 @@ langs:
     funs:
       - name: fileName
         returnType: "xs:string"
-        shortDescription: "Returns the current filename"
+        shortDescription: "Returns the simple name of the current file"
         description: "Returns the current simple filename without path but including the extension.
                       This can be used to write rules that check filename naming conventions.
-                      
+
                       <p>This function is available since PMD 6.38.0.</p>"
         notes: "The function can be called on any node."
         examples:
           - code: "//b[pmd:fileName() = 'Foo.xml']"
             outcome: "Matches any `&lt;b&gt;` tags in files called `Foo.xml`."
+
+      - name: beginLine
+        returnType: "xs:int"
+        parameters:
+          - *node_param
+        shortDescription: "Returns the begin line of the given node"
+        description: "Returns the begin line of the given node in the source text.
+                      Line numbers are 1-based.
+
+                      <p>This function is available since PMD 6.44.0.</p>"
+        notes: *not_ctx_dependent
+        examples:
+          - code: "//b[pmd:beginLine(.) > 5]"
+            outcome: "Matches any `&lt;b&gt;` node which starts after the fifth line."
+
+      - name: endLine
+        returnType: "xs:int"
+        parameters:
+          - *node_param
+        shortDescription: "Returns the end line of the given node"
+        description: "Returns the end line of the given node in the source text.
+                      Line numbers are 1-based.
+
+                      <p>This function is available since PMD 6.44.0.</p>"
+        notes: *not_ctx_dependent
+        examples:
+          - code: "//b[pmd:endLine(.) == pmd:beginLine(.)]"
+            outcome: "Matches any `&lt;b&gt;` node which doesn't span more than one line."
 
 
   - name: "Java"

--- a/docs/_includes/custom/xpath_fun_doc.html
+++ b/docs/_includes/custom/xpath_fun_doc.html
@@ -4,7 +4,11 @@
 
 ### {{ lang.name }}
 
+{% if lang.header %}
+{{ lang.header | render_markdown }}
+{% else %}
 {{ lang.name }} functions are in the namespace `{{ lang.ns }}`.
+{% endif %}
 
 <div class="table-responsive">
     <table width="100%">

--- a/docs/_includes/custom/xpath_fun_doc.html
+++ b/docs/_includes/custom/xpath_fun_doc.html
@@ -50,6 +50,10 @@
 
                             <dl>
                                 <dd>{{ fun.description | render_markdown }}</dd>
+                                {% if fun.since %}
+                                <dt>Since</dt>
+                                <dd>PMD {{ fun.since }}</dd>
+                                {% endif %}
                                 <dt>Remarks</dt>
                                 <dd>{{ fun.notes | render_markdown }}</dd>
 

--- a/docs/pages/pmd/languages/xml.md
+++ b/docs/pages/pmd/languages/xml.md
@@ -1,5 +1,5 @@
 ---
-title: XML
+title: Processing XML files
 permalink: pmd_languages_xml.html
 last_updated: March 2021 (6.33.0)
 ---
@@ -18,7 +18,9 @@ table lists the languages currently provided by the `pmd-xml` maven module.
 | wsdl        | Web Services Description Language |
 | xsl         | Extensible Stylesheet Language    |
 
-Each of those languages has a separate rule index.
+Each of those languages has a separate rule index, and may provide domain-specific
+[XPath functions](pmd_userdocs_extending_writing_xpath_rules.html#pmd-extension-functions).
+At their core they use the same parsing facilities though.
 
 ### File attribution
 
@@ -31,7 +33,8 @@ arguments, for instance:
 ```
 $ ./run.sh pmd -d /home/me/src/xml-file.ext -f text -R ruleset.xml --force-language xml
 ```
-Please refer to [PMD CLI reference](pmd_userdocs_cli_reference.html#analyze-other-xml-formats).
+Please refer to [PMD CLI reference](pmd_userdocs_cli_reference.html#analyze-other-xml-formats)
+for more examples.
 
 
 ### XPath rules in XML
@@ -41,13 +44,16 @@ the use of this class is not recommended for XML languages. Instead, since 6.44.
 are advised to use {% xml::lang.xml.rule.DomXPathRule %}. This rule class interprets
 XPath queries exactly as regular XPath, while `XPathRule` works on a wrapper for the
 DOM which is inconsistent with the XPath spec. Since `DomXPathRule` conforms to the
-XPath spec, you can test XML queries in any stock XPath testing tool, or use resources
-like StackOverflow to write XPath queries.
+XPath spec, you can
+- test XML queries in any stock XPath testing tool, or use resources like StackOverflow
+  to help you write XPath queries.
+- match XML comments and processing instructions
+- use standard XPath functions like `text()` or `fn:string`
 
 {% include note.html content="The Rule Designer only works with `XPathRule`, and the tree it prints is inconsistent with the DOM representation used by `DomXPathRule`. You can use an online free XPath testing tool to test your query instead." %}
 
 Here's an example declaration of a `DomXPathRule`:
-```
+```xml
 <rule name="MyXPathRule"
       language="xml"
       message="A message"

--- a/docs/pages/pmd/languages/xml.md
+++ b/docs/pages/pmd/languages/xml.md
@@ -1,0 +1,69 @@
+---
+title: XML
+permalink: pmd_languages_xml.html
+last_updated: March 2021 (6.33.0)
+---
+
+## The XML language module
+
+PMD has an XML language module which exposes the [DOM](https://de.wikipedia.org/wiki/Document_Object_Model)
+of an XML document as an AST. Different flavours of XML are represented by separate
+language instances, which all use the same parser under the hood. The following
+table lists the languages currently provided by the `pmd-xml` maven module.
+
+| Language ID | Description                       |
+|-------------|-----------------------------------|
+| xml         | Generic XML language              |
+| pom         | Maven Project Object Model (POM)  |
+| wsdl        | Web Services Description Language |
+| xsl         | Extensible Stylesheet Language    |
+
+Each of those languages has a separate rule index.
+
+### File attribution
+
+Any file ending with `.xml` is associated with the `xml` language. Other XML flavours
+use more specific extensions, like `.xsl`.
+
+Some XML-based file formats do not conventionally use a `.xml` extension. To associate
+these files with the XML language, you need to use the `--force-language xml` command-line
+arguments, for instance:
+```
+$ ./run.sh pmd -d /home/me/src/xml-file.ext -f text -R ruleset.xml --force-language xml
+```
+Please refer to [PMD CLI reference](pmd_userdocs_cli_reference.html#analyze-other-xml-formats).
+
+
+### XPath rules in XML
+
+While other languages use {% jdoc core::lang.rule.XPathRule %} to create XPath rules,
+the use of this class is not recommended for XML languages. Instead, since 6.44.0, you
+are advised to use {% xml::lang.xml.rule.DomXPathRule %}. This rule class interprets
+XPath queries exactly as regular XPath, while `XPathRule` works on a wrapper for the
+DOM which is inconsistent with the XPath spec. Since `DomXPathRule` conforms to the
+XPath spec, you can test XML queries in any stock XPath testing tool, or use resources
+like StackOverflow to write XPath queries.
+
+{% include note.html content="The Rule Designer only works with `XPathRule`, and the tree it prints is inconsistent with the DOM representation used by `DomXPathRule`. You can use an online free XPath testing tool to test your query instead." %}
+
+Here's an example declaration of a `DomXPathRule`:
+```
+<rule name="MyXPathRule"
+      language="xml"
+      message="A message"
+      class="net.sourceforge.pmd.lang.xml.rule.DomXPathRule">
+
+      <properties>
+        <property name="xpath">
+            <value><![CDATA[
+            /a/b/c[@attr = "5"]
+            ]]></value>
+        </property>
+        <!-- Note: the property "version" is unsupported. -->
+      </properties>
+</rule>
+```
+The most important change is the `class` attribute, which doesn't point to `XPathRule`
+but to `DomXPathRule`. Please see the Javadoc for {% xml::lang.xml.rule.DomXPathRule %}
+for more info about the differences with `XPathRule`.
+

--- a/docs/pages/pmd/languages/xml.md
+++ b/docs/pages/pmd/languages/xml.md
@@ -1,7 +1,7 @@
 ---
 title: Processing XML files
 permalink: pmd_languages_xml.html
-last_updated: March 2021 (6.33.0)
+last_updated: March 2022 (6.44.0)
 ---
 
 ## The XML language module

--- a/docs/pages/pmd/languages/xml.md
+++ b/docs/pages/pmd/languages/xml.md
@@ -41,7 +41,7 @@ for more examples.
 
 While other languages use {% jdoc core::lang.rule.XPathRule %} to create XPath rules,
 the use of this class is not recommended for XML languages. Instead, since 6.44.0, you
-are advised to use {% xml::lang.xml.rule.DomXPathRule %}. This rule class interprets
+are advised to use {% jdoc xml::lang.xml.rule.DomXPathRule %}. This rule class interprets
 XPath queries exactly as regular XPath, while `XPathRule` works on a wrapper for the
 DOM which is inconsistent with the XPath spec. Since `DomXPathRule` conforms to the
 XPath spec, you can
@@ -70,6 +70,6 @@ Here's an example declaration of a `DomXPathRule`:
 </rule>
 ```
 The most important change is the `class` attribute, which doesn't point to `XPathRule`
-but to `DomXPathRule`. Please see the Javadoc for {% xml::lang.xml.rule.DomXPathRule %}
+but to `DomXPathRule`. Please see the Javadoc for {% jdoc xml::lang.xml.rule.DomXPathRule %}
 for more info about the differences with `XPathRule`.
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -52,7 +52,8 @@ for information about the differences with `XPathRule` and examples.
 The new XPath functions `pmd:startLine`, `pmd:endLine`, `pmd:startColumn`,
 and `pmd:endColumn` are now available in XPath rules for all languages. They
 replace the node attributes `@BeginLine`, `@EndLine` and such. These attributes
-will be deprecated in a future release.
+are now deprecated for removal (from the XPath API, not the Java getter).
+
 
 Please refer to [the documentation](https://pmd.github.io/latest/pmd_userdocs_extending_writing_xpath_rules.html#pmd-extension-functions) of these functions for more information, including usage samples.
 
@@ -123,6 +124,11 @@ The CLI itself remains compatible, if you run PMD via command-line, no action is
 * Several members of {% jdoc core::cli.PMDCommandLineInterface %} have been explicitly deprecated.
   The whole class however was deprecated long ago already with 6.30.0. It is internal API and should
   not be used.
+
+* The XPath attributes `@BeginLine`, `@EndLine`, `@BeginColumn` and `@EndColumn`,
+available on all nodes, are deprecated. They should be replaced with calls to the
+new functions `pmd:startLine`, `pmd:endLine`, `pmd:startColumn`, and `pmd:endColumn`.
+See [New XPath functions](#new-xpath-functions).
 
 #### Experimental APIs
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -14,6 +14,51 @@ This is a {{ site.pmd.release_type }} release.
 
 ### New and noteworthy
 
+#### Better XML XPath support
+
+The new rule class {% jdoc xml::lang.xml.rule.DomXPathRule %} is intended to replace
+usage of the `XPathRule` for XML rules. This rule executes the XPath query in a different
+way, which sticks to the XPath specification. This means the expression is interpreted
+the same way in PMD as in all other XPath development tools that stick to the standard.
+You can for instance test the expression in an online XPath editor.
+
+Prefer using this class to define XPath rules: replace the value of the `class`
+attribute with `net.sourceforge.pmd.lang.xml.rule.DomXPathRule` like so:
+```xml
+<rule name="MyXPathRule"
+      language="xml"
+      message="A message"
+      class="net.sourceforge.pmd.lang.xml.rule.DomXPathRule">
+
+      <properties>
+        <property name="xpath">
+            <value><![CDATA[
+            /a/b/c[@attr = "5"]
+            ]]></value>
+        </property>
+        <!-- Note: the property "version" is ignored, remove it. The query is XPath 2. -->
+      </properties>
+</rule>
+```
+
+The rule is more powerful than `XPathRule`, as it can now handle XML namespaces,
+comments and processing instructions. Please refer to the Javadoc of {% jdoc xml::lang.xml.rule.DomXPathRule %}
+for information about the differences with `XPathRule` and examples.
+
+`XPathRule` is still perfectly supported for all other languages, including Apex and Java.
+
+#### New XPath functions
+
+The new XPath functions `pmd:startLine`, `pmd:endLine`, `pmd:startColumn`,
+and `pmd:endColumn` are now available in XPath rules for all languages. They
+replace the node attributes `@BeginLine`, `@EndLine` and such. These attributes
+will be deprecated in a future release.
+
+Please refer to [the documentation](https://pmd.github.io/latest/pmd_userdocs_extending_writing_xpath_rules.html#pmd-extension-functions) of these functions for more information, including usage samples.
+
+Note that the function `pmd:endColumn` returns an exclusive index, while the
+attribute `@EndColumn` is inclusive. This is for forward compatibility with PMD 7,
+which uses exclusive end indices.
 
 #### New programmatic API
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -52,8 +52,7 @@ for information about the differences with `XPathRule` and examples.
 The new XPath functions `pmd:startLine`, `pmd:endLine`, `pmd:startColumn`,
 and `pmd:endColumn` are now available in XPath rules for all languages. They
 replace the node attributes `@BeginLine`, `@EndLine` and such. These attributes
-are now deprecated for removal (from the XPath API, not the Java getter).
-
+will be deprecated in a future release.
 
 Please refer to [the documentation](https://pmd.github.io/latest/pmd_userdocs_extending_writing_xpath_rules.html#pmd-extension-functions) of these functions for more information, including usage samples.
 
@@ -124,11 +123,6 @@ The CLI itself remains compatible, if you run PMD via command-line, no action is
 * Several members of {% jdoc core::cli.PMDCommandLineInterface %} have been explicitly deprecated.
   The whole class however was deprecated long ago already with 6.30.0. It is internal API and should
   not be used.
-
-* The XPath attributes `@BeginLine`, `@EndLine`, `@BeginColumn` and `@EndColumn`,
-available on all nodes, are deprecated. They should be replaced with calls to the
-new functions `pmd:startLine`, `pmd:endLine`, `pmd:startColumn`, and `pmd:endColumn`.
-See [New XPath functions](#new-xpath-functions).
 
 #### Experimental APIs
 

--- a/pmd-core/pom.xml
+++ b/pmd-core/pom.xml
@@ -150,7 +150,6 @@
             <groupId>net.sourceforge.saxon</groupId>
             <artifactId>saxon</artifactId>
             <classifier>dom</classifier>
-            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/Node.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/Node.java
@@ -178,17 +178,13 @@ public interface Node {
      */
     boolean hasImageEqualTo(String image);
 
-    @DeprecatedAttribute(replaceWith = "pmd:startLine(.)")
     int getBeginLine();
 
-    @DeprecatedAttribute(replaceWith = "pmd:startColumn(.)")
     int getBeginColumn();
 
-    @DeprecatedAttribute(replaceWith = "pmd:endLine(.)")
     int getEndLine();
 
     // FIXME should not be inclusive
-    @DeprecatedAttribute(replaceWith = "pmd:endColumn(.)")
     int getEndColumn();
 
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/Node.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/Node.java
@@ -178,13 +178,17 @@ public interface Node {
      */
     boolean hasImageEqualTo(String image);
 
+    @DeprecatedAttribute(replaceWith = "pmd:startLine(.)")
     int getBeginLine();
 
+    @DeprecatedAttribute(replaceWith = "pmd:startColumn(.)")
     int getBeginColumn();
 
+    @DeprecatedAttribute(replaceWith = "pmd:endLine(.)")
     int getEndLine();
 
     // FIXME should not be inclusive
+    @DeprecatedAttribute(replaceWith = "pmd:endColumn(.)")
     int getEndColumn();
 
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQuery.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/SaxonXPathRuleQuery.java
@@ -177,7 +177,11 @@ public class SaxonXPathRuleQuery extends AbstractXPathRuleQuery {
     }
 
 
-    private ValueRepresentation getRepresentation(final PropertyDescriptor<?> descriptor, final Object value) {
+    /**
+     * Internal: this has been moved in PMD 7.
+     */
+    @InternalApi
+    public static ValueRepresentation getRepresentation(final PropertyDescriptor<?> descriptor, final Object value) {
         if (descriptor.isMultiValue()) {
             return getSequenceRepresentation((List<?>) value);
         } else {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/xpath/PMDFunctions.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/xpath/PMDFunctions.java
@@ -22,6 +22,10 @@ import net.sf.saxon.om.Item;
 public final class PMDFunctions {
 
     private static final Logger LOG = Logger.getLogger(PMDFunctions.class.getName());
+    /** Used by the XML module to associate PMD nodes with DOM nodes. */
+    @Deprecated
+    @InternalApi
+    public static final String PMD_NODE_USER_DATA = "pmd.node";
 
     private PMDFunctions() { }
 
@@ -75,7 +79,7 @@ public final class PMDFunctions {
         } else if (item instanceof NodeWrapper) {
             return itemToNode(((NodeWrapper) item).getUnderlyingNode());
         } else if (item instanceof org.w3c.dom.Node) {
-            return itemToNode(((org.w3c.dom.Node) item).getUserData("pmd.node"));
+            return itemToNode(((org.w3c.dom.Node) item).getUserData(PMD_NODE_USER_DATA));
         }
         LOG.fine("Cannot call pmd:filename on " + item);
         return null;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/xpath/PMDFunctions.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/xpath/PMDFunctions.java
@@ -15,6 +15,7 @@ import net.sourceforge.pmd.lang.ast.xpath.saxon.ElementNode;
 import net.sf.saxon.dom.NodeWrapper;
 import net.sf.saxon.expr.XPathContext;
 import net.sf.saxon.om.Item;
+import net.sf.saxon.om.NodeInfo;
 
 
 @InternalApi
@@ -61,14 +62,24 @@ public final class PMDFunctions {
         return node == null ? null : FileNameXPathFunction.getFileName(node);
     }
 
-    public static int beginLine(Item item) {
+    public static int startLine(NodeInfo item) {
         Node node = Objects.requireNonNull(itemToNode(item), "not a node " + item);
         return node.getBeginLine();
     }
 
-    public static int endLine(Item item) {
+    public static int endLine(NodeInfo item) {
         Node node = Objects.requireNonNull(itemToNode(item), "not a node " + item);
         return node.getEndLine();
+    }
+
+    public static int startColumn(NodeInfo item) {
+        Node node = Objects.requireNonNull(itemToNode(item), "not a node " + item);
+        return node.getBeginColumn();
+    }
+
+    public static int endColumn(NodeInfo item) {
+        Node node = Objects.requireNonNull(itemToNode(item), "not a node " + item);
+        return node.getEndColumn() + 1; // exclusive
     }
 
     private static Node itemToNode(Object item) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/xpath/PMDFunctions.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/xpath/PMDFunctions.java
@@ -4,17 +4,24 @@
 
 package net.sourceforge.pmd.lang.xpath;
 
+import java.util.logging.Logger;
+
 import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.ast.xpath.internal.FileNameXPathFunction;
 import net.sourceforge.pmd.lang.ast.xpath.saxon.ElementNode;
 
+import net.sf.saxon.dom.NodeWrapper;
 import net.sf.saxon.expr.XPathContext;
+import net.sf.saxon.om.Item;
 
 
 @InternalApi
 @Deprecated
 public final class PMDFunctions {
+
+    private static final Logger LOG = Logger.getLogger(PMDFunctions.class.getName());
+
     private PMDFunctions() { }
 
     public static boolean matches(String s, String pattern1) {
@@ -34,17 +41,32 @@ public final class PMDFunctions {
     }
 
     public static boolean matches(String s, String pattern1, String pattern2, String pattern3, String pattern4,
-            String pattern5) {
+                                  String pattern5) {
         return MatchesFunction.matches(s, pattern1, pattern2, pattern3, pattern4, pattern5);
     }
 
     public static boolean matches(String s, String pattern1, String pattern2, String pattern3, String pattern4,
-            String pattern5, String pattern6) {
+                                  String pattern5, String pattern6) {
         return MatchesFunction.matches(s, pattern1, pattern2, pattern3, pattern4, pattern5, pattern6);
     }
 
     public static String fileName(final XPathContext context) {
-        Node ctxNode = ((ElementNode) context.getContextItem()).getUnderlyingNode();
-        return FileNameXPathFunction.getFileName(ctxNode);
+        Item contextItem = context.getContextItem();
+        Node node = itemToNode(contextItem);
+        return node == null ? null : FileNameXPathFunction.getFileName(node);
+    }
+
+    private static Node itemToNode(Object item) {
+        if (item instanceof Node) {
+            return (Node) item;
+        } else if (item instanceof ElementNode) { // todo pmd 7 remove this branch as ElementNode extends NodeWrapper
+            return itemToNode(((ElementNode) item).getUnderlyingNode());
+        } else if (item instanceof NodeWrapper) {
+            return itemToNode(((NodeWrapper) item).getUnderlyingNode());
+        } else if (item instanceof org.w3c.dom.Node) {
+            return itemToNode(((org.w3c.dom.Node) item).getUserData("pmd.node"));
+        }
+        LOG.fine("Cannot call pmd:filename on " + item);
+        return null;
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/xpath/PMDFunctions.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/xpath/PMDFunctions.java
@@ -92,7 +92,7 @@ public final class PMDFunctions {
         } else if (item instanceof org.w3c.dom.Node) {
             return itemToNode(((org.w3c.dom.Node) item).getUserData(PMD_NODE_USER_DATA));
         }
-        LOG.fine("Cannot call pmd:filename on " + item);
+        LOG.fine("Cannot call function on " + item);
         return null;
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/xpath/PMDFunctions.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/xpath/PMDFunctions.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.xpath;
 
+import java.util.Objects;
 import java.util.logging.Logger;
 
 import net.sourceforge.pmd.annotation.InternalApi;
@@ -54,6 +55,16 @@ public final class PMDFunctions {
         Item contextItem = context.getContextItem();
         Node node = itemToNode(contextItem);
         return node == null ? null : FileNameXPathFunction.getFileName(node);
+    }
+
+    public static int beginLine(Item item) {
+        Node node = Objects.requireNonNull(itemToNode(item), "not a node " + item);
+        return node.getBeginLine();
+    }
+
+    public static int endLine(Item item) {
+        Node node = Objects.requireNonNull(itemToNode(item), "not a node " + item);
+        return node.getEndLine();
     }
 
     private static Node itemToNode(Object item) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/DataMap.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/DataMap.java
@@ -46,7 +46,7 @@ public final class DataMap<K> {
      * @return Value associated with the key (nullable)
      */
     @SuppressWarnings("unchecked")
-    public <T> T get(DataKey<? extends K, ? super T> key) {
+    public <T> T get(DataKey<? extends K, ? extends T> key) {
         return (T) map.get(key);
     }
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNode.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNode.java
@@ -4,7 +4,12 @@
 
 package net.sourceforge.pmd.lang.ast;
 
+import java.nio.file.Paths;
+
+import net.sourceforge.pmd.lang.ast.xpath.internal.FileNameXPathFunction;
+
 public class DummyNode extends AbstractNode {
+
     private final boolean findBoundary;
     private final String xpathName;
 
@@ -54,5 +59,19 @@ public class DummyNode extends AbstractNode {
     @Override
     public boolean isFindBoundary() {
         return findBoundary;
+    }
+
+    public static class DummyRootNode extends DummyNode implements RootNode {
+
+        public DummyRootNode() {
+            this("afile.txt");
+        }
+
+        public DummyRootNode(String fileName) {
+            super(0);
+            // remove prefixed path segments.
+            String simpleFileName = Paths.get(fileName).getFileName().toString();
+            getUserMap().set(FileNameXPathFunction.FILE_NAME_KEY, simpleFileName);
+        }
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/xpath/DocumentNavigatorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/xpath/DocumentNavigatorTest.java
@@ -11,19 +11,13 @@ import static org.junit.Assert.fail;
 import org.junit.Test;
 
 import net.sourceforge.pmd.lang.ast.DummyNode;
+import net.sourceforge.pmd.lang.ast.DummyNode.DummyRootNode;
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.ast.RootNode;
 
 /**
  * Unit test for {@link DocumentNavigator}
  */
 public class DocumentNavigatorTest {
-
-    private static class DummyRootNode extends DummyNode implements RootNode {
-        DummyRootNode(int id) {
-            super(id);
-        }
-    }
 
     @Test
     public void getDocumentNode() {
@@ -36,7 +30,7 @@ public class DocumentNavigatorTest {
             assertNotNull(e);
         }
 
-        Node root = new DummyRootNode(1);
+        Node root = new DummyRootNode();
         Node n = new DummyNode(1);
         root.jjtAddChild(n, 0);
         n.jjtSetParent(root);

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/XPathRuleTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/XPathRuleTest.java
@@ -199,7 +199,7 @@ public class XPathRuleTest {
 
     @Test
     public void testEndColumn() {
-        Report report = executeRule(makeXPath("//*[pmd:endColumn(.)=1]"),
+        Report report = executeRule(makeXPath("//*[pmd:endColumn(.)>1]"),
                                     newRoot("src/Foo.cls"));
 
         assertThat(report.getViolations(), hasSize(1));

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/XPathRuleTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/XPathRuleTest.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.rule;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 
 import org.hamcrest.Matchers;
@@ -13,11 +14,13 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
+import net.sourceforge.pmd.Report;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.junit.JavaUtilLoggingRule;
 import net.sourceforge.pmd.lang.DummyLanguageModule;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.ast.DummyNode;
+import net.sourceforge.pmd.lang.ast.DummyNode.DummyRootNode;
 import net.sourceforge.pmd.lang.ast.DummyNodeWithDeprecatedAttribute;
 import net.sourceforge.pmd.lang.ast.DummyNodeWithListAndEnum;
 import net.sourceforge.pmd.lang.ast.xpath.Attribute;
@@ -154,6 +157,47 @@ public class XPathRuleTest {
         return xpr;
     }
 
+
+    public XPathRule makeXPath(String xpathExpr) {
+        XPathRule xpr = new XPathRule(XPathVersion.XPATH_2_0, xpathExpr);
+        xpr.setName("name");
+        xpr.setMessage("gotcha");
+        return xpr;
+    }
+
+    @Test
+    public void testFileNameInXpath() {
+        Report report = executeRule(makeXPath("//*[pmd:fileName() = 'Foo.cls']"),
+                                    newRoot("src/Foo.cls"));
+
+        assertThat(report.getViolations(), hasSize(1));
+    }
+
+    @Test
+    public void testBeginLine() {
+        Report report = executeRule(makeXPath("//*[pmd:beginLine(.)=1]"),
+                                    newRoot("src/Foo.cls"));
+
+        assertThat(report.getViolations(), hasSize(1));
+    }
+
+    @Test
+    public void testEndLine() {
+        Report report = executeRule(makeXPath("//*[pmd:endLine(.)=1]"),
+                                    newRoot("src/Foo.cls"));
+
+        assertThat(report.getViolations(), hasSize(1));
+    }
+
+
+    public Report executeRule(net.sourceforge.pmd.Rule rule, DummyNode node) {
+        RuleContext ctx = new RuleContext();
+        ctx.setReport(new Report());
+        ctx.setLanguageVersion(LanguageRegistry.getLanguage(DummyLanguageModule.NAME).getDefaultVersion());
+        eval(ctx, rule, node);
+        return ctx.getReport();
+    }
+
     public void eval(RuleContext ctx, net.sourceforge.pmd.Rule rule, DummyNode node) {
         ctx.setCurrentRule(rule);
         rule.apply(singletonList(node), ctx);
@@ -162,6 +206,12 @@ public class XPathRuleTest {
 
     public DummyNode newNode() {
         DummyNode dummy = new DummyNodeWithDeprecatedAttribute(2);
+        dummy.setCoords(1, 1, 1, 2);
+        return dummy;
+    }
+
+    public DummyNode.DummyRootNode newRoot(String fileName) {
+        DummyRootNode dummy = new DummyRootNode(fileName);
         dummy.setCoords(1, 1, 1, 2);
         return dummy;
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/XPathRuleTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/XPathRuleTest.java
@@ -175,7 +175,15 @@ public class XPathRuleTest {
 
     @Test
     public void testBeginLine() {
-        Report report = executeRule(makeXPath("//*[pmd:beginLine(.)=1]"),
+        Report report = executeRule(makeXPath("//*[pmd:startLine(.)=1]"),
+                                    newRoot("src/Foo.cls"));
+
+        assertThat(report.getViolations(), hasSize(1));
+    }
+
+    @Test
+    public void testBeginCol() {
+        Report report = executeRule(makeXPath("//*[pmd:startColumn(.)=1]"),
                                     newRoot("src/Foo.cls"));
 
         assertThat(report.getViolations(), hasSize(1));
@@ -189,6 +197,13 @@ public class XPathRuleTest {
         assertThat(report.getViolations(), hasSize(1));
     }
 
+    @Test
+    public void testEndColumn() {
+        Report report = executeRule(makeXPath("//*[pmd:endColumn(.)=1]"),
+                                    newRoot("src/Foo.cls"));
+
+        assertThat(report.getViolations(), hasSize(1));
+    }
 
     public Report executeRule(net.sourceforge.pmd.Rule rule, DummyNode node) {
         RuleContext ctx = new RuleContext();

--- a/pmd-xml/pom.xml
+++ b/pmd-xml/pom.xml
@@ -47,6 +47,11 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
+        <dependency>
+            <groupId>net.sourceforge.saxon</groupId>
+            <artifactId>saxon</artifactId>
+            <classifier>dom</classifier>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/AbstractDomNodeProxy.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/AbstractDomNodeProxy.java
@@ -19,7 +19,10 @@ import net.sourceforge.pmd.lang.ast.AbstractNode;
  *
  * @author Clément Fournier
  * @since 6.1.0
+ *
+ * @deprecated Will be removed in PMD 7, use subclasses as PMD Nodes but not DOM nodes.
  */
+@Deprecated
 public abstract class AbstractDomNodeProxy extends AbstractNode implements org.w3c.dom.Node {
 
     protected final org.w3c.dom.Node node;

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/XmlNodeWrapper.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/XmlNodeWrapper.java
@@ -19,6 +19,7 @@ import org.w3c.dom.Text;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.ast.xpath.Attribute;
 import net.sourceforge.pmd.lang.dfa.DataFlowNode;
+import net.sourceforge.pmd.lang.xpath.PMDFunctions;
 import net.sourceforge.pmd.util.CompoundIterator;
 
 
@@ -38,7 +39,7 @@ public class XmlNodeWrapper extends AbstractDomNodeProxy implements XmlNode {
 
     public XmlNodeWrapper(XmlParser parser, org.w3c.dom.Node domNode) {
         super(domNode);
-        domNode.setUserData("pmd.node", this, null);
+        domNode.setUserData(PMDFunctions.PMD_NODE_USER_DATA, this, null);
         this.parser = parser;
     }
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/XmlNodeWrapper.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/XmlNodeWrapper.java
@@ -24,6 +24,8 @@ import net.sourceforge.pmd.util.CompoundIterator;
 
 /**
  * Proxy wrapping an XML DOM node ({@link org.w3c.dom.Node}) to implement PMD interfaces.
+ * Note: you should only use it as a PMD {@link Node}, the DOM Node implementation
+ * is inconsistent. If you need a dom node, call {@link #getNode()}.
  *
  * @author Clément Fournier
  * @since 6.1.0
@@ -36,7 +38,12 @@ public class XmlNodeWrapper extends AbstractDomNodeProxy implements XmlNode {
 
     public XmlNodeWrapper(XmlParser parser, org.w3c.dom.Node domNode) {
         super(domNode);
+        domNode.setUserData("pmd.node", this, null);
         this.parser = parser;
+    }
+
+    protected XmlNode wrap(org.w3c.dom.Node domNode) {
+        return parser.wrapDomNode(domNode);
     }
 
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/XmlParser.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/XmlParser.java
@@ -91,13 +91,18 @@ public class XmlParser {
      */
     public static class RootXmlNode extends XmlNodeWrapper implements RootNode {
 
-        RootXmlNode(XmlParser parser, Node domNode) {
+        RootXmlNode(XmlParser parser, Document domNode) {
             super(parser, domNode);
         }
 
         @Override
         public XmlNode wrap(Node domNode) {
             return super.wrap(domNode);
+        }
+
+        @Override
+        public Document getNode() {
+            return (Document) super.getNode();
         }
     }
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/XmlParser.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/XmlParser.java
@@ -90,8 +90,14 @@ public class XmlParser {
      * The root should implement {@link RootNode}.
      */
     public static class RootXmlNode extends XmlNodeWrapper implements RootNode {
+
         RootXmlNode(XmlParser parser, Node domNode) {
             super(parser, domNode);
+        }
+
+        @Override
+        public XmlNode wrap(Node domNode) {
+            return super.wrap(domNode);
         }
     }
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/DomXPathRule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/DomXPathRule.java
@@ -127,6 +127,8 @@ public class DomXPathRule extends AbstractRule {
     public DomXPathRule() {
         definePropertyDescriptor(XPATH_EXPR);
         definePropertyDescriptor(DEFAULT_NS_URI);
+        // for compatibility, but is ignored.
+        definePropertyDescriptor(XPathRule.VERSION_DESCRIPTOR);
     }
 
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/DomXPathRule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/DomXPathRule.java
@@ -69,7 +69,7 @@ import net.sourceforge.pmd.properties.PropertyFactory;
  *
  * <h4>Namespace-sensitivity</h4>
  *
- * <p>Another large difference is that this rule is namespace-sensitive.
+ * <p>Another important difference is that this rule is namespace-sensitive.
  * If the tested XML documents use a schema ({@code xmlns} attribute on the root),
  * you should set the property {@code defaultNsUri} on the rule with
  * the value of the {@code xmlns} attribute. Otherwise node tests won't

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/DomXPathRule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/DomXPathRule.java
@@ -22,10 +22,35 @@ import net.sourceforge.pmd.properties.PropertyFactory;
  * class is strongly recommended over the standard {@link XPathRule}, which
  * is mostly useful in other PMD languages.
  *
- * <p>The XPath expression is namespace-sensitive. If the tested XML documents
- * use a schema ({@code xmlns} attribute on the root), you should set the property
- * {@code defaultNsUri} on the rule with the value of the {@code xmlns} attribute.
- * Otherwise node tests won't match unless you use a wildcard URI prefix ({@code *:nodeName}).
+ * <h3>Differences with {@link XPathRule}</h3>
+ *
+ * This rule and {@link XPathRule} do not accept exactly the same queries,
+ * because {@link XPathRule} implements the XPath spec in an ad-hoc way.
+ * The main differences are:
+ * <ul>
+ * <li>{@link XPathRule} uses <i>elements</i> to represent text nodes.
+ * This is contrary to the XPath spec, in which element and text nodes
+ * are different kinds of nodes. To replace the query {@code //elt/text[@Image="abc"]},
+ * use the XPath function {@code text()}, eg {@code //elt[text()="abc"]}.
+ * <li>{@link XPathRule} adds additional attributes to each element
+ * (eg {@code @BeginLine} and {@code @Image}). These attributes are not
+ * XML attributes, so they are not accessible using DomXPathRule rule.
+ * Instead, use the XPath functions {@code pmd:beginLine(node)} and {@code pmd:beginLine(node)}.
+ * For instance, replace {@code //elt[@EndLine - @BeginLine > 10]} with
+ * {@code elt[pmd:endLine(.) - pmd:beginLine(.) > 10]}.
+ * <li>{@link XPathRule} uses an element called {@code "document"} as the
+ * root node of every XML AST. This node does not have the correct node kind,
+ * as it's an element, not a document. To replace {@code /document/RootNode},
+ * use just {@code /RootNode}.
+ * </ul>
+ *
+ * <h4>Namespace-sensitivity</h4>
+ *
+ * <p>Another large difference is that this rule is namespace-sensitive.
+ * If the tested XML documents use a schema ({@code xmlns} attribute on the root),
+ * you should set the property {@code defaultNsUri} on the rule with
+ * the value of the {@code xmlns} attribute. Otherwise node tests won't
+ * match unless you use a wildcard URI prefix ({@code *:nodeName}).
  *
  * <p>For instance for the document
  * <pre>{@code

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/DomXPathRule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/DomXPathRule.java
@@ -42,6 +42,26 @@ import net.sourceforge.pmd.properties.PropertyFactory;
  * root node of every XML AST. This node does not have the correct node kind,
  * as it's an element, not a document. To replace {@code /document/RootNode},
  * use just {@code /RootNode}.
+ * <li>{@link XPathRule} ignores comments and processing instructions
+ * (eg FXML's {@code <?import javafx.Node ?>}).
+ * This rule makes them accessible with the regular XPath syntax.
+ * The following finds all comments in the file:
+ * <pre>{@code
+ *  //comment()
+ * }</pre>
+ * The following finds only top-level comments starting with "prefix":
+ * <pre>{@code
+ *  /comment()[fn:starts-with(fn:string(.), "prefix")]
+ * }</pre>
+ * Note the use of {@code fn:string}.
+ *
+ * As an example of matching processing instructions, the following
+ * fetches all {@code <?import ... ?>} processing instructions.
+ * <pre>{@code
+ *  /processing-instruction('import')
+ * }</pre>
+ * The string value of the instruction can be found with {@code fn:string}.
+ * </li>
  * </ul>
  *
  * <p>Additionally, this rule only supports XPath 2.0, with no option

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/DomXPathRule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/DomXPathRule.java
@@ -1,0 +1,55 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.xml.rule;
+
+import java.util.List;
+
+import net.sourceforge.pmd.RuleContext;
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.rule.AbstractRule;
+import net.sourceforge.pmd.lang.xml.ast.XmlParser.RootXmlNode;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
+
+public class DomXPathRule extends AbstractRule {
+
+    SaxonDomXPathQuery query;
+
+    private static final PropertyDescriptor<String> XPATH_EXPR
+        = PropertyFactory.stringProperty("xpath")
+                         .desc("An XPath 2.0 expression that will be evaluated against the root DOM")
+                         .defaultValue("") // no default value
+                         .build();
+
+
+    public DomXPathRule() {
+        definePropertyDescriptor(XPATH_EXPR);
+    }
+
+
+    public DomXPathRule(String xpath) {
+        this();
+        setProperty(XPATH_EXPR, xpath);
+    }
+
+    @Override
+    public void apply(List<? extends Node> nodes, RuleContext ctx) {
+        for (Node n : nodes) {
+            RootXmlNode root = (RootXmlNode) n;
+            SaxonDomXPathQuery query = getXPathQuery();
+            for (Node foundNode : query.evaluate(root, this)) {
+                ctx.addViolation(foundNode);
+            }
+        }
+    }
+
+    private SaxonDomXPathQuery getXPathQuery() {
+        if (query == null) {
+            query = new SaxonDomXPathQuery(getProperty(XPATH_EXPR), getPropertyDescriptors());
+        }
+        return query;
+    }
+
+}

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/DomXPathRule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/DomXPathRule.java
@@ -44,6 +44,9 @@ import net.sourceforge.pmd.properties.PropertyFactory;
  * use just {@code /RootNode}.
  * </ul>
  *
+ * <p>Additionally, this rule only supports XPath 2.0, with no option
+ * for configuration. This will be bumped to XPath 3.1 in PMD 7.
+ *
  * <h4>Namespace-sensitivity</h4>
  *
  * <p>Another large difference is that this rule is namespace-sensitive.

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/DomXPathRule.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/DomXPathRule.java
@@ -35,9 +35,9 @@ import net.sourceforge.pmd.properties.PropertyFactory;
  * <li>{@link XPathRule} adds additional attributes to each element
  * (eg {@code @BeginLine} and {@code @Image}). These attributes are not
  * XML attributes, so they are not accessible using DomXPathRule rule.
- * Instead, use the XPath functions {@code pmd:beginLine(node)} and {@code pmd:beginLine(node)}.
+ * Instead, use the XPath functions {@code pmd:startLine(node)}, {@code pmd:endLine(node)} and related.
  * For instance, replace {@code //elt[@EndLine - @BeginLine > 10]} with
- * {@code elt[pmd:endLine(.) - pmd:beginLine(.) > 10]}.
+ * {@code elt[pmd:endLine(.) - pmd:startLine(.) > 10]}.
  * <li>{@link XPathRule} uses an element called {@code "document"} as the
  * root node of every XML AST. This node does not have the correct node kind,
  * as it's an element, not a document. To replace {@code /document/RootNode},

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/SaxonDomXPathQuery.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/SaxonDomXPathQuery.java
@@ -1,0 +1,154 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.xml.rule;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+
+import org.apache.commons.lang3.exception.ContextedRuntimeException;
+
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.rule.xpath.SaxonXPathRuleQuery;
+import net.sourceforge.pmd.lang.xml.ast.XmlNode;
+import net.sourceforge.pmd.lang.xml.ast.XmlParser.RootXmlNode;
+import net.sourceforge.pmd.lang.xpath.Initializer;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertySource;
+import net.sourceforge.pmd.util.DataMap;
+import net.sourceforge.pmd.util.DataMap.DataKey;
+import net.sourceforge.pmd.util.DataMap.SimpleDataKey;
+
+import net.sf.saxon.Configuration;
+import net.sf.saxon.dom.DocumentWrapper;
+import net.sf.saxon.dom.NodeWrapper;
+import net.sf.saxon.om.NamePool;
+import net.sf.saxon.om.NamespaceConstant;
+import net.sf.saxon.om.ValueRepresentation;
+import net.sf.saxon.sxpath.IndependentContext;
+import net.sf.saxon.sxpath.XPathDynamicContext;
+import net.sf.saxon.sxpath.XPathEvaluator;
+import net.sf.saxon.sxpath.XPathExpression;
+import net.sf.saxon.sxpath.XPathStaticContext;
+import net.sf.saxon.sxpath.XPathVariable;
+import net.sf.saxon.trans.XPathException;
+
+final class SaxonDomXPathQuery {
+
+    private static final NamePool NAME_POOL = new NamePool();
+
+    private static final SimpleDataKey<DocumentWrapper> SAXON_DOM_WRAPPER
+        = DataMap.simpleDataKey("pmd.saxon.dom.wrapper");
+
+    private final String xpath;
+    private final XPathExpression xpathExpression;
+    private final Map<PropertyDescriptor<?>, XPathVariable> xpathVariables;
+
+    private final Configuration configuration;
+
+    public SaxonDomXPathQuery(String xpath, List<PropertyDescriptor<?>> properties) {
+        this.xpath = xpath;
+        final XPathEvaluator xpathEvaluator = new XPathEvaluator();
+        final XPathStaticContext xpathStaticContext = xpathEvaluator.getStaticContext();
+        ((IndependentContext) xpathStaticContext).declareNamespace("fn", NamespaceConstant.FN);
+        configuration = xpathStaticContext.getConfiguration();
+        configuration.setNamePool(NAME_POOL);
+
+        // Register PMD functions
+        Initializer.initialize((IndependentContext) xpathStaticContext);
+
+        this.xpathVariables = makeXPathVariables(properties, xpathStaticContext);
+
+        try {
+            this.xpathExpression = xpathEvaluator.createExpression(xpath);
+        } catch (final XPathException e) {
+            throw new ContextedRuntimeException(e)
+                .addContextValue("XPath", xpath);
+        }
+    }
+
+    private Map<PropertyDescriptor<?>, XPathVariable> makeXPathVariables(List<PropertyDescriptor<?>> accessibleProperties, XPathStaticContext xpathStaticContext) {
+        Map<PropertyDescriptor<?>, XPathVariable> xpathVariables = new HashMap<>();
+        for (final PropertyDescriptor<?> propertyDescriptor : accessibleProperties) {
+            final String name = propertyDescriptor.name();
+            if (!isExcludedProperty(name)) {
+                final XPathVariable xpathVariable = xpathStaticContext.declareVariable(null, name);
+                xpathVariables.put(propertyDescriptor, xpathVariable);
+            }
+        }
+        return Collections.unmodifiableMap(xpathVariables);
+    }
+
+    private boolean isExcludedProperty(String name) {
+        return "xpath".equals(name)
+               || "violationSuppressRegex".equals(name)
+               || "violationSuppressXPath".equals(name);
+    }
+
+    @Override
+    public String toString() {
+        return xpath;
+    }
+
+    public List<Node> evaluate(RootXmlNode root, PropertySource propertyValues) {
+        DocumentWrapper wrapper = getSaxonDomWrapper(root);
+        XPathDynamicContext dynamicContext = createDynamicContext(wrapper, propertyValues);
+        try {
+            List<Node> result = new ArrayList<>();
+            for (Object item : xpathExpression.evaluate(dynamicContext)) {
+                if (item instanceof NodeWrapper) {
+                    NodeWrapper nodeInfo = (NodeWrapper) item;
+                    Object domNode = nodeInfo.getUnderlyingNode();
+                    if (domNode instanceof org.w3c.dom.Node) {
+                        XmlNode wrapped = root.wrap((org.w3c.dom.Node) domNode);
+                        result.add(wrapped);
+                    }
+                }
+            }
+            return result;
+        } catch (XPathException e) {
+            throw new ContextedRuntimeException(e)
+                .addContextValue("XPath", xpath);
+        }
+
+    }
+
+    private DocumentWrapper getSaxonDomWrapper(RootXmlNode node) {
+        DataMap<DataKey<?, ?>> userMap = node.getUserMap();
+        if (userMap.isSet(SAXON_DOM_WRAPPER)) {
+            return userMap.get(SAXON_DOM_WRAPPER);
+        }
+        org.w3c.dom.Node domRoot = node.getNode();
+        DocumentWrapper wrapper = new DocumentWrapper(
+            domRoot, domRoot.getBaseURI(), configuration
+        );
+        userMap.set(SAXON_DOM_WRAPPER, wrapper);
+        return wrapper;
+    }
+
+    private XPathDynamicContext createDynamicContext(final DocumentWrapper elementNode, PropertySource properties) {
+        final XPathDynamicContext dynamicContext = xpathExpression.createDynamicContext(elementNode);
+
+        // Set variable values on the dynamic context
+        for (final Entry<PropertyDescriptor<?>, XPathVariable> entry : xpathVariables.entrySet()) {
+            Object value = properties.getProperty(entry.getKey());
+            Objects.requireNonNull(value, "null property value for " + entry.getKey());
+            final ValueRepresentation saxonValue = SaxonXPathRuleQuery.getRepresentation(entry.getKey(), entry.getValue());
+            try {
+                dynamicContext.setVariable(entry.getValue(), saxonValue);
+            } catch (XPathException e) {
+                throw new ContextedRuntimeException(e)
+                    .addContextValue("Variable", entry.getValue())
+                    .addContextValue("XPath", xpath);
+            }
+        }
+        return dynamicContext;
+    }
+
+}

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/SaxonDomXPathQuery.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/SaxonDomXPathQuery.java
@@ -102,6 +102,7 @@ final class SaxonDomXPathQuery {
 
     private boolean isExcludedProperty(String name) {
         return "xpath".equals(name)
+               || "defaultNsUri".equals(name)
                || "violationSuppressRegex".equals(name)
                || "violationSuppressXPath".equals(name);
     }

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/SaxonDomXPathQuery.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/SaxonDomXPathQuery.java
@@ -55,14 +55,15 @@ final class SaxonDomXPathQuery {
     private static final SimpleDataKey<PmdDocumentWrapper> SAXON_DOM_WRAPPER
         = DataMap.simpleDataKey("pmd.saxon.dom.wrapper");
 
+    /** The XPath expression as a string. */
     private final String xpath;
-    /** Cached xpath expression for URI of "". */
+    /** The executable XPath expression. */
     private final XPathExpressionWithProperties xpathExpression;
 
 
     private final Configuration configuration;
 
-    public SaxonDomXPathQuery(String xpath, String defaultNsUri, List<PropertyDescriptor<?>> properties) {
+    SaxonDomXPathQuery(String xpath, String defaultNsUri, List<PropertyDescriptor<?>> properties) {
         this.xpath = xpath;
         configuration = new Configuration();
         configuration.setNamePool(NAME_POOL);
@@ -119,11 +120,10 @@ final class SaxonDomXPathQuery {
 
     public List<Node> evaluate(RootXmlNode root, PropertySource propertyValues) {
         PmdDocumentWrapper wrapper = getSaxonDomWrapper(root);
-        XPathExpressionWithProperties expression = this.xpathExpression;
 
         try {
             List<Node> result = new ArrayList<>();
-            for (Item item : expression.evaluate(wrapper, propertyValues)) {
+            for (Item item : this.xpathExpression.evaluate(wrapper, propertyValues)) {
                 if (item instanceof NodeWrapper) {
                     NodeWrapper nodeInfo = (NodeWrapper) item;
                     Object domNode = nodeInfo.getUnderlyingNode();

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/SaxonDomXPathQuery.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/SaxonDomXPathQuery.java
@@ -180,11 +180,10 @@ final class SaxonDomXPathQuery {
             return dynamicContext;
         }
 
-        private ValueRepresentation getSaxonValue(PropertySource properties, Entry<PropertyDescriptor<?>, XPathVariable> entry) {
+        private static ValueRepresentation getSaxonValue(PropertySource properties, Entry<PropertyDescriptor<?>, XPathVariable> entry) {
             Object value = properties.getProperty(entry.getKey());
             Objects.requireNonNull(value, "null property value for " + entry.getKey());
-            final ValueRepresentation saxonValue = SaxonXPathRuleQuery.getRepresentation(entry.getKey(), value);
-            return saxonValue;
+            return SaxonXPathRuleQuery.getRepresentation(entry.getKey(), value);
         }
     }
 

--- a/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/rule/XmlXPathRuleTest.java
+++ b/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/rule/XmlXPathRuleTest.java
@@ -208,7 +208,7 @@ public class XmlXPathRuleTest {
 
     @Test
     public void testLocationFuns() {
-        Rule rule = makeXPath("//Flow[pmd:beginLine(.) != pmd:endLine(.)]");
+        Rule rule = makeXPath("//Flow[pmd:startLine(.) != pmd:endLine(.)]");
         Report report = xml.executeRule(rule, "<Flow><a/></Flow>");
         assertSize(report, 0);
         report = xml.executeRule(rule, "<Flow>\n<a/>\n</Flow>");

--- a/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/rule/XmlXPathRuleTest.java
+++ b/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/rule/XmlXPathRuleTest.java
@@ -122,6 +122,14 @@ public class XmlXPathRuleTest {
     }
 
     @Test
+    public void testRootExpr() {
+        Report report = xml.executeRule(makeXPath("/"),
+                                        "<Flow><a/></Flow>");
+
+        assertSize(report, 1);
+    }
+
+    @Test
     public void testLocationFuns() {
         Rule rule = makeXPath("//Flow[pmd:beginLine(.) != pmd:endLine(.)]");
         Report report = xml.executeRule(rule, "<Flow><a/></Flow>");

--- a/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/rule/XmlXPathRuleTest.java
+++ b/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/rule/XmlXPathRuleTest.java
@@ -9,9 +9,8 @@ import static net.sourceforge.pmd.lang.ast.test.TestUtilsKt.assertSize;
 import org.junit.Test;
 
 import net.sourceforge.pmd.Report;
+import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.lang.LanguageRegistry;
-import net.sourceforge.pmd.lang.rule.XPathRule;
-import net.sourceforge.pmd.lang.rule.xpath.XPathVersion;
 import net.sourceforge.pmd.lang.xml.XmlLanguageModule;
 import net.sourceforge.pmd.lang.xml.XmlParsingHelper;
 
@@ -19,8 +18,8 @@ public class XmlXPathRuleTest {
 
     final XmlParsingHelper xml = XmlParsingHelper.XML;
 
-    private XPathRule makeXPath(String expression) {
-        XPathRule rule = new XPathRule(XPathVersion.XPATH_2_0, expression);
+    private Rule makeXPath(String expression) {
+        DomXPathRule rule = new DomXPathRule(expression);
         rule.setLanguage(LanguageRegistry.getLanguage(XmlLanguageModule.NAME));
         rule.setMessage("XPath Rule Failed");
         return rule;

--- a/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/rule/XmlXPathRuleTest.java
+++ b/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/rule/XmlXPathRuleTest.java
@@ -121,4 +121,13 @@ public class XmlXPathRuleTest {
         assertSize(report, 0);
     }
 
+    @Test
+    public void testLocationFuns() {
+        Rule rule = makeXPath("//Flow[pmd:beginLine(.) != pmd:endLine(.)]");
+        Report report = xml.executeRule(rule, "<Flow><a/></Flow>");
+        assertSize(report, 0);
+        report = xml.executeRule(rule, "<Flow>\n<a/>\n</Flow>");
+        assertSize(report, 1);
+    }
+
 }

--- a/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/rule/XmlXPathRuleTest.java
+++ b/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/rule/XmlXPathRuleTest.java
@@ -177,6 +177,36 @@ public class XmlXPathRuleTest {
     }
 
     @Test
+    public void testXmlNsFunctions() {
+        // https://github.com/pmd/pmd/issues/2766
+        Report report = xml.executeRule(
+            makeXPath("/manifest[namespace-uri-for-prefix('android', .) = 'http://schemas.android.com/apk/res/android']"),
+            "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
+            + "<manifest xmlns:android=\"http://schemas.android.com/apk/res/android\"\n"
+            + "         package=\"com.a.b\">\n"
+            + "\n"
+            + "        <application\n"
+            + "             android:allowBackup=\"true\"\n"
+            + "             android:icon=\"@mipmap/ic_launcher\"\n"
+            + "             android:label=\"@string/app_name\"\n"
+            + "             android:roundIcon=\"@mipmap/ic_launcher_round\"\n"
+            + "             android:supportsRtl=\"true\"\n"
+            + "             android:theme=\"@style/AppTheme\">\n"
+            + "         <activity android:name=\".MainActivity\">\n"
+            + "             <intent-filter>\n"
+            + "                 <action android:name=\"android.intent.action.MAIN\" />\n"
+            + "\n"
+            + "                 <category android:name=\"android.intent.category.LAUNCHER\" />\n"
+            + "             </intent-filter>\n"
+            + "         </activity>\n"
+            + "     </application>\n"
+            + "\n"
+            + "</manifest>");
+
+        assertSize(report, 1);
+    }
+
+    @Test
     public void testLocationFuns() {
         Rule rule = makeXPath("//Flow[pmd:beginLine(.) != pmd:endLine(.)]");
         Report report = xml.executeRule(rule, "<Flow><a/></Flow>");

--- a/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/rule/XmlXPathRuleTest.java
+++ b/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/rule/XmlXPathRuleTest.java
@@ -35,4 +35,42 @@ public class XmlXPathRuleTest {
         assertSize(report, 1);
     }
 
+    @Test
+    public void testTextFunctionInXpath() {
+        // https://github.com/pmd/pmd/issues/915
+        Report report = xml.executeRule(makeXPath("//app[text()[1]='app2']"),
+                                        "<a><app>app2</app></a>");
+
+        assertSize(report, 1);
+    }
+
+    @Test
+    public void testRootNode() {
+        // https://github.com/pmd/pmd/issues/3413#issuecomment-1072614398
+        // Note that the test is *:Flow, because Saxon DOM is namespace sensitive, and the xmlns
+        // attribute is interpreted as the ns of the document
+        Report report = xml.executeRule(makeXPath("/*:Flow"),
+                                        "<Flow xmlns=\"http://soap.sforce.com/2006/04/metadata\">\n"
+                                        + "</Flow>");
+
+        assertSize(report, 1);
+    }
+
+    @Test
+    public void testNoNamespaceRoot() {
+        Report report = xml.executeRule(makeXPath("/Flow"),
+                                        "<Flow>\n"
+                                        + "</Flow>");
+
+        assertSize(report, 1);
+    }
+
+    @Test
+    public void testNamespaceDescendant() {
+        Report report = xml.executeRule(makeXPath("//a"),
+                                        "<Flow xmlns='http://soap.sforce.com/2006/04/metadata'><a/></Flow>");
+
+        assertSize(report, 1);
+    }
+
 }


### PR DESCRIPTION
## Describe the PR

Not necessarily for PMD 6.44

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #3863 
- Closes #915 as won't fix, as the issue is Jaxen-specific. This PR adds a solution which only supports XPath 2.
- Fixes #2766 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)
  - [ ] Release notes
  - [x] Maybe language specific doc page for XML
- [ ] Update the designer? It should display the XML tree as a DOM instead of our wrapper.
- [x] Add a property for default namespace of the rule/ namespace declarations.
