### PR TITLE
[ci] Add additional repository for spring-framework-build

### DIFF
--- a/.ci/files/project-list.xml
+++ b/.ci/files/project-list.xml
@@ -134,6 +134,25 @@ index 6021fa574d..15d29ed699 100644
 EOF
 ) | patch --strip=1
 
+# Patch 4: Add https://maven.repository.redhat.com/ga/ as repository in order to resolve
+#   dependency com.ibm.websphere/uow/6.0.2.17
+#   See https://spring.io/blog/2020/10/29/notice-of-permissions-changes-to-repo-spring-io-fall-and-winter-2020
+(cat <<EOF
+diff --git a/build.gradle b/build.gradle
+index 6021fa57..8319ff76 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -291,6 +291,7 @@ configure(allprojects) { project ->
+ 		}
+ 		repositories {
+ 			mavenCentral()
++			maven { url "https://maven.repository.redhat.com/ga/" }
+ 			maven { url "https://repo.spring.io/libs-spring-framework-build" }
+ 		}
+ 	}
+EOF
+) | patch --strip=1
+
 ./gradlew --console=plain --build-cache --no-daemon --max-workers=4 build testClasses -x test -x javadoc -x api -x asciidoctor -x asciidoctorPdf
 ./gradlew --console=plain --build-cache --no-daemon --max-workers=4 createSquishClasspath -q > classpath.txt
 ]]></build-command>


### PR DESCRIPTION
## Describe the PR

Currently regression tester is failing, because the dependency com.ibm.websphere/uow/6.0.2.17 is missing:

```
  Execution failed for task ':spring-tx:compileKotlin'.
  > Error while evaluating property 'filteredArgumentsMap' of task ':spring-tx:compileKotlin'
     > Could not resolve all files for configuration ':spring-tx:compileClasspath'.
        > Could not resolve com.ibm.websphere:uow:6.0.2.17.
          Required by:
              project :spring-tx
           > Could not resolve com.ibm.websphere:uow:6.0.2.17.
              > Could not get resource 'https://repo.spring.io/libs-spring-framework-build/com/ibm/websphere/uow/6.0.2.17/uow-6.0.2.17.pom'.
                 > Could not GET 'https://repo.spring.io/libs-spring-framework-build/com/ibm/websphere/uow/6.0.2.17/uow-6.0.2.17.pom'. Received status code 401 from server: Unauthorized
```

The repo "repo.spring.io" doesn't allow to download non-spring artifacts anonymously anymore, see https://spring.io/blog/2020/10/29/notice-of-permissions-changes-to-repo-spring-io-fall-and-winter-2020

Adding https://maven.repository.redhat.com/ga/ as an additional repository should solve the problem.
