### PR TITLE
[java] UnnecessaryImport false positive for on-demand imports of nested classes (fix for #4082)

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryImportRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryImportRule.java
@@ -210,6 +210,20 @@ public class UnnecessaryImportRule extends AbstractJavaRule {
             }
         }
 
+        // check on-demand imports for inner classes
+        it = imports.iterator();
+        while (it.hasNext()) {
+            ImportWrapper i = it.next();
+            if (!i.isStaticOnDemand() && i.isOnDemand()) {
+                String possibleClassName = i.getFullName() + "$" + candName;
+                Class<?> possibleClazz = referenceNode.getRoot().getClassTypeResolver()
+                        .loadClassOrNull(possibleClassName);
+                if (possibleClazz != null) {
+                    it.remove();
+                }
+            }
+        }
+
         // check static on-demand imports
         it = imports.iterator();
         while (it.hasNext()) {
@@ -217,6 +231,20 @@ public class UnnecessaryImportRule extends AbstractJavaRule {
             if (i.isStaticOnDemand() && i.matches(candFullName, candName)) {
                 it.remove();
                 return;
+            }
+        }
+
+        // check static on-demand imports for static inner classes
+        it = imports.iterator();
+        while (it.hasNext()) {
+            ImportWrapper i = it.next();
+            if (i.isStaticOnDemand()) {
+                String possibleClassName = i.getFullName() + "$" + candName;
+                Class<?> possibleClazz = referenceNode.getRoot().getClassTypeResolver()
+                        .loadClassOrNull(possibleClassName);
+                if (possibleClazz != null) {
+                    it.remove();
+                }
             }
         }
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/package2/C.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/package2/C.java
@@ -7,9 +7,9 @@ package net.sourceforge.pmd.lang.java.rule.codestyle.unnecessaryimport.package2;
 public class C {
     private C() { }
 
-    public class IC {}
+    public class IC { }
 
-    public static class ISC {}
+    public static class ISC { }
 
     public static final String V = "";
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/package2/C.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/package2/C.java
@@ -7,5 +7,9 @@ package net.sourceforge.pmd.lang.java.rule.codestyle.unnecessaryimport.package2;
 public class C {
     private C() { }
 
+    public class IC {}
+
+    public static class ISC {}
+
     public static final String V = "";
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryImport.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryImport.xml
@@ -917,6 +917,34 @@ public class U {
     </test-code>
 
     <test-code>
+        <description>[java] UnnecessaryImport false positive for on-demand imports of non-static nested classes</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+package net.sourceforge.pmd.lang.java.rule.codestyle.unnecessaryimport.package1;
+
+import net.sourceforge.pmd.lang.java.rule.codestyle.unnecessaryimport.package2.C.*; // SUPPRESS CHECKSTYLE needed for test case
+
+public class U {
+    IC c;
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] UnnecessaryImport false positive for static on-demand imports of static nested classes</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+package net.sourceforge.pmd.lang.java.rule.codestyle.unnecessaryimport.package1;
+
+import static net.sourceforge.pmd.lang.java.rule.codestyle.unnecessaryimport.package2.C.*; // SUPPRESS CHECKSTYLE needed for test case
+
+public class U {
+    ISC sc;
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>Necessary imports for @snippet tags introduced with JEP 413 in Java 18</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
On-demand imports for nested classes (non-static or static) are reported as false positives for `UnnecessaryImport` rule.

When nested classes imported on-demand their full class name is `ParentClass$NestedClass`, so imported nested class must be searched in classpath using that full name.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #4082 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

