### PR TITLE
[cli] Fix java version in run.sh script

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -15,6 +15,8 @@ This is a {{ site.pmd.release_type }} release.
 ### New and noteworthy
 
 ### Fixed Issues
+* cli
+    * [#4118](https://github.com/pmd/pmd/issues/4118): \[cli] run.sh designer reports "integer expression expected"
 
 ### API Changes
 

--- a/pmd-dist/src/main/resources/scripts/designer.bat
+++ b/pmd-dist/src/main/resources/scripts/designer.bat
@@ -4,35 +4,41 @@ set OPTS=
 set MAIN_CLASS=net.sourceforge.pmd.util.fxdesigner.DesignerStarter
 
 
-:: sets the jver variable to the java version, eg 901 for 9.0.1+x or 180 for 1.8.0_171-b11
+:: sets the jver variable to the java version, eg 90 for 9.0.1+x or 80 for 1.8.0_171-b11 or 110 for 11.0.6.1
 :: sets the jvendor variable to either java (oracle) or openjdk
 for /f tokens^=1^,3^,4^,5^ delims^=.-_+^"^  %%j in ('java -version 2^>^&1 ^| find "version"') do (
   set jvendor=%%j
   if %%l EQU ea (
-    set /A "jver=%%k00"
+    set /A "jver=%%k0"
   ) else (
-    set /A jver=%%k%%l%%m
+    if %%k EQU 1 (
+      :: for java version 1.7.x, 1.8.x, ignore the first 1.
+      set /A "jver=%%l%%m"
+    ) else (
+      set /A "jver=%%k%%l"
+    )
   )
 )
 
+
 Set "jreopts="
 :: oracle java 9 and 10 has javafx included as a module
-if /I "%jvendor%" EQU "java" (
-    if %jver% GEQ 900 (
-        if %jver% LSS 1100 (
+if /I %jvendor% == java (
+    if %jver% GEQ 90 (
+        if %jver% LSS 110 (
             :: enable reflection
-            Set jreopts=--add-opens javafx.controls/javafx.scene.control.skin=ALL-UNNAMED
+            set jreopts=--add-opens javafx.controls/javafx.scene.control.skin=ALL-UNNAMED
         )
     )
 )
 
 set "_needjfxlib=0"
-if /I "%jvendor%" EQU "openjdk" set _needjfxlib=1
-if /I "%jvendor%" EQU "java" (
-    if %jver% GEQ 1100 set _needjfxlib=1
+if /I %jvendor% == openjdk set _needjfxlib=1
+if /I %jvendor% == java (
+    if %jver% GEQ 110 set _needjfxlib=1
 )
 if %_needjfxlib% EQU 1 (
-    if %jver% LSS 1000 (
+    if %jver% LSS 100 (
         echo For openjfx at least java 10 is required.
         pause
         exit

--- a/pmd-dist/src/main/resources/scripts/run.sh
+++ b/pmd-dist/src/main/resources/scripts/run.sh
@@ -2,7 +2,7 @@
 
 usage() {
     echo "Usage:"
-    echo "    $(basename $0) <application-name> [-h|-v] ..."
+    echo "    $(basename "$0") <application-name> [-h|-v] ..."
     echo ""
     echo "application-name: valid options are: $(valid_app_options)"
     echo "-h print this help"
@@ -60,9 +60,9 @@ java_heapsize_settings() {
 
 
 set_lib_dir() {
-  if [ -z ${LIB_DIR} ]; then
+  if [ -z "${LIB_DIR}" ]; then
     # Allow for symlinks to this script
-    if [ -L $0 ]; then
+    if [ -L "$0" ]; then
       local script_real_loc=$(readlink "$0")
     else
       local script_real_loc=$0
@@ -83,23 +83,25 @@ check_lib_dir() {
 }
 
 function script_exit() {
-    echo $1 >&2
+    echo "$1" >&2
     exit 1
 }
 
 determine_java_version() {
     local full_ver=$(java -version 2>&1)
-    # java_ver is eg "18" for java 1.8, "90" for java 9.0, "100" for java 10.0.x
-    readonly java_ver=$(echo $full_ver | sed -n '{
+    # java_ver is eg "80" for java 1.8, "90" for java 9.0, "100" for java 10.0.x
+    readonly java_ver=$(echo "$full_ver" | sed -n '{
         # replace early access versions, e.g. 11-ea with 11.0.0
         s/-ea/.0.0/
         # replace versions such as 10 with 10.0.0
         s/version "\([0-9]\{1,\}\)"/version "\1.0.0"/
+        # replace old java versions 1.x.* (java 1.7, java 1.8) with x.*
+        s/version "1\.\(.*\)"/version "\1"/
         # extract the major and minor parts of the version
-        s/^.* version "\(.*\)\.\(.*\)\..*".*$/\1\2/p
+        s/^.* version "\([0-9]\{1,\}\)\.\([0-9]\{1,\}\).*".*$/\1\2/p
     }')
     # java_vendor is either java (oracle) or openjdk
-    readonly java_vendor=$(echo $full_ver | sed -n -e 's/^\(.*\) version .*$/\1/p')
+    readonly java_vendor=$(echo "$full_ver" | sed -n -e 's/^\(.*\) version .*$/\1/p')
 }
 
 jre_specific_vm_options() {
@@ -197,7 +199,7 @@ case "${APPNAME}" in
     readonly CLASSNAME="net.sourceforge.pmd.util.treeexport.TreeExportCli"
     ;;
   *)
-    echo "${APPNAME} is NOT a valid application name, valid options are:$(valid_app_options)"
+    echo "${APPNAME} is NOT a valid application name, valid options are: $(valid_app_options)"
     ;;
 esac
 

--- a/pmd-dist/src/test/resources/scripts/designertest.bat
+++ b/pmd-dist/src/test/resources/scripts/designertest.bat
@@ -1,0 +1,103 @@
+@echo off
+
+:: BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+
+::
+:: Simple manual test script
+:: - code is copied from designer.bat to be tested here (so please check, it might be out of sync)
+:: - mostly the function "determine_java_version" is tested here
+:: - just run it with "designertest.bat" and look at the output
+:: - test cases are at the end of this script
+::
+
+GOTO :main
+
+:determine_java_version
+:: sets the jver variable to the java version, eg 90 for 9.0.1+x or 80 for 1.8.0_171-b11 or 110 for 11.0.6.1
+:: sets the jvendor variable to either java (oracle) or openjdk
+for /f tokens^=1^,3^,4^,5^ delims^=.-_+^"^  %%j in (%full_version%) do (
+  set jvendor=%%j
+  if %%l EQU ea (
+    set /A "jver=%%k0"
+  ) else (
+    if %%k EQU 1 (
+      :: for java version 1.7.x, 1.8.x, ignore the first 1.
+      set /A "jver=%%l%%m"
+    ) else (
+      set /A "jver=%%k%%l"
+    )
+  )
+)
+
+set detection=
+if %jver% GEQ 70 (
+    if %jver% LSS 80 (
+        set detection="detected java 7"
+    )
+)
+if [%detection%] == [] (
+    if %jver% GEQ 80 (
+        if %jver% LSS 90 (
+            set detection="detected java 8"
+        )
+    )
+)
+if [%detection%] == [] (
+    if %jver% GEQ 90 (
+        if %jver% LSS 110 (
+          if %jvendor% == java (
+              set detection="detected java 9 or 10 from oracle"
+          )
+        )
+    )
+)
+if [%detection%] == [] (
+    if %jvendor% == openjdk (
+        set detection="detected java 11 from oracle or any openjdk"
+    )
+)
+if [%detection%] == [] (
+    if %jvendor% == java (
+        if %jver% GEQ 110 (
+            set detection="detected java 11 from oracle or any openjdk"
+        )
+    )
+)
+
+EXIT /B
+
+
+
+:run_test
+set full_version=%1
+set expected_vendor=%2
+set expected_version=%3
+set expected_detection=%4
+
+CALL :determine_java_version
+
+echo full_version: %full_version%
+if %jver% == %expected_version% ( echo jver: %jver% [32mOK[0m ) ELSE ( echo jver: %jver% [31mEXPECTED: %expected_version% [0m )
+if %jvendor% == %expected_vendor% ( echo jvendor: %jvendor% [32mOK[0m ) ELSE ( echo jvendor: %jvendor% [31mEXPECTED: %expected_vendor% [0m )
+if [%detection%] == [%expected_detection%] ( echo detection: %detection% [32mOK[0m ) ELSE ( echo detection: %detection% [31mEXPECTED: %expected_detection% [0m )
+echo.
+
+EXIT /B
+
+:main
+
+CALL :run_test "java version ""1.7.0_80"""                java      70    "detected java 7"
+CALL :run_test "openjdk version ""1.7.0_352"""            openjdk   70    "detected java 7"
+CALL :run_test "java version ""1.8.0_271"""               java      80    "detected java 8"
+CALL :run_test "openjdk version ""1.8.0_345"""            openjdk   80    "detected java 8"
+CALL :run_test "java version ""9.0.4"""                   java      90    "detected java 9 or 10 from oracle"
+CALL :run_test "openjdk version ""9.0.4"""                openjdk   90    "detected java 11 from oracle or any openjdk"
+CALL :run_test "java version ""10.0.2"" 2018-07-17"       java      100   "detected java 9 or 10 from oracle"
+CALL :run_test "openjdk version ""11.0.6"" 2022-08-12"    openjdk   110   "detected java 11 from oracle or any openjdk"
+CALL :run_test "openjdk version ""11.0.6.1"" 2022-08-12"  openjdk   110   "detected java 11 from oracle or any openjdk"
+CALL :run_test "java version ""11.0.13"" 2021-10-19 LTS"  java      110   "detected java 11 from oracle or any openjdk"
+CALL :run_test "openjdk version ""17.0.4"" 2022-08-12"    openjdk   170   "detected java 11 from oracle or any openjdk"
+CALL :run_test "openjdk version ""17.1.4"" 2022-08-12"    openjdk   171   "detected java 11 from oracle or any openjdk"
+CALL :run_test "openjdk version ""17.0.4.1"" 2022-08-12"  openjdk   170   "detected java 11 from oracle or any openjdk"
+CALL :run_test "openjdk version ""18.0.2.1"" 2022-08-18"  openjdk   180   "detected java 11 from oracle or any openjdk"
+CALL :run_test "openjdk version ""19-ea"" 2022-09-20"     openjdk   190   "detected java 11 from oracle or any openjdk"

--- a/pmd-dist/src/test/resources/scripts/runtest.sh
+++ b/pmd-dist/src/test/resources/scripts/runtest.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+# BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+
+#
+# Simple manual test script
+# - code is copied from run.sh to be tested here (so please check, it might be out of sync)
+# - mostly the function "determine_java_version" is tested here
+# - just run it with "./runtest.sh" and look at the output
+# - test cases are at the end of this script
+#
+
+export LANG=en_US.UTF-8
+
+FULL_JAVA_VERSION=""
+
+get_full_java_version() {
+  #java -version 2>&1
+  #echo "openjdk version \"11.0.6\" 2022-08-12"
+  echo "$FULL_JAVA_VERSION"
+}
+
+determine_java_version() {
+    local full_ver=$(get_full_java_version)
+    # java_ver is eg "80" for java 1.8, "90" for java 9.0, "100" for java 10.0.x
+    java_ver=$(echo "$full_ver" | sed -n '{
+        # replace early access versions, e.g. 11-ea with 11.0.0
+        s/-ea/.0.0/
+        # replace versions such as 10 with 10.0.0
+        s/version "\([0-9]\{1,\}\)"/version "\1.0.0"/
+        # replace old java versions 1.x.* (java 1.7, java 1.8) with x.*
+        s/version "1\.\(.*\)"/version "\1"/
+        # extract the major and minor parts of the version
+        s/^.* version "\([0-9]\{1,\}\)\.\([0-9]\{1,\}\).*".*$/\1\2/p
+    }')
+    # java_vendor is either java (oracle) or openjdk
+    java_vendor=$(echo "$full_ver" | sed -n -e 's/^\(.*\) version .*$/\1/p')
+}
+
+jre_specific_vm_options() {
+    options=""
+    if [ "$java_ver" -ge 70 ] && [ "$java_ver" -lt 80 ]
+    then
+      options="detected java 7"
+    elif [ "$java_ver" -ge 80 ] && [ "$java_ver" -lt 90 ]
+    then
+      options="detected java 8"
+    elif [ "$java_ver" -ge 90 ] && [ "$java_ver" -lt 110 ] && [ "$java_vendor" = "java" ]
+    then
+      options="detected java 9 or 10 from oracle"
+    elif [ "$java_vendor" = "openjdk" ] || ( [ "$java_vendor" = "java" ] && [ "$java_ver" -ge 110 ] )
+    then
+      options="detected java 11 from oracle or any openjdk"
+    fi
+    echo $options
+}
+
+run_test() {
+  FULL_JAVA_VERSION="$1"
+  EXPECTED_VENDOR="$2"
+  EXPECTED_VER="$3"
+  EXPECTED="$4"
+  echo "Testing: '${FULL_JAVA_VERSION}'"
+  determine_java_version
+  java_opts="$(jre_specific_vm_options)"
+  echo -n "java_ver: $java_ver "
+  if [ "$EXPECTED_VER" = "$java_ver" ]; then echo -e "\e[32mOK\e[0m"; else echo -e "\e[31mFAILED\e[0m"; fi
+  echo -n "java_vendor: $java_vendor "
+  if [ "$EXPECTED_VENDOR" = "$java_vendor" ]; then echo -e "\e[32mOK\e[0m"; else echo -e "\e[31mFAILED\e[0m"; fi
+  echo -n "java_opts: $java_opts "
+  if [ "$EXPECTED" = "$java_opts" ]; then echo -e "\e[32mOK\e[0m"; else echo -e "\e[31mFAILED\e[0m - expected: ${EXPECTED}"; fi
+  echo
+}
+
+run_test "java version \"1.7.0_80\""                "java"      "70"    "detected java 7"
+run_test "openjdk version \"1.7.0_352\""            "openjdk"   "70"    "detected java 7"
+run_test "java version \"1.8.0_271\""               "java"      "80"    "detected java 8"
+run_test "openjdk version \"1.8.0_345\""            "openjdk"   "80"    "detected java 8"
+run_test "java version \"9.0.4\""                   "java"      "90"    "detected java 9 or 10 from oracle"
+run_test "openjdk version \"9.0.4\""                "openjdk"   "90"    "detected java 11 from oracle or any openjdk"
+run_test "java version \"10.0.2\" 2018-07-17"       "java"      "100"   "detected java 9 or 10 from oracle"
+run_test "openjdk version \"11.0.6\" 2022-08-12"    "openjdk"   "110"   "detected java 11 from oracle or any openjdk"
+run_test "openjdk version \"11.0.6.1\" 2022-08-12"  "openjdk"   "110"   "detected java 11 from oracle or any openjdk"
+run_test "java version \"11.0.13\" 2021-10-19 LTS"  "java"      "110"   "detected java 11 from oracle or any openjdk"
+run_test "openjdk version \"17.0.4\" 2022-08-12"    "openjdk"   "170"   "detected java 11 from oracle or any openjdk"
+run_test "openjdk version \"17.1.4\" 2022-08-12"    "openjdk"   "171"   "detected java 11 from oracle or any openjdk"
+run_test "openjdk version \"17.0.4.1\" 2022-08-12"  "openjdk"   "170"   "detected java 11 from oracle or any openjdk"
+run_test "openjdk version \"18.0.2.1\" 2022-08-18"  "openjdk"   "180"   "detected java 11 from oracle or any openjdk"
+run_test "openjdk version \"19-ea\" 2022-09-20"     "openjdk"   "190"   "detected java 11 from oracle or any openjdk"


### PR DESCRIPTION
## Describe the PR

Fixes run.sh. It spits out a warning when the version looks like "11.0.6.1". Also, we produced version "180" for java 1.8, but expected it later in the script to be "80". This is also fixed.

~Draft because I'm currently checking designer.bat under Windows...~

## Related issues

- Fixes #4118 

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

