### PR TITLE
[lua] Fix several related Lua parsing issues found when using CPD

### DIFF
--- a/pmd-lua/src/main/antlr4/net/sourceforge/pmd/lang/lua/antlr4/Lua.g4
+++ b/pmd-lua/src/main/antlr4/net/sourceforge/pmd/lang/lua/antlr4/Lua.g4
@@ -60,6 +60,7 @@ Tested by Matt Hargett with:
     - Entire codebase for luvit: https://github.com/luvit/luvit/
     - Entire codebase for lit: https://github.com/luvit/lit/
     - Entire codebase and test suite for neovim v0.7.2: https://github.com/neovim/neovim/tree/v0.7.2
+    - Entire codebase for World of Warcraft Interface: https://github.com/tomrus88/BlizzardInterfaceCode
 */
 
 grammar Lua;
@@ -288,7 +289,7 @@ HexExponentPart
 
 fragment
 EscapeSequence
-    : '\\' [abfnrtvz"'\\]
+    : '\\' [abfnrtvz"'|$#\\]
     | '\\' '\r'? '\n'
     | DecimalEscape
     | HexEscape

--- a/pmd-lua/src/main/antlr4/net/sourceforge/pmd/lang/lua/antlr4/Lua.g4
+++ b/pmd-lua/src/main/antlr4/net/sourceforge/pmd/lang/lua/antlr4/Lua.g4
@@ -330,7 +330,7 @@ SingleLineInputCharacter
     ;
 
 COMMENT
-    : '--['  NESTED_STR ']' -> channel(HIDDEN)
+    : '--[' NESTED_STR ']' -> channel(HIDDEN)
     ;
 
 LINE_COMMENT

--- a/pmd-lua/src/main/antlr4/net/sourceforge/pmd/lang/lua/antlr4/Lua.g4
+++ b/pmd-lua/src/main/antlr4/net/sourceforge/pmd/lang/lua/antlr4/Lua.g4
@@ -331,7 +331,7 @@ COMMENT
 fragment InputCharacter:       ~[\r\n\u0085\u2028\u2029];
 
 LINE_COMMENT
-    :   '--' InputCharacter* -> skip
+    :   '--' InputCharacter* -> channel(HIDDEN)
     ;
 
 WS

--- a/pmd-lua/src/main/antlr4/net/sourceforge/pmd/lang/lua/antlr4/Lua.g4
+++ b/pmd-lua/src/main/antlr4/net/sourceforge/pmd/lang/lua/antlr4/Lua.g4
@@ -334,7 +334,7 @@ COMMENT
     ;
 
 LINE_COMMENT
-    :   '--' SingleLineInputCharacter* -> channel(HIDDEN)
+    : '--' SingleLineInputCharacter* -> channel(HIDDEN)
     ;
 
 WS

--- a/pmd-lua/src/main/antlr4/net/sourceforge/pmd/lang/lua/antlr4/Lua.g4
+++ b/pmd-lua/src/main/antlr4/net/sourceforge/pmd/lang/lua/antlr4/Lua.g4
@@ -61,6 +61,7 @@ Tested by Matt Hargett with:
     - Entire codebase for lit: https://github.com/luvit/lit/
     - Entire codebase and test suite for neovim v0.7.2: https://github.com/neovim/neovim/tree/v0.7.2
     - Entire codebase for World of Warcraft Interface: https://github.com/tomrus88/BlizzardInterfaceCode
+    - Benchmarks and conformance test suite for Luau 0.537: https://github.com/Roblox/luau/tree/0.537
 */
 
 grammar Lua;

--- a/pmd-lua/src/main/antlr4/net/sourceforge/pmd/lang/lua/antlr4/Lua.g4
+++ b/pmd-lua/src/main/antlr4/net/sourceforge/pmd/lang/lua/antlr4/Lua.g4
@@ -290,7 +290,7 @@ HexExponentPart
 
 fragment
 EscapeSequence
-    : '\\' [abfnrtvz"'|$#\\]
+    : '\\' [abfnrtvz"'|$#\\]   // World of Warcraft Lua additionally escapes |$# 
     | '\\' '\r'? '\n'
     | DecimalEscape
     | HexEscape
@@ -324,14 +324,17 @@ HexDigit
     : [0-9a-fA-F]
     ;
 
+fragment
+SingleLineInputCharacter
+    : ~[\r\n\u0085\u2028\u2029]
+    ;
+
 COMMENT
     : '--['  NESTED_STR ']' -> channel(HIDDEN)
     ;
 
-fragment InputCharacter:       ~[\r\n\u0085\u2028\u2029];
-
 LINE_COMMENT
-    :   '--' InputCharacter* -> channel(HIDDEN)
+    :   '--' SingleLineInputCharacter* -> channel(HIDDEN)
     ;
 
 WS
@@ -339,5 +342,5 @@ WS
     ;
 
 SHEBANG
-    : '#' '!' InputCharacter* -> channel(HIDDEN)
+    : '#' '!' SingleLineInputCharacter* -> channel(HIDDEN)
     ;

--- a/pmd-lua/src/test/resources/net/sourceforge/pmd/lang/lua/cpd/testdata/factorial.lua
+++ b/pmd-lua/src/test/resources/net/sourceforge/pmd/lang/lua/cpd/testdata/factorial.lua
@@ -1,4 +1,4 @@
--- defines a factorial function
+-- defines [a] `factorial` 'function'
     function fact (n)
       if n == 0 then
         return 1
@@ -8,6 +8,5 @@
     end
     
     print("enter a number:")
-    a = io.read("*number")        -- read a number
-    print(fact(a))
-
+    a = io.read("*number")        --[[ `read` ([a]) "number" ]]
+    print(fact(a)) --comment then EOF

--- a/pmd-lua/src/test/resources/net/sourceforge/pmd/lang/lua/cpd/testdata/helloworld.lua
+++ b/pmd-lua/src/test/resources/net/sourceforge/pmd/lang/lua/cpd/testdata/helloworld.lua
@@ -1,2 +1,4 @@
  print("Hello World")
-
+--[[
+    author's `statement` [ok?]|"not ok"
+]]

--- a/pmd-lua/src/test/resources/net/sourceforge/pmd/lang/lua/cpd/testdata/tabWidth.lua
+++ b/pmd-lua/src/test/resources/net/sourceforge/pmd/lang/lua/cpd/testdata/tabWidth.lua
@@ -1,2 +1,6 @@
 	print("Hello World")
-
+	--[=[
+		"other" [[multiline]]  = [comment] `style`
+	]=]
+	--[====[ 
+	]====]


### PR DESCRIPTION
## Describe the PR

The Lua ANTLR grammar had parsing issues with escaped characters in comments, multiline comments with line breaks, and a few other bits and pieces. Informed by looking at the C# and Go grammars.

I enhanced the existing sample Lua files to reproduce the issues in a way that didn't require modifying their CPD snapshots.
I then tested against some of the largest corpus' of Lua code availble in open source, including test suites from multiple other parsers.

If this looks good here, I'll upstream to antlr4's repo.

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)
