### PR TITLE
fix documentation link

### DIFF
--- a/docs/pages/pmd/userdocs/tools/tools.md
+++ b/docs/pages/pmd/userdocs/tools/tools.md
@@ -197,7 +197,7 @@ To install the PMD plugin for Eclipse:
 *   Start Eclipse and open a project
 *   Select "Help"->"Software Updates"->"Find and Install"
 *   Click "Next", then click "New remote site"
-*   Enter "PMD" into the Name field and <https://dl.bintray.com/pmd/pmd-eclipse-plugin/updates/> into the URL field
+*   Enter "PMD" into the Name field and select the URL of the version you need from [here](https://pmd.github.io/pmd-eclipse-plugin-p2-site/) and into the URL field
 *   Click through the rest of the dialog boxes to install the plugin
 
 Alternatively, you can download the latest zip file and follow the above procedures


### PR DESCRIPTION
## Describe the PR

The Eclipse plugin URL is a broken link. (https://pmd.github.io/latest/pmd_userdocs_tools.html#eclipse)
I have searched for the correct URL (https://pmd.github.io/pmd-eclipse-plugin-p2-site/). It seems to vary from version to version. (is the perception correct?)

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

