### PR TITLE
Fix #4211 EmptyMethodInAbstractClassShouldBeAbstract : Exclude lombok's @Synchronized annotation

### DIFF
--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -681,6 +681,7 @@ usage by developers who should be implementing their own versions in the concret
     /ClassOrInterfaceBody
     /ClassOrInterfaceBodyDeclaration
     /MethodDeclaration[@Abstract = false() and @Native = false()]
+    [not(//MarkerAnnotation/Name[pmd-java:typeIs('lombok.Synchronized')])]
     [
         ( boolean(./Block[count(./BlockStatement) =  1]/BlockStatement/Statement/ReturnStatement/Expression/PrimaryExpression/PrimaryPrefix/Literal/NullLiteral) = true() )
         or

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/EmptyMethodInAbstractClassShouldBeAbstract.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/EmptyMethodInAbstractClassShouldBeAbstract.xml
@@ -205,4 +205,18 @@ public abstract class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+    <description>[java] EmptyMethodInAbstractClassShouldBeAbstract should considers lombok's @Synchronized #4211</description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+    import lombok.Synchronized;
+    public abstract class Test {
+       @Synchronized
+       public void isVisible() {
+           ;
+       }
+    }
+            ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR
This PR excludes lombok @Synchronized  annotation which make method Synchronized and and add some code in the method  but PMD can not checked.
<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #4211

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

