### PR TITLE
[java] Deprecate rules ExcessiveClassLength and ExcessiveMethodLength

### DIFF
--- a/docs/pages/next_major_development.md
+++ b/docs/pages/next_major_development.md
@@ -1497,96 +1497,132 @@ large projects, with many duplications, it was causing `OutOfMemoryError`s (see 
 
 ### List of currently deprecated rules
 
-* The Java rules {% rule java/codestyle/VariableNamingConventions %}, {% rule java/codestyle/MIsLeadingVariableName %},
-    {% rule java/codestyle/SuspiciousConstantFieldName %}, and {% rule java/codestyle/AvoidPrefixingMethodParameters %} are
-    now deprecated, and will be removed with version 7.0.0. They are replaced by the more general
-    {% rule java/codestyle/FieldNamingConventions %}, {% rule java/codestyle/FormalParameterNamingConventions %}, and
-    {% rule java/codestyle/LocalVariableNamingConventions %}.
+These rules will be removed with PMD 7.0.0.
 
-* The Java rule {% rule java/codestyle/AbstractNaming %} is deprecated
-    in favour of {% rule java/codestyle/ClassNamingConventions %}.
+* Since 6.0.0: The Java rules {% rule java/design/NcssConstructorCount %}, {% rule java/design/NcssMethodCount %},
+  and {% rule java/design/NcssTypeCount %} have been deprecated. They will be replaced by the new rule
+  {% rule java/design/NcssCount %}.
 
-* The Java rules {% rule java/codestyle/WhileLoopsMustUseBraces %}, {% rule java/codestyle/ForLoopsMustUseBraces %}, {% rule java/codestyle/IfStmtsMustUseBraces %}, and {% rule java/codestyle/IfElseStmtsMustUseBraces %}
-    are deprecated. They will be replaced by the new rule {% rule java/codestyle/ControlStatementBraces %}.
+* Since 6.0.0: The Java rule `LooseCoupling` in ruleset `java-typeresolution` is deprecated. Use the rule with the
+  same name from category `bestpractices` instead: {% rule java/bestpractices/LooseCoupling %}.
 
-* The Java rules {% rule java/design/NcssConstructorCount %}, {% rule java/design/NcssMethodCount %}, and {% rule java/design/NcssTypeCount %} have been
-    deprecated. They will be replaced by the new rule {% rule java/design/NcssCount %} in the category `design`.
+* Since 6.0.0: The Java rule `CloneMethodMustImplementCloneable` in ruleset `java-typeresolution` is deprecated.
+  Use the rule with the same name from category `errorprone` instead:
+  {% rule java/errorprone/CloneMethodMustImplementCloneable %}.
 
-* The Java rule `LooseCoupling` in ruleset `java-typeresolution` is deprecated. Use the rule with the same name from category `bestpractices` instead.
+* Since 6.0.0: The Java rule `UnusedImports` in ruleset `java-typeresolution` is deprecated. Use the rule with
+  the same name from category `bestpractices` instead: {% rule java/bestpractices/UnusedImports %}.
 
-* The Java rule `CloneMethodMustImplementCloneable` in ruleset `java-typeresolution` is deprecated. Use the rule with the same name from category `errorprone` instead.
+* Since 6.0.0: The Java rule `SignatureDeclareThrowsException` in ruleset `java-typeresolution` is deprecated.
+  Use the rule with the same name from category `design` instead:
+  {% rule java/design/SignatureDeclareThrowsException %}.
 
-* The Java rule `UnusedImports` in ruleset `java-typeresolution` is deprecated. Use the rule with
-    the same name from category `bestpractices` instead.
+* Since 6.0.0: The Java rule `EmptyStaticInitializer` in ruleset `java-empty` is deprecated.
+  Use the rule {% rule java/errorprone/EmptyInitializer %} instead, which covers both static and non-static
+  empty initializers.
 
-* The Java rule `SignatureDeclareThrowsException` in ruleset `java-typeresolution` is deprecated. Use the rule with the same name from category `design` instead.
+* Since 6.0.0: The Java rules `GuardDebugLogging` (ruleset `java-logging-jakarta-commons`) and
+  `GuardLogStatementJavaUtil` (ruleset `java-logging-java`) have been deprecated. Use the rule
+  {% rule java/bestpractices/GuardLogStatement %} instead, which covers all cases regardless of the logging framework.
 
-* The Java rule `EmptyStaticInitializer` in ruleset `java-empty` is deprecated. Use the rule {% rule java/errorprone/EmptyInitializer %}, which covers both static and non-static empty initializers.`
+* Since 6.2.0: The Java rules {% rule java/codestyle/WhileLoopsMustUseBraces %},
+  {% rule java/codestyle/ForLoopsMustUseBraces %}, {% rule java/codestyle/IfStmtsMustUseBraces %}, and
+  {% rule java/codestyle/IfElseStmtsMustUseBraces %} are deprecated. They will be replaced by the new rule
+  {% rule java/codestyle/ControlStatementBraces %}.
 
-* The Java rules `GuardDebugLogging` (ruleset `java-logging-jakarta-commons`) and `GuardLogStatementJavaUtil`
-    (ruleset `java-logging-java`) have been deprecated. Use the rule {% rule java/bestpractices/GuardLogStatement %}, which covers all cases regardless of the logging framework.
+* Since 6.3.0: The Java rule {% rule java/codestyle/AbstractNaming %} is deprecated
+  in favour of {% rule java/codestyle/ClassNamingConventions %}.
 
-* The Java rule {% rule "java/multithreading/UnsynchronizedStaticDateFormatter" %} has been deprecated and
-    will be removed with PMD 7.0.0. The rule is replaced by the more general
-    {% rule "java/multithreading/UnsynchronizedStaticFormatter" %}.
+* Since 6.7.0: The Java rules {% rule java/codestyle/VariableNamingConventions %},
+  {% rule java/codestyle/MIsLeadingVariableName %}, {% rule java/codestyle/SuspiciousConstantFieldName %}, and
+  {% rule java/codestyle/AvoidPrefixingMethodParameters %} are now deprecated. They are replaced by the more general
+  {% rule java/codestyle/FieldNamingConventions %}, {% rule java/codestyle/FormalParameterNamingConventions %}, and
+  {% rule java/codestyle/LocalVariableNamingConventions %}.
 
-* The two Java rules {% rule "java/bestpractices/PositionLiteralsFirstInComparisons" %}
-    and {% rule "java/bestpractices/PositionLiteralsFirstInCaseInsensitiveComparisons" %} (ruleset `java-bestpractices`)
-    have been deprecated in favor of the new rule {% rule "java/bestpractices/LiteralsFirstInComparisons" %}.
+* Since 6.11.0: The Java rule {% rule java/multithreading/UnsynchronizedStaticDateFormatter %} has been deprecated.
+  The rule is replaced by the more general {% rule java/multithreading/UnsynchronizedStaticFormatter %}.
 
-* The Java rule [`AvoidFinalLocalVariable`](https://pmd.github.io/pmd-6.16.0/pmd_rules_java_codestyle.html#avoidfinallocalvariable) (`java-codestyle`) has been deprecated
-    and will be removed with PMD 7.0.0. The rule is controversial and also contradicts other existing
-    rules such as [`LocalVariableCouldBeFinal`](https://pmd.github.io/pmd-6.16.0/pmd_rules_java_codestyle.html#localvariablecouldbefinal). If the goal is to avoid defining
-    constants in a scope smaller than the class, then the rule [`AvoidDuplicateLiterals`](https://pmd.github.io/pmd-6.16.0/pmd_rules_java_errorprone.html#avoidduplicateliterals)
-    should be used instead.
+* Since 6.15.0: The Apex rule {% rule apex/codestyle/VariableNamingConventions %} has been deprecated. The rule is
+  replaced by the more general rules {% rule apex/codestyle/FieldNamingConventions %},
+  {% rule apex/codestyle/FormalParameterNamingConventions %}, {% rule apex/codestyle/LocalVariableNamingConventions %},
+  and {% rule apex/codestyle/PropertyNamingConventions %}.
 
-* The Apex rule [`VariableNamingConventions`](https://pmd.github.io/pmd-6.15.0/pmd_rules_apex_codestyle.html#variablenamingconventions) (`apex-codestyle`) has been deprecated and
-    will be removed with PMD 7.0.0. The rule is replaced by the more general rules
-    [`FieldNamingConventions`](https://pmd.github.io/pmd-6.15.0/pmd_rules_apex_codestyle.html#fieldnamingconventions),
-    [`FormalParameterNamingConventions`](https://pmd.github.io/pmd-6.15.0/pmd_rules_apex_codestyle.html#formalparameternamingconventions),
-    [`LocalVariableNamingConventions`](https://pmd.github.io/pmd-6.15.0/pmd_rules_apex_codestyle.html#localvariablenamingconventions), and
-    [`PropertyNamingConventions`](https://pmd.github.io/pmd-6.15.0/pmd_rules_apex_codestyle.html#propertynamingconventions).
+* Since 6.15.0: The Java rule {% rule java/errorprone/LoggerIsNotStaticFinal %} has been deprecated.
+  The rule is replaced by {% rule java/errorprone/ProperLogger %}.
 
-* The Java rule [`LoggerIsNotStaticFinal`](https://pmd.github.io/pmd-6.15.0/pmd_rules_java_errorprone.html#loggerisnotstaticfinal) (`java-errorprone`) has been deprecated
-    and will be removed with PMD 7.0.0. The rule is replaced by [`ProperLogger`](https://pmd.github.io/pmd-6.15.0/pmd_rules_java_errorprone.html#properlogger).
+* Since 6.16.0: The Java rule {% rule java/codestyle/AvoidFinalLocalVariable %} has been deprecated.
+  The rule is controversial and also contradicts other existing rules such as
+  {% rule java/codestyle/LocalVariableCouldBeFinal %}. If the goal is to avoid defining
+  constants in a scope smaller than the class, then the rule {% rule java/errorprone/AvoidDuplicateLiterals %}
+  should be used instead.
 
-* The Java rule {% rule "java/errorprone/DataflowAnomalyAnalysis" %} (`java-errorprone`)
-    is deprecated in favour of {% rule "java/bestpractices/UnusedAssignment" %} (`java-bestpractices`),
-    which was introduced in PMD 6.26.0.
+* Since 6.19.0: The Java rule {% rule java/errorprone/InvalidSlf4jMessageFormat %} has been renamed to
+  {% rule java/errorprone/InvalidLogMessageFormat %}.
 
-* The java rule {% rule "java/codestyle/DefaultPackage" %} has been deprecated in favor of
-    {% rule "java/codestyle/CommentDefaultAccessModifier" %}.
+* Since 6.24.0: The two Java rules {% rule java/bestpractices/PositionLiteralsFirstInComparisons %}
+  and {% rule java/bestpractices/PositionLiteralsFirstInCaseInsensitiveComparisons %}
+  have been deprecated in favor of the new rule {% rule java/bestpractices/LiteralsFirstInComparisons %}.
 
-* The Java rule {% rule "java/errorprone/CloneThrowsCloneNotSupportedException" %} has been deprecated without
-    replacement.
+* Since 6.27.0: The Java rule {% rule java/errorprone/DataflowAnomalyAnalysis %}
+  is deprecated in favour of {% rule java/bestpractices/UnusedAssignment %},
+  which was introduced in PMD 6.26.0.
 
-* The following Java rules are deprecated and removed from the quickstart ruleset,
-    as the new rule {% rule java/bestpractices/SimplifiableTestAssertion %} merges
-    their functionality:
-    * {% rule java/bestpractices/UseAssertEqualsInsteadOfAssertTrue %}
-    * {% rule java/bestpractices/UseAssertNullInsteadOfAssertTrue %}
-    * {% rule java/bestpractices/UseAssertSameInsteadOfAssertTrue %}
-    * {% rule java/bestpractices/UseAssertTrueInsteadOfAssertEquals %}
-    * {% rule java/design/SimplifyBooleanAssertion %}
+* Since 6.29.0: The Apex rules {% rule apex/performance/AvoidDmlStatementsInLoops %},
+  {% rule apex/performance/AvoidSoqlInLoops %}, and {% rule apex/performance/AvoidSoslInLoops %} are deprecated
+  in favor of the new rule {% rule apex/performance/OperationWithLimitsInLoop %}.
 
-* The Java rule {% rule java/errorprone/ReturnEmptyArrayRatherThanNull %} is deprecated and removed from
-    the quickstart ruleset, as the new rule {% rule java/errorprone/ReturnEmptyCollectionRatherThanNull %}
-    supersedes it.
+* Since 6.29.0: The Java rule {% rule java/errorprone/DoNotCallSystemExit %} has been renamed to
+  {% rule/java/errorprone/DoNotTerminateVM %}.
 
-* The following Java rules are deprecated and removed from the quickstart ruleset,
-    as the new rule {% rule java/bestpractices/PrimitiveWrapperInstantiation %} merges
-    their functionality:
-    * {% rule java/performance/BooleanInstantiation %}
-    * {% rule java/performance/ByteInstantiation %}
-    * {% rule java/performance/IntegerInstantiation %}
-    * {% rule java/performance/LongInstantiation %}
-    * {% rule java/performance/ShortInstantiation %}
+* Since 6.31:0: The Java rule {% rule java/performance/AvoidUsingShortType %} is deprecated
+  for removal without replacement.
 
-* The Java rule {% rule java/performance/UnnecessaryWrapperObjectCreation %} is deprecated
-    with no planned replacement before PMD 7. In it's current state, the rule is not useful
-    as it finds only contrived cases of creating a primitive wrapper and unboxing it explicitly
-    in the same expression. In PMD 7 this and more cases will be covered by a
-    new rule `UnnecessaryBoxing`.
+* Since 6.31.0: The Java rule {% rule java/performance/SimplifyStartsWith %} is deprecated
+  for removal without replacement.
+
+* Since 6.34.0: The Java rules {% rule java/bestpractices/UnusedImports %}, {% rule java/codestyle/DuplicateImports %},
+  {% rule java/codestyle/DontImportJavaLang %}, and {% rule java/errorprone/ImportFromSamePackage %} are
+  deprecated. These rules are replaced by {% rule java/codestyle/UnnecessaryImport %}.
+
+* Since 6.35.0: The Java rule {% rule java/codestyle/DefaultPackage %} has been deprecated in favor of
+  {% rule java/codestyle/CommentDefaultAccessModifier %}.
+
+* Since 6.35.0: The Java rule {% rule java/errorprone/CloneThrowsCloneNotSupportedException %} has been
+  deprecated without replacement.
+
+* Since 6.36.0: The Java rule {% rule java/errorprone/BadComparison %} has been renamed to
+  {% rule java/errorprone/ComparisonWithNaN %}.
+
+* Since 6.37.0: The following Java rules are deprecated and removed from the quickstart ruleset,
+  as the new rule {% rule java/bestpractices/SimplifiableTestAssertion %} merges
+  their functionality:
+  * {% rule java/bestpractices/UseAssertEqualsInsteadOfAssertTrue %}
+  * {% rule java/bestpractices/UseAssertNullInsteadOfAssertTrue %}
+  * {% rule java/bestpractices/UseAssertSameInsteadOfAssertTrue %}
+  * {% rule java/bestpractices/UseAssertTrueInsteadOfAssertEquals %}
+  * {% rule java/design/SimplifyBooleanAssertion %}
+
+* Since 6.37.0: The Java rule {% rule java/errorprone/ReturnEmptyArrayRatherThanNull %} is deprecated and removed from
+  the quickstart ruleset, as the new rule {% rule java/errorprone/ReturnEmptyCollectionRatherThanNull %}
+  supersedes it.
+
+* Since 6.37.0: The following Java rules are deprecated and removed from the quickstart ruleset,
+  as the new rule {% rule java/bestpractices/PrimitiveWrapperInstantiation %} merges
+  their functionality:
+  * {% rule java/performance/BooleanInstantiation %}
+  * {% rule java/performance/ByteInstantiation %}
+  * {% rule java/performance/IntegerInstantiation %}
+  * {% rule java/performance/LongInstantiation %}
+  * {% rule java/performance/ShortInstantiation %}
+
+* Since 6.37.0: The Java rule {% rule java/performance/UnnecessaryWrapperObjectCreation %} is deprecated
+  with no planned replacement before PMD 7. In its current state, the rule is not useful
+  as it finds only contrived cases of creating a primitive wrapper and unboxing it explicitly
+  in the same expression. In PMD 7 this and more cases will be covered by a
+  new rule `UnnecessaryBoxing`.
+
+* Since 6.37.0: The Java rule {% rule java/errorprone/MissingBreakInSwitch %} has been renamed to
+  {% rule java/errorprone/ImplicitSwitchFallThrough %}.
 
 * Since 6.46.0: The following Java rules are deprecated and removed from the quickstart ruleset, as the new rule
   {% rule java/codestyle/EmptyControlStatement %} merges their functionality:
@@ -1599,8 +1635,12 @@ large projects, with many duplications, it was causing `OutOfMemoryError`s (see 
     * {% rule java/errorprone/EmptyTryBlock %}
     * {% rule java/errorprone/EmptyWhileStmt %}
 
-* Since 6.46.0: The Java rule {% rule java/errorprone/EmptyStatementNotInLoop %} is deprecated and removed from the quickstart
-  ruleset. Use the new rule {% rule java/codestyle/UnnecessarySemicolon %} instead.
-
 * Since 6.52.0: The Java rule {% rule java/errorprone/BeanMembersShouldSerialize %} has been renamed to
   {% rule java/errorprone/NonSerializableClass %}.
+
+* Since 6.53.0: The Java rules {% rule java/design/ExcessiveClassLength %} and
+  {% rule java/design/ExcessiveMethodLength %} have been deprecated. The rule
+  {% rule java/design/NcssCount %} can be used instead.
+
+* Since 6.53.0: The Java rule {% rule java/errorprone/EmptyStatementNotInLoop %} is deprecated.
+  Use the rule {% rule java/codestyle/UnnecessarySemicolon %} instead.

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -20,6 +20,11 @@ This is a {{ site.pmd.release_type }} release.
   have been deprecated. The rule {% rule java/design/NcssCount %} can be used instead.
   The deprecated rules will be removed with PMD 7.0.0.
 
+* The Java rule {% rule java/errorprone/EmptyStatementNotInLoop %} is deprecated.
+  Use the rule {% rule java/codestyle/UnnecessarySemicolon %} instead.
+  Note: Actually it was announced to be deprecated since 6.46.0 but the rule was not marked as deprecated yet.
+  This has been done now.
+
 ### Fixed Issues
 
 * java-design

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -27,6 +27,15 @@ This is a {{ site.pmd.release_type }} release.
 
 ### API Changes
 
+#### Deprecated APIs
+
+##### Internal API
+
+Those APIs are not intended to be used by clients, and will be hidden or removed with PMD 7.0.0. You can identify
+them with the `@InternalApi` annotation. You'll also get a deprecation warning.
+
+* {% jdoc java::lang.java.rule.design.ExcessiveLengthRule %} (Java)
+
 ### External Contributions
 
 {% endtocmaker %}

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -34,10 +34,9 @@ This is a {{ site.pmd.release_type }} release.
 
 #### Deprecated APIs
 
-##### Internal API
+##### For removal
 
-Those APIs are not intended to be used by clients, and will be hidden or removed with PMD 7.0.0. You can identify
-them with the `@InternalApi` annotation. You'll also get a deprecation warning.
+These classes / APIs have been deprecated and will be removed with PMD 7.0.0.
 
 * {% jdoc java::lang.java.rule.design.ExcessiveLengthRule %} (Java)
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -14,7 +14,16 @@ This is a {{ site.pmd.release_type }} release.
 
 ### New and noteworthy
 
+#### Deprecated rules
+
+* The Java rules {% rule java/design/ExcessiveClassLength %} and {% rule java/design/ExcessiveMethodLength %}
+  have been deprecated. The rule {% rule java/design/NcssCount %} can be used instead.
+  The deprecated rules will be removed with PMD 7.0.0.
+
 ### Fixed Issues
+
+* java-design
+    * [#2127](https://github.com/pmd/pmd/issues/2127): \[java] Deprecate rules ExcessiveClassLength and ExcessiveMethodLength
 
 ### API Changes
 

--- a/pmd-apex/src/main/resources/category/apex/codestyle.xml
+++ b/pmd-apex/src/main/resources/category/apex/codestyle.xml
@@ -351,7 +351,7 @@ A variable naming conventions rule - customize this to your liking.  Currently, 
 checks for final variables that should be fully capitalized and non-final variables
 that should not include underscores.
 
-This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+_Note:_ This rule is deprecated since PMD 6.15.0 and will be removed with PMD 7.0.0. The rule is replaced
 by the more general rules {% rule "apex/codestyle/FieldNamingConventions" %},
 {% rule "apex/codestyle/FormalParameterNamingConventions" %},
 {% rule "apex/codestyle/LocalVariableNamingConventions" %}, and

--- a/pmd-apex/src/main/resources/category/apex/performance.xml
+++ b/pmd-apex/src/main/resources/category/apex/performance.xml
@@ -64,7 +64,7 @@ public class Foo {
         <description>
 Avoid DML statements inside loops to avoid hitting the DML governor limit. Instead, try to batch up the data into a list and invoke your DML once on that list of data outside the loop.
 
-This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+_Note:_ This rule is deprecated since PMD 6.29.0 and will be removed with PMD 7.0.0. The rule is replaced
 by the more general rule {% rule "apex/performance/OperationWithLimitsInLoop" %}.
         </description>
         <priority>3</priority>
@@ -93,7 +93,7 @@ public class Something {
         <description>
 New objects created within loops should be checked to see if they can created outside them and reused.
 
-This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+_Note:_ This rule is deprecated since PMD 6.29.0 and will be removed with PMD 7.0.0. The rule is replaced
 by the more general rule {% rule "apex/performance/OperationWithLimitsInLoop" %}.
         </description>
         <priority>3</priority>
@@ -120,7 +120,7 @@ public class Something {
         <description>
 Sosl calls within loops can cause governor limit exceptions.
 
-This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+_Note:_ This rule is deprecated since PMD 6.29.0 and will be removed with PMD 7.0.0. The rule is replaced
 by the more general rule {% rule "apex/performance/OperationWithLimitsInLoop" %}.
         </description>
         <priority>3</priority>

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveClassLengthRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveClassLengthRule.java
@@ -9,7 +9,10 @@ import net.sourceforge.pmd.lang.java.ast.ASTAnyTypeDeclaration;
 /**
  * This rule detects when a class exceeds a certain threshold. i.e. if a class
  * has more than 1000 lines of code.
+ *
+ * @deprecated Use {@link NcssCountRule} instead.
  */
+@Deprecated
 public class ExcessiveClassLengthRule extends ExcessiveLengthRule {
     public ExcessiveClassLengthRule() {
         super(ASTAnyTypeDeclaration.class);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveLengthRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveLengthRule.java
@@ -15,7 +15,10 @@ import net.sourceforge.pmd.stat.DataPoint;
  *
  * <p>To implement an ExcessiveLength rule, you pass in the Class of node you want
  * to check, and this does the rest for you.</p>
+ *
+ * @deprecated This base class is not needed anymore and will be removed with PMD 7.
  */
+@Deprecated
 public class ExcessiveLengthRule extends AbstractStatisticalJavaRule {
     private Class<?> nodeClass;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveLengthRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveLengthRule.java
@@ -4,7 +4,6 @@
 
 package net.sourceforge.pmd.lang.java.rule.design;
 
-import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractStatisticalJavaRule;
 import net.sourceforge.pmd.stat.DataPoint;
@@ -20,7 +19,6 @@ import net.sourceforge.pmd.stat.DataPoint;
  * @deprecated This base class is not needed anymore and will be removed with PMD 7.
  */
 @Deprecated
-@InternalApi
 public class ExcessiveLengthRule extends AbstractStatisticalJavaRule {
     private Class<?> nodeClass;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveLengthRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveLengthRule.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.design;
 
+import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractStatisticalJavaRule;
 import net.sourceforge.pmd.stat.DataPoint;
@@ -19,6 +20,7 @@ import net.sourceforge.pmd.stat.DataPoint;
  * @deprecated This base class is not needed anymore and will be removed with PMD 7.
  */
 @Deprecated
+@InternalApi
 public class ExcessiveLengthRule extends AbstractStatisticalJavaRule {
     private Class<?> nodeClass;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveMethodLengthRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveMethodLengthRule.java
@@ -10,7 +10,10 @@ import net.sourceforge.pmd.lang.java.ast.ASTMethodOrConstructorDeclaration;
 /**
  * This rule detects when a method exceeds a certain threshold. i.e. if a method
  * has more than x lines of code.
+ *
+ * @deprecated Use {@link NcssCountRule} instead.
  */
+@Deprecated
 public class ExcessiveMethodLengthRule extends ExcessiveLengthRule {
     public ExcessiveMethodLengthRule() {
         super(ASTMethodOrConstructorDeclaration.class);

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -1205,7 +1205,8 @@ String name,
 Position literals first in comparisons, if the second argument is null then NullPointerExceptions
 can be avoided, they will just return false.
 
-This rule is replaced by the more general rule {% rule "LiteralsFirstInComparisons" %}.
+_Note:_ This rule is deprecated since PMD 6.24.0 and will be removed with PMD 7.0.0. The rule is replaced
+by the more general rule {% rule "LiteralsFirstInComparisons" %}.
         </description>
         <priority>3</priority>
         <example>
@@ -1230,7 +1231,8 @@ class Foo {
 Position literals first in comparisons, if the second argument is null then NullPointerExceptions
 can be avoided, they will just return false.
 
-This rule is replaced by the more general rule {% rule "LiteralsFirstInComparisons" %}.
+_Note:_ This rule is deprecated since PMD 6.24.0 and will be removed with PMD 7.0.0. The rule is replaced
+by the more general rule {% rule "LiteralsFirstInComparisons" %}.
         </description>
         <priority>3</priority>
         <example>
@@ -1687,8 +1689,8 @@ Reports import statements that are not used within the file. This also reports
 duplicate imports, and imports from the same package. The simplest fix is just
 to delete those imports.
 
-This rule is deprecated since PMD 6.34.0. Use the rule {% rule "java/codestyle/UnnecessaryImport" %}
-from category codestyle instead.
+_Note:_ This rule is deprecated since PMD 6.34.0 and will be removed with PMD 7.0.0.
+Use the rule {% rule "java/codestyle/UnnecessaryImport" %} from category codestyle instead.
         </description>
         <priority>4</priority>
         <example>
@@ -1783,7 +1785,8 @@ public class Something {
         <description>
 This rule detects JUnit assertions in object equality. These assertions should be made by more specific methods, like assertEquals.
 
-Deprecated since PMD 6.37.0, use {% rule SimplifiableTestAssertion %} instead.
+_Note:_ This rule is deprecated since PMD 6.37.0 and will be removed with PMD 7.0.0.
+Use {% rule SimplifiableTestAssertion %} instead.
         </description>
         <priority>3</priority>
         <properties>
@@ -1837,7 +1840,8 @@ public class FooTest extends TestCase {
 This rule detects JUnit assertions in object references equality. These assertions should be made by
 more specific methods, like assertNull, assertNotNull.
 
-Deprecated since PMD 6.37.0, use {% rule SimplifiableTestAssertion %} instead.
+_Note:_ This rule is deprecated since PMD 6.37.0 and will be removed with PMD 7.0.0.
+Use {% rule SimplifiableTestAssertion %} instead.
         </description>
         <priority>3</priority>
         <properties>
@@ -1894,7 +1898,8 @@ public class FooTest extends TestCase {
 This rule detects JUnit assertions in object references equality. These assertions should be made
 by more specific methods, like assertSame, assertNotSame.
 
-Deprecated since PMD 6.37.0, use {% rule SimplifiableTestAssertion %} instead.
+_Note:_ This rule is deprecated since PMD 6.37.0 and will be removed with PMD 7.0.0.
+Use {% rule SimplifiableTestAssertion %} instead.
         </description>
         <priority>3</priority>
         <properties>
@@ -1947,7 +1952,8 @@ public class FooTest extends TestCase {
         <description>
 When asserting a value is the same as a literal or Boxed boolean, use assertTrue/assertFalse, instead of assertEquals.
 
-Deprecated since PMD 6.37.0, use {% rule SimplifiableTestAssertion %} instead.
+_Note:_ This rule is deprecated since PMD 6.37.0 and will be removed with PMD 7.0.0.
+Use {% rule SimplifiableTestAssertion %} instead.
         </description>
         <priority>3</priority>
         <properties>

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -19,7 +19,7 @@
         <description>
 Abstract classes should be named 'AbstractXXX'.
 
-This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+_Note:_ This rule is deprecated since PMD 6.3.0 and will be removed with PMD 7.0.0. The rule is replaced
 by {% rule java/codestyle/ClassNamingConventions %}.
         </description>
         <priority>3</priority>
@@ -108,7 +108,7 @@ avoid local literals being declared in a scope smaller than the class.
 Also note, that this rule is the opposite of {% rule "java/codestyle/LocalVariableCouldBeFinal" %}.
 Having both rules enabled results in contradictory violations being reported.
 
-This rule is deprecated and will be removed with PMD 7.0.0. There is no replacement planned.
+_Note:_ This rule is deprecated since PMD 6.16.0 and will be removed with PMD 7.0.0. There is no replacement planned.
 If the goal is to avoid defining constants in a scope smaller than the class, then the rule
 {% rule "java/errorprone/AvoidDuplicateLiterals" %} should be used instead.
         </description>
@@ -155,7 +155,7 @@ Prefixing parameters by 'in' or 'out' pollutes the name of the parameters and re
 To indicate whether or not a parameter will be modify in a method, its better to document method
 behavior with Javadoc.
 
-This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+_Note:_ This rule is deprecated since PMD 6.7.0 and will be removed with PMD 7.0.0. The rule is replaced
 by the more general rule {% rule java/codestyle/FormalParameterNamingConventions %}.
         </description>
         <priority>4</priority>
@@ -573,7 +573,8 @@ while (true) {  // preferred approach
 Use explicit scoping instead of accidental usage of default package private level.
 The rule allows methods and fields annotated with Guava's @VisibleForTesting and JUnit 5's annotations.
 
-This rule is deprecated since PMD 6.35.0. It assumes that any usage of package-access is accidental,
+_Note:_ This rule is deprecated since PMD 6.35.0 and will be removed with PMD 7.0.0.
+It assumes that any usage of package-access is accidental,
 and by doing so, prohibits using a really fundamental and useful feature of the language.
 
 To satisfy the rule, you have to make the member public even if it doesn't need to, or make it protected,
@@ -623,8 +624,8 @@ or MethodDeclaration[@PackagePrivate= true()]
         <description>
 Avoid importing anything from the package 'java.lang'.  These classes are automatically imported (JLS 7.5.3).
 
-This rule is deprecated since PMD 6.34.0. Use the rule {% rule "java/codestyle/UnnecessaryImport" %}
-from category codestyle instead.
+_Note:_ This rule is deprecated since PMD 6.34.0 and will be removed with PMD 7.0.0.
+Use the rule {% rule "java/codestyle/UnnecessaryImport" %} from category codestyle instead.
         </description>
         <priority>4</priority>
         <example>
@@ -652,8 +653,8 @@ public class Foo {}
         <description>
 Duplicate or overlapping import statements should be avoided.
 
-This rule is deprecated since PMD 6.34.0. Use the rule {% rule "java/codestyle/UnnecessaryImport" %}
-from category codestyle instead.
+_Note:_ This rule is deprecated since PMD 6.34.0 and will be removed with PMD 7.0.0.
+Use the rule {% rule "java/codestyle/UnnecessaryImport" %} from category codestyle instead.
         </description>
         <priority>4</priority>
         <example>
@@ -934,7 +935,7 @@ Avoid using 'for' statements without using curly braces. If the code formatting 
 indentation is lost then it becomes difficult to separate the code being controlled
 from the rest.
 
-This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+_Note:_ This rule is deprecated since PMD 6.2.0 and will be removed with PMD 7.0.0. The rule is replaced
 by the rule {% rule java/codestyle/ControlStatementBraces %}.
         </description>
         <priority>3</priority>
@@ -1082,7 +1083,7 @@ Avoid using if..else statements without using surrounding braces. If the code fo
 or indentation is lost then it becomes difficult to separate the code being controlled
 from the rest.
 
-This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+_Note:_ This rule is deprecated since PMD 6.2.0 and will be removed with PMD 7.0.0. The rule is replaced
 by the rule {% rule java/codestyle/ControlStatementBraces %}.
         </description>
         <priority>3</priority>
@@ -1125,7 +1126,7 @@ Avoid using if statements without using braces to surround the code block. If th
 formatting or indentation is lost then it becomes difficult to separate the code being
 controlled from the rest.
 
-This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+_Note:_ This rule is deprecated since PMD 6.2.0 and will be removed with PMD 7.0.0. The rule is replaced
 by the rule {% rule java/codestyle/ControlStatementBraces %}.
         </description>
         <priority>3</priority>
@@ -1487,7 +1488,7 @@ public class Foo {
         <description>
 Detects when a non-field has a name starting with 'm_'.  This usually denotes a field and could be confusing.
 
-This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+_Note:_ This rule is deprecated since PMD 6.7.0 and will be removed with PMD 7.0.0. The rule is replaced
 by the more general rule
 {% rule java/codestyle/LocalVariableNamingConventions %}.
         </description>
@@ -1881,7 +1882,7 @@ public class Something {
 Field names using all uppercase characters - Sun's Java naming conventions indicating constants - should
 be declared as final.
 
-This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+_Note:_ This rule is deprecated since PMD 6.7.0 and will be removed with PMD 7.0.0. The rule is replaced
 by the more general rule {% rule java/codestyle/FieldNamingConventions %}.
         </description>
         <priority>3</priority>
@@ -2464,7 +2465,7 @@ A variable naming conventions rule - customize this to your liking.  Currently, 
 checks for final variables that should be fully capitalized and non-final variables
 that should not include underscores.
 
-This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+_Note:_ This rule is deprecated since PMD 6.7.0 and will be removed with PMD 7.0.0. The rule is replaced
 by the more general rules {% rule java/codestyle/FieldNamingConventions %},
 {% rule java/codestyle/FormalParameterNamingConventions %}, and
 {% rule java/codestyle/LocalVariableNamingConventions %}.
@@ -2493,7 +2494,7 @@ Avoid using 'while' statements without using braces to surround the code block. 
 formatting or indentation is lost then it becomes difficult to separate the code being
 controlled from the rest.
 
-This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+_Note:_ This rule is deprecated since PMD 6.2.0 and will be removed with PMD 7.0.0. The rule is replaced
 by the rule {% rule java/codestyle/ControlStatementBraces %}.
         </description>
         <priority>3</priority>

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -675,6 +675,7 @@ public void bar() {
     <rule name="ExcessiveClassLength"
           language="java"
           since="0.6"
+          deprecated="true"
           message="Avoid really long classes."
           class="net.sourceforge.pmd.lang.java.rule.design.ExcessiveClassLengthRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#excessiveclasslength">
@@ -682,6 +683,16 @@ public void bar() {
 Excessive class file lengths are usually indications that the class may be burdened with excessive
 responsibilities that could be provided by external classes or functions. In breaking these methods
 apart the code becomes more manageable and ripe for reuse.
+
+This rule is deprecated since PMD 6.53.0 and will be removed with PMD 7.0.0.
+
+The rule is based on the simple metric lines of code (LoC). The reasons for deprecation are:
+* LoC is a noisy metric, NCSS (non-commenting source statements) is a more solid metric
+(results are code-style independent, comment-insensitive)
+* LoC is easily circumvented by bad code style (e.g. stuffing several assignments into one, concatenating code lines)
+* Enforcing length limits with LoC is not very meaningful, could even be called a bad practice
+
+In order to find "big" classes, the rule {% rule NcssCount %} can be used instead.
         </description>
         <priority>3</priority>
         <example>
@@ -732,6 +743,7 @@ public class Foo {
     <rule name="ExcessiveMethodLength"
           language="java"
           since="0.6"
+          deprecated="true"
           message="Avoid really long methods."
           class="net.sourceforge.pmd.lang.java.rule.design.ExcessiveMethodLengthRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#excessivemethodlength">
@@ -740,6 +752,16 @@ When methods are excessively long this usually indicates that the method is doin
 name/signature might suggest. They also become challenging for others to digest since excessive
 scrolling causes readers to lose focus.
 Try to reduce the method length by creating helper methods and removing any copy/pasted code.
+
+This rule is deprecated since PMD 6.53.0 and will be removed with PMD 7.0.0.
+
+The rule is based on the simple metric lines of code (LoC). The reasons for deprecation are:
+* LoC is a noisy metric, NCSS (non-commenting source statements) is a more solid metric
+(results are code-style independent, comment-insensitive)
+* LoC is easily circumvented by bad code style (e.g. stuffing several assignments into one, concatenating code lines)
+* Enforcing length limits with LoC is not very meaningful, could even be called a bad practice
+
+In order to find "big" methods, the rule {% rule NcssCount %} can be used instead.
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -684,7 +684,7 @@ Excessive class file lengths are usually indications that the class may be burde
 responsibilities that could be provided by external classes or functions. In breaking these methods
 apart the code becomes more manageable and ripe for reuse.
 
-This rule is deprecated since PMD 6.53.0 and will be removed with PMD 7.0.0.
+_Note:_ This rule is deprecated since PMD 6.53.0 and will be removed with PMD 7.0.0.
 
 The rule is based on the simple metric lines of code (LoC). The reasons for deprecation are:
 * LoC is a noisy metric, NCSS (non-commenting source statements) is a more solid metric
@@ -753,7 +753,7 @@ name/signature might suggest. They also become challenging for others to digest 
 scrolling causes readers to lose focus.
 Try to reduce the method length by creating helper methods and removing any copy/pasted code.
 
-This rule is deprecated since PMD 6.53.0 and will be removed with PMD 7.0.0.
+_Note:_ This rule is deprecated since PMD 6.53.0 and will be removed with PMD 7.0.0.
 
 The rule is based on the simple metric lines of code (LoC). The reasons for deprecation are:
 * LoC is a noisy metric, NCSS (non-commenting source statements) is a more solid metric
@@ -1164,7 +1164,7 @@ This rule uses the NCSS (Non-Commenting Source Statements) algorithm to determin
 of code for a given constructor. NCSS ignores comments, and counts actual statements. Using this algorithm,
 lines of code that are split are counted as one.
 
-This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+_Note:_ This rule is deprecated since PMD 6.0.0 and will be removed with PMD 7.0.0. The rule is replaced
 by the rule {% rule java/design/NcssCount %}.
         </description>
         <priority>3</priority>
@@ -1242,7 +1242,7 @@ This rule uses the NCSS (Non-Commenting Source Statements) algorithm to determin
 of code for a given method. NCSS ignores comments, and counts actual statements. Using this algorithm,
 lines of code that are split are counted as one.
 
-This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+_Note:_ This rule is deprecated since PMD 6.0.0 and will be removed with PMD 7.0.0. The rule is replaced
 by the rule {% rule java/design/NcssCount %}.
         </description>
         <priority>3</priority>
@@ -1277,7 +1277,7 @@ This rule uses the NCSS (Non-Commenting Source Statements) algorithm to determin
 of code for a given type. NCSS ignores comments, and counts actual statements. Using this algorithm,
 lines of code that are split are counted as one.
 
-This rule is deprecated and will be removed with PMD 7.0.0. The rule is replaced
+_Note:_ This rule is deprecated since PMD 6.0.0 and will be removed with PMD 7.0.0. The rule is replaced
 by the rule {% rule java/design/NcssCount %}.
         </description>
         <priority>3</priority>
@@ -1455,7 +1455,8 @@ as:
 
     assertFalse(expr);
 
-Deprecated since PMD 6.37.0, use {% rule java/bestpractices/SimplifiableTestAssertion %} instead.
+_Note:_ This rule is deprecated since PMD 6.37.0 and will be removed with PMD 7.0.0.
+Use {% rule SimplifiableTestAssertion %} instead.
         </description>
         <priority>3</priority>
         <properties>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -957,7 +957,8 @@ public class Foo implements Cloneable {
         <description>
 The method clone() should throw a CloneNotSupportedException.
 
-This rule is deprecated since PMD 6.35.0 without replacement. The rule has no real value as
+_Note:_ This rule is deprecated since PMD 6.35.0 and will be removed with PMD 7.0.0 without replacement.
+The rule has no real value as
 `CloneNotSupportedException` is a checked exception and therefore you need to deal with it while
 implementing the `clone()` method. You either need to declare the exception or catch it. If you catch it,
 then subclasses can't throw it themselves explicitly. However, `Object.clone()` will still throw this
@@ -1117,7 +1118,7 @@ class Foo {
             Finally, comparisons like `someDouble <= Double.NaN` are nonsensical
             and will always evaluate to false.
             
-            This rule has been renamed from "BadComparison" with PMD 6.36.0.
+            This rule has been renamed from "BadComparison" in PMD 6.36.0.
         ]]></description>
         <priority>3</priority>
         <properties>
@@ -1192,7 +1193,8 @@ From those informations there can be found various problems.
 1. DU - Anomaly: A recently defined variable is undefined. These anomalies may appear in normal source text.
 2. DD - Anomaly: A recently defined variable is redefined. This is ominous but don't have to be a bug.
 
-This rule is deprecated. Use {% rule "java/bestpractices/UnusedAssignment" %} in category bestpractices instead.
+_Note:_ This rule is deprecated since PMD 6.27.0 and will be removed with PMD 7.0.0. The rule is replaced
+by the rule {% rule "java/bestpractices/UnusedAssignment" %}.
         </description>
         <priority>5</priority>
         <example>
@@ -1391,7 +1393,7 @@ running on the same application server.
 
 This rule also checks for the equivalent calls `Runtime.getRuntime().exit()` and `Runtime.getRuntime().halt()`.
 
-This rule was called *DoNotCallSystemExit* until PMD 6.29.0.
+This rule has been renamed from "DoNotCallSystemExit" in PMD 6.29.0.
         </description>
         <priority>3</priority>
         <properties>
@@ -1597,8 +1599,8 @@ public class Foo {
         <description>
 Empty finally blocks serve no purpose and should be removed.
 
-This rule is deprecated since PMD 6.46.0. Use the rule {% rule "java/codestyle/EmptyControlStatement" %}
-from category codestyle instead.
+_Note:_ This rule is deprecated since PMD 6.46.0 and will be removed with PMD 7.0.0.
+Use the rule {% rule "java/codestyle/EmptyControlStatement" %} from category codestyle instead.
         </description>
         <priority>3</priority>
         <properties>
@@ -1636,8 +1638,8 @@ public class Foo {
         <description>
 Empty If Statement finds instances where a condition is checked but nothing is done about it.
 
-This rule is deprecated since PMD 6.46.0. Use the rule {% rule "java/codestyle/EmptyControlStatement" %}
-from category codestyle instead.
+_Note:_ This rule is deprecated since PMD 6.46.0 and will be removed with PMD 7.0.0.
+Use the rule {% rule "java/codestyle/EmptyControlStatement" %} from category codestyle instead.
         </description>
         <priority>3</priority>
         <properties>
@@ -1674,8 +1676,8 @@ public class Foo {
         <description>
 Empty initializers serve no purpose and should be removed.
 
-This rule is deprecated since PMD 6.46.0. Use the rule {% rule "java/codestyle/EmptyControlStatement" %}
-from category codestyle instead.
+_Note:_ This rule is deprecated since PMD 6.46.0 and will be removed with PMD 7.0.0.
+Use the rule {% rule "java/codestyle/EmptyControlStatement" %} from category codestyle instead.
         </description>
         <priority>3</priority>
         <properties>
@@ -1707,8 +1709,8 @@ public class Foo {
         <description>
 Empty block statements serve no purpose and should be removed.
 
-This rule is deprecated since PMD 6.46.0. Use the rule {% rule "java/codestyle/EmptyControlStatement" %}
-from category codestyle instead.
+_Note:_ This rule is deprecated since PMD 6.46.0 and will be removed with PMD 7.0.0.
+Use the rule {% rule "java/codestyle/EmptyControlStatement" %} from category codestyle instead.
         </description>
         <priority>3</priority>
         <properties>
@@ -1736,6 +1738,7 @@ public class Foo {
     <rule name="EmptyStatementNotInLoop"
           language="java"
           since="1.5"
+          deprecated="true"
           message="An empty statement (semicolon) not part of a loop"
           class="net.sourceforge.pmd.lang.rule.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#emptystatementnotinloop">
@@ -1743,6 +1746,9 @@ public class Foo {
 An empty statement (or a semicolon by itself) that is not used as the sole body of a 'for'
 or 'while' loop is probably a bug.  It could also be a double semicolon, which has no purpose
 and should be removed.
+
+_Note:_ This rule is deprecated since PMD 6.53.0 and will be removed with PMD 7.0.0.
+Use the rule {% rule java/codestyle/UnnecessarySemicolon %} instead.
         </description>
         <priority>3</priority>
         <properties>
@@ -1786,8 +1792,8 @@ public void doit() {
         <description>
 Empty switch statements serve no purpose and should be removed.#
 
-This rule is deprecated since PMD 6.46.0. Use the rule {% rule "java/codestyle/EmptyControlStatement" %}
-from category codestyle instead.
+_Note:_ This rule is deprecated since PMD 6.46.0 and will be removed with PMD 7.0.0.
+Use the rule {% rule "java/codestyle/EmptyControlStatement" %} from category codestyle instead.
         </description>
         <priority>3</priority>
         <properties>
@@ -1819,8 +1825,8 @@ public void bar() {
         <description>
 Empty synchronized blocks serve no purpose and should be removed.
 
-This rule is deprecated since PMD 6.46.0. Use the rule {% rule "java/codestyle/EmptyControlStatement" %}
-from category codestyle instead.
+_Note:_ This rule is deprecated since PMD 6.46.0 and will be removed with PMD 7.0.0.
+Use the rule {% rule "java/codestyle/EmptyControlStatement" %} from category codestyle instead.
         </description>
         <priority>3</priority>
         <properties>
@@ -1852,8 +1858,8 @@ public class Foo {
         <description>
 Avoid empty try blocks - what's the point?
 
-This rule is deprecated since PMD 6.46.0. Use the rule {% rule "java/codestyle/EmptyControlStatement" %}
-from category codestyle instead.
+_Note:_ This rule is deprecated since PMD 6.46.0 and will be removed with PMD 7.0.0.
+Use the rule {% rule "java/codestyle/EmptyControlStatement" %} from category codestyle instead.
         </description>
         <priority>3</priority>
         <properties>
@@ -1892,8 +1898,8 @@ Empty While Statement finds all instances where a while statement does nothing.
 If it is a timing loop, then you should use Thread.sleep() for it; if it is
 a while loop that does a lot in the exit expression, rewrite it to make it clearer.
 
-This rule is deprecated since PMD 6.46.0. Use the rule {% rule "java/codestyle/EmptyControlStatement" %}
-from category codestyle instead.
+_Note:_ This rule is deprecated since PMD 6.46.0 and will be removed with PMD 7.0.0.
+Use the rule {% rule "java/codestyle/EmptyControlStatement" %} from category codestyle instead.
         </description>
         <priority>3</priority>
         <properties>
@@ -2142,7 +2148,7 @@ public class Foo {
 Switch statements without break or return statements for each case option
 may indicate problematic behaviour. Empty cases are ignored as these indicate an intentional fall-through.
 
-This rule has been renamed from "MissingBreakInSwitch" with PMD 6.37.0.
+This rule has been renamed from "MissingBreakInSwitch" in PMD 6.37.0.
         </description>
         <priority>3</priority>
         <properties>
@@ -2196,8 +2202,8 @@ public void bar(int status) {
         <description>
 There is no need to import a type that lives in the same package.
 
-This rule is deprecated since PMD 6.34.0. Use the rule {% rule "java/codestyle/UnnecessaryImport" %}
-from category codestyle instead.
+_Note:_ This rule is deprecated since PMD 6.34.0 and will be removed with PMD 7.0.0.
+Use the rule {% rule "java/codestyle/UnnecessaryImport" %} from category codestyle instead.
         </description>
         <priority>3</priority>
         <example>
@@ -2263,6 +2269,8 @@ Check for messages in slf4j and log4j2 (since 6.19.0) loggers with non matching 
 
 Since 6.32.0 in addition to parameterized message placeholders (`{}`) also format specifiers of string formatted
 messages are supported (`%s`).
+
+This rule has been renamed from "InvalidSlf4jMessageFormat" in PMD 6.19.0.
         </description>
         <priority>5</priority>
         <example>
@@ -2371,7 +2379,7 @@ public class Foo extends TestCase {
         <description>
 In most cases, the Logger reference can be declared as static and final.
 
-This rule is deprecated and will be removed with PMD 7.0.0.
+_Note:_ This rule is deprecated since PMD 6.15.0 and will be removed with PMD 7.0.0.
 The rule is replaced by {% rule java/errorprone/ProperLogger %}.
         </description>
         <priority>2</priority>
@@ -2929,7 +2937,8 @@ For any method that returns an array, it is a better to return an empty array ra
 null reference. This removes the need for null checking all results and avoids inadvertent
 NullPointerExceptions.
 
-Deprecated since PMD 6.37.0, use {% rule java/errorprone/ReturnEmptyCollectionRatherThanNull %} instead.
+_Note:_ This rule is deprecated since PMD 6.37.0 and will be removed with PMD 7.0.0.
+Use {% rule java/errorprone/ReturnEmptyCollectionRatherThanNull %} instead.
         </description>
         <priority>1</priority>
         <properties>

--- a/pmd-java/src/main/resources/category/java/multithreading.xml
+++ b/pmd-java/src/main/resources/category/java/multithreading.xml
@@ -322,7 +322,8 @@ SimpleDateFormat instances are not synchronized. Sun recommends using separate f
 for each thread. If multiple threads must access a static formatter, the formatter must be
 synchronized on block level.
 
-This rule has been deprecated in favor of the rule {% rule UnsynchronizedStaticFormatter %}.
+_Note:_ This rule has been deprecated since PMD 6.11.0 and will be removed with PMD 7.0.0. The rule is replaced
+by the more general rule {% rule UnsynchronizedStaticFormatter %}.
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -317,7 +317,8 @@ public class Something {
           deprecated="true"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_performance.html#avoidusingshorttype">
         <description>
-Note: this rule is deprecated, as its rationale does not hold.
+_Note:_ This rule is deprecated since PMD 6.31.0 and will be removed with PMD 7.0.0.
+There is no planned replacement. This rule is deprecated, as its rationale does not hold.
 
 Java uses the 'short' type to reduce memory usage, not to optimize calculation. In fact, the JVM does not have any
 arithmetic capabilities for the short type: the JVM must convert the short into an int, do the proper calculation
@@ -392,7 +393,8 @@ bi4 = new BigInteger(0);                 // reference BigInteger.ZERO instead
 Avoid instantiating Boolean objects; you can reference Boolean.TRUE, Boolean.FALSE, or call Boolean.valueOf() instead.
 Note that new Boolean() is deprecated since JDK 9 for that reason.
 
-Deprecated since PMD 6.37.0, use {% rule java/bestpractices/PrimitiveWrapperInstantiation %} instead.
+_Note:_ This rule is deprecated since PMD 6.37.0 and will be removed with PMD 7.0.0.
+Use {% rule java/bestpractices/PrimitiveWrapperInstantiation %} instead.
         </description>
         <priority>2</priority>
         <example>
@@ -416,7 +418,8 @@ Calling new Byte() causes memory allocation that can be avoided by the static By
 It makes use of an internal cache that recycles earlier instances making it more memory efficient.
 Note that new Byte() is deprecated since JDK 9 for that reason.
 
-Deprecated since PMD 6.37.0, use {% rule java/bestpractices/PrimitiveWrapperInstantiation %} instead.
+_Note:_ This rule is deprecated since PMD 6.37.0 and will be removed with PMD 7.0.0.
+Use {% rule java/bestpractices/PrimitiveWrapperInstantiation %} instead.
         </description>
         <priority>2</priority>
         <properties>
@@ -597,7 +600,8 @@ Calling new Integer() causes memory allocation that can be avoided by the static
 It makes use of an internal cache that recycles earlier instances making it more memory efficient.
 Note that new Integer() is deprecated since JDK 9 for that reason.
 
-Deprecated since PMD 6.37.0, use {% rule java/bestpractices/PrimitiveWrapperInstantiation %} instead.
+_Note:_ This rule is deprecated since PMD 6.37.0 and will be removed with PMD 7.0.0.
+Use {% rule java/bestpractices/PrimitiveWrapperInstantiation %} instead.
         </description>
         <priority>2</priority>
         <properties>
@@ -634,7 +638,8 @@ Calling new Long() causes memory allocation that can be avoided by the static Lo
 It makes use of an internal cache that recycles earlier instances making it more memory efficient.
 Note that new Long() is deprecated since JDK 9 for that reason.
 
-Deprecated since PMD 6.37.0, use {% rule java/bestpractices/PrimitiveWrapperInstantiation %} instead.
+_Note:_ This rule is deprecated since PMD 6.37.0 and will be removed with PMD 7.0.0.
+Use {% rule java/bestpractices/PrimitiveWrapperInstantiation %} instead.
         </description>
         <priority>2</priority>
         <properties>
@@ -753,7 +758,8 @@ public class C {
           deprecated="true"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_performance.html#simplifystartswith">
         <description>
-Note: this rule is deprecated for removal, as the optimization is insignificant.
+_Note:_ This rule is deprecated since PMD 6.31.0 and will be removed with PMD 7.0.0. There is no planned replacement.
+The rule is deprecated for removal, as the optimization is insignificant.
 
 Calls to `string.startsWith("x")` with a string literal of length 1 can be rewritten using `string.charAt(0)`,
 at the expense of some readability. To prevent `IndexOutOfBoundsException` being thrown by the `charAt` method,
@@ -808,7 +814,8 @@ Calling new Short() causes memory allocation that can be avoided by the static S
 It makes use of an internal cache that recycles earlier instances making it more memory efficient.
 Note that new Short() is deprecated since JDK 9 for that reason.
 
-Deprecated since PMD 6.37.0, use {% rule java/bestpractices/PrimitiveWrapperInstantiation %} instead.
+_Note:_ This rule is deprecated since PMD 6.37.0 and will be removed with PMD 7.0.0.
+Use {% rule java/bestpractices/PrimitiveWrapperInstantiation %} instead.
         </description>
         <priority>2</priority>
         <properties>
@@ -924,7 +931,9 @@ Most wrapper classes provide static conversion methods that avoid the need to cr
 just to create the primitive forms. Using these avoids the cost of creating objects that also need to be
 garbage-collected later.
 
-Deprecated since PMD 6.37.0. The planned replacement is not expected before PMD 7.0.0.
+_Note:_ This rule is deprecated since PMD 6.37.0 and will be removed with PMD 7.0.0.
+The planned replacement is not expected before PMD 7.0.0. In PMD 7 the new rule
+`UnnecessaryBoxing` can be used instead.
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/main/resources/rulesets/java/quickstart.xml
+++ b/pmd-java/src/main/resources/rulesets/java/quickstart.xml
@@ -133,9 +133,7 @@
     <!-- <rule ref="category/java/design.xml/DataClass" /> -->
     <rule ref="category/java/design.xml/DoNotExtendJavaLangError" />
     <!-- <rule ref="category/java/design.xml/ExceptionAsFlowControl" /> -->
-    <!-- <rule ref="category/java/design.xml/ExcessiveClassLength" /> -->
     <!-- <rule ref="category/java/design.xml/ExcessiveImports" /> -->
-    <!-- <rule ref="category/java/design.xml/ExcessiveMethodLength" /> -->
     <!-- <rule ref="category/java/design.xml/ExcessiveParameterList" /> -->
     <!-- <rule ref="category/java/design.xml/ExcessivePublicCount" /> -->
     <rule ref="category/java/design.xml/FinalFieldCouldBeStatic"/>


### PR DESCRIPTION
## Describe the PR

- Fixes #2127 
- Makes the documentation about deprecated rules consistent
  - in next_major_development.md
  - in the actual rule documentation
- Marks EmptyStatementNotInLoop as deprecated (seems to have been forgotten in PMD 6.46.0).

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

