### PR TITLE
[java] ClassWithOnlyPrivateConstructorsShouldBeFinal: Exclude lombok annotations

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -15,6 +15,8 @@ This is a {{ site.pmd.release_type }} release.
 ### New and noteworthy
 
 ### Fixed Issues
+* java-design
+    * [#4188](https://github.com/pmd/pmd/issues/4188): \[java] ClassWithOnlyPrivateConstructorsShouldBeFinal false positive with Lombok's @<!-- -->NoArgsConstructor
 
 ### API Changes
 

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -330,7 +330,7 @@ public void foo() throws RuntimeException {
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#classwithonlyprivateconstructorsshouldbefinal">
         <description>
 A class with only private constructors should be final, unless the private constructor
-is invoked by a inner class.
+is invoked by an inner class.
         </description>
         <priority>1</priority>
         <properties>
@@ -339,6 +339,18 @@ is invoked by a inner class.
                 <value>
 <![CDATA[
 //TypeDeclaration
+  (: no lombok constructor annotations :)
+  [not(Annotation[pmd-java:typeIs('lombok.NoArgsConstructor')
+               or pmd-java:typeIs('lombok.RequiredArgsConstructor')
+               or pmd-java:typeIs('lombok.AllArgsConstructor')]
+     [not(.//MemberValuePair[@MemberName='access'])
+       or .//MemberValuePair[@MemberName='access']
+                            [.//Name[@Image!='PRIVATE']
+                                    [@Image!='AccessLevel.PRIVATE']
+                                    [@Image!='lombok.AccessLevel.PRIVATE']
+                            ]
+     ]
+  )]
   /ClassOrInterfaceDeclaration
   [@Final = false()]
   (: at least one private constructor :)
@@ -347,7 +359,7 @@ is invoked by a inner class.
   [not(./ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/ConstructorDeclaration[(@Public = true()) or (@Protected = true()) or (@PackagePrivate = true())])]
   (: not a base class in the same compilation unit :)
   [not(@SimpleName = ../../TypeDeclaration/ClassOrInterfaceDeclaration/ExtendsList/ClassOrInterfaceType/@Image)]
-  (: not a base class for a inner class in the same compilation unit :)
+  (: not a base class for an inner class in the same compilation unit :)
   [not(@SimpleName = .//ClassOrInterfaceDeclaration/ExtendsList/ClassOrInterfaceType/@Image)]
 ]]>
                 </value>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ClassWithOnlyPrivateConstructorsShouldBeFinal.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ClassWithOnlyPrivateConstructorsShouldBeFinal.xml
@@ -188,4 +188,73 @@ class Another {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[java] ClassWithOnlyPrivateConstructorsShouldBeFinal false positive with Lombok's @NoArgsConstructor #4188</description>
+        <expected-problems>7</expected-problems>
+        <expected-linenumbers>10,19,29,38,47,56,61</expected-linenumbers>
+        <code><![CDATA[
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@NoArgsConstructor
+class NoArgs1 { private NoArgs1(String a) {} } // no violation
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+class NoArgs2 { private NoArgs2(String a) {} } // violation: only private ctors
+
+@NoArgsConstructor(access = AccessLevel.PUBLIC)
+class NoArgs3 { private NoArgs3(String a) {} } // no violation
+
+@lombok.NoArgsConstructor
+class NoArgs4 { private NoArgs4(String a) {} } // no violation
+
+@lombok.NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+class NoArgs5 { private NoArgs5(String a) {} } // violation: only private ctors
+
+@lombok.NoArgsConstructor(access = lombok.AccessLevel.PUBLIC)
+class NoArgs6 { private NoArgs6(String a) {} } // no violation
+
+
+@RequiredArgsConstructor
+class RequiredArgs1 { private RequiredArgs1(String a) {} } // no violation
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+class RequiredArgs2 { private RequiredArgs2(String a) {} } // violation: only private ctors
+
+@RequiredArgsConstructor(access = AccessLevel.PUBLIC)
+class RequiredArgs3 { private RequiredArgs3(String a) {} } // no violation
+
+@lombok.RequiredArgsConstructor
+class RequiredArgs4 { private RequiredArgs4(String a) {} } // no violation
+
+@lombok.RequiredArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+class RequiredArgs5 { private RequiredArgs5(String a) {} } // violation: only private ctors
+
+@lombok.RequiredArgsConstructor(access = lombok.AccessLevel.PUBLIC)
+class RequiredArgs6 { private RequiredArgs6(String a) {} } // no violation
+
+@AllArgsConstructor
+class AllArgs1 { private AllArgs1(String a) {} } // no violation
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+class AllArgs2 { private AllArgs2(String a) {} } // violation: only private ctors
+
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+class AllArgs3 { private AllArgs3(String a) {} } // no violation
+
+@lombok.AllArgsConstructor
+class AllArgs4 { private AllArgs4(String a) {} } // no violation
+
+@lombok.AllArgsConstructor(access = lombok.AccessLevel.PRIVATE)
+class AllArgs5 { private AllArgs5(String a) {} } // violation: only private ctors
+
+@lombok.AllArgsConstructor(access = lombok.AccessLevel.PUBLIC)
+class AllArgs6 { private AllArgs6(String a) {} } // no violation
+
+class OtherClass { private OtherClass(String a) {} } // violation: only private ctors
+]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Excludes constructor related lombok annotations (NoArgsConstructor, AllArgsConstructor, RequiredArgsConstructor)

## Related issues

- Fixes #4188

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

