### PR TITLE
[java] Fix #4477: A false-positive about SignatureDeclareThrowsException

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
@@ -79,6 +79,8 @@ public final class TestFrameworksUtil {
                 || method.isAnnotationPresent("org.junit.BeforeClass")
                 || method.isAnnotationPresent("org.junit.After")
                 || method.isAnnotationPresent("org.junit.AfterClass")
+                || method.isAnnotationPresent("org.testng.annotations.AfterClass")
+                || method.isAnnotationPresent("org.testng.annotations.BeforeClass")
                 || isJUnit3Class(method.getEnclosingType())
                         && ("setUp".equals(method.getName())
                             || "tearDown".equals(method.getName()));

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
@@ -45,6 +45,18 @@ public final class TestFrameworksUtil {
                                                                "org.testng.Assert",
                                                                "junit.framework.Assert",
                                                                "junit.framework.TestCase");
+    private static final Set<String> TEST_CONFIGURATION_ANNOTATIONS =
+        setOf("org.testng.annotations.AfterClass",
+                "org.testng.annotations.AfterGroups",
+                "org.testng.annotations.AfterMethod",
+                "org.testng.annotations.AfterSuite",
+                "org.testng.annotations.AfterTest",
+                "org.testng.annotations.BeforeClass",
+                "org.testng.annotations.BeforeGroups",
+                "org.testng.annotations.BeforeMethod",
+                "org.testng.annotations.BeforeSuite",
+                "org.testng.annotations.BeforeTest"
+        );
 
     private TestFrameworksUtil() {
         // utility class
@@ -79,8 +91,7 @@ public final class TestFrameworksUtil {
                 || method.isAnnotationPresent("org.junit.BeforeClass")
                 || method.isAnnotationPresent("org.junit.After")
                 || method.isAnnotationPresent("org.junit.AfterClass")
-                || method.isAnnotationPresent("org.testng.annotations.AfterClass")
-                || method.isAnnotationPresent("org.testng.annotations.BeforeClass")
+                || TEST_CONFIGURATION_ANNOTATIONS.stream().anyMatch(method::isAnnotationPresent)
                 || isJUnit3Class(method.getEnclosingType())
                         && ("setUp".equals(method.getName())
                             || "tearDown".equals(method.getName()));

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/SignatureDeclareThrowsException.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/SignatureDeclareThrowsException.xml
@@ -259,4 +259,16 @@ public final class Namespace {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#4477:[java] SignatureDeclareThrowsException: false-positive with TestNG annotations</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import net.sourceforge.pmd.lang.java.rule.design.signaturedeclarethrowsexception.MyTestCase;
+public class Foo extends MyTestCase {
+    @org.testng.annotations.AfterClass
+    void setUp() throws Exception {}
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
This PR excludes `org.testng.annotations.AfterClass` and `org.testng.annotations.BeforeClass` which cause FP when using in a unit test method and throwing an exception is allowed.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #4477 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

