### PR TITLE
[core] Allow more XPath rules to use the rulechain

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonExprTransformations.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonExprTransformations.java
@@ -118,9 +118,18 @@ final class SaxonExprTransformations {
      * @return The subexpression, wrapped in a copy of all top-level let expression from the original.
      */
     static Expression copyTopLevelLets(Expression subexpr, Expression original) {
-        // Does it need them?
-        if (subexpr.equals(original)) {
+        if (!(original instanceof LetExpression)) {
             return subexpr;
+        }
+
+        // Does it need them? Or is it already the same variable under the same assignment?
+        if (subexpr instanceof LetExpression) {
+            final LetExpression letSubexpr = (LetExpression) subexpr;
+            final LetExpression letOriginal = (LetExpression) original;
+            if (letOriginal.getVariableQName().equals(letSubexpr.getVariableQName())
+                    && letSubexpr.getSequence().toString().equals(letOriginal.getSequence().toString())) {
+                return subexpr;
+            }
         }
         
         final SaxonExprVisitor topLevelLetCopier = new SaxonExprVisitor() {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonXPathRuleQuery.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonXPathRuleQuery.java
@@ -226,6 +226,7 @@ public class SaxonXPathRuleQuery {
             Expression modified = subexpression;
             modified = SaxonExprTransformations.hoistFilters(modified);
             modified = SaxonExprTransformations.reduceRoot(modified);
+            modified = SaxonExprTransformations.copyTopLevelLets(modified, expr);
             RuleChainAnalyzer rca = new RuleChainAnalyzer(xpathEvaluator.getConfiguration());
             final Expression finalExpr = rca.visit(modified); // final because of lambda
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SplitUnions.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SplitUnions.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import net.sf.saxon.expr.Expression;
+import net.sf.saxon.expr.LetExpression;
 import net.sf.saxon.expr.VennExpression;
 import net.sf.saxon.expr.parser.Token;
 import net.sf.saxon.expr.sort.DocumentSorter;
@@ -40,8 +41,8 @@ class SplitUnions extends SaxonExprVisitor {
 
     @Override
     public Expression visit(Expression e) {
-        // only flatten toplevel unions
-        if (e instanceof VennExpression || e instanceof DocumentSorter) {
+        // only flatten top level unions - skip sorters and let around it
+        if (e instanceof VennExpression || e instanceof DocumentSorter || e instanceof LetExpression) {
             return super.visit(e);
         } else {
             return e;

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonXPathRuleQueryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonXPathRuleQueryTest.java
@@ -373,6 +373,16 @@ class SaxonXPathRuleQueryTest {
         assertExpression(expectedSubexpression, query.nodeNameToXPaths.get("DoStatement").get(0));
     }
 
+    @Test
+    void ruleChainVisitsWithUnionsAndLets() {
+        PropertyDescriptor<Boolean> boolProperty = PropertyFactory.booleanProperty("checkAll").desc("test").defaultValue(true).build();
+        SaxonXPathRuleQuery query = createQuery("//dummyNode[$checkAll and ClassOrInterfaceType] | //ForStatement[not($checkAll)]", boolProperty);
+        List<String> ruleChainVisits = query.getRuleChainVisits();
+        assertEquals(2, ruleChainVisits.size());
+        assertTrue(ruleChainVisits.contains("dummyNode"));
+        assertTrue(ruleChainVisits.contains("ForStatement"));
+    }
+
     private static void assertExpression(String expected, Expression actual) {
         assertEquals(normalizeExprDump(expected),
                      normalizeExprDump(actual.toString()));


### PR DESCRIPTION
## Describe the PR
 
- When a rule uses a property Saxon produces a top-level LetExpression
 - Since LetExpressions can also be used to "cache" expensive operations during rule evaluation we generally ignored them, but we don't anymore.
 - If a LetExpression was for an expensive operation, we still refrain from using the rulechain so it's only evaluated once

With this changeset, rules such as `AvoidLiteralsInIfCondition` and `ControlStatementBraces` can make use of the rulechain in PMD 7 as they used to in PMD 6, and run significantly faster.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

