### PR TITLE
[java] Make missing class warnings debug level

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/SemanticErrorReporter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/SemanticErrorReporter.java
@@ -108,7 +108,7 @@ public interface SemanticErrorReporter {
 
             @Override
             public void warning(Node location, String message, Object... args) {
-                logMessage(Level.WARN, location, message, args);
+                logMessage(Level.DEBUG, location, message, args);
             }
 
             @Override


### PR DESCRIPTION
Ref #3914

This makes the noisy warnings invisible. The rest of the ticket is about making them visible but not so noisy, we can implement that later.

## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

