### PR TITLE
[java] AbstractClassWithoutAnyMethod - exclude lombok constructor annotations

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -15,6 +15,8 @@ This is a {{ site.pmd.release_type }} release.
 ### New and noteworthy
 
 ### Fixed Issues
+* java-design
+    * [#4189](https://github.com/pmd/pmd/issues/4189): \[java] AbstractClassWithoutAnyMethod should consider lombok's @<!-- -->AllArgsConstructor
 
 ### API Changes
 

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -31,7 +31,12 @@ protected constructor in order to prevent instantiation than make the class misl
     [@Abstract = true()]
     [not(./ClassOrInterfaceBody/*/ConstructorDeclaration)]
     [not(./ClassOrInterfaceBody/*/MethodDeclaration)]
-    [not(../Annotation/MarkerAnnotation/Name[pmd-java:typeIs('com.google.auto.value.AutoValue')])]
+    [not(../Annotation[pmd-java:typeIs('com.google.auto.value.AutoValue')
+                    or pmd-java:typeIs('lombok.AllArgsConstructor')
+                    or pmd-java:typeIs('lombok.NoArgsConstructor')
+                    or pmd-java:typeIs('lombok.RequiredArgsConstructor')
+                      ]
+    )]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AbstractClassWithoutAnyMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/AbstractClassWithoutAnyMethod.xml
@@ -102,4 +102,32 @@ class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[java] AbstractClassWithoutAnyMethod should consider lombok's @AllArgsConstructor #4189</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@AllArgsConstructor
+abstract class AllArgs {
+    private String field;
+    public int otherField;
+}
+
+@NoArgsConstructor
+abstract class NoArgs {
+    private String field;
+    public int otherField;
+}
+
+@RequiredArgsConstructor
+abstract class RequiredArgs {
+    private String field;
+    public int otherField;
+}
+]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Related issues

- Fixes #4189

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

