### PR TITLE
Bump pmd-designer from 7.0.0-SNAPSHOT to 7.0.0-rc1

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -39,6 +39,10 @@ for all.</p>
 This section lists the most important changes from the last release candidate.
 The remaining section describe the complete release notes for 7.0.0.
 
+**Updated PMD Designer**
+This PMD release ships a new version of the pmd-designer.
+For the changes, see [PMD Designer Changelog](https://github.com/pmd/pmd-designer/releases/tag/7.0.0-rc1).
+
 Fixed Issues:
 * java-codestyle
   * [#4273](https://github.com/pmd/pmd/issues/4273): \[java] CommentDefaultAccessModifier ignoredAnnotations should include "org.junit.jupiter.api.extension.RegisterExtension" by default
@@ -93,6 +97,11 @@ For more information, see the [Detailed Release Notes for PMD 7](pmd_release_not
 Contributors: [Lucas Soncini](https://github.com/lsoncini) (@lsoncini),
 [Matías Fraga](https://github.com/matifraga) (@matifraga),
 [Tomás De Lucca](https://github.com/tomidelucca) (@tomidelucca)
+
+#### Updated PMD Designer
+
+This PMD release ships a new version of the pmd-designer.
+For the changes, see [PMD Designer Changelog](https://github.com/pmd/pmd-designer/releases/tag/7.0.0-rc1).
 
 ### 🎉 Language Related Changes
 

--- a/docs/pages/release_notes_pmd7.md
+++ b/docs/pages/release_notes_pmd7.md
@@ -441,6 +441,11 @@ Contributors: [Lucas Soncini](https://github.com/lsoncini) (@lsoncini),
 [Matías Fraga](https://github.com/matifraga) (@matifraga),
 [Tomás De Lucca](https://github.com/tomidelucca) (@tomidelucca)
 
+### Updated PMD Designer
+
+This PMD release ships a new version of the pmd-designer.
+For the changes, see [PMD Designer Changelog](https://github.com/pmd/pmd-designer/releases/tag/7.0.0-rc1).
+
 ## 🎉 Language Related Changes
 
 ### New: Swift support

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
 
         <pmd.build-tools.version>21</pmd.build-tools.version>
 
-        <pmd-designer.version>7.0.0-SNAPSHOT</pmd-designer.version>
+        <pmd-designer.version>7.0.0-rc1</pmd-designer.version>
         <javacc.jar>${settings.localRepository}/net/java/dev/javacc/javacc/${javacc.version}/javacc-${javacc.version}.jar</javacc.jar>
         <javacc.outputDirectory>${project.build.directory}/generated-sources/javacc</javacc.outputDirectory>
         <javacc.ant.wrapper>${project.basedir}/../javacc-wrapper.xml</javacc.ant.wrapper>


### PR DESCRIPTION
## Describe the PR

- Updates pmd-designer to the stable version. See https://github.com/pmd/pmd-designer/releases/tag/7.0.0-rc1
- Fixes the issue, that PMD 7.0.0-rc1 is not reproducible according to procedure used here https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/net/sourceforge/pmd/README.md
The following error occurs when trying to rebuild 7.0.0-rc1:

```
[ERROR] Failed to execute goal on project pmd-cli: Could not resolve dependencies for project net.sourceforge.pmd:pmd-cli:jar:7.0.0-rc1: Could not find artifact net.sourceforge.pmd:pmd-ui:jar:7.0.0-SNAPSHOT in default (https://repo.maven.apache.org/maven2) -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal on project pmd-cli: Could not resolve dependencies for project net.sourceforge.pmd:pmd-cli:jar:7.0.0-rc1: Could not find artifact net.sourceforge.pmd:pmd-ui:jar:7.0.0-SNAPSHOT in default (https://repo.maven.apache.org/maven2)
```
## Ready?

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

