### PR TITLE
[java] Move TypeResTest rule out of security.xml

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TypeResTestRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TypeResTestRule.java
@@ -1,8 +1,8 @@
-/**
+/*
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
-package net.sourceforge.pmd.lang.java.rule.security;
+package net.sourceforge.pmd.lang.java.rule.internal;
 
 import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -17,11 +17,9 @@ import net.sourceforge.pmd.lang.java.types.TypeSystem;
 import net.sourceforge.pmd.util.StringUtil;
 
 /**
- * @deprecated This is just a toy rule that counts the proportion of resolved types in a codebase,
- *     not meant as a real rule
+ * This is just a toy rule that counts the proportion of resolved types
+ * in a codebase, not meant as a real rule.
  */
-// TODO Move this rule to a (internal) diagnostics category/ruleset
-@Deprecated
 @SuppressWarnings("PMD")
 public class TypeResTestRule extends AbstractJavaRule {
 

--- a/pmd-java/src/main/resources/category/java/security.xml
+++ b/pmd-java/src/main/resources/category/java/security.xml
@@ -63,18 +63,4 @@ public class Foo {
 ]]>
         </example>
     </rule>
-
-    <rule name="TypeResTest"
-          language="java"
-          since="7.0.0"
-          message="Type Resolution Test"
-          class="net.sourceforge.pmd.lang.java.rule.security.TypeResTestRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_security.html#typerestest">
-        <description>
-This is just a toy rule that counts the proportion of resolved types in a codebase, not meant as a real rule.
-
-It is used to test the capability of PMD's own type resolution.
-        </description>
-        <priority>3</priority>
-    </rule>
 </ruleset>

--- a/pmd-java/src/main/resources/rulesets/java/internal/diagnostics.xml
+++ b/pmd-java/src/main/resources/rulesets/java/internal/diagnostics.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset name="Diagnostics"
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+    <description>
+        Contains rules for internal use.
+    </description>
+
+    <rule name="TypeResTest"
+          language="java"
+          since="7.0.0"
+          message="Type Resolution Test"
+          class="net.sourceforge.pmd.lang.java.rule.internal.TypeResTestRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_diagnostics.html#typerestest">
+        <description>
+            This is just a toy rule that counts the proportion of resolved types in a codebase, not meant as a real rule.
+
+            It is used to test the capability of PMD's own type resolution.
+        </description>
+        <priority>3</priority>
+    </rule>
+
+</ruleset>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
Create a diagnostics.xml internal ruleset for TypeResTestRule

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #4367

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

