### PR TITLE
[core] Fix cache population

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/AbstractAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/AbstractAnalysisCache.java
@@ -79,6 +79,13 @@ public abstract class AbstractAnalysisCache implements AnalysisCache {
 
             if (result) {
                 LOG.debug("Incremental Analysis cache HIT");
+                
+                /*
+                 * Update cached violation "filename" to match the appropriate text document,
+                 * so we can honor relativized paths for the current run
+                 */
+                final String displayName = document.getDisplayName();
+                analysisResult.getViolations().forEach(v -> ((CachedRuleViolation) v).setFileDisplayName(displayName));
             } else {
                 LOG.debug("Incremental Analysis cache MISS - {}",
                           analysisResult != null ? "file changed" : "no previous result found");

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/AbstractAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/AbstractAnalysisCache.java
@@ -211,19 +211,12 @@ public abstract class AbstractAnalysisCache implements AnalysisCache {
 
     @Override
     public FileAnalysisListener startFileAnalysis(TextDocument file) {
-        String fileName = file.getPathId();
-        AnalysisResult analysisResult = updatedResultsCache.get(fileName);
-        if (analysisResult == null) {
-            analysisResult = new AnalysisResult(file.getCheckSum());
-        }
-        final AnalysisResult nonNullAnalysisResult = analysisResult;
+        final String fileName = file.getPathId();
 
         return new FileAnalysisListener() {
             @Override
             public void onRuleViolation(RuleViolation violation) {
-                synchronized (nonNullAnalysisResult) {
-                    nonNullAnalysisResult.addViolation(violation);
-                }
+                updatedResultsCache.get(fileName).addViolation(violation);
             }
 
             @Override

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/CachedRuleViolation.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/CachedRuleViolation.java
@@ -129,7 +129,7 @@ public final class CachedRuleViolation implements RuleViolation {
         FileLocation location = violation.getLocation();
         stream.writeInt(location.getStartPos().getLine());
         stream.writeInt(location.getStartPos().getColumn());
-        stream.writeInt(location.getEndPos().getColumn());
+        stream.writeInt(location.getEndPos().getLine());
         stream.writeInt(location.getEndPos().getColumn());
         Map<String, String> additionalInfo = violation.getAdditionalInfo();
         stream.writeInt(additionalInfo.size());

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/CachedRuleViolation.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/CachedRuleViolation.java
@@ -33,11 +33,12 @@ public final class CachedRuleViolation implements RuleViolation {
     private final CachedRuleMapper mapper;
 
     private final String description;
-    private final FileLocation location;
     private final String ruleClassName;
     private final String ruleName;
     private final String ruleTargetLanguage;
     private final Map<String, String> additionalInfo;
+
+    private FileLocation location;
 
     private CachedRuleViolation(final CachedRuleMapper mapper, final String description,
                                 final String fileName, final String ruleClassName, final String ruleName,
@@ -51,6 +52,11 @@ public final class CachedRuleViolation implements RuleViolation {
         this.ruleName = ruleName;
         this.ruleTargetLanguage = ruleTargetLanguage;
         this.additionalInfo = additionalInfo;
+    }
+    
+    public void setFileDisplayName(String displayName) {
+        this.location = FileLocation.range(displayName,
+                TextRange2d.range2d(getBeginLine(), getBeginColumn(), getEndLine(), getEndColumn()));
     }
 
     @Override

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/FileAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/FileAnalysisCache.java
@@ -132,7 +132,7 @@ public class FileAnalysisCache extends AbstractAnalysisCache {
                 for (final Map.Entry<String, AnalysisResult> resultEntry : updatedResultsCache.entrySet()) {
                     final List<RuleViolation> violations = resultEntry.getValue().getViolations();
 
-                    outputStream.writeUTF(resultEntry.getKey()); // the full filename
+                    outputStream.writeUTF(resultEntry.getKey()); // the path id
                     outputStream.writeLong(resultEntry.getValue().getFileChecksum());
 
                     outputStream.writeInt(violations.size());

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/NioTextFile.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/NioTextFile.java
@@ -47,7 +47,8 @@ class NioTextFile extends BaseCloseable implements TextFile {
         this.charset = charset;
         this.languageVersion = languageVersion;
         // using the URI here, that handles files inside zip archives automatically (schema "jar:file:...!/path/inside/zip")
-        this.pathId = path.toUri().toString();
+        // normalization ensures cannonical paths
+        this.pathId = path.normalize().toUri().toString();
     }
 
     @Override

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cache/FileAnalysisCacheTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cache/FileAnalysisCacheTest.java
@@ -118,7 +118,8 @@ class FileAnalysisCacheTest {
 
         final RuleViolation rv = mock(RuleViolation.class);
         when(rv.getFilename()).thenReturn(sourceFile.getDisplayName());
-        when(rv.getLocation()).thenReturn(FileLocation.range(sourceFile.getDisplayName(), TextRange2d.range2d(1, 2, 3, 4)));
+        final TextRange2d textLocation = TextRange2d.range2d(1, 2, 3, 4);
+        when(rv.getLocation()).thenReturn(FileLocation.range(sourceFile.getDisplayName(), textLocation));
         final net.sourceforge.pmd.Rule rule = mock(net.sourceforge.pmd.Rule.class, Mockito.RETURNS_SMART_NULLS);
         when(rule.getLanguage()).thenReturn(mock(Language.class));
         when(rv.getRule()).thenReturn(rule);
@@ -133,6 +134,12 @@ class FileAnalysisCacheTest {
 
         final List<RuleViolation> cachedViolations = reloadedCache.getCachedViolations(sourceFile);
         assertEquals(1, cachedViolations.size(), "Cached rule violations count mismatch");
+        final RuleViolation cachedViolation = cachedViolations.get(0);
+        assertEquals(sourceFile.getDisplayName(), cachedViolation.getFilename());
+        assertEquals(textLocation.getStartLine(), cachedViolation.getBeginLine());
+        assertEquals(textLocation.getStartColumn(), cachedViolation.getBeginColumn());
+        assertEquals(textLocation.getEndLine(), cachedViolation.getEndLine());
+        assertEquals(textLocation.getEndColumn(), cachedViolation.getEndColumn());
     }
 
     @Test

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cache/FileAnalysisCacheTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cache/FileAnalysisCacheTest.java
@@ -43,6 +43,7 @@ import net.sourceforge.pmd.lang.document.TextDocument;
 import net.sourceforge.pmd.lang.document.TextFile;
 import net.sourceforge.pmd.lang.document.TextFileContent;
 import net.sourceforge.pmd.lang.document.TextRange2d;
+import net.sourceforge.pmd.reporting.FileAnalysisListener;
 
 class FileAnalysisCacheTest {
 
@@ -111,6 +112,8 @@ class FileAnalysisCacheTest {
     void testStorePersistsFilesWithViolations() throws IOException {
         final FileAnalysisCache cache = new FileAnalysisCache(newCacheFile);
         cache.checkValidity(mock(RuleSets.class), mock(ClassLoader.class));
+        final FileAnalysisListener cacheListener = cache.startFileAnalysis(sourceFile);
+        
         cache.isUpToDate(sourceFile);
 
         final RuleViolation rv = mock(RuleViolation.class);
@@ -120,7 +123,7 @@ class FileAnalysisCacheTest {
         when(rule.getLanguage()).thenReturn(mock(Language.class));
         when(rv.getRule()).thenReturn(rule);
 
-        cache.startFileAnalysis(sourceFile).onRuleViolation(rv);
+        cacheListener.onRuleViolation(rv);
         cache.persist();
 
         final FileAnalysisCache reloadedCache = new FileAnalysisCache(newCacheFile);

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cache/internal/ZipFileFingerprinterTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cache/internal/ZipFileFingerprinterTest.java
@@ -40,6 +40,32 @@ class ZipFileFingerprinterTest extends AbstractClasspathEntryFingerprinterTest {
         assertEquals(baselineFingerprint, updateFingerprint(file));
         assertNotEquals(originalFileSize, file.length());
     }
+    
+    @Test
+    void zipEntryOrderDoesNotAffectFingerprint() throws IOException {
+        final File zipFile = tempDir.resolve("foo.jar").toFile();
+        final ZipEntry fooEntry = new ZipEntry("lib/Foo.class");
+        final ZipEntry barEntry = new ZipEntry("lib/Bar.class");
+        overwriteZipFileContents(zipFile, fooEntry, barEntry);
+        final long baselineFingerprint = getBaseLineFingerprint(zipFile);
+        
+        // swap order
+        overwriteZipFileContents(zipFile, barEntry, fooEntry);
+        assertEquals(baselineFingerprint, updateFingerprint(zipFile));
+    }
+    
+    @Test
+    void nonClassZipEntryDoesNotAffectFingerprint() throws IOException {
+        final File zipFile = tempDir.resolve("foo.jar").toFile();
+        final ZipEntry fooEntry = new ZipEntry("lib/Foo.class");
+        final ZipEntry barEntry = new ZipEntry("bar.properties");
+        overwriteZipFileContents(zipFile, fooEntry);
+        final long baselineFingerprint = getBaseLineFingerprint(zipFile);
+        
+        // add a properties file to the jar
+        overwriteZipFileContents(zipFile, fooEntry, barEntry);
+        assertEquals(baselineFingerprint, updateFingerprint(zipFile));
+    }
 
     @Override
     protected ClasspathEntryFingerprinter newFingerPrinter() {

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/AnalysisCacheIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/AnalysisCacheIT.java
@@ -54,7 +54,7 @@ class AnalysisCacheIT extends AbstractBinaryDistributionTest {
         resultFromCache.assertErrorOutputContains("Incremental Analysis cache HIT");
 
         // An error with the relative path should exist, but no with the absolute one
-        resultFromCache.assertExecutionResult(4, "", "src/test/resources/sample-source/java/JumbledIncrementer.java:8:\tJumbledIncrementer:\t".replace('/',  File.pathSeparatorChar));
+        resultFromCache.assertExecutionResult(4, "", "src/test/resources/sample-source/java/JumbledIncrementer.java:8:\tJumbledIncrementer:\t".replace('/', File.pathSeparatorChar));
         resultFromCache.assertNoErrorInReport(srcDir + File.pathSeparator + "JumbledIncrementer.java:8:\tJumbledIncrementer:\t");
     }
 }

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/AnalysisCacheIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/AnalysisCacheIT.java
@@ -25,7 +25,7 @@ class AnalysisCacheIT extends AbstractBinaryDistributionTest {
         
         // Ensure we have violations and a non-empty cache file
         assertTrue(cacheFile.toFile().length() > 0, "cache file is empty after run");
-        result.assertExecutionResult(4, "", srcDir + File.pathSeparator + "JumbledIncrementer.java:8:\tJumbledIncrementer:\t");
+        result.assertExecutionResult(4, "", srcDir + File.separator + "JumbledIncrementer.java:8:\tJumbledIncrementer:\t");
         
         // rerun from cache
         ExecutionResult resultFromCache = PMDExecutor.runPMD(createTemporaryReportFile(), tempDir, "-d", srcDir, "-R", "src/test/resources/rulesets/sample-ruleset.xml",
@@ -45,7 +45,7 @@ class AnalysisCacheIT extends AbstractBinaryDistributionTest {
         
         // Ensure we have violations and a non-empty cache file
         assertTrue(cacheFile.toFile().length() > 0, "cache file is empty after run");
-        result.assertExecutionResult(4, "", srcDir + File.pathSeparator + "JumbledIncrementer.java:8:\tJumbledIncrementer:\t");
+        result.assertExecutionResult(4, "", srcDir + File.separator + "JumbledIncrementer.java:8:\tJumbledIncrementer:\t");
         
         // rerun from cache with relativized paths
         ExecutionResult resultFromCache = PMDExecutor.runPMD(createTemporaryReportFile(), tempDir, "-d", Paths.get(".").toAbsolutePath().relativize(Paths.get(srcDir)).toString(), "-R", "src/test/resources/rulesets/sample-ruleset.xml",
@@ -54,7 +54,7 @@ class AnalysisCacheIT extends AbstractBinaryDistributionTest {
         resultFromCache.assertErrorOutputContains("Incremental Analysis cache HIT");
 
         // An error with the relative path should exist, but no with the absolute one
-        resultFromCache.assertExecutionResult(4, "", "src/test/resources/sample-source/java/JumbledIncrementer.java:8:\tJumbledIncrementer:\t".replace('/', File.pathSeparatorChar));
-        resultFromCache.assertNoErrorInReport(srcDir + File.pathSeparator + "JumbledIncrementer.java:8:\tJumbledIncrementer:\t");
+        resultFromCache.assertExecutionResult(4, "", "src/test/resources/sample-source/java/JumbledIncrementer.java:8:\tJumbledIncrementer:\t".replace('/', File.separatorChar));
+        resultFromCache.assertNoErrorInReport(srcDir + File.separator + "JumbledIncrementer.java:8:\tJumbledIncrementer:\t");
     }
 }

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/AnalysisCacheIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/AnalysisCacheIT.java
@@ -25,7 +25,7 @@ class AnalysisCacheIT extends AbstractBinaryDistributionTest {
         
         // Ensure we have violations and a non-empty cache file
         assertTrue(cacheFile.toFile().length() > 0, "cache file is empty after run");
-        result.assertExecutionResult(4, "", srcDir + "/JumbledIncrementer.java:8:\tJumbledIncrementer:\t");
+        result.assertExecutionResult(4, "", srcDir + File.pathSeparator + "JumbledIncrementer.java:8:\tJumbledIncrementer:\t");
         
         // rerun from cache
         ExecutionResult resultFromCache = PMDExecutor.runPMD(createTemporaryReportFile(), tempDir, "-d", srcDir, "-R", "src/test/resources/rulesets/sample-ruleset.xml",
@@ -45,7 +45,7 @@ class AnalysisCacheIT extends AbstractBinaryDistributionTest {
         
         // Ensure we have violations and a non-empty cache file
         assertTrue(cacheFile.toFile().length() > 0, "cache file is empty after run");
-        result.assertExecutionResult(4, "", srcDir + "/JumbledIncrementer.java:8:\tJumbledIncrementer:\t");
+        result.assertExecutionResult(4, "", srcDir + File.pathSeparator + "JumbledIncrementer.java:8:\tJumbledIncrementer:\t");
         
         // rerun from cache with relativized paths
         ExecutionResult resultFromCache = PMDExecutor.runPMD(createTemporaryReportFile(), tempDir, "-d", Paths.get(".").toAbsolutePath().relativize(Paths.get(srcDir)).toString(), "-R", "src/test/resources/rulesets/sample-ruleset.xml",
@@ -54,7 +54,7 @@ class AnalysisCacheIT extends AbstractBinaryDistributionTest {
         resultFromCache.assertErrorOutputContains("Incremental Analysis cache HIT");
 
         // An error with the relative path should exist, but no with the absolute one
-        resultFromCache.assertExecutionResult(4, "", "src/test/resources/sample-source/java/JumbledIncrementer.java:8:\tJumbledIncrementer:\t");
-        resultFromCache.assertNoErrorInReport(srcDir + "/JumbledIncrementer.java:8:\tJumbledIncrementer:\t");
+        resultFromCache.assertExecutionResult(4, "", "src/test/resources/sample-source/java/JumbledIncrementer.java:8:\tJumbledIncrementer:\t".replace('/',  File.pathSeparatorChar));
+        resultFromCache.assertNoErrorInReport(srcDir + File.pathSeparator + "JumbledIncrementer.java:8:\tJumbledIncrementer:\t");
     }
 }

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/AnalysisCacheIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/AnalysisCacheIT.java
@@ -1,0 +1,60 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.it;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+
+class AnalysisCacheIT extends AbstractBinaryDistributionTest {
+
+    private final String srcDir = new File(".", "src/test/resources/sample-source/java/").getAbsolutePath();
+
+    @Test
+    void testPmdCachedResultMatches() throws Exception {
+        final Path cacheFile = createTemporaryReportFile();
+        
+        ExecutionResult result = PMDExecutor.runPMD(createTemporaryReportFile(), tempDir, "-d", srcDir, "-R", "src/test/resources/rulesets/sample-ruleset.xml",
+                "-f", "text", "--cache", cacheFile.toAbsolutePath().toString(), "--no-progress");
+        
+        // Ensure we have violations and a non-empty cache file
+        assertTrue(cacheFile.toFile().length() > 0, "cache file is empty after run");
+        result.assertExecutionResult(4, "", srcDir + "/JumbledIncrementer.java:8:\tJumbledIncrementer:\t");
+        
+        // rerun from cache
+        ExecutionResult resultFromCache = PMDExecutor.runPMD(createTemporaryReportFile(), tempDir, "-d", srcDir, "-R", "src/test/resources/rulesets/sample-ruleset.xml",
+                "-f", "text", "--cache", cacheFile.toAbsolutePath().toString(), "--no-progress", "-v");
+
+        // expect identical
+        result.assertIdenticalResults(resultFromCache);
+        resultFromCache.assertErrorOutputContains("Incremental Analysis cache HIT");
+    }
+    
+    @Test
+    void testPmdCachedResultsAreRelativized() throws Exception {
+        final Path cacheFile = createTemporaryReportFile();
+        
+        ExecutionResult result = PMDExecutor.runPMD(createTemporaryReportFile(), tempDir, "-d", srcDir, "-R", "src/test/resources/rulesets/sample-ruleset.xml",
+                "-f", "text", "--cache", cacheFile.toAbsolutePath().toString(), "--no-progress");
+        
+        // Ensure we have violations and a non-empty cache file
+        assertTrue(cacheFile.toFile().length() > 0, "cache file is empty after run");
+        result.assertExecutionResult(4, "", srcDir + "/JumbledIncrementer.java:8:\tJumbledIncrementer:\t");
+        
+        // rerun from cache with relativized paths
+        ExecutionResult resultFromCache = PMDExecutor.runPMD(createTemporaryReportFile(), tempDir, "-d", Paths.get(".").toAbsolutePath().relativize(Paths.get(srcDir)).toString(), "-R", "src/test/resources/rulesets/sample-ruleset.xml",
+                "-f", "text", "--cache", cacheFile.toAbsolutePath().toString(), "--no-progress", "-v");
+        
+        resultFromCache.assertErrorOutputContains("Incremental Analysis cache HIT");
+
+        // An error with the relative path should exist, but no with the absolute one
+        resultFromCache.assertExecutionResult(4, "", "src/test/resources/sample-source/java/JumbledIncrementer.java:8:\tJumbledIncrementer:\t");
+        resultFromCache.assertNoErrorInReport(srcDir + "/JumbledIncrementer.java:8:\tJumbledIncrementer:\t");
+    }
+}

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistributionIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistributionIT.java
@@ -116,13 +116,13 @@ class BinaryDistributionIT extends AbstractBinaryDistributionTest {
 
     @Test
     void testPmdHelp() throws Exception {
-        ExecutionResult result = PMDExecutor.runPMD(tempDir, "-h");
+        ExecutionResult result = PMDExecutor.runPMD(null, tempDir, "-h");
         result.assertExecutionResult(0, SUPPORTED_LANGUAGES_PMD);
     }
 
     @Test
     void testPmdNoArgs() throws Exception {
-        ExecutionResult result = PMDExecutor.runPMD(tempDir); // without any argument, display usage help and error
+        ExecutionResult result = PMDExecutor.runPMD(null, tempDir); // without any argument, display usage help and error
         result.assertExecutionResultErrOutput(2, "Usage: pmd check ");
     }
 
@@ -132,15 +132,13 @@ class BinaryDistributionIT extends AbstractBinaryDistributionTest {
 
         ExecutionResult result;
 
-        result = PMDExecutor.runPMD(tempDir, "-d", srcDir, "-R", "src/test/resources/rulesets/sample-ruleset.xml",
-                "-r", createTemporaryReportFile().toString());
+        result = PMDExecutor.runPMD(createTemporaryReportFile(), tempDir, "-d", srcDir, "-R", "src/test/resources/rulesets/sample-ruleset.xml");
         result.assertExecutionResult(4);
         result.assertErrorOutputContains("[main] INFO net.sourceforge.pmd.cli.commands.internal.AbstractPmdSubcommand - Log level is at INFO");
 
 
         // now with debug
-        result = PMDExecutor.runPMD(tempDir, "-d", srcDir, "-R", "src/test/resources/rulesets/sample-ruleset.xml",
-                "-r", createTemporaryReportFile().toString(), "--debug");
+        result = PMDExecutor.runPMD(createTemporaryReportFile(), tempDir, "-d", srcDir, "-R", "src/test/resources/rulesets/sample-ruleset.xml", "--debug");
         result.assertExecutionResult(4);
         result.assertErrorOutputContains("[main] INFO net.sourceforge.pmd.cli.commands.internal.AbstractPmdSubcommand - Log level is at TRACE");
     }

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/ExecutionResult.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/ExecutionResult.java
@@ -136,6 +136,13 @@ public class ExecutionResult {
     public void assertErrorOutputContains(String message) {
         assertTrue(errorOutput.contains(message), "erroroutput didn't contain " + message);
     }
+    
+    public void assertIdenticalResults(ExecutionResult other) {
+    	// Notice we don't check for error output, as log messages may differ due to cache
+    	assertEquals(exitCode, other.exitCode, "Exit codes differ");
+    	assertEquals(output, other.output, "Outputs differ");
+    	assertEquals(report, other.report, "Reports differ");
+    }
 
     static class Builder {
         private int exitCode;

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/ExecutionResult.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/ExecutionResult.java
@@ -138,10 +138,10 @@ public class ExecutionResult {
     }
     
     public void assertIdenticalResults(ExecutionResult other) {
-    	// Notice we don't check for error output, as log messages may differ due to cache
-    	assertEquals(exitCode, other.exitCode, "Exit codes differ");
-    	assertEquals(output, other.output, "Outputs differ");
-    	assertEquals(report, other.report, "Reports differ");
+        // Notice we don't check for error output, as log messages may differ due to cache
+        assertEquals(exitCode, other.exitCode, "Exit codes differ");
+        assertEquals(output, other.output, "Outputs differ");
+        assertEquals(report, other.report, "Reports differ");
     }
 
     static class Builder {

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/PMDExecutor.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/PMDExecutor.java
@@ -56,8 +56,8 @@ public class PMDExecutor {
         ProcessBuilder pb = new ProcessBuilder(cmd);
         
         if (reportFile != null) {
-        	arguments.add(REPORTFILE_FLAG);
-        	arguments.add(reportFile.toString());
+            arguments.add(REPORTFILE_FLAG);
+            arguments.add(reportFile.toString());
         }
         
         pb.command().addAll(arguments);
@@ -124,7 +124,7 @@ public class PMDExecutor {
     }
 
     public static ExecutionResult runPMDRules(Path reportFile, Path tempDir, String sourceDirectory, String ruleset, String formatter) throws Exception {
-    	return runPMD(tempDir, reportFile, SOURCE_DIRECTORY_FLAG, sourceDirectory, RULESET_FLAG, ruleset,
+        return runPMD(tempDir, reportFile, SOURCE_DIRECTORY_FLAG, sourceDirectory, RULESET_FLAG, ruleset,
                     FORMAT_FLAG, formatter, REPORTFILE_FLAG, reportFile.toAbsolutePath().toString(), NO_PROGRESSBAR_FLAG);
     }
 

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/PMDExecutor.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/PMDExecutor.java
@@ -54,6 +54,12 @@ public class PMDExecutor {
 
     static ExecutionResult runCommand(String cmd, List<String> arguments, Path reportFile) throws Exception {
         ProcessBuilder pb = new ProcessBuilder(cmd);
+        
+        if (reportFile != null) {
+        	arguments.add(REPORTFILE_FLAG);
+        	arguments.add(reportFile.toString());
+        }
+        
         pb.command().addAll(arguments);
         pb.redirectErrorStream(false);
         
@@ -118,27 +124,23 @@ public class PMDExecutor {
     }
 
     public static ExecutionResult runPMDRules(Path reportFile, Path tempDir, String sourceDirectory, String ruleset, String formatter) throws Exception {
-        if (SystemUtils.IS_OS_WINDOWS) {
-            return runPMDWindows(tempDir, reportFile, SOURCE_DIRECTORY_FLAG, sourceDirectory, RULESET_FLAG, ruleset,
+    	return runPMD(tempDir, reportFile, SOURCE_DIRECTORY_FLAG, sourceDirectory, RULESET_FLAG, ruleset,
                     FORMAT_FLAG, formatter, REPORTFILE_FLAG, reportFile.toAbsolutePath().toString(), NO_PROGRESSBAR_FLAG);
-        } else {
-            return runPMDUnix(tempDir, reportFile, SOURCE_DIRECTORY_FLAG, sourceDirectory, RULESET_FLAG, ruleset,
-                    FORMAT_FLAG, formatter, REPORTFILE_FLAG, reportFile.toAbsolutePath().toString(), NO_PROGRESSBAR_FLAG);
-        }
     }
 
     /**
      * Executes PMD found in tempDir with the given command line arguments.
+     * @param reportFile The location where to store the result. If null, the report will be discarded.
      * @param tempDir the directory, to which the binary distribution has been extracted
      * @param arguments the arguments to execute PMD with
      * @return collected result of the execution
      * @throws Exception if the execution fails for any reason (executable not found, ...)
      */
-    public static ExecutionResult runPMD(Path tempDir, String... arguments) throws Exception {
+    public static ExecutionResult runPMD(Path reportFile, Path tempDir, String... arguments) throws Exception {
         if (SystemUtils.IS_OS_WINDOWS) {
-            return runPMDWindows(tempDir, null, arguments);
+            return runPMDWindows(tempDir, reportFile, arguments);
         } else {
-            return runPMDUnix(tempDir, null, arguments);
+            return runPMDUnix(tempDir, reportFile, arguments);
         }
     }
 }

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/PMDExecutor.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/PMDExecutor.java
@@ -124,8 +124,8 @@ public class PMDExecutor {
     }
 
     public static ExecutionResult runPMDRules(Path reportFile, Path tempDir, String sourceDirectory, String ruleset, String formatter) throws Exception {
-        return runPMD(tempDir, reportFile, SOURCE_DIRECTORY_FLAG, sourceDirectory, RULESET_FLAG, ruleset,
-                    FORMAT_FLAG, formatter, REPORTFILE_FLAG, reportFile.toAbsolutePath().toString(), NO_PROGRESSBAR_FLAG);
+        return runPMD(reportFile, tempDir, SOURCE_DIRECTORY_FLAG, sourceDirectory, RULESET_FLAG, ruleset,
+                    FORMAT_FLAG, formatter, NO_PROGRESSBAR_FLAG);
     }
 
     /**


### PR DESCRIPTION
## Describe the PR

Fix the population of the analysis cache, otherwise it is always stored as empty.

When the cache was migrated to a `FileAnalysisListener` the implementation was broken, and it kept working on a local var that was never accessible when persisting the cache. This updated implementation is simpler, avoids explicit (and useless) synchronization, and actually get the cache working once again.

Also, with the introduction of `pathIds` for text documents, the cached reports would output file names as urls, being different to the uncached ones. We revamp the logic to not only fix that, but also allow us to honor relativized roots at each execution, regardless of the cache's state.

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

