### PR TITLE
[java] Fix #4449 AvoidAccessibilityAlteration: Correctly handle Lambda expressions in PrivilegedAction scenarios

### DIFF
--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -87,6 +87,8 @@ suppression methods (e.g. by using `@SuppressWarnings` annotation).
     [not(ancestor::ConstructorCall[1][pmd-java:typeIs('java.security.PrivilegedAction')]/AnonymousClassDeclaration)]
     (: exclude inner privileged action classes :)
     [not(ancestor::ClassOrInterfaceDeclaration[1][pmd-java:typeIs('java.security.PrivilegedAction')])]
+    (: exclude privileged action lambdas :)
+    [not(ancestor::LambdaExpression[pmd-java:typeIs('java.security.PrivilegedAction')])]
 ]]>
                 </value>
             </property>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidAccessibilityAlteration.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidAccessibilityAlteration.xml
@@ -184,4 +184,39 @@ public class Violation {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>setAccessible is ok in LambdaExpression</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+
+        import java.lang.reflect.Constructor;
+        import java.lang.reflect.Field;
+        import java.lang.reflect.Method;
+        import java.security.AccessController;
+        import java.security.PrivilegedAction;
+
+        public class Violation {
+
+            private void invalidSetAccessCalls() throws NoSuchMethodException, SecurityException {
+                Constructor<?> constructor = this.getClass().getDeclaredConstructor(String.class);
+                
+                // deliberate accessibility alteration
+                String privateField = AccessController.doPrivileged((PrivilegedAction<String>)() -> {
+                    try {
+                        Field field = Violation.class.getDeclaredField("aPrivateField");
+                        field.setAccessible(true);    //no violation
+                        return (String) field.get(null);
+                    } catch (ReflectiveOperationException | SecurityException e) {
+                        throw new RuntimeException(e);
+                    }
+                });
+            }
+        }
+
+        ]]></code>
+    </test-code>
+
+
+
 </test-data>


### PR DESCRIPTION
## Describe the PR
This PR addresses a false positive in the AvoidAccessibilityAlteration rule when using Lambda expressions with PMD 7.0. The update includes changes to the XPath rule to handle Lambda expressions correctly and avoid false positives.
<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes  #4449

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

