### PR TITLE
[java] ImmutableField - deprecate property ignoredAnnotations

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -21,6 +21,13 @@ This is a {{ site.pmd.release_type }} release.
   either inherit from JUnit 3 TestCase or have at least one method annotated with the Test annotations from
   JUnit4/5 or TestNG.
 
+* The property `ignoredAnnotations` of rule {% rule java/design/ImmutableField %} has been deprecated  and doesn't
+  have any effect anymore.
+  Since PMD 6.47.0, the rule only considers fields, that are initialized once and never changed. If the field is just
+  declared but never explicitly initialized, it won't be reported. That's the typical case when a framework sets
+  the field value by reflection. Therefore, the property is not needed anymore. If there is a special case where
+  this rule misidentifies fields as immutable, then the rule should be suppressed for these fields explicitly.
+
 ### Fixed Issues
 * cli
     * [#4215](https://github.com/pmd/pmd/discussions/4215): NullPointerException when trying to open designer
@@ -33,6 +40,7 @@ This is a {{ site.pmd.release_type }} release.
     * [#2867](https://github.com/pmd/pmd/issues/2867): \[java] Separate pattern for test classes in ClassNamingConventions rule for Java
     * [#4201](https://github.com/pmd/pmd/issues/4201): \[java] CommentDefaultAccessModifier should consider lombok's @<!-- -->Value
 * java-design
+    * [#4175](https://github.com/pmd/pmd/issues/4175): \[java] ImmutableField - deprecate property `ignoredAnnotations`
     * [#4200](https://github.com/pmd/pmd/issues/4200): \[java] ClassWithOnlyPrivateConstructorsShouldBeFinal should consider lombok's @<!-- -->Value
 * java-errorprone
     * [#4185](https://github.com/pmd/pmd/issues/4185): \[java] InvalidLogMessageFormat rule produces a NPE

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractIgnoredAnnotationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractIgnoredAnnotationRule.java
@@ -23,12 +23,16 @@ public abstract class AbstractIgnoredAnnotationRule extends AbstractJavaRule {
 
     private final PropertyDescriptor<List<String>> ignoredAnnotationsDescriptor
         = stringListProperty("ignoredAnnotations")
-        .desc("Fully qualified names of the annotation types that should be ignored by this rule")
+        .desc(defaultIgnoredAnnotationsDescription())
         .defaultValue(defaultSuppressionAnnotations())
         .build();
 
     protected Collection<String> defaultSuppressionAnnotations() {
         return Collections.emptyList();
+    }
+
+    protected String defaultIgnoredAnnotationsDescription() {
+        return "Fully qualified names of the annotation types that should be ignored by this rule";
     }
 
     protected AbstractIgnoredAnnotationRule() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ImmutableFieldRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ImmutableFieldRule.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.design;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -22,7 +23,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTTryStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableInitializer;
 import net.sourceforge.pmd.lang.java.ast.ASTWhileStatement;
 import net.sourceforge.pmd.lang.java.ast.AccessNode;
-import net.sourceforge.pmd.lang.java.ast.Annotatable;
 import net.sourceforge.pmd.lang.java.rule.AbstractLombokAwareRule;
 import net.sourceforge.pmd.lang.java.symboltable.JavaNameOccurrence;
 import net.sourceforge.pmd.lang.java.symboltable.VariableNameDeclaration;
@@ -32,6 +32,17 @@ import net.sourceforge.pmd.lang.symboltable.NameOccurrence;
  * @author Olander
  */
 public class ImmutableFieldRule extends AbstractLombokAwareRule {
+
+
+    @Override
+    protected String defaultIgnoredAnnotationsDescription() {
+        return "deprecated! " + super.defaultIgnoredAnnotationsDescription();
+    }
+
+    @Override
+    protected Collection<String> defaultSuppressionAnnotations() {
+        return Collections.emptyList();
+    }
 
     @Override
     public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
@@ -45,8 +56,7 @@ public class ImmutableFieldRule extends AbstractLombokAwareRule {
             AccessNode accessNodeParent = field.getAccessNodeParent();
             if (accessNodeParent.isStatic() || !accessNodeParent.isPrivate() || accessNodeParent.isFinal()
                     || accessNodeParent.isVolatile()
-                    || hasLombokAnnotation(node)
-                    || hasIgnoredAnnotation((Annotatable) accessNodeParent)) {
+                    || hasLombokAnnotation(node)) {
                 continue;
             }
 

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -886,6 +886,12 @@ of the field or by a constructor. This helps in converting existing classes to b
 Note that this rule does not enforce referenced object to be immutable itself. A class can still be mutable, even
 if all its member fields are declared final. This is referred to as shallow immutability. For more information on
 mutability, see Effective Java, 3rd Edition, Item 17: Minimize mutability.
+
+Note: The property `ignoredAnnotations` is deprecated since PMD 6.52.0 and doesn't have any effect anymore.
+Since PMD 6.47.0, the rule only considers fields, that are initialized once and never changed. If the field is just
+declared but never explicitly initialized, it won't be reported. That's the typical case when a framework sets
+the field value by reflection. Therefore, the property is not needed anymore. If there is a special case where
+this rule misidentifies fields as immutable, then the rule should be suppressed for these fields explicitly.
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ImmutableField.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ImmutableField.xml
@@ -475,6 +475,7 @@ class Foo {
         <code><![CDATA[
 public class Foo {
     @Deprecated
+    @SuppressWarnings("PMD.ImmutableField")
     private int x;
 
     public Foo() {


### PR DESCRIPTION
## Describe the PR

- Fixes #4175

Note: The only use case for this annotations was #1056. But I think, such special cases should be dealt with suppressing the cases.

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

