### PR TITLE
[java] Fix sonar build (pmd7)

### DIFF
--- a/pmd-java/pom.xml
+++ b/pmd-java/pom.xml
@@ -63,18 +63,13 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <executions>
-                    <execution>                                           
-                        <id>default-testCompile</id>
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>testCompile</goal>
-                        </goals>                   
-
+                    <execution>
+                        <id>java-test-compile</id>
                         <!-- Have test-compile produce parameter metadata for reflection tests -->
                         <configuration>
                             <parameters>true</parameters>
                         </configuration>
-                    </execution>                
+                    </execution>
                 </executions>
             </plugin>
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/AbstractSymbolTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/AbstractSymbolTest.java
@@ -16,7 +16,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.junit.Assert;
@@ -118,7 +120,7 @@ public abstract class AbstractSymbolTest {
         JClassSymbol sym = resolveSymbol(actualClass);
 
         List<JMethodSymbol> ms = sym.getDeclaredMethods();
-        Method[] actualMethods = actualClass.getDeclaredMethods();
+        List<Method> actualMethods = Arrays.stream(actualClass.getDeclaredMethods()).filter(m -> !m.isSynthetic()).collect(Collectors.toList());
    
         for (final Method m : actualMethods) {
             JMethodSymbol mSym = ms.stream().filter(it -> it.getSimpleName().equals(m.getName()))
@@ -143,7 +145,7 @@ public abstract class AbstractSymbolTest {
         JClassSymbol sym = resolveSymbol(actualClass);
         
         List<JFieldSymbol> fs = sym.getDeclaredFields();
-        Field[] actualFields = actualClass.getDeclaredFields();
+        List<Field> actualFields = Arrays.stream(actualClass.getDeclaredFields()).filter(f -> !f.isSynthetic()).collect(Collectors.toList());
         
         for (final Field f : actualFields) {
             JFieldSymbol fSym = fs.stream().filter(it -> it.getSimpleName().equals(f.getName()))
@@ -160,7 +162,7 @@ public abstract class AbstractSymbolTest {
         JClassSymbol sym = resolveSymbol(actualClass);
 
         List<JMethodSymbol> ms = sym.getDeclaredMethods();
-        Method[] actualMethods = actualClass.getDeclaredMethods();
+        List<Method> actualMethods = Arrays.stream(actualClass.getDeclaredMethods()).filter(m -> !m.isSynthetic()).collect(Collectors.toList());
    
         for (final Method m : actualMethods) {
             JMethodSymbol mSym = ms.stream().filter(it -> it.getSimpleName().equals(m.getName()))
@@ -202,8 +204,8 @@ public abstract class AbstractSymbolTest {
 
     private void assertAllFieldsMatch(Class<?> actualClass, JClassSymbol sym) {
         List<JFieldSymbol> fs = sym.getDeclaredFields();
-        Field[] actualFields = actualClass.getDeclaredFields();
-        Assert.assertEquals(actualFields.length, fs.size());
+        List<Field> actualFields = Arrays.stream(actualClass.getDeclaredFields()).filter(f -> !f.isSynthetic()).collect(Collectors.toList());
+        Assert.assertEquals(actualFields.size(), fs.size());
    
         for (final Field f : actualFields) {
             JFieldSymbol fSym = fs.stream().filter(it -> it.getSimpleName().equals(f.getName()))
@@ -219,9 +221,9 @@ public abstract class AbstractSymbolTest {
     
     private void assertAllMethodsMatch(Class<?> actualClass, JClassSymbol sym) {
         List<JMethodSymbol> ms = sym.getDeclaredMethods();
-        Method[] actualMethods = actualClass.getDeclaredMethods();
-        Assert.assertEquals(actualMethods.length, ms.size());
-   
+        List<Method> actualMethods = Arrays.stream(actualClass.getDeclaredMethods()).filter(m -> !m.isSynthetic()).collect(Collectors.toList());
+        Assert.assertEquals(actualMethods.size(), ms.size());
+
         for (final Method m : actualMethods) {
             JMethodSymbol mSym = ms.stream().filter(it -> it.getSimpleName().equals(m.getName()))
                     .findFirst().orElseThrow(AssertionError::new);


### PR DESCRIPTION
* Ignore synthetic methods and fields in tests:
  When running PMD build for sonar and coveralls, the jacoco agent will insert a synthetic 
  method "$jacocoInit()" and synthetic field "$jacocoData".
  Both are not present in the class files on disk, which
  are used for the asm-based symbol analyzer.
  See question "My code uses reflection. Why does it fail when I execute it with JaCoCo?" on https://www.jacoco.org/jacoco/trunk/doc/faq.html

  For now, all synthetic methods and fields are ignored
  and not just the two jacoco specific ones.
* Compile test sources only once
  In the parent pom, the "default-testCompile" execution
  is disabled in favor of "java-test-compile". Just
  override the configuration for "java-test-compile"
  instead of re-adding the default execution.


This should fix the build on github ci for branch pmd/7.0.x and it should make the build slightly faster (pmd-java's test sources where compiled always twice).
