### PR TITLE
Disable maven-pmd-plugin option linkXRef

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -436,7 +436,7 @@
                         </execution>
                     </executions>
                     <configuration>
-                        <linkXRef>true</linkXRef>
+                        <linkXRef>false</linkXRef>
                         <minimumTokens>100</minimumTokens>
                         <targetJdk>1.${java.version}</targetJdk>
                         <rulesets>


### PR DESCRIPTION
We don't have the jxr plugin and also don't create reports. Disabling this option avoids the many warnings like `[WARNING] Unable to locate Source XRef to link to - DISABLED`.