### PR TITLE
[scala] Upgrade scala-library to 2.12.7 / 2.13.9 and scalameta to 4.6.0

### DIFF
--- a/pmd-scala-modules/pmd-scala-common/pom.xml
+++ b/pmd-scala-modules/pmd-scala-common/pom.xml
@@ -13,7 +13,7 @@
     </parent>
 
     <properties>
-        <scalameta.version>4.2.0</scalameta.version>
+        <scalameta.version>4.6.0</scalameta.version>
     </properties>
 
     <build>

--- a/pmd-scala-modules/pmd-scala-common/src/test/resources/net/sourceforge/pmd/lang/scala/ast/testdata/package.txt
+++ b/pmd-scala-modules/pmd-scala-common/src/test/resources/net/sourceforge/pmd/lang/scala/ast/testdata/package.txt
@@ -11,10 +11,11 @@
             +- DefnType
             |  +- TypeName
             |  +- TypeSelect
-            |     +- TermSelect
-            |     |  +- TermName
-            |     |  +- TermName
-            |     +- TypeName
+            |  |  +- TermSelect
+            |  |  |  +- TermName
+            |  |  |  +- TermName
+            |  |  +- TypeName
+            |  +- TypeBounds
             +- DefnVal
             |  +- PatVar
             |  |  +- TermName
@@ -26,10 +27,11 @@
             +- DefnType
             |  +- TypeName
             |  +- TypeSelect
-            |     +- TermSelect
-            |     |  +- TermName
-            |     |  +- TermName
-            |     +- TypeName
+            |  |  +- TermSelect
+            |  |  |  +- TermName
+            |  |  |  +- TermName
+            |  |  +- TypeName
+            |  +- TypeBounds
             +- DefnVal
             |  +- PatVar
             |  |  +- TermName
@@ -51,8 +53,9 @@
             |  |  +- TypeName
             |  |  +- TypeBounds
             |  +- TypeApply
-            |     +- TypeName
-            |     +- TypeName
+            |  |  +- TypeName
+            |  |  +- TypeName
+            |  +- TypeBounds
             +- DefnVal
             |  +- ModAnnot
             |  |  +- Init
@@ -79,12 +82,13 @@
                |  +- TypeName
                |  +- TypeBounds
                +- TypeApply
-                  +- TypeSelect
-                  |  +- TermSelect
-                  |  |  +- TermSelect
-                  |  |  |  +- TermName
-                  |  |  |  +- TermName
-                  |  |  +- TermName
-                  |  +- TypeName
-                  +- TypeName
-                  +- TypeName
+               |  +- TypeSelect
+               |  |  +- TermSelect
+               |  |  |  +- TermSelect
+               |  |  |  |  +- TermName
+               |  |  |  |  +- TermName
+               |  |  |  +- TermName
+               |  |  +- TypeName
+               |  +- TypeName
+               |  +- TypeName
+               +- TypeBounds

--- a/pmd-scala-modules/pmd-scala_2.12/pom.xml
+++ b/pmd-scala-modules/pmd-scala_2.12/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>${scalaVersion}.10</version>
+            <version>${scalaVersion}.17</version>
         </dependency>
         <dependency>
             <groupId>org.scalameta</groupId>

--- a/pmd-scala-modules/pmd-scala_2.13/pom.xml
+++ b/pmd-scala-modules/pmd-scala_2.13/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>org.scala-lang</groupId>
             <artifactId>scala-library</artifactId>
-            <version>${scalaVersion}.3</version>
+            <version>${scalaVersion}.9</version>
         </dependency>
         <dependency>
             <groupId>org.scalameta</groupId>


### PR DESCRIPTION
## Describe the PR

* Bump scala-library from 2.13.3 to 2.13.9
* Bump scala-library from 2.12.10 to 2.12.17
* Bump scalameta from 4.2.0 to 4.6.0

## Related issues

* Fixes https://github.com/pmd/pmd/security/dependabot/28
* Fixes https://github.com/advisories/GHSA-8qv5-68g4-248j
* Fixes CVE-2022-36944

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

