### PR TITLE
[apex] ApexBadCrypto bug fix for #4427 - inline detection of hard coded values

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexBadCryptoRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexBadCryptoRule.java
@@ -8,10 +8,15 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import net.sourceforge.pmd.lang.apex.ast.*;
+import net.sourceforge.pmd.lang.apex.ast.ASTFieldDeclaration;
+import net.sourceforge.pmd.lang.apex.ast.ASTLiteralExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
+import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
+import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration;
+import net.sourceforge.pmd.lang.apex.ast.ASTVariableExpression;
+import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.apex.rule.internal.Helper;
-import scala.concurrent.impl.FutureConvertersImpl;
 
 /**
  * Finds encryption schemes using hardcoded IV, hardcoded key

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexBadCryptoRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexBadCryptoRule.java
@@ -8,14 +8,10 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import net.sourceforge.pmd.lang.apex.ast.ASTFieldDeclaration;
-import net.sourceforge.pmd.lang.apex.ast.ASTMethodCallExpression;
-import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
-import net.sourceforge.pmd.lang.apex.ast.ASTVariableDeclaration;
-import net.sourceforge.pmd.lang.apex.ast.ASTVariableExpression;
-import net.sourceforge.pmd.lang.apex.ast.ApexNode;
+import net.sourceforge.pmd.lang.apex.ast.*;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.apex.rule.internal.Helper;
+import scala.concurrent.impl.FutureConvertersImpl;
 
 /**
  * Finds encryption schemes using hardcoded IV, hardcoded key
@@ -104,7 +100,19 @@ public class ApexBadCryptoRule extends AbstractApexRule {
     }
 
     private void reportIfHardCoded(Object data, Object potentialIV) {
-        if (potentialIV instanceof ASTVariableExpression) {
+        if (potentialIV instanceof ASTMethodCallExpression) {
+            ASTMethodCallExpression expression = (ASTMethodCallExpression) potentialIV;
+            if (expression.getNumChildren()>1) {
+                Object potentialStaticIV = expression.getChild(1);
+                if (potentialStaticIV instanceof ASTLiteralExpression) {
+                    ASTLiteralExpression variable = (ASTLiteralExpression) potentialStaticIV;
+                    if (variable.isString()) {
+                        addViolation(data, variable);
+                    }
+                }
+            }
+        }
+        else if (potentialIV instanceof ASTVariableExpression) {
             ASTVariableExpression variable = (ASTVariableExpression) potentialIV;
             if (potentiallyStaticBlob.contains(Helper.getFQVariableName(variable))) {
                 addViolation(data, variable);

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexBadCryptoRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexBadCryptoRule.java
@@ -107,7 +107,7 @@ public class ApexBadCryptoRule extends AbstractApexRule {
     private void reportIfHardCoded(Object data, Object potentialIV) {
         if (potentialIV instanceof ASTMethodCallExpression) {
             ASTMethodCallExpression expression = (ASTMethodCallExpression) potentialIV;
-            if (expression.getNumChildren()>1) {
+            if (expression.getNumChildren() > 1) {
                 Object potentialStaticIV = expression.getChild(1);
                 if (potentialStaticIV instanceof ASTLiteralExpression) {
                     ASTLiteralExpression variable = (ASTLiteralExpression) potentialStaticIV;
@@ -116,8 +116,7 @@ public class ApexBadCryptoRule extends AbstractApexRule {
                     }
                 }
             }
-        }
-        else if (potentialIV instanceof ASTVariableExpression) {
+        } else if (potentialIV instanceof ASTVariableExpression) {
             ASTVariableExpression variable = (ASTVariableExpression) potentialIV;
             if (potentiallyStaticBlob.contains(Helper.getFQVariableName(variable))) {
                 addViolation(data, variable);

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexBadCrypto.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexBadCrypto.xml
@@ -98,4 +98,33 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Apex Crypto inline hardcoded IV</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public Foo() {
+        Blob key = Crypto.generateAesKey(128);
+        Blob data = Blob.valueOf('Data to be encrypted');
+        Blob encrypted = Crypto.encrypt('AES128', key, Blob.valueOf('0000000000000000'), data);
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Apex Crypto Inline hardcoded Key</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Foo {
+    public Foo() {
+        Blob data = Blob.valueOf('Data to be encrypted');
+        Blob IV = Crypto.generateAesKey(128);
+        Blob encrypted = Crypto.encrypt('AES128', Blob.valueOf('Hard Coded Key'), IV, data);
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

This PR is targeted at fixing an issue with the ApexBadCrypto test.  The test was not catching situations where the hard coded values were inline with the method call.  Modified the detection code and added two additional unit tests to catch that scenario.  

## Related issues

- Fixes #4427

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

