### PR TITLE
[java] CommentDefaultAccessModifier - ignore org.junit.jupiter.api.extension.RegisterExtension by default

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/CommentDefaultAccessModifierRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/CommentDefaultAccessModifierRule.java
@@ -53,6 +53,7 @@ public class CommentDefaultAccessModifierRule extends AbstractJavaRulechainRule 
             "android.support.annotation.VisibleForTesting",
             "co.elastic.clients.util.VisibleForTesting",
             "org.junit.jupiter.api.Test",
+            "org.junit.jupiter.api.extension.RegisterExtension",
             "org.junit.jupiter.api.ParameterizedTest",
             "org.junit.jupiter.api.RepeatedTest",
             "org.junit.jupiter.api.TestFactory",

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/CommentDefaultAccessModifier.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/CommentDefaultAccessModifier.xml
@@ -463,6 +463,7 @@ import org.junit.jupiter.api.ParameterizedTest;
 import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 class SomeTest {
 
@@ -481,6 +482,9 @@ class SomeTest {
 
   @RepeatedTest(10)
   void repeatedTest() {}
+
+  @RegisterExtension
+  void registerExtenstionTest(){}
 }
         ]]></code>
     </test-code>


### PR DESCRIPTION
Default value of "ignoredAnnotations" now include "org.junit.jupiter.api.extension.RegisterExtension" .

- Fixes #4273 