### PR TITLE
[core] Rules with the same regex properties should be equal

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
@@ -8,12 +8,10 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 
@@ -369,54 +367,22 @@ public abstract class AbstractRule extends AbstractPropertySource implements Rul
      */
     @Override
     public boolean equals(Object o) {
-        if (o == null) {
-            return false; // trivial
-        }
-
         if (this == o) {
             return true; // trivial
         }
-
-        boolean equality = getClass() == o.getClass();
-
-        if (equality) {
-            Rule that = (Rule) o;
-            equality = getName().equals(that.getName()) && getPriority().equals(that.getPriority());
-
-            if (equality) {
-                // Before calling equals on the properties, replace any Pattern with it pattern string
-                // This is only needed for RegexProperties.
-                Map<PropertyDescriptor<?>, Object> propertiesWithValues = new HashMap<>();
-                getPropertiesByPropertyDescriptor()
-                        .forEach((key, value) -> {
-                            Object newValue = value;
-                            if (newValue instanceof Pattern) {
-                                newValue = ((Pattern) newValue).pattern();
-                            }
-                            propertiesWithValues.put(key, newValue);
-                        });
-                Map<PropertyDescriptor<?>, Object> thatPropertiesWithValues = new HashMap<>();
-                that.getPropertiesByPropertyDescriptor()
-                        .forEach((key, value) -> {
-                            Object newValue = value;
-                            if (newValue instanceof Pattern) {
-                                newValue = ((Pattern) newValue).pattern();
-                            }
-                            thatPropertiesWithValues.put(key, newValue);
-                        });
-
-                equality = propertiesWithValues.equals(thatPropertiesWithValues);
-            }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
         }
 
-        return equality;
+        AbstractRule that = (AbstractRule) o;
+        return Objects.equals(getName(), that.getName())
+                && Objects.equals(getPriority(), that.getPriority())
+                && super.equals(o);
     }
 
     @Override
     public int hashCode() {
-        Object propertyValues = getPropertiesByPropertyDescriptor();
-        return getClass().getName().hashCode() + (getName() != null ? getName().hashCode() : 0)
-                + getPriority().hashCode() + (propertyValues != null ? propertyValues.hashCode() : 0);
+        return Objects.hash(getName(), getPriority(), super.hashCode());
     }
 
     @SuppressWarnings("unchecked")

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/AbstractPropertySource.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/AbstractPropertySource.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 
 /**
@@ -217,4 +218,41 @@ public abstract class AbstractPropertySource implements PropertySource {
         return descriptor.errorFor(getProperty(descriptor));
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        AbstractPropertySource that = (AbstractPropertySource) o;
+
+        if (!Objects.equals(propertyDescriptors, that.propertyDescriptors)) {
+            return false;
+        }
+
+        // Convert the values to strings for comparisons. This is needed at least for RegexProperties,
+        // as java.util.regex.Pattern doesn't implement equals().
+        Map<String, String> propertiesWithValues = new HashMap<>();
+        propertyDescriptors.forEach(propertyDescriptor -> {
+            Object value = propertyValuesByDescriptor.getOrDefault(propertyDescriptor, propertyDescriptor.defaultValue());
+            @SuppressWarnings({"unchecked", "rawtypes"})
+            String valueString = ((PropertyDescriptor) propertyDescriptor).asDelimitedString(value);
+            propertiesWithValues.put(propertyDescriptor.name(), valueString);
+        });
+        Map<String, String> thatPropertiesWithValues = new HashMap<>();
+        that.propertyDescriptors.forEach(propertyDescriptor -> {
+            Object value = that.propertyValuesByDescriptor.getOrDefault(propertyDescriptor, propertyDescriptor.defaultValue());
+            @SuppressWarnings({"unchecked", "rawtypes"})
+            String valueString = ((PropertyDescriptor) propertyDescriptor).asDelimitedString(value);
+            thatPropertiesWithValues.put(propertyDescriptor.name(), valueString);
+        });
+        return Objects.equals(propertiesWithValues, thatPropertiesWithValues);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(propertyDescriptors, propertyValuesByDescriptor);
+    }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/AbstractRuleTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/AbstractRuleTest.java
@@ -206,7 +206,7 @@ class AbstractRuleTest {
     }
 
     @Test
-    void twoRulesetsWithRulesUsingPatternPropertiesShouldBeEqual() {
+    void twoRulesUsingPatternPropertiesShouldBeEqual() {
         class MockRuleWithPatternProperty extends net.sourceforge.pmd.lang.rule.MockRule {
             MockRuleWithPatternProperty(String defaultValue) {
                 super();

--- a/pmd-core/src/test/java/net/sourceforge/pmd/AbstractRuleTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/AbstractRuleTest.java
@@ -204,6 +204,21 @@ class AbstractRuleTest {
     }
 
     @Test
+    void twoRulesetsWithRulesUsingPatternPropertiesShouldBeEqual() {
+        class MockRuleWithPatternProperty extends net.sourceforge.pmd.lang.rule.MockRule {
+            MockRuleWithPatternProperty() {
+                super();
+                definePropertyDescriptor(PropertyFactory.regexProperty("myRegexProperty")
+                        .desc("description")
+                        .defaultValue("abc")
+                        .build());
+            }
+        }
+
+        assertEquals(new MockRuleWithPatternProperty(), new MockRuleWithPatternProperty());
+    }
+
+    @Test
     void testDeepCopyRule() {
         MyRule r1 = new MyRule();
         MyRule r2 = (MyRule) r1.deepCopy();

--- a/pmd-core/src/test/java/net/sourceforge/pmd/AbstractRuleTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/AbstractRuleTest.java
@@ -8,6 +8,7 @@ import static net.sourceforge.pmd.ReportTestUtil.getReportForRuleApply;
 import static net.sourceforge.pmd.properties.constraints.NumericConstraints.inRange;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -15,6 +16,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.util.Collections;
+import java.util.regex.Pattern;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -206,16 +208,32 @@ class AbstractRuleTest {
     @Test
     void twoRulesetsWithRulesUsingPatternPropertiesShouldBeEqual() {
         class MockRuleWithPatternProperty extends net.sourceforge.pmd.lang.rule.MockRule {
-            MockRuleWithPatternProperty() {
+            MockRuleWithPatternProperty(String defaultValue) {
                 super();
                 definePropertyDescriptor(PropertyFactory.regexProperty("myRegexProperty")
                         .desc("description")
-                        .defaultValue("abc")
+                        .defaultValue(defaultValue)
                         .build());
             }
         }
 
-        assertEquals(new MockRuleWithPatternProperty(), new MockRuleWithPatternProperty());
+        assertEquals(new MockRuleWithPatternProperty("abc"), new MockRuleWithPatternProperty("abc"));
+        assertNotEquals(new MockRuleWithPatternProperty("abc"), new MockRuleWithPatternProperty("def"));
+
+        MockRuleWithPatternProperty rule1 = new MockRuleWithPatternProperty("abc");
+        PropertyDescriptor<Pattern> myRegexProperty1 = (PropertyDescriptor<Pattern>) rule1.getPropertyDescriptor("myRegexProperty");
+        rule1.setProperty(myRegexProperty1, Pattern.compile("ghi"));
+        MockRuleWithPatternProperty rule2 = new MockRuleWithPatternProperty("abc");
+        PropertyDescriptor<Pattern> myRegexProperty2 = (PropertyDescriptor<Pattern>) rule1.getPropertyDescriptor("myRegexProperty");
+        rule2.setProperty(myRegexProperty2, Pattern.compile("ghi"));
+        assertEquals(rule1, rule2);
+
+        rule2.setProperty(myRegexProperty2, Pattern.compile("jkl"));
+        assertNotEquals(rule1, rule2);
+
+        // the two rules have the same value, one using default, the other using an explicit value.
+        // they use effectively the same value, although the default values of the properties are different.
+        assertEquals(new MockRuleWithPatternProperty("jkl"), rule2);
     }
 
     @Test


### PR DESCRIPTION
## Describe the PR

Found this while upgrading PMD Eclipse Plugin to 7.0.0. In the plugin, we often verify that we have the same ruleset active by executing `RuleSet#equals()`. This doesn't work as soon as a rule uses `java.util.regex.Pattern` based properties. The reason is, that `Pattern` doesn't override `equals` - see also https://stackoverflow.com/questions/52103427/why-these-two-java-util-pattern-are-not-equal

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

