### PR TITLE
[core] Add "--debug" flag for CPD

### DIFF
--- a/docs/pages/pmd/userdocs/cpd/cpd.md
+++ b/docs/pages/pmd/userdocs/cpd/cpd.md
@@ -73,6 +73,9 @@ Novice as much as advanced readers may want to [read on on Refactoring Guru](htt
                description="Sources code language."
                default="java"
     %}
+    {% include custom/cli_option_row.html options="--debug,--verbose"
+               description="Debug mode. Prints more log output."
+    %}
     {% include custom/cli_option_row.html options="--encoding"
                description="Character encoding to use when processing files. If not specified, CPD uses the system default encoding."
     %}

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -44,6 +44,7 @@ Being based on a proper Antlr grammar, CPD can:
 * apex
     * [#4056](https://github.com/pmd/pmd/pull/4056): \[apex] ApexSOQLInjection: Add support count query
 * core
+    * [#3796](https://github.com/pmd/pmd/issues/3796): \[core] CPD should also provide a `--debug` flag
     * [#4021](https://github.com/pmd/pmd/pull/4021): \[core] CPD: Add total number of tokens to XML reports
     * [#4031](https://github.com/pmd/pmd/issues/4031): \[core] If report is written to stdout, stdout should not be closed
     * [#4051](https://github.com/pmd/pmd/issues/4051): \[doc] Additional rulesets are not listed in documentation
@@ -65,6 +66,11 @@ Being based on a proper Antlr grammar, CPD can:
     * [#3976](https://github.com/pmd/pmd/pull/3976): \[test] Extract xml schema module
 
 ### API Changes
+
+#### CPD CLI
+
+* CPD has a new CLI option `--debug`. This option has the same behavior as in PMD. It enables more verbose
+  logging output.
 
 #### Rule Test Framework
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
@@ -141,6 +141,9 @@ public class CPDConfiguration extends AbstractConfiguration {
             description = "By default CPD exits with status 4 if code duplications are found. Disable this option with '-failOnViolation false' to exit with 0 instead and just write the report.")
     private boolean failOnViolation = true;
 
+    @Parameter(names = { "--debug", "--verbose" }, description = "Debug mode.")
+    private boolean debug = false;
+
     // this has to be a public static class, so that JCommander can use it!
     public static class LanguageConverter implements IStringConverter<Language> {
 
@@ -539,5 +542,15 @@ public class CPDConfiguration extends AbstractConfiguration {
 
     public void setFailOnViolation(boolean failOnViolation) {
         this.failOnViolation = failOnViolation;
+    }
+
+    @Override
+    public boolean isDebug() {
+        return debug;
+    }
+
+    @Override
+    public void setDebug(boolean debug) {
+        this.debug = debug;
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CPDCommandLineInterfaceTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CPDCommandLineInterfaceTest.java
@@ -4,6 +4,9 @@
 
 package net.sourceforge.pmd.cpd;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -99,7 +102,7 @@ public class CPDCommandLineInterfaceTest {
         CPD.StatusCode statusCode = CPD.runCpd("--minimum-tokens", "340", "--language", "java", "--files",
                 SRC_DIR, "--debug");
         assertEquals(CPD.StatusCode.OK, statusCode);
-        assertTrue(errLog.getLog().contains("Tokenizing ")); // this is a debug logging
+        assertThat(errLog.getLog(), containsString("Tokenizing ")); // this is a debug logging
     }
 
     @Test
@@ -108,6 +111,6 @@ public class CPDCommandLineInterfaceTest {
         CPD.StatusCode statusCode = CPD.runCpd("--minimum-tokens", "340", "--language", "java", "--files",
                 SRC_DIR);
         assertEquals(CPD.StatusCode.OK, statusCode);
-        assertFalse(errLog.getLog().contains("Tokenizing ")); // this is a debug logging
+        assertThat(errLog.getLog(), not(containsString("Tokenizing "))); // this is a debug logging
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CPDCommandLineInterfaceTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CPDCommandLineInterfaceTest.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.cpd;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -17,9 +18,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.SystemErrRule;
 import org.junit.contrib.java.lang.system.SystemOutRule;
 import org.junit.rules.TemporaryFolder;
 
@@ -39,6 +40,10 @@ public class CPDCommandLineInterfaceTest {
 
     @Rule
     public final SystemOutRule log = new SystemOutRule().enableLog().muteForSuccessfulTests();
+
+    @Rule
+    public final SystemErrRule errLog = new SystemErrRule().enableLog().muteForSuccessfulTests();
+
     @Rule
     public final JavaUtilLoggingRule loggingRule = new JavaUtilLoggingRule(PMD.class.getPackage().getName()).mute();
     @Rule
@@ -65,8 +70,8 @@ public class CPDCommandLineInterfaceTest {
         CPD.StatusCode statusCode = CPD.runCpd("--minimum-tokens", "340", "--language", "java", "--files",
                 SRC_DIR, "--format", "xml");
         final String expectedFilesXml = getExpectedFileEntriesXml(NUMBER_OF_TOKENS.keySet());
-        Assert.assertEquals(CPD.StatusCode.OK, statusCode);
-        Assert.assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "\n" + "<pmd-cpd>" + "\n" + expectedFilesXml + "</pmd-cpd>", log.getLog());
+        assertEquals(CPD.StatusCode.OK, statusCode);
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "\n" + "<pmd-cpd>" + "\n" + expectedFilesXml + "</pmd-cpd>", log.getLog());
     }
 
     @Test
@@ -80,12 +85,29 @@ public class CPDCommandLineInterfaceTest {
 
         CPD.StatusCode statusCode = CPD.runCpd("--minimum-tokens", "340", "--language", "java", "--filelist",
                 filelist.toAbsolutePath().toString(), "--format", "xml", "-failOnViolation", "true");
-        Assert.assertEquals(CPD.StatusCode.OK, statusCode);
-        Assert.assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "\n" + "<pmd-cpd>" + "\n" + expectedFilesXml + "</pmd-cpd>", log.getLog());
+        assertEquals(CPD.StatusCode.OK, statusCode);
+        assertEquals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>" + "\n" + "<pmd-cpd>" + "\n" + expectedFilesXml + "</pmd-cpd>", log.getLog());
         assertTrue(loggingRule.getLog().contains("Some deprecated options were used on the command-line, including -failOnViolation"));
         assertTrue(loggingRule.getLog().contains("Consider replacing it with --fail-on-violation"));
         // only one parameter is logged
         assertFalse(loggingRule.getLog().contains("Some deprecated options were used on the command-line, including --filelist"));
         assertFalse(loggingRule.getLog().contains("Consider replacing it with --file-list"));
+    }
+
+    @Test
+    public void testDebugLogging() {
+        CPD.StatusCode statusCode = CPD.runCpd("--minimum-tokens", "340", "--language", "java", "--files",
+                SRC_DIR, "--debug");
+        assertEquals(CPD.StatusCode.OK, statusCode);
+        assertTrue(errLog.getLog().contains("Tokenizing ")); // this is a debug logging
+    }
+
+    @Test
+    public void testNormalLogging() {
+        loggingRule.clear();
+        CPD.StatusCode statusCode = CPD.runCpd("--minimum-tokens", "340", "--language", "java", "--files",
+                SRC_DIR);
+        assertEquals(CPD.StatusCode.OK, statusCode);
+        assertFalse(errLog.getLog().contains("Tokenizing ")); // this is a debug logging
     }
 }


### PR DESCRIPTION

## Describe the PR

- Also adds the alternative `--verbose`, but doesn't add the single character options.
- Adds a couple of debug log statements to CPD - currently we do not seem to use logging very often here - usually a System.err print is used. But that's something for later to improve.
- Fixes #3796

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

