### PR TITLE
[apex] Deprecate ApexRootNode.getApexVersion

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexRootNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexRootNode.java
@@ -47,6 +47,7 @@ public abstract class ApexRootNode<T extends Compilation> extends AbstractApexNo
      * {@code node.getApexVersion() >= Version.V176.getExternal()}
      * @return the apex version
      */
+    @Deprecated
     public double getApexVersion() {
         return node.getDefiningType().getCodeUnitDetails().getVersion().getExternal();
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexUnitTestRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexUnitTestRule.java
@@ -9,8 +9,6 @@ import net.sourceforge.pmd.lang.apex.ast.ASTModifierNode;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 
-import apex.jorje.services.Version;
-
 /**
  * Do special checks for apex unit test classes and methods
  *

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexUnitTestRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexUnitTestRule.java
@@ -33,7 +33,7 @@ public abstract class AbstractApexUnitTestRule extends AbstractApexRule {
      */
     @Override
     public Object visit(final ASTUserClass node, final Object data) {
-        if (!isTestMethodOrClass(node) && node.getApexVersion() >= Version.V176.getExternal()) {
+        if (!isTestMethodOrClass(node)) {
             return data;
         }
         return super.visit(node, data);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestShouldNotUseSeeAllDataTrueRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestShouldNotUseSeeAllDataTrueRule.java
@@ -13,8 +13,6 @@ import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexUnitTestRule;
 
-import apex.jorje.services.Version;
-
 /**
  * <p>
  * It's a very bad practice to use @isTest(seeAllData=true) in Apex unit tests,

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestShouldNotUseSeeAllDataTrueRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestShouldNotUseSeeAllDataTrueRule.java
@@ -29,7 +29,7 @@ public class ApexUnitTestShouldNotUseSeeAllDataTrueRule extends AbstractApexUnit
     @Override
     public Object visit(final ASTUserClass node, final Object data) {
         // @isTest(seeAllData) was introduced in v24, and was set to false by default
-        if (!isTestMethodOrClass(node) && node.getApexVersion() >= Version.V176.getExternal()) {
+        if (!isTestMethodOrClass(node)) {
             return data;
         }
 


### PR DESCRIPTION
Update the rules that utilize it. Assume Apex version is >= V176.

## Describe the PR

This was discussed in https://github.com/pmd/pmd/pull/4251 in the context of replacing the Apex AST. This functionality is [feasible but] not planned for the new AST. It's also not fully certain how it behaves in the existing AST.

The two uses of `ApexRootNode.getApexVersion` are in AbstractApexUnitTestRule.java and ApexUnitTestShouldNotUseSeeAllDataTrueRule.java. It determines whether to also visit test methods without `@IsTest` if they predate the `@isTest` introduction API version 24. Assuming that `getApexVersion` actually parses the metadata API, this could lead to false negatives in rules that would otherwise fire on test-only code.