### PR TITLE
Fix AddEmptyString false-negative issue

### DIFF
--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -26,6 +26,8 @@ It is much better to use one of the type-specific toString() methods instead.
                 <value>
 <![CDATA[
 //AdditiveExpression/PrimaryExpression/PrimaryPrefix/Literal[@Image='""' and not(ancestor::Annotation)]
+|
+//AdditiveExpression/PrimaryExpression/PrimaryPrefix/Name[contains(string-join(//VariableInitializer/Expression/PrimaryExpression/PrimaryPrefix/Literal[@Image='""']/../../../../../VariableDeclaratorId/@Name,','),@Image)]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/AddEmptyString.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/AddEmptyString.xml
@@ -3,7 +3,73 @@
     xmlns="http://pmd.sourceforge.net/rule-tests"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+    <test-code>
+	    <description>Test case in issue 3625</description>
+	    <expected-problems>1</expected-problems>
+	    <code><![CDATA[
+public class Main {
+	public void func() {
+		final String var = "";
+		String test = var + "123"; // should report a warning here
+	}
+}
 
+	    ]]></code>
+    </test-code>
+    <test-code>
+	    <description>Local Variables be empty String</description>
+	    <expected-problems>3</expected-problems>
+	    <code><![CDATA[
+public class Main
+{
+	public static void main(String[] args)
+	{
+		String string1 = "";
+		String string2 = "";
+		String string3 = "";
+
+		String a = string1 + 114;
+		String b = string2 + 514;
+		String c = string3 + 1919810;
+	}
+}
+	    ]]></code>
+    </test-code>
+    <test-code>
+	    <description>Local and global variables be empty String</description>
+	    <expected-problems>4</expected-problems>
+	    <code><![CDATA[
+public class Main
+{
+	final String outerString1 = "";
+	final String outerString2 = "";
+
+	public static void main(String[] args)
+	{
+		final String innerString1 = "";
+		final String innerString2 = "";
+
+		String a = outerString1 + 114;
+		String b = outerString2 + 514;
+		String c = innerString1 + 1919;
+		String d = innerString2 + 810;
+	}
+}
+	    ]]></code>
+    </test-code>
+    <test-code>
+	    <description>Test case in issue 3625</description>
+	    <expected-problems>1</expected-problems>
+	    <code><![CDATA[
+public class Main {
+	public void func() {
+		final String var = "";
+		String test = var + "123"; // should report a warning here
+	}
+}
+
+	    ]]></code>
+    </test-code>
     <test-code>
         <description>Bad add</description>
         <expected-problems>1</expected-problems>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
In the AddEmptyString check in `performance.xml` of `java`, the expression `String a = "" + 123;` will trigger the violation. However, if the empty string is stored by a variable, it won' trigger.
## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes https://github.com/pmd/pmd/issues/3936

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

