### PR TITLE
[core] Use always UTF-8 encoding for SARIF

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -16,6 +16,7 @@ This is a {{ site.pmd.release_type }} release.
 
 ### Fixed Issues
 * core
+  * [#3881](https://github.com/pmd/pmd/issues/3881): \[core] SARIF renderer depends on platform default encoding
   * [#3882](https://github.com/pmd/pmd/pull/3882): \[core] Fix AssertionError about exhaustive switch
 
 ### API Changes

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/SarifRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/SarifRenderer.java
@@ -5,12 +5,14 @@
 package net.sourceforge.pmd.renderers;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 
 import net.sourceforge.pmd.Report;
 import net.sourceforge.pmd.RuleViolation;
 import net.sourceforge.pmd.renderers.internal.sarif.SarifLog;
 import net.sourceforge.pmd.renderers.internal.sarif.SarifLogBuilder;
+import net.sourceforge.pmd.util.IOUtil;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -69,5 +71,10 @@ public class SarifRenderer extends AbstractIncrementingRenderer {
         final SarifLog sarifLog = sarifLogBuilder.build();
         final String json = gson.toJson(sarifLog);
         writer.write(json);
+    }
+
+    @Override
+    public void setReportFile(String reportFilename) {
+        this.setWriter(IOUtil.createWriter(StandardCharsets.UTF_8, reportFilename));
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/IOUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/IOUtil.java
@@ -74,14 +74,30 @@ public final class IOUtil {
      * @return the writer, never null
      */
     public static Writer createWriter(String reportFile) {
+        return createWriter(getDefaultCharset(), reportFile);
+    }
+
+    /**
+     * Creates a writer that writes to the given file or to stdout.
+     * The file is created if it does not exist.
+     *
+     * <p>Unlike {@link #createWriter(String)}, this method always uses
+     * the given charset. Even for writing to stdout. It never
+     * falls back to the default charset.</p>
+     *
+     * @param charset the charset to be used (required)
+     * @param reportFile the file name (optional)
+     * @return
+     */
+    public static Writer createWriter(Charset charset, String reportFile) {
         try {
             if (StringUtils.isBlank(reportFile)) {
-                return createWriter();
+                return new OutputStreamWriter(System.out, charset);
             }
             Path path = new File(reportFile).toPath().toAbsolutePath();
             Files.createDirectories(path.getParent()); // ensure parent dir exists
             // this will create the file if it doesn't exist
-            return Files.newBufferedWriter(path, getDefaultCharset());
+            return Files.newBufferedWriter(path, charset);
         } catch (IOException e) {
             throw new IllegalArgumentException(e);
         }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/FooRule.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/FooRule.java
@@ -18,6 +18,7 @@ public class FooRule extends AbstractRule {
     public FooRule() {
         setLanguage(LanguageRegistry.getLanguage(DummyLanguageModule.NAME));
         setName("Foo");
+        setDescription("Description with Unicode Character U+2013: – .");
     }
 
     @Override
@@ -28,11 +29,6 @@ public class FooRule extends AbstractRule {
     @Override
     public String getRuleSetName() {
         return "RuleSet";
-    }
-
-    @Override
-    public String getDescription() {
-        return "desc";
     }
 
     @Override

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/CodeClimateRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/CodeClimateRendererTest.java
@@ -10,7 +10,6 @@ import org.junit.Test;
 
 import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.Report;
-import net.sourceforge.pmd.ReportTest;
 import net.sourceforge.pmd.lang.rule.XPathRule;
 
 public class CodeClimateRendererTest extends AbstractRendererTest {
@@ -26,7 +25,7 @@ public class CodeClimateRendererTest extends AbstractRendererTest {
                 + "\"content\":{\"body\":\"## Foo\\n\\nSince: PMD null\\n\\nPriority: Low\\n\\n"
                 + "[Categories](https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#categories): Style\\n\\n"
                 + "[Remediation Points](https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#remediation-points): 50000\\n\\n"
-                + "desc\\n\\n"
+                + "Description with Unicode Character U+2013: – .\\n\\n"
                 + "### [PMD properties](https://pmd.github.io/latest/pmd_userdocs_configuring_rules.html#rule-properties)\\n\\n"
                 + "Name | Value | Description\\n" + "--- | --- | ---\\n"
                 + "violationSuppressRegex | | Suppress violations with messages matching a regular expression\\n"
@@ -41,7 +40,7 @@ public class CodeClimateRendererTest extends AbstractRendererTest {
                 + "\"content\":{\"body\":\"## Foo\\n\\nSince: PMD null\\n\\nPriority: Low\\n\\n"
                 + "[Categories](https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#categories): Style\\n\\n"
                 + "[Remediation Points](https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#remediation-points): 50000\\n\\n"
-                + "desc\\n\\n"
+                + "Description with Unicode Character U+2013: – .\\n\\n"
                 + "### [PMD properties](https://pmd.github.io/latest/pmd_userdocs_configuring_rules.html#rule-properties)\\n\\n"
                 + "Name | Value | Description\\n" + "--- | --- | ---\\n"
                 + "violationSuppressRegex | | Suppress violations with messages matching a regular expression\\n"
@@ -63,7 +62,7 @@ public class CodeClimateRendererTest extends AbstractRendererTest {
                 + "\"content\":{\"body\":\"## Foo\\n\\nSince: PMD null\\n\\nPriority: Low\\n\\n"
                 + "[Categories](https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#categories): Style\\n\\n"
                 + "[Remediation Points](https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#remediation-points): 50000\\n\\n"
-                + "desc\\n\\n"
+                + "Description with Unicode Character U+2013: – .\\n\\n"
                 + "### [PMD properties](https://pmd.github.io/latest/pmd_userdocs_configuring_rules.html#rule-properties)\\n\\n"
                 + "Name | Value | Description\\n" + "--- | --- | ---\\n"
                 + "violationSuppressRegex | | Suppress violations with messages matching a regular expression\\n"
@@ -89,11 +88,11 @@ public class CodeClimateRendererTest extends AbstractRendererTest {
         XPathRule theRule = new XPathRule();
         theRule.setProperty(XPathRule.XPATH_DESCRIPTOR, "//dummyNode");
         // Setup as FooRule
-        theRule.setDescription("desc");
+        theRule.setDescription("Description with Unicode Character U+2013: – .");
         theRule.setName("Foo");
 
         report.addRuleViolation(newRuleViolation(1, 1, 1, 2, theRule));
-        String rendered = ReportTest.render(getRenderer(), report);
+        String rendered = renderReport(getRenderer(), report);
 
         // Output should be the exact same as for non xpath rules
         assertEquals(filter(getExpected()), filter(rendered));

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/HTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/HTMLRendererTest.java
@@ -14,7 +14,6 @@ import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.Report;
 import net.sourceforge.pmd.Report.ConfigurationError;
 import net.sourceforge.pmd.Report.ProcessingError;
-import net.sourceforge.pmd.ReportTest;
 
 public class HTMLRendererTest extends AbstractRendererTest {
 
@@ -100,7 +99,7 @@ public class HTMLRendererTest extends AbstractRendererTest {
         renderer.setProperty(HTMLRenderer.HTML_EXTENSION, false);
 
         Report rep = reportOneViolation();
-        String actual = ReportTest.render(renderer, rep);
+        String actual = renderReport(renderer, rep);
         assertEquals(filter(getExpected(linkPrefix, "L1")), filter(actual));
     }
 
@@ -113,7 +112,7 @@ public class HTMLRendererTest extends AbstractRendererTest {
         renderer.setProperty(HTMLRenderer.HTML_EXTENSION, false);
 
         Report rep = reportOneViolation();
-        String actual = ReportTest.render(renderer, rep);
+        String actual = renderReport(renderer, rep);
         assertEquals(filter(getExpected(linkPrefix, "")), filter(actual));
     }
 
@@ -126,7 +125,7 @@ public class HTMLRendererTest extends AbstractRendererTest {
         renderer.setProperty(HTMLRenderer.HTML_EXTENSION, false);
 
         Report rep = reportOneViolation();
-        String actual = ReportTest.render(renderer, rep);
+        String actual = renderReport(renderer, rep);
         assertEquals(filter(getExpected(linkPrefix, "1")), filter(actual));
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/JsonRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/JsonRendererTest.java
@@ -19,7 +19,6 @@ import net.sourceforge.pmd.FooRule;
 import net.sourceforge.pmd.Report;
 import net.sourceforge.pmd.Report.ConfigurationError;
 import net.sourceforge.pmd.Report.ProcessingError;
-import net.sourceforge.pmd.ReportTest;
 
 public class JsonRendererTest extends AbstractRendererTest {
 
@@ -92,7 +91,7 @@ public class JsonRendererTest extends AbstractRendererTest {
         suppressedLines.put(1, "test");
         rep.suppress(suppressedLines);
         rep.addRuleViolation(newRuleViolation(1, 1, 1, 1, new FooRule()));
-        String actual = ReportTest.render(getRenderer(), rep);
+        String actual = renderReport(getRenderer(), rep);
         String expected = readFile("expected-suppressed.json");
         Assert.assertEquals(filter(expected), filter(actual));
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/SarifRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/SarifRendererTest.java
@@ -14,15 +14,26 @@ import org.apache.commons.io.IOUtils;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 
 import net.sourceforge.pmd.Report;
-import net.sourceforge.pmd.ReportTest;
 import net.sourceforge.pmd.Rule;
 
+
 public class SarifRendererTest extends AbstractRendererTest {
+
+    @org.junit.Rule
+    public RestoreSystemProperties systemProperties = new RestoreSystemProperties();
+
     @Override
     public Renderer getRenderer() {
         return new SarifRenderer();
+    }
+
+    @Test
+    public void testRendererWithASCII() throws Exception {
+        System.setProperty("file.encoding", StandardCharsets.US_ASCII.name());
+        testRenderer(StandardCharsets.UTF_8);
     }
 
     @Override
@@ -80,7 +91,7 @@ public class SarifRendererTest extends AbstractRendererTest {
     @Test
     public void testRendererMultipleLocations() throws Exception {
         Report rep = reportThreeViolationsTwoRules();
-        String actual = ReportTest.render(getRenderer(), rep);
+        String actual = renderReport(getRenderer(), rep);
 
         JSONObject json = new JSONObject(actual);
         JSONArray results = json.getJSONArray("runs").getJSONObject(0).getJSONArray("results");

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/SummaryHTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/SummaryHTMLRendererTest.java
@@ -16,7 +16,6 @@ import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.Report;
 import net.sourceforge.pmd.Report.ConfigurationError;
 import net.sourceforge.pmd.Report.ProcessingError;
-import net.sourceforge.pmd.ReportTest;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.rule.ParametricRuleViolation;
@@ -121,7 +120,7 @@ public class SummaryHTMLRendererTest extends AbstractRendererTest {
         Report rep = createEmptyReportWithSuppression();
         Renderer renderer = getRenderer();
         renderer.setShowSuppressedViolations(true);
-        String actual = ReportTest.render(renderer, rep);
+        String actual = renderReport(renderer, rep);
         assertEquals("<html><head><title>PMD</title></head><body>" + PMD.EOL + "<center><h2>Summary</h2></center>"
                 + PMD.EOL + "<table align=\"center\" cellspacing=\"0\" cellpadding=\"3\">" + PMD.EOL
                 + "<tr><th>Rule name</th><th>Number of violations</th></tr>" + PMD.EOL + "</table>" + PMD.EOL
@@ -142,7 +141,7 @@ public class SummaryHTMLRendererTest extends AbstractRendererTest {
         Report rep = createEmptyReportWithSuppression();
         Renderer renderer = getRenderer();
         renderer.setShowSuppressedViolations(false);
-        String actual = ReportTest.render(renderer, rep);
+        String actual = renderReport(renderer, rep);
         assertEquals(getExpectedEmpty(), actual);
     }
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/YAHTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/YAHTMLRendererTest.java
@@ -24,7 +24,6 @@ import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.Report;
 import net.sourceforge.pmd.Report.ConfigurationError;
 import net.sourceforge.pmd.Report.ProcessingError;
-import net.sourceforge.pmd.ReportTest;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.RuleViolation;
@@ -67,7 +66,7 @@ public class YAHTMLRendererTest extends AbstractRendererTest {
         report.addRuleViolation(newRuleViolation(1, 1, 1, 1, "net.sf.pmd.test", "YAHTMLSampleClass1"));
         report.addRuleViolation(newRuleViolation(1, 1, 1, 2, "net.sf.pmd.test", "YAHTMLSampleClass1"));
         report.addRuleViolation(newRuleViolation(1, 1, 1, 1, "net.sf.pmd.other", "YAHTMLSampleClass2"));
-        String actual = ReportTest.render(getRenderer(), report);
+        String actual = renderReport(getRenderer(), report);
         assertEquals(filter(getExpected()), filter(actual));
 
         String[] htmlFiles = outputDir.list();

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/sarif/expected-multiple-locations.sarif.json
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/sarif/expected-multiple-locations.sarif.json
@@ -15,10 +15,10 @@
                 "text": "blah"
               },
               "fullDescription": {
-                "text": "desc"
+                "text": "Description with Unicode Character U+2013: – ."
               },
               "help": {
-                "text": "desc"
+                "text": "Description with Unicode Character U+2013: – ."
               },
               "properties": {
                 "ruleset": "RuleSet",

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/sarif/expected-multiple.sarif.json
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/sarif/expected-multiple.sarif.json
@@ -15,10 +15,10 @@
                 "text": "blah"
               },
               "fullDescription": {
-                "text": "desc"
+                "text": "Description with Unicode Character U+2013: – ."
               },
               "help": {
-                "text": "desc"
+                "text": "Description with Unicode Character U+2013: – ."
               },
               "properties": {
                 "ruleset": "RuleSet",

--- a/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/sarif/expected.sarif.json
+++ b/pmd-core/src/test/resources/net/sourceforge/pmd/renderers/sarif/expected.sarif.json
@@ -15,10 +15,10 @@
                 "text": "blah"
               },
               "fullDescription": {
-                "text": "desc"
+                "text": "Description with Unicode Character U+2013: – ."
               },
               "help": {
-                "text": "desc"
+                "text": "Description with Unicode Character U+2013: – ."
               },
               "properties": {
                 "ruleset": "RuleSet",


### PR DESCRIPTION
## Describe the PR

* a bit of refactoring in the abstractrenderer test 
* using now a temporary file to have the full roundtrip instead of a stringwriter which never has encoding problems
* this is fixed now for SARIF, we might have a similar issue for codeclimate (also JSON output)

## Related issues

- Fixes #3881

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

