### PR TITLE
[java] WhileLoopWithLiteralBoolean - don't limit to two bool literals

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -15,6 +15,8 @@ This is a {{ site.pmd.release_type }} release.
 ### New and noteworthy
 
 ### Fixed Issues
+* java-bestpractices
+    * [#4250](https://github.com/pmd/pmd/issues/4250): \[java] WhileLoopWithLiteralBoolean - false negative with complex expressions still occurs in PMD 6.52.0
 
 ### API Changes
 

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -2187,15 +2187,16 @@ a block `{}` is sufficient.
             <property name="xpath">
                 <value>
 <![CDATA[
-(: while loops with single boolean literal, maybe parenthesized :)
+(: while loops with single boolean literal 'false', maybe parenthesized :)
 //WhileStatement[Expression/(.|(PrimaryExpression/PrimaryPrefix/Expression))/PrimaryExpression/PrimaryPrefix/Literal/BooleanLiteral[@True = false()]]
 |
-(: do-while loops with single boolean literal, maybe parenthesized :)
+(: do-while loops with single boolean literal ('false' or 'true'), maybe parenthesized :)
 //DoStatement[Expression/(.|(PrimaryExpression/PrimaryPrefix/Expression))/PrimaryExpression/PrimaryPrefix/Literal/BooleanLiteral]
 |
 (: while loops with conditional or'ed boolean literals, maybe parenthesized :)
 //WhileStatement[Expression/(InclusiveOrExpression|ConditionalOrExpression|(PrimaryExpression/PrimaryPrefix/Expression/(InclusiveOrExpression|ConditionalOrExpression)))
-    [count(PrimaryExpression/PrimaryPrefix/Literal/BooleanLiteral) = 2]
+    (: no var access :)
+    [count(PrimaryExpression/PrimaryPrefix/Name) = 0]
     (: at least one false literal :)
     [count(PrimaryExpression/PrimaryPrefix/Literal/BooleanLiteral[@True = false()]) >= 1]]
 |
@@ -2206,14 +2207,19 @@ a block `{}` is sufficient.
 |
 (: do-while loops with conditional or'ed boolean literals, maybe parenthesized :)
 //DoStatement[Expression/(InclusiveOrExpression|ConditionalOrExpression|(PrimaryExpression/PrimaryPrefix/Expression/(InclusiveOrExpression|ConditionalOrExpression)))
-    [count(PrimaryExpression/PrimaryPrefix/Literal/BooleanLiteral) = 2]]
+    (: at least one true literal :)
+    [count(PrimaryExpression/PrimaryPrefix/Literal/BooleanLiteral[@True = true()]) >= 1
+      (: or no var access - that means, we have only boolean literals here :)
+      or count(PrimaryExpression/PrimaryPrefix/Name) = 0
+    ]]
 |
 (: do-while loops with conditional and'ed boolean literals, maybe parenthesized :)
 //DoStatement[Expression/(AndExpression|ConditionalAndExpression|(PrimaryExpression/PrimaryPrefix/Expression/(AndExpression|ConditionalAndExpression)))
     (: at least one false literal :)
     [count(PrimaryExpression/PrimaryPrefix/Literal/BooleanLiteral[@True = false()]) >= 1
-      (: or two true literals (e.g. true & true) :)
-      or count(PrimaryExpression/PrimaryPrefix/Literal/BooleanLiteral[@True = true()]) = 2]]
+      (: or no var access - that means, we have only boolean literals here :)
+      or count(PrimaryExpression/PrimaryPrefix/Name) = 0
+    ]]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -2209,16 +2209,18 @@ a block `{}` is sufficient.
 //DoStatement[Expression/(InclusiveOrExpression|ConditionalOrExpression|(PrimaryExpression/PrimaryPrefix/Expression/(InclusiveOrExpression|ConditionalOrExpression)))
     (: at least one true literal :)
     [count(PrimaryExpression/PrimaryPrefix/Literal/BooleanLiteral[@True = true()]) >= 1
-      (: or no var access - that means, we have only boolean literals here :)
-      or count(PrimaryExpression/PrimaryPrefix/Name) = 0
+      (: or only boolean literal and no no var access :)
+      or count(PrimaryExpression/PrimaryPrefix/Literal/BooleanLiteral) >= 1
+      and count(PrimaryExpression/PrimaryPrefix/Name) = 0
     ]]
 |
 (: do-while loops with conditional and'ed boolean literals, maybe parenthesized :)
 //DoStatement[Expression/(AndExpression|ConditionalAndExpression|(PrimaryExpression/PrimaryPrefix/Expression/(AndExpression|ConditionalAndExpression)))
     (: at least one false literal :)
     [count(PrimaryExpression/PrimaryPrefix/Literal/BooleanLiteral[@True = false()]) >= 1
-      (: or no var access - that means, we have only boolean literals here :)
-      or count(PrimaryExpression/PrimaryPrefix/Name) = 0
+      (: or only boolean literal and no no var access :)
+      or count(PrimaryExpression/PrimaryPrefix/Literal/BooleanLiteral) >= 1
+      and count(PrimaryExpression/PrimaryPrefix/Name) = 0
     ]]
 ]]>
                 </value>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/WhileLoopWithLiteralBoolean.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/WhileLoopWithLiteralBoolean.xml
@@ -330,4 +330,18 @@ public class Foo {
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>False positives without literal booleans</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public void func(int x, int y) {
+        do {
+            System.out.println("Testing");
+        } while (x==0 || y==2);
+    }
+}
+]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/WhileLoopWithLiteralBoolean.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/WhileLoopWithLiteralBoolean.xml
@@ -22,8 +22,8 @@ class Foo {
 
     <test-code>
         <description>do while true | true</description>
-        <expected-problems>4</expected-problems>
-        <expected-linenumbers>3,4,5,6</expected-linenumbers>
+        <expected-problems>8</expected-problems>
+        <expected-linenumbers>3,4,5,6,9,10,11,12</expected-linenumbers>
         <code><![CDATA[
 class Foo {
     {
@@ -31,6 +31,12 @@ class Foo {
         do { } while (true || true);
         do { } while ((true | true));
         do { } while ((true || true));
+
+        boolean otherBool = false;
+        do { } while (true | otherBool);
+        do { } while (true || otherBool);
+        do { } while ((true | otherBool));
+        do { } while ((true || otherBool));
     }
 }
         ]]></code>
@@ -54,8 +60,8 @@ class Foo {
 
     <test-code>
         <description>do while false | false #3455</description>
-        <expected-problems>2</expected-problems>
-        <expected-linenumbers>3,5</expected-linenumbers>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>3,5,8,10</expected-linenumbers>
         <code><![CDATA[
 class Foo {
     {
@@ -63,26 +69,85 @@ class Foo {
         } while (false | false);
         do {
         } while ((false | false));
+
+        do {
+        } while (false || false);
+        do {
+        } while ((false || false));
     }
 }
         ]]></code>
     </test-code>
 
     <test-code>
-        <description>do while false || false #3455</description>
-        <expected-problems>2</expected-problems>
-        <expected-linenumbers>3,6</expected-linenumbers>
+        <description>do while false &amp; false</description>
+        <expected-problems>8</expected-problems>
+        <expected-linenumbers>3,5,7,9,13,15,17,19</expected-linenumbers>
         <code><![CDATA[
 class Foo {
     {
         do {
-        } while (false || false);
-
+        } while (false & false);
         do {
-        } while ((false || false));
+        } while ((false & false));
+        do {
+        } while (false && false);
+        do {
+        } while ((false && false));
+
+        boolean otherBool = true;
+        do {
+        } while (false & otherBool);
+        do {
+        } while ((false & otherBool));
+        do {
+        } while (false && otherBool);
+        do {
+        } while ((false && otherBool));
     }
 }
         ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>do while true &amp;&amp; true</description>
+        <expected-problems>8</expected-problems>
+        <expected-linenumbers>3,5,7,9,12,14,16,18</expected-linenumbers>
+        <code><![CDATA[
+class Foo {
+    {
+        do {
+        } while (true & true);
+        do {
+        } while ((true & true));
+        do {
+        } while (true && true);
+        do {
+        } while ((true && true));
+
+        do {
+        } while (true & true & true);
+        do {
+        } while ((true & true & true));
+        do {
+        } while (true && true && true);
+        do {
+        } while ((true && true && true));
+
+        // the following loops are not reported, because they depend on otherBool
+        boolean otherBool = true;
+        do {
+        } while (true & otherBool);
+        do {
+        } while ((true & otherBool));
+        do {
+        } while (true && otherBool);
+        do {
+        } while ((true && otherBool));
+    }
+}
+
+]]></code>
     </test-code>
 
     <test-code>
@@ -129,8 +194,8 @@ class Foo {
 
     <test-code>
         <description>while false | false</description>
-        <expected-problems>4</expected-problems>
-        <expected-linenumbers>3,4,5,6</expected-linenumbers>
+        <expected-problems>8</expected-problems>
+        <expected-linenumbers>3,4,5,6,8,9,10,11</expected-linenumbers>
         <code><![CDATA[
 class Foo {
     {
@@ -138,6 +203,11 @@ class Foo {
         while ((false | false)) { }
         while (false || false) { }
         while ((false || false)) { }
+
+        while (false | false | false) { }
+        while ((false | false | false)) { }
+        while (false || false || false) { }
+        while ((false || false || false)) { }
     }
 }
         ]]></code>
@@ -229,6 +299,33 @@ class Foo {
         do {} while ((true & true));
         do {} while (true && true);
         do {} while ((true && true));
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] WhileLoopWithLiteralBoolean - false negative with complex expressions still occurs in PMD 6.52.0 #4250</description>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>3,7,11,15</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public void func() {
+        do {
+            // Loop Body
+        } while (false || false || false || false); // This is a false negative
+
+        do {
+            // Loop Body
+        } while (false | false | false | false | false); // This is a similar false negative.
+
+        do {            //reported: WhileLoopWithLiteralBoolean:    The loop can be simplified.
+            // Loop Body
+        } while (false && false && false && false);
+
+        do {            //reported: WhileLoopWithLiteralBoolean:    The loop can be simplified.
+            // Loop Body
+        } while (false & false & false & false & false);
     }
 }
 ]]></code>


### PR DESCRIPTION
- Fixes #4250

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

