### PR TITLE
[cli] Replace hard dependency to pmd-designer

### DIFF
--- a/pmd-cli/pom.xml
+++ b/pmd-cli/pom.xml
@@ -90,13 +90,6 @@
             <scope>runtime</scope>
         </dependency>
 
-        <!-- Needed for Designer command -->
-        <dependency>
-            <groupId>net.sourceforge.pmd</groupId>
-            <artifactId>pmd-ui</artifactId>
-            <version>${pmd-designer.version}</version>
-        </dependency>
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/DesignerCommand.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/DesignerCommand.java
@@ -4,11 +4,30 @@
 
 package net.sourceforge.pmd.cli.commands.internal;
 
-import net.sourceforge.pmd.cli.internal.CliExitCode;
-import net.sourceforge.pmd.util.fxdesigner.DesignerStarter;
-import net.sourceforge.pmd.util.fxdesigner.DesignerStarter.ExitStatus;
-import net.sourceforge.pmd.util.fxdesigner.DesignerVersion;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URI;
+import java.net.URLConnection;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
+import net.sourceforge.pmd.cli.internal.CliExitCode;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.IVersionProvider;
 import picocli.CommandLine.Option;
@@ -25,9 +44,67 @@ public class DesignerCommand extends AbstractPmdSubcommand {
     @Override
     protected CliExitCode execute() {
         final String[] rawArgs = spec.commandLine().getParseResult().expandedArgs().toArray(new String[0]);
-        final ExitStatus status = DesignerStarter.launchGui(rawArgs);
 
-        return status == ExitStatus.OK ? CliExitCode.OK : CliExitCode.ERROR;
+        Path pmdDistDir = Paths.get(System.getenv("PMD_DIST_DIR"));
+        Path pmdLibDir = pmdDistDir.resolve("lib");
+        try (Stream<Path> files = Files.list(pmdLibDir)) {
+            List<Path> uiJars = files.filter(p -> p.getFileName().toString().startsWith("pmd-ui")).collect(Collectors.toList());
+            System.out.println("uiJars = " + uiJars);
+            if (uiJars.isEmpty()) {
+                downloadLatestPmdDesigner(pmdLibDir);
+            }
+            if (uiJars.size() > 1) {
+                throw new RuntimeException("Multiple pmd-ui jars detected");
+            }
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        try {
+            Class<?> designerStarter = DesignerCommand.class.getClassLoader().loadClass("net.sourceforge.pmd.util.fxdesigner.DesignerStarter");
+            Method launchGui = designerStarter.getDeclaredMethod("launchGui", String[].class);
+            Object result = launchGui.invoke(null, (Object) rawArgs);
+            Method getCode = result.getClass().getMethod("getCode");
+            int exitCode = (int) getCode.invoke(result);
+            return exitCode == 0 ? CliExitCode.OK : CliExitCode.ERROR;
+        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private void downloadLatestPmdDesigner(Path pmdLibDir) throws IOException {
+        URI latestPmdDesignerRelease = URI.create("https://api.github.com/repos/pmd/pmd-designer/releases/latest");
+        URLConnection urlConnection = latestPmdDesignerRelease.toURL().openConnection();
+        String downloadUrl = null;
+        String jarFileName = null;
+        try (InputStream inputStream = urlConnection.getInputStream()) {
+            JsonElement jsonElement = JsonParser.parseReader(new InputStreamReader(inputStream, StandardCharsets.UTF_8));
+            String tagName = jsonElement.getAsJsonObject().get("tag_name").getAsString();
+            System.out.println("tagName = " + tagName);
+            JsonArray assets = jsonElement.getAsJsonObject().get("assets").getAsJsonArray();
+            Map<String, String> assetUrls = new HashMap<>();
+            for (int i = 0; i < assets.size(); i++) {
+                String name = assets.get(i).getAsJsonObject().get("name").getAsString();
+                String url = assets.get(i).getAsJsonObject().get("browser_download_url").getAsString();
+                assetUrls.put(name, url);
+            }
+            System.out.println("assetUrls = " + assetUrls);
+
+            jarFileName = "pmd-ui-" + tagName + ".jar";
+            downloadUrl = assetUrls.get(jarFileName);
+        }
+
+        URLConnection urlConnection1 = URI.create(downloadUrl).toURL().openConnection();
+        Path target = pmdLibDir.resolve(jarFileName);
+        try (BufferedInputStream in = new BufferedInputStream(urlConnection1.getInputStream());
+             OutputStream out = Files.newOutputStream(target)) {
+            byte[] buffer = new byte[8192];
+            int read;
+            while ((read = in.read(buffer)) >= 0) {
+                out.write(buffer, 0, read);
+            }
+        }
+        System.out.println("Downloaded to " + target);
     }
 }
 
@@ -35,7 +112,9 @@ class DesignerVersionProvider implements IVersionProvider {
 
     @Override
     public String[] getVersion() throws Exception {
-        return new String[] { "PMD Rule Designer " + DesignerVersion.getCurrentVersion() };
+        Class<?> designerVersion = DesignerCommand.class.getClassLoader().loadClass("net.sourceforge.pmd.util.fxdesigner.DesignerVersion");
+        String currentVersion = (String) designerVersion.getDeclaredMethod("getCurrentVersion").invoke(null);
+        return new String[] { "PMD Rule Designer " + currentVersion };
     }
     
 }

--- a/pmd-dist/pom.xml
+++ b/pmd-dist/pom.xml
@@ -149,11 +149,6 @@
         </dependency>
         <dependency>
             <groupId>net.sourceforge.pmd</groupId>
-            <artifactId>pmd-ui</artifactId>
-            <version>${pmd-designer.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>net.sourceforge.pmd</groupId>
             <artifactId>pmd-languages-deps</artifactId>
             <version>${project.version}</version>
             <type>pom</type>

--- a/pmd-dist/src/main/resources/scripts/pmd
+++ b/pmd-dist/src/main/resources/scripts/pmd
@@ -45,9 +45,8 @@ java_heapsize_settings() {
     esac
 }
 
-
-set_lib_dir() {
-  if [ -z "${LIB_DIR}" ]; then
+set_pmd_dist_dir() {
+  if [ -z "${PMD_DIST_DIR}" ]; then
     # Allow for symlinks to this script
     if [ -L "$0" ]; then
       local script_real_loc=$(readlink "$0")
@@ -56,10 +55,14 @@ set_lib_dir() {
     fi
     local script_dir=$(dirname "${script_real_loc}")
 
-    pushd "${script_dir}/../lib" >/dev/null
-    readonly LIB_DIR=$(pwd -P)
+    pushd "${script_dir}/.." >/dev/null
+    readonly PMD_DIST_DIR=$(pwd -P)
     popd >/dev/null
   fi
+}
+
+set_lib_dir() {
+  readonly LIB_DIR="${PMD_DIST_DIR}/lib"
 }
 
 check_lib_dir() {
@@ -69,19 +72,7 @@ check_lib_dir() {
 }
 
 set_conf_dir() {
-  if [ -z ${CONF_DIR} ]; then
-    # Allow for symlinks to this script
-    if [ -L $0 ]; then
-      local script_real_loc=$(readlink "$0")
-    else
-      local script_real_loc=$0
-    fi
-    local script_dir=$(dirname "${script_real_loc}")
-
-    pushd "${script_dir}/../conf" >/dev/null
-    readonly CONF_DIR=$(pwd -P)
-    popd >/dev/null
-  fi
+  readonly CONF_DIR="${PMD_DIST_DIR}/conf"
 }
 
 check_conf_dir() {
@@ -183,6 +174,7 @@ readonly APPNAME="${1}"
 
 is_cygwin
 
+set_pmd_dist_dir
 set_lib_dir
 check_lib_dir
 set_conf_dir
@@ -200,4 +192,5 @@ cygwin_paths
 
 java_heapsize_settings
 
+export PMD_DIST_DIR
 java ${HEAPSIZE} ${PMD_JAVA_OPTS} $(jre_specific_vm_options) -cp "${classpath}" net.sourceforge.pmd.cli.PmdCli "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,6 @@
 
         <pmd.build-tools.version>21</pmd.build-tools.version>
 
-        <pmd-designer.version>7.0.0-SNAPSHOT</pmd-designer.version>
         <javacc.jar>${settings.localRepository}/net/java/dev/javacc/javacc/${javacc.version}/javacc-${javacc.version}.jar</javacc.jar>
         <javacc.outputDirectory>${project.build.directory}/generated-sources/javacc</javacc.outputDirectory>
         <javacc.ant.wrapper>${project.basedir}/../javacc-wrapper.xml</javacc.ant.wrapper>


### PR DESCRIPTION
## Describe the PR

- this is right now just a prototype. Will need to be cleaned up, but it is workable.
- uses reflection to call DesignerStarter - that way, we can remove the build dependency to pmd-designer
- remove the pmd-designer dependency also from pmd-dist. We don't include the pmd-ui jar anymore.
- When starting the designer, first check, if there is jar file for pmd-ui present. If not, try to download the latest release from github releases

Note:
- pmd.bat needs to be adjusted as well to expose the PMD_DIST_DIR environment variable
- After downloading the jar, the designer still can't be found: It's not possible to inject a new jar into the classpath of a running process. Maybe we can fiddle with the classloader here, but easiest solution would be to just tell the user, that the download was ok and "pmd designer" needs to be run again.
- we could provide a flag "--force-download" or "--re-download" or "--update", in order to check whether there is a new pmd-designer available.
- we could use a specific version instead of latest when trying to find the pmd-designer release on github


## Related issues

- Refs #4446 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

