### PR TITLE
[java] Make ASTVariableDeclarator not be a TypeNode

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclarator.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclarator.java
@@ -18,11 +18,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *
  * <pre class="grammar">
  *
- * VariableDeclarator ::= {@linkplain ASTVariableDeclaratorId VariableDeclaratorId} {@link ASTArrayDimensions ArrayDimensions}? ( "=" {@linkplain ASTExpression Expression} )?
+ * VariableDeclarator ::= {@linkplain ASTVariableDeclaratorId VariableDeclaratorId} ( "=" {@linkplain ASTExpression Expression} )?
  *
  * </pre>
  */
-public class ASTVariableDeclarator extends AbstractJavaTypeNode implements InternalInterfaces.VariableIdOwner {
+public class ASTVariableDeclarator extends AbstractJavaNode implements InternalInterfaces.VariableIdOwner {
 
     ASTVariableDeclarator(int id) {
         super(id);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ast/LazyTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ast/LazyTypeResolver.java
@@ -29,7 +29,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTBooleanLiteral;
 import net.sourceforge.pmd.lang.java.ast.ASTCastExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTCharLiteral;
 import net.sourceforge.pmd.lang.java.ast.ASTClassLiteral;
-import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.ASTConditionalExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
 import net.sourceforge.pmd.lang.java.ast.ASTEnumConstant;
@@ -147,18 +146,6 @@ public final class LazyTypeResolver extends JavaVisitorBase<TypingContext, @NonN
     public JTypeMirror visitJavaNode(JavaNode node, TypingContext ctx) {
         throw new IllegalArgumentException("Not a type node:" + node);
     }
-
-
-    @Override
-    public JTypeMirror visit(ASTVariableDeclarator node, TypingContext ctx) {
-        return ts.NO_TYPE; // TODO shouldn't be a typenode (do you mean type of variable, or type of initializer?)
-    }
-
-    @Override
-    public JTypeMirror visit(ASTCompilationUnit node, TypingContext ctx) {
-        return ts.NO_TYPE; // TODO shouldn't be a typenode
-    }
-
 
     @Override
     public JTypeMirror visit(ASTFormalParameter node, TypingContext ctx) {


### PR DESCRIPTION
## Describe the PR


<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #4317 - in the case of ASTCompilationUnit that was already done.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

