### PR TITLE
[java] fix false negative with unnecessary parenthesis #3949

### DIFF
--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -813,14 +813,19 @@ in each object at runtime.
  [@Final=true() and @Static=false()]
  [not(preceding-sibling::Annotation/MarkerAnnotation/Name[@Image="Builder.Default"]
     and //ImportDeclaration/Name[@Image="lombok.Builder"])]
+ [not(ReferenceType)]
 /VariableDeclarator
  [VariableInitializer/Expression/PrimaryExpression[not(PrimarySuffix)]
-  /PrimaryPrefix/*
+  /PrimaryPrefix[not(./AllocationExpression/ClassOrInterfaceType[pmd-java:typeIs('java.lang.Thread')])]
+    /*
     [
         self::Literal (: literal :)
         or
         (: another static field :)
         self::Name[@Image=//FieldDeclaration[@Static=true()]/VariableDeclarator/@Name]
+        or
+        (:unnecessary parenthesis :)
+        descendant-or-self::Literal
     ]
  ]
 /VariableDeclaratorId

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/FinalFieldCouldBeStatic.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/FinalFieldCouldBeStatic.xml
@@ -192,4 +192,16 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>
+            #3949 - FinalFieldCouldBeStatic false negative with unnecessary parenthesis
+        </description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public final int BAR = (42);
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Fix false negative about the rule FinalFieldCouldBeStatic caused by the ignorance of parenthesized literal

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #3949

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

