### PR TITLE
[core] Bump kotlin to version 1.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <kotlin.compiler.jvmTarget>${maven.compiler.test.target}</kotlin.compiler.jvmTarget>
         <kotlin.version>1.7.0</kotlin.version>
         <kotest.version>4.4.3</kotest.version>
-        <dokka.version>1.4.32</dokka.version>
+        <dokka.version>1.6.21</dokka.version>
 
 
         <javacc.version>5.0</javacc.version>

--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
 
 
         <kotlin.compiler.jvmTarget>${maven.compiler.test.target}</kotlin.compiler.jvmTarget>
-        <kotlin.version>1.4.32</kotlin.version>
+        <kotlin.version>1.7.0</kotlin.version>
         <kotest.version>4.4.3</kotest.version>
         <dokka.version>1.4.32</dokka.version>
 


### PR DESCRIPTION
## Describe the PR

This bumps the version of kotlin and dokka so that PMD can be built with JDK 17.

## Related issues

- Fixes #4009

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

