### PR TITLE
[testing] Use custom surefire console reporter

### DIFF
--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTPatternTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTPatternTest.kt
@@ -15,10 +15,11 @@ class ASTPatternTest : ParserTestSpec({
     parserTest("Test patterns only available on JDK16 or higher (including preview)",
         javaVersions = JavaVersion.except(typePatternsVersions)) {
 
-        expectParseException("Pattern Matching for instanceof is only supported with JDK >= 16") {
-            parseAstExpression("obj instanceof Class c")
+        "obj instanceof Class c" should {
+            expectParseException("Pattern Matching for instanceof is only supported with JDK >= 16") {
+                parseAstExpression(it)
+            }
         }
-
     }
 
     parserTest("Test simple patterns", javaVersions = typePatternsVersions) {

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/Java11Test.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/Java11Test.kt
@@ -2,6 +2,8 @@
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
+package net.sourceforge.pmd.lang.java.ast
+
 import io.kotest.matchers.shouldBe
 import net.sourceforge.pmd.lang.java.ast.*
 import net.sourceforge.pmd.lang.java.ast.JavaVersion.*

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/KotlinTestingDsl.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/KotlinTestingDsl.kt
@@ -5,6 +5,8 @@
 package net.sourceforge.pmd.lang.java.ast
 
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.scopes.AbstractContainerScope
+import io.kotest.core.test.TestScope
 import io.kotest.matchers.string.shouldContain
 import net.sourceforge.pmd.lang.ast.Node
 import net.sourceforge.pmd.lang.ast.test.Assertions
@@ -96,10 +98,12 @@ enum class JavaVersion : Comparable<JavaVersion> {
  * @property otherImports Other imports, without the `import` and semicolon
  * @property genClassHeader Header of the enclosing class used in parsing contexts like parseExpression, etc. E.g. "class Foo"
  */
-open class ParserTestCtx(val javaVersion: JavaVersion = JavaVersion.Latest,
-                         val importedTypes: MutableList<Class<*>> = mutableListOf(),
-                         val otherImports: MutableList<String> = mutableListOf(),
-                         var genClassHeader: String = "class Foo") {
+open class ParserTestCtx(
+    testScope : TestScope,
+    val javaVersion: JavaVersion = JavaVersion.Latest,
+    val importedTypes: MutableList<Class<*>> = mutableListOf(),
+    val otherImports: MutableList<String> = mutableListOf(),
+    var genClassHeader: String = "class Foo") : AbstractContainerScope(testScope) {
 
     /** Imports to add to the top of the parsing contexts. */
     internal val imports: List<String>

--- a/pom.xml
+++ b/pom.xml
@@ -931,6 +931,16 @@
                 <artifactId>protobuf-java</artifactId>
                 <version>3.16.3</version>
             </dependency>
+
+            <!-- Make sure to use the correct version the JUnit5 needs. E.g. 5.8.2 needs 1.8.2
+                 Kotest might bring a wrong version.
+                 see junit5.version -->
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-commons</artifactId>
+                <version>1.8.2</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <argLine>-Xmx512m -Dfile.encoding=${project.build.sourceEncoding} ${extraArgLine}</argLine>
         <extraArgLine /> <!-- empty by default, profiles set it as needed -->
 
-        <pmd.build-tools.version>19</pmd.build-tools.version>
+        <pmd.build-tools.version>20-SNAPSHOT</pmd.build-tools.version>
 
         <pmd-designer.version>6.49.0</pmd-designer.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
 
 
         <javacc.version>5.0</javacc.version>
-        <surefire.version>3.0.0-M7</surefire.version>
+        <surefire.version>3.0.0-M8</surefire.version>
         <checkstyle.version>10.3.3</checkstyle.version>
         <checkstyle.plugin.version>3.2.0</checkstyle.plugin.version>
         <pmd.plugin.version>3.19.0</pmd.plugin.version>
@@ -265,7 +265,6 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${surefire.version}</version>
                     <configuration>
-                        <forkMode>once</forkMode>
                         <runOrder>alphabetical</runOrder>
                         <systemPropertyVariables>
                             <mvn.project.src.test.resources>${project.build.testResources[0].directory}</mvn.project.src.test.resources>

--- a/pom.xml
+++ b/pom.xml
@@ -269,6 +269,21 @@
                         <systemPropertyVariables>
                             <mvn.project.src.test.resources>${project.build.testResources[0].directory}</mvn.project.src.test.resources>
                         </systemPropertyVariables>
+                        <statelessTestsetInfoReporter implementation="net.sourceforge.pmd.buildtools.surefire.PMDStatelessTestSetInfoConsoleReporter">
+                            <showFailedTests>true</showFailedTests>
+                            <showSuccessfulTests>false</showSuccessfulTests>
+                            <showSkippedTests>true</showSkippedTests>
+                            <usePhrasedFileName>true</usePhrasedFileName>
+                            <usePhrasedClassNameInRunning>true</usePhrasedClassNameInRunning>
+                            <usePhrasedClassNameInTestCaseSummary>true</usePhrasedClassNameInTestCaseSummary>
+                        </statelessTestsetInfoReporter>
+
+                        <statelessTestsetReporter implementation="org.apache.maven.plugin.surefire.extensions.junit5.JUnit5Xml30StatelessReporter">
+                            <usePhrasedFileName>true</usePhrasedFileName>
+                            <usePhrasedTestSuiteClassName>true</usePhrasedTestSuiteClassName>
+                            <usePhrasedTestCaseClassName>true</usePhrasedTestCaseClassName>
+                            <usePhrasedTestCaseMethodName>true</usePhrasedTestCaseMethodName>
+                        </statelessTestsetReporter>
                     </configuration>
                     <dependencies>
                         <!-- Junit5 Platform Engine for Junit 3 & 4 -->
@@ -282,6 +297,11 @@
                             <groupId>io.kotest</groupId>
                             <artifactId>kotest-runner-junit5-jvm</artifactId>
                             <version>${kotest.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>net.sourceforge.pmd</groupId>
+                            <artifactId>pmd-build-tools-config</artifactId>
+                            <version>${pmd.build-tools.version}</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
## Describe the PR

Enables the custom surefire console reporter (pmd/build-tools#27) so that we don't see strange output anymore with 0 tests executed.

This also refactors ParserTestSpec slightly, so that we don't depend anymore on kotests internal API to register a test case. We now have our own test scopes, where we can register test cases.

## Related issues

- Fixes #4236 

