### PR TITLE
[test] Properly reset log level in slf4j-simple

### DIFF
--- a/pmd-core/src/test/java/net/sourceforge/pmd/cli/CoreCliTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cli/CoreCliTest.java
@@ -76,7 +76,7 @@ class CoreCliTest {
 
         assertTrue(Files.exists(reportFile), "Report file should exist");
 
-        runPmdSuccessfully("--no-cache", "-d", srcDir, "-R", DUMMY_RULESET, "-r", reportFile);
+        runPmdSuccessfully("--no-progress", "--no-cache", "-d", srcDir, "-R", DUMMY_RULESET, "-r", reportFile);
 
         assertNotEquals(readString(reportFile), STRING_TO_REPLACE);
     }
@@ -90,7 +90,7 @@ class CoreCliTest {
 
         assertTrue(Files.exists(reportFile), "Report file should exist");
 
-        runPmdSuccessfully("--no-cache", "--dir", srcDir, "--rulesets", DUMMY_RULESET, "--report-file", reportFile);
+        runPmdSuccessfully("--no-progress", "--no-cache", "--dir", srcDir, "--rulesets", DUMMY_RULESET, "--report-file", reportFile);
 
         assertNotEquals(readString(reportFile), STRING_TO_REPLACE, "Report file should have been overwritten");
     }
@@ -102,7 +102,7 @@ class CoreCliTest {
         assertFalse(Files.exists(reportFile), "Report file should not exist");
 
         try {
-            runPmdSuccessfully("--no-cache", "-d", srcDir, "-R", DUMMY_RULESET, "-r", reportFile);
+            runPmdSuccessfully("--no-progress", "--no-cache", "-d", srcDir, "-R", DUMMY_RULESET, "-r", reportFile);
             assertTrue(Files.exists(reportFile), "Report file should have been created");
         } finally {
             Files.deleteIfExists(reportFile);
@@ -115,7 +115,7 @@ class CoreCliTest {
 
         assertFalse(Files.exists(reportFile), "Report file should not exist");
 
-        runPmdSuccessfully("--no-cache", "--dir", srcDir, "--rulesets", DUMMY_RULESET, "--report-file", reportFile);
+        runPmdSuccessfully("--no-progress", "--no-cache", "--dir", srcDir, "--rulesets", DUMMY_RULESET, "--report-file", reportFile);
 
         assertTrue(Files.exists(reportFile), "Report file should have been created");
     }
@@ -128,7 +128,7 @@ class CoreCliTest {
 
         // restoring system properties: --debug might change logging properties
         SystemLambda.restoreSystemProperties(() -> {
-            runPmdSuccessfully("--no-cache", "--dir", srcDir, "--rulesets", DUMMY_RULESET, "--report-file", reportFile, "--debug");
+            runPmdSuccessfully("--no-progress", "--no-cache", "--dir", srcDir, "--rulesets", DUMMY_RULESET, "--report-file", reportFile, "--debug");
         });
 
         assertTrue(Files.exists(reportFile), "Report file should have been created");
@@ -142,7 +142,7 @@ class CoreCliTest {
 
         assertFalse(Files.exists(reportFile), "Report file should not exist");
 
-        String log = runPmdSuccessfully("-no-cache", "-dir", srcDir, "-rulesets", DUMMY_RULESET, "-reportfile", reportFile);
+        String log = runPmdSuccessfully("--no-progress", "-no-cache", "-dir", srcDir, "-rulesets", DUMMY_RULESET, "-reportfile", reportFile);
 
         assertTrue(Files.exists(reportFile), "Report file should have been created");
         assertTrue(log.contains("Some deprecated options were used on the command-line, including -rulesets"));
@@ -167,7 +167,7 @@ class CoreCliTest {
         assertFalse(Files.exists(absoluteReportFile), "Report file must not exist yet! " + absoluteReportFile);
 
         try {
-            runPmdSuccessfully("--no-cache", "-d", srcDir, "-R", DUMMY_RULESET, "-r", reportFile);
+            runPmdSuccessfully("--no-progress", "--no-cache", "-d", srcDir, "-R", DUMMY_RULESET, "-r", reportFile);
             assertTrue(Files.exists(absoluteReportFile), "Report file should have been created");
         } finally {
             Files.deleteIfExists(absoluteReportFile);
@@ -182,7 +182,7 @@ class CoreCliTest {
         assertFalse(Files.exists(absoluteReportFile), "Report file must not exist yet!");
 
         try {
-            runPmdSuccessfully("--no-cache", "--dir", srcDir, "--rulesets", DUMMY_RULESET, "--report-file", reportFile);
+            runPmdSuccessfully("--no-progress", "--no-cache", "--dir", srcDir, "--rulesets", DUMMY_RULESET, "--report-file", reportFile);
             assertTrue(Files.exists(absoluteReportFile), "Report file should have been created");
         } finally {
             Files.deleteIfExists(absoluteReportFile);
@@ -193,21 +193,21 @@ class CoreCliTest {
     void debugLogging() throws Exception {
         // restoring system properties: --debug might change logging properties
         SystemLambda.restoreSystemProperties(() -> {
-            String log = runPmdSuccessfully("--debug", "--no-cache", "--dir", srcDir, "--rulesets", DUMMY_RULESET);
+            String log = runPmdSuccessfully("--no-progress", "--debug", "--no-cache", "--dir", srcDir, "--rulesets", DUMMY_RULESET);
             assertThat(log, containsString("[main] INFO net.sourceforge.pmd.PMD - Log level is at TRACE"));
         });
     }
 
     @Test
     void defaultLogging() throws Exception {
-        String log = runPmdSuccessfully("--no-cache", "--dir", srcDir, "--rulesets", DUMMY_RULESET);
+        String log = runPmdSuccessfully("--no-progress", "--no-cache", "--dir", srcDir, "--rulesets", DUMMY_RULESET);
         assertThat(log, containsString("[main] INFO net.sourceforge.pmd.PMD - Log level is at INFO"));
     }
 
     @Test
     void testDeprecatedRulesetSyntaxOnCommandLine() throws Exception {
         String log = SystemLambda.tapSystemErrAndOut(() -> {
-            runPmd(StatusCode.VIOLATIONS_FOUND, "--no-cache", "--dir", srcDir, "--rulesets", "dummy-basic");
+            runPmd(StatusCode.VIOLATIONS_FOUND, "--no-progress", "--no-cache", "--dir", srcDir, "--rulesets", "dummy-basic");
         });
         assertThat(log, containsString("Ruleset reference 'dummy-basic' uses a deprecated form, use 'rulesets/dummy/basic.xml' instead"));
     }
@@ -224,7 +224,7 @@ class CoreCliTest {
         try {
             System.setOut(out);
             SystemLambda.tapSystemErrAndOut(() -> {
-                runPmd(StatusCode.VIOLATIONS_FOUND, "--no-cache", "--dir", srcDir, "--rulesets", "dummy-basic");
+                runPmd(StatusCode.VIOLATIONS_FOUND, "--no-progress", "--no-cache", "--dir", srcDir, "--rulesets", "dummy-basic");
             });
         } finally {
             System.setOut(originalOut);

--- a/pmd-java/src/test/java/net/sourceforge/pmd/cli/CLITest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/cli/CLITest.java
@@ -45,23 +45,23 @@ public class CLITest extends BaseCLITest {
 
     @Test
     public void minimalArgs() {
-        runTest("-d", SOURCE_FOLDER, "-f", "text", "-R", RSET_NO_VIOLATION);
+        runTest("--no-progress", "-d", SOURCE_FOLDER, "-f", "text", "-R", RSET_NO_VIOLATION);
     }
 
     @Test
     public void minimumPriority() {
-        String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", RSET_WITH_VIOLATION, "-min", "1", };
+        String[] args = { "--no-progress", "-d", SOURCE_FOLDER, "-f", "text", "-R", RSET_WITH_VIOLATION, "-min", "1", };
         runTest(args);
     }
 
     @Test
     public void usingDebug() {
-        runTest("-d", SOURCE_FOLDER, "-f", "text", "-R", RSET_NO_VIOLATION, "-debug");
+        runTest("--no-progress", "-d", SOURCE_FOLDER, "-f", "text", "-R", RSET_NO_VIOLATION, "-debug");
     }
 
     @Test
     public void usingDebugLongOption() {
-        runTest("-d", SOURCE_FOLDER, "-f", "text", "-R", RSET_NO_VIOLATION, "--debug");
+        runTest("--no-progress", "-d", SOURCE_FOLDER, "-f", "text", "-R", RSET_NO_VIOLATION, "--debug");
     }
 
     @Test
@@ -73,7 +73,7 @@ public class CLITest extends BaseCLITest {
 
     @Test
     public void exitStatusNoViolations() {
-        runTest("-d", SOURCE_FOLDER, "-f", "text", "-R", "rulesets/testing/rset-without-violations.xml");
+        runTest("--no-progress", "-d", SOURCE_FOLDER, "-f", "text", "-R", "rulesets/testing/rset-without-violations.xml");
     }
 
     @Test
@@ -103,7 +103,7 @@ public class CLITest extends BaseCLITest {
      */
     @Test
     public void testWrongRuleset() {
-        String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "category/java/designn.xml", };
+        String[] args = { "--no-progress", "-d", SOURCE_FOLDER, "-f", "text", "-R", "category/java/designn.xml", };
         String log = runTest(StatusCode.ERROR, args);
         assertThat(log, containsString("Cannot resolve rule/ruleset reference "
                                        + "'category/java/designn.xml'"));
@@ -114,7 +114,7 @@ public class CLITest extends BaseCLITest {
      */
     @Test
     public void testWrongRulesetWithRulename() {
-        String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", "category/java/designn.xml/UseCollectionIsEmpty", };
+        String[] args = { "--no-progress", "-d", SOURCE_FOLDER, "-f", "text", "-R", "category/java/designn.xml/UseCollectionIsEmpty", };
         String log = runTest(StatusCode.ERROR, args);
         assertThat(log, containsString("Cannot resolve rule/ruleset reference"
                                        + " 'category/java/designn.xml/UseCollectionIsEmpty'"));
@@ -125,7 +125,7 @@ public class CLITest extends BaseCLITest {
      */
     @Test
     public void testWrongRulename() {
-        String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", RSET_WITH_VIOLATION + "/ThisRuleDoesNotExist", };
+        String[] args = { "--no-progress", "-d", SOURCE_FOLDER, "-f", "text", "-R", RSET_WITH_VIOLATION + "/ThisRuleDoesNotExist", };
         String log = runTest(StatusCode.OK, args);
         assertThat(log, containsString("No rules found. Maybe you misspelled a rule name?"
                                        + " (" + RSET_WITH_VIOLATION + "/ThisRuleDoesNotExist)"));

--- a/pmd-java/src/test/java/net/sourceforge/pmd/cli/CLITest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/cli/CLITest.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.cli;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -80,6 +81,7 @@ public class CLITest extends BaseCLITest {
         String[] args = { "-d", SOURCE_FOLDER, "-f", "text", "-R", RSET_WITH_VIOLATION, "--no-progress", };
         String log = runTest(StatusCode.VIOLATIONS_FOUND, args);
         assertThat(log, containsString("Violation from test-rset-1.xml"));
+        assertThat(log, not(containsPattern("Adding file .*"))); // not in debug mode
     }
 
     @Test


### PR DESCRIPTION

## Describe the PR

Reset log level of already created loggers via reflection. This increases our coupling to slf4j-simple internals, but it really only changes anything in VMs that run multiple instances of PMD one after the other (presumably, mostly our tests).
<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #4234
- Unblocks #4060 and #4235

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

