### PR TITLE
[core] Support environment variable CLASSPATH with pmd.bat under Windows

### DIFF
--- a/docs/pages/pmd/userdocs/cli_reference.md
+++ b/docs/pages/pmd/userdocs/cli_reference.md
@@ -189,8 +189,22 @@ if you want to analyze a project, that uses one of OpenJDK's [Preview Language F
 
 Just set the environment variable `PMD_JAVA_OPTS` before executing PMD, e.g.
 
-    export PMD_JAVA_OPTS="--enable-preview"
-    ./run.sh pmd -d ../../../src/main/java/ -f text -R rulesets/java/quickstart.xml
+```shell
+export PMD_JAVA_OPTS="--enable-preview"
+./run.sh pmd -d ../../../src/main/java/ -f text -R rulesets/java/quickstart.xml
+```
+
+## Additional runtime classpath
+
+If you develop custom rules and package them as a jar file, you need to add it to PMD's runtime classpath.
+You can either copy the jar file into the `lib/` subfolder alongside the other jar files, that are in PMD's
+standard distribution.
+
+Or you can set the environment variable `CLASSPATH` before starting PMD, e.g.
+
+```shell
+CLASSPATH=custom-rule-example.jar ./run.sh pmd -d ../../../src/main/java/ -f text -R myrule.xml
+```
 
 ## Exit Status
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -15,6 +15,8 @@ This is a {{ site.pmd.release_type }} release.
 ### New and noteworthy
 
 ### Fixed Issues
+* core
+  * [#4395](https://github.com/pmd/pmd/issues/4395): \[core] Support environment variable CLASSPATH with pmd.bat under Windows
 * java-errorprone
   * [#4393](https://github.com/pmd/pmd/issues/4393): \[java] MissingStaticMethodInNonInstantiatableClass false-positive for Lombok's @UtilityClass for classes with non-private fields
 

--- a/pmd-dist/src/main/resources/scripts/pmd.bat
+++ b/pmd-dist/src/main/resources/scripts/pmd.bat
@@ -2,5 +2,10 @@
 set TOPDIR="%~dp0.."
 set OPTS=
 set MAIN_CLASS=net.sourceforge.pmd.PMD
+set PMD_CLASSPATH=%TOPDIR%\lib\*
 
-java %PMD_JAVA_OPTS% -classpath %TOPDIR%\lib\* %OPTS% %MAIN_CLASS% %*
+if [%CLASSPATH%] NEQ [] (
+    set PMD_CLASSPATH=%CLASSPATH%;%PMD_CLASSPATH%
+)
+
+java %PMD_JAVA_OPTS% -classpath %PMD_CLASSPATH% %OPTS% %MAIN_CLASS% %*


### PR DESCRIPTION
## Describe the PR

Fixes the problem found in https://github.com/pmd/pmd/discussions/4391

The environment `CLASSPATH` is supported in `run.sh` for a long time, but this was obviously never added to pmd.bat.

Note: This needs to be ported to PMD 7 as well - there we seem to support `CLASSPATH` only in the bash script, but not in `pmd.bat`.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

