### PR TITLE
Use maven-pmd-plugin 3.18.0-pmd7-SNAPSHOT for pmd7

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -244,12 +244,15 @@ ${rendered_release_notes}"
 # Runs the dogfood ruleset with the currently built pmd against itself
 #
 function pmd_ci_dogfood() {
+    local mpmdVersion=()
     ./mvnw versions:set -DnewVersion="${PMD_CI_MAVEN_PROJECT_VERSION}-dogfood" -DgenerateBackupPoms=false
     sed -i 's/<version>[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}.*<\/version>\( *<!-- pmd.dogfood.version -->\)/<version>'"${PMD_CI_MAVEN_PROJECT_VERSION}"'<\/version>\1/' pom.xml
     if [ "${PMD_CI_MAVEN_PROJECT_VERSION}" = "7.0.0-SNAPSHOT" ]; then
         sed -i 's/pmd-dogfood-config\.xml/pmd-dogfood-config7.xml/' pom.xml
+        mpmdVersion=(-Denforcer.skip=true -Dpmd.plugin.version=3.18.0-pmd7-SNAPSHOT)
     fi
     ./mvnw verify --show-version --errors --batch-mode --no-transfer-progress "${PMD_MAVEN_EXTRA_OPTS[@]}" \
+        "${mpmdVersion[@]}" \
         -DskipTests \
         -Dmaven.javadoc.skip=true \
         -Dmaven.source.skip=true \

--- a/pom.xml
+++ b/pom.xml
@@ -965,6 +965,17 @@
                 <enabled>true</enabled>
             </snapshots>
         </pluginRepository>
+        <pluginRepository>
+            <id>apache.snapshots</id>
+            <name>Apache Snapshot Repository</name>
+            <url>https://repository.apache.org/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </pluginRepository>
     </pluginRepositories>
 
     <profiles>


### PR DESCRIPTION
## Describe the PR

With the last m-pmd-p release, it is not anymore forward compatible with PMD7.
The following errors occurs on our dogfood run:

https://github.com/pmd/pmd/runs/6813394883?check_suite_focus=true#step:7:11734

```
Error:  Failed to execute goal org.apache.maven.plugins:maven-pmd-plugin:3.17.0:pmd (pmd) on project pmd-core:
Execution pmd of goal org.apache.maven.plugins:maven-pmd-plugin:3.17.0:pmd failed:
An API incompatibility was encountered while executing org.apache.maven.plugins:maven-pmd-plugin:3.17.0:pmd:
java.lang.NoSuchMethodError: 'net.sourceforge.pmd.Report net.sourceforge.pmd.Report.filterViolations(net.sourceforge.pmd.util.Predicate)'
```

I've created a new branch for the plugin at https://github.com/apache/maven-pmd-plugin/tree/pmd7 . See https://github.com/apache/maven-pmd-plugin/compare/pmd7 for the diff.
It's available here: https://repository.apache.org/content/groups/snapshots/org/apache/maven/plugins/maven-pmd-plugin/3.18.0-pmd7-SNAPSHOT/ - but the deployment of this SNAPSHOT is not automated and potentially could vanish (in that case I need to redeploy it).

This branch can be used to also see some possible compatibility problems (e.g. suppressed warnings type changed from "nopmd" to "//nopmd"). But that's for later.

This PR now is just to verify, the (dogfood) build works with pmd7 again. I plan to push this change to master, so that our build scripts are the same on both branches.
