### PR TITLE
[core] Add plain text language

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/PlainTextLanguage.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/PlainTextLanguage.java
@@ -1,0 +1,154 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.util.Collections;
+import java.util.Map;
+
+import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.RuleContext;
+import net.sourceforge.pmd.RuleViolation;
+import net.sourceforge.pmd.annotation.Experimental;
+import net.sourceforge.pmd.lang.ast.AbstractNode;
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.ast.ParseException;
+import net.sourceforge.pmd.lang.ast.RootNode;
+import net.sourceforge.pmd.lang.ast.SourceCodePositioner;
+import net.sourceforge.pmd.lang.rule.AbstractRuleViolationFactory;
+import net.sourceforge.pmd.lang.rule.ParametricRuleViolation;
+import net.sourceforge.pmd.lang.rule.RuleViolationFactory;
+import net.sourceforge.pmd.util.IOUtil;
+
+/**
+ * A dummy language implementation whose parser produces a single node.
+ * This is provided for cases where a non-null language is required, but
+ * the parser is not useful. This is useful eg to mock rules when no other
+ * language is on the classpath. This language is not exposed by {@link LanguageRegistry}
+ * and can only be used explicitly with {@link #getInstance()}.
+ *
+ * @author Clément Fournier
+ * @since 6.48.0
+ */
+@Experimental
+public final class PlainTextLanguage extends BaseLanguageModule {
+
+    private static final Language INSTANCE = new PlainTextLanguage();
+
+    static final String TERSE_NAME = "text";
+
+    private PlainTextLanguage() {
+        super("Plain text", "Plain text", TERSE_NAME,"plain-text-file-goo-extension");
+        addVersion("default", new TextLvh(), true);
+    }
+
+    /**
+     * Returns the singleton instance of this language.
+     */
+    public static Language getInstance() {
+        return INSTANCE;
+    }
+
+    private static class TextLvh extends AbstractLanguageVersionHandler {
+
+        private static final RuleViolationFactory RV_FACTORY = new AbstractRuleViolationFactory() {
+            @Override
+            protected RuleViolation createRuleViolation(Rule rule, RuleContext ruleContext, Node node, String s) {
+                return new ParametricRuleViolation<>(rule, ruleContext, node, s);
+            }
+
+            @Override
+            protected RuleViolation createRuleViolation(Rule rule, RuleContext ruleContext, Node node, String s, int i, int i1) {
+                return new ParametricRuleViolation<>(rule, ruleContext, node, s);
+            }
+        };
+
+        @Override
+        public RuleViolationFactory getRuleViolationFactory() {
+            return RV_FACTORY;
+        }
+
+        @Override
+        public Parser getParser(final ParserOptions parserOptions) {
+            return new Parser() {
+                @Override
+                public ParserOptions getParserOptions() {
+                    return parserOptions;
+                }
+
+                @Override
+                public TokenManager getTokenManager(String s, Reader reader) {
+                    return null;
+                }
+
+                @Override
+                public boolean canParse() {
+                    return true;
+                }
+
+                @Override
+                public Node parse(String s, Reader reader) throws ParseException {
+                    try {
+                        return new PlainTextFile(IOUtil.readToString(reader));
+                    } catch (IOException e) {
+                        throw new ParseException(e);
+                    }
+                }
+
+                @Override
+                public Map<Integer, String> getSuppressMap() {
+                    return Collections.emptyMap();
+                }
+            };
+        }
+    }
+
+    /**
+     * The only node produced by the parser of {@link PlainTextLanguage}.
+     */
+    public static final class PlainTextFile extends AbstractNode implements RootNode {
+
+        PlainTextFile(String fileText) {
+            super(0);
+            SourceCodePositioner positioner = new SourceCodePositioner(fileText);
+            this.beginLine = 1;
+            this.beginColumn = 1;
+            this.endLine = positioner.getLastLine();
+            this.endColumn = positioner.getLastLineColumn();
+        }
+
+        @Override
+        public String getXPathNodeName() {
+            return "TextFile";
+        }
+
+        @Override
+        public String getImage() {
+            return null;
+        }
+
+        @Override
+        public void setImage(String image) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void remove() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removeChildAtIndex(int childIndex) {
+            throw new IndexOutOfBoundsException();
+        }
+
+        @Override
+        public String toString() {
+            return "Plain text file (" + endLine + "lines)";
+        }
+    }
+
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/PlainTextLanguage.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/PlainTextLanguage.java
@@ -41,7 +41,7 @@ public final class PlainTextLanguage extends BaseLanguageModule {
     static final String TERSE_NAME = "text";
 
     private PlainTextLanguage() {
-        super("Plain text", "Plain text", TERSE_NAME,"plain-text-file-goo-extension");
+        super("Plain text", "Plain text", TERSE_NAME, "plain-text-file-goo-extension");
         addVersion("default", new TextLvh(), true);
     }
 

--- a/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/DummyLanguageModule.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/test/lang/DummyLanguageModule.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.RuleViolation;
+import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.AbstractLanguageVersionHandler;
 import net.sourceforge.pmd.lang.AbstractParser;
 import net.sourceforge.pmd.lang.BaseLanguageModule;
@@ -30,7 +31,12 @@ import net.sourceforge.pmd.test.lang.ast.DummyNode;
 
 /**
  * Dummy language used for testing PMD.
+ *
+ * @deprecated Don't use this directly. We can probably remove this in favour of plaintextlanguage
+ *  when https://github.com/pmd/pmd/issues/3918 is merged
  */
+@Deprecated
+@InternalApi
 public class DummyLanguageModule extends BaseLanguageModule {
 
     public static final String NAME = "Dummy";


### PR DESCRIPTION
## Describe the PR

Add a "plain text" language in pmd core. This in inacessible from the CLI and other things. It's experimental.

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- One step of #2435, the rest has to be done in pmd 7 and is blocked on #3918
- Unblocks #3976 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

