### PR TITLE
Bump kotlin from 1.4.10 to 1.4.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
 
         <kotlin.compiler.jvmTarget>${maven.compiler.test.target}</kotlin.compiler.jvmTarget>
         <kotlin.version>1.4.32</kotlin.version>
-        <kotest.version>4.3.1</kotest.version>
+        <kotest.version>4.4.3</kotest.version>
         <dokka.version>1.4.32</dokka.version>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 
 
         <kotlin.compiler.jvmTarget>${maven.compiler.test.target}</kotlin.compiler.jvmTarget>
-        <kotlin.version>1.4.10</kotlin.version>
+        <kotlin.version>1.4.32</kotlin.version>
         <kotest.version>4.3.1</kotest.version>
         <dokka.version>1.4.32</dokka.version>
 


### PR DESCRIPTION
## Describe the PR

Fixes https://nvd.nist.gov/vuln/detail/CVE-2020-29582

See https://sbom.lift.sonatype.com/report/T1-a0368c8f29fdaa555824-1b7e275cc8607e-1651305084-d9e3a9499436490b8797b8a1babecb91 for the report from last release.

Also updates kotest to 4.4.3, which is the last compatible version (kotest 4.5.0 introduces breaking changes).