### PR TITLE
[java] Fix #4224 MissingStaticMethodInNonInstantiatableClass: Exclude lombok's UtilityClass 

### DIFF
--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2579,6 +2579,8 @@ See the property `annotations`.
             <property name="xpath">
                 <value>
 <![CDATA[
+//TypeDeclaration[Annotation[pmd-java:typeIs('lombok.experimental.UtilityClass')]]
+|
 //ClassOrInterfaceDeclaration[@Nested= false() and @Local= false()]
 [
   (

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2579,7 +2579,18 @@ See the property `annotations`.
             <property name="xpath">
                 <value>
 <![CDATA[
-//TypeDeclaration[Annotation[pmd-java:typeIs('lombok.experimental.UtilityClass')]]
+//TypeDeclaration
+[
+Annotation[pmd-java:typeIs('lombok.experimental.UtilityClass')]
+and
+(
+(: no methods :)
+not(./ClassOrInterfaceDeclaration/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/MethodDeclaration)
+or
+(: only private methods :)
+count(./ClassOrInterfaceDeclaration/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/MethodDeclaration) = count(./ClassOrInterfaceDeclaration/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/MethodDeclaration[@Private=true()])
+)
+]
 |
 //ClassOrInterfaceDeclaration[@Nested= false() and @Local= false()]
 [

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/MissingStaticMethodInNonInstantiatableClass.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/MissingStaticMethodInNonInstantiatableClass.xml
@@ -379,4 +379,19 @@ public class Scratch {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#4224 [java] MissingStaticMethodInNonInstantiatableClass should considers lombok's UtilityClass</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public final class Test {
+   private int x;
+}
+
+
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/MissingStaticMethodInNonInstantiatableClass.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/MissingStaticMethodInNonInstantiatableClass.xml
@@ -391,7 +391,56 @@ public final class Test {
    private int x;
 }
 
-
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#4224 [java] MissingStaticMethodInNonInstantiatableClass should considers lombok's UtilityClass</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public final class Test {
+    public int test(){
+        return 0;
+    }
+   private int x;
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>#4224 [java] MissingStaticMethodInNonInstantiatableClass should considers lombok's UtilityClass</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public final class Test {
+    private int test(){
+        return 0;
+    }
+   private int x;
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>#4224 [java] MissingStaticMethodInNonInstantiatableClass should considers lombok's UtilityClass</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public final class Test {
+    private int test(){
+        return 0;
+    }
+    public int test0(){
+        return 0;
+    }
+   private int x;
+}
+        ]]></code>
+    </test-code>
+
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
This PR excludes lombok's UtilityClass  which create a private method which throw a exception but PMD treats it as a false negative.
## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #4224 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

