### PR TITLE
[java] Use type resolution for UseArrayListInsteadOfVector

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -19,6 +19,8 @@ This is a {{ site.pmd.release_type }} release.
     * [#4144](https://github.com/pmd/pmd/pull/4144) \[doc] Update docs to reflect supported languages
 * java-documentation
     * [#4141](https://github.com/pmd/pmd/issues/4141): \[java] UncommentedEmptyConstructor FP when constructor annotated with @<!-- -->Autowired
+* java-performance
+    * [#4148](https://github.com/pmd/pmd/issues/4148): \[java] UseArrayListInsteadOfVector ignores Vector when other classes are imported
 
 ### API Changes
 

--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -928,16 +928,15 @@ ArrayList is a much better Collection implementation than Vector if thread-safe 
             <property name="version" value="2.0"/>
             <property name="xpath">
                 <value>
-<![CDATA[
-//CompilationUnit[not(ImportDeclaration) or ImportDeclaration[@ImportedName='java.util.Vector']]
-  //AllocationExpression/ClassOrInterfaceType
-    [@Image='Vector' or @Image='java.util.Vector']
+                    <![CDATA[
+//AllocationExpression/ClassOrInterfaceType[pmd-java:typeIs('java.util.Vector')]
 ]]>
                 </value>
             </property>
         </properties>
         <example>
 <![CDATA[
+import java.util.*;
 public class SimpleTest extends TestCase {
     public void testX() {
     Collection c1 = new Vector();

--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -929,7 +929,7 @@ ArrayList is a much better Collection implementation than Vector if thread-safe 
             <property name="xpath">
                 <value>
                     <![CDATA[
-//AllocationExpression/ClassOrInterfaceType[pmd-java:typeIs('java.util.Vector')]
+//AllocationExpression/ClassOrInterfaceType[pmd-java:typeIsExactly('java.util.Vector')]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/UseArrayListInsteadOfVector.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/UseArrayListInsteadOfVector.xml
@@ -5,9 +5,11 @@
     xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
 
     <test-code>
-        <description>TEST0</description>
+        <description>No problem using List and ArrayList</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
+import java.util.ArrayList;
+import java.util.List;
 public class Bar {
     void x() {
         List v = new ArrayList();
@@ -17,9 +19,11 @@ public class Bar {
     </test-code>
 
     <test-code>
-        <description>TEST1</description>
+        <description>Just using Vector</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
         <code><![CDATA[
+import java.util.Vector;
 public class Bar {
     void x() {
         Vector v = new Vector();
@@ -29,9 +33,11 @@ public class Bar {
     </test-code>
 
     <test-code>
-        <description>TEST2</description>
+        <description>Using Vector as field</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>3</expected-linenumbers>
         <code><![CDATA[
+import java.util.Vector;
 public class Bar {
     Vector v = new Vector();
     void x() {}
@@ -40,9 +46,12 @@ public class Bar {
     </test-code>
 
     <test-code>
-        <description>TEST3</description>
+        <description>Using Vector as List</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
         <code><![CDATA[
+import java.util.List;
+import java.util.Vector;
 public class Bar {
     List v = new Vector();
     void x() {}
@@ -53,6 +62,7 @@ public class Bar {
     <test-code>
         <description>#1146 real problem</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
         <code><![CDATA[
 import java.util.Vector;
 public class Foo {
@@ -74,5 +84,36 @@ public class Foo {
     }
 }
         ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] UseArrayListInsteadOfVector ignores Vector when other classes are imported #4148 - sample 1</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code><![CDATA[
+import org.Annotation;
+// import java.util.Vector; Note: explicitly not importing... unresolved type
+@Annotation
+public class C {
+    void x() {
+        Vector v = new Vector();  // should report a warning in this line, but no warnings
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] UseArrayListInsteadOfVector ignores Vector when other classes are imported #4148 - sample 2</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+import some.OtherClass;
+
+public class C {
+    void x() {
+        java.util.Vector v = new java.util.Vector();  // should report a warning
+    }
+}
+]]></code>
     </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/UseArrayListInsteadOfVector.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/UseArrayListInsteadOfVector.xml
@@ -116,4 +116,15 @@ public class C {
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Only consider Vector and not subclasses</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.Stack;
+class StackUser {
+    Stack s = new Stack();
+}
+]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Just uses type resolution to detect `java.util.Vector`

## Related issues

- Fixes #4148

## Ready?

- [x] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

