### PR TITLE
[java] Fix False-positive UnnecessaryFullyQualifiedName when nested and non-nest… #4103

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryFullyQualifiedNameRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryFullyQualifiedNameRule.java
@@ -188,10 +188,11 @@ public class UnnecessaryFullyQualifiedNameRule extends AbstractJavaRule {
 
         if (matches.isEmpty()) {
             if (isJavaLangImplicit(node)) {
-                addViolation(data, node, new Object[]{node.getImage(), "java.lang.*", "implicit "});
+                asCtx(data).addViolation(node,
+                        node.getImage(), "java.lang.*", "implicit ");
             } else if (isSamePackage(node, name)) {
                 if (!hasSameSimpleNameInScope(node)) {
-                    addViolation(data, node, new Object[]{node.getImage(), currentPackage + ".*", "same package "});
+                    asCtx(data).addViolation(node, node.getImage(), currentPackage + ".*", "same package ");
                 }
             }
         } else {
@@ -217,10 +218,9 @@ public class UnnecessaryFullyQualifiedNameRule extends AbstractJavaRule {
             return false;
         }
 
-        final String nodeSimpleName = nodeType.getSimpleName();
-
         for (ASTClassOrInterfaceDeclaration declarationDescendant : declarationDescendants) {
-            if (nodeSimpleName.equals(declarationDescendant.getSimpleName())) {
+            if (nodeType.getSimpleName().equals(declarationDescendant.getSimpleName())
+                    && !nodeType.getName().equals(declarationDescendant.getQualifiedName().toString())) {
                 return true;
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryFullyQualifiedNameRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryFullyQualifiedNameRule.java
@@ -204,7 +204,7 @@ public class UnnecessaryFullyQualifiedNameRule extends AbstractJavaRule {
                 String importStr = firstMatch.getImportedName() + (firstMatch.isImportOnDemand() ? ".*" : "");
                 String type = firstMatch.isStatic() ? "static " : "";
 
-                addViolation(data, node, new Object[]{node.getImage(), importStr, type});
+                asCtx(data).addViolation(node, node.getImage(), importStr, type);
             }
         }
     }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryFullyQualifiedName.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryFullyQualifiedName.xml
@@ -642,6 +642,21 @@ public class OuterTestClass {
     </test-code>
 
     <test-code>
+        <description>Should report fully-qualified name usage of a class in itself.</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <code><![CDATA[
+package net.sourceforge.pmd.lang.java.rule.codestyle.unnecessaryfullyqualifiedname;
+
+public class TestClass {
+    public static net.sourceforge.pmd.lang.java.rule.codestyle.unnecessaryfullyqualifiedname.TestClass INSTANCE(){
+        return new TestClass();
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>#2098 false positive with annotated package</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryFullyQualifiedName.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryFullyQualifiedName.xml
@@ -623,6 +623,25 @@ public class UnnecessaryFullyQualifiedName {
     </test-code>
 
     <test-code>
+        <description>False positive when same package inner class is referenced (not enum)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+package net.sourceforge.pmd.lang.java.rule.codestyle.unnecessaryfullyqualifiedname;
+
+public class OuterTestClass {
+	public static class TestClass{
+        private final net.sourceforge.pmd.lang.java.rule.codestyle.unnecessaryfullyqualifiedname.TestClass test;
+
+        public TestClass(net.sourceforge.pmd.lang.java.rule.codestyle.unnecessaryfullyqualifiedname.TestClass test){
+
+            this.test = test;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>#2098 false positive with annotated package</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryFullyQualifiedName.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryFullyQualifiedName.xml
@@ -623,7 +623,7 @@ public class UnnecessaryFullyQualifiedName {
     </test-code>
 
     <test-code>
-        <description>False positive when same package inner class is referenced (not enum)</description>
+        <description>False positive when same package inner class is referenced (not enum) #4085</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 package net.sourceforge.pmd.lang.java.rule.codestyle.unnecessaryfullyqualifiedname;
@@ -642,7 +642,7 @@ public class OuterTestClass {
     </test-code>
 
     <test-code>
-        <description>Should report fully-qualified name usage of a class in itself.</description>
+        <description>Should report fully-qualified name usage of a class in itself #4085</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>4</expected-linenumbers>
         <code><![CDATA[


### PR DESCRIPTION
…ed classes with the same name and in the same package are used together https://github.com/pmd/pmd/issues/4085

## Describe the PR

Additional search and exclusion of inner classes/interfaces with the same simple name as fully qualified class usage is added.

## Related issues

- Fixes #4085 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

