### PR TITLE
[core] CPD: Added begin and end token to XML reports

### DIFF
--- a/docs/pages/pmd/userdocs/cpd/cpd_report_formats.md
+++ b/docs/pages/pmd/userdocs/cpd/cpd_report_formats.md
@@ -104,9 +104,9 @@ Example:
    <file path="/home/pmd/source/pmd-core/src/test/java/net/sourceforge/pmd/RuleReferenceTest.java" totalNumberOfTokens="523"/>
    <file path="/home/pmd/source/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/JaxenXPathRuleQueryTest.java" totalNumberOfTokens="120"/>
    <duplication lines="33" tokens="239">
-      <file column="29" endcolumn="75" endline="64" line="32"
+      <file column="29" endcolumn="75" endline="64" line="32" begintoken="2356" endtoken="2594"
             path="/home/pmd/source/pmd-core/src/test/java/net/sourceforge/pmd/RuleReferenceTest.java"/>
-      <file column="37" endcolumn="75" endline="100" line="68"
+      <file column="37" endcolumn="75" endline="100" line="68" begintoken="5700" endtoken="5938"
             path="/home/pmd/source/pmd-core/src/test/java/net/sourceforge/pmd/RuleReferenceTest.java"/>
       <codefragment><![CDATA[    public void testOverride() {
         final StringProperty PROPERTY1_DESCRIPTOR = new StringProperty("property1", "Test property", null, 0f);
@@ -143,11 +143,11 @@ Example:
         validateOverriddenValues(PROPERTY1_DESCRIPTOR, PROPERTY2_DESCRIPTOR, ruleReference);]]></codefragment>
    </duplication>
    <duplication lines="16" tokens="110">
-      <file column="9" endcolumn="28" endline="81" line="66"
+      <file column="9" endcolumn="28" endline="81" line="66" begintoken="3000" endtoken="3109"
             path="/home/pmd/source/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/JaxenXPathRuleQueryTest.java"/>
-      <file column="9" endcolumn="28" endline="103" line="88"
+      <file column="9" endcolumn="28" endline="103" line="88" begintoken="3200" endtoken="3309"
             path="/home/pmd/source/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/JaxenXPathRuleQueryTest.java"/>
-      <file column="9" endcolumn="28" endline="125" line="110"
+      <file column="9" endcolumn="28" endline="125" line="110" begintoken="3400" endtoken="3509"
             path="/home/pmd/source/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/JaxenXPathRuleQueryTest.java"/>
       <codefragment><![CDATA[        JaxenXPathRuleQuery query = createQuery(xpath);
         List<String> ruleChainVisits = query.getRuleChainVisits();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/Mark.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/Mark.java
@@ -35,6 +35,10 @@ public class Mark implements Comparable<Mark> {
         return this.token.getBeginColumn(); // TODO Java 1.8 make optional
     }
 
+    public int getBeginTokenIndex() {
+        return this.token.getIndex();
+    }
+
     public int getEndLine() {
         return getBeginLine() + getLineCount() - 1;
     }
@@ -46,6 +50,10 @@ public class Mark implements Comparable<Mark> {
      */
     public int getEndColumn() {
         return this.endToken == null ? -1 : this.endToken.getEndColumn(); // TODO Java 1.8 make optional
+    }
+
+    public int getEndTokenIndex() {
+        return this.endToken == null ? -1 : this.endToken.getIndex();
     }
 
     public int getLineCount() {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLRenderer.java
@@ -152,6 +152,12 @@ public final class XMLRenderer implements Renderer, CPDRenderer, CPDReportRender
             if (endCol != -1) {
                 file.setAttribute("endcolumn", String.valueOf(endCol));
             }
+            final int beginIndex = mark.getBeginTokenIndex();
+            final int endIndex = mark.getEndTokenIndex();
+            file.setAttribute("begintoken", String.valueOf(beginIndex));
+            if (endIndex != -1) {
+                file.setAttribute("endtoken", String.valueOf(endIndex));
+            }
             duplication.appendChild(file);
         }
         return duplication;

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/XMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/XMLRendererTest.java
@@ -217,6 +217,38 @@ public class XMLRendererTest {
     }
 
     @Test
+    public void testGetDuplicationStartEnd() throws IOException, ParserConfigurationException, SAXException {
+        TokenEntry.clearImages();
+        final CPDReportRenderer renderer = new XMLRenderer();
+        final List<Match> matches = new ArrayList<>();
+        final String filename = "/var/Foo.java";
+        final int lineCount = 6;
+        final String codeFragment = "code\nfragment";
+        final Mark mark1 = createMark("public", filename, 1, lineCount, codeFragment, 2, 3);
+        final Mark mark2 = createMark("stuff", filename, 73, lineCount, codeFragment, 4, 5);
+        final Match match = new Match(75, mark1, mark2);
+        matches.add(match);
+        final Map<String, Integer> numberOfTokensPerFile = new HashMap<>();
+        numberOfTokensPerFile.put(filename, 888);
+        final CPDReport report = new CPDReport(matches, numberOfTokensPerFile);
+        final StringWriter writer = new StringWriter();
+        renderer.render(report, writer);
+        final String xmlOutput = writer.toString();
+        final Document doc = DocumentBuilderFactory.newInstance().newDocumentBuilder()
+                .parse(new ByteArrayInputStream(xmlOutput.getBytes(ENCODING)));
+        final NodeList files = doc.getElementsByTagName("file");
+        final Node dup_1 = files.item(1);
+        final NamedNodeMap attrs_1 = dup_1.getAttributes();
+        assertEquals("0", attrs_1.getNamedItem("begintoken").getNodeValue());
+        assertEquals("1", attrs_1.getNamedItem("endtoken").getNodeValue());
+
+        final Node dup_2 = files.item(2);
+        final NamedNodeMap attrs_2 = dup_2.getAttributes();
+        assertEquals("2", attrs_2.getNamedItem("begintoken").getNodeValue());
+        assertEquals("3", attrs_2.getNamedItem("endtoken").getNodeValue());
+    }
+
+    @Test
     public void testRendererEncodedPath() throws IOException {
         CPDRenderer renderer = new XMLRenderer();
         List<Match> list = new ArrayList<>();


### PR DESCRIPTION
## Describe the PR

Extends the XML output of CPD by adding the indices of the starting and ending tokens in each code duplication entry, like this:

```
<file column="29" endcolumn="75" endline="64" line="32" begintoken="2356" endtoken="2594"
  path="/home/pmd/source/pmd-core/src/test/java/net/sourceforge/pmd/RuleReferenceTest.java"/>
```

This is to further help the use case as described in https://github.com/pmd/pmd/pull/4021#issuecomment-1165635048

## Related issues

Continuation of the work done in [#4021](https://github.com/pmd/pmd/pull/4021).

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

