### PR TITLE
[core] Fix ast-dump CLI when reading from stdin

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/AbstractParser.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/AbstractParser.java
@@ -42,9 +42,13 @@ public abstract class AbstractParser implements Parser {
     @Deprecated
     public static Node doParse(Parser parser, String fileName, Reader source) {
         Node rootNode = parser.parse(fileName, source);
+        setFileName(fileName, rootNode);
+        return rootNode;
+    }
+
+    public static void setFileName(String fileName, Node rootNode) {
         // remove prefixed path segments.
         String simpleFileName = Paths.get(fileName).getFileName().toString();
         rootNode.getUserMap().set(FileNameXPathFunction.FILE_NAME_KEY, simpleFileName);
-        return rootNode;
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/Io.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/Io.java
@@ -1,0 +1,29 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.treeexport;
+
+import java.io.InputStream;
+import java.io.PrintStream;
+
+/**
+ * Abstraction over system streams. Useful to unit-test a CLI program.
+ *
+ * @author Clément Fournier
+ */
+final class Io {
+
+    public static final Io SYSTEM = new Io(System.out, System.err, System.in);
+    public final PrintStream stdout;
+    public final PrintStream stderr;
+    public final InputStream stdin;
+
+    public Io(PrintStream stdout,
+              PrintStream stderr,
+              InputStream stdin) {
+        this.stdout = stdout;
+        this.stderr = stderr;
+        this.stdin = stdin;
+    }
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/Io.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/Io.java
@@ -19,9 +19,7 @@ final class Io {
     public final PrintStream stderr;
     public final InputStream stdin;
 
-    public Io(PrintStream stdout,
-              PrintStream stderr,
-              InputStream stdin) {
+    Io(PrintStream stdout, PrintStream stderr, InputStream stdin) {
         this.stdout = stdout;
         this.stderr = stderr;
         this.stdin = stdin;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeExportCli.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeExportCli.java
@@ -47,16 +47,14 @@ public class TreeExportCli {
     private String encoding = StandardCharsets.UTF_8.name();
     @DynamicParameter(names = "-P", description = "Properties for the renderer.")
     private Map<String, String> properties = new HashMap<>();
-    private final Io io;
-
     @Parameter(names = { "--help", "-h" }, description = "Display usage.", help = true)
     private boolean help;
-
     @Parameter(names = "--file", description = "The file to dump")
     private String file;
-
     @Parameter(names = { "--read-stdin", "-i" }, description = "Read source from standard input")
     private boolean readStdin;
+
+    private final Io io;
 
     TreeExportCli(Io io) {
         this.io = io;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeExportCli.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeExportCli.java
@@ -162,20 +162,23 @@ public class TreeExportCli {
 
         @SuppressWarnings("PMD.CloseResource")
         Reader source;
+        String fileName;
         if (file == null && !readStdin) {
             throw bail("One of --file or --read-stdin must be mentioned");
         } else if (readStdin) {
             System.err.println("Reading from stdin...");
             source = new StringReader(readFromSystemIn());
+            fileName = "stdin";
         } else {
             source = Files.newBufferedReader(new File(file).toPath(), Charset.forName(encoding));
+            fileName = file;
         }
 
         // disable warnings for deprecated attributes
         Logger.getLogger(Attribute.class.getName()).setLevel(Level.OFF);
 
         try (Reader reader = source) {
-            Node root = AbstractParser.doParse(parser, file, reader);
+            Node root = AbstractParser.doParse(parser, fileName, reader);
             languageHandler.getQualifiedNameResolutionFacade(this.getClass().getClassLoader()).start(root);
 
             renderer.renderSubtree(root, System.out);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeExportCli.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeExportCli.java
@@ -4,21 +4,20 @@
 
 package net.sourceforge.pmd.util.treeexport;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.io.Reader;
-import java.io.StringReader;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Scanner;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.io.input.CloseShieldInputStream;
 import org.apache.commons.lang3.StringEscapeUtils;
 
 import net.sourceforge.pmd.annotation.Experimental;
@@ -39,6 +38,7 @@ import com.beust.jcommander.ParameterException;
 
 @Experimental
 public class TreeExportCli {
+
     @Parameter(names = { "--format", "-f" }, description = "The output format.")
     private String format = "xml";
     @Parameter(names = { "--language", "-l" }, description = "Specify the language to use.")
@@ -47,6 +47,7 @@ public class TreeExportCli {
     private String encoding = StandardCharsets.UTF_8.name();
     @DynamicParameter(names = "-P", description = "Properties for the renderer.")
     private Map<String, String> properties = new HashMap<>();
+    private final Io io;
 
     @Parameter(names = { "--help", "-h" }, description = "Display usage.", help = true)
     private boolean help;
@@ -57,33 +58,54 @@ public class TreeExportCli {
     @Parameter(names = { "--read-stdin", "-i" }, description = "Read source from standard input")
     private boolean readStdin;
 
+    TreeExportCli(Io io) {
+        this.io = io;
+    }
 
-    public static void main(String[] args) throws IOException {
-        TreeExportCli cli = new TreeExportCli();
-        JCommander jcommander = new JCommander(cli);
+    public static void main(String... args) {
+        TreeExportCli cli = new TreeExportCli(Io.SYSTEM);
+        System.exit(cli.runMain(args));
+    }
+
+    public int runMain(String... args) {
+        try {
+            return runMainOrThrow(args);
+        } catch (AbortedError e) {
+            return 1;
+        } catch (IOException e) {
+            io.stderr.println("Error: " + e);
+            e.printStackTrace(io.stderr);
+            return 1;
+        }
+    }
+
+    private int runMainOrThrow(String[] args) throws IOException {
+
+        JCommander jcommander = new JCommander(this);
 
         try {
             jcommander.parse(args);
         } catch (ParameterException e) {
-            System.err.println(e.getMessage());
-            cli.usage(jcommander);
-            System.exit(1);
+            io.stderr.println(e.getMessage());
+            usage(jcommander);
+            return 1;
         }
 
-        if (cli.help) {
-            cli.usage(jcommander);
-            System.exit(0);
+        if (help) {
+            usage(jcommander);
+            return 0;
         }
 
 
-        TreeRendererDescriptor descriptor = TreeRenderers.findById(cli.format);
+        TreeRendererDescriptor descriptor = TreeRenderers.findById(this.format);
         if (descriptor == null) {
-            throw cli.bail("Unknown format '" + cli.format + "'");
+            throw this.bail("Unknown format '" + this.format + "'");
         }
 
-        PropertySource bundle = parseProperties(cli, descriptor);
+        PropertySource bundle = parseProperties(this, descriptor);
 
-        cli.run(descriptor.produceRenderer(bundle));
+        run(descriptor.produceRenderer(bundle));
+        return 0;
     }
 
     public static PropertySource parseProperties(TreeExportCli cli, TreeRendererDescriptor descriptor) {
@@ -166,8 +188,8 @@ public class TreeExportCli {
         if (file == null && !readStdin) {
             throw bail("One of --file or --read-stdin must be mentioned");
         } else if (readStdin) {
-            System.err.println("Reading from stdin...");
-            source = new StringReader(readFromSystemIn());
+            io.stderr.println("Reading from stdin...");
+            source = readFromSystemIn();
             fileName = "stdin";
         } else {
             source = Files.newBufferedReader(new File(file).toPath(), Charset.forName(encoding));
@@ -181,28 +203,19 @@ public class TreeExportCli {
             Node root = AbstractParser.doParse(parser, fileName, reader);
             languageHandler.getQualifiedNameResolutionFacade(this.getClass().getClassLoader()).start(root);
 
-            renderer.renderSubtree(root, System.out);
+            renderer.renderSubtree(root, io.stdout);
         }
     }
 
-    private String readFromSystemIn() {
-
-
-        StringBuilder sb = new StringBuilder();
-        try (Scanner scanner = new Scanner(new CloseShieldInputStream(System.in))) {
-            while (scanner.hasNextLine()) {
-                sb.append(scanner.nextLine());
-            }
-        }
-        return sb.toString();
-
+    private Reader readFromSystemIn() {
+        return new BufferedReader(new InputStreamReader(io.stdin));
     }
 
     private void printWarning() {
-        System.err.println("-------------------------------------------------------------------------------");
-        System.err.println("This command line utility is experimental. It might change at any time without");
-        System.err.println("prior notice.");
-        System.err.println("-------------------------------------------------------------------------------");
+        io.stderr.println("-------------------------------------------------------------------------------");
+        io.stderr.println("This command line utility is experimental. It might change at any time without");
+        io.stderr.println("prior notice.");
+        io.stderr.println("-------------------------------------------------------------------------------");
     }
 
     private static <T> void setProperty(PropertyDescriptor<T> descriptor, PropertySource bundle, String value) {
@@ -210,10 +223,13 @@ public class TreeExportCli {
     }
 
 
-    private RuntimeException bail(String message) {
-        System.err.println(message);
-        System.err.println("Use --help for usage information");
-        System.exit(1);
-        return new RuntimeException();
+    private AbortedError bail(String message) {
+        io.stderr.println(message);
+        io.stderr.println("Use --help for usage information");
+        return new AbortedError();
+    }
+
+    private static class AbortedError extends Error {
+
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeRenderers.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeRenderers.java
@@ -50,7 +50,9 @@ public final class TreeRenderers {
 
     static final PropertyDescriptor<String> XML_LINE_SEPARATOR =
         PropertyFactory.stringProperty("lineSeparator")
-                       .desc("Line separator to use. The default is platform-specific.")
+                       .desc("Line separator to use. The default is platform-specific. "
+                             + "The values 'CR', 'CRLF', 'LF', '\\r', '\\r\\n' and '\\n' can be used "
+                             + "to represent a carriage return, line feed and their combination more easily.")
                        .defaultValue(System.lineSeparator())
                        .build();
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/XmlTreeRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/XmlTreeRenderer.java
@@ -221,13 +221,33 @@ public final class XmlTreeRenderer implements TreeRenderer {
 
         /**
          * Sets the string that should be used to separate lines. The
-         * default is the platform-specific line separator.
+         * default is the platform-specific line separator. The following
+         * special values are interpreted specially: {@code CR}, {@code CRLF},
+         * {@code LF}, {@code \r}, {@code \r\n} and {@code \n}. The latter
+         * three use literal backslashes and are interpreted like Java
+         * escapes. The former three are named aliases for the same.
          *
          * @throws NullPointerException If the argument is null
          */
         public XmlRenderingConfig lineSeparator(String lineSeparator) {
-            this.lineSeparator = Objects.requireNonNull(lineSeparator);
+            this.lineSeparator = interpretLineSep(lineSeparator);
             return this;
+        }
+
+        private static String interpretLineSep(String lineSeparator) {
+            switch (lineSeparator) {
+            case "CR":
+            case "\\r":
+                return "\r";
+            case "CRLF":
+            case "\\r\\n":
+                return "\r\n";
+            case "LF":
+            case "\\n":
+                return "\n";
+            default:
+                return lineSeparator;
+            }
         }
 
         /**

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageModule.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageModule.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang;
 
+import java.io.IOException;
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -11,14 +12,17 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.io.IOUtils;
 import org.jaxen.Navigator;
 
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.RuleViolation;
 import net.sourceforge.pmd.lang.ast.DummyNode;
+import net.sourceforge.pmd.lang.ast.DummyNode.DummyRootNode;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.ast.ParseException;
+import net.sourceforge.pmd.lang.ast.SourceCodePositioner;
 import net.sourceforge.pmd.lang.ast.xpath.AbstractASTXPathHandler;
 import net.sourceforge.pmd.lang.ast.xpath.DocumentNavigator;
 import net.sourceforge.pmd.lang.rule.AbstractRuleChainVisitor;
@@ -110,11 +114,14 @@ public class DummyLanguageModule extends BaseLanguageModule {
             return new AbstractParser(parserOptions) {
                 @Override
                 public Node parse(String fileName, Reader source) throws ParseException {
-                    DummyNode node = new DummyNode(1);
-                    node.testingOnlySetBeginLine(1);
-                    node.testingOnlySetBeginColumn(1);
-                    node.setImage("Foo");
-                    return node;
+                    try {
+                        String text = IOUtils.toString(source);
+                        DummyRootNode rootNode = readLispNode(text);
+                        AbstractParser.setFileName(fileName, rootNode);
+                        return rootNode;
+                    } catch (IOException e) {
+                        throw new ParseException(e);
+                    }
                 }
 
                 @Override
@@ -135,7 +142,71 @@ public class DummyLanguageModule extends BaseLanguageModule {
         }
     }
 
+    /**
+     * Creates a tree of nodes that corresponds to the nesting structures
+     * of parentheses in the text. The image of each node is also populated.
+     * This is useful to create non-trivial trees with all the relevant
+     * data (eg coordinates) set properly.
+     *
+     * Eg {@code (a(b)x(c))} will create a tree with a node "a", with two
+     * children "b" and "c". "x" is ignored. The node "a" is not the root
+     * node, it has a {@link DummyRootNode} as parent, whose image is "".
+     */
+    private static DummyRootNode readLispNode(String text) {
+        final DummyRootNode root = new DummyRootNode();
+        DummyNode top = root;
+        SourceCodePositioner positioner = new SourceCodePositioner(text);
+        top.setCoords(1, 1, positioner.getLastLine(), positioner.getLastLineColumn());
+        int lastNodeStart = 0;
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (c == '(') {
+                DummyNode node = new DummyNode();
+                node.setParent(top);
+                top.jjtAddChild(node, top.getNumChildren());
+                // setup coordinates
+                int bline = positioner.lineNumberFromOffset(i);
+                int bcol = positioner.columnFromOffset(bline, i);
+                node.setBeginLine(bline);
+                node.setBeginColumn(bcol);
+                // cut out image
+                if (top.getImage() == null) {
+                    // image may be non null if this is not the first child of 'top'
+                    // eg in (a(b)x(c)), the image of the parent is set to "a".
+                    // When we're processing "(c", we ignore "x".
+                    String image = text.substring(lastNodeStart, i);
+                    top.setImage(image);
+                }
+                lastNodeStart = i + 1;
+                // node is the top of the stack now
+                top = node;
+            } else if (c == ')') {
+                if (top == null) {
+                    throw new ParseException("Unbalanced parentheses: " + text);
+                }
+                // setup coordinates
+                int eline = positioner.lineNumberFromOffset(i);
+                int ecol = positioner.columnFromOffset(eline, i);
+                top.setEndLine(eline);
+                top.setEndColumn(ecol);
+
+                if (top.getImage() == null) {
+                    // cut out image (if node doesn't have children it hasn't been populated yet)
+                    String image = text.substring(lastNodeStart, i);
+                    top.setImage(image);
+                    lastNodeStart = i + 1;
+                }
+                top = top.getParent();
+            }
+        }
+        if (top != root) {
+            throw new ParseException("Unbalanced parentheses: " + text);
+        }
+        return root;
+    }
+
     public static class RuleViolationFactory extends AbstractRuleViolationFactory {
+
         @Override
         protected RuleViolation createRuleViolation(Rule rule, RuleContext ruleContext, Node node, String message) {
             return createRuleViolation(rule, ruleContext, node, message, 0, 0);
@@ -143,7 +214,7 @@ public class DummyLanguageModule extends BaseLanguageModule {
 
         @Override
         protected RuleViolation createRuleViolation(Rule rule, RuleContext ruleContext, Node node, String message,
-                int beginLine, int endLine) {
+                                                    int beginLine, int endLine) {
             ParametricRuleViolation<Node> rv = new ParametricRuleViolation<Node>(rule, ruleContext, node, message) {
                 public String getPackageName() {
                     this.packageName = "foo"; // just for testing variable expansion

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageModule.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/DummyLanguageModule.java
@@ -54,12 +54,27 @@ public class DummyLanguageModule extends BaseLanguageModule {
         addVersion("1.8", new Handler(), "8");
     }
 
+    public static Language getInstance() {
+        return LanguageRegistry.getLanguage(NAME);
+    }
+
+    public static DummyRootNode parse(String code) {
+        return parse(code, "nofilename");
+    }
+
+    public static DummyRootNode parse(String code, String filename) {
+        DummyRootNode rootNode = readLispNode(code);
+        AbstractParser.setFileName(filename, rootNode);
+        return rootNode;
+    }
+
     /**
      * @deprecated for removal with PMD 7. A language dependent rule chain visitor is not needed anymore.
-     *      See {@link RuleChainVisitor}.
+     *     See {@link RuleChainVisitor}.
      */
     @Deprecated
     public static class DummyRuleChainVisitor extends AbstractRuleChainVisitor {
+
         @Override
         protected void visit(Rule rule, Node node, RuleContext ctx) {
             rule.apply(Arrays.asList(node), ctx);

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNode.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNode.java
@@ -5,13 +5,18 @@
 package net.sourceforge.pmd.lang.ast;
 
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 
+import net.sourceforge.pmd.lang.ast.xpath.Attribute;
 import net.sourceforge.pmd.lang.ast.xpath.internal.FileNameXPathFunction;
 
 public class DummyNode extends AbstractNode {
 
     private final boolean findBoundary;
     private final String xpathName;
+    private final List<Attribute> attributes = new ArrayList<>();
 
     public DummyNode(int id) {
         this(id, false);
@@ -29,11 +34,21 @@ public class DummyNode extends AbstractNode {
         super(id);
         this.findBoundary = findBoundary;
         this.xpathName = xpathName;
+
+        Iterator<Attribute> iter = super.getXPathAttributesIterator();
+        while (iter.hasNext()) {
+            attributes.add(iter.next());
+        }
     }
 
     @Override
     public DummyNode getParent() {
         return (DummyNode) super.getParent();
+    }
+
+    @Override
+    public DummyNode getChild(int index) {
+        return (DummyNode) super.getChild(index);
     }
 
     public void setParent(DummyNode node) {
@@ -76,6 +91,20 @@ public class DummyNode extends AbstractNode {
     @Override
     public boolean isFindBoundary() {
         return findBoundary;
+    }
+
+    public void setXPathAttribute(String name, String value) {
+        attributes.add(new Attribute(this, name, value));
+    }
+
+
+    public void clearXPathAttributes() {
+        attributes.clear();
+    }
+
+    @Override
+    public Iterator<Attribute> getXPathAttributesIterator() {
+        return attributes.iterator();
     }
 
     public static class DummyRootNode extends DummyNode implements RootNode {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNode.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNode.java
@@ -31,12 +31,29 @@ public class DummyNode extends AbstractNode {
         this.xpathName = xpathName;
     }
 
+    @Override
+    public DummyNode getParent() {
+        return (DummyNode) super.getParent();
+    }
+
+    public void setParent(DummyNode node) {
+        jjtSetParent(node);
+    }
+
     public void setBeginColumn(int i) {
         beginColumn = i;
     }
 
     public void setBeginLine(int i) {
         beginLine = i;
+    }
+
+    public void setEndLine(int i) {
+        super.testingOnlySetEndColumn(i);
+    }
+
+    public void setEndColumn(int i) {
+        super.testingOnlySetEndColumn(i);
     }
 
     public void setCoords(int bline, int bcol, int eline, int ecol) {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/designer/DesignerTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/designer/DesignerTest.java
@@ -27,7 +27,8 @@ public class DesignerTest {
                 "doesn't matter");
         String xml = Designer.getXmlTreeCode(compilationUnit);
         assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-                + "<dummyNode BeginColumn=\"1\" BeginLine=\"1\" EndColumn=\"0\" EndLine=\"0\" FindBoundary=\"false\"\n"
-                + "           Image=\"Foo\"\n" + "           SingleLine=\"false\"/>", xml);
+                     + "<dummyNode BeginColumn=\"1\" BeginLine=\"1\" EndColumn=\"14\" EndLine=\"1\" FindBoundary=\"false\"\n"
+                     + "           Image=\"\"\n"
+                     + "           SingleLine=\"true\"/>", xml);
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/TreeExportCliTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/TreeExportCliTest.java
@@ -1,0 +1,188 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.util.treeexport;
+
+import static org.hamcrest.Matchers.containsString;
+
+import java.io.BufferedWriter;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.io.IOUtils;
+import org.hamcrest.Matcher;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import net.sourceforge.pmd.lang.ast.DummyNode;
+import net.sourceforge.pmd.lang.ast.xpath.Attribute;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertySource;
+
+/**
+ *
+ */
+public class TreeExportCliTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void testReadStandardInput() {
+        IoSpy spy = IoSpy.withStdin("(a(b))");
+        int status = spy.runMain("-i", "-f", "xml");
+        Assert.assertEquals(0, status);
+        spy.assertThatStdout(containsString("<?xml version='1.0' encoding='UTF-8' ?>\n"
+                                            + "<dummyNode Image=''>\n"
+                                            + "    <dummyNode Image='a'>\n"
+                                            + "        <dummyNode Image='b' />\n"
+                                            + "    </dummyNode>\n"
+                                            + "</dummyNode>"));
+    }
+
+    @Test
+    public void testReadFile() throws IOException {
+        File file = newFileWithContents("(a(b))");
+        IoSpy spy = new IoSpy();
+        int status = spy.runMain("--file", file.getAbsolutePath(), "-f", "xml");
+        Assert.assertEquals(0, status);
+        spy.assertThatStdout(containsString("<?xml version='1.0' encoding='UTF-8' ?>\n"
+                                            + "<dummyNode Image=''>\n"
+                                            + "    <dummyNode Image='a'>\n"
+                                            + "        <dummyNode Image='b' />\n"
+                                            + "    </dummyNode>\n"
+                                            + "</dummyNode>"));
+    }
+
+    private File newFileWithContents(String data) throws IOException {
+        File file = tmp.newFile();
+        try (BufferedWriter br = Files.newBufferedWriter(file.toPath(), StandardCharsets.UTF_8)) {
+            br.write(data);
+        }
+        return file;
+    }
+
+    private static InputStream stdinContaining(String input) {
+        return IOUtils.toInputStream(input, StandardCharsets.UTF_8);
+    }
+
+    static class IoSpy {
+
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        final ByteArrayOutputStream err = new ByteArrayOutputStream();
+        final Io io;
+
+        IoSpy(InputStream stdin) {
+            io = new Io(new PrintStream(out), new PrintStream(err), stdin);
+        }
+
+        IoSpy() {
+            this(stdinContaining(""));
+        }
+
+        void assertThatStdout(Matcher<? super String> str) {
+            MatcherAssert.assertThat("stdout", out.toString(), str);
+        }
+
+        int runMain(String... args) {
+            return new TreeExportCli(io).runMain(args);
+        }
+
+        static IoSpy withStdin(String contents) {
+            return new IoSpy(stdinContaining(contents));
+        }
+    }
+
+    @Test
+    public void testXmlPropertiesAvailable() {
+
+
+        PropertySource properties = TreeRenderers.XML.newPropertyBundle();
+
+        MatcherAssert.assertThat(properties.getPropertyDescriptors(),
+                                 Matchers.<PropertyDescriptor<?>>containsInAnyOrder(TreeRenderers.XML_LINE_SEPARATOR,
+                                                                                    TreeRenderers.XML_RENDER_COMMON_ATTRIBUTES,
+                                                                                    TreeRenderers.XML_RENDER_PROLOG,
+                                                                                    TreeRenderers.XML_USE_SINGLE_QUOTES));
+
+    }
+
+    @Test
+    public void testXmlDescriptorDump() throws IOException {
+
+        PropertySource bundle = TreeRenderers.XML.newPropertyBundle();
+
+        bundle.setProperty(TreeRenderers.XML_RENDER_PROLOG, false);
+        bundle.setProperty(TreeRenderers.XML_USE_SINGLE_QUOTES, false);
+        bundle.setProperty(TreeRenderers.XML_LINE_SEPARATOR, "\n");
+
+        TreeRenderer renderer = TreeRenderers.XML.produceRenderer(bundle);
+
+        StringBuilder out = new StringBuilder();
+
+        renderer.renderSubtree(dummyTree1(), out);
+        Assert.assertEquals("<dummyNode foo=\"bar\" ohio=\"4\">\n"
+                            + "    <dummyNode o=\"ha\" />\n"
+                            + "    <dummyNode />\n"
+                            + "</dummyNode>\n", out.toString());
+
+    }
+
+
+    public MyDummyNode dummyTree1() {
+        MyDummyNode dummy = new MyDummyNode();
+
+        dummy.setXPathAttribute("foo", "bar");
+        dummy.setXPathAttribute("ohio", "4");
+
+        MyDummyNode dummy1 = new MyDummyNode();
+
+        dummy1.setXPathAttribute("o", "ha");
+
+        MyDummyNode dummy2 = new MyDummyNode();
+
+        dummy.jjtAddChild(dummy1, 0);
+        dummy.jjtAddChild(dummy2, 1);
+        return dummy;
+    }
+
+    private static class MyDummyNode extends DummyNode {
+
+
+        private final Map<String, String> attributes = new HashMap<>();
+
+        public void setXPathAttribute(String name, String value) {
+            attributes.put(name, value);
+        }
+
+        @Override
+        public Iterator<Attribute> getXPathAttributesIterator() {
+
+            List<Attribute> attrs = new ArrayList<>();
+            for (String name : attributes.keySet()) {
+                attrs.add(new Attribute(this, name, attributes.get(name)));
+            }
+
+            return attrs.iterator();
+        }
+
+
+    }
+
+
+}

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/TreeExportCliTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/TreeExportCliTest.java
@@ -14,25 +14,14 @@ import java.io.InputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.Matcher;
 import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
-import net.sourceforge.pmd.lang.ast.DummyNode;
-import net.sourceforge.pmd.lang.ast.xpath.Attribute;
-import net.sourceforge.pmd.properties.PropertyDescriptor;
-import net.sourceforge.pmd.properties.PropertySource;
 
 /**
  *
@@ -107,82 +96,4 @@ public class TreeExportCliTest {
             return new IoSpy(stdinContaining(contents));
         }
     }
-
-    @Test
-    public void testXmlPropertiesAvailable() {
-
-
-        PropertySource properties = TreeRenderers.XML.newPropertyBundle();
-
-        MatcherAssert.assertThat(properties.getPropertyDescriptors(),
-                                 Matchers.<PropertyDescriptor<?>>containsInAnyOrder(TreeRenderers.XML_LINE_SEPARATOR,
-                                                                                    TreeRenderers.XML_RENDER_COMMON_ATTRIBUTES,
-                                                                                    TreeRenderers.XML_RENDER_PROLOG,
-                                                                                    TreeRenderers.XML_USE_SINGLE_QUOTES));
-
-    }
-
-    @Test
-    public void testXmlDescriptorDump() throws IOException {
-
-        PropertySource bundle = TreeRenderers.XML.newPropertyBundle();
-
-        bundle.setProperty(TreeRenderers.XML_RENDER_PROLOG, false);
-        bundle.setProperty(TreeRenderers.XML_USE_SINGLE_QUOTES, false);
-        bundle.setProperty(TreeRenderers.XML_LINE_SEPARATOR, "\n");
-
-        TreeRenderer renderer = TreeRenderers.XML.produceRenderer(bundle);
-
-        StringBuilder out = new StringBuilder();
-
-        renderer.renderSubtree(dummyTree1(), out);
-        Assert.assertEquals("<dummyNode foo=\"bar\" ohio=\"4\">\n"
-                            + "    <dummyNode o=\"ha\" />\n"
-                            + "    <dummyNode />\n"
-                            + "</dummyNode>\n", out.toString());
-
-    }
-
-
-    public MyDummyNode dummyTree1() {
-        MyDummyNode dummy = new MyDummyNode();
-
-        dummy.setXPathAttribute("foo", "bar");
-        dummy.setXPathAttribute("ohio", "4");
-
-        MyDummyNode dummy1 = new MyDummyNode();
-
-        dummy1.setXPathAttribute("o", "ha");
-
-        MyDummyNode dummy2 = new MyDummyNode();
-
-        dummy.jjtAddChild(dummy1, 0);
-        dummy.jjtAddChild(dummy2, 1);
-        return dummy;
-    }
-
-    private static class MyDummyNode extends DummyNode {
-
-
-        private final Map<String, String> attributes = new HashMap<>();
-
-        public void setXPathAttribute(String name, String value) {
-            attributes.put(name, value);
-        }
-
-        @Override
-        public Iterator<Attribute> getXPathAttributesIterator() {
-
-            List<Attribute> attrs = new ArrayList<>();
-            for (String name : attributes.keySet()) {
-                attrs.add(new Attribute(this, name, attributes.get(name)));
-            }
-
-            return attrs.iterator();
-        }
-
-
-    }
-
-
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/TreeExportCliTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/TreeExportCliTest.java
@@ -34,7 +34,7 @@ public class TreeExportCliTest {
     @Test
     public void testReadStandardInput() {
         IoSpy spy = IoSpy.withStdin("(a(b))");
-        int status = spy.runMain("-i", "-f", "xml");
+        int status = spy.runMain("-i", "-f", "xml", "-PlineSeparator=LF");
         Assert.assertEquals(0, status);
         spy.assertThatStdout(containsString("<?xml version='1.0' encoding='UTF-8' ?>\n"
                                             + "<dummyNode Image=''>\n"
@@ -48,7 +48,7 @@ public class TreeExportCliTest {
     public void testReadFile() throws IOException {
         File file = newFileWithContents("(a(b))");
         IoSpy spy = new IoSpy();
-        int status = spy.runMain("--file", file.getAbsolutePath(), "-f", "xml");
+        int status = spy.runMain("--file", file.getAbsolutePath(), "-f", "xml", "-PlineSeparator=LF");
         Assert.assertEquals(0, status);
         spy.assertThatStdout(containsString("<?xml version='1.0' encoding='UTF-8' ?>\n"
                                             + "<dummyNode Image=''>\n"

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/TreeRenderersTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/TreeRenderersTest.java
@@ -5,11 +5,6 @@
 package net.sourceforge.pmd.util.treeexport;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -18,8 +13,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import net.sourceforge.pmd.lang.DummyLanguageModule;
 import net.sourceforge.pmd.lang.ast.DummyNode;
-import net.sourceforge.pmd.lang.ast.xpath.Attribute;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertySource;
 
@@ -74,44 +69,17 @@ public class TreeRenderersTest {
     }
 
 
-    public MyDummyNode dummyTree1() {
-        MyDummyNode dummy = new MyDummyNode();
-
+    public static DummyNode dummyTree1() {
+        DummyNode dummy = DummyLanguageModule.parse("(parent(child1)(child2))").getChild(0);
+        dummy.clearXPathAttributes();
         dummy.setXPathAttribute("foo", "bar");
         dummy.setXPathAttribute("ohio", "4");
 
-        MyDummyNode dummy1 = new MyDummyNode();
-
+        DummyNode dummy1 = dummy.getChild(0);
+        dummy1.clearXPathAttributes();
         dummy1.setXPathAttribute("o", "ha");
-
-        MyDummyNode dummy2 = new MyDummyNode();
-
-        dummy.jjtAddChild(dummy1, 0);
-        dummy.jjtAddChild(dummy2, 1);
+        dummy.getChild(1).clearXPathAttributes();
         return dummy;
-    }
-
-    private static class MyDummyNode extends DummyNode {
-
-
-        private final Map<String, String> attributes = new HashMap<>();
-
-        public void setXPathAttribute(String name, String value) {
-            attributes.put(name, value);
-        }
-
-        @Override
-        public Iterator<Attribute> getXPathAttributesIterator() {
-
-            List<Attribute> attrs = new ArrayList<>();
-            for (String name : attributes.keySet()) {
-                attrs.add(new Attribute(this, name, attributes.get(name)));
-            }
-
-            return attrs.iterator();
-        }
-
-
     }
 
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/XmlTreeRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/XmlTreeRendererTest.java
@@ -5,11 +5,6 @@
 package net.sourceforge.pmd.util.treeexport;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Rule;
@@ -31,7 +26,7 @@ public class XmlTreeRendererTest {
     @Test
     public void testRenderWithAttributes() throws IOException {
 
-        DummyNode dummy = dummyTree1();
+        DummyNode dummy = TreeRenderersTest.dummyTree1();
 
         XmlRenderingConfig strat = new XmlRenderingConfig();
         strat.lineSeparator("\n");
@@ -53,7 +48,7 @@ public class XmlTreeRendererTest {
     @Test
     public void testRenderWithCustomLineSep() throws IOException {
 
-        DummyNode dummy = dummyTree1();
+        DummyNode dummy = TreeRenderersTest.dummyTree1();
 
         XmlRenderingConfig strat = new XmlRenderingConfig();
         strat.lineSeparator("\r\n");
@@ -75,7 +70,7 @@ public class XmlTreeRendererTest {
     @Test
     public void testRenderWithCustomIndent() throws IOException {
 
-        DummyNode dummy = dummyTree1();
+        DummyNode dummy = TreeRenderersTest.dummyTree1();
 
         XmlRenderingConfig strat = new XmlRenderingConfig().lineSeparator("").indentWith("");
 
@@ -97,7 +92,7 @@ public class XmlTreeRendererTest {
     @Test
     public void testRenderWithNoAttributes() throws IOException {
 
-        DummyNode dummy = dummyTree1();
+        DummyNode dummy = TreeRenderersTest.dummyTree1();
 
         XmlRenderingConfig strat = new XmlRenderingConfig() {
             @Override
@@ -124,7 +119,7 @@ public class XmlTreeRendererTest {
     @Test
     public void testRenderFilterAttributes() throws IOException {
 
-        DummyNode dummy = dummyTree1();
+        DummyNode dummy = TreeRenderersTest.dummyTree1();
 
         XmlRenderingConfig strategy = new XmlRenderingConfig() {
             @Override
@@ -150,7 +145,7 @@ public class XmlTreeRendererTest {
     @Test
     public void testInvalidAttributeName() throws IOException {
 
-        MyDummyNode dummy = dummyTree1();
+        DummyNode dummy = TreeRenderersTest.dummyTree1();
 
         dummy.setXPathAttribute("&notAName", "foo");
 
@@ -171,7 +166,7 @@ public class XmlTreeRendererTest {
     @Test
     public void testEscapeAttributes() throws IOException {
 
-        MyDummyNode dummy = dummyTree1();
+        DummyNode dummy = TreeRenderersTest.dummyTree1();
 
         dummy.setXPathAttribute("eh", " 'a &> b\" ");
 
@@ -194,7 +189,7 @@ public class XmlTreeRendererTest {
     @Test
     public void testEscapeDoubleAttributes() throws IOException {
 
-        MyDummyNode dummy = dummyTree1();
+        DummyNode dummy = TreeRenderersTest.dummyTree1();
 
         dummy.setXPathAttribute("eh", " 'a &> b\" ");
 
@@ -217,7 +212,7 @@ public class XmlTreeRendererTest {
     @Test
     public void testNoProlog() throws IOException {
 
-        DummyNode dummy = dummyTree1();
+        DummyNode dummy = TreeRenderersTest.dummyTree1();
 
 
         XmlRenderingConfig strat = new XmlRenderingConfig().lineSeparator("\n").renderProlog(false);
@@ -239,7 +234,7 @@ public class XmlTreeRendererTest {
     @Test
     public void testDefaultLineSep() throws IOException {
 
-        DummyNode dummy = dummyTree1();
+        DummyNode dummy = TreeRenderersTest.dummyTree1();
 
         XmlTreeRenderer renderer = new XmlTreeRenderer();
 
@@ -253,47 +248,6 @@ public class XmlTreeRendererTest {
                                 + "    <dummyNode o='ha' />" + System.lineSeparator()
                                 + "    <dummyNode />" + System.lineSeparator()
                                 + "</dummyNode>" + System.lineSeparator(), out.toString());
-
-    }
-
-
-    public MyDummyNode dummyTree1() {
-        MyDummyNode dummy = new MyDummyNode();
-
-        dummy.setXPathAttribute("foo", "bar");
-        dummy.setXPathAttribute("ohio", "4");
-
-        MyDummyNode dummy1 = new MyDummyNode();
-
-        dummy1.setXPathAttribute("o", "ha");
-
-        MyDummyNode dummy2 = new MyDummyNode();
-
-        dummy.jjtAddChild(dummy1, 0);
-        dummy.jjtAddChild(dummy2, 1);
-        return dummy;
-    }
-
-    private static class MyDummyNode extends DummyNode {
-
-
-        private final Map<String, String> attributes = new HashMap<>();
-
-        public void setXPathAttribute(String name, String value) {
-            attributes.put(name, value);
-        }
-
-        @Override
-        public Iterator<Attribute> getXPathAttributesIterator() {
-
-            List<Attribute> attrs = new ArrayList<>();
-            for (String name : attributes.keySet()) {
-                attrs.add(new Attribute(this, name, attributes.get(name)));
-            }
-
-            return attrs.iterator();
-        }
-
 
     }
 


### PR DESCRIPTION

## Describe the PR

Bug was introduced in e64d485384

This is the stacktrace
```
$ pmdrun ast-dump -i -f xml -l java    
-------------------------------------------------------------------------------
This command line utility is experimental. It might change at any time without
prior notice.
-------------------------------------------------------------------------------
Reading from stdin...
class X {}
Exception in thread "main" java.lang.NullPointerException
	at java.base/sun.nio.fs.UnixPath.normalizeAndCheck(UnixPath.java:75)
	at java.base/sun.nio.fs.UnixPath.<init>(UnixPath.java:69)
	at java.base/sun.nio.fs.UnixFileSystem.getPath(UnixFileSystem.java:279)
	at java.base/java.nio.file.Path.of(Path.java:147)
	at java.base/java.nio.file.Paths.get(Paths.java:69)
	at net.sourceforge.pmd.lang.AbstractParser.doParse(AbstractParser.java:46)
	at net.sourceforge.pmd.util.treeexport.TreeExportCli.run(TreeExportCli.java:178)
	at net.sourceforge.pmd.util.treeexport.TreeExportCli.main(TreeExportCli.java:86)
```

The rest of the PR adds tests for the tree export cli, and cleans up some related tests

41b03fec64b239029ca078cb1d047dd141fa9da6 is standalone enough to be its own PR but I think it's a nice improvement and it is directly useful here.

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->


## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

