### PR TITLE
[apex] Summit-AST Apex module - Part 2 - expression nodes

### DIFF
--- a/pmd-apex/pom.xml
+++ b/pmd-apex/pom.xml
@@ -13,7 +13,6 @@
 
     <properties>
         <java.version>8</java.version>
-        <kotlin.version>1.7.0</kotlin.version>
     </properties>
 
     <build>

--- a/pmd-apex/pom.xml
+++ b/pmd-apex/pom.xml
@@ -104,11 +104,24 @@
         </dependency>
 
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib-jdk8</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
             <groupId>com.google.summit</groupId>
-            <artifactId>summit</artifactId>
-            <version>1.0</version>
-            <scope>system</scope>
-            <systemPath>${project.basedir}/SummitLib_deploy.jar</systemPath>
+            <artifactId>summit-ast</artifactId>
+            <version>1.0.0</version>
         </dependency>
 
         <dependency>

--- a/pmd-apex/pom.xml
+++ b/pmd-apex/pom.xml
@@ -13,6 +13,7 @@
 
     <properties>
         <java.version>8</java.version>
+        <kotlin.version>1.7.0</kotlin.version>
     </properties>
 
     <build>
@@ -103,24 +104,11 @@
         </dependency>
 
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-stdlib-jdk8</artifactId>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.summit</groupId>
-            <artifactId>summit-ast</artifactId>
-            <version>0.9.0-SNAPSHOT</version>
+            <artifactId>summit</artifactId>
+            <version>1.0</version>
+            <scope>system</scope>
+            <systemPath>${project.basedir}/SummitLib_deploy.jar</systemPath>
         </dependency>
 
         <dependency>

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTArrayLoadExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTArrayLoadExpression.java
@@ -4,9 +4,6 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-import com.google.summit.ast.Node;
-import net.sourceforge.pmd.annotation.InternalApi;
-
 import com.google.summit.ast.expression.ArrayExpression;
 
 public class ASTArrayLoadExpression extends AbstractApexNode.Single<ArrayExpression> {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTArrayLoadExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTArrayLoadExpression.java
@@ -7,12 +7,14 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTArrayLoadExpression extends AbstractApexNode.Single<Node> {
+import com.google.summit.ast.expression.ArrayExpression;
+
+public class ASTArrayLoadExpression extends AbstractApexNode.Single<ArrayExpression> {
 
     @Deprecated
     @InternalApi
-    public ASTArrayLoadExpression(Node arrayLoadExpression) {
-        super(arrayLoadExpression);
+    public ASTArrayLoadExpression(ArrayExpression arrayExpression) {
+        super(arrayExpression);
     }
 
     @Override

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTArrayLoadExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTArrayLoadExpression.java
@@ -11,9 +11,7 @@ import com.google.summit.ast.expression.ArrayExpression;
 
 public class ASTArrayLoadExpression extends AbstractApexNode.Single<ArrayExpression> {
 
-    @Deprecated
-    @InternalApi
-    public ASTArrayLoadExpression(ArrayExpression arrayExpression) {
+    ASTArrayLoadExpression(ArrayExpression arrayExpression) {
         super(arrayExpression);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTArrayStoreExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTArrayStoreExpression.java
@@ -7,12 +7,14 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTArrayStoreExpression extends AbstractApexNode.Single<Node> {
+import com.google.summit.ast.expression.ArrayExpression;
+
+public class ASTArrayStoreExpression extends AbstractApexNode.Single<ArrayExpression> {
 
     @Deprecated
     @InternalApi
-    public ASTArrayStoreExpression(Node arrayStoreExpression) {
-        super(arrayStoreExpression);
+    public ASTArrayStoreExpression(ArrayExpression arrayExpression) {
+        super(arrayExpression);
     }
 
     @Override

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTArrayStoreExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTArrayStoreExpression.java
@@ -11,9 +11,7 @@ import com.google.summit.ast.expression.ArrayExpression;
 
 public class ASTArrayStoreExpression extends AbstractApexNode.Single<ArrayExpression> {
 
-    @Deprecated
-    @InternalApi
-    public ASTArrayStoreExpression(ArrayExpression arrayExpression) {
+    ASTArrayStoreExpression(ArrayExpression arrayExpression) {
         super(arrayExpression);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTArrayStoreExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTArrayStoreExpression.java
@@ -4,9 +4,6 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-import com.google.summit.ast.Node;
-import net.sourceforge.pmd.annotation.InternalApi;
-
 import com.google.summit.ast.expression.ArrayExpression;
 
 public class ASTArrayStoreExpression extends AbstractApexNode.Single<ArrayExpression> {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBlockStatement.java
@@ -5,9 +5,6 @@
 package net.sourceforge.pmd.lang.apex.ast;
 
 import com.google.summit.ast.Node;
-import net.sourceforge.pmd.annotation.InternalApi;
-
-import com.google.summit.ast.Node;
 import com.google.summit.ast.SourceLocation;
 
 public class ASTBlockStatement extends AbstractApexNode.Single<Node> {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBlockStatement.java
@@ -7,6 +7,9 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
+import com.google.summit.ast.Node;
+import com.google.summit.ast.SourceLocation;
+
 public class ASTBlockStatement extends AbstractApexNode.Single<Node> {
     private boolean curlyBrace;
 
@@ -34,8 +37,8 @@ public class ASTBlockStatement extends AbstractApexNode.Single<Node> {
         // check, whether the this block statement really begins with a curly brace
         // unfortunately, for-loop and if-statements always contain a block statement,
         // regardless whether curly braces where present or not.
-        // char firstChar = source.charAt(node.getLoc().getStartIndex());
-        // curlyBrace = firstChar == '{';
-        // TODO(b/239648780)
+        SourceLocation loc = node.getSourceLocation();
+        String sourceRegion = loc.extractFrom(source);
+        this.curlyBrace = sourceRegion.charAt(0) == '{';
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBlockStatement.java
@@ -13,9 +13,7 @@ import com.google.summit.ast.SourceLocation;
 public class ASTBlockStatement extends AbstractApexNode.Single<Node> {
     private boolean curlyBrace;
 
-    @Deprecated
-    @InternalApi
-    public ASTBlockStatement(Node blockStatement) {
+    ASTBlockStatement(Node blockStatement) {
         super(blockStatement);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBooleanExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBooleanExpression.java
@@ -12,8 +12,8 @@ public class ASTBooleanExpression extends AbstractApexNode.Single<BinaryExpressi
 
     @Deprecated
     @InternalApi
-    public ASTBooleanExpression(BinaryExpression booleanExpression) {
-        super(booleanExpression);
+    public ASTBooleanExpression(BinaryExpression binaryExpression) {
+        super(binaryExpression);
     }
 
     @Override

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBooleanExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBooleanExpression.java
@@ -10,9 +10,7 @@ import com.google.summit.ast.expression.BinaryExpression;
 
 public class ASTBooleanExpression extends AbstractApexNode.Single<BinaryExpression> {
 
-    @Deprecated
-    @InternalApi
-    public ASTBooleanExpression(BinaryExpression binaryExpression) {
+    ASTBooleanExpression(BinaryExpression binaryExpression) {
         super(binaryExpression);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBooleanExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBooleanExpression.java
@@ -4,8 +4,6 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-import net.sourceforge.pmd.annotation.InternalApi;
-
 import com.google.summit.ast.expression.BinaryExpression;
 
 public class ASTBooleanExpression extends AbstractApexNode.Single<BinaryExpression> {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTCastExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTCastExpression.java
@@ -7,12 +7,14 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTCastExpression extends AbstractApexNode.Single<Node> {
+import com.google.summit.ast.expression.CastExpression;
+
+public class ASTCastExpression extends AbstractApexNode.Single<CastExpression> {
 
     @Deprecated
     @InternalApi
-    public ASTCastExpression(Node node) {
-        super(node);
+    public ASTCastExpression(CastExpression castExpression) {
+        super(castExpression);
     }
 
     @Override

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTCastExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTCastExpression.java
@@ -4,9 +4,6 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-import com.google.summit.ast.Node;
-import net.sourceforge.pmd.annotation.InternalApi;
-
 import com.google.summit.ast.expression.CastExpression;
 
 public class ASTCastExpression extends AbstractApexNode.Single<CastExpression> {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTCastExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTCastExpression.java
@@ -11,9 +11,7 @@ import com.google.summit.ast.expression.CastExpression;
 
 public class ASTCastExpression extends AbstractApexNode.Single<CastExpression> {
 
-    @Deprecated
-    @InternalApi
-    public ASTCastExpression(CastExpression castExpression) {
+    ASTCastExpression(CastExpression castExpression) {
         super(castExpression);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTClassRefExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTClassRefExpression.java
@@ -7,12 +7,14 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTClassRefExpression extends AbstractApexNode.Single<Node> {
+import com.google.summit.ast.expression.TypeRefExpression;
+
+public class ASTClassRefExpression extends AbstractApexNode.Single<TypeRefExpression> {
 
     @Deprecated
     @InternalApi
-    public ASTClassRefExpression(Node classRefExpression) {
-        super(classRefExpression);
+    public ASTClassRefExpression(TypeRefExpression typeRefExpression) {
+        super(typeRefExpression);
     }
 
     @Override

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTClassRefExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTClassRefExpression.java
@@ -11,9 +11,7 @@ import com.google.summit.ast.expression.TypeRefExpression;
 
 public class ASTClassRefExpression extends AbstractApexNode.Single<TypeRefExpression> {
 
-    @Deprecated
-    @InternalApi
-    public ASTClassRefExpression(TypeRefExpression typeRefExpression) {
+    ASTClassRefExpression(TypeRefExpression typeRefExpression) {
         super(typeRefExpression);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTClassRefExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTClassRefExpression.java
@@ -4,9 +4,6 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-import com.google.summit.ast.Node;
-import net.sourceforge.pmd.annotation.InternalApi;
-
 import com.google.summit.ast.expression.TypeRefExpression;
 
 public class ASTClassRefExpression extends AbstractApexNode.Single<TypeRefExpression> {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTEmptyReferenceExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTEmptyReferenceExpression.java
@@ -5,7 +5,7 @@
 package net.sourceforge.pmd.lang.apex.ast;
 
 public final class ASTEmptyReferenceExpression extends AbstractApexNode.Empty {
-    
+
     @Override
     public Object jjtAccept(ApexParserVisitor visitor, Object data) {
         return visitor.visit(this, data);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTEmptyReferenceExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTEmptyReferenceExpression.java
@@ -4,19 +4,15 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-import com.google.summit.ast.Node;
-
-public final class ASTEmptyReferenceExpression extends AbstractApexNode.Single<Node> {
-
-
-    ASTEmptyReferenceExpression(Node node) {
-        super(node);
-    }
-
-
+public final class ASTEmptyReferenceExpression extends AbstractApexNode.Empty {
+    
     @Override
     public Object jjtAccept(ApexParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
     }
 
+    @Override
+    public String getDefiningType() {
+        return null;
+    }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTExpressionStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTExpressionStatement.java
@@ -4,9 +4,6 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-import com.google.summit.ast.Node;
-import net.sourceforge.pmd.annotation.InternalApi;
-
 import com.google.summit.ast.statement.ExpressionStatement;
 
 public class ASTExpressionStatement extends AbstractApexNode.Single<ExpressionStatement> {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTExpressionStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTExpressionStatement.java
@@ -7,7 +7,9 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTExpressionStatement extends AbstractApexNode.Single<Node> {
+import com.google.summit.ast.statement.ExpressionStatement;
+
+public class ASTExpressionStatement extends AbstractApexNode.Single<ExpressionStatement> {
 
     @Deprecated
     @InternalApi
@@ -20,6 +22,7 @@ public class ASTExpressionStatement extends AbstractApexNode.Single<Node> {
         return visitor.visit(this, data);
     }
 
+    /*
     private int beginColumnDiff = -1;
 
     @Override
@@ -42,4 +45,6 @@ public class ASTExpressionStatement extends AbstractApexNode.Single<Node> {
 
         return super.getBeginColumn() - beginColumnDiff;
     }
+     */
+    // TODO(b/239648780)
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTExpressionStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTExpressionStatement.java
@@ -13,7 +13,7 @@ public class ASTExpressionStatement extends AbstractApexNode.Single<ExpressionSt
 
     @Deprecated
     @InternalApi
-    public ASTExpressionStatement(Node expressionStatement) {
+    public ASTExpressionStatement(ExpressionStatement expressionStatement) {
         super(expressionStatement);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTExpressionStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTExpressionStatement.java
@@ -11,9 +11,7 @@ import com.google.summit.ast.statement.ExpressionStatement;
 
 public class ASTExpressionStatement extends AbstractApexNode.Single<ExpressionStatement> {
 
-    @Deprecated
-    @InternalApi
-    public ASTExpressionStatement(ExpressionStatement expressionStatement) {
+    ASTExpressionStatement(ExpressionStatement expressionStatement) {
         super(expressionStatement);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclaration.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclaration.java
@@ -4,9 +4,6 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-import com.google.summit.ast.Node;
-import net.sourceforge.pmd.annotation.InternalApi;
-
 import com.google.summit.ast.declaration.FieldDeclaration;
 
 public class ASTFieldDeclaration extends AbstractApexNode.Single<FieldDeclaration> {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclaration.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclaration.java
@@ -13,7 +13,7 @@ public class ASTFieldDeclaration extends AbstractApexNode.Single<FieldDeclaratio
 
     @Deprecated
     @InternalApi
-    public ASTFieldDeclaration(Node fieldDeclaration) {
+    public ASTFieldDeclaration(FieldDeclaration fieldDeclaration) {
         super(fieldDeclaration);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclaration.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclaration.java
@@ -11,9 +11,7 @@ import com.google.summit.ast.declaration.FieldDeclaration;
 
 public class ASTFieldDeclaration extends AbstractApexNode.Single<FieldDeclaration> {
 
-    @Deprecated
-    @InternalApi
-    public ASTFieldDeclaration(FieldDeclaration fieldDeclaration) {
+    ASTFieldDeclaration(FieldDeclaration fieldDeclaration) {
         super(fieldDeclaration);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclaration.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclaration.java
@@ -7,7 +7,9 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTFieldDeclaration extends AbstractApexNode.Single<Node> {
+import com.google.summit.ast.declaration.FieldDeclaration;
+
+public class ASTFieldDeclaration extends AbstractApexNode.Single<FieldDeclaration> {
 
     @Deprecated
     @InternalApi
@@ -26,16 +28,6 @@ public class ASTFieldDeclaration extends AbstractApexNode.Single<Node> {
     }
 
     public String getName() {
-        /*
-        if (node.getFieldInfo() != null) {
-            return node.getFieldInfo().getName();
-        }
-        ASTVariableExpression variable = getFirstChildOfType(ASTVariableExpression.class);
-        if (variable != null) {
-            return variable.getImage();
-        }
-         */
-        // TODO(b/239648780)
-        return null;
+        return node.getId().getString();
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclarationStatements.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclarationStatements.java
@@ -4,15 +4,12 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-import com.google.summit.ast.Node;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
-
-import net.sourceforge.pmd.Rule;
-import net.sourceforge.pmd.annotation.InternalApi;
 
 import com.google.summit.ast.declaration.FieldDeclarationGroup;
+
+import net.sourceforge.pmd.Rule;
 
 public class ASTFieldDeclarationStatements extends AbstractApexNode.Single<FieldDeclarationGroup>
         implements CanSuppressWarnings {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclarationStatements.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclarationStatements.java
@@ -17,9 +17,7 @@ import com.google.summit.ast.declaration.FieldDeclarationGroup;
 public class ASTFieldDeclarationStatements extends AbstractApexNode.Single<FieldDeclarationGroup>
         implements CanSuppressWarnings {
 
-    @Deprecated
-    @InternalApi
-    public ASTFieldDeclarationStatements(FieldDeclarationGroup fieldDeclarationStatements) {
+    ASTFieldDeclarationStatements(FieldDeclarationGroup fieldDeclarationStatements) {
         super(fieldDeclarationStatements);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclarationStatements.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclarationStatements.java
@@ -12,12 +12,14 @@ import java.util.stream.Collectors;
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTFieldDeclarationStatements extends AbstractApexNode.Single<Node>
+import com.google.summit.ast.declaration.FieldDeclarationGroup;
+
+public class ASTFieldDeclarationStatements extends AbstractApexNode.Single<FieldDeclarationGroup>
         implements CanSuppressWarnings {
 
     @Deprecated
     @InternalApi
-    public ASTFieldDeclarationStatements(Node fieldDeclarationStatements) {
+    public ASTFieldDeclarationStatements(FieldDeclarationGroup fieldDeclarationStatements) {
         super(fieldDeclarationStatements);
     }
 
@@ -43,14 +45,7 @@ public class ASTFieldDeclarationStatements extends AbstractApexNode.Single<Node>
     }
 
     public String getTypeName() {
-        /*
-        if (node.getTypeName() != null) {
-            List<Identifier> names = node.getTypeName().getNames();
-            return names.stream().map(Identifier::getValue).collect(Collectors.joining("."));
-        }
-         */
-        // TODO(b/239648780)
-        return null;
+        return node.getType().asCodeString();
     }
 
     /*

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTInstanceOfExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTInstanceOfExpression.java
@@ -4,9 +4,6 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-import com.google.summit.ast.Node;
-import net.sourceforge.pmd.annotation.InternalApi;
-
 import com.google.summit.ast.expression.BinaryExpression;
 
 public class ASTInstanceOfExpression extends AbstractApexNode.Single<BinaryExpression> {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTInstanceOfExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTInstanceOfExpression.java
@@ -7,12 +7,14 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTInstanceOfExpression extends AbstractApexNode.Single<Node> {
+import com.google.summit.ast.expression.BinaryExpression;
+
+public class ASTInstanceOfExpression extends AbstractApexNode.Single<BinaryExpression> {
 
     @Deprecated
     @InternalApi
-    public ASTInstanceOfExpression(Node instanceOfExpression) {
-        super(instanceOfExpression);
+    public ASTInstanceOfExpression(BinaryExpression binaryExpression) {
+        super(binaryExpression);
     }
 
     @Override

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTInstanceOfExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTInstanceOfExpression.java
@@ -11,9 +11,7 @@ import com.google.summit.ast.expression.BinaryExpression;
 
 public class ASTInstanceOfExpression extends AbstractApexNode.Single<BinaryExpression> {
 
-    @Deprecated
-    @InternalApi
-    public ASTInstanceOfExpression(BinaryExpression binaryExpression) {
+    ASTInstanceOfExpression(BinaryExpression binaryExpression) {
         super(binaryExpression);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralExpression.java
@@ -15,9 +15,7 @@ import com.google.summit.ast.expression.LiteralExpression;
 
 public class ASTLiteralExpression extends AbstractApexNode.Single<LiteralExpression> {
 
-    @Deprecated
-    @InternalApi
-    public ASTLiteralExpression(LiteralExpression literalExpression) {
+    ASTLiteralExpression(LiteralExpression literalExpression) {
         super(literalExpression);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralExpression.java
@@ -11,7 +11,9 @@ import org.apache.commons.lang3.reflect.FieldUtils;
 
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTLiteralExpression extends AbstractApexNode.Single<Node> {
+import com.google.summit.ast.expression.LiteralExpression;
+
+public class ASTLiteralExpression extends AbstractApexNode.Single<LiteralExpression> {
 
     @Deprecated
     @InternalApi
@@ -25,64 +27,75 @@ public class ASTLiteralExpression extends AbstractApexNode.Single<Node> {
         return visitor.visit(this, data);
     }
 
-    /*
+    public enum LiteralType {
+        STRING,
+        INTEGER,
+        LONG,
+        DOUBLE,
+        DECIMAL,
+        TRUE,
+        FALSE,
+        NULL
+    }
+
     public LiteralType getLiteralType() {
-        return node.getLiteralType();
+        if (node instanceof LiteralExpression.StringVal) {
+            return LiteralType.STRING;
+        } else if (node instanceof LiteralExpression.BooleanVal) {
+            return ((LiteralExpression.BooleanVal) node).getValue() ? LiteralType.TRUE : LiteralType.FALSE;
+        } else if (node instanceof LiteralExpression.IntegerVal) {
+            return LiteralType.INTEGER;
+        } else if (node instanceof LiteralExpression.DoubleVal) {
+            return LiteralType.DOUBLE;
+        } else if (node instanceof LiteralExpression.LongVal) {
+            return LiteralType.LONG;
+        } else if (false) { // TODO(b/239648780)
+            return LiteralType.DECIMAL;
+        } else if (node instanceof LiteralExpression.NullVal) {
+            return LiteralType.NULL;
+        } else {
+            return null;
+        }
     }
      */
     // TODO(b/239648780)
 
     public boolean isString() {
-        // return node.getLiteralType() == LiteralType.STRING;
-        // TODO(b/239648780)
-        return false;
+        return getLiteralType() == LiteralType.STRING;
     }
 
     public boolean isBoolean() {
-        // return node.getLiteralType() == LiteralType.TRUE || node.getLiteralType() == LiteralType.FALSE;
-        // TODO(b/239648780)
-        return false;
+        return getLiteralType() == LiteralType.TRUE || getLiteralType() == LiteralType.FALSE;
     }
 
     public boolean isInteger() {
-        // return node.getLiteralType() == LiteralType.INTEGER;
-        // TODO(b/239648780)
-        return false;
+        return getLiteralType() == LiteralType.INTEGER;
     }
 
     public boolean isDouble() {
-        // return node.getLiteralType() == LiteralType.DOUBLE;
-        // TODO(b/239648780)
-        return false;
+        return getLiteralType() == LiteralType.DOUBLE;
     }
 
     public boolean isLong() {
-        // return node.getLiteralType() == LiteralType.LONG;
-        // TODO(b/239648780)
-        return false;
+        return getLiteralType() == LiteralType.LONG;
     }
 
     public boolean isDecimal() {
-        // return node.getLiteralType() == LiteralType.DECIMAL;
-        // TODO(b/239648780)
-        return false;
+        return getLiteralType() == LiteralType.DECIMAL;
     }
 
     public boolean isNull() {
-        // return node.getLiteralType() == LiteralType.NULL;
-        // TODO(b/239648780)
-        return false;
+        return getLiteralType() == LiteralType.NULL;
     }
 
     @Override
     public String getImage() {
-        /*
-        if (node.getLiteral() != null) {
-            return String.valueOf(node.getLiteral());
+        if (isString()) {
+            return ((LiteralExpression.StringVal) node).getValue();
+        } else if (isNull()) {
+            return "";
         }
-         */
-        // TODO(b/239648780)
-        return null;
+        return node.asCodeString();
     }
 
     public String getName() {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralExpression.java
@@ -17,7 +17,7 @@ public class ASTLiteralExpression extends AbstractApexNode.Single<LiteralExpress
 
     @Deprecated
     @InternalApi
-    public ASTLiteralExpression(Node literalExpression) {
+    public ASTLiteralExpression(LiteralExpression literalExpression) {
         super(literalExpression);
     }
 
@@ -57,8 +57,6 @@ public class ASTLiteralExpression extends AbstractApexNode.Single<LiteralExpress
             return null;
         }
     }
-     */
-    // TODO(b/239648780)
 
     public boolean isString() {
         return getLiteralType() == LiteralType.STRING;

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralExpression.java
@@ -4,13 +4,6 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-import com.google.summit.ast.Node;
-import java.util.Optional;
-
-import org.apache.commons.lang3.reflect.FieldUtils;
-
-import net.sourceforge.pmd.annotation.InternalApi;
-
 import com.google.summit.ast.expression.LiteralExpression;
 
 public class ASTLiteralExpression extends AbstractApexNode.Single<LiteralExpression> {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethod.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethod.java
@@ -4,13 +4,11 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-import com.google.summit.ast.Node;
+import com.google.summit.ast.declaration.MethodDeclaration;
+
 import net.sourceforge.pmd.Rule;
-import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.apex.metrics.signature.ApexOperationSignature;
 import net.sourceforge.pmd.lang.ast.SignedNode;
-
-import com.google.summit.ast.declaration.MethodDeclaration;
 
 public class ASTMethod extends AbstractApexNode.Single<MethodDeclaration> implements ApexQualifiableNode,
        SignedNode<ASTMethod>, CanSuppressWarnings {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethod.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethod.java
@@ -10,12 +10,24 @@ import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.apex.metrics.signature.ApexOperationSignature;
 import net.sourceforge.pmd.lang.ast.SignedNode;
 
-public class ASTMethod extends AbstractApexNode.Single<Node> implements ApexQualifiableNode,
+import com.google.summit.ast.declaration.MethodDeclaration;
+
+public class ASTMethod extends AbstractApexNode.Single<MethodDeclaration> implements ApexQualifiableNode,
        SignedNode<ASTMethod>, CanSuppressWarnings {
+
+    /**
+     * Internal name used by constructors.
+     */
+    public static final String CONSTRUCTOR_ID = "<init>";
+
+    /**
+     * Internal name used by static initialization blocks.
+     */
+    public static final String STATIC_INIT_ID = "<clinit>";
 
     @Deprecated
     @InternalApi
-    public ASTMethod(Node method) {
+    public ASTMethod(MethodDeclaration method) {
         super(method);
     }
 
@@ -24,17 +36,30 @@ public class ASTMethod extends AbstractApexNode.Single<Node> implements ApexQual
         return visitor.visit(this, data);
     }
 
+    /**
+     * Returns the name of the method, converting the parser name to the internal PMD name as
+     * needed.
+     */
+    private String getName() {
+        if (node.isAnonymousInitializationCode()) {
+            return STATIC_INIT_ID;
+        } else if (node.isConstructor()) {
+            return CONSTRUCTOR_ID;
+        } else if (getParent() instanceof ASTProperty) {
+            return ASTProperty.formatAccessorName((ASTProperty) getParent());
+        } else {
+            return node.getId().getString();
+        }
+    }
+
     @Override
     public String getImage() {
-        // return node.getMethodInfo().getName();
-        // TODO(b/239648780)
-        return null;
+        return getName();
+        // TODO(b/239648780): differs from #getCanonicalName in some instances
     }
 
     public String getCanonicalName() {
-        // return node.getMethodInfo().getCanonicalName();
-        // TODO(b/239648780)
-        return null;
+        return getName();
     }
 
     @Override
@@ -123,9 +148,7 @@ public class ASTMethod extends AbstractApexNode.Single<Node> implements ApexQual
     }
 
     public boolean isConstructor() {
-        // return node.getMethodInfo().isConstructor();
-        // TODO(b/239648780)
-        return false;
+        return node.isConstructor();
     }
 
     public ASTModifierNode getModifiers() {
@@ -133,14 +156,10 @@ public class ASTMethod extends AbstractApexNode.Single<Node> implements ApexQual
     }
 
     public String getReturnType() {
-        // return node.getMethodInfo().getEmitSignature().getReturnType().getApexName();
-        // TODO(b/239648780)
-        return null;
+        return node.getReturnType().asCodeString();
     }
 
     public int getArity() {
-        // return node.getMethodInfo().getParameterTypes().size();
-        // TODO(b/239648780)
-        return 0;
+        return node.getParameterDeclarations().size();
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethod.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethod.java
@@ -25,9 +25,7 @@ public class ASTMethod extends AbstractApexNode.Single<MethodDeclaration> implem
      */
     public static final String STATIC_INIT_ID = "<clinit>";
 
-    @Deprecated
-    @InternalApi
-    public ASTMethod(MethodDeclaration method) {
+    ASTMethod(MethodDeclaration method) {
         super(method);
     }
 
@@ -55,11 +53,14 @@ public class ASTMethod extends AbstractApexNode.Single<MethodDeclaration> implem
     @Override
     public String getImage() {
         return getName();
-        // TODO(b/239648780): differs from #getCanonicalName in some instances
     }
 
     public String getCanonicalName() {
-        return getName();
+        if (node.isConstructor()) {
+            return CONSTRUCTOR_ID;
+        } else {
+            return getName();
+        }
     }
 
     @Override

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodCallExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodCallExpression.java
@@ -7,8 +7,6 @@ package net.sourceforge.pmd.lang.apex.ast;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import net.sourceforge.pmd.annotation.InternalApi;
-
 import com.google.summit.ast.Identifier;
 import com.google.summit.ast.expression.CallExpression;
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodCallExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodCallExpression.java
@@ -20,9 +20,7 @@ public class ASTMethodCallExpression extends AbstractApexNode.Single<CallExpress
      */
     private final List<Identifier> receiverComponents;
 
-    @Deprecated
-    @InternalApi
-    public ASTMethodCallExpression(CallExpression callExpression, List<Identifier> receiverComponents) {
+    ASTMethodCallExpression(CallExpression callExpression, List<Identifier> receiverComponents) {
         super(callExpression);
         this.receiverComponents = receiverComponents;
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodCallExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodCallExpression.java
@@ -4,16 +4,27 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-import com.google.summit.ast.Node;
-import java.util.Iterator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTMethodCallExpression extends AbstractApexNode.Single<Node> {
+import com.google.summit.ast.Identifier;
+import com.google.summit.ast.expression.CallExpression;
+
+public class ASTMethodCallExpression extends AbstractApexNode.Single<CallExpression> {
+
+    /**
+     * The {@link Identifier}s that constitute the {@link CallExpression#getReceiver() receiver} of
+     * this method call.
+     */
+    private final List<Identifier> receiverComponents;
+
     @Deprecated
     @InternalApi
-    public ASTMethodCallExpression(Node methodCallExpression) {
-        super(methodCallExpression);
+    public ASTMethodCallExpression(CallExpression callExpression, List<Identifier> receiverComponents) {
+        super(callExpression);
+        this.receiverComponents = receiverComponents;
     }
 
     @Override
@@ -22,27 +33,14 @@ public class ASTMethodCallExpression extends AbstractApexNode.Single<Node> {
     }
 
     public String getMethodName() {
-        // return node.getMethodName();
-        // TODO(b/239648780)
-        return null;
+        return node.getId().getString();
     }
 
     public String getFullMethodName() {
-        /*
-        final String methodName = getMethodName();
-        StringBuilder typeName = new StringBuilder();
-        for (Iterator<Identifier> it = node.getReferenceContext().getNames().iterator(); it.hasNext();) {
-            typeName.append(it.next().getValue()).append('.');
-        }
-        return typeName.toString() + methodName;
-         */
-        // TODO(b/239648780)
-        return null;
+        return receiverComponents.stream().map(id -> id.getString() + ".").collect(Collectors.joining()) + getMethodName();
     }
 
     public int getInputParametersSize() {
-        // return node.getInputParameters().size();
-        // TODO(b/239648780)
-        return 0;
+        return node.getArgs().size();
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPostfixExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPostfixExpression.java
@@ -12,8 +12,8 @@ public class ASTPostfixExpression extends AbstractApexNode.Single<UnaryExpressio
 
     @Deprecated
     @InternalApi
-    public ASTPostfixExpression(UnaryExpression postfixExpression) {
-        super(postfixExpression);
+    public ASTPostfixExpression(UnaryExpression unaryExpression) {
+        super(unaryExpression);
     }
 
     @Override

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPostfixExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPostfixExpression.java
@@ -4,8 +4,6 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-import net.sourceforge.pmd.annotation.InternalApi;
-
 import com.google.summit.ast.expression.UnaryExpression;
 
 public class ASTPostfixExpression extends AbstractApexNode.Single<UnaryExpression> {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPostfixExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPostfixExpression.java
@@ -10,9 +10,7 @@ import com.google.summit.ast.expression.UnaryExpression;
 
 public class ASTPostfixExpression extends AbstractApexNode.Single<UnaryExpression> {
 
-    @Deprecated
-    @InternalApi
-    public ASTPostfixExpression(UnaryExpression unaryExpression) {
+    ASTPostfixExpression(UnaryExpression unaryExpression) {
         super(unaryExpression);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPrefixExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPrefixExpression.java
@@ -12,8 +12,8 @@ public class ASTPrefixExpression extends AbstractApexNode.Single<UnaryExpression
 
     @Deprecated
     @InternalApi
-    public ASTPrefixExpression(UnaryExpression prefixExpression) {
-        super(prefixExpression);
+    public ASTPrefixExpression(UnaryExpression unaryExpression) {
+        super(unaryExpression);
     }
 
     @Override

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPrefixExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPrefixExpression.java
@@ -10,9 +10,7 @@ import com.google.summit.ast.expression.UnaryExpression;
 
 public class ASTPrefixExpression extends AbstractApexNode.Single<UnaryExpression> {
 
-    @Deprecated
-    @InternalApi
-    public ASTPrefixExpression(UnaryExpression unaryExpression) {
+    ASTPrefixExpression(UnaryExpression unaryExpression) {
         super(unaryExpression);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPrefixExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPrefixExpression.java
@@ -4,8 +4,6 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-import net.sourceforge.pmd.annotation.InternalApi;
-
 import com.google.summit.ast.expression.UnaryExpression;
 
 public class ASTPrefixExpression extends AbstractApexNode.Single<UnaryExpression> {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTProperty.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTProperty.java
@@ -7,11 +7,18 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTProperty extends AbstractApexNode.Single<Node> {
+import com.google.summit.ast.declaration.PropertyDeclaration;
+
+public class ASTProperty extends AbstractApexNode.Single<PropertyDeclaration> {
+
+    /**
+     * Prefix added to the property name to create an internal accessor name.
+     */
+    private static final String ACCESSOR_PREFIX = "__sfdc_";
 
     @Deprecated
     @InternalApi
-    public ASTProperty(Node property) {
+    public ASTProperty(PropertyDeclaration property) {
         super(property);
     }
 
@@ -21,12 +28,18 @@ public class ASTProperty extends AbstractApexNode.Single<Node> {
     }
 
     public String getType() {
-        // return node.getFieldInfo().getType().getApexName();
-        // TODO(b/239648780)
-        return null;
+        return node.getType().asCodeString();
     }
 
     public ASTModifierNode getModifiers() {
         return getFirstChildOfType(ASTModifierNode.class);
+    }
+
+    /**
+     * Returns the internal accessor (getter/setter) name of an {@link ASTProperty}. The accessor name is the
+     * constant {@link #ACCESSOR_PREFIX} prepended to the name of the property.
+     */
+    public static String formatAccessorName(ASTProperty property) {
+        return ACCESSOR_PREFIX + property.node.getId().getString();
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTProperty.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTProperty.java
@@ -16,9 +16,7 @@ public class ASTProperty extends AbstractApexNode.Single<PropertyDeclaration> {
      */
     private static final String ACCESSOR_PREFIX = "__sfdc_";
 
-    @Deprecated
-    @InternalApi
-    public ASTProperty(PropertyDeclaration property) {
+    ASTProperty(PropertyDeclaration property) {
         super(property);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTProperty.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTProperty.java
@@ -4,9 +4,6 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-import com.google.summit.ast.Node;
-import net.sourceforge.pmd.annotation.InternalApi;
-
 import com.google.summit.ast.declaration.PropertyDeclaration;
 
 public class ASTProperty extends AbstractApexNode.Single<PropertyDeclaration> {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTReferenceExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTReferenceExpression.java
@@ -18,9 +18,7 @@ public class ASTReferenceExpression extends AbstractApexNode.Many<Identifier> {
     private final ReferenceType referenceType;
     private final boolean isSafe;
 
-    @Deprecated
-    @InternalApi
-    public ASTReferenceExpression(List<Identifier> identifiers, ReferenceType referenceType, boolean isSafe) {
+    ASTReferenceExpression(List<Identifier> identifiers, ReferenceType referenceType, boolean isSafe) {
         super(identifiers);
         this.referenceType = referenceType;
         this.isSafe = isSafe;

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTReferenceExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTReferenceExpression.java
@@ -4,12 +4,8 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-import com.google.summit.ast.Node;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import net.sourceforge.pmd.annotation.InternalApi;
 
 import com.google.summit.ast.Identifier;
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTReferenceExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTReferenceExpression.java
@@ -11,20 +11,25 @@ import java.util.stream.Collectors;
 
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTReferenceExpression extends AbstractApexNode.Single<Node> {
+import com.google.summit.ast.Identifier;
+
+public class ASTReferenceExpression extends AbstractApexNode.Many<Identifier> {
+
+    private final ReferenceType referenceType;
+    private final boolean isSafe;
 
     @Deprecated
     @InternalApi
-    public ASTReferenceExpression(Node referenceExpression) {
-        super(referenceExpression);
+    public ASTReferenceExpression(List<Identifier> identifiers, ReferenceType referenceType, boolean isSafe) {
+        super(identifiers);
+        this.referenceType = referenceType;
+        this.isSafe = isSafe;
     }
-
 
     @Override
     public Object jjtAccept(ApexParserVisitor visitor, Object data) {
         return visitor.visit(this, data);
     }
-
 
     /*
     public IdentifierContext getContext() {
@@ -33,50 +38,35 @@ public class ASTReferenceExpression extends AbstractApexNode.Single<Node> {
      */
     // TODO(b/239648780)
 
-
     /*
     public ReferenceType getReferenceType() {
-        return node.getReferenceType();
+        return referenceType;
     }
      */
     // TODO(b/239648780)
 
     @Override
     public String getImage() {
-        /*
-        if (node.getNames() != null && !node.getNames().isEmpty()) {
-            return node.getNames().get(0).getValue();
+        if (!nodes.isEmpty()) {
+            return nodes.get(0).getString();
         }
-         */
-        // TODO(b/239648780)
-        return null;
+        return "";
     }
 
     public List<String> getNames() {
-        /*
-        List<Identifier> identifiers = node.getNames();
-        if (identifiers != null) {
-            return identifiers.stream().map(id -> id.getValue()).collect(Collectors.toList());
-        }
-         */
-        // TODO(b/239648780)
-        return Collections.emptyList();
+        return nodes.stream().map(Identifier::getString).collect(Collectors.toList());
     }
 
     public boolean isSafeNav() {
-        // return node.isSafeNav();
-        // TODO(b/239648780)
-        return false;
+        return this.isSafe;
     }
 
     public boolean isSObjectType() {
-        /*
-        List<Identifier> identifiers = node.getNames();
-        if (identifiers != null) {
-            return identifiers.stream().anyMatch(id -> "sobjecttype".equalsIgnoreCase(id.getValue()));
-        }
-         */
-        // TODO(b/239648780)
-        return false;
+        return nodes.stream().anyMatch(id -> "sobjecttype".contentEquals(id.getString()));
+    }
+
+    @Override
+    public boolean hasRealLoc() {
+        return !nodes.isEmpty();
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSuperMethodCallExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSuperMethodCallExpression.java
@@ -7,12 +7,14 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTSuperMethodCallExpression extends AbstractApexNode.Single<Node> {
+import com.google.summit.ast.expression.CallExpression;
+
+public class ASTSuperMethodCallExpression extends AbstractApexNode.Single<CallExpression> {
 
     @Deprecated
     @InternalApi
-    public ASTSuperMethodCallExpression(Node superMethodCallExpression) {
-        super(superMethodCallExpression);
+    public ASTSuperMethodCallExpression(CallExpression callExpression) {
+        super(callExpression);
     }
 
     @Override

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSuperMethodCallExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSuperMethodCallExpression.java
@@ -11,9 +11,7 @@ import com.google.summit.ast.expression.CallExpression;
 
 public class ASTSuperMethodCallExpression extends AbstractApexNode.Single<CallExpression> {
 
-    @Deprecated
-    @InternalApi
-    public ASTSuperMethodCallExpression(CallExpression callExpression) {
+    ASTSuperMethodCallExpression(CallExpression callExpression) {
         super(callExpression);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSuperMethodCallExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSuperMethodCallExpression.java
@@ -4,9 +4,6 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-import com.google.summit.ast.Node;
-import net.sourceforge.pmd.annotation.InternalApi;
-
 import com.google.summit.ast.expression.CallExpression;
 
 public class ASTSuperMethodCallExpression extends AbstractApexNode.Single<CallExpression> {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSuperVariableExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSuperVariableExpression.java
@@ -7,12 +7,14 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTSuperVariableExpression extends AbstractApexNode.Single<Node> {
+import com.google.summit.ast.expression.SuperExpression;
+
+public class ASTSuperVariableExpression extends AbstractApexNode.Single<SuperExpression> {
 
     @Deprecated
     @InternalApi
-    public ASTSuperVariableExpression(Node superVariableExpression) {
-        super(superVariableExpression);
+    public ASTSuperVariableExpression(SuperExpression superExpression) {
+        super(superExpression);
     }
 
     @Override

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSuperVariableExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSuperVariableExpression.java
@@ -11,9 +11,7 @@ import com.google.summit.ast.expression.SuperExpression;
 
 public class ASTSuperVariableExpression extends AbstractApexNode.Single<SuperExpression> {
 
-    @Deprecated
-    @InternalApi
-    public ASTSuperVariableExpression(SuperExpression superExpression) {
+    ASTSuperVariableExpression(SuperExpression superExpression) {
         super(superExpression);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSuperVariableExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSuperVariableExpression.java
@@ -4,9 +4,6 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-import com.google.summit.ast.Node;
-import net.sourceforge.pmd.annotation.InternalApi;
-
 import com.google.summit.ast.expression.SuperExpression;
 
 public class ASTSuperVariableExpression extends AbstractApexNode.Single<SuperExpression> {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTernaryExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTernaryExpression.java
@@ -11,9 +11,7 @@ import com.google.summit.ast.expression.TernaryExpression;
 
 public class ASTTernaryExpression extends AbstractApexNode.Single<TernaryExpression> {
 
-    @Deprecated
-    @InternalApi
-    public ASTTernaryExpression(TernaryExpression ternaryExpression) {
+    ASTTernaryExpression(TernaryExpression ternaryExpression) {
         super(ternaryExpression);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTernaryExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTernaryExpression.java
@@ -4,9 +4,6 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-import com.google.summit.ast.Node;
-import net.sourceforge.pmd.annotation.InternalApi;
-
 import com.google.summit.ast.expression.TernaryExpression;
 
 public class ASTTernaryExpression extends AbstractApexNode.Single<TernaryExpression> {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTernaryExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTernaryExpression.java
@@ -7,7 +7,9 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTTernaryExpression extends AbstractApexNode.Single<Node> {
+import com.google.summit.ast.expression.TernaryExpression;
+
+public class ASTTernaryExpression extends AbstractApexNode.Single<TernaryExpression> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTernaryExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTernaryExpression.java
@@ -13,7 +13,7 @@ public class ASTTernaryExpression extends AbstractApexNode.Single<TernaryExpress
 
     @Deprecated
     @InternalApi
-    public ASTTernaryExpression(Node ternaryExpression) {
+    public ASTTernaryExpression(TernaryExpression ternaryExpression) {
         super(ternaryExpression);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThisMethodCallExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThisMethodCallExpression.java
@@ -7,12 +7,14 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTThisMethodCallExpression extends AbstractApexNode.Single<Node> {
+import com.google.summit.ast.expression.CallExpression;
+
+public class ASTThisMethodCallExpression extends AbstractApexNode.Single<CallExpression> {
 
     @Deprecated
     @InternalApi
-    public ASTThisMethodCallExpression(Node thisMethodCallExpression) {
-        super(thisMethodCallExpression);
+    public ASTThisMethodCallExpression(CallExpression callExpression) {
+        super(callExpression);
     }
 
     @Override

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThisMethodCallExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThisMethodCallExpression.java
@@ -11,9 +11,7 @@ import com.google.summit.ast.expression.CallExpression;
 
 public class ASTThisMethodCallExpression extends AbstractApexNode.Single<CallExpression> {
 
-    @Deprecated
-    @InternalApi
-    public ASTThisMethodCallExpression(CallExpression callExpression) {
+    ASTThisMethodCallExpression(CallExpression callExpression) {
         super(callExpression);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThisMethodCallExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThisMethodCallExpression.java
@@ -4,9 +4,6 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-import com.google.summit.ast.Node;
-import net.sourceforge.pmd.annotation.InternalApi;
-
 import com.google.summit.ast.expression.CallExpression;
 
 public class ASTThisMethodCallExpression extends AbstractApexNode.Single<CallExpression> {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThisVariableExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThisVariableExpression.java
@@ -11,9 +11,7 @@ import com.google.summit.ast.expression.ThisExpression;
 
 public class ASTThisVariableExpression extends AbstractApexNode.Single<ThisExpression> {
 
-    @Deprecated
-    @InternalApi
-    public ASTThisVariableExpression(ThisExpression thisExpression) {
+    ASTThisVariableExpression(ThisExpression thisExpression) {
         super(thisExpression);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThisVariableExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThisVariableExpression.java
@@ -7,12 +7,14 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTThisVariableExpression extends AbstractApexNode.Single<Node> {
+import com.google.summit.ast.expression.ThisExpression;
+
+public class ASTThisVariableExpression extends AbstractApexNode.Single<ThisExpression> {
 
     @Deprecated
     @InternalApi
-    public ASTThisVariableExpression(Node thisVariableExpression) {
-        super(thisVariableExpression);
+    public ASTThisVariableExpression(ThisExpression thisExpression) {
+        super(thisExpression);
     }
 
     @Override

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThisVariableExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThisVariableExpression.java
@@ -4,9 +4,6 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-import com.google.summit.ast.Node;
-import net.sourceforge.pmd.annotation.InternalApi;
-
 import com.google.summit.ast.expression.ThisExpression;
 
 public class ASTThisVariableExpression extends AbstractApexNode.Single<ThisExpression> {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClass.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClass.java
@@ -33,7 +33,7 @@ public class ASTUserClass extends ApexRootNode<ClassDeclaration> implements ASTU
 
     @Override
     public String getImage() {
-        return node.getId().asCodeString();
+        return node.getId().getString();
     }
 
     @Override

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClass.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClass.java
@@ -18,9 +18,7 @@ public class ASTUserClass extends ApexRootNode<ClassDeclaration> implements ASTU
 
     private ApexQualifiedName qname;
 
-    @Deprecated
-    @InternalApi
-    public ASTUserClass(ClassDeclaration userClass) {
+    ASTUserClass(ClassDeclaration userClass) {
         super(userClass);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClass.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClass.java
@@ -7,11 +7,10 @@ package net.sourceforge.pmd.lang.apex.ast;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import net.sourceforge.pmd.Rule;
-import net.sourceforge.pmd.annotation.InternalApi;
-
 import com.google.summit.ast.TypeRef;
 import com.google.summit.ast.declaration.ClassDeclaration;
+
+import net.sourceforge.pmd.Rule;
 
 public class ASTUserClass extends ApexRootNode<ClassDeclaration> implements ASTUserClassOrInterface<ClassDeclaration>,
         CanSuppressWarnings {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserEnum.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserEnum.java
@@ -8,9 +8,7 @@ import net.sourceforge.pmd.annotation.InternalApi;
 
 import com.google.summit.ast.declaration.TypeDeclaration;
 
-public class ASTUserEnum extends ApexRootNode<TypeDeclaration> implements ApexQualifiableNode {
-
-    private ApexQualifiedName qname;
+public class ASTUserEnum extends ApexRootNode<TypeDeclaration> {
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserEnum.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserEnum.java
@@ -8,7 +8,9 @@ import net.sourceforge.pmd.annotation.InternalApi;
 
 import com.google.summit.ast.declaration.TypeDeclaration;
 
-public class ASTUserEnum extends ApexRootNode<TypeDeclaration> {
+public class ASTUserEnum extends ApexRootNode<TypeDeclaration> implements ApexQualifiableNode {
+
+    private ApexQualifiedName qname;
 
     @Deprecated
     @InternalApi

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserInterface.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserInterface.java
@@ -29,7 +29,7 @@ public class ASTUserInterface extends ApexRootNode<InterfaceDeclaration> impleme
 
     @Override
     public String getImage() {
-        return node.getId().asCodeString();
+        return node.getId().getString();
     }
 
     @Override

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserInterface.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserInterface.java
@@ -4,12 +4,9 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-import java.util.stream.Collectors;
+import com.google.summit.ast.declaration.InterfaceDeclaration;
 
 import net.sourceforge.pmd.Rule;
-import net.sourceforge.pmd.annotation.InternalApi;
-
-import com.google.summit.ast.declaration.InterfaceDeclaration;
 
 public class ASTUserInterface extends ApexRootNode<InterfaceDeclaration> implements ASTUserClassOrInterface<InterfaceDeclaration>,
        CanSuppressWarnings {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserInterface.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserInterface.java
@@ -16,9 +16,7 @@ public class ASTUserInterface extends ApexRootNode<InterfaceDeclaration> impleme
 
     private ApexQualifiedName qname;
 
-    @Deprecated
-    @InternalApi
-    public ASTUserInterface(InterfaceDeclaration userInterface) {
+    ASTUserInterface(InterfaceDeclaration userInterface) {
         super(userInterface);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableExpression.java
@@ -11,9 +11,7 @@ import com.google.summit.ast.Identifier;
 
 public class ASTVariableExpression extends AbstractApexNode.Single<Identifier> {
 
-    @Deprecated
-    @InternalApi
-    public ASTVariableExpression(Identifier identifier) {
+    ASTVariableExpression(Identifier identifier) {
         super(identifier);
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableExpression.java
@@ -7,12 +7,14 @@ package net.sourceforge.pmd.lang.apex.ast;
 import com.google.summit.ast.Node;
 import net.sourceforge.pmd.annotation.InternalApi;
 
-public class ASTVariableExpression extends AbstractApexNode.Single<Node> {
+import com.google.summit.ast.Identifier;
+
+public class ASTVariableExpression extends AbstractApexNode.Single<Identifier> {
 
     @Deprecated
     @InternalApi
-    public ASTVariableExpression(Node variableExpression) {
-        super(variableExpression);
+    public ASTVariableExpression(Identifier identifier) {
+        super(identifier);
     }
 
     @Override
@@ -22,12 +24,6 @@ public class ASTVariableExpression extends AbstractApexNode.Single<Node> {
 
     @Override
     public String getImage() {
-        /*
-        if (node.getIdentifier() != null) {
-            return node.getIdentifier().getValue();
-        }
-         */
-        // TODO(b/239648780)
-        return null;
+        return node.getString();
     }
 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableExpression.java
@@ -4,9 +4,6 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-import com.google.summit.ast.Node;
-import net.sourceforge.pmd.annotation.InternalApi;
-
 import com.google.summit.ast.Identifier;
 
 public class ASTVariableExpression extends AbstractApexNode.Single<Identifier> {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNode.java
@@ -33,6 +33,25 @@ public abstract class AbstractApexNode extends AbstractApexNodeBase implements A
             super(node.getClass());
             this.node = node;
         }
+
+        @Override
+        void calculateLineNumbers(SourceCodePositioner positioner) {
+            setLineNumbers(node.getSourceLocation());
+        }
+
+        @Override
+        public boolean hasRealLoc() {
+            return !node.getSourceLocation().isUnknown();
+        }
+
+        @Override
+        public String getLocation() {
+            if (hasRealLoc()) {
+                return String.valueOf(node.getSourceLocation());
+            } else {
+                return "no location";
+            }
+        }
     }
 
     /**
@@ -50,10 +69,60 @@ public abstract class AbstractApexNode extends AbstractApexNodeBase implements A
             super(nodes.getClass());
             this.nodes = nodes;
         }
+
+        @Override
+        void calculateLineNumbers(SourceCodePositioner positioner) {
+            for (Node node : nodes) {
+                setLineNumbers(node.getSourceLocation());
+            }
+        }
+
+        @Override
+        public boolean hasRealLoc() {
+            return false;
+        }
+
+        @Override
+        public String getLocation() {
+            return "no location";
+        }
+    }
+
+    /**
+     * {@link AbstractApexNode} that doesn't directly wrap a {@link Node}.
+     *
+     * @deprecated Use {@link ApexNode}
+     */
+    @Deprecated
+    @InternalApi
+    public static abstract class Empty extends AbstractApexNode {
+
+        protected Empty() {
+            super(Void.class);
+        }
+
+        @Override
+        void calculateLineNumbers(SourceCodePositioner positioner) {
+            // no operation
+        }
+
+        @Override
+        public boolean hasRealLoc() {
+            return false;
+        }
+
+        @Override
+        public String getLocation() {
+            return "no location";
+        }
     }
 
     protected AbstractApexNode(Class<?> klass) {
         super(klass);
+    }
+
+    protected AbstractApexNode() {
+        this(Void.class);
     }
 
     @Override
@@ -71,42 +140,15 @@ public abstract class AbstractApexNode extends AbstractApexNodeBase implements A
         return (Iterable<? extends ApexNode<?>>) super.children();
     }
 
-    void calculateLineNumbers(SourceCodePositioner positioner) {
-        if (!hasRealLoc()) {
-            return;
-        }
-
-        // Location loc = node.getLoc();
-        // calculateLineNumbers(positioner, loc.getStartIndex(), loc.getEndIndex());
-        // TODO(b/239648780)
-    }
+    abstract void calculateLineNumbers(SourceCodePositioner positioner);
 
     protected void handleSourceCode(String source) {
         // default implementation does nothing
     }
 
-    @Override
-    public boolean hasRealLoc() {
-        try {
-            // Location loc = node.getLoc();
-            // return loc != null && Locations.isReal(loc);
-            // TODO(b/239648780)
-            return false;
-        } catch (IndexOutOfBoundsException | NullPointerException e) {
-            // bug in apex-jorje? happens on some ReferenceExpression nodes
-            return false;
-        }
-    }
+    public abstract boolean hasRealLoc();
 
-    public String getLocation() {
-        if (hasRealLoc()) {
-            // return String.valueOf(node.getLoc());
-            // TODO(b/239648780)
-            return null;
-        } else {
-            return "no location";
-        }
-    }
+    public abstract String getLocation();
 
     // private TypeInfo getDefiningTypeOrNull() {
     //     try {
@@ -119,11 +161,10 @@ public abstract class AbstractApexNode extends AbstractApexNodeBase implements A
 
     @Override
     public String getDefiningType() {
-        // TypeInfo definingType = getDefiningTypeOrNull();
-        // if (definingType != null) {
-        //     return definingType.getApexName();
-        // }
-        // TODO(b/239648780)
+        ApexRootNode<?> rootNode = this instanceof ApexRootNode ? (ApexRootNode<?>) this : getFirstParentOfType(ApexRootNode.class);
+        if (rootNode != null) {
+            return rootNode.node.getQualifiedName();
+        }
         return null;
     }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNodeBase.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNodeBase.java
@@ -7,7 +7,8 @@ package net.sourceforge.pmd.lang.apex.ast;
 import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.ast.AbstractNode;
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.ast.SourceCodePositioner;
+
+import com.google.summit.ast.SourceLocation;
 
 /**
  * @deprecated Use {@link ApexNode}
@@ -20,19 +21,15 @@ public abstract class AbstractApexNodeBase extends AbstractNode {
         super(klass.hashCode());
     }
 
-    /* package */ void calculateLineNumbers(SourceCodePositioner positioner, int startOffset, int endOffset) {
-        // end column will be interpreted as inclusive, while endOffset/endIndex
-        // is exclusive
-        endOffset -= 1;
-
-        this.beginLine = positioner.lineNumberFromOffset(startOffset);
-        this.beginColumn = positioner.columnFromOffset(this.beginLine, startOffset);
-        this.endLine = positioner.lineNumberFromOffset(endOffset);
-        this.endColumn = positioner.columnFromOffset(this.endLine, endOffset);
-
-        if (this.endColumn < 0) {
-            this.endColumn = 0;
+    void setLineNumbers(SourceLocation loc) {
+        if (loc.isUnknown()) {
+            return;
         }
+
+        this.beginLine = loc.getStartLine();
+        this.beginColumn = loc.getStartColumn();
+        this.endLine = loc.getEndLine();
+        this.endColumn = loc.getEndColumn();
     }
 
     /**

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexTreeBuilder.kt
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexTreeBuilder.kt
@@ -15,11 +15,32 @@ import com.google.summit.ast.Node
 import com.google.summit.ast.TypeRef
 import com.google.summit.ast.declaration.ClassDeclaration
 import com.google.summit.ast.declaration.EnumDeclaration
+import com.google.summit.ast.declaration.FieldDeclaration
+import com.google.summit.ast.declaration.FieldDeclarationGroup
 import com.google.summit.ast.declaration.InterfaceDeclaration
+import com.google.summit.ast.declaration.MethodDeclaration
+import com.google.summit.ast.declaration.PropertyDeclaration
 import com.google.summit.ast.declaration.TriggerDeclaration
 import com.google.summit.ast.declaration.TypeDeclaration
+import com.google.summit.ast.expression.ArrayExpression
+import com.google.summit.ast.expression.AssignExpression
+import com.google.summit.ast.expression.BinaryExpression
+import com.google.summit.ast.expression.CallExpression
+import com.google.summit.ast.expression.CastExpression
+import com.google.summit.ast.expression.Expression
+import com.google.summit.ast.expression.FieldExpression
+import com.google.summit.ast.expression.LiteralExpression
+import com.google.summit.ast.expression.SuperExpression
+import com.google.summit.ast.expression.TernaryExpression
+import com.google.summit.ast.expression.ThisExpression
+import com.google.summit.ast.expression.TypeRefExpression
+import com.google.summit.ast.expression.UnaryExpression
+import com.google.summit.ast.expression.VariableExpression
 import com.google.summit.ast.modifier.KeywordModifier
+import com.google.summit.ast.modifier.KeywordModifier.Keyword
 import com.google.summit.ast.modifier.Modifier
+import com.google.summit.ast.statement.CompoundStatement
+import com.google.summit.ast.statement.ExpressionStatement
 
 @Deprecated("internal")
 @InternalApi
@@ -55,67 +76,300 @@ class ApexTreeBuilder(val sourceCode: String, val parserOptions: ApexParserOptio
             null
         )
 
-    /**
-     * Builds an [ApexNode] wrapper for [node].
-     *
-     * Sets the parent of the resulting [ApexNode] to [parent], if it's not `null`.
-     */
-    private fun build(node: Node?, parent: ApexNode<*>?): ApexNode<*>? {
-        val wrapper: ApexNode<*>? =
-            when (node) {
-                null -> null
-                is CompilationUnit -> build(node.typeDeclaration, parent)
-                is TypeDeclaration -> buildTypeDeclaration(node)
-                is Identifier,
-                is KeywordModifier,
-                is TypeRef -> null
-                else -> {
-                    println("No adapter exists for type ${node::class.qualifiedName}")
-                    // TODO(b/239648780): temporary print
-                    null
-                }
+    /** Builds an [ApexNode] wrapper for [node]. */
+    private fun build(node: Node?, parent: ApexNode<*>?): ApexNode<*>? =
+        when (node) {
+            null -> null
+            is CompilationUnit -> build(node.typeDeclaration, parent)
+            is TypeDeclaration -> buildTypeDeclaration(node)
+            is MethodDeclaration -> buildMethodDeclaration(node, parent)
+            is PropertyDeclaration -> buildPropertyDeclaration(node)
+            is FieldDeclarationGroup -> buildFieldDeclarationGroup(node)
+            is FieldDeclaration -> ASTFieldDeclaration(node).apply { buildChildren(node, parent = this) }
+            is CompoundStatement -> ASTBlockStatement(node).apply { buildChildren(node, parent = this) }
+            is ExpressionStatement ->
+                ASTExpressionStatement(node).apply { buildChildren(node, parent = this) }
+            is AssignExpression ->
+                ASTAssignmentExpression(node).apply { buildChildren(node, parent = this) }
+            is ArrayExpression -> buildArrayExpression(node)
+            is LiteralExpression ->
+                ASTLiteralExpression(node).apply { buildChildren(node, parent = this) }
+            is CastExpression -> ASTCastExpression(node).apply { buildChildren(node, parent = this) }
+            is BinaryExpression -> buildBinaryExpression(node)
+            is UnaryExpression -> buildUnaryExpression(node)
+            is SuperExpression ->
+                ASTSuperVariableExpression(node).apply { buildChildren(node, parent = this) }
+            is ThisExpression ->
+                ASTThisVariableExpression(node).apply { buildChildren(node, parent = this) }
+            is TypeRefExpression ->
+                ASTClassRefExpression(node).apply { buildChildren(node, parent = this) }
+            is FieldExpression -> buildFieldExpression(node)
+            is VariableExpression -> buildVariableExpression(node)
+            is CallExpression -> buildCallExpression(node)
+            is TernaryExpression -> buildTernaryExpression(node)
+            is Identifier,
+            is KeywordModifier,
+            is TypeRef -> null
+            else -> {
+                println("No adapter exists for type ${node::class.qualifiedName}")
+                // TODO(b/239648780): temporary print
+                null
             }
+        }
 
-        wrapper?.setParent(parent)
-        return wrapper
-    }
-
-    /** Calls [build] on each of [nodes]. */
-    private fun build(nodes: List<Node>, parent: ApexNode<*>?) = nodes.forEach { build(it, parent) }
+    /** Builds an [ApexNode] wrapper for [node] and sets its parent to [parent]. */
+    private fun buildAndSetParent(node: Node?, parent: ApexNode<*>) =
+        build(node, parent)?.also { it.setParent(parent) }
 
     /**
-     * Calls [build] on each [child][Node.getChildren] of [node].
+     * Builds an [ApexNode] wrapper for each [child][Node.getChildren] of [node] and sets its parent
+     * to [parent].
      *
      * If [exclude] is provided, child nodes matching this predicate are not visited.
      */
     private fun buildChildren(
         node: Node,
-        parent: ApexNode<*>?,
+        parent: ApexNode<*>,
         exclude: (Node) -> Boolean = { false } // exclude none by default
-    ) = node.getChildren().filterNot(exclude).forEach { build(it, parent) }
+    ) = node.getChildren().filterNot(exclude).forEach { buildAndSetParent(it, parent) }
 
     /** Builds an [ApexRootNode] wrapper for the [TypeDeclaration] node. */
     private fun buildTypeDeclaration(node: TypeDeclaration) =
         when (node) {
             is ClassDeclaration ->
                 ASTUserClass(node).apply {
-                    val modifiers = buildModifiers(node.modifiers)
-                    modifiers.setParent(this)
+                    buildModifiers(node.modifiers).also { it.setParent(this) }
                     buildChildren(node, parent = this, exclude = { it in node.modifiers })
                 }
             is InterfaceDeclaration ->
                 ASTUserInterface(node).apply {
-                    val modifiers = buildModifiers(node.modifiers)
-                    modifiers.setParent(this)
+                    buildModifiers(node.modifiers).also { it.setParent(this) }
                     buildChildren(node, parent = this, exclude = { it in node.modifiers })
                 }
             is EnumDeclaration -> ASTUserEnum(node) // TODO(b/239648780): enum body is untranslated
             is TriggerDeclaration -> ASTUserTrigger(node) // TODO(b/239648780): visit children
         }
 
+    /** Builds an [ASTMethod] wrapper for the [MethodDeclaration] node. */
+    private fun buildMethodDeclaration(node: MethodDeclaration, parent: ApexNode<*>?) =
+        when {
+            node.isAnonymousInitializationCode() && !node.hasKeyword(Keyword.STATIC) ->
+                build(node.body, parent)
+            else -> {
+                ASTMethod(node).apply {
+                    buildModifiers(node.modifiers).also { it.setParent(this) }
+                    buildChildren(node, parent = this, exclude = { it in node.modifiers })
+                }
+            }
+        }
+
+    /** Builds an [ASTProperty] wrapper for the [PropertyDeclaration] node. */
+    private fun buildPropertyDeclaration(node: PropertyDeclaration) =
+        ASTProperty(node).apply {
+            buildModifiers(node.modifiers).also { it.setParent(this) }
+            buildChildren(node, parent = this, exclude = { it in node.modifiers })
+        }
+
+    /** Builds an [ASTFieldDeclarationStatements] wrapper for the [FieldDeclarationGroup] node. */
+    private fun buildFieldDeclarationGroup(node: FieldDeclarationGroup) =
+        ASTFieldDeclarationStatements(node).apply {
+            buildModifiers(node.modifiers).also { it.setParent(this) }
+            buildChildren(node, parent = this, exclude = { it in node.modifiers })
+        }
+
+    /**
+     * Builds an [ASTArrayStoreExpression] or [ASTArrayLoadExpression] wrapper for the
+     * [ArrayExpression] node.
+     */
+    private fun buildArrayExpression(node: ArrayExpression) =
+        if ((node.parent as? AssignExpression)?.target == node) {
+            ASTArrayStoreExpression(node)
+        } else {
+            ASTArrayLoadExpression(node)
+        }
+            .apply { buildChildren(node, parent = this) }
+
+    /**
+     * Builds an [ASTBinaryExpression], [ASTBooleanExpression], or [ASTInstanceOfExpression] wrapper
+     * for the [BinaryExpression] node.
+     */
+    private fun buildBinaryExpression(node: BinaryExpression) =
+        when (node.op) {
+            BinaryExpression.Operator.INSTANCEOF -> ASTInstanceOfExpression(node)
+            BinaryExpression.Operator.GREATER_THAN_OR_EQUAL,
+            BinaryExpression.Operator.GREATER_THAN,
+            BinaryExpression.Operator.LESS_THAN,
+            BinaryExpression.Operator.LESS_THAN_OR_EQUAL,
+            BinaryExpression.Operator.EQUAL,
+            BinaryExpression.Operator.NOT_EQUAL,
+            BinaryExpression.Operator.ALTERNATIVE_NOT_EQUAL,
+            BinaryExpression.Operator.EXACTLY_EQUAL,
+            BinaryExpression.Operator.EXACTLY_NOT_EQUAL,
+            BinaryExpression.Operator.LOGICAL_AND,
+            BinaryExpression.Operator.LOGICAL_OR -> ASTBooleanExpression(node)
+            BinaryExpression.Operator.ADDITION,
+            BinaryExpression.Operator.SUBTRACTION,
+            BinaryExpression.Operator.MULTIPLICATION,
+            BinaryExpression.Operator.DIVISION,
+            BinaryExpression.Operator.MODULO,
+            BinaryExpression.Operator.LEFT_SHIFT,
+            BinaryExpression.Operator.RIGHT_SHIFT_SIGNED,
+            BinaryExpression.Operator.RIGHT_SHIFT_UNSIGNED,
+            BinaryExpression.Operator.BITWISE_AND,
+            BinaryExpression.Operator.BITWISE_OR,
+            BinaryExpression.Operator.BITWISE_XOR -> ASTBinaryExpression(node)
+        }.apply { buildChildren(node, parent = this) }
+
+    /**
+     * Builds an [ASTPrefixExpression] or [ASTPostfixExpression] wrapper for the [UnaryExpression]
+     * node.
+     */
+    private fun buildUnaryExpression(node: UnaryExpression) =
+        when (node.op) {
+            UnaryExpression.Operator.PLUS,
+            UnaryExpression.Operator.NEGATION,
+            UnaryExpression.Operator.LOGICAL_COMPLEMENT,
+            UnaryExpression.Operator.BITWISE_NOT,
+            UnaryExpression.Operator.PRE_INCREMENT,
+            UnaryExpression.Operator.PRE_DECREMENT,
+            -> ASTPrefixExpression(node)
+            UnaryExpression.Operator.POST_INCREMENT,
+            UnaryExpression.Operator.POST_DECREMENT,
+            -> ASTPostfixExpression(node)
+        }.apply { buildChildren(node, parent = this) }
+
+    /** Builds an [ASTVariableExpression] wrapper for the [FieldExpression] node. */
+    private fun buildFieldExpression(node: FieldExpression): ASTVariableExpression {
+        val (receiver, components, isSafe) = flattenExpression(node)
+        return ASTVariableExpression(components.last()).apply {
+            buildReferenceExpression(
+                components.dropLast(1),
+                receiver,
+                referenceTypeOf(expr = node),
+                isSafe
+            )
+                .also { it.setParent(this) }
+        }
+    }
+
+    /** Builds an [ASTVariableExpression] wrapper for the [VariableExpression] node. */
+    private fun buildVariableExpression(node: VariableExpression): ASTVariableExpression {
+        val (receiver, components, isSafe) = flattenExpression(node)
+        return ASTVariableExpression(components.last()).apply {
+            buildReferenceExpression(
+                components.dropLast(1),
+                receiver,
+                referenceTypeOf(expr = node),
+                isSafe
+            )
+                .also { it.setParent(this) }
+        }
+    }
+
+    /**
+     * Builds an [ASTMethodCallExpression], [ASTThisMethodCallExpression], or
+     * [ASTSuperMethodCallExpression] wrapper for the [CallExpression] node.
+     */
+    private fun buildCallExpression(node: CallExpression) =
+        when (node.id.string.lowercase()) {
+            "this" -> ASTThisMethodCallExpression(node).apply { buildChildren(node, parent = this) }
+            "super" -> ASTSuperMethodCallExpression(node).apply { buildChildren(node, parent = this) }
+            else -> {
+                val (receiver, components, isSafe) = flattenExpression(node.receiver)
+                ASTMethodCallExpression(node, components).apply {
+                    buildReferenceExpression(components, receiver, ReferenceType.METHOD, isSafe).also {
+                        it.setParent(this)
+                    }
+                    buildChildren(node, parent = this, exclude = { it == node.receiver })
+                }
+            }
+        }
+
+    /**
+     * Result of [flattenExpression].
+     *
+     * @param remainder remaining [Expression] that could not be flattened
+     * @param components list of extracted [Identifier]s
+     * @param isSafe whether a safe [access][FieldExpression.isSafe] or [call][CallExpression.isSafe]
+     * was found
+     */
+    private data class FlatExpression(
+        val remainder: Expression?,
+        val components: List<Identifier>,
+        val isSafe: Boolean
+    )
+
+    /**
+     * Attempts to flatten an [Expression] tree containing variable references into a list of
+     * [Identifier]s. Applicable nodes are [FieldExpression] and [VariableExpression].
+     */
+    private fun flattenExpression(
+        node: Expression?,
+        components: List<Identifier> = emptyList()
+    ): FlatExpression =
+        when (node) {
+            is FieldExpression ->
+                if (node.isSafe) {
+                    // Don't flatten a safe access
+                    FlatExpression(
+                        remainder = node.obj,
+                        components = listOf(node.field) + components,
+                        isSafe = true
+                    )
+                } else {
+                    // Extract node.field and continue flattening
+                    flattenExpression(node = node.obj, components = listOf(node.field) + components)
+                }
+            is VariableExpression ->
+                // Extract node.id and stop
+                FlatExpression(remainder = null, components = listOf(node.id) + components, isSafe = false)
+            else ->
+                // Can't flatten
+                FlatExpression(remainder = node, components, isSafe = false)
+        }
+
+    /**
+     * Builds an [ASTReferenceExpression] or [ASTEmptyReferenceExpression] from [components].
+     *
+     * @param components the [Identifier]s in this reference expression
+     * @param receiver the node that is being accessed
+     * @param isSafe whether this is a safe access
+     */
+    private fun buildReferenceExpression(
+        components: List<Identifier>,
+        receiver: Node?,
+        referenceType: ReferenceType,
+        isSafe: Boolean
+    ) =
+        if (receiver == null && components.isEmpty()) {
+            ASTEmptyReferenceExpression()
+        } else {
+            ASTReferenceExpression(components, referenceType, isSafe)
+        }
+            .apply { buildAndSetParent(receiver, parent = this) }
+
+    /** Determines the [ReferenceType] of an [Expression]. */
+    private fun referenceTypeOf(expr: Expression) =
+        if ((expr.parent as? AssignExpression)?.target == expr) {
+            ReferenceType.STORE
+        } else {
+            ReferenceType.LOAD
+        }
+
+    /** Builds an [ASTTernaryExpression] wrapper for the [TernaryExpression]. */
+    private fun buildTernaryExpression(node: TernaryExpression) =
+        ASTTernaryExpression(node).apply {
+            buildCondition(node.condition).also { it.setParent(this) }
+            buildChildren(node, parent = this, exclude = { it == node.condition })
+        }
+
+    /** Builds an [ASTStandardCondition] wrapper for the [condition]. */
+    private fun buildCondition(condition: Node?) =
+        ASTStandardCondition(condition).apply { buildAndSetParent(condition, this) }
+
     /** Builds an [ASTModifierNode] wrapper for the list of [Modifier]s. */
     private fun buildModifiers(modifiers: List<Modifier>) =
-        ASTModifierNode(modifiers).apply { build(modifiers, parent = this) }
+        ASTModifierNode(modifiers).apply { modifiers.forEach { buildAndSetParent(it, parent = this) } }
 
     /**
      * If [parent] is not null, adds this [ApexNode] as a [child][ApexNode.jjtAddChild] and sets

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ReferenceType.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ReferenceType.java
@@ -1,0 +1,9 @@
+package net.sourceforge.pmd.lang.apex.ast;
+
+public enum ReferenceType {
+    LOAD,
+    STORE,
+    METHOD,
+    CLASS,
+    NONE
+}


### PR DESCRIPTION
Second part of [Summit-AST](https://github.com/google/summit-ast)-based Apex module.

Changes
* Build expression nodes
  * Build assignment expressions
  * Build array expressions
  * Build literal expressions
  * Build cast expressions
  * Build operator expressions
  * Build `this`/`super` expressions
  * Build type reference expressions
  * Build field/variable expressions
  * Build method call expressions
  * Build ternary expressions

* Refactor `AbstractApexNode`
  * Add default implementations for some methods
  * Add Empty constructor (where PMD node does not correspond to Summit Node)
  * Implement `AbstractApexNode.getDefiningType`
    
* Implement reference types
  * Implement `ASTReferenceExpression.isSObjectType`
  * Implement `ASTReferenceExpression.hasRealLoc`
  * Fix `ASTEmptyReferenceExpression.getDefiningType`

* Miscellaneous
  * Implement `ASTMethodCallExpression.getFullMethodName` 
  * Update `ASTLiteralExpression.getImage`
  * Replace `Triple` with `data class`
  * Fix `BITWISE_XOR`
  * Replace `Identifier.asCodeString` with `getString`
  * Fix `ASTLiteralExpression.getImage`
  * Updated Summit-AST to released version (1.0.0)

Related issues: 
- #3766

