### PR TITLE
[java] CommentDefaultAccessModifier - add co.elastic.clients.util.VisibleForTesting as default suppressed annotation

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/CommentDefaultAccessModifierRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/CommentDefaultAccessModifierRule.java
@@ -57,6 +57,7 @@ public class CommentDefaultAccessModifierRule extends AbstractIgnoredAnnotationR
         Collection<String> ignoredStrings = new ArrayList<>();
         ignoredStrings.add("com.google.common.annotations.VisibleForTesting");
         ignoredStrings.add("android.support.annotation.VisibleForTesting");
+        ignoredStrings.add("co.elastic.clients.util.VisibleForTesting");
         ignoredStrings.add("org.junit.jupiter.api.Test");
         ignoredStrings.add("org.junit.jupiter.api.ParameterizedTest");
         ignoredStrings.add("org.junit.jupiter.api.RepeatedTest");

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/CommentDefaultAccessModifier.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/CommentDefaultAccessModifier.xml
@@ -344,7 +344,7 @@ public class CommentDefaultAccessModifier {
     </test-code>
 
     <test-code>
-        <description>Use property ignoredAnnotations (see #1343)</description>
+        <description>[java] CommentDefaultAccessModifier - add co.elastic.clients.util.VisibleForTesting to as default suppressed annotations #4285</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 import co.elastic.clients.util.VisibleForTesting;

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/CommentDefaultAccessModifier.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/CommentDefaultAccessModifier.xml
@@ -343,6 +343,18 @@ public class CommentDefaultAccessModifier {
         ]]></code>
     </test-code>
 
+    <test-code>
+        <description>Use property ignoredAnnotations (see #1343)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import co.elastic.clients.util.VisibleForTesting;
+
+public class Foo {
+    @VisibleForTesting void method() {}
+}
+        ]]></code>
+    </test-code>
+
     <code-fragment id="constructor-with-default-access-modifier-rule"><![CDATA[
 public class Foo {
    Foo() {} // should be reported


### PR DESCRIPTION
## Describe the PR

The rule CommentDefaultAccessModifier ignores @VisibleForTesting as stated by the documentation:

_This rule ignores by default all cases that have a @VisibleForTesting annotation or any JUnit5 annotation_
https://pmd.github.io/pmd/pmd_rules_java_codestyle.html#commentdefaultaccessmodifier

This should also apply to the annotation [co.elastic.clients.util.VisibleForTesting](https://github.com/elastic/elasticsearch-java/blob/main/java-client/src/main/java/co/elastic/clients/util/VisibleForTesting.java)  from the elastic provided java client, [elasticsearch-java](https://github.com/elastic/elasticsearch-java),.

## Ready?

- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)


