### PR TITLE
[ci] Improve release scripts

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -55,6 +55,11 @@ function build() {
     # stop early for invalid maven version and branch/tag combination
     pmd_ci_maven_verify_version || exit 0
 
+    # allow snapshot dependencies in release candidate builds:
+    if [[ "${PMD_CI_MAVEN_PROJECT_VERSION}" == *-rc* ]]; then
+        PMD_MAVEN_EXTRA_OPTS+=(-Denforcer.skip=true)
+    fi
+
     if [ "$(pmd_ci_utils_get_os)" != "linux" ]; then
         pmd_ci_log_group_start "Build with mvnw"
             ./mvnw clean verify --show-version --errors --batch-mode --no-transfer-progress "${PMD_MAVEN_EXTRA_OPTS[@]}"

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -55,12 +55,9 @@ function build() {
     # stop early for invalid maven version and branch/tag combination
     pmd_ci_maven_verify_version || exit 0
 
-    # allow snapshot dependencies in release candidate builds:
-    if [[ "${PMD_CI_MAVEN_PROJECT_VERSION}" == *-rc* ]]; then
-        PMD_MAVEN_EXTRA_OPTS+=(-Denforcer.skip=true)
-    fi
-
-    # skip tests when doing a release build
+    # skip tests when doing a release build - this makes the process faster
+    # it's a manual task now to verify that a release is only started, when the main branch
+    # was green before. This is usually checked via a local build, see ./do-release.sh
     if pmd_ci_maven_isReleaseBuild; then
         PMD_MAVEN_EXTRA_OPTS+=(-DskipTests=true)
     fi

--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -60,6 +60,11 @@ function build() {
         PMD_MAVEN_EXTRA_OPTS+=(-Denforcer.skip=true)
     fi
 
+    # skip tests when doing a release build
+    if pmd_ci_maven_isReleaseBuild; then
+        PMD_MAVEN_EXTRA_OPTS+=(-DskipTests=true)
+    fi
+
     if [ "$(pmd_ci_utils_get_os)" != "linux" ]; then
         pmd_ci_log_group_start "Build with mvnw"
             ./mvnw clean verify --show-version --errors --batch-mode --no-transfer-progress "${PMD_MAVEN_EXTRA_OPTS[@]}"

--- a/do-release.sh
+++ b/do-release.sh
@@ -169,6 +169,7 @@ git commit -a -m "Prepare pmd release ${RELEASE_VERSION}"
     -Dtag="pmd_releases/${RELEASE_VERSION}" \
     -DreleaseVersion="${RELEASE_VERSION}" \
     -DdevelopmentVersion="${DEVELOPMENT_VERSION}" \
+    -DscmCommentPrefix="[release] " \
     -Pgenerate-rule-docs
 
 

--- a/do-release.sh
+++ b/do-release.sh
@@ -165,26 +165,12 @@ git commit -a -m "Prepare pmd release ${RELEASE_VERSION}"
     fi
 )
 
-# for release candidates, allow snapshot dependencies
-if [[ "${RELEASE_VERSION}" == *-rc* ]]; then
-  ./mvnw versions:set -DnewVersion="${RELEASE_VERSION}" -DgenerateBackupPoms=false
-  git commit -S -a -m "[release] prepare release pmd_releases/${RELEASE_VERSION}"
-  git tag -a -s -m "[release] tag pmd_releases/${RELEASE_VERSION}" "pmd_releases/${RELEASE_VERSION}"
-  # test build
-  ./mvnw clean verify -Denforcer.skip=true
-  ./mvnw versions:set -DnewVersion="${DEVELOPMENT_VERSION}" -DgenerateBackupPoms=false
-  git commit -S -a -m "[release] prepare for next development iteration"
-  # push
-  git push origin
-  git push origin tag "pmd_releases/${RELEASE_VERSION}"
-else
-  ./mvnw -B release:clean release:prepare \
-      -Dtag="pmd_releases/${RELEASE_VERSION}" \
-      -DreleaseVersion="${RELEASE_VERSION}" \
-      -DdevelopmentVersion="${DEVELOPMENT_VERSION}" \
-      -DscmCommentPrefix="[release] " \
-      -Pgenerate-rule-docs
-fi
+./mvnw -B release:clean release:prepare \
+    -Dtag="pmd_releases/${RELEASE_VERSION}" \
+    -DreleaseVersion="${RELEASE_VERSION}" \
+    -DdevelopmentVersion="${DEVELOPMENT_VERSION}" \
+    -Pgenerate-rule-docs
+
 
 echo
 echo "Tag has been pushed.... now check github actions: <https://github.com/pmd/pmd/actions>"


### PR DESCRIPTION
## Describe the PR

This contains a fix and small improvement:

- The release of 7.0.0-rc1 failed on github actions (https://github.com/pmd/pmd/actions/runs/4519047623), as we have a snapshot dependency to pmd-designer:
  ```
  Error:  Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.2.1:enforce (enforce-no-snapshots) on project pmd-cli: 
  Error:  Rule 0: org.apache.maven.enforcer.rules.dependency.RequireReleaseDeps failed with message:
  Error:  No Snapshots Allowed!
  Error:  net.sourceforge.pmd:pmd-cli:jar:7.0.0-rc1
  Error:     net.sourceforge.pmd:pmd-ui:jar:7.0.0-SNAPSHOT <--- is not a release dependency
  Error:  -> [Help 1]
  ```
 The enforcer plugin will verify, that we don't reference snapshot dependencies for release versions. This change will disable the enforcer plugin for release candidates, like I have done already in the do-release.sh script (01617c4c7b0b77d11804a0e14681f598381ff9f5).

- This change will skip the unit test execution for release builds. This should make the release process a bit faster. But it makes a big assumption: We run the tests on regular builds from the master branch (:heavy_check_mark:) and we won't release from a broken master branch... that's the risk
