### PR TITLE
[cli] Fix NPE when only `--file-list` is specified

### DIFF
--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/PmdCommand.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/PmdCommand.java
@@ -275,7 +275,9 @@ public class PmdCommand extends AbstractAnalysisPmdSubcommand {
      */
     public PMDConfiguration toConfiguration() {
         final PMDConfiguration configuration = new PMDConfiguration();
-        configuration.setInputPathList(inputPaths);
+        if (inputPaths != null) {
+            configuration.setInputPathList(inputPaths);
+        }
         configuration.setInputFilePath(fileListPath);
         configuration.setIgnoreFilePath(ignoreListPath);
         configuration.setInputUri(uri);

--- a/pmd-cli/src/test/java/net/sourceforge/pmd/cli/PmdCliTest.java
+++ b/pmd-cli/src/test/java/net/sourceforge/pmd/cli/PmdCliTest.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.cli;
 
 import static net.sourceforge.pmd.cli.internal.CliExitCode.ERROR;
 import static net.sourceforge.pmd.cli.internal.CliExitCode.OK;
+import static net.sourceforge.pmd.cli.internal.CliExitCode.USAGE_ERROR;
 import static net.sourceforge.pmd.cli.internal.CliExitCode.VIOLATIONS_FOUND;
 import static net.sourceforge.pmd.util.CollectionUtil.listOf;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -40,7 +41,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 import net.sourceforge.pmd.RuleContext;
-import net.sourceforge.pmd.cli.internal.CliExitCode;
 import net.sourceforge.pmd.internal.Slf4jSimpleConfiguration;
 import net.sourceforge.pmd.internal.util.IOUtil;
 import net.sourceforge.pmd.lang.ast.Node;
@@ -196,7 +196,7 @@ class PmdCliTest extends BaseCliTest {
 
     @Test
     void testDeprecatedRulesetSyntaxOnCommandLine() throws Exception {
-        CliExecutionResult result = runCli(CliExitCode.VIOLATIONS_FOUND, "--dir", srcDir.toString(), "--rulesets", "dummy-basic");
+        CliExecutionResult result = runCli(VIOLATIONS_FOUND, "--dir", srcDir.toString(), "--rulesets", "dummy-basic");
         result.checkStdErr(containsString("Ruleset reference 'dummy-basic' uses a deprecated form, use 'rulesets/dummy/basic.xml' instead"));
     }
 
@@ -219,13 +219,13 @@ class PmdCliTest extends BaseCliTest {
 
     @Test
     void testMissingRuleset() throws Exception {
-        CliExecutionResult result = runCli(CliExitCode.USAGE_ERROR);
+        CliExecutionResult result = runCli(USAGE_ERROR);
         result.checkStdErr(containsString("Missing required option: '--rulesets=<rulesets>'"));
     }
     
     @Test
     void testMissingSource() throws Exception {
-        CliExecutionResult result = runCli(CliExitCode.USAGE_ERROR, "--rulesets", RULESET_NO_VIOLATIONS);
+        CliExecutionResult result = runCli(USAGE_ERROR, "--rulesets", RULESET_NO_VIOLATIONS);
         result.checkStdErr(containsString("Please provide a parameter for source root directory"));
     }
 
@@ -234,7 +234,7 @@ class PmdCliTest extends BaseCliTest {
      */
     @Test
     void testWrongCliOptionsDoPrintUsage() throws Exception {
-        runCli(CliExitCode.USAGE_ERROR, "--invalid", "--rulesets", RULESET_NO_VIOLATIONS, "-d", srcDir.toString())
+        runCli(USAGE_ERROR, "--invalid", "--rulesets", RULESET_NO_VIOLATIONS, "-d", srcDir.toString())
                 .verify(result -> {
                     result.checkStdErr(containsString("Unknown option: '--invalid'"));
                     result.checkStdErr(containsString("Usage: pmd check"));
@@ -342,7 +342,7 @@ class PmdCliTest extends BaseCliTest {
     @Test
     void testNoRelativizeWithAbsoluteSrcDir() throws Exception {
         assertTrue(srcDir.isAbsolute(), "srcDir should be absolute");
-        runCli(CliExitCode.VIOLATIONS_FOUND, "--dir", srcDir.toString(), "--rulesets",
+        runCli(VIOLATIONS_FOUND, "--dir", srcDir.toString(), "--rulesets",
                 DUMMY_RULESET_WITH_VIOLATIONS)
                 .verify(result -> result.checkStdOut(
                         containsString(srcDir.resolve("someSource.dummy").toString())));
@@ -357,7 +357,7 @@ class PmdCliTest extends BaseCliTest {
         String relativeSrcDir = "src/test/resources/net/sourceforge/pmd/cli/src";
         assertTrue(Files.isDirectory(cwd.resolve(relativeSrcDir)));
 
-        runCli(CliExitCode.VIOLATIONS_FOUND, "--dir", relativeSrcDir, "--rulesets",
+        runCli(VIOLATIONS_FOUND, "--dir", relativeSrcDir, "--rulesets",
                 DUMMY_RULESET_WITH_VIOLATIONS)
                 .verify(result -> result.checkStdOut(
                         containsString("\n" + IOUtil.normalizePath(relativeSrcDir + "/somefile.dummy"))));
@@ -375,7 +375,7 @@ class PmdCliTest extends BaseCliTest {
         // use the parent directory
         String relativeSrcDirWithParent = relativeSrcDir + File.separator + "..";
 
-        runCli(CliExitCode.VIOLATIONS_FOUND, "--dir", relativeSrcDirWithParent, "--rulesets",
+        runCli(VIOLATIONS_FOUND, "--dir", relativeSrcDirWithParent, "--rulesets",
                 DUMMY_RULESET_WITH_VIOLATIONS)
                 .verify(result -> result.checkStdOut(
                         containsString("\n" + relativeSrcDirWithParent + IOUtil.normalizePath("/src/somefile.dummy"))));
@@ -393,7 +393,7 @@ class PmdCliTest extends BaseCliTest {
         String root = cwd.getRoot().toString();
         String absoluteSrcPath = cwd.resolve(relativeSrcDir).resolve("somefile.dummy").toString();
 
-        runCli(CliExitCode.VIOLATIONS_FOUND, "--dir", relativeSrcDir, "--rulesets",
+        runCli(VIOLATIONS_FOUND, "--dir", relativeSrcDir, "--rulesets",
                 DUMMY_RULESET_WITH_VIOLATIONS, "--relativize-paths-with", root)
                 .verify(result -> result.checkStdOut(
                         containsString("\n" + absoluteSrcPath))
@@ -402,7 +402,7 @@ class PmdCliTest extends BaseCliTest {
 
     @Test
     void testRelativizeWith() throws Exception {
-        runCli(CliExitCode.VIOLATIONS_FOUND, "--dir", srcDir.toString(), "--rulesets",
+        runCli(VIOLATIONS_FOUND, "--dir", srcDir.toString(), "--rulesets",
                 DUMMY_RULESET_WITH_VIOLATIONS, "-z", srcDir.getParent().toString())
                 .verify(result -> {
                     result.checkStdOut(not(containsString(srcDir.resolve("someSource.dummy").toString())));
@@ -415,7 +415,7 @@ class PmdCliTest extends BaseCliTest {
         // srcDir = /tmp/junit123/src
         // symlinkedSrcDir = /tmp/junit123/sources -> /tmp/junit123/src
         Path symlinkedSrcDir = Files.createSymbolicLink(tempRoot().resolve("sources"), srcDir);
-        runCli(CliExitCode.VIOLATIONS_FOUND, "--dir", symlinkedSrcDir.toString(), "--rulesets",
+        runCli(VIOLATIONS_FOUND, "--dir", symlinkedSrcDir.toString(), "--rulesets",
                 DUMMY_RULESET_WITH_VIOLATIONS, "-z", symlinkedSrcDir.toString())
                 .verify(result -> {
                     result.checkStdOut(not(containsString(srcDir.resolve("someSource.dummy").toString())));
@@ -432,7 +432,7 @@ class PmdCliTest extends BaseCliTest {
         Files.delete(tempPath);
         Path symlinkedSrcDir = Files.createSymbolicLink(tempPath, srcDir);
         // relativizing against parent of symlinkedSrcDir: /tmp
-        runCli(CliExitCode.VIOLATIONS_FOUND, "--dir", symlinkedSrcDir.toString(), "--rulesets",
+        runCli(VIOLATIONS_FOUND, "--dir", symlinkedSrcDir.toString(), "--rulesets",
                 DUMMY_RULESET_WITH_VIOLATIONS, "-z", symlinkedSrcDir.getParent().toString())
                 .verify(result -> {
                     result.checkStdOut(not(containsString(srcDir.resolve("someSource.dummy").toString())));
@@ -445,7 +445,7 @@ class PmdCliTest extends BaseCliTest {
 
     @Test
     void testRelativizeWithMultiple() throws Exception {
-        runCli(CliExitCode.VIOLATIONS_FOUND, "--dir", srcDir.toString(), "--rulesets",
+        runCli(VIOLATIONS_FOUND, "--dir", srcDir.toString(), "--rulesets",
                 DUMMY_RULESET_WITH_VIOLATIONS, "-z", srcDir.getParent().toString() + "," + srcDir.toString())
                 .verify(result -> {
                     result.checkStdOut(not(containsString(srcDir.resolve("someSource.dummy").toString())));
@@ -455,12 +455,22 @@ class PmdCliTest extends BaseCliTest {
 
     @Test
     void testRelativizeWithFileIsError() throws Exception {
-        runCli(CliExitCode.USAGE_ERROR, "--dir", srcDir.toString(), "--rulesets",
+        runCli(USAGE_ERROR, "--dir", srcDir.toString(), "--rulesets",
                 DUMMY_RULESET_WITH_VIOLATIONS, "-z", srcDir.resolve("someSource.dummy").toString())
                 .verify(result -> result.checkStdErr(
                         containsString(
                                 "Expected a directory path for option '--relativize-paths-with', found a file: "
                                         + srcDir.resolve("someSource.dummy"))
+                ));
+    }
+
+    @Test
+    void testFileListOnly() throws Exception {
+        Path filelist = tempDir.resolve("filelist.txt");
+        writeString(filelist, srcDir.resolve("someSource.dummy") + System.lineSeparator());
+        runCli(VIOLATIONS_FOUND, "--file-list", filelist.toString(), "-f", "text", "-R", RULESET_WITH_VIOLATION)
+                .verify(r -> r.checkStdOut(
+                        containsString("Violation from ReportAllRootNodes")
                 ));
     }
 


### PR DESCRIPTION
## Describe the PR

This fixes the following NPE:

```
java.lang.NullPointerException
	at net.sourceforge.pmd.util.AssertionUtil.requireContainsNoNullValue(AssertionUtil.java:30)
	at net.sourceforge.pmd.PMDConfiguration.setInputPathList(PMDConfiguration.java:515)
	at net.sourceforge.pmd.cli.commands.internal.PmdCommand.toConfiguration(PmdCommand.java:278)
	at net.sourceforge.pmd.cli.commands.internal.PmdCommand.execute(PmdCommand.java:328)
	at net.sourceforge.pmd.cli.commands.internal.AbstractPmdSubcommand.call(AbstractPmdSubcommand.java:35)
	at net.sourceforge.pmd.cli.commands.internal.AbstractPmdSubcommand.call(AbstractPmdSubcommand.java:20)
	at picocli.CommandLine.executeUserObject(CommandLine.java:2041)
	at picocli.CommandLine.access$1500(CommandLine.java:148)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2461)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2453)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2415)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2273)
	at picocli.CommandLine$RunLast.execute(CommandLine.java:2417)
	at picocli.CommandLine.execute(CommandLine.java:2170)
	at net.sourceforge.pmd.cli.PmdCli.main(PmdCli.java:18)
```

We use `--file-list` in the pmd-github-action and without this fix, it won't work...
