### PR TITLE
[java] Fix #4225 MissingStaticMethodInNonInstantiatableClass: Exclude lombok's @NoArgsConstructor annotation

### DIFF
--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2579,7 +2579,10 @@ See the property `annotations`.
             <property name="xpath">
                 <value>
 <![CDATA[
-//ClassOrInterfaceDeclaration[@Nested= false() and @Local= false()]
+//TypeDeclaration
+(: no lombok constructor annotations :)
+[not(Annotation[pmd-java:typeIs('lombok.NoArgsConstructor')])]
+/ClassOrInterfaceDeclaration[@Nested= false() and @Local= false()]
 [
   (
     (: at least one constructor :)

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2581,7 +2581,9 @@ See the property `annotations`.
 <![CDATA[
 //TypeDeclaration
 (: no lombok constructor annotations :)
-[not(Annotation[pmd-java:typeIs('lombok.NoArgsConstructor')])]
+[not(Annotation[pmd-java:typeIs('lombok.NoArgsConstructor') or
+                pmd-java:typeIs('lombok.RequiredArgsConstructor') or
+                pmd-java:typeIs('lombok.AllArgsConstructor')])]
 /ClassOrInterfaceDeclaration[@Nested= false() and @Local= false()]
 [
   (

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/MissingStaticMethodInNonInstantiatableClass.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/MissingStaticMethodInNonInstantiatableClass.xml
@@ -394,5 +394,32 @@ public class Test {
 
         ]]></code>
     </test-code>
+    <test-code>
+        <description>#4225 [java] MissingStaticMethodInNonInstantiatableClass should consider Lombok's @RequiredArgsConstructor</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
+public class Test {
+   private Test(int a, int b, int c, String abc, long d, double p,
+    String[] arr, int data, long in, float fl, String res) { } // 11 params
+}
+
+        ]]></code>
+    </test-code>
+    <test-code>
+    <description>#4225 [java] MissingStaticMethodInNonInstantiatableClass should consider Lombok's @AllArgsConstructor</description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class Test {
+   private Test(int a, int b, int c, String abc, long d, double p,
+    String[] arr, int data, long in, float fl, String res) { } // 11 params
+}
+
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/MissingStaticMethodInNonInstantiatableClass.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/MissingStaticMethodInNonInstantiatableClass.xml
@@ -379,4 +379,20 @@ public class Scratch {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#4225 [java] MissingStaticMethodInNonInstantiatableClass should consider Lombok's @NoArgsConstructor</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class Test {
+   private Test(int a, int b, int c, String abc, long d, double p,
+    String[] arr, int data, long in, float fl, String res) { } // 11 params
+}
+
+        ]]></code>
+    </test-code>
+
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
This PR excludes lombok's @NoArgsConstructor annotation which generates a public constructor but PMD treats it as a false positive.
## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #4225

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

