### PR TITLE
[core] Refactor usage of snakeyaml

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -15,6 +15,8 @@ This is a {{ site.pmd.release_type }} release.
 ### New and noteworthy
 
 ### Fixed Issues
+* core
+  * [#4329](https://github.com/pmd/pmd/pull/4329): [core] Refactor usage of snakeyaml
 
 ### API Changes
 

--- a/pmd-apex-jorje/pom.xml
+++ b/pmd-apex-jorje/pom.xml
@@ -115,11 +115,15 @@
         <artifactId>slf4j-api</artifactId>
         <!-- apex jorje actually depends on 1.7.20 (https://github.com/forcedotcom/salesforcedx-vscode/commit/631b8cfb85cff5e989bfea13bca681b6cedcb003) -->
     </dependency>
-    <dependency>
+    <!-- apex jorje actually depends on 1.17 (https://github.com/forcedotcom/salesforcedx-vscode/commit/631b8cfb85cff5e989bfea13bca681b6cedcb003)
+      however, it is not really needed, so we don't add it here as a dependency,
+      so that it doesn't end up in pmd-dist
+     -->
+    <!--<dependency>
         <groupId>org.yaml</groupId>
         <artifactId>snakeyaml</artifactId>
-        <!-- apex jorje actually depends on 1.17 (https://github.com/forcedotcom/salesforcedx-vscode/commit/631b8cfb85cff5e989bfea13bca681b6cedcb003) -->
     </dependency>
+    -->
     <dependency>
         <groupId>aopalliance</groupId>
         <artifactId>aopalliance</artifactId>

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/docs/SidebarGenerator.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/docs/SidebarGenerator.java
@@ -20,7 +20,10 @@ import org.apache.commons.lang3.SystemUtils;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.DumperOptions.FlowStyle;
 import org.yaml.snakeyaml.DumperOptions.LineBreak;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.yaml.snakeyaml.representer.Representer;
 
 import net.sourceforge.pmd.RuleSet;
 import net.sourceforge.pmd.lang.Language;
@@ -87,20 +90,18 @@ public class SidebarGenerator {
 
     public Map<String, Object> loadSidebar() throws IOException {
         try (Reader reader = Files.newBufferedReader(sidebarPath, StandardCharsets.UTF_8)) {
-            Yaml yaml = new Yaml();
-            @SuppressWarnings("unchecked")
-            Map<String, Object> sidebar = (Map<String, Object>) yaml.load(reader);
-            return sidebar;
+            Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
+            return yaml.load(reader);
         }
     }
 
     public void writeSidebar(Map<String, Object> sidebar) throws IOException {
-        DumperOptions options = new DumperOptions();
-        options.setDefaultFlowStyle(FlowStyle.BLOCK);
+        DumperOptions dumperOptions = new DumperOptions();
+        dumperOptions.setDefaultFlowStyle(FlowStyle.BLOCK);
         if (SystemUtils.IS_OS_WINDOWS) {
-            options.setLineBreak(LineBreak.WIN);
+            dumperOptions.setLineBreak(LineBreak.WIN);
         }
-        Yaml yaml = new Yaml(options);
+        Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()), new Representer(dumperOptions), dumperOptions);
         writer.write(sidebarPath, Arrays.asList(yaml.dump(sidebar)));
         System.out.println("Generated " + sidebarPath);
     }

--- a/pmd-doc/src/test/java/net/sourceforge/pmd/docs/SidebarGeneratorTest.java
+++ b/pmd-doc/src/test/java/net/sourceforge/pmd/docs/SidebarGeneratorTest.java
@@ -21,7 +21,10 @@ import org.junit.Test;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.DumperOptions.FlowStyle;
 import org.yaml.snakeyaml.DumperOptions.LineBreak;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
+import org.yaml.snakeyaml.representer.Representer;
 
 import net.sourceforge.pmd.RuleSet;
 import net.sourceforge.pmd.RulesetsFactoryUtils;
@@ -49,12 +52,12 @@ public class SidebarGeneratorTest {
         SidebarGenerator generator = new SidebarGenerator(writer, FileSystems.getDefault().getPath(".."));
         List<Map<String, Object>> result = generator.generateRuleReferenceSection(rulesets);
 
-        DumperOptions options = new DumperOptions();
-        options.setDefaultFlowStyle(FlowStyle.BLOCK);
+        DumperOptions dumperOptions = new DumperOptions();
+        dumperOptions.setDefaultFlowStyle(FlowStyle.BLOCK);
         if (SystemUtils.IS_OS_WINDOWS) {
-            options.setLineBreak(LineBreak.WIN);
+            dumperOptions.setLineBreak(LineBreak.WIN);
         }
-        String yaml = new Yaml(options).dump(result);
+        String yaml = new Yaml(new SafeConstructor(new LoaderOptions()), new Representer(dumperOptions), dumperOptions).dump(result);
 
         String expected = MockedFileWriter.normalizeLineSeparators(
                 IOUtil.readToString(SidebarGeneratorTest.class.getResourceAsStream("sidebar.yml"), StandardCharsets.UTF_8));


### PR DESCRIPTION
It was a dependency via apex-jorje, but there snakeyaml is actually not needed.

During generating doc, we use snakeyaml to load the sidebar and modify it. The code has been adjusted to use SafeConstructor to mitigate the risk.

- Fixes https://github.com/pmd/pmd/security/dependabot/33
- Fixes CVE-2022-1471
- Fixes https://github.com/advisories/GHSA-mjmj-j48q-9wg2

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)
