### PR TITLE
[apex] ApexSOQLInjection: Add support count query

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
@@ -28,7 +28,7 @@ import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.apex.rule.internal.Helper;
 
 /**
- * Detects if variables in Database.query(variable) is escaped with
+ * Detects if variables in Database.query(variable) or Database.countQuery is escaped with
  * String.escapeSingleQuotes
  *
  * @author sergey.gorbaty
@@ -46,6 +46,7 @@ public class ApexSOQLInjectionRule extends AbstractApexRule {
     private static final String STRING = "String";
     private static final String DATABASE = "Database";
     private static final String QUERY = "query";
+    private static final String COUNT_QUERY = "countQuery";
     private static final Pattern SELECT_PATTERN = Pattern.compile("^select[\\s]+?.*?$", Pattern.CASE_INSENSITIVE);
     private final Set<String> safeVariables = new HashSet<>();
     private final Map<String, Boolean> selectContainingVariables = new HashMap<>();
@@ -94,7 +95,7 @@ public class ApexSOQLInjectionRule extends AbstractApexRule {
                 .findDescendantsOfType(ASTMethodCallExpression.class);
 
         for (ASTMethodCallExpression m : potentialDbQueryCalls) {
-            if (!Helper.isTestMethodOrClass(m) && Helper.isMethodName(m, DATABASE, QUERY)) {
+            if (!Helper.isTestMethodOrClass(m) && isQueryMethodCall(m)) {
                 reportStrings(m, data);
                 reportVariables(m, data);
             }
@@ -104,6 +105,10 @@ public class ApexSOQLInjectionRule extends AbstractApexRule {
         selectContainingVariables.clear();
 
         return data;
+    }
+
+    private boolean isQueryMethodCall(ASTMethodCallExpression m) {
+        return Helper.isMethodName(m, DATABASE, QUERY) || Helper.isMethodName(m, DATABASE, COUNT_QUERY);
     }
 
     private void findSafeVariablesInSignature(ASTMethod m) {

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSOQLInjection.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSOQLInjection.xml
@@ -336,7 +336,7 @@ public class Foo {
 public class Foo {
     public void test1() {
         String field1 = getSomeID();
-        String field2 = 'SELECT Id FROM Account WHERE Id =';
+        String field2 = 'SELECT COUNT() FROM Account WHERE Id =';
         Database.countQuery(field2 + field1);
     }
 }
@@ -350,7 +350,7 @@ public class Foo {
 public class Foo {
     public void test1() {
         String field1 = getSomeID();
-        String field2 = 'SELECT Id FROM Account WHERE Id =' + field1;
+        String field2 = 'SELECT COUNT() FROM Account WHERE Id =' + field1;
         Database.countQuery(field2);
     }
 }
@@ -364,7 +364,7 @@ public class Foo {
 public class Foo {
     public void test1() {
         String field1 = 'someIDhere';
-        String field2 = 'SELECT Id FROM Account WHERE Id =';
+        String field2 = 'SELECT COUNT() FROM Account WHERE Id =';
         Database.countQuery(field2 + field1);
     }
 }
@@ -378,7 +378,7 @@ public class Foo {
 public class Foo {
     public void test1() {
         String field1 = String.escapeSingleQuotes('yo');
-        String field2 = 'SELECT Id FROM Account WHERE Id =' + field1;
+        String field2 = 'SELECT COUNT() FROM Account WHERE Id =' + field1;
         Database.countQuery(field2);
     }
 }
@@ -392,7 +392,7 @@ public class Foo {
 public class Foo {
     public void test1() {
         String field1 = String.escapeSingleQuotes('yo');
-        Database.countQuery('SELECT Id FROM Account WHERE Id =' + field1);
+        Database.countQuery('SELECT COUNT() FROM Account WHERE Id =' + field1);
     }
 }
         ]]></code>
@@ -406,7 +406,7 @@ public class Foo {
 
     public void test1(String field1) {
         field2 = String.escapeSingleQuotes(field1);
-        Database.countQuery('SELECT Id FROM Account WHERE Id =' + field2);
+        Database.countQuery('SELECT COUNT() FROM Account WHERE Id =' + field2);
     }
 }
         ]]></code>
@@ -418,7 +418,7 @@ public class Foo {
         <code><![CDATA[
 public class Foo {
     public void test1() {
-        Database.countQuery('SELECT Id FROM Account');
+        Database.countQuery('SELECT COUNT() FROM Account');
     }
 }
         ]]></code>
@@ -430,7 +430,7 @@ public class Foo {
         <code><![CDATA[
 public class Foo {
     public void test1(String t1) {
-        Database.countQuery('SELECT Id FROM Account' + t1);
+        Database.countQuery('SELECT COUNT() FROM Account' + t1);
     }
 }
         ]]></code>
@@ -442,7 +442,7 @@ public class Foo {
         <code><![CDATA[
 public class Foo {
     public void test1(String t1, String t2) {
-        Database.countQuery('SELECT Id FROM Account ' + t1 + ' WHERE ' + t2 + ';');
+        Database.countQuery('SELECT COUNT() FROM Account ' + t1 + ' WHERE ' + t2 + ';');
     }
 }
         ]]></code>
@@ -454,7 +454,7 @@ public class Foo {
         <code><![CDATA[
 public class Foo {
     public void test1(List<String> t1) {
-        Database.countQuery('SELECT Id FROM Account ' + string.join(t1, ','));
+        Database.countQuery('SELECT COUNT() FROM Account ' + string.join(t1, ','));
     }
 }
         ]]></code>
@@ -467,7 +467,7 @@ public class Foo {
 public class Foo {
     public void test1() {
         String field1 = 'yo';
-        Database.countQuery('SELECT Id FROM Account WHERE Id =' + field1);
+        Database.countQuery('SELECT COUNT() FROM Account WHERE Id =' + field1);
     }
 }
         ]]></code>
@@ -480,7 +480,7 @@ public class Foo {
 public class Foo {
     public static String field1 = 'yo';
     public void test1() {
-        Database.countQuery('SELECT Id FROM Account WHERE Id =' + field1 + 'string');
+        Database.countQuery('SELECT COUNT() FROM Account WHERE Id =' + field1 + 'string');
     }
 }
         ]]></code>
@@ -493,7 +493,7 @@ public class Foo {
 public class Foo {
     public void test1() {
         String field1 = 'yo';
-        Database.countQuery('SELECT Id FROM Account WHERE Id =' + field1 + 'string');
+        Database.countQuery('SELECT COUNT() FROM Account WHERE Id =' + field1 + 'string');
     }
 }
         ]]></code>
@@ -505,7 +505,7 @@ public class Foo {
         <code><![CDATA[
 public class Foo {
     public void test1(String field1) {
-        Database.countQuery('SELECT Id FROM Account WHERE Id =' + String.escapeSingleQuotes(field1) + 'string');
+        Database.countQuery('SELECT COUNT() FROM Account WHERE Id =' + String.escapeSingleQuotes(field1) + 'string');
     }
 }
         ]]></code>
@@ -518,7 +518,7 @@ public class Foo {
 public class Foo {
     public void test1() {
         Integer field1 = 4;
-        Database.countQuery('SELECT Id FROM Account LIMIT ' + field1);
+        Database.countQuery('SELECT COUNT() FROM Account LIMIT ' + field1);
     }
 }
         ]]></code>
@@ -531,7 +531,7 @@ public class Foo {
 public class Foo {
     public void test1() {
         String name = 'Name';
-        String someQuery = 'SELECT Id, ' + name + ' FROM ' + String.escapeSingleQuotes(objectName);
+        String someQuery = 'SELECT COUNT(' + name + ') FROM ' + String.escapeSingleQuotes(objectName);
         Database.countQuery(someQuery);
     }
 }
@@ -545,7 +545,7 @@ public class Foo {
 public class Foo {
     public void test1(String objectName) {
         String name = 'Name';
-        String someQuery = 'SELECT Id, ' + name + ' FROM ' + objectName;
+        String someQuery = 'SELECT COUNT(' + name + ') FROM ' + objectName;
         Database.countQuery(someQuery);
     }
 }
@@ -575,7 +575,7 @@ public class Foo {
 public class Foo {
 
     public List<SObject> test1(String objName) {
-        String baseQuery = 'Select Id, Name From ' + String.escapeSingleQuotes(objName);
+        String baseQuery = 'Select Count() From ' + String.escapeSingleQuotes(objName);
         return Database.countQuery(baseQuery + ' LIMIT 1');
     }
 }
@@ -589,7 +589,7 @@ public class Foo {
 public class Foo {
     public void test1(String objName, String lim) { // "limit" is a kw
         Integer nLimit = Integer.valueOf(lim);
-        List<SObject> res = Database.countQuery('Select Id, Name From ' + String.escapeSingleQuotes(objName) + ' LIMIT ' + nLimit);
+        List<SObject> res = Database.countQuery('Select Count() From ' + String.escapeSingleQuotes(objName) + ' LIMIT ' + nLimit);
     }
 }
         ]]></code>
@@ -603,7 +603,7 @@ public class Foo {
     public void test1() {
         ID someId;
         someId = getId();
-        List<SObject> res = Database.countQuery('Select Id, Name From Account Where Id=' + someId);
+        List<SObject> res = Database.countQuery('Select Count() From Account Where Id=' + someId);
     }
 }
         ]]></code>
@@ -615,7 +615,7 @@ public class Foo {
         <code><![CDATA[
 public class Foo {
     public void test1(ID someId, String name) {
-        List<SObject> res = Database.countQuery('Select Id,' + name + ' From Account Where Id=' + someId);
+        List<SObject> res = Database.countQuery('Select Count(' + name + ') From Account Where Id=' + someId);
     }
 }
         ]]></code>
@@ -627,7 +627,7 @@ public class Foo {
         <code><![CDATA[
 public class Foo {
     public void test1(String name) {
-        List<SObject> res = Database.countQuery('Select Id,Name From ' + (name == 'Account' ? name : 'Cases'));
+        List<SObject> res = Database.countQuery('Select Count() From ' + (name == 'Account' ? name : 'Cases'));
     }
 }
         ]]></code>
@@ -642,7 +642,7 @@ public class Foo {
     class MyNestedClass {
         public void test1() {
             String field1 = getSomeID();
-            String field2 = 'SELECT Id FROM Account WHERE Id =';
+            String field2 = 'SELECT Count() FROM Account WHERE Id =';
             Database.countQuery(field2 + field1);
         }
     }

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSOQLInjection.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSOQLInjection.xml
@@ -4,6 +4,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
 
+    <!-- Database.query() tests -->
     <test-code>
         <description>Potentially unsafe SOQL on concatenation of variables 1</description>
         <expected-problems>1</expected-problems>
@@ -320,6 +321,329 @@ public class Foo {
             String field1 = getSomeID();
             String field2 = 'SELECT Id FROM Account WHERE Id =';
             Database.query(field2 + field1);
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+    
+    <!-- Database.countQuery tests -->
+    <test-code>
+        <description>Potentially unsafe SOQL on concatenation of variables 1</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public void test1() {
+        String field1 = getSomeID();
+        String field2 = 'SELECT Id FROM Account WHERE Id =';
+        Database.countQuery(field2 + field1);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Potentially unsafe SOQL on concatenation of variables 2</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void test1() {
+        String field1 = getSomeID();
+        String field2 = 'SELECT Id FROM Account WHERE Id =' + field1;
+        Database.countQuery(field2);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Safe SOQL concatenation of hardcoded variables</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void test1() {
+        String field1 = 'someIDhere';
+        String field2 = 'SELECT Id FROM Account WHERE Id =';
+        Database.countQuery(field2 + field1);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Safe SOQL on concatenation of variables</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void test1() {
+        String field1 = String.escapeSingleQuotes('yo');
+        String field2 = 'SELECT Id FROM Account WHERE Id =' + field1;
+        Database.countQuery(field2);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Safe SOQL + merged variable from a literal</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void test1() {
+        String field1 = String.escapeSingleQuotes('yo');
+        Database.countQuery('SELECT Id FROM Account WHERE Id =' + field1);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Safe SOQL + merged variable</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+
+    public void test1(String field1) {
+        field2 = String.escapeSingleQuotes(field1);
+        Database.countQuery('SELECT Id FROM Account WHERE Id =' + field2);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>No issue when SOQL is called</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void test1() {
+        Database.countQuery('SELECT Id FROM Account');
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Potentially unsafe SOQL with variable concatenation</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void test1(String t1) {
+        Database.countQuery('SELECT Id FROM Account' + t1);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Potentially unsafe SOQL with multiple variable concatenation</description>
+        <expected-problems>2</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void test1(String t1, String t2) {
+        Database.countQuery('SELECT Id FROM Account ' + t1 + ' WHERE ' + t2 + ';');
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Safe SOQL with List concatenation</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void test1(List<String> t1) {
+        Database.countQuery('SELECT Id FROM Account ' + string.join(t1, ','));
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>SOQL + merged variable from literal</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void test1() {
+        String field1 = 'yo';
+        Database.countQuery('SELECT Id FROM Account WHERE Id =' + field1);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>SOQL with merged with field variable</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public static String field1 = 'yo';
+    public void test1() {
+        Database.countQuery('SELECT Id FROM Account WHERE Id =' + field1 + 'string');
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>SOQL with merged variable from literal 2</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void test1() {
+        String field1 = 'yo';
+        Database.countQuery('SELECT Id FROM Account WHERE Id =' + field1 + 'string');
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Safe SOQL + merged variable</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void test1(String field1) {
+        Database.countQuery('SELECT Id FROM Account WHERE Id =' + String.escapeSingleQuotes(field1) + 'string');
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Dynamic SOQL with Integer</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void test1() {
+        Integer field1 = 4;
+        Database.countQuery('SELECT Id FROM Account LIMIT ' + field1);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Dynamic safe escaped SOQL with multipart</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void test1() {
+        String name = 'Name';
+        String someQuery = 'SELECT Id, ' + name + ' FROM ' + String.escapeSingleQuotes(objectName);
+        Database.countQuery(someQuery);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Dynamic safe escaped SOQL with multipart</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void test1(String objectName) {
+        String name = 'Name';
+        String someQuery = 'SELECT Id, ' + name + ' FROM ' + objectName;
+        Database.countQuery(someQuery);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Unsafe SOQL merged from many variables</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+
+    public List<SObject> test1(String fieldNameQuery, String objName) {
+        String baseQuery = 'Select ';
+        String finalObjectQuery;
+        finalObjectQuery = baseQuery + fieldNameQuery + ' from ' + objName;
+        return Database.countQuery(finalObjectQuery);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Literal concatenation in the query method is safe</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+
+    public List<SObject> test1(String objName) {
+        String baseQuery = 'Select Id, Name From ' + String.escapeSingleQuotes(objName);
+        return Database.countQuery(baseQuery + ' LIMIT 1');
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Integer is safe in query</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void test1(String objName, String lim) { // "limit" is a kw
+        Integer nLimit = Integer.valueOf(lim);
+        List<SObject> res = Database.countQuery('Select Id, Name From ' + String.escapeSingleQuotes(objName) + ' LIMIT ' + nLimit);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>ID var decl is safe in query</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void test1() {
+        ID someId;
+        someId = getId();
+        List<SObject> res = Database.countQuery('Select Id, Name From Account Where Id=' + someId);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Safe ID and unsafe String from method signature</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void test1(ID someId, String name) {
+        List<SObject> res = Database.countQuery('Select Id,' + name + ' From Account Where Id=' + someId);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Ternary operator condition var is safe but resulting type isn't</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void test1(String name) {
+        List<SObject> res = Database.countQuery('Select Id,Name From ' + (name == 'Account' ? name : 'Cases'));
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Potentially unsafe SOQL on concatenation of variables in nested class</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    class MyNestedClass {
+        public void test1() {
+            String field1 = getSomeID();
+            String field2 = 'SELECT Id FROM Account WHERE Id =';
+            Database.countQuery(field2 + field1);
         }
     }
 }


### PR DESCRIPTION
**Rule:** [ApexSOQLInjection](https://pmd.github.io/latest/pmd_rules_apex_security.html#apexsoqlinjection)

## Describe the PR

PMD currently has a check for calls to [`Database.query`](https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_methods_system_database.htm#apex_System_Database_query) to check that it correctly protects against soql injection. However, the very similar method [`Database.countQuery`](https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_methods_system_database.htm#apex_System_Database_countQuery) doesn't have these checks.

This PR adds support for detecting soql injections in the `countQuery` method in the same way we support the `query` method.

This PR fixes a potential false-negative.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

I didn't open an issue for this because fixing it was super fast. Let me know if you want one though for a more centralised discussion!

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

