### PR TITLE
[doc] Add architecture decision records

### DIFF
--- a/docs/_data/sidebars/pmd_sidebar.yml
+++ b/docs/_data/sidebars/pmd_sidebar.yml
@@ -469,6 +469,9 @@ entries:
     - title: Old release notes
       url: /pmd_release_notes_old.html
       output: web, pdf
+    - title: Decisions
+      url: /pmd_projectdocs_decisions.html
+      output: web, pdf
     - title: null
       output: web, pdf
       subfolders:

--- a/docs/pages/pmd/projectdocs/decisions.md
+++ b/docs/pages/pmd/projectdocs/decisions.md
@@ -1,0 +1,14 @@
+---
+title: Architecture Design Decisions
+sidebar: pmd_sidebar
+permalink: pmd_projectdocs_decisions.html
+last_updated: July 2022
+---
+
+<ul>
+{% for page in site.pages %}
+    {% if page.adr == true and page.adr_status != "" %}
+        <li><a href="{{ page.url }}">{{ page.title }}</a> ({{ page.adr_status }})</li>
+    {% endif %}
+{% endfor %}
+</ul>

--- a/docs/pages/pmd/projectdocs/decisions.md
+++ b/docs/pages/pmd/projectdocs/decisions.md
@@ -1,5 +1,5 @@
 ---
-title: Architecture Design Decisions
+title: Architecture Decisions
 sidebar: pmd_sidebar
 permalink: pmd_projectdocs_decisions.html
 last_updated: July 2022

--- a/docs/pages/pmd/projectdocs/decisions/adr-1.md
+++ b/docs/pages/pmd/projectdocs/decisions/adr-1.md
@@ -1,0 +1,52 @@
+---
+title: ADR 1 - Use architecture decision records
+sidebar: pmd_sidebar
+permalink: pmd_projectdocs_decisions_adr_1.html
+sidebaractiveurl: /pmd_projectdocs_decisions.html
+adr: true
+# Proposed / Accepted / Deprecated / Superseded
+adr_status: "Proposed"
+last_updated: July 2022
+---
+
+# Context
+
+PMD has grown over 20 years as an open-source project. Along the way many decisions have been made, but they are not
+explicitly documented. PMD is also developed by many individuals and the original developers might
+not even be around anymore.
+
+Without having documentation records about decisions it is hard for new developers to understand the reasons
+of past decisions. This might lead to either ignore these past (unknown) decisions and change it without
+fully understanding its consequences. This could create new issues down the road, e.g. a decision supporting
+a requirement that is not tested.
+
+On the other hand, accepting the past decisions without challenging it might slow down the project and
+possible innovations. It could lead to a situation where the developers are afraid to change anything
+in order to not break the system.
+
+Past decisions have been made within context and the context can change. Therefore, past decisions can still be
+valid today, or they don't apply anymore. In that case, the decision should be revisited.
+
+See also the blog post [Documenting Architecture Decisions](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions)
+by Michael Nygard.
+
+There are many templates around to choose from. <https://github.com/joelparkerhenderson/architecture-decision-record>
+gives a nice summary.
+
+# Decision
+
+We will document the decisions we make as a project as a collection of "Architecture Decision Records".
+In order to keep it simple, we will use only a simple template proposed by Michael Nygard.
+The documents are stored together with the source code and are part of the generated documentation site.
+
+# Status
+
+{{ page.adr_status }}
+
+# Consequences
+
+Explicitly documenting decisions has the benefit that new developers joining the projects know about the decisions
+and can read the context and consequences of the decisions. This will likely also improve the overall quality
+as the decisions need to be formulated and written down. Everybody is on the same page.
+
+However, this also adds additional tasks, and it takes time to write down and document the decisions.

--- a/docs/pages/pmd/projectdocs/decisions/adr-1.md
+++ b/docs/pages/pmd/projectdocs/decisions/adr-1.md
@@ -5,7 +5,7 @@ permalink: pmd_projectdocs_decisions_adr_1.html
 sidebaractiveurl: /pmd_projectdocs_decisions.html
 adr: true
 # Proposed / Accepted / Deprecated / Superseded
-adr_status: "Proposed"
+adr_status: "Accepted"
 last_updated: September 2022
 ---
 
@@ -62,6 +62,8 @@ as the decisions need to be formulated and written down. Everybody is on the sam
 However, this also adds additional tasks, and it takes time to write down and document the decisions.
 
 # Change History
+
+2022-09-30: Status changed to "Accepted".
 
 2022-09-06: Added section "Change History" to the template. Added "Last updated" to "Status" section.
 

--- a/docs/pages/pmd/projectdocs/decisions/adr-1.md
+++ b/docs/pages/pmd/projectdocs/decisions/adr-1.md
@@ -6,7 +6,7 @@ sidebaractiveurl: /pmd_projectdocs_decisions.html
 adr: true
 # Proposed / Accepted / Deprecated / Superseded
 adr_status: "Proposed"
-last_updated: July 2022
+last_updated: September 2022
 ---
 
 # Context
@@ -31,7 +31,7 @@ See also the blog post [Documenting Architecture Decisions](https://cognitect.co
 by Michael Nygard.
 
 There are many templates around to choose from. <https://github.com/joelparkerhenderson/architecture-decision-record>
-gives a nice summary.
+gives a nice summary. The page <https://adr.github.io/> gives a good overview on ADR and for adr-related tooling.
 
 # Decision
 
@@ -39,9 +39,19 @@ We will document the decisions we make as a project as a collection of "Architec
 In order to keep it simple, we will use only a simple template proposed by Michael Nygard.
 The documents are stored together with the source code and are part of the generated documentation site.
 
+A new ADR should be proposed with a pull request to open the discussion.
+The initial status of the new ADR is "Proposed". When maintainer consensus is reached during the PR
+review, then the status is changed to "Accepted" when the PR is merged.
+A new entry in the "Change History" section should be added, when the PR is merged.
+
+In order to propose a change to an existing ADR a new pull request should be opened which modifies the ADR.
+The change can be to amend the ADR or to challenge it and maybe deprecate it. A new entry in the
+"Change History" section should be added to summary the change. When maintainer consensus is reached
+during the PR review, then the PR can be merged and the ADR is updated.
+
 # Status
 
-{{ page.adr_status }}
+{{ page.adr_status }} (Last updated: {{ page.last_updated }})
 
 # Consequences
 
@@ -50,3 +60,9 @@ and can read the context and consequences of the decisions. This will likely als
 as the decisions need to be formulated and written down. Everybody is on the same page.
 
 However, this also adds additional tasks, and it takes time to write down and document the decisions.
+
+# Change History
+
+2022-09-06: Added section "Change History" to the template. Added "Last updated" to "Status" section.
+
+2022-07-28: Proposed initial version.

--- a/docs/pages/pmd/projectdocs/decisions/adr-2.md
+++ b/docs/pages/pmd/projectdocs/decisions/adr-2.md
@@ -1,0 +1,65 @@
+---
+title: ADR 2 - Policy on the use of Kotlin for development
+sidebar: pmd_sidebar
+permalink: pmd_projectdocs_decisions_adr_2.html
+sidebaractiveurl: /pmd_projectdocs_decisions.html
+adr: true
+# Proposed / Accepted / Deprecated / Superseded
+adr_status: "Proposed"
+last_updated: July 2022
+---
+
+# Context
+
+We currently use Kotlin only for unit tests at some places (e.g. pmd-lang-test module provides a couple of base
+test classes). We were cautious to expand Kotlin because of poor development support outside JetBrain's
+IntelliJ IDEA. E.g. the [Kotlin Plugin for Eclipse](https://marketplace.eclipse.org/content/kotlin-plugin-eclipse)
+doesn't work properly as described in the reviews.
+
+For VS Code there is a [Kotlin Plugin](https://marketplace.visualstudio.com/items?itemName=mathiasfrohlich.Kotlin)
+with basic features. Online IDEs like gitpod.io and GitHub Codespaces are often based on VS Code.
+
+Using Kotlin means, that we accept, that PMD can only be developed with IntelliJ IDEA. This feels like a vendor lock-in.
+
+Also, bringing in a mix of languages might make maintenance a bit harder and make it harder for new contributors.
+However - PMD is a tool that deals with many, many languages anyway, so this is maybe not a real argument.
+
+Nevertheless, extending the usage of Kotlin within PMD can also increase contributions.
+
+# Decision
+
+We are generally open to the idea to increase usage of Kotlin within PMD. In order to gain experience
+and to keep it within bounds and therefore maintainable we came up with the following rules:
+
+* The module `pmd-core` should stay in plain Java. This helps in keeping binary compatibility when changing sources.
+  `pmd-core` contains the main APIs for all language modules. We currently release all modules at the same time,
+  so this is not a real problem for now. But that might change in the future: Because only few language modules have
+  actual changes per release, it doesn't really make sense to release everything as long as the modules stay
+  compatible. But that's another story.
+* For (unit) testing, Kotlin can be used in `pmd-core` and in the language modules. The test frameworks can also
+  use Kotlin (`pmd-test` doesn't yet, `pmd-lang-test` does already).
+* Additionally: from now on, we allow to have the individual language modules be implemented in different languages
+  when it makes sense. So, a language module might decide to use plain Java (like now) or also Kotlin
+  (or other languages if it fits).
+* When mixing languages (e.g. Java + Kotlin), we need to care that the modules can still be used with plain Java.
+  E.g. when writing custom rules: `pmd-java` provides a couple of APIs for rules (like symbol table, type resolution)
+  and we should not force the users to use Kotlin (at least not for language modules which already exist and
+  for which users might have written custom rules in Java already).
+* It is also possible to write the entire language module in Kotlin only. Then the rules would be written in Kotlin
+  as well. And the possible problems when mixing languages are gone. But that applies only for new language modules.
+  For compatibility reasons an existing language modules shouldn't be rewritten into Kotlin. That would be a
+  major version change.
+
+# Status
+
+{{ page.adr_status }}
+
+# Consequences
+
+Allowing more Kotlin in PMD can attract new contributions. It might make it easier to develop small DSLs.
+Also, other languages than Kotlin could be used, e.g. for `pmd-scala` Scala might make sense.
+
+On the other side, other IDEs than IntelliJ IDEA will have a difficult time to deal with PMD's source code.
+Eclipse can't be used practically anymore.
+
+Maintaining a polyglot code base with multiple languages is likely to be more challenging.

--- a/docs/pages/pmd/projectdocs/decisions/adr-2.md
+++ b/docs/pages/pmd/projectdocs/decisions/adr-2.md
@@ -6,7 +6,7 @@ sidebaractiveurl: /pmd_projectdocs_decisions.html
 adr: true
 # Proposed / Accepted / Deprecated / Superseded
 adr_status: "Proposed"
-last_updated: July 2022
+last_updated: September 2022
 ---
 
 # Context
@@ -39,27 +39,31 @@ and to keep it within bounds and therefore maintainable we came up with the foll
 * For (unit) testing, Kotlin can be used in `pmd-core` and in the language modules. The test frameworks can also
   use Kotlin (`pmd-test` doesn't yet, `pmd-lang-test` does already).
 * Additionally: from now on, we allow to have the individual language modules be implemented in different languages
-  when it makes sense. So, a language module might decide to use plain Java (like now) or also Kotlin
-  (or other languages if it fits).
+  when it makes sense. So, a language module might decide to use plain Java (like now) or also Kotlin.
 * When mixing languages (e.g. Java + Kotlin), we need to care that the modules can still be used with plain Java.
   E.g. when writing custom rules: `pmd-java` provides a couple of APIs for rules (like symbol table, type resolution)
   and we should not force the users to use Kotlin (at least not for language modules which already exist and
   for which users might have written custom rules in Java already).
 * It is also possible to write the entire language module in Kotlin only. Then the rules would be written in Kotlin
   as well. And the possible problems when mixing languages are gone. But that applies only for new language modules.
-  For compatibility reasons an existing language modules shouldn't be rewritten into Kotlin. That would be a
+* When refactoring an existing language module from Java only to introduce Kotlin, care needs to be taken to
+  not make incompatible changes. If compatibility (binary or source) can't be maintained, then that would be a
   major version change.
 
 # Status
 
-{{ page.adr_status }}
+{{ page.adr_status }} (Last updated: {{ page.last_updated }})
 
 # Consequences
 
 Allowing more Kotlin in PMD can attract new contributions. It might make it easier to develop small DSLs.
-Also, other languages than Kotlin could be used, e.g. for `pmd-scala` Scala might make sense.
+In the future we might also consider to use other languages than Kotlin, e.g. for `pmd-scala` Scala might make sense.
 
-On the other side, other IDEs than IntelliJ IDEA will have a difficult time to deal with PMD's source code.
-Eclipse can't be used practically anymore.
+On the other side, other IDEs than IntelliJ IDEA will have a difficult time to deal with PMD's source code
+when Kotlin is used. Eclipse can't be used practically anymore.
 
 Maintaining a polyglot code base with multiple languages is likely to be more challenging.
+
+# Change History
+
+2022-07-28: Proposed initial version.

--- a/docs/pages/pmd/projectdocs/decisions/adr-2.md
+++ b/docs/pages/pmd/projectdocs/decisions/adr-2.md
@@ -5,7 +5,7 @@ permalink: pmd_projectdocs_decisions_adr_2.html
 sidebaractiveurl: /pmd_projectdocs_decisions.html
 adr: true
 # Proposed / Accepted / Deprecated / Superseded
-adr_status: "Proposed"
+adr_status: "Accepted"
 last_updated: September 2022
 ---
 
@@ -65,5 +65,7 @@ when Kotlin is used. Eclipse can't be used practically anymore.
 Maintaining a polyglot code base with multiple languages is likely to be more challenging.
 
 # Change History
+
+2022-09-30: Changed status to "Accepted".
 
 2022-07-28: Proposed initial version.

--- a/docs/pages/pmd/projectdocs/decisions/adr-NNN.md
+++ b/docs/pages/pmd/projectdocs/decisions/adr-NNN.md
@@ -2,6 +2,7 @@
 title: ADR NNN - Template
 sidebar: pmd_sidebar
 permalink: pmd_projectdocs_decisions_adr_NNN.html
+sidebaractiveurl: /pmd_projectdocs_decisions.html
 adr: true
 # Proposed / Accepted / Deprecated / Superseded
 adr_status: ""

--- a/docs/pages/pmd/projectdocs/decisions/adr-NNN.md
+++ b/docs/pages/pmd/projectdocs/decisions/adr-NNN.md
@@ -21,8 +21,14 @@ What is the change that we're proposing and/or doing?
 
 # Status
 
-{{ page.adr_status }}
+{{ page.adr_status }} (Last updated: {{ page.last_updated }})
 
 # Consequences
 
 What becomes easier or more difficult to do because of this change?
+
+# Change History
+
+YYYY-MM-DD: Add xyz.
+
+YYYY-MM-DD: Proposed initial version.

--- a/docs/pages/pmd/projectdocs/decisions/adr-NNN.md
+++ b/docs/pages/pmd/projectdocs/decisions/adr-NNN.md
@@ -1,0 +1,27 @@
+---
+title: ADR NNN - Template
+sidebar: pmd_sidebar
+permalink: pmd_projectdocs_decisions_adr_NNN.html
+adr: true
+# Proposed / Accepted / Deprecated / Superseded
+adr_status: ""
+last_updated: July 2022
+---
+
+<!-- https://github.com/joelparkerhenderson/architecture-decision-record/blob/main/templates/decision-record-template-by-michael-nygard/index.md -->
+
+# Context
+
+What is the issue that we're seeing that is motivating this decision or change?
+
+# Decision
+
+What is the change that we're proposing and/or doing?
+
+# Status
+
+{{ page.adr_status }}
+
+# Consequences
+
+What becomes easier or more difficult to do because of this change?


### PR DESCRIPTION
## Describe the PR

This is a first draft on adding explicit decision records to our project.
It came up as a question in #3766 about Kotlin usage.

I'm not sure in what details we would need to describe the decisions or which decisions at all. I guess, we need to learn this over time.

Feel free to give feedback or ask questions - the goal is to have the decision records as an agreement and understandable by everybody.

I've integrated these into the doc site, they appear under "Project documentation":
![grafik](https://user-images.githubusercontent.com/1573684/181506149-f5619913-839d-4221-b440-b68f7cc38c1d.png)

But since these documents are simple markdown files, they can also be seen directly on github.