### PR TITLE
Provide Software Bill of Materials (SBOM)

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -179,6 +179,11 @@ function pmd_ci_deploy_build_artifacts() {
     # Deploy to sourceforge files https://sourceforge.net/projects/pmd/files/pmd/
     pmd_ci_sourceforge_uploadFile "pmd/${PMD_CI_MAVEN_PROJECT_VERSION}" "pmd-dist/target/pmd-bin-${PMD_CI_MAVEN_PROJECT_VERSION}.zip"
     pmd_ci_sourceforge_uploadFile "pmd/${PMD_CI_MAVEN_PROJECT_VERSION}" "pmd-dist/target/pmd-src-${PMD_CI_MAVEN_PROJECT_VERSION}.zip"
+    # Deploy SBOM
+    cp pmd-dist/target/bom.xml  "pmd-dist/target/pmd-${PMD_CI_MAVEN_PROJECT_VERSION}-cyclonedx.xml"
+    cp pmd-dist/target/bom.json "pmd-dist/target/pmd-${PMD_CI_MAVEN_PROJECT_VERSION}-cyclonedx.json"
+    pmd_ci_sourceforge_uploadFile "pmd/${PMD_CI_MAVEN_PROJECT_VERSION}" "pmd-dist/target/pmd-${PMD_CI_MAVEN_PROJECT_VERSION}-cyclonedx.xml"
+    pmd_ci_sourceforge_uploadFile "pmd/${PMD_CI_MAVEN_PROJECT_VERSION}" "pmd-dist/target/pmd-${PMD_CI_MAVEN_PROJECT_VERSION}-cyclonedx.json"
 
     if pmd_ci_maven_isReleaseBuild; then
         # create a draft github release
@@ -188,6 +193,9 @@ function pmd_ci_deploy_build_artifacts() {
         # Deploy to github releases
         pmd_ci_gh_releases_uploadAsset "$GH_RELEASE" "pmd-dist/target/pmd-bin-${PMD_CI_MAVEN_PROJECT_VERSION}.zip"
         pmd_ci_gh_releases_uploadAsset "$GH_RELEASE" "pmd-dist/target/pmd-src-${PMD_CI_MAVEN_PROJECT_VERSION}.zip"
+        # Deploy SBOM
+        pmd_ci_gh_releases_uploadAsset "$GH_RELEASE" "pmd-dist/target/pmd-${PMD_CI_MAVEN_PROJECT_VERSION}-cyclonedx.xml"
+        pmd_ci_gh_releases_uploadAsset "$GH_RELEASE" "pmd-dist/target/pmd-${PMD_CI_MAVEN_PROJECT_VERSION}-cyclonedx.json"
     fi
 }
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -40,6 +40,8 @@ This section lists the most important changes from the last release candidate.
 The remaining section describe the complete release notes for 7.0.0.
 
 Fixed Issues:
+* miscellaneous
+  * [#4462](https://github.com/pmd/pmd/issues/4462): Provide Software Bill of Materials (SBOM)
 * java-codestyle
   * [#4273](https://github.com/pmd/pmd/issues/4273): \[java] CommentDefaultAccessModifier ignoredAnnotations should include "org.junit.jupiter.api.extension.RegisterExtension" by default
 * java-errorprone
@@ -208,6 +210,7 @@ See [Detailed Release Notes for PMD 7](pmd_release_notes_pmd7.html).
     * [#2497](https://github.com/pmd/pmd/issues/2497): PMD 7 Logo page
     * [#2498](https://github.com/pmd/pmd/issues/2498): Update PMD 7 Logo in documentation
     * [#3797](https://github.com/pmd/pmd/issues/3797): \[all] Use JUnit5
+    * [#4462](https://github.com/pmd/pmd/issues/4462): Provide Software Bill of Materials (SBOM)
 * ant
     * [#4080](https://github.com/pmd/pmd/issues/4080): \[ant] Split off Ant integration into a new submodule
 * core

--- a/pmd-dist/src/main/resources/assemblies/pmd-bin.xml
+++ b/pmd-dist/src/main/resources/assemblies/pmd-bin.xml
@@ -53,6 +53,19 @@
         </fileSet>
     </fileSets>
 
+    <files>
+        <file>
+            <source>target/bom.xml</source>
+            <outputDirectory>sbom</outputDirectory>
+            <destName>pmd-${project.version}-cyclonedx.xml</destName>
+        </file>
+        <file>
+            <source>target/bom.json</source>
+            <outputDirectory>sbom</outputDirectory>
+            <destName>pmd-${project.version}-cyclonedx.json</destName>
+        </file>
+    </files>
+
     <dependencySets>
         <!-- shell completion goes to shell/ -->
         <dependencySet>

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistributionIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/it/BinaryDistributionIT.java
@@ -87,6 +87,8 @@ class BinaryDistributionIT extends AbstractBinaryDistributionTest {
         result.add(basedir + "shell/pmd-completion.sh");
         result.add(basedir + "lib/pmd-core-" + PMDVersion.VERSION + ".jar");
         result.add(basedir + "lib/pmd-java-" + PMDVersion.VERSION + ".jar");
+        result.add(basedir + "sbom/pmd-" + PMDVersion.VERSION + "-cyclonedx.xml");
+        result.add(basedir + "sbom/pmd-" + PMDVersion.VERSION + "-cyclonedx.json");
         return result;
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -503,6 +503,11 @@
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>0.8.8</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.cyclonedx</groupId>
+                    <artifactId>cyclonedx-maven-plugin</artifactId>
+                    <version>2.7.6</version>
+                </plugin>
                 <!--This plugin's configuration is used to store Eclipse
                     m2e settings only. It has no influence on the Maven build itself. -->
                 <plugin>
@@ -623,6 +628,26 @@
                     <serverId>ossrh</serverId>
                     <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>makeAggregateBom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <!-- https://github.com/CycloneDX/cyclonedx-maven-plugin/issues/326 -->
+                <dependencies>
+                    <dependency>
+                        <groupId>org.ow2.asm</groupId>
+                        <artifactId>asm</artifactId>
+                        <version>9.5</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
## Describe the PR

- Add cyclonedx plugin to generate SBOM (Software Bill of Materials)
- The SBOM is attached and deployed into maven central
- The SBOM is also included in the binary distribution of PMD

See https://github.com/CycloneDX/cyclonedx-maven-plugin

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

