### PR TITLE
[javascript] InaccurateNumericLiteral - consider underscores

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -33,6 +33,8 @@ The rule is part of the quickstart.xml ruleset.
     * [#4163](https://github.com/pmd/pmd/issues/4163): \[doc] Broken links on page "Architecture Decisions"
 * java-documentation
     * [#4141](https://github.com/pmd/pmd/issues/4141): \[java] UncommentedEmptyConstructor FP when constructor annotated with @<!-- -->Autowired
+* javascript
+    * [#4165](https://github.com/pmd/pmd/issues/4165): \[javascript] InaccurateNumericLiteral underscore separator notation false positive
 
 ### API Changes
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTNumberLiteral.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTNumberLiteral.java
@@ -23,7 +23,10 @@ public class ASTNumberLiteral extends AbstractEcmascriptNode<NumberLiteral> {
 
     public String getNormalizedImage() {
         String image = getImage();
+        image = image.replaceAll("_", "");
         image = normalizeHexIntegerLiteral(image);
+        image = normalizeBinaryLiteral(image);
+        image = normalizeOctalLiteral(image);
         image = image.replace('e', 'E');
         if (image.indexOf('.') == -1 && image.indexOf('E') == -1) {
             image = image + ".0";
@@ -34,6 +37,20 @@ public class ASTNumberLiteral extends AbstractEcmascriptNode<NumberLiteral> {
     private String normalizeHexIntegerLiteral(String image) {
         if (image.startsWith("0x") || image.startsWith("0X")) {
             return String.valueOf(Integer.parseInt(image.substring(2), 16));
+        }
+        return image;
+    }
+
+    private String normalizeBinaryLiteral(String image) {
+        if (image.startsWith("0b") || image.startsWith("0B")) {
+            return String.valueOf(Integer.parseInt(image.substring(2), 2));
+        }
+        return image;
+    }
+
+    private String normalizeOctalLiteral(String image) {
+        if (image.startsWith("0o") || image.startsWith("0O")) {
+            return String.valueOf(Integer.parseInt(image.substring(2), 8));
         }
         return image;
     }

--- a/pmd-javascript/src/test/resources/net/sourceforge/pmd/lang/ecmascript/rule/errorprone/xml/InnaccurateNumericLiteral.xml
+++ b/pmd-javascript/src/test/resources/net/sourceforge/pmd/lang/ecmascript/rule/errorprone/xml/InnaccurateNumericLiteral.xml
@@ -58,4 +58,17 @@ var hex1 = 0x20;
 var hex2 = 0X20;
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[javascript] InaccurateNumericLiteral underscore separator notation false positive #4165</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+const value1a = 1_000_000; // number
+const value1b = 1_000.12_34; // decimal
+const value2 = 0b1010_0001_1000_0101; // binary
+const value3 = 0xA0_B0; // hex
+const value4 = 9_223_372_036_854_775_807n; // big int
+const value5 = 0o1234_5670; // octal
+]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Related issues

- Fixes #4165

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

