### PR TITLE
[core] Fix current sonatype lift issues

### DIFF
--- a/pmd-apex/src/test/java/net/sourceforge/pmd/cpd/ApexCpdTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/cpd/ApexCpdTest.java
@@ -11,18 +11,18 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
 
-import org.apache.commons.io.FilenameUtils;
 import org.junit.Before;
 import org.junit.Test;
 
 import net.sourceforge.pmd.lang.apex.ApexLanguageModule;
+import net.sourceforge.pmd.util.IOUtil;
 
 public class ApexCpdTest {
     private File testdir;
 
     @Before
     public void setUp() {
-        String path = FilenameUtils.normalize("src/test/resources/net/sourceforge/pmd/cpd/issue427");
+        String path = IOUtil.normalizePath("src/test/resources/net/sourceforge/pmd/cpd/issue427");
         testdir = new File(path);
     }
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexParserTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexParserTest.java
@@ -14,13 +14,12 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Test;
 
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.ast.xpath.internal.FileNameXPathFunction;
+import net.sourceforge.pmd.util.IOUtil;
 
 import apex.jorje.semantic.ast.compilation.Compilation;
 
@@ -154,7 +153,7 @@ public class ApexParserTest extends ApexParserTestBase {
 
         for (File file : fList) {
             if (file.isFile() && file.getName().endsWith(".cls")) {
-                String sourceCode = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
+                String sourceCode = IOUtil.readFileToString(file, StandardCharsets.UTF_8);
                 ApexNode<Compilation> rootNode = parse(sourceCode);
                 Assert.assertNotNull(rootNode);
             }
@@ -167,7 +166,7 @@ public class ApexParserTest extends ApexParserTestBase {
      */
     @Test
     public void parseInheritedSharingClass() throws IOException {
-        String source = IOUtils.toString(ApexParserTest.class.getResourceAsStream("InheritedSharing.cls"),
+        String source = IOUtil.readToString(ApexParserTest.class.getResourceAsStream("InheritedSharing.cls"),
                 StandardCharsets.UTF_8);
         ApexNode<Compilation> rootNode = parse(source);
         Assert.assertNotNull(rootNode);
@@ -180,7 +179,7 @@ public class ApexParserTest extends ApexParserTestBase {
      */
     @Test
     public void stackOverflowDuringClassParsing() throws Exception {
-        String source = IOUtils.toString(ApexParserTest.class.getResourceAsStream("StackOverflowClass.cls"),
+        String source = IOUtil.readToString(ApexParserTest.class.getResourceAsStream("StackOverflowClass.cls"),
                 StandardCharsets.UTF_8);
         ApexNode<Compilation> rootNode = parse(source);
         Assert.assertNotNull(rootNode);
@@ -191,7 +190,7 @@ public class ApexParserTest extends ApexParserTestBase {
 
     @Test
     public void verifyLineColumnNumbersInnerClasses() throws Exception {
-        String source = IOUtils.toString(ApexParserTest.class.getResourceAsStream("InnerClassLocations.cls"),
+        String source = IOUtil.readToString(ApexParserTest.class.getResourceAsStream("InnerClassLocations.cls"),
                 StandardCharsets.UTF_8);
         source = source.replaceAll("\r\n", "\n");
         ApexNode<Compilation> rootNode = parse(source);

--- a/pmd-java/src/test/java/net/sourceforge/pmd/ant/PMDTaskTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/ant/PMDTaskTest.java
@@ -9,14 +9,16 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 
-import org.apache.commons.io.FileUtils;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.contrib.java.lang.system.RestoreSystemProperties;
 import org.junit.rules.ExternalResource;
 import org.junit.rules.TestRule;
+
+import net.sourceforge.pmd.util.IOUtil;
 
 public class PMDTaskTest extends AbstractAntTestHelper {
 
@@ -132,7 +134,7 @@ public class PMDTaskTest extends AbstractAntTestHelper {
         setDefaultCharset("cp1252");
 
         executeTarget("testFormatterEncodingWithXML");
-        String report = FileUtils.readFileToString(currentTempFile(), "UTF-8");
+        String report = IOUtil.readFileToString(currentTempFile(), StandardCharsets.UTF_8);
         assertTrue(report.contains("someVariableWithÜmlaut"));
     }
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/coverage/PMDCoverageTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/coverage/PMDCoverageTest.java
@@ -14,7 +14,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Rule;
@@ -27,6 +26,7 @@ import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.lang.LanguageRegistry;
 import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.lang.java.JavaLanguageModule;
+import net.sourceforge.pmd.util.IOUtil;
 
 public class PMDCoverageTest {
 
@@ -80,7 +80,7 @@ public class PMDCoverageTest {
 
             System.err.println("Running PMD with: " + Arrays.toString(args));
             PMD.runPmd(args);
-            report = FileUtils.readFileToString(f, StandardCharsets.UTF_8);
+            report = IOUtil.readFileToString(f, StandardCharsets.UTF_8);
 
             assertEquals("Nothing should be output to stdout", 0, output.getLog().length());
 

--- a/pom.xml
+++ b/pom.xml
@@ -932,6 +932,16 @@
                 <artifactId>classgraph</artifactId>
                 <version>4.8.112</version>
             </dependency>
+
+            <!-- transitive dependency through org.scalameta:trees_2.13
+                 upgrade to 3.16.1 to fix CVE-2021-22569 A potential Denial of Service issue in protobuf-java
+                 https://github.com/protocolbuffers/protobuf/security/advisories/GHSA-wrvw-hg22-4m67
+            -->
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>3.16.1</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -922,6 +922,16 @@
                 <version>13.0</version>
                 <scope>test</scope>
             </dependency>
+
+            <!-- transitive dependency through io.kotest/kotest-runner-junit5-jvm@4.4.3
+                 upgrade to 4.8.112 to fix [sonatype-2021-1074] CWE-611: Improper Restriction of XML External Entity Reference ('XXE')
+                 https://github.com/classgraph/classgraph/releases/tag/classgraph-4.8.112
+              -->
+            <dependency>
+                <groupId>io.github.classgraph</groupId>
+                <artifactId>classgraph</artifactId>
+                <version>4.8.112</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -893,6 +893,15 @@
                 <artifactId>kotest-runner-junit5-jvm</artifactId>
                 <version>${kotest.version}</version>
                 <scope>test</scope>
+                <exclusions>
+                    <!-- exclude transitive dependency to fix CVE-2021-29425
+                         kotest 4.4.3 depends on commons-io 2.6
+                      -->
+                    <exclusion>
+                        <groupId>commons-io</groupId>
+                        <artifactId>commons-io</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>io.kotest</groupId>


### PR DESCRIPTION
## Describe the PR

There are still some issues from the last release: https://sbom.lift.sonatype.com/report/T1-a0368c8f29fdaa555824-1b7e275cc8607e-1653729393-f78e070c82454f4dba74cfafc8d9c0ac

* This PR removes the last reference to commons-io, which was still used as a transitive test dependency
* Upgrade classgraph (used by kotest)
* Upgrade protobuf-java (used by scala)

## Related issues

- Followup on #3968 and #3942

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

