### PR TITLE
[core] Allow building PMD under Java 18+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <pmd.website.baseurl>https://pmd.github.io/pmd</pmd.website.baseurl>
 
-        <argLine>-Xmx512m -Dfile.encoding=${project.build.sourceEncoding}</argLine>
+        <argLine>-Xmx512m -Dfile.encoding=${project.build.sourceEncoding} ${extraArgLine}</argLine>
+        <extraArgLine></extraArgLine> <!-- empty by default, profiles set it as needed -->
 
         <pmd.build-tools.version>18</pmd.build-tools.version>
 
@@ -1008,6 +1009,17 @@
     </pluginRepositories>
 
     <profiles>
+        <profile>
+            <id>Java 18+</id>
+            <activation>
+                <jdk>[18,)</jdk>
+            </activation>
+            <properties>
+                <!-- java.security.manager=allow is needed under Java 18+ for usages of org.junit.contrib.java.lang.system.ExpectedSystemExit -->
+                <extraArgLine>-Djava.security.manager=allow</extraArgLine>
+            </properties>
+        </profile>
+
         <profile>
             <id>pmd-release</id>
             <properties>


### PR DESCRIPTION
 - Tests would fail due to the internal usage of SecurityManager without this flag
