### PR TITLE
[java] Catch LinkageError in UselessOverridingMethodRule

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -17,6 +17,8 @@ This is a {{ site.pmd.release_type }} release.
 ### Fixed Issues
 * core
   * [#3882](https://github.com/pmd/pmd/pull/3882): \[core] Fix AssertionError about exhaustive switch
+* java
+  * [#3889](https://github.com/pmd/pmd/pull/3889): \[java] Catch LinkageError in UselessOverridingMethodRule
 
 ### API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UselessOverridingMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/UselessOverridingMethodRule.java
@@ -265,7 +265,7 @@ public class UselessOverridingMethodRule extends AbstractJavaRule {
         while (superType != null && declaredMethod == null) {
             try {
                 declaredMethod = superType.getDeclaredMethod(overriddenMethodName, typeArgumentArray);
-            } catch (NoSuchMethodException | SecurityException e) {
+            } catch (LinkageError | ReflectiveOperationException | SecurityException e) {
                 declaredMethod = null;
             }
             superType = superType.getSuperclass();


### PR DESCRIPTION
## Describe the PR

Might occur when the auxclasspath is incomplete.

I've found this while trying to upgrade pmd-eclipse-plugin to use tycho 2.7.0. There's something wrong with the eclipse/osgi classpath... so lot's of warnings for missing classes/incomplete auxclasspath, but also the following stacktrace:

```
Exception in thread "main" java.lang.NoClassDefFoundError: org/eclipse/swt/widgets/Composite
	at java.lang.Class.getDeclaredMethods0(Native Method)
	at java.lang.Class.privateGetDeclaredMethods(Class.java:2701)
	at java.lang.Class.getDeclaredMethod(Class.java:2128)
	at net.sourceforge.pmd.lang.java.rule.design.UselessOverridingMethodRule.modifiersChanged(UselessOverridingMethodRule.java:267)
	at net.sourceforge.pmd.lang.java.rule.design.UselessOverridingMethodRule.visit(UselessOverridingMethodRule.java:221)
	at net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration.jjtAccept(ASTMethodDeclaration.java:37)
	at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:222)
	at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:269)
	at net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBodyDeclaration.jjtAccept(ASTClassOrInterfaceBodyDeclaration.java:44)
	at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:222)
	at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:264)
	at net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBody.jjtAccept(ASTClassOrInterfaceBody.java:35)
	at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:222)
	at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:234)
	at net.sourceforge.pmd.lang.java.rule.design.UselessOverridingMethodRule.visit(UselessOverridingMethodRule.java:71)
	at net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration.jjtAccept(ASTClassOrInterfaceDeclaration.java:55)
	at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:222)
	at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:419)
	at net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration.jjtAccept(ASTTypeDeclaration.java:39)
	at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:222)
	at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visit(AbstractJavaRule.java:394)
	at net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit.jjtAccept(ASTCompilationUnit.java:44)
	at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.visitAll(AbstractJavaRule.java:164)
	at net.sourceforge.pmd.lang.java.rule.AbstractJavaRule.apply(AbstractJavaRule.java:158)
	at net.sourceforge.pmd.lang.rule.AbstractDelegateRule.apply(AbstractDelegateRule.java:336)
	at net.sourceforge.pmd.RuleSet.apply(RuleSet.java:670)
	at net.sourceforge.pmd.RuleSets.apply(RuleSets.java:163)
	at net.sourceforge.pmd.SourceCodeProcessor.processSource(SourceCodeProcessor.java:209)
	at net.sourceforge.pmd.SourceCodeProcessor.processSourceCodeWithoutCache(SourceCodeProcessor.java:118)
	at net.sourceforge.pmd.SourceCodeProcessor.processSourceCode(SourceCodeProcessor.java:100)
	at net.sourceforge.pmd.SourceCodeProcessor.processSourceCode(SourceCodeProcessor.java:62)
	at net.sourceforge.pmd.processor.PmdRunnable.call(PmdRunnable.java:85)
	at net.sourceforge.pmd.processor.PmdRunnable.call(PmdRunnable.java:29)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:750)
Caused by: java.lang.ClassNotFoundException: org.eclipse.swt.widgets.Composite
	at java.net.URLClassLoader.findClass(URLClassLoader.java:387)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:418)
	at net.sourceforge.pmd.util.ClasspathClassLoader.loadClass(ClasspathClassLoader.java:126)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:351)
	... 39 more
```

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

