### PR TITLE
[doc] Add supported CPD languages

### DIFF
--- a/docs/pages/pmd/userdocs/cpd/cpd.md
+++ b/docs/pages/pmd/userdocs/cpd/cpd.md
@@ -220,8 +220,10 @@ This behavior has been introduced to ease CPD integration into scripts or hooks,
 * Dart
 * EcmaScript (JavaScript)
 * Fortran
+* Gherkin (Cucumber)
 * Go
 * Groovy
+* Html
 * Java
 * Jsp
 * Kotlin


### PR DESCRIPTION
Languages were missing in the documentation

## Describe the PR

When running the command line with the help flags (`run.sh cpd --help`), Html and Gherkin show up as supported languages, but they are missing in the documentation.

Since Gherkin is almost a synonym of Cucumber (just like ecmascript and javascript) I added it between braces since most people will be looking for cucumber.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #

## Ready?

I checked with Gherkin and this works like a charm

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

