### PR TITLE
[scala] Fix build of pmd-scala-common

### DIFF
--- a/pmd-scala-modules/pmd-scala-common/pom.xml
+++ b/pmd-scala-modules/pmd-scala-common/pom.xml
@@ -34,6 +34,24 @@
             </testResource>
         </testResources>
 
+        <plugins>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+
         <pluginManagement>
             <plugins>
                 <plugin>
@@ -75,6 +93,15 @@
                             </configuration>
                         </execution>
                     </executions>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                        <source>8</source>
+                        <target>8</target>
+                    </configuration>
                 </plugin>
 
                 <plugin>

--- a/pmd-scala-modules/pmd-scala_2.12/pom.xml
+++ b/pmd-scala-modules/pmd-scala_2.12/pom.xml
@@ -21,6 +21,21 @@
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <phase>test-compile</phase>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pmd-scala-modules/pmd-scala_2.13/pom.xml
+++ b/pmd-scala-modules/pmd-scala_2.13/pom.xml
@@ -21,6 +21,20 @@
                 <artifactId>kotlin-maven-plugin</artifactId>
                 <groupId>org.jetbrains.kotlin</groupId>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>java-compile</id>
+                        <phase>compile</phase>
+                    </execution>
+                    <execution>
+                        <id>java-test-compile</id>
+                        <phase>test-compile</phase>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
## Describe the PR

This module doesn't compile as it is missing dependencies that are provided in its children modules (version-specific scala modules). For instance: https://github.com/pmd/pmd/runs/5800411266?check_suite_focus=true#step:7:7667

This disables the java compilation phase in the common module. It is still enabled in the child modules of course.

I'm not sure why this didn't show up in CI until recently. I've been seeing this locally since #2547

I'm also not sure this should only target pmd 7. Hence the draft status.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- #2547

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

