### PR TITLE
[java] Fix IllegalStateException in UseDiamongOperator rule

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseDiamondOperatorRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseDiamondOperatorRule.java
@@ -133,8 +133,16 @@ public class UseDiamondOperatorRule extends AbstractJavaRulechainRule {
         MethodCallSite fakeCallSite = infer.newCallSite(mirror, targetType);
         infer.inferInvocationRecursively(fakeCallSite);
 
-        return mirror.isEquivalentToUnderlyingAst()
-            && topmostContext.acceptsType(mirror.getInferredType());
+        try {
+            return mirror.isEquivalentToUnderlyingAst()
+                && topmostContext.acceptsType(mirror.getInferredType());
+        } catch (IllegalStateException e) {
+            /*
+             * overload resolution may complaint it's incomplete if there are missing types.
+             * The missing type info may be relevant to the user, but this exception is not, swallow it
+             */
+            return false;
+        }
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseDiamondOperatorRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseDiamondOperatorRule.java
@@ -133,16 +133,8 @@ public class UseDiamondOperatorRule extends AbstractJavaRulechainRule {
         MethodCallSite fakeCallSite = infer.newCallSite(mirror, targetType);
         infer.inferInvocationRecursively(fakeCallSite);
 
-        try {
-            return mirror.isEquivalentToUnderlyingAst()
-                && topmostContext.acceptsType(mirror.getInferredType());
-        } catch (IllegalStateException e) {
-            /*
-             * overload resolution may complaint it's incomplete if there are missing types.
-             * The missing type info may be relevant to the user, but this exception is not, swallow it
-             */
-            return false;
-        }
+        return mirror.isEquivalentToUnderlyingAst()
+            && topmostContext.acceptsType(mirror.getInferredType());
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/BaseInvocMirror.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/BaseInvocMirror.java
@@ -40,6 +40,9 @@ abstract class BaseInvocMirror<T extends InvocationNode> extends BasePolyMirror<
     public boolean isEquivalentToUnderlyingAst() {
         MethodCtDecl ctDecl = getCtDecl();
         AssertionUtil.validateState(ctDecl != null, "overload resolution is not complete");
+        if (ctDecl.isFailed()) {
+            return false; // be conservative
+        }
         if (!myNode.getMethodType().getSymbol().equals(ctDecl.getMethodType().getSymbol())) {
             return false;
         } else if (myNode instanceof ASTConstructorCall && ((ASTConstructorCall) myNode).isAnonymousClass()

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UseDiamondOperator.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UseDiamondOperator.xml
@@ -404,4 +404,19 @@ public class Generic<T> {
             }
             ]]></code>
     </test-code>
+    
+    <test-code>
+        <description>IllegalStateException overload resolution not complete</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            import non.existing.ForOverloadResolution;
+            import java.util.HashMap;
+            
+            class OverloadFailure {
+                public void foo() {
+                    ForOverloadResolution.method(new HashMap<String, Object>());
+                }
+            }
+            ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

 - An IllegalStateException is produced when the inference context corresponds to an invocation of an unresolved method.
 - The rule effectively can't determine if the diamond operator can be used, but the current message of "overload resolution is not complete" is noisy, not actionable to the user (the issue is a missing class in the auxclasspath, not the overload resolution itself), and prevents the rule from continuing to analyze the current file.
 - The current fix is not elegant, and probably subpar (maybe the Infer logic could remove the check and deal with this seemlessly?) but I fear that code is too complex for me to make that call / change at this time. @oowekyala I'd love your help here.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

