### PR TITLE
[core] Log semantic error warnings without debug note

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/SemanticErrorReporter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/SemanticErrorReporter.java
@@ -92,7 +92,7 @@ public interface SemanticErrorReporter {
             private SemanticException exception = null;
 
             private String locPrefix(Node loc) {
-                return "at " + loc.getReportLocation()
+                return "at " + loc.getReportLocation().startPosToStringWithFile()
                     + ": ";
             }
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/processor/PmdRunnableTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/processor/PmdRunnableTest.java
@@ -127,7 +127,7 @@ class PmdRunnableTest {
         Report report = process(versionWithParserThatReportsSemanticError());
 
         verify(reporter, times(1))
-            .log(eq(Level.ERROR), eq("at !debug only! test.dummy:1:1: " + TEST_MESSAGE_SEMANTIC_ERROR));
+            .log(eq(Level.ERROR), eq("at test.dummy:1:1: " + TEST_MESSAGE_SEMANTIC_ERROR));
         verify(rule, never()).apply(Mockito.any(), Mockito.any());
 
         assertEquals(1, report.getProcessingErrors().size());


### PR DESCRIPTION
## Describe the PR

Removes the "!debug only!" in the log warnings.

E.g. previously:

```
[main] WARN net.sourceforge.pmd.cli.commands.internal.PmdCommand - at !debug only! jdk-master/src/java.base/share/classes/jdk/internal/io/JdkConsoleImpl.java:48:46: Cannot resolve symbol JdkConsole
```

And now:

```
[main] WARN net.sourceforge.pmd.cli.commands.internal.PmdCommand - at jdk-master/src/java.base/share/classes/jdk/internal/io/JdkConsoleImpl.java:48:46: Cannot resolve symbol JdkConsole
```

