### PR TITLE
[doc] Improve side bar by Adding Release Date

### DIFF
--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -2,6 +2,7 @@
 
 <ul id="mysidebar" class="nav">
     <li class="sidebarTitle">{{sidebar[0].product}} {{sidebar[0].version | replace: '!PMD_VERSION!', site.pmd.version}}</li>
+    <div class="sidebarTitleDate">Release date: {{site.pmd.date}}</div>
     {% for entry in sidebar %}
     {% for folder in entry.folders %}
     {% if folder.output contains "web" %}

--- a/docs/css/pmd-customstyles.css
+++ b/docs/css/pmd-customstyles.css
@@ -88,3 +88,9 @@ details[open] summary {
 .xpath-fun-doc .code-examples dt {
     font-weight: normal;
 }
+
+div.sidebarTitleDate {
+    margin-top:2.5px;
+    margin-bottom:5px;
+    margin-left:5px; 
+}

--- a/docs/css/theme-blue.css
+++ b/docs/css/theme-blue.css
@@ -97,7 +97,7 @@ li.sidebarTitle {
     font-weight:normal;
     font-size:130%;
     color: #ED1951;
-    margin-bottom:10px;
-    margin-left: 5px;
+    margin-bottom:2.5px;
+    margin-left:5px;
 
 }

--- a/docs/css/theme-green.css
+++ b/docs/css/theme-green.css
@@ -93,7 +93,7 @@ li.sidebarTitle {
     font-weight:normal;
     font-size:130%;
     color: #ED1951;
-    margin-bottom:10px;
-    margin-left: 5px;
+    margin-bottom:2.5px;
+    margin-left:5px;
 
 }


### PR DESCRIPTION
## Describe the PR

- Added the release date under the stable version number on the left sidebar
- Slightly modified the CSS style and made the release date look natural
- The local rendering result is shown in the image below
![image](https://user-images.githubusercontent.com/26801257/160952755-9b03ae86-ece3-4ea1-a86f-a86a8ac4092d.png)

## Related issues

- Fixes issue #2505

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

