### PR TITLE
[java] ImmutableField: Remove deprecated property "ignoredAnnotations"

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -50,6 +50,10 @@ The remaining section describe the complete release notes for 7.0.0.
   in order to have the same meaning as in 6.55.0. That will make it easier if you upgrade from 6.55.0 to 7.0.0.
   However, that means, that you need to change these method calls if you have migrated to 7.0.0-rc1 already.
 
+#### Rule Changes
+* {% rule "java/design/ImmutableField" %}: the property `ignoredAnnotations` has been removed. The property was
+  deprecated since PMD 6.52.0.
+
 #### Fixed Issues
 * core
   * [#2500](https://github.com/pmd/pmd/issues/2500): \[core] Clarify API for ANTLR based languages
@@ -200,6 +204,8 @@ Contributors: [Lucas Soncini](https://github.com/lsoncini) (@lsoncini),
 * {% rule "java/documentation/CommentContent" %}: The properties `caseSensitive` and `disallowedTerms` are removed. The
   new property `fobiddenRegex` can be used now to define the disallowed terms with a single regular
   expression.
+* {% rule "java/design/ImmutableField" %}: the property `ignoredAnnotations` has been removed. The property was
+  deprecated since PMD 6.52.0.
 
 #### Removed Rules
 

--- a/docs/pages/release_notes_pmd7.md
+++ b/docs/pages/release_notes_pmd7.md
@@ -550,6 +550,8 @@ Related issue: [[core] Explicitly name all language versions (#4120)](https://gi
 * {% rule "java/documentation/CommentContent" %}: The properties `caseSensitive` and `disallowedTerms` are removed. The
   new property `fobiddenRegex` can be used now to define the disallowed terms with a single regular
   expression.
+* {% rule "java/design/ImmutableField" %}: the property `ignoredAnnotations` has been removed. The property was
+  deprecated since PMD 6.52.0.
 
 ### Deprecated Rules
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ImmutableFieldRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ImmutableFieldRule.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.lang.java.rule.design;
 
 import static net.sourceforge.pmd.util.CollectionUtil.setOf;
 
-import java.util.List;
 import java.util.Set;
 
 import net.sourceforge.pmd.lang.ast.NodeStream;
@@ -25,14 +24,9 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.rule.internal.DataflowPass;
 import net.sourceforge.pmd.lang.java.rule.internal.DataflowPass.AssignmentEntry;
 import net.sourceforge.pmd.lang.java.rule.internal.DataflowPass.DataflowResult;
-import net.sourceforge.pmd.lang.java.rule.internal.JavaPropertyUtil;
-import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.util.CollectionUtil;
 
 public class ImmutableFieldRule extends AbstractJavaRulechainRule {
-
-    private static final PropertyDescriptor<List<String>> IGNORED_ANNOTS =
-        JavaPropertyUtil.ignoredAnnotationsDescriptor();
 
     private static final Set<String> INVALIDATING_CLASS_ANNOT =
         setOf(
@@ -51,7 +45,6 @@ public class ImmutableFieldRule extends AbstractJavaRulechainRule {
 
     public ImmutableFieldRule() {
         super(ASTFieldDeclaration.class);
-        definePropertyDescriptor(IGNORED_ANNOTS);
     }
 
 
@@ -61,8 +54,7 @@ public class ImmutableFieldRule extends AbstractJavaRulechainRule {
         if (field.getEffectiveVisibility().isAtMost(Visibility.V_PRIVATE)
             && !field.getModifiers().hasAny(JModifier.VOLATILE, JModifier.STATIC, JModifier.FINAL)
             && !JavaAstUtils.hasAnyAnnotation(enclosingType, INVALIDATING_CLASS_ANNOT)
-            && !JavaAstUtils.hasAnyAnnotation(field, INVALIDATING_FIELD_ANNOT)
-            && !JavaAstUtils.hasAnyAnnotation(field, getProperty(IGNORED_ANNOTS))) {
+            && !JavaAstUtils.hasAnyAnnotation(field, INVALIDATING_FIELD_ANNOT)) {
 
             DataflowResult dataflow = DataflowPass.getDataflowResult(field.getRoot());
 
@@ -89,9 +81,9 @@ public class ImmutableFieldRule extends AbstractJavaRulechainRule {
 
                 if (!hasWrite && !isBlank) {
                     //todo this case may also handle static fields easily.
-                    addViolation(data, varId, varId.getName());
+                    asCtx(data).addViolation(varId, varId.getName());
                 } else if (hasWrite && defaultValueDoesNotReachEndOfCtor(dataflow, varId)) {
-                    addViolation(data, varId, varId.getName());
+                    asCtx(data).addViolation(varId, varId.getName());
                 }
             }
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ImmutableField.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ImmutableField.xml
@@ -497,23 +497,6 @@ class Foo {
     </test-code>
 
     <test-code>
-        <description>#1056 [java] Property ignoredAnnotations does not work for SingularField and ImmutableField</description>
-        <rule-property name="ignoredAnnotations">java.lang.Deprecated</rule-property>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-public class Foo {
-    @Deprecated
-    @SuppressWarnings("PMD.ImmutableField")
-    private int x;
-
-    public Foo() {
-        x = 2;
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
         <description>#1792 Immutable field should still be detected with @Delegate</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[


### PR DESCRIPTION
## Describe the PR

As figured out in #4474, the property `ignoredAnnotations` is unfortunately not deprecated anymore in 7.0.0-rc1. So that we don't forget to remove this property - because it is indeed deprecated since 6.52.0 - let's just remove it immediately.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

