### PR TITLE
Downgrade slf4j to 1.7.36

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/ant/internal/PMDTaskImpl.java
@@ -239,7 +239,7 @@ public class PMDTaskImpl {
         Slf4jSimpleConfiguration.installJulBridge();
         // need to reload the logger with the new configuration
         Logger log = LoggerFactory.getLogger(PMDTaskImpl.class);
-        log.atLevel(level).log("Logging is at {}", level);
+        log.info("Logging is at {}", level);
         try {
             doTask();
         } finally {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/SemanticErrorReporter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/SemanticErrorReporter.java
@@ -83,7 +83,25 @@ public interface SemanticErrorReporter {
 
             private String logMessage(Level level, Node location, String message, Object[] args) {
                 String fullMessage = makeMessage(location, message, args);
-                logger.atLevel(level).log(fullMessage);
+                switch (level) {
+                case ERROR:
+                    logger.error(fullMessage);
+                    break;
+                case WARN:
+                    logger.warn(fullMessage);
+                    break;
+                case INFO:
+                    logger.info(fullMessage);
+                    break;
+                case DEBUG:
+                    logger.debug(fullMessage);
+                    break;
+                case TRACE:
+                    logger.trace(fullMessage);
+                    break;
+                default:
+                    throw new AssertionError("Invalid log level: " + level);
+                }
                 return fullMessage;
             }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/log/internal/SimpleMessageReporter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/log/internal/SimpleMessageReporter.java
@@ -26,11 +26,42 @@ public class SimpleMessageReporter extends MessageReporterBase implements Messag
 
     @Override
     protected boolean isLoggableImpl(Level level) {
-        return backend.isEnabledForLevel(level);
+        switch (level) {
+        case ERROR:
+            return backend.isErrorEnabled();
+        case WARN:
+            return backend.isWarnEnabled();
+        case INFO:
+            return backend.isInfoEnabled();
+        case DEBUG:
+            return backend.isDebugEnabled();
+        case TRACE:
+            return backend.isTraceEnabled();
+        default:
+            return false;
+        }
     }
 
     @Override
     protected void logImpl(Level level, String message, Object[] formatArgs) {
-        backend.atLevel(level).log(message, formatArgs);
+        switch (level) {
+        case ERROR:
+            backend.error(message, formatArgs);
+            break;
+        case WARN:
+            backend.warn(message, formatArgs);
+            break;
+        case INFO:
+            backend.info(message, formatArgs);
+            break;
+        case DEBUG:
+            backend.debug(message, formatArgs);
+            break;
+        case TRACE:
+            backend.trace(message, formatArgs);
+            break;
+        default:
+            throw new AssertionError("Invalid log level: " + level);
+        }
     }
 }

--- a/pmd-core/src/main/java/org/slf4j/PmdLoggerFactoryFriend.java
+++ b/pmd-core/src/main/java/org/slf4j/PmdLoggerFactoryFriend.java
@@ -1,0 +1,26 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package org.slf4j;
+
+import net.sourceforge.pmd.annotation.InternalApi;
+
+/**
+ * This class is for internal use only.
+ * <p>
+ * It is needed to reinitialize the underlying logging in case the configuration is changed.
+ * </p>
+ * @deprecated internal, do not use
+ */
+@Deprecated
+@InternalApi
+public final class PmdLoggerFactoryFriend {
+    private PmdLoggerFactoryFriend() {
+        // helper
+    }
+
+    public static void reset() {
+        LoggerFactory.reset();
+    }
+}

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cli/CoreCliTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cli/CoreCliTest.java
@@ -195,19 +195,22 @@ public class CoreCliTest {
 
     @Test
     public void debugLogging() {
-        runPmdSuccessfully("--debug", "--no-cache", "--dir", srcDir, "--rulesets", DUMMY_RULESET);
+        Path reportFile = tempRoot().resolve("out/reportFile.txt");
+        runPmdSuccessfully("--debug", "--no-cache", "--dir", srcDir, "--rulesets", DUMMY_RULESET, "-r", reportFile);
         assertThat(errStreamCaptor.getLog(), containsString("[main] INFO net.sourceforge.pmd.PMD - Log level is at TRACE"));
     }
 
     @Test
     public void defaultLogging() {
-        runPmdSuccessfully("--no-cache", "--dir", srcDir, "--rulesets", DUMMY_RULESET);
+        Path reportFile = tempRoot().resolve("out/reportFile.txt");
+        runPmdSuccessfully("--no-cache", "--dir", srcDir, "--rulesets", DUMMY_RULESET, "-r", reportFile);
         assertThat(errStreamCaptor.getLog(), containsString("[main] INFO net.sourceforge.pmd.PMD - Log level is at INFO"));
     }
 
     @Test
     public void testDeprecatedRulesetSyntaxOnCommandLine() {
-        runPmd(StatusCode.VIOLATIONS_FOUND, "--no-cache", "--dir", srcDir, "--rulesets", "dummy-basic");
+        Path reportFile = tempRoot().resolve("out/reportFile.txt");
+        runPmd(StatusCode.VIOLATIONS_FOUND, "--no-cache", "--dir", srcDir, "--rulesets", "dummy-basic", "-r", reportFile);
         MatcherAssert.assertThat(errStreamCaptor.getLog(), containsString("Ruleset reference 'dummy-basic' uses a deprecated form, use 'rulesets/dummy/basic.xml' instead"));
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
         <ant.version>1.10.12</ant.version>
         <javadoc.plugin.version>3.2.0</javadoc.plugin.version>
         <antlr.version>4.8</antlr.version>
-        <slf4j.version>2.0.0-alpha6</slf4j.version>
+        <slf4j.version>1.7.36</slf4j.version>
         <saxon.version>10.7</saxon.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
## Describe the PR

* Downgrade slf4j from 2 to 1.7.36
* Obviously using slf4j was too ambitious, see https://github.com/pmd/pmd/pull/3808#issuecomment-1161717663
* Using slf4j 1.7.x makes PMD compatible when using in sonar


## Related issues

- Refs #3789
- Refs #896 


## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

