### PR TITLE
[core] Improve benchmarking

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/processor/PmdRunnable.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/processor/PmdRunnable.java
@@ -64,7 +64,7 @@ abstract class PmdRunnable implements Runnable {
     public void run() throws FileAnalysisException {
         TimeTracker.initThread();
 
-        try (TimedOperation to = TimeTracker.startOperation(TimedOperationCategory.FILE_PROCESSING);
+        try (TimedOperation ignored = TimeTracker.startOperation(TimedOperationCategory.FILE_PROCESSING);
             FileAnalysisListener listener = globalListener.startFileAnalysis(textFile)) {
 
             RuleSets ruleSets = getRulesets();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/processor/PmdRunnable.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/processor/PmdRunnable.java
@@ -64,10 +64,11 @@ abstract class PmdRunnable implements Runnable {
     public void run() throws FileAnalysisException {
         TimeTracker.initThread();
 
-        RuleSets ruleSets = getRulesets();
+        try (TimedOperation to = TimeTracker.startOperation(TimedOperationCategory.FILE_PROCESSING);
+            FileAnalysisListener listener = globalListener.startFileAnalysis(textFile)) {
 
-        try (FileAnalysisListener listener = globalListener.startFileAnalysis(textFile)) {
-
+            RuleSets ruleSets = getRulesets();
+            
             // Coarse check to see if any RuleSet applies to file, will need to do a finer RuleSet specific check later
             if (ruleSets.applies(textFile)) {
                 try (TextDocument textDocument = TextDocument.create(textFile);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AstDisambiguationPass.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AstDisambiguationPass.java
@@ -12,7 +12,6 @@ import java.util.Iterator;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import net.sourceforge.pmd.benchmark.TimeTracker;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.ast.NodeStream;
 import net.sourceforge.pmd.lang.ast.impl.javacc.JavaccToken;
@@ -56,7 +55,7 @@ final class AstDisambiguationPass {
      */
     public static void disambigWithCtx(NodeStream<? extends JavaNode> nodes, ReferenceCtx ctx) {
         assert ctx != null : "Null context";
-        TimeTracker.bench("AST disambiguation", () -> nodes.forEach(it -> it.acceptVisitor(DisambigVisitor.INSTANCE, ctx)));
+        nodes.forEach(it -> it.acceptVisitor(DisambigVisitor.INSTANCE, ctx));
     }
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/internal/JavaAstProcessor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/internal/JavaAstProcessor.java
@@ -165,7 +165,7 @@ public final class JavaAstProcessor {
      */
     public void process(ASTCompilationUnit acu) {
 
-        SymbolResolver knownSyms = TimeTracker.bench("1. Symbol resolution", () -> SymbolResolutionPass.traverse(this, acu));
+        SymbolResolver knownSyms = TimeTracker.bench("Symbol resolution", () -> SymbolResolutionPass.traverse(this, acu));
 
         // Now symbols are on the relevant nodes
         this.symResolver = SymbolResolver.layer(knownSyms, this.symResolver);
@@ -174,12 +174,12 @@ public final class JavaAstProcessor {
         // as scopes depend on type resolution in some cases.
         InternalApiBridge.initTypeResolver(acu, this, typeInferenceLogger);
 
-        TimeTracker.bench("2. Symbol table resolution", () -> SymbolTableResolver.traverse(this, acu));
-        TimeTracker.bench("3. AST disambiguation", () -> InternalApiBridge.disambigWithCtx(NodeStream.of(acu), ReferenceCtx.root(this, acu)));
-        TimeTracker.bench("4. Force type resolution", () -> InternalApiBridge.forceTypeResolutionPhase(this, acu));
-        TimeTracker.bench("5. Comment assignment", () -> InternalApiBridge.assignComments(acu));
-        TimeTracker.bench("6. Usage resolution", () -> InternalApiBridge.usageResolution(this, acu));
-        TimeTracker.bench("7. Override resolution", () -> InternalApiBridge.overrideResolution(this, acu));
+        TimeTracker.bench("Symbol table resolution", () -> SymbolTableResolver.traverse(this, acu));
+        TimeTracker.bench("AST disambiguation", () -> InternalApiBridge.disambigWithCtx(NodeStream.of(acu), ReferenceCtx.root(this, acu)));
+        TimeTracker.bench("Force type resolution", () -> InternalApiBridge.forceTypeResolutionPhase(this, acu));
+        TimeTracker.bench("Comment assignment", () -> InternalApiBridge.assignComments(acu));
+        TimeTracker.bench("Usage resolution", () -> InternalApiBridge.usageResolution(this, acu));
+        TimeTracker.bench("Override resolution", () -> InternalApiBridge.overrideResolution(this, acu));
     }
 
     public TypeSystem getTypeSystem() {


### PR DESCRIPTION
## Describe the PR

#### Rule benchmarking:
 - Recover the old behavior, where the number of rule applications is split from the number of tree transversals.
   - This means that rules that are applied, but didn't match any node where previously unlisted, but know show they were applied to all files, and evaluated 0 nodes.
   - This also allows to more neatly understand which rules are making use of the rulechain and which don't.

#### Language Processing Stages:
 - Remove numbers from Java LPS names
   - Only Java used them, so it was inconsistent
   - The numbers relate to the order they are executed, but don't necessarily imply a required order (ie: `Comment Assignment` could be done at any point in reality)
   - Since the benchmark report sorts by time spent on each one, the numbered labels are simply confusing
   - AST Disambiguation is only tracked in the dedicated phase started by the AstProcessor, having the `AstDissambiguation Pass` track this was inconsistent.
     - Since these passes can be triggered by the symbol table LPS phase, we ended up double counting total time (2 nested "LPS phases" were counting total time on top of each other).
     - This however puts all disambiguation passes done for symbol table as symbol table cost, which although accurate,
    may not help to identify speed up opportunities as clearly, but the benchmark is not a profiling tool.

#### Unaccounted:
 - Unaccounted time was significantly larger than it used to be, and in proportion took about 10% of total execution time. Properly account attaining ruleset copies, TextDocuments, and overall parser and rule setup as processing time.
## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

