### PR TITLE
[java] fix #4141 Update UncommentedEmptyConstructor - ignore @Autowired annotations

### DIFF
--- a/pmd-java/src/main/resources/category/java/documentation.xml
+++ b/pmd-java/src/main/resources/category/java/documentation.xml
@@ -102,7 +102,10 @@ and unintentional empty constructors.
                         [@containsComment = false()]
                         [not(BlockStatement)]
                         [$ignoreExplicitConstructorInvocation = true() or not(ExplicitConstructorInvocation)]
-                        [not(../Annotation/MarkerAnnotation/Name[pmd-java:typeIs('javax.inject.Inject')])]
+                        [not(../Annotation/MarkerAnnotation/Name[
+                                                                pmd-java:typeIs('javax.inject.Inject')
+                                                             or pmd-java:typeIs('org.springframework.beans.factory.annotation.Autowired')
+                                                                ])]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/documentation/xml/UncommentedEmptyConstructor.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/documentation/xml/UncommentedEmptyConstructor.xml
@@ -187,4 +187,30 @@ public class MyClass {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#4141 UncommentedEmptyConstructor FP when annotated constructor with @Autowired</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.springframework.beans.factory.annotation.Autowired;
+public class Bug {
+    @Autowired
+    public Bug() {
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#4141 UncommentedEmptyConstructor FP when annotated constructor with @Autowired</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Bug {
+    @org.springframework.beans.factory.annotation.Autowired
+    public Bug() {
+    }
+}
+        ]]></code>
+    </test-code>
+
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
I reivise the rule  UncommentedEmptyConstructor and make the annotation @Autowired can be detected

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #4141

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

