### PR TITLE
[java] Improve CommentSize

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaComment.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaComment.java
@@ -116,7 +116,7 @@ public class JavaComment implements Reportable {
      * Trim the start of the provided line to remove a comment
      * markup opener ({@code //, /*, /**, *}) or closer {@code * /}.
      */
-    private static Chars removeCommentMarkup(Chars line) {
+    public static Chars removeCommentMarkup(Chars line) {
         line = line.trim().removeSuffix("*/");
         int subseqFrom = 0;
         if (line.startsWith('/', 0)) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentSizeRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/documentation/CommentSizeRule.java
@@ -5,14 +5,8 @@
 package net.sourceforge.pmd.lang.java.rule.documentation;
 
 import static net.sourceforge.pmd.properties.constraints.NumericConstraints.positive;
-import static net.sourceforge.pmd.util.CollectionUtil.setOf;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-
-import org.apache.commons.lang3.StringUtils;
-
+import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.document.Chars;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
 import net.sourceforge.pmd.lang.java.ast.JavaComment;
@@ -37,12 +31,6 @@ public class CommentSizeRule extends AbstractJavaRulechainRule {
                          .desc("Maximum line length")
                          .require(positive()).defaultValue(80).build();
 
-    static final Set<Chars> IGNORED_LINES = setOf(Chars.wrap("//"),
-                                                  Chars.wrap("/*"),
-                                                  Chars.wrap("/**"),
-                                                  Chars.wrap("*"),
-                                                  Chars.wrap("*/"));
-
     public CommentSizeRule() {
         super(ASTCompilationUnit.class);
         definePropertyDescriptor(MAX_LINES);
@@ -59,29 +47,14 @@ public class CommentSizeRule extends AbstractJavaRulechainRule {
                     + ": Too many lines", comment.getBeginLine(), comment.getEndLine());
             }
 
-            List<Integer> lineNumbers = overLengthLineIndicesIn(comment);
-            if (lineNumbers.isEmpty()) {
-                continue;
-            }
-
-            int offset = comment.getBeginLine();
-            for (int lineNum : lineNumbers) {
-                int lineNumWithOff = lineNum + offset;
-                addViolationWithMessage(
-                    data,
-                    cUnit,
-                    this.getMessage() + ": Line too long",
-                    lineNumWithOff,
-                    lineNum
-                );
-            }
+            reportLinesTooLong(cUnit, asCtx(data), comment);
         }
 
         return null;
     }
 
     private static boolean hasRealText(Chars line) {
-        return !StringUtils.isBlank(line) && !IGNORED_LINES.contains(line.trim());
+        return !JavaComment.removeCommentMarkup(line).isEmpty();
     }
 
     private boolean hasTooManyLines(JavaComment comment) {
@@ -91,8 +64,7 @@ public class CommentSizeRule extends AbstractJavaRulechainRule {
         int i = 0;
         int maxLines = getProperty(MAX_LINES);
         for (Chars line : comment.getText().lines()) {
-            boolean real = hasRealText(line);
-            if (real) {
+            if (hasRealText(line)) {
                 lastLineWithText = i;
                 if (firstLineWithText == -1) {
                     firstLineWithText = i;
@@ -106,18 +78,21 @@ public class CommentSizeRule extends AbstractJavaRulechainRule {
         return false;
     }
 
-    private List<Integer> overLengthLineIndicesIn(JavaComment comment) {
+    private void reportLinesTooLong(ASTCompilationUnit acu, RuleContext ctx, JavaComment comment) {
 
         int maxLength = getProperty(MAX_LINE_LENGTH);
 
-        List<Integer> indices = new ArrayList<>();
+        int offset = comment.getReportLocation().getStartLine();
         int i = 0;
         for (Chars line : comment.getFilteredLines(true)) {
             if (line.length() > maxLength) {
-                indices.add(i);
+                ctx.addViolationWithPosition(acu,
+                                             i + offset,
+                                             i + offset,
+                                             getMessage() + ": Line too long");
             }
+            i++;
         }
-        return indices;
     }
 
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/documentation/xml/CommentSize.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/documentation/xml/CommentSize.xml
@@ -27,4 +27,25 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>Line too long</description>
+        <rule-property name="maxLineLength">5</rule-property>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+//
+
+
+/* 4
+ * 5 way too long
+ */
+public class Foo {
+    public Foo() {
+    }
+
+    public void doNothing() {
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

CommentSize didn't report long lines on the right lines but always on the first line of the comment.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

