### PR TITLE
[java] Add java-regression-tests for regression testing

### DIFF
--- a/.ci/files/project-list.xml
+++ b/.ci/files/project-list.xml
@@ -169,4 +169,12 @@ EOF
     <tag>v2.3.0</tag>
     <src-subpath>samples</src-subpath>
   </project>
+
+  <project>
+    <name>java-regression-tests</name>
+    <type>git</type>
+    <connection>https://github.com/pmd/java-regression-tests.git</connection>
+    <tag>main</tag>
+    <auxclasspath-command>realpath java-regression-tests-*.jar</auxclasspath-command>
+  </project>
 </projectlist>

--- a/.ci/files/project-list.xml
+++ b/.ci/files/project-list.xml
@@ -173,7 +173,7 @@ EOF
   <project>
     <name>java-regression-tests</name>
     <type>git</type>
-    <connection>https://github.com/pmd/java-regression-tests.git</connection>
+    <connection>https://github.com/pmd/java-regression-tests</connection>
     <tag>main</tag>
     <auxclasspath-command>realpath java-regression-tests-*.jar</auxclasspath-command>
   </project>

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -20,7 +20,10 @@ This release of PMD adds support for [Luau](https://github.com/Roblox/luau), a g
 from Lua. This means, that the Lua language in PMD can now parse both Lua and Luau.
 
 ### Fixed Issues
-* [#4116](https://github.com/pmd/pmd/pull/4116): \[core] Missing --file arg in TreeExport CLI example
+* core
+    * [#4116](https://github.com/pmd/pmd/pull/4116): \[core] Missing --file arg in TreeExport CLI example
+* java
+    * [#3431](https://github.com/pmd/pmd/issues/3431): \[java] Add sample java project to regression-tester which uses new language constructs
 
 ### API Changes
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMD.java
@@ -63,6 +63,7 @@ import net.sourceforge.pmd.util.log.internal.SimpleMessageReporter;
  */
 public class PMD {
 
+
     private static final Logger LOG = Logger.getLogger(PMD.class.getName());
 
     /**


### PR DESCRIPTION
The new repo with the sample code is https://github.com/pmd/java-regression-tests

It builds with java19 - the produced jar file is committed, so that we don't need to build it again when running regression tests (we would need to install also java 19 in addition to the already installed java7+8+11)

## Related issues

- Fixes #3431

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

