### PR TITLE
ImmutableField: Ignore fields annotated with @Inject

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ImmutableFieldRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ImmutableFieldRule.java
@@ -50,6 +50,7 @@ public class ImmutableFieldRule extends AbstractLombokAwareRule {
         defaultValues.add("org.mockito.InjectMocks");
         defaultValues.add("org.springframework.beans.factory.annotation.Autowired");
         defaultValues.add("org.springframework.boot.test.mock.mockito.MockBean");
+        defaultValues.add("javax.inject.Inject");
 
         return defaultValues;
     }


### PR DESCRIPTION
## Describe the PR

Ignore fields when annotated with `@Inject`, since they cannot be made final.

## Related issues

- Fixes #4011

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

