### PR TITLE
[java] ImmutableField - remove @Getter

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -60,6 +60,7 @@ The remaining section describe the complete release notes for 7.0.0.
   * [#4273](https://github.com/pmd/pmd/issues/4273): \[java] CommentDefaultAccessModifier ignoredAnnotations should include "org.junit.jupiter.api.extension.RegisterExtension" by default
 * java-design
   * [#4254](https://github.com/pmd/pmd/issues/4254): \[java] ImmutableField - false positive with Lombok @<!-- -->Setter
+  * [#4490](https://github.com/pmd/pmd/issues/4490): \[java] ImmutableField - false negative with Lombok @<!-- -->Getter
 * java-errorprone
   * [#4449](https://github.com/pmd/pmd/issues/4449): \[java] AvoidAccessibilityAlteration: Possible false positive in AvoidAccessibilityAlteration rule when using Lambda expression
 * java-multithreading
@@ -379,6 +380,7 @@ Language specific fixes:
     * [#3786](https://github.com/pmd/pmd/issues/3786): \[java] SimplifyBooleanReturns should consider operator precedence
     * [#4238](https://github.com/pmd/pmd/pull/4238):   \[java] Make LawOfDemeter not use the rulechain
     * [#4254](https://github.com/pmd/pmd/issues/4254): \[java] ImmutableField - false positive with Lombok @<!-- -->Setter
+    * [#4490](https://github.com/pmd/pmd/issues/4490): \[java] ImmutableField - false negative with Lombok @<!-- -->Getter
 * java-documentation
     * [#4369](https://github.com/pmd/pmd/pull/4369):   \[java] Improve CommentSize
     * [#4416](https://github.com/pmd/pmd/pull/4416):   \[java] Fix reported line number in CommentContentRule

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ImmutableFieldRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ImmutableFieldRule.java
@@ -38,14 +38,12 @@ public class ImmutableFieldRule extends AbstractJavaRulechainRule {
         setOf(
             "lombok.Builder",
             "lombok.Data",
-            "lombok.Getter",
             "lombok.Setter",
             "lombok.Value"
         );
 
     private static final Set<String> INVALIDATING_FIELD_ANNOT =
         setOf(
-            "lombok.Getter",
             "lombok.Setter"
         );
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ImmutableField.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/ImmutableField.xml
@@ -418,10 +418,8 @@ public class CombinersTest {
         <description>#410 [java] ImmutableField: False positive with lombok on class</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-import lombok.Getter;
 import lombok.Setter;
 
-@Getter
 @Setter
 public class Foo {
     private String id;
@@ -441,7 +439,6 @@ import lombok.Getter;
 import lombok.Setter;
 
 public class Foo {
-    @Getter
     @Setter
     private String id;
 
@@ -827,6 +824,25 @@ public class MyTable implements Serializable
    {
       return m_id;
    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#4490 False negative with Lombok @Getter only</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code><![CDATA[
+import lombok.Getter;
+import lombok.Setter;
+
+class Foo {
+    @Getter
+    private String name = "tada";
+
+    @Getter
+    @Setter
+    private String name2 = "tada";
 }
 ]]></code>
     </test-code>


### PR DESCRIPTION
## Describe the PR

This fixes a potential false negative when @Getter is used. See discussion on #4474:

> I think that a field (or class) being annotated with the `@Getter` annotation should not be a > reason to exempt from the ImmutableField rule. After all, it only generates a getter, meaning > the field can still be marked final.
>
> _Originally posted by @PimvanderLoos in https://github.com/pmd/pmd/issues/4474#issuecomment-1511014310_

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

