### PR TITLE
[java] Improve TestClassWithoutTestCases

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -25,6 +25,13 @@ This is a {{ site.pmd.release_type }} release.
 
 The rule is part of the quickstart.xml ruleset.
 
+#### Modified Rules
+
+* The Java rule {% rule java/errorprone/TestClassWithoutTestCases %} has a new property `testClassPattern`. This is
+  used to detect empty test classes by name. Previously this rule could only detect empty JUnit3 test cases
+  properly. To switch back to the old behavior, this property can be set to an empty value which disables the
+  test class detection by pattern.
+
 ### Fixed Issues
 * apex
     * [#4149](https://github.com/pmd/pmd/issues/4149): \[apex] New rule: ApexUnitTestClassShouldHaveRunAs
@@ -32,6 +39,9 @@ The rule is part of the quickstart.xml ruleset.
     * [#4144](https://github.com/pmd/pmd/pull/4144) \[doc] Update docs to reflect supported languages
 * java-documentation
     * [#4141](https://github.com/pmd/pmd/issues/4141): \[java] UncommentedEmptyConstructor FP when constructor annotated with @<!-- -->Autowired
+* java-errorprone
+    * [#929](https://github.com/pmd/pmd/issues/929): \[java] Inconsistent results with TestClassWithoutTestCases
+    * [#2636](https://github.com/pmd/pmd/issues/2636): \[java] TestClassWithoutTestCases false positive with JUnit5 ParameterizedTest
 
 ### API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJUnitRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJUnitRule.java
@@ -34,6 +34,7 @@ public abstract class AbstractJUnitRule extends AbstractJavaRule {
     protected static final String JUNIT3_CLASS_NAME = "junit.framework.TestCase";
     protected static final String JUNIT4_CLASS_NAME = "org.junit.Test";
     protected static final String JUNIT5_CLASS_NAME = "org.junit.jupiter.api.Test";
+    private static final String JUNIT5_NESTED = "org.junit.jupiter.api.Nested";
     private static final Set<String> JUNIT5_TEST_ANNOTATIONS = new HashSet<>(Arrays.asList(
             JUNIT5_CLASS_NAME,
             "org.junit.jupiter.api.RepeatedTest",
@@ -159,6 +160,10 @@ public abstract class AbstractJUnitRule extends AbstractJavaRule {
                 || isTestClassJUnit4(type) && method.isPublic() && doesNodeContainJUnitAnnotation(method.getParent(), JUNIT4_CLASS_NAME)
                 || isTestClassJUnit5(type) && doesNodeContainJUnitAnnotation(method.getParent(), JUNIT5_TEST_ANNOTATIONS)
                 || doesNodeContainJUnitAnnotation(method.getParent(), TESTNG_ANNOTATION);
+    }
+
+    public static boolean isJUnit5NestedClass(ASTClassOrInterfaceBody innerClassDecl) {
+        return doesNodeContainJUnitAnnotation((JavaNode) innerClassDecl.getNthParent(2), JUNIT5_NESTED);
     }
 
     public boolean isJUnitMethod(ASTMethodDeclaration method, Object data) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJUnitRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJUnitRule.java
@@ -4,7 +4,11 @@
 
 package net.sourceforge.pmd.lang.java.rule;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.annotation.InternalApi;
@@ -30,6 +34,14 @@ public abstract class AbstractJUnitRule extends AbstractJavaRule {
     protected static final String JUNIT3_CLASS_NAME = "junit.framework.TestCase";
     protected static final String JUNIT4_CLASS_NAME = "org.junit.Test";
     protected static final String JUNIT5_CLASS_NAME = "org.junit.jupiter.api.Test";
+    private static final Set<String> JUNIT5_TEST_ANNOTATIONS = new HashSet<>(Arrays.asList(
+            JUNIT5_CLASS_NAME,
+            "org.junit.jupiter.api.RepeatedTest",
+            "org.junit.jupiter.api.TestFactory",
+            "org.junit.jupiter.api.TestTemplate",
+            "org.junit.jupiter.params.ParameterizedTest"));
+
+    private static final String TESTNG_ANNOTATION = "org.testng.annotations.Test";
 
     protected boolean isJUnit3Class;
     protected boolean isJUnit4Class;
@@ -92,12 +104,12 @@ public abstract class AbstractJUnitRule extends AbstractJavaRule {
 
         if (isJUnit4Class && isJUnit5Class) {
             isJUnit4Class &= hasImports(node, JUNIT4_CLASS_NAME);
-            isJUnit5Class &= hasImports(node, JUNIT5_CLASS_NAME);
+            isJUnit5Class &= hasImports(node, JUNIT5_TEST_ANNOTATIONS);
         }
     }
 
     public static boolean isTestClass(ASTClassOrInterfaceBody node) {
-        return !isAbstractClass(node)
+        return !isAbstractClass(node) && node.getParent() instanceof ASTClassOrInterfaceDeclaration
                 && (isTestClassJUnit3(node) || isTestClassJUnit4(node) || isTestClassJUnit5(node));
     }
 
@@ -131,7 +143,7 @@ public abstract class AbstractJUnitRule extends AbstractJavaRule {
         Node parent = node.getParent();
         if (parent instanceof TypeNode) {
             TypeNode type = (TypeNode) parent;
-            return isJUnit5Class(type) && hasImports(type, JUNIT5_CLASS_NAME);
+            return isJUnit5Class(type) && hasImports(type, JUNIT5_TEST_ANNOTATIONS);
         }
         return false;
     }
@@ -145,7 +157,8 @@ public abstract class AbstractJUnitRule extends AbstractJavaRule {
         ASTClassOrInterfaceBody type = method.getFirstParentOfType(ASTClassOrInterfaceBody.class);
         return isTestClassJUnit3(type) && method.isPublic() && method.isVoid() && method.getName().startsWith("test")
                 || isTestClassJUnit4(type) && method.isPublic() && doesNodeContainJUnitAnnotation(method.getParent(), JUNIT4_CLASS_NAME)
-                || isTestClassJUnit5(type) && doesNodeContainJUnitAnnotation(method.getParent(), JUNIT5_CLASS_NAME);
+                || isTestClassJUnit5(type) && doesNodeContainJUnitAnnotation(method.getParent(), JUNIT5_TEST_ANNOTATIONS)
+                || doesNodeContainJUnitAnnotation(method.getParent(), TESTNG_ANNOTATION);
     }
 
     public boolean isJUnitMethod(ASTMethodDeclaration method, Object data) {
@@ -170,7 +183,7 @@ public abstract class AbstractJUnitRule extends AbstractJavaRule {
     }
 
     private boolean isJUnit5Method(ASTMethodDeclaration method) {
-        return isJUnit5Class && doesNodeContainJUnitAnnotation(method.getParent(), JUNIT5_CLASS_NAME);
+        return isJUnit5Class && doesNodeContainJUnitAnnotation(method.getParent(), JUNIT5_TEST_ANNOTATIONS);
     }
 
     private boolean isJUnit3Method(ASTMethodDeclaration method) {
@@ -186,34 +199,72 @@ public abstract class AbstractJUnitRule extends AbstractJavaRule {
     }
 
     private static boolean isJUnit5Class(JavaNode node) {
-        return doesNodeContainJUnitAnnotation(node, JUNIT5_CLASS_NAME);
+        return doesNodeContainJUnitAnnotation(node, JUNIT5_TEST_ANNOTATIONS);
     }
 
     private static boolean doesNodeContainJUnitAnnotation(JavaNode node, String annotationTypeClassName) {
+        return doesNodeContainJUnitAnnotation(node, Collections.singleton(annotationTypeClassName));
+    }
+
+    private static boolean doesNodeContainJUnitAnnotation(JavaNode node, Set<String> annotationTypeClassNames) {
         List<ASTAnnotation> annotations = node.findDescendantsOfType(ASTAnnotation.class);
         for (ASTAnnotation annotation : annotations) {
             Node annotationTypeNode = annotation.getChild(0);
             TypeNode annotationType = (TypeNode) annotationTypeNode;
             if (annotationType.getType() == null) {
                 ASTName name = annotationTypeNode.getFirstChildOfType(ASTName.class);
-                if (name != null && (name.hasImageEqualTo("Test") || name.hasImageEqualTo(annotationTypeClassName))) {
-                    return true;
+                if (name != null) {
+                    for (String annotationTypeName : annotationTypeClassNames) {
+                        if (areNamesEqual(name, annotationTypeName)) {
+                            return true;
+                        }
+                    }
                 }
-            } else if (TypeTestUtil.isA(annotationTypeClassName, annotationType)) {
-                return true;
+            } else {
+                for (String annotationTypeClassName : annotationTypeClassNames) {
+                    if (TypeTestUtil.isA(annotationTypeClassName, annotationType)) {
+                        return true;
+                    }
+                }
             }
         }
         return false;
     }
 
     private static boolean hasImports(JavaNode node, String className) {
+        return hasImports(node, Collections.singleton(className));
+    }
+
+    private static boolean hasImports(JavaNode node, Set<String> classNames) {
         List<ASTImportDeclaration> imports = node.getRoot().findDescendantsOfType(ASTImportDeclaration.class);
         for (ASTImportDeclaration importDeclaration : imports) {
             ASTName name = importDeclaration.getFirstChildOfType(ASTName.class);
-            if (name != null && name.hasImageEqualTo(className)) {
+            // imports are always fully qualified
+            if (name != null && classNames.contains(name.getImage())) {
                 return true;
             }
         }
         return false;
+    }
+
+    /**
+     * Compares the name against the given fully qualified name. If a direct comparison doesn't
+     * work, try to compare as a simple name.
+     *
+     * <p>Note: This method is only used, if the auxclasspath is incomplete.</p>
+     */
+    private static boolean areNamesEqual(ASTName node, String fullyQualifiedAnnotationName) {
+        String simpleName = node.getImage();
+        if (simpleName.equals(fullyQualifiedAnnotationName)) {
+            return true;
+        }
+
+        String simpleAnnotationName = fullyQualifiedAnnotationName;
+        int lastDot = fullyQualifiedAnnotationName.lastIndexOf('.');
+        if (lastDot != -1) {
+            simpleAnnotationName = fullyQualifiedAnnotationName.substring(lastDot + 1);
+        }
+        // when comparing by simple name, double check whether we have a import to avoid false positives
+        return simpleName.equals(simpleAnnotationName) && hasImports(node, fullyQualifiedAnnotationName);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/TestClassWithoutTestCasesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/TestClassWithoutTestCasesRule.java
@@ -5,23 +5,35 @@
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 
 import java.util.List;
+import java.util.regex.Pattern;
 
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBody;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceBodyDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTPackageDeclaration;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJUnitRule;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
 
 public class TestClassWithoutTestCasesRule extends AbstractJavaRule {
 
+    private static final PropertyDescriptor<Pattern> TEST_CLASS_PATTERN = PropertyFactory.regexProperty("testClassPattern")
+            .defaultValue("^(.*\\.)?Test.*$|^(.*\\.)?.*Tests?$|^(.*\\.)?.*TestCase$")
+            .desc("Test class name pattern to identify test classes by their fully qualified name. "
+                    + "A empty pattern disables test class detection by name. Since PMD 6.51.0.")
+            .build();
+
     public TestClassWithoutTestCasesRule() {
         addRuleChainVisit(ASTClassOrInterfaceBody.class);
+        definePropertyDescriptor(TEST_CLASS_PATTERN);
     }
 
     @Override
     public Object visit(ASTClassOrInterfaceBody node, Object data) {
-        if (AbstractJUnitRule.isTestClass(node)) {
+        if (AbstractJUnitRule.isTestClass(node) || isTestClassByPattern(node)) {
             List<ASTClassOrInterfaceBodyDeclaration> declarations = node.findChildrenOfType(ASTClassOrInterfaceBodyDeclaration.class);
             int testMethods = 0;
             for (ASTClassOrInterfaceBodyDeclaration decl : declarations) {
@@ -34,6 +46,36 @@ public class TestClassWithoutTestCasesRule extends AbstractJavaRule {
             }
         }
         return data;
+    }
+
+    private boolean isTestClassByPattern(ASTClassOrInterfaceBody node) {
+        Pattern testClassPattern = getProperty(TEST_CLASS_PATTERN);
+        if (testClassPattern.pattern().isEmpty()) {
+            // detection by pattern is disabled
+            return false;
+        }
+
+        ASTClassOrInterfaceDeclaration classDecl = null;
+        if (node.getParent() instanceof ASTClassOrInterfaceDeclaration) {
+            classDecl = (ASTClassOrInterfaceDeclaration) node.getParent();
+        }
+
+        // classDecl can be null in case of anonymous classes or enum constants
+        if (classDecl == null || classDecl.isAbstract() || classDecl.isInterface()) {
+            return false;
+        }
+
+        StringBuilder fullyQualifiedName = new StringBuilder();
+        ASTPackageDeclaration packageDeclaration = classDecl.getRoot().getPackageDeclaration();
+        if (packageDeclaration != null) {
+            fullyQualifiedName.append(packageDeclaration.getName()).append('.');
+        }
+        List<ASTClassOrInterfaceDeclaration> parentClasses = classDecl.getParentsOfType(ASTClassOrInterfaceDeclaration.class);
+        for (int i = parentClasses.size() - 1; i >= 0; i--) {
+            fullyQualifiedName.append(parentClasses.get(i).getSimpleName()).append('.');
+        }
+        fullyQualifiedName.append(classDecl.getSimpleName());
+        return testClassPattern.matcher(fullyQualifiedName).find();
     }
 
     private boolean isTestMethod(ASTClassOrInterfaceBodyDeclaration decl) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/TestClassWithoutTestCasesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/TestClassWithoutTestCasesRule.java
@@ -36,12 +36,15 @@ public class TestClassWithoutTestCasesRule extends AbstractJavaRule {
         if (AbstractJUnitRule.isTestClass(node) || isTestClassByPattern(node)) {
             List<ASTClassOrInterfaceBodyDeclaration> declarations = node.findChildrenOfType(ASTClassOrInterfaceBodyDeclaration.class);
             int testMethods = 0;
+            int nestedTestClasses = 0;
             for (ASTClassOrInterfaceBodyDeclaration decl : declarations) {
                 if (isTestMethod(decl)) {
                     testMethods++;
+                } else if (isNestedClass(decl)) {
+                    nestedTestClasses++;
                 }
             }
-            if (testMethods == 0) {
+            if (testMethods == 0 && nestedTestClasses == 0) {
                 addViolation(data, node);
             }
         }
@@ -82,6 +85,15 @@ public class TestClassWithoutTestCasesRule extends AbstractJavaRule {
         JavaNode node = decl.getDeclarationNode();
         if (node instanceof ASTMethodDeclaration) {
             return AbstractJUnitRule.isTestMethod((ASTMethodDeclaration) node);
+        }
+        return false;
+    }
+
+    private boolean isNestedClass(ASTClassOrInterfaceBodyDeclaration decl) {
+        JavaNode node = decl.getDeclarationNode();
+        if (node instanceof ASTClassOrInterfaceDeclaration) {
+            ASTClassOrInterfaceDeclaration classDecl = (ASTClassOrInterfaceDeclaration) node;
+            return classDecl.isAnnotationPresent("org.junit.jupiter.api.Nested");
         }
         return false;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/TestClassWithoutTestCasesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/TestClassWithoutTestCasesRule.java
@@ -21,7 +21,7 @@ import net.sourceforge.pmd.properties.PropertyFactory;
 public class TestClassWithoutTestCasesRule extends AbstractJavaRule {
 
     private static final PropertyDescriptor<Pattern> TEST_CLASS_PATTERN = PropertyFactory.regexProperty("testClassPattern")
-            .defaultValue("^(.*\\.)?Test.*$|^(.*\\.)?.*Tests?$|^(.*\\.)?.*TestCase$")
+            .defaultValue("^(?:.*\\.)?Test[^\\.]*$|^(?:.*\\.)?.*Tests?$|^(?:.*\\.)?.*TestCase$")
             .desc("Test class name pattern to identify test classes by their fully qualified name. "
                     + "A empty pattern disables test class detection by name. Since PMD 6.51.0.")
             .build();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/TestClassWithoutTestCasesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/TestClassWithoutTestCasesRule.java
@@ -33,7 +33,7 @@ public class TestClassWithoutTestCasesRule extends AbstractJavaRule {
 
     @Override
     public Object visit(ASTClassOrInterfaceBody node, Object data) {
-        if (AbstractJUnitRule.isTestClass(node) || isTestClassByPattern(node)) {
+        if (AbstractJUnitRule.isTestClass(node) || AbstractJUnitRule.isJUnit5NestedClass(node) || isTestClassByPattern(node)) {
             List<ASTClassOrInterfaceBodyDeclaration> declarations = node.findChildrenOfType(ASTClassOrInterfaceBodyDeclaration.class);
             int testMethods = 0;
             int nestedTestClasses = 0;
@@ -90,10 +90,9 @@ public class TestClassWithoutTestCasesRule extends AbstractJavaRule {
     }
 
     private boolean isNestedClass(ASTClassOrInterfaceBodyDeclaration decl) {
-        JavaNode node = decl.getDeclarationNode();
-        if (node instanceof ASTClassOrInterfaceDeclaration) {
-            ASTClassOrInterfaceDeclaration classDecl = (ASTClassOrInterfaceDeclaration) node;
-            return classDecl.isAnnotationPresent("org.junit.jupiter.api.Nested");
+        JavaNode node = decl.getParent();
+        if (node instanceof ASTClassOrInterfaceBody) {
+            return AbstractJUnitRule.isJUnit5NestedClass((ASTClassOrInterfaceBody) node);
         }
         return false;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/TestClassWithoutTestCasesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/TestClassWithoutTestCasesRule.java
@@ -45,10 +45,18 @@ public class TestClassWithoutTestCasesRule extends AbstractJavaRule {
                 }
             }
             if (testMethods == 0 && nestedTestClasses == 0) {
-                addViolation(data, node);
+                addViolation(data, node, getSimpleClassName(node));
             }
         }
         return data;
+    }
+
+    private String getSimpleClassName(ASTClassOrInterfaceBody node) {
+        JavaNode parent = node.getParent();
+        if (parent instanceof ASTClassOrInterfaceDeclaration) {
+            return ((ASTClassOrInterfaceDeclaration) parent).getSimpleName();
+        }
+        return "<anon>";
     }
 
     private boolean isTestClassByPattern(ASTClassOrInterfaceBody node) {

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -3336,8 +3336,12 @@ public void foo() {
           class="net.sourceforge.pmd.lang.java.rule.errorprone.TestClassWithoutTestCasesRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#testclasswithouttestcases">
         <description>
-Test classes end with the suffix Test. Having a non-test class with that name is not a good practice,
-since most people will assume it is a test case. Test classes have test methods named testXXX.
+Test classes end with the suffix "Test" or "TestCase". Having a non-test class with that name is not a good practice,
+since most people will assume it is a test case. Test classes have test methods named "testXXX" (JUnit3) or use
+annotations (e.g. `@Test`).
+
+The suffix can be configured using the property `testClassPattern`. To disable the detection of possible test classes
+by name, set this property to an empty string.
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -3332,13 +3332,13 @@ public void foo() {
     <rule name="TestClassWithoutTestCases"
           language="java"
           since="3.0"
-          message="This class name ends with 'Test' but contains no test cases"
+          message="The class ''{0}'' might be a test class, but it contains no test cases."
           class="net.sourceforge.pmd.lang.java.rule.errorprone.TestClassWithoutTestCasesRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#testclasswithouttestcases">
         <description>
-Test classes end with the suffix "Test" or "TestCase". Having a non-test class with that name is not a good practice,
-since most people will assume it is a test case. Test classes have test methods named "testXXX" (JUnit3) or use
-annotations (e.g. `@Test`).
+Test classes typically end with the suffix "Test", "Tests" or "TestCase". Having a non-test class with that name
+is not a good practice, since most people will assume it is a test case. Test classes have test methods
+named "testXXX" (JUnit3) or use annotations (e.g. `@Test`).
 
 The suffix can be configured using the property `testClassPattern`. To disable the detection of possible test classes
 by name, set this property to an empty string.

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/TestClassWithoutTestCases.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/TestClassWithoutTestCases.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
 
     <test-code>
-        <description>failure case</description>
+        <description>JUnit3: failure case</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 import junit.framework.TestCase;
@@ -15,7 +15,7 @@ public class FooTest extends TestCase {
     </test-code>
 
     <test-code>
-        <description>test method should be public</description>
+        <description>JUnit3: test method should be public</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 import junit.framework.TestCase;
@@ -26,7 +26,7 @@ public class FooTest extends TestCase {
     </test-code>
 
     <test-code>
-        <description>inner class should get checked</description>
+        <description>JUnit3: inner class should get checked</description>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>2</expected-linenumbers>
         <code><![CDATA[
@@ -38,8 +38,10 @@ public class FooTest extends TestCase {
     </test-code>
 
     <test-code>
-        <description>test method in inner class not valid</description>
+        <description>JUnit3: test method in inner class not valid</description>
+        <rule-property name="testClassPattern"></rule-property>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>2</expected-linenumbers>
         <code><![CDATA[
 import junit.framework.TestCase;
 public class Foo extends TestCase {
@@ -49,7 +51,7 @@ public class Foo extends TestCase {
     </test-code>
 
     <test-code>
-        <description>abstract classes are ok</description>
+        <description>JUnit3: abstract classes are ok</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 import junit.framework.TestCase;
@@ -87,7 +89,8 @@ public @interface FooTest {
     </test-code>
 
     <test-code>
-        <description>failure case does not extend TestCase</description>
+        <description>failure case does not extend TestCase and testClassPattern is not used</description>
+        <rule-property name="testClassPattern"></rule-property>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class FooTest {
@@ -96,7 +99,17 @@ public class FooTest {
     </test-code>
 
     <test-code>
-        <description>#1453 False positive when the test class extends an other.</description>
+        <description>failure case does not extend TestCase and default testClassPattern</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>1</expected-linenumbers>
+        <code><![CDATA[
+public class FooTest {
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>JUnit4: #1453 False positive when the test class extends an other.</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 import static org.junit.Assert.*;
@@ -113,7 +126,7 @@ public class MyTest extends YourTest {
     </test-code>
 
     <test-code>
-        <description>#428 [java] PMD requires public modifier on JUnit 5 test</description>
+        <description>JUnit5: #428 [java] PMD requires public modifier on JUnit 5 test</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 import org.junit.jupiter.api.Test;
@@ -127,7 +140,7 @@ class JUnit5Test {
     </test-code>
 
     <test-code>
-        <description>false positive with anonymous class inside test class</description>
+        <description>JUnit4: false positive with anonymous class inside test class</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 import org.junit.Assert;
@@ -147,7 +160,7 @@ public class MyTest {
     </test-code>
 
     <test-code>
-        <description>[java] TestClassWithoutTestCases reports wrong classes in a file #3624</description>
+        <description>JUnit4: [java] TestClassWithoutTestCases reports wrong classes in a file #3624</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 import org.junit.Test;
@@ -162,5 +175,104 @@ public class MyTest {
 
 class Helper { }
         ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>JUnit5: [java] TestClassWithoutTestCases false positive with JUnit5 parameterized test #2636</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+final class SampleTest extends Object {
+    @ParameterizedTest
+    @ValueSource(ints = {1})
+    void doesTest(final int num) {
+        Assertions.assertTrue(num > 0);
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>JUnit5: [java] TestClassWithoutTestCases false positive with JUnit5 normal test #2636</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.junit.jupiter.api.Test;
+
+final class SampleTest {
+    @Test
+    void doesTest() {
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>empty package-private test class identified by default testClassPattern</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>1</expected-linenumbers>
+        <code><![CDATA[
+class SampleTest { }
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>empty test class identified by special testClassPattern</description>
+        <rule-property name="testClassPattern">my\.pkg\..*Case</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>2</expected-linenumbers>
+        <code><![CDATA[
+package my.pkg;
+class MyEmptyCase { }
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>empty test class identified by special testClassPattern and nested classes</description>
+        <rule-property name="testClassPattern">my\.pkg\..*Case$</rule-property>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>2,3</expected-linenumbers>
+        <code><![CDATA[
+package my.pkg;
+class MyEmptyCase {
+    class MyNestedCase { }
+    class OtherNestedClass { }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>empty test class identified by special testClassPattern - other package</description>
+        <rule-property name="testClassPattern">my\.pkg\..*Case</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+package my.other.pkg;
+class MyEmptyCase { }
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>TestNG based test class without import</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class SampleTest {
+    @org.testng.annotations.Test
+    public void runAssertions() {}
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>TestNG based test class with import</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.testng.annotations.Test;
+public class SampleTest {
+    @Test
+    public void runAssertions() {}
+}
+]]></code>
     </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/TestClassWithoutTestCases.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/TestClassWithoutTestCases.xml
@@ -275,4 +275,41 @@ public class SampleTest {
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>JUnit5 @Nested tests with tests</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class DemoNestedTest {
+    @Nested
+    class SomeTest {
+        @Test
+        void isCorrect() {
+            assertTrue(42 == 42);
+        }
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>JUnit5 @Nested tests without tests</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code><![CDATA[
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class DemoNestedTest {
+    @Nested
+    class SomeTest {
+        // missing tests
+    }
+}
+]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/TestClassWithoutTestCases.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/TestClassWithoutTestCases.xml
@@ -7,6 +7,10 @@
     <test-code>
         <description>JUnit3: failure case</description>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>2</expected-linenumbers>
+        <expected-messages>
+            <message>The class 'FooTest' might be a test class, but it contains no test cases.</message>
+        </expected-messages>
         <code><![CDATA[
 import junit.framework.TestCase;
 public class FooTest extends TestCase {
@@ -234,6 +238,10 @@ class MyEmptyCase { }
         <rule-property name="testClassPattern">my\.pkg\..*Case$</rule-property>
         <expected-problems>2</expected-problems>
         <expected-linenumbers>2,3</expected-linenumbers>
+        <expected-messages>
+            <message>The class 'MyEmptyCase' might be a test class, but it contains no test cases.</message>
+            <message>The class 'MyNestedCase' might be a test class, but it contains no test cases.</message>
+        </expected-messages>
         <code><![CDATA[
 package my.pkg;
 class MyEmptyCase {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/TestClassWithoutTestCases.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/TestClassWithoutTestCases.xml
@@ -342,4 +342,23 @@ class SampleTest {
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Default pattern shouldn't match inner classes that are not named test</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>2,9</expected-linenumbers>
+        <code><![CDATA[
+package org.example;
+public final class TestInputConfiguration {
+    public static final class Builder {
+        public TestInputConfiguration build() {
+            return new TestInputConfiguration();
+        }
+    }
+
+    public static final class InnerTest {
+    }
+}
+]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/TestClassWithoutTestCases.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/TestClassWithoutTestCases.xml
@@ -230,7 +230,7 @@ class MyEmptyCase { }
     </test-code>
 
     <test-code>
-        <description>empty test class identified by special testClassPattern and nested classes</description>
+        <description>empty test class identified by special testClassPattern with nested classes</description>
         <rule-property name="testClassPattern">my\.pkg\..*Case$</rule-property>
         <expected-problems>2</expected-problems>
         <expected-linenumbers>2,3</expected-linenumbers>
@@ -284,7 +284,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class DemoNestedTest {
+class DemoNestedTests {
     @Nested
     class SomeTest {
         @Test
@@ -298,17 +298,39 @@ class DemoNestedTest {
 
     <test-code>
         <description>JUnit5 @Nested tests without tests</description>
-        <expected-problems>1</expected-problems>
-        <expected-linenumbers>6</expected-linenumbers>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>6,11</expected-linenumbers>
         <code><![CDATA[
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-class DemoNestedTest {
+class DemoNestedTests {
     @Nested
     class SomeTest {
         // missing tests
     }
+
+    @Nested
+    class Other {
+        // missing tests
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Ignore other nested classes that are not test classes</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code><![CDATA[
+import org.junit.jupiter.api.Test;
+class SampleTest {
+    @Test
+    void usesNestedHelperClass() { }
+
+    private static class TestHelper {} // matches the default testClassPattern
+
+    private static class Other {}
 }
 ]]></code>
     </test-code>


### PR DESCRIPTION
## Describe the PR

- Added new property "testClassPatterns" to property detect empty test classes. The default value are the same patterns as [maven-surefire-plugin](https://maven.apache.org/surefire/maven-surefire-plugin/test-mojo.html#includes) uses.
- Added support for different JUnit5 annotations (like ParameterizedTest)
- Added support for TestNG

## Related issues

- Fixes #929
- Fixes #2636

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

