### PR TITLE
[core] Fix missing --file arg in TreeExport CLI example

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeExportCli.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeExportCli.java
@@ -139,7 +139,7 @@ public class TreeExportCli {
         sb.append(System.lineSeparator())
             .append(System.lineSeparator());
 
-        sb.append("Example: ast-dump --format xml --language java MyFile.java")
+        sb.append("Example: ast-dump --format xml --language java --file MyFile.java")
             .append(System.lineSeparator());
 
         System.err.print(sb);


### PR DESCRIPTION
## Describe the PR

missing --file arg in TreeExport -  "Example: ast-dump --format xml --language java --file MyFile.java" added

The official doc is correct: https://pmd.github.io/latest/pmd_devdocs_experimental_ast_dump.html

## Related issues

- Fixes "[core] Missing --file arg in TreeExport CLI example"

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

