### PR TITLE
[core] Renderers are started now by PmdAnalyzer

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -16,6 +16,9 @@ This is a {{ site.pmd.release_type }} release.
 
 ### Fixed Issues
 
+*   core
+    *   [#3884](https://github.com/pmd/pmd/issues/3884): \[core] XML report via ant task contains XML header twice
+
 ### API Changes
 
 ### External Contributions

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/Formatter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/Formatter.java
@@ -106,7 +106,6 @@ public class Formatter {
             }
             renderer = createRenderer();
             renderer.setWriter(writer);
-            renderer.start();
         } catch (IOException ioe) {
             throw new BuildException(ioe.getMessage(), ioe);
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XMLRenderer.java
@@ -24,7 +24,6 @@ import javax.xml.stream.XMLStreamWriter;
 import org.apache.commons.io.output.WriterOutputStream;
 import org.apache.commons.lang3.StringUtils;
 
-import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.PMDVersion;
 import net.sourceforge.pmd.Report;
 import net.sourceforge.pmd.RuleViolation;
@@ -69,7 +68,7 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
     public void start() throws IOException {
         String encoding = getProperty(ENCODING);
         String unmarkedEncoding = toUnmarkedEncoding(encoding);
-        lineSeparator = PMD.EOL.getBytes(unmarkedEncoding);
+        lineSeparator = System.lineSeparator().getBytes(unmarkedEncoding);
 
         try {
             xmlWriter.writeStartDocument(encoding, "1.0");

--- a/pmd-core/src/test/java/net/sourceforge/pmd/ant/PMDTaskTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/ant/PMDTaskTest.java
@@ -80,4 +80,22 @@ public class PMDTaskTest {
             Assert.assertEquals("sample.dummy:0:\tSampleXPathRule:\tTest Rule 2", actual);
         }
     }
+
+    @Test
+    public void testXmlFormatter() throws IOException {
+        buildRule.executeTarget("testXmlFormatter");
+
+        try (InputStream in = new FileInputStream("target/pmd-ant-xml.xml");
+             InputStream expectedStream = PMDTaskTest.class.getResourceAsStream("xml/expected-pmd-ant-xml.xml")) {
+            String actual = IOUtils.toString(in, StandardCharsets.UTF_8);
+            actual = actual.replaceFirst("timestamp=\"[^\"]+\"", "timestamp=\"\"");
+            actual = actual.replaceFirst("\\.xsd\" version=\"[^\"]+\"", ".xsd\" version=\"\"");
+
+            String expected = IOUtils.toString(expectedStream, StandardCharsets.UTF_8);
+            expected = expected.replaceFirst("timestamp=\"[^\"]+\"", "timestamp=\"\"");
+            expected = expected.replaceFirst("\\.xsd\" version=\"[^\"]+\"", ".xsd\" version=\"\"");
+
+            Assert.assertEquals(expected, actual);
+        }
+    }
 }

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/ant/xml/expected-pmd-ant-xml.xml
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/ant/xml/expected-pmd-ant-xml.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<pmd xmlns="http://pmd.sourceforge.net/report/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://pmd.sourceforge.net/report/2.0.0 http://pmd.sourceforge.net/report_2_0_0.xsd" version="6.45.0-SNAPSHOT" timestamp="2022-03-31T17:55:43.046">
+<file name="sample.dummy">
+<violation beginline="0" endline="0" begincolumn="1" endcolumn="0" rule="SampleXPathRule" ruleset="Test Ruleset" package="foo" externalInfoUrl="${pmd.website.baseurl}/rules/dummy/basic.xml#SampleXPathRule" priority="3">
+Test Rule 2
+</violation>
+</file>
+</pmd>

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/ant/xml/pmdtasktest.xml
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/ant/xml/pmdtasktest.xml
@@ -34,4 +34,14 @@
             </fileset>
         </pmd>
     </target>
+
+    <target name="testXmlFormatter">
+        <pmd noCache="true" shortFilenames="true">
+            <ruleset>${pmd.home}/src/test/resources/rulesets/dummy/basic.xml</ruleset>
+            <formatter type="xml" toFile="${pmd.home}/target/pmd-ant-xml.xml" />
+            <fileset dir="${pmd.home}/src/test/resources/net/sourceforge/pmd/ant/src">
+                <include name="**/*dummy"/>
+            </fileset>
+        </pmd>
+    </target>
 </project>


### PR DESCRIPTION
PMDTask doesn't need to start it itself.

- Fixes #3884

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

