### PR TITLE
[apex] Feature/unused variable bind false positive with dynamic SOQL

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableRule.java
@@ -5,11 +5,20 @@
 package net.sourceforge.pmd.lang.apex.rule.bestpractices;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTBlockStatement;
+import net.sourceforge.pmd.lang.apex.ast.ASTLiteralExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTReferenceExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration;
 import net.sourceforge.pmd.lang.apex.ast.ASTVariableExpression;
@@ -17,6 +26,14 @@ import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 
 public class UnusedLocalVariableRule extends AbstractApexRule {
+    private static final Set<String> DATABASE_QUERY_METHODS = new HashSet<>(Arrays.asList(
+            "Database.query".toLowerCase(Locale.ROOT),
+            "Database.getQueryLocator".toLowerCase(Locale.ROOT),
+            "Database.countQuery".toLowerCase(Locale.ROOT)
+    ));
+
+    private static final Pattern BINDING_VARIABLE = Pattern.compile("(?i):([a-z0-9]+)");
+
     public UnusedLocalVariableRule() {
         addRuleChainVisit(ASTVariableDeclaration.class);
     }
@@ -48,7 +65,56 @@ public class UnusedLocalVariableRule extends AbstractApexRule {
             }
         }
 
+        List<String> soqlBindingVariables = findBindingsInSOQLStringLiterals(variableContext);
+        if (soqlBindingVariables.contains(variableName.toLowerCase(Locale.ROOT))) {
+            return data;
+        }
+
         addViolation(data, node, variableName);
         return data;
+    }
+
+    private List<String> findBindingsInSOQLStringLiterals(ASTBlockStatement variableContext) {
+        List<String> bindingVariables = new ArrayList<>();
+
+        List<ASTMethodCallExpression> methodCalls = variableContext.findDescendantsOfType(ASTMethodCallExpression.class)
+            .stream()
+            .filter(m -> DATABASE_QUERY_METHODS.contains(m.getFullMethodName().toLowerCase(Locale.ROOT)))
+            .collect(Collectors.toList());
+
+        methodCalls.forEach(databaseMethodCall -> {
+            List<String> stringLiterals = new ArrayList<>();
+            stringLiterals.addAll(databaseMethodCall.findDescendantsOfType(ASTLiteralExpression.class)
+                    .stream()
+                    .filter(ASTLiteralExpression::isString)
+                    .map(ASTLiteralExpression::getImage)
+                    .collect(Collectors.toList()));
+
+            databaseMethodCall.findDescendantsOfType(ASTVariableExpression.class).forEach(variableUsage -> {
+                String referencedVariable = variableUsage.getImage();
+
+                // Search other usages of the same variable within this code block
+                variableContext.findDescendantsOfType(ASTVariableExpression.class)
+                        .stream()
+                        .filter(usage -> referencedVariable.equalsIgnoreCase(usage.getImage()))
+                        .forEach(usage -> {
+                            stringLiterals.addAll(usage.getParent()
+                                    .findChildrenOfType(ASTLiteralExpression.class)
+                                    .stream()
+                                    .filter(ASTLiteralExpression::isString)
+                                    .map(ASTLiteralExpression::getImage)
+                                    .collect(Collectors.toList()));
+                        });
+            });
+
+            stringLiterals.forEach(s -> {
+                Matcher matcher = BINDING_VARIABLE.matcher(s);
+                while (matcher.find()) {
+                    bindingVariables.add(matcher.group(1).toLowerCase(Locale.ROOT));
+                }
+            });
+        });
+
+        return bindingVariables;
     }
 }

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/UnusedLocalVariable.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/UnusedLocalVariable.xml
@@ -109,6 +109,24 @@ class Foo {
         return bar;
     }
 }
-        ]]></code>
+        ]]>
+        </code>
+    </test-code>
+
+    <test-code>
+        <description>[apex] UnusedLocalVariable - false positive on string query #2669</description>
+        <expected-problems>0</expected-problems>
+        <code>
+            <![CDATA[
+class Foo {
+    public Database.QueryLocator start(Database.BatchableContext BC) {
+        String customValue  = 'Test';
+        String query = 'SELECT Id FROM Case ';
+        query += 'WHERE CustomField__c = :customValue ';
+        return Database.getQueryLocator(query);
+    }
+}
+        ]]>
+        </code>
     </test-code>
 </test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/UnusedLocalVariable.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/UnusedLocalVariable.xml
@@ -119,11 +119,40 @@ class Foo {
         <code>
             <![CDATA[
 class Foo {
-    public Database.QueryLocator start(Database.BatchableContext BC) {
-        String customValue  = 'Test';
+    public Database.QueryLocator start1(Database.BatchableContext BC) {
+        String customValue = 'Test';
         String query = 'SELECT Id FROM Case ';
         query += 'WHERE CustomField__c = :customValue ';
         return Database.getQueryLocator(query);
+    }
+
+    public Database.QueryLocator start2(Database.BatchableContext BC) {
+        String customValue = 'Test';
+        return Database.getQueryLocator('SELECT Id From Case WHERE CustomField__c = :customValue');
+    }
+
+    public void doQuery1() {
+        String customValue = 'Test';
+        String query = 'SELECT Id FROM Case ';
+        query += 'WHERE CustomField__c = :customValue ';
+        Database.query(query);
+    }
+
+    public void doQuery2() {
+        String customValue = 'Test';
+        Database.query('SELECT Id From Case WHERE CustomField__c = :customValue');
+    }
+
+    public void doCount1() {
+        String customValue = 'Test';
+        String query = 'SELECT Id FROM Case ';
+        query += 'WHERE CustomField__c = :customValue ';
+        Database.countQuery(query);
+    }
+
+    public void doCount2() {
+        String customValue = 'Test';
+        Database.countQuery('SELECT Id From Case WHERE CustomField__c = :customValue');
     }
 }
         ]]>


### PR DESCRIPTION
## Describe the PR
This PR fix the false positive issue on UnusedLocalVariable rule, when variable is used as bind variable in string soql query.


## Related issues

- Fixes #2669
- Refs #3489

## Ready?
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

