### PR TITLE
[core] CPD - implement CPDReportRenderer for all renderers

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
@@ -189,7 +189,7 @@ public class CPDConfiguration extends AbstractConfiguration {
                 setRenderer((Renderer) renderer);
             } else {
                 System.err.println("Class '" + className + "' is not a supported renderer, defaulting to SimpleRenderer.");
-                setRenderer(new SimpleRenderer());
+                setRenderer((CPDReportRenderer) new SimpleRenderer());
             }
         }
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CSVRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CSVRenderer.java
@@ -13,8 +13,9 @@ import org.apache.commons.lang3.StringEscapeUtils;
 
 import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.cpd.renderer.CPDRenderer;
+import net.sourceforge.pmd.cpd.renderer.CPDReportRenderer;
 
-public class CSVRenderer implements Renderer, CPDRenderer {
+public class CSVRenderer implements Renderer, CPDRenderer, CPDReportRenderer {
 
     private final char separator;
     private final boolean lineCountPerFile;
@@ -80,5 +81,10 @@ public class CSVRenderer implements Renderer, CPDRenderer {
             writer.append(PMD.EOL);
         }
         writer.flush();
+    }
+
+    @Override
+    public void render(CPDReport report, Writer writer) throws IOException {
+        render(report.getMatches().iterator(), writer);
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/SimpleRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/SimpleRenderer.java
@@ -11,9 +11,10 @@ import java.util.Iterator;
 
 import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.cpd.renderer.CPDRenderer;
+import net.sourceforge.pmd.cpd.renderer.CPDReportRenderer;
 import net.sourceforge.pmd.util.StringUtil;
 
-public class SimpleRenderer implements Renderer, CPDRenderer {
+public class SimpleRenderer implements Renderer, CPDRenderer, CPDReportRenderer {
 
     private String separator;
     private boolean trimLeadingWhitespace;
@@ -87,5 +88,10 @@ public class SimpleRenderer implements Renderer, CPDRenderer {
             renderOn(writer, match);
         }
         writer.flush();
+    }
+
+    @Override
+    public void render(CPDReport report, Writer writer) throws IOException {
+        render(report.getMatches().iterator(), writer);
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/VSRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/VSRenderer.java
@@ -11,8 +11,9 @@ import java.util.Iterator;
 
 import net.sourceforge.pmd.PMD;
 import net.sourceforge.pmd.cpd.renderer.CPDRenderer;
+import net.sourceforge.pmd.cpd.renderer.CPDReportRenderer;
 
-public class VSRenderer implements Renderer, CPDRenderer {
+public class VSRenderer implements Renderer, CPDRenderer, CPDReportRenderer {
 
     @Override
     public String render(Iterator<Match> matches) {
@@ -38,5 +39,10 @@ public class VSRenderer implements Renderer, CPDRenderer {
             }
         }
         writer.flush();
+    }
+
+    @Override
+    public void render(CPDReport report, Writer writer) throws IOException {
+        render(report.getMatches().iterator(), writer);
     }
 }


### PR DESCRIPTION
## Describe the PR

This PR makes all old CPD renderers implement the new interface CPDReportRenderer.
This opens up a forward compatible migration path for e.g. maven-pmd-plugin when migrating to PMD 7.

## Related issues

- relates #4340 
- relates #4341 
- needed for #4235 
  - after this (#4343) and #4341 are merged into master and master is merged into pmd/7.0.x, it should be possible to create a maven-pmd-plugin version that is compatible with pmd7 without using workaround (see https://github.com/apache/maven-pmd-plugin/tree/pmd7 )

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

