### PR TITLE
[visualforce] Replace uses of Jorje types in pmd-visualforce

### DIFF
--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/ApexClassPropertyTypes.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/ApexClassPropertyTypes.java
@@ -23,8 +23,6 @@ import net.sourceforge.pmd.lang.apex.ApexLanguageModule;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.ast.Node;
 
-import apex.jorje.semantic.symbol.type.BasicType;
-
 /**
  * Responsible for storing a mapping of Apex Class properties that can be referenced from Visualforce to the type of the
  * property.
@@ -51,8 +49,8 @@ class ApexClassPropertyTypes extends SalesforceFieldTypes {
                         Node node = parser.parse(apexFilePath.toString(), reader);
                         ApexClassPropertyTypesVisitor visitor = new ApexClassPropertyTypesVisitor();
                         visitor.visit((ApexNode<?>) node, null);
-                        for (Pair<String, BasicType> variable : visitor.getVariables()) {
-                            putDataType(variable.getKey(), DataType.fromBasicType(variable.getValue()));
+                        for (Pair<String, String> variable : visitor.getVariables()) {
+                            putDataType(variable.getKey(), DataType.fromTypeName(variable.getValue()));
                         }
                     } catch (IOException e) {
                         throw new ContextedRuntimeException(e)

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/ApexClassPropertyTypesVisitor.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/ApexClassPropertyTypesVisitor.java
@@ -12,13 +12,10 @@ import org.apache.commons.lang3.tuple.Pair;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
 import net.sourceforge.pmd.lang.apex.ast.ASTModifierNode;
+import net.sourceforge.pmd.lang.apex.ast.ASTProperty;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.ast.ApexParserVisitorAdapter;
-
-import apex.jorje.semantic.symbol.member.method.Generated;
-import apex.jorje.semantic.symbol.member.method.MethodInfo;
-import apex.jorje.semantic.symbol.type.BasicType;
 
 /**
  * Visits an Apex class to determine a mapping of referenceable expressions to expression type.
@@ -37,15 +34,15 @@ final class ApexClassPropertyTypesVisitor extends ApexParserVisitorAdapter {
     private static final String RETURN_TYPE_VOID = "void";
 
     /**
-     * Pairs of (variableName, BasicType)
+     * Pairs of (variableName, typeName)
      */
-    private final List<Pair<String, BasicType>> variables;
+    private final List<Pair<String, String>> variables;
 
     ApexClassPropertyTypesVisitor() {
         this.variables = new ArrayList<>();
     }
 
-    public List<Pair<String, BasicType>> getVariables() {
+    public List<Pair<String, String>> getVariables() {
         return this.variables;
     }
 
@@ -55,11 +52,10 @@ final class ApexClassPropertyTypesVisitor extends ApexParserVisitorAdapter {
      */
     @Override
     public Object visit(ASTMethod node, Object data) {
-        MethodInfo mi = node.getNode().getMethodInfo();
-        if (mi.getParameterTypes().isEmpty()
+        if (node.getArity() == 0
                 && isVisibleToVisualForce(node)
-                && !RETURN_TYPE_VOID.equalsIgnoreCase(mi.getReturnType().getApexName())
-                && (mi.getGenerated().equals(Generated.USER) || mi.isPropertyAccessor())) {
+                && !RETURN_TYPE_VOID.equalsIgnoreCase(node.getReturnType())
+                && (node.hasRealLoc() || node.getFirstParentOfType(ASTProperty.class) != null)) {
             StringBuilder sb = new StringBuilder();
             List<ASTUserClass> parents = node.getParentsOfType(ASTUserClass.class);
             Collections.reverse(parents);
@@ -74,7 +70,7 @@ final class ApexClassPropertyTypesVisitor extends ApexParserVisitorAdapter {
             }
             sb.append(name);
 
-            variables.add(Pair.of(sb.toString(), mi.getReturnType().getBasicType()));
+            variables.add(Pair.of(sb.toString(), node.getReturnType()));
         }
         return super.visit((ApexNode<?>) node, data);
     }

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/DataType.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/DataType.java
@@ -12,6 +12,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
 
+import apex.jorje.semantic.symbol.type.BasicType;
+
 /**
  * Represents all data types that can be referenced from a Visualforce page. This enum consolidates the data types
  * available to CustomFields and Apex. It uses the naming convention of CustomFields.
@@ -100,6 +102,42 @@ public enum DataType {
         }
 
         return dataType;
+    }
+
+    /**
+     * Map to correct instance, returns {@code Unknown} if the value can't be mapped.
+     *
+     * Use {@link fromTypeName} instead.
+     */
+    @Deprecated
+    public static DataType fromBasicType(BasicType value) {
+        if (value != null) {
+            switch(value) {
+            case BOOLEAN:
+               return Checkbox;
+            case CURRENCY:
+                return Currency;
+            case DATE:
+                return Date;
+            case DATE_TIME:
+                return DateTime;
+            case ID:
+                return Lookup;
+            case DECIMAL:
+            case DOUBLE:
+            case INTEGER:
+            case LONG:
+                return Number;
+            case STRING:
+                return Text;
+            case TIME:
+                return Time;
+            default:
+                break;
+            }
+        }
+        LOGGER.fine("Unable to determine DataType of " + value);
+        return Unknown;
     }
 
     /**

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/DataType.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/DataType.java
@@ -112,9 +112,9 @@ public enum DataType {
     @Deprecated
     public static DataType fromBasicType(BasicType value) {
         if (value != null) {
-            switch(value) {
+            switch (value) {
             case BOOLEAN:
-               return Checkbox;
+                return Checkbox;
             case CURRENCY:
                 return Currency;
             case DATE:

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/DataType.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/DataType.java
@@ -12,8 +12,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Logger;
 
-import apex.jorje.semantic.symbol.type.BasicType;
-
 /**
  * Represents all data types that can be referenced from a Visualforce page. This enum consolidates the data types
  * available to CustomFields and Apex. It uses the naming convention of CustomFields.
@@ -22,10 +20,10 @@ import apex.jorje.semantic.symbol.type.BasicType;
  */
 public enum DataType {
     AutoNumber(false),
-    Checkbox(false, BasicType.BOOLEAN),
-    Currency(false, BasicType.CURRENCY),
-    Date(false, BasicType.DATE),
-    DateTime(false, BasicType.DATE_TIME),
+    Checkbox(false, "Boolean"),
+    Currency(false, "Currency"),
+    Date(false, "Date"),
+    DateTime(false, "Datetime"),
     Email(false),
     EncryptedText(true),
     ExternalLookup(true),
@@ -35,19 +33,19 @@ public enum DataType {
     IndirectLookup(false),
     Location(false),
     LongTextArea(true),
-    Lookup(false, BasicType.ID),
+    Lookup(false, "ID"),
     MasterDetail(false),
     MetadataRelationship(false),
     MultiselectPicklist(true),
     Note(true),
-    Number(false, BasicType.DECIMAL, BasicType.DOUBLE, BasicType.INTEGER, BasicType.LONG),
+    Number(false, "Decimal", "Double", "Integer", "Long"),
     Percent(false),
     Phone(false),
     Picklist(true),
     Summary(false),
-    Text(true, BasicType.STRING),
+    Text(true, "String"),
     TextArea(true),
-    Time(false, BasicType.TIME),
+    Time(false, "Time"),
     Url(false),
     /**
      * Indicates that Metatada was found, but it's type was not mappable. This could because it is a type which isn't
@@ -64,9 +62,10 @@ public enum DataType {
     public final boolean requiresEscaping;
 
     /**
-     * The set of {@link BasicType}s that map to this type. Multiple types can map to a single instance of this enum.
+     * The set of primitive type names that map to this type. Multiple types can map to a single instance of this enum.
+     * Note: these strings are not case-normalized.
      */
-    private final Set<BasicType> basicTypes;
+    private final Set<String> basicTypeNames;
 
     /**
      * A case insensitive map of the enum name to its instance. The case metadata is not guaranteed to have the correct
@@ -75,15 +74,15 @@ public enum DataType {
     private static final Map<String, DataType> CASE_INSENSITIVE_MAP = new HashMap<>();
 
     /**
-     * Map of BasicType to DataType. Multiple BasicTypes may map to one DataType.
+     * A case insensitive map of the primitive type names to DataType. Multiple types may map to one DataType.
      */
-    private static final Map<BasicType, DataType> BASIC_TYPE_MAP = new HashMap<>();
+    private static final Map<String, DataType> BASIC_TYPE_MAP = new HashMap<>();
 
     static {
         for (DataType dataType : DataType.values()) {
             CASE_INSENSITIVE_MAP.put(dataType.name().toLowerCase(Locale.ROOT), dataType);
-            for (BasicType basicType : dataType.basicTypes) {
-                BASIC_TYPE_MAP.put(basicType, dataType);
+            for (String typeName : dataType.basicTypeNames) {
+                BASIC_TYPE_MAP.put(typeName.toLowerCase(Locale.ROOT), dataType);
             }
         }
     }
@@ -106,8 +105,9 @@ public enum DataType {
     /**
      * Map to correct instance, returns {@code Unknown} if the value can't be mapped.
      */
-    public static DataType fromBasicType(BasicType value) {
-        DataType dataType = value != null ? BASIC_TYPE_MAP.get(value) : null;
+    public static DataType fromTypeName(String value) {
+        value = value != null ? value : "";
+        DataType dataType = BASIC_TYPE_MAP.get(value.toLowerCase(Locale.ROOT));
 
         if (dataType == null) {
             dataType = DataType.Unknown;
@@ -121,11 +121,11 @@ public enum DataType {
         this(requiresEscaping, null);
     }
 
-    DataType(boolean requiresEscaping, BasicType... basicTypes) {
+    DataType(boolean requiresEscaping, String... basicTypeNames) {
         this.requiresEscaping = requiresEscaping;
-        this.basicTypes = new HashSet<>();
-        if (basicTypes != null) {
-            this.basicTypes.addAll(Arrays.asList(basicTypes));
+        this.basicTypeNames = new HashSet<>();
+        if (basicTypeNames != null) {
+            this.basicTypeNames.addAll(Arrays.asList(basicTypeNames));
         }
     }
 }

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/DataType.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/vf/DataType.java
@@ -68,19 +68,19 @@ public enum DataType {
     private final Set<String> basicTypeNames;
 
     /**
-     * A case insensitive map of the enum name to its instance. The case metadata is not guaranteed to have the correct
+     * A map of the lower-case-normalized enum name to its instance. The case metadata is not guaranteed to have the correct
      * case.
      */
-    private static final Map<String, DataType> CASE_INSENSITIVE_MAP = new HashMap<>();
+    private static final Map<String, DataType> CASE_NORMALIZED_MAP = new HashMap<>();
 
     /**
-     * A case insensitive map of the primitive type names to DataType. Multiple types may map to one DataType.
+     * A map of the lower-case-normalized primitive type names to DataType. Multiple types may map to one DataType.
      */
     private static final Map<String, DataType> BASIC_TYPE_MAP = new HashMap<>();
 
     static {
         for (DataType dataType : DataType.values()) {
-            CASE_INSENSITIVE_MAP.put(dataType.name().toLowerCase(Locale.ROOT), dataType);
+            CASE_NORMALIZED_MAP.put(dataType.name().toLowerCase(Locale.ROOT), dataType);
             for (String typeName : dataType.basicTypeNames) {
                 BASIC_TYPE_MAP.put(typeName.toLowerCase(Locale.ROOT), dataType);
             }
@@ -92,7 +92,7 @@ public enum DataType {
      */
     public static DataType fromString(String value) {
         value = value != null ? value : "";
-        DataType dataType = CASE_INSENSITIVE_MAP.get(value.toLowerCase(Locale.ROOT));
+        DataType dataType = CASE_NORMALIZED_MAP.get(value.toLowerCase(Locale.ROOT));
 
         if (dataType == null) {
             dataType = DataType.Unknown;

--- a/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/vf/ApexClassPropertyTypesVisitorTest.java
+++ b/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/vf/ApexClassPropertyTypesVisitorTest.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.vf;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -28,8 +29,6 @@ import net.sourceforge.pmd.lang.apex.ApexLanguageModule;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.ast.Node;
 
-import apex.jorje.semantic.symbol.type.BasicType;
-
 public class ApexClassPropertyTypesVisitorTest {
     @Test
     public void testApexClassIsProperlyParsed() throws IOException {
@@ -46,21 +45,21 @@ public class ApexClassPropertyTypesVisitorTest {
             visitor.visit((ApexNode<?>) node, null);
         }
 
-        List<Pair<String, BasicType>> variables = visitor.getVariables();
+        List<Pair<String, String>> variables = visitor.getVariables();
         assertEquals(7, variables.size());
-        Map<String, BasicType> variableNameToVariableType = new Hashtable<>();
-        for (Pair<String, BasicType> variable : variables) {
+        Map<String, String> variableNameToVariableType = new Hashtable<>();
+        for (Pair<String, String> variable : variables) {
             // Map the values and ensure there were no duplicates
-            BasicType previous = variableNameToVariableType.put(variable.getKey(), variable.getValue());
+            String previous = variableNameToVariableType.put(variable.getKey(), variable.getValue());
             assertNull(variable.getKey(), previous);
         }
 
-        assertEquals(BasicType.ID, variableNameToVariableType.get("ApexController.AccountIdProp"));
-        assertEquals(BasicType.ID, variableNameToVariableType.get("ApexController.AccountId"));
-        assertEquals(BasicType.STRING, variableNameToVariableType.get("ApexController.AccountName"));
-        assertEquals(BasicType.APEX_OBJECT, variableNameToVariableType.get("ApexController.InnerController"));
-        assertEquals(BasicType.ID, variableNameToVariableType.get("ApexController.InnerController.InnerAccountIdProp"));
-        assertEquals(BasicType.ID, variableNameToVariableType.get("ApexController.InnerController.InnerAccountId"));
-        assertEquals(BasicType.STRING, variableNameToVariableType.get("ApexController.InnerController.InnerAccountName"));
+        assertTrue("ID".equalsIgnoreCase(variableNameToVariableType.get("ApexController.AccountIdProp")));
+        assertTrue("ID".equalsIgnoreCase(variableNameToVariableType.get("ApexController.AccountId")));
+        assertTrue("String".equalsIgnoreCase(variableNameToVariableType.get("ApexController.AccountName")));
+        assertTrue("ApexController.InnerController".equalsIgnoreCase(variableNameToVariableType.get("ApexController.InnerController")));
+        assertTrue("ID".equalsIgnoreCase(variableNameToVariableType.get("ApexController.InnerController.InnerAccountIdProp")));
+        assertTrue("ID".equalsIgnoreCase(variableNameToVariableType.get("ApexController.InnerController.InnerAccountId")));
+        assertTrue("String".equalsIgnoreCase(variableNameToVariableType.get("ApexController.InnerController.InnerAccountName")));
     }
 }

--- a/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/vf/DataTypeTest.java
+++ b/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/vf/DataTypeTest.java
@@ -10,8 +10,6 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
-import apex.jorje.semantic.symbol.type.BasicType;
-
 public class DataTypeTest {
     @Test
     public void testFromString() {
@@ -22,12 +20,15 @@ public class DataTypeTest {
     }
 
     @Test
-    public void testFromBasicType() {
-        assertEquals(DataType.Checkbox, DataType.fromBasicType(BasicType.BOOLEAN));
-        assertEquals(DataType.Number, DataType.fromBasicType(BasicType.DECIMAL));
-        assertEquals(DataType.Number, DataType.fromBasicType(BasicType.DOUBLE));
-        assertEquals(DataType.Unknown, DataType.fromBasicType(BasicType.APEX_OBJECT));
-        assertEquals(DataType.Unknown, DataType.fromBasicType(null));
+    public void testFromTypeName() {
+        assertEquals(DataType.Checkbox, DataType.fromTypeName("Boolean"));
+        assertEquals(DataType.Currency, DataType.fromTypeName("Currency"));
+        assertEquals(DataType.DateTime, DataType.fromTypeName("Datetime"));
+        assertEquals(DataType.Number, DataType.fromTypeName("DECIMAL"));
+        assertEquals(DataType.Number, DataType.fromTypeName("double"));
+        assertEquals(DataType.Text, DataType.fromTypeName("string"));
+        assertEquals(DataType.Unknown, DataType.fromTypeName("Object"));
+        assertEquals(DataType.Unknown, DataType.fromTypeName(null));
     }
 
     @Test

--- a/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/vf/DataTypeTest.java
+++ b/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/vf/DataTypeTest.java
@@ -10,6 +10,8 @@ import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 
+import apex.jorje.semantic.symbol.type.BasicType;
+
 public class DataTypeTest {
     @Test
     public void testFromString() {
@@ -29,6 +31,15 @@ public class DataTypeTest {
         assertEquals(DataType.Text, DataType.fromTypeName("string"));
         assertEquals(DataType.Unknown, DataType.fromTypeName("Object"));
         assertEquals(DataType.Unknown, DataType.fromTypeName(null));
+    }
+
+    @Test
+    public void testDeprecatedFromBasicType() {
+        assertEquals(DataType.Checkbox, DataType.fromBasicType(BasicType.BOOLEAN));
+        assertEquals(DataType.Number, DataType.fromBasicType(BasicType.DECIMAL));
+        assertEquals(DataType.Number, DataType.fromBasicType(BasicType.DOUBLE));
+        assertEquals(DataType.Unknown, DataType.fromBasicType(BasicType.APEX_OBJECT));
+        assertEquals(DataType.Unknown, DataType.fromBasicType(null));
     }
 
     @Test


### PR DESCRIPTION
Store and compare primitive type names as Strings instead of using Jorje BasicType enum.
Rewrote some logic using PMD AST instead of raw Jorje nodes.

There ought to be no change in behavior.
Update unit tests and add a few more cases.

In furtherance of: https://github.com/pmd/pmd/issues/3766