### PR TITLE
[core] Internalize some methods in Ant Formatter

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -39,6 +39,7 @@ the CPD GUI. See [#3974](https://github.com/pmd/pmd/pull/3974) for details.
 * cli
     * [#1445](https://github.com/pmd/pmd/issues/1445): \[core] Allow CLI to take globs as parameters
 * core
+    * [#3787](https://github.com/pmd/pmd/issues/3787): \[core] Internalize some methods in Ant Formatter
     * [#3942](https://github.com/pmd/pmd/issues/3942): \[core] common-io path traversal vulnerability (CVE-2021-29425)
 * cs (c#)
     * [#3974](https://github.com/pmd/pmd/pull/3974): \[cs] Add option to ignore C# attributes (annotations)
@@ -68,6 +69,15 @@ the CPD GUI. See [#3974](https://github.com/pmd/pmd/pull/3974) for details.
 - {% jdoc core::PMDConfiguration#getInputPaths() %} and
 {% jdoc core::PMDConfiguration#setInputPaths(java.lang.String) %} are now deprecated.
 A new set of methods have been added, which use lists and do not rely on comma splitting.
+
+#### Internal API
+
+Those APIs are not intended to be used by clients, and will be hidden or removed with PMD 7.0.0.
+You can identify them with the `@InternalApi` annotation. You'll also get a deprecation warning.
+
+- The methods {% jdoc !!core::ant.Formatter#start(java.lang.String) %},
+{% jdoc !!core::ant.Formatter#end(net.sourceforge.pmd.Report) %}, {% jdoc !!core::ant.Formatter#getRenderer() %},
+and {% jdoc !!core::ant.Formatter#isNoOutputSupplied() %} have been internalized.
 
 ### External Contributions
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/Formatter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/Formatter.java
@@ -61,10 +61,14 @@ public class Formatter {
         this.parameters.add(parameter);
     }
 
+    @Deprecated
+    @InternalApi
     public Renderer getRenderer() {
         return renderer;
     }
 
+    @Deprecated
+    @InternalApi
     public void start(String baseDir) {
 
         Properties properties = createProperties();
@@ -111,6 +115,8 @@ public class Formatter {
         }
     }
 
+    @Deprecated
+    @InternalApi
     public void end(Report errorReport) {
         try {
             renderer.renderFileReport(errorReport);
@@ -125,6 +131,8 @@ public class Formatter {
         }
     }
 
+    @Deprecated
+    @InternalApi
     public boolean isNoOutputSupplied() {
         return toFile == null && !toConsole;
     }
@@ -233,6 +241,7 @@ public class Formatter {
         return null;
     }
 
+    @Deprecated
     @InternalApi
     public Renderer toRenderer(final Project project, List<String> inputPaths) {
         this.start(project.getBaseDir().toString());


### PR DESCRIPTION
## Describe the PR

Internalizes the methods that should only called by us internally.
Note: `end(Report)` is not called anymore at all. It was used before the refactoring to PmdAnalysis, when the ant task dealt on its own with processing errors by catching exceptions...

## Related issues

- Fixes #3787

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)
