### PR TITLE
[plsql] Fix plsql parsing exception

### DIFF
--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -2124,7 +2124,11 @@ void QueryTableExpression() #void :
   |
     TableCollectionExpression()
   |
-    [ <LATERAL> ] "(" Subquery() [ SubqueryRestrictionClause() ] ")"
+    LOOKAHEAD(5) "(" [ LOOKAHEAD(2) SchemaName() "." ] TableName() [TableAlias()] ")"  
+  |  
+    LOOKAHEAD(3) [ <LATERAL> ] "(" Subquery() [ SubqueryRestrictionClause() ] ")"
+  | 
+    LOOKAHEAD(3) "(" JoinClause() ")"
   )
 }
 

--- a/pmd-plsql/etc/grammar/PldocAST.jjt
+++ b/pmd-plsql/etc/grammar/PldocAST.jjt
@@ -2126,9 +2126,9 @@ void QueryTableExpression() #void :
   |
     LOOKAHEAD(5) "(" [ LOOKAHEAD(2) SchemaName() "." ] TableName() [TableAlias()] ")"  
   |  
-    LOOKAHEAD(3) [ <LATERAL> ] "(" Subquery() [ SubqueryRestrictionClause() ] ")"
+    LOOKAHEAD(5) [ <LATERAL> ] "(" Subquery() [ SubqueryRestrictionClause() ] ")"
   | 
-    LOOKAHEAD(3) "(" JoinClause() ")"
+    "(" JoinClause() ")"
   )
 }
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ParenthesisGroupTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ParenthesisGroupTest.java
@@ -1,0 +1,32 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.plsql.ast;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import net.sourceforge.pmd.lang.plsql.AbstractPLSQLParserTst;
+
+public class ParenthesisGroupTest extends AbstractPLSQLParserTst {
+
+    @Test
+    public void parseParenthesisGroup0() {
+        ASTInput input = plsql.parseResource("ParenthesisGroup0.pls");
+        Assert.assertNotNull(input);
+    }
+    
+    @Test
+    public void parseParenthesisGroup1() {
+        ASTInput input = plsql.parseResource("ParenthesisGroup1.pls");
+        Assert.assertNotNull(input);
+    }
+    
+    @Test
+    public void parseParenthesisGroup2() {
+        ASTInput input = plsql.parseResource("ParenthesisGroup2.pls");
+        Assert.assertNotNull(input);
+    }
+    
+}

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/ParenthesisGroup0.pls
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/ParenthesisGroup0.pls
@@ -1,0 +1,21 @@
+CREATE OR REPLACE PROCEDURE EXAMPLE_PROCEDURE IS
+   --
+   CURSOR c_example IS
+      SELECT a.owner, u.object_name, p.aggregate
+        FROM (USER_OBJECTS u) INNER JOIN (ALL_OBJECTS a) ON
+               u.object_name = a.object_name AND u.object_type = a.object_type AND u.object_id = a.object_id)
+               INNER JOIN (ALL_PROCEDURES p) ON
+               p.owner = a.owner AND p.object_name = a.object_name AND p.object_type = a.object_type
+       WHERE a.owner = USER;
+   --
+BEGIN
+   --
+   FOR l_object IN c_example LOOP
+      --
+      DBMS_OUTPUT.Put_Line(l_object.owner);
+      DBMS_OUTPUT.Put_Line(l_object.object_name);
+      DBMS_OUTPUT.Put_Line(l_object.aggregate);
+      --
+   END LOOP;
+   --
+END EXAMPLE_PROCEDURE;

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/ParenthesisGroup1.pls
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/ParenthesisGroup1.pls
@@ -1,0 +1,21 @@
+CREATE OR REPLACE PROCEDURE EXAMPLE_PROCEDURE IS
+   --
+   CURSOR c_example IS
+      SELECT a.owner, u.object_name, p.aggregate
+        FROM (((USER_OBJECTS u) INNER JOIN (ALL_OBJECTS a) ON
+               u.object_name = a.object_name AND u.object_type = a.object_type AND u.object_id = a.object_id)
+               INNER JOIN (ALL_PROCEDURES p) ON
+               p.owner = a.owner AND p.object_name = a.object_name AND p.object_type = a.object_type)
+       WHERE a.owner = USER;
+   --
+BEGIN
+   --
+   FOR l_object IN c_example LOOP
+      --
+      DBMS_OUTPUT.Put_Line(l_object.owner);
+      DBMS_OUTPUT.Put_Line(l_object.object_name);
+      DBMS_OUTPUT.Put_Line(l_object.aggregate);
+      --
+   END LOOP;
+   --
+END EXAMPLE_PROCEDURE;

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/ParenthesisGroup2.pls
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/ParenthesisGroup2.pls
@@ -1,0 +1,15 @@
+CREATE OR REPLACE PROCEDURE TEST_PROCEDURE IS
+    --
+    CURSOR c_test IS
+        SELECT si.sid, sn.name, sa.age, ss.score, sp.parent
+        FROM ((((STUDENT_INFO si) INNER JOIN (STUDENT_AGE sa) on si.sid = sa.sid)
+            INNER JOIN
+            (STUDENT_SCORE ss) on si.sid = sp.sid)
+            INNER JOIN
+            (STUDENT_PARENT sp) on si.sid = sp.sid)
+        WHERE si.sid = '114514';
+    --
+BEGIN
+    --
+    --
+END EXAMPLE_PROCEDURE;


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
This PR fixes the plsql parser exception encountered in issue 3706. By changing the grammar in .jjt file, this parse error has been fixed and passed all added unit tests.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes https://github.com/pmd/pmd/issues/3706

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

