### PR TITLE
[java] Fix NPE in CloseResourceRule

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
@@ -216,7 +216,7 @@ public class CloseResourceRule extends AbstractJavaRule {
 
     private TypeNode getRuntimeTypeOfVariable(ASTVariableDeclaratorId var) {
         ASTExpression initExpr = var.getInitializer();
-        return isRuntimeType(initExpr) ? initExpr : null;
+        return var.isTypeInferred() || isRuntimeType(initExpr) ? initExpr : null;
     }
 
     private boolean isRuntimeType(ASTExpression expr) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
@@ -2013,4 +2013,20 @@ public record MyRecord(boolean a) {
 }
         ]]></code>
     </test-code>
+    
+    <test-code>
+        <description>NullPointerException with type inference</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.ArrayList;
+
+public class LocalVariableTypeInference {
+
+    public void aMethod() {
+        var list = new ArrayList<String>();  // infers ArrayList<String>
+        var stream = list.stream();          // infers Stream<String>, is never closed
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

When using type inference and initializing through a method call rather than a direct constructor call, the rule would detect the var as being a `Closeable`, yet fail to retrieve the proper type to check if it was whitelisted / which error message to produce.

We now look at wether there is type inference in play when deciding wether computing the runtime type is required.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

