### PR TITLE
[dist] Fix pmd.bat script

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -52,6 +52,7 @@ The remaining section describe the complete release notes for 7.0.0.
 
 #### Fixed Issues
 * cli
+  * [#4482](https://github.com/pmd/pmd/issues/4482): \[cli] pmd.bat can only be executed once
   * [#4484](https://github.com/pmd/pmd/issues/4484): \[cli] ast-dump with no properties produce an NPE
 * core
   * [#2500](https://github.com/pmd/pmd/issues/2500): \[core] Clarify API for ANTLR based languages
@@ -277,6 +278,7 @@ See [Detailed Release Notes for PMD 7]({{ baseurl }}pmd_release_notes_pmd7.html)
     * [#2234](https://github.com/pmd/pmd/issues/2234): \[core] Consolidate PMD CLI into a single command
     * [#3828](https://github.com/pmd/pmd/issues/3828): \[core] Progress reporting
     * [#4079](https://github.com/pmd/pmd/issues/4079): \[cli] Split off CLI implementation into a pmd-cli submodule
+    * [#4482](https://github.com/pmd/pmd/issues/4482): \[cli] pmd.bat can only be executed once
     * [#4484](https://github.com/pmd/pmd/issues/4484): \[cli] ast-dump with no properties produce an NPE
 * doc
     * [#2501](https://github.com/pmd/pmd/issues/2501): \[doc] Verify ANTLR Documentation

--- a/pmd-dist/src/main/resources/scripts/pmd
+++ b/pmd-dist/src/main/resources/scripts/pmd
@@ -95,6 +95,13 @@ function script_exit() {
     exit 1
 }
 
+function check_java() {
+  java -version >/dev/null 2>&1
+  if [ $? -ne 0 ]; then
+    script_exit "No java executable found in PATH"
+  fi
+}
+
 determine_java_version() {
     local full_ver=$(java -version 2>&1)
     # java_ver is eg "80" for java 1.8, "90" for java 9.0, "100" for java 10.0.x
@@ -182,6 +189,8 @@ function add_openjfx_classpath() {
 readonly APPNAME="${1}"
 
 is_cygwin
+
+check_java
 
 set_lib_dir
 check_lib_dir

--- a/pmd-dist/src/main/resources/scripts/pmd.bat
+++ b/pmd-dist/src/main/resources/scripts/pmd.bat
@@ -1,19 +1,26 @@
 @echo off
+rem make all variables local to not add new global environment variables to the current cmd session
+setlocal
 set TOPDIR="%~dp0.."
 set OPTS=
 set COMMAND=%1
 set MAIN_CLASS=net.sourceforge.pmd.cli.PmdCli
 
+rem check whether java is available at all
+java -version > nul 2>&1 || (
+    echo No java executable found in PATH
+    exit /b 1
+)
 
-:: sets the jver variable to the java version, eg 90 for 9.0.1+x or 80 for 1.8.0_171-b11 or 110 for 11.0.6.1
-:: sets the jvendor variable to either java (oracle) or openjdk
+rem sets the jver variable to the java version, eg 90 for 9.0.1+x or 80 for 1.8.0_171-b11 or 110 for 11.0.6.1
+rem sets the jvendor variable to either java (oracle) or openjdk
 for /f tokens^=1^,3^,4^,5^ delims^=.-_+^"^  %%j in ('java -version 2^>^&1 ^| findstr /c:"version"') do (
   set jvendor=%%j
   if %%l EQU ea (
     set /A "jver=%%k0"
   ) else (
     if %%k EQU 1 (
-      :: for java version 1.7.x, 1.8.x, ignore the first 1.
+      rem for java version 1.7.x, 1.8.x, ignore the first 1.
       set /A "jver=%%l%%m"
     ) else (
       set /A "jver=%%k%%l"
@@ -22,11 +29,11 @@ for /f tokens^=1^,3^,4^,5^ delims^=.-_+^"^  %%j in ('java -version 2^>^&1 ^| fin
 )
 
 Set "jreopts="
-:: oracle java 9 and 10 has javafx included as a module
+rem oracle java 9 and 10 has javafx included as a module
 if /I %jvendor% == java (
     if %jver% GEQ 90 (
         if %jver% LSS 110 (
-            :: enable reflection
+            rem enable reflection
             SETLOCAL EnableDelayedExpansion
             rem java9 and java10 from oracle contain javafx as a module
             rem open internal module of javafx to reflection (for our TreeViewWrapper)
@@ -38,7 +45,6 @@ if /I %jvendor% == java (
             set "jreopts=!jreopts! --add-opens javafx.graphics/com.sun.javafx.geom=ALL-UNNAMED"
             rem Warn of remaining illegal accesses
             set "jreopts=!jreopts! --illegal-access=warn"
-
         )
     )
 )
@@ -53,25 +59,21 @@ if [%COMMAND%] == [designer] (
 if %_needjfxlib% EQU 1 (
     if %jver% LSS 100 (
         echo For openjfx at least java 10 is required.
-        pause
-        exit
+        exit /b 1
     )
-    if [%JAVAFX_HOME%] EQU [] (
+    if not defined JAVAFX_HOME (
         echo The environment variable JAVAFX_HOME is missing.
-        pause
-        exit
+        exit /b 1
     )
-    :: The wildcard will include only jar files, but we need to access also
-    :: property files such as javafx.properties that lay bare in the dir
+    rem The wildcard will include only jar files, but we need to access also
+    rem property files such as javafx.properties that lay bare in the dir
     set pmd_classpath=%TOPDIR%\conf;%TOPDIR%\lib\*;%JAVAFX_HOME%\lib\*;%JAVAFX_HOME%\lib\
 ) else (
     set pmd_classpath=%TOPDIR%\conf;%TOPDIR%\lib\*
 )
 
-if [%CLASSPATH%] NEQ [] (
-    set classpath=%CLASSPATH%;%pmd_classpath%
-) else (
-    set classpath=%pmd_classpath%
+if defined CLASSPATH (
+    set pmd_classpath=%CLASSPATH%;%pmd_classpath%
 )
 
 java %PMD_JAVA_OPTS% %jreopts% -classpath %pmd_classpath% %OPTS% %MAIN_CLASS% %*

--- a/pmd-dist/src/test/resources/scripts/pmdtest.bat
+++ b/pmd-dist/src/test/resources/scripts/pmdtest.bat
@@ -1,27 +1,27 @@
 @echo off
 
-:: BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+rem BSD-style license; for more info see http://pmd.sourceforge.net/license.html
 
-::
-:: Simple manual test script
-:: - code is copied from designer.bat to be tested here (so please check, it might be out of sync)
-:: - mostly the function "determine_java_version" is tested here
-:: - just run it with "designertest.bat" and look at the output
-:: - test cases are at the end of this script
-::
+rem
+rem Simple manual test script
+rem - code is copied from designer.bat to be tested here (so please check, it might be out of sync)
+rem - mostly the function "determine_java_version" is tested here
+rem - just run it with "designertest.bat" and look at the output
+rem - test cases are at the end of this script
+rem
 
 GOTO :main
 
 :determine_java_version
-:: sets the jver variable to the java version, eg 90 for 9.0.1+x or 80 for 1.8.0_171-b11 or 110 for 11.0.6.1
-:: sets the jvendor variable to either java (oracle) or openjdk
+rem sets the jver variable to the java version, eg 90 for 9.0.1+x or 80 for 1.8.0_171-b11 or 110 for 11.0.6.1
+rem sets the jvendor variable to either java (oracle) or openjdk
 for /f tokens^=1^,3^,4^,5^ delims^=.-_+^"^  %%j in (%full_version%) do (
   set jvendor=%%j
   if %%l EQU ea (
     set /A "jver=%%k0"
   ) else (
     if %%k EQU 1 (
-      :: for java version 1.7.x, 1.8.x, ignore the first 1.
+      rem for java version 1.7.x, 1.8.x, ignore the first 1.
       set /A "jver=%%l%%m"
     ) else (
       set /A "jver=%%k%%l"
@@ -67,6 +67,24 @@ if [%detection%] == [] (
 EXIT /B
 
 
+:check_for_java_command
+set cmd=%1
+echo cmd=%1
+%cmd% -version > nul 2>&1 || (
+    echo No java executable not found in PATH
+    EXIT /B 1
+)
+EXIT /B 0
+
+:check_classpath_extension
+setlocal
+set cp=%1
+echo testing cp=%1
+if defined cp (
+    echo classpath is not empty
+)
+endlocal
+EXIT /B
 
 :run_test
 set full_version=%1
@@ -85,6 +103,16 @@ echo.
 EXIT /B
 
 :main
+
+CALL :check_for_java_command javanotfound
+echo errorlevel: %ERRORLEVEL%
+
+CALL :check_classpath_extension
+CALL :check_classpath_extension a\b.jar
+CALL :check_classpath_extension "a\b.jar;c\d.jar"
+CALL :check_classpath_extension "a\b.jar"
+CALL :check_classpath_extension "a"\b.jar
+CALL :check_classpath_extension "a"\b.jar;"c"\d.jar
 
 CALL :run_test "java version ""1.7.0_80"""                java      70    "detected java 7"
 CALL :run_test "openjdk version ""1.7.0_352"""            openjdk   70    "detected java 7"

--- a/pmd-dist/src/test/resources/scripts/pmdtest.bat
+++ b/pmd-dist/src/test/resources/scripts/pmdtest.bat
@@ -4,9 +4,9 @@ rem BSD-style license; for more info see http://pmd.sourceforge.net/license.html
 
 rem
 rem Simple manual test script
-rem - code is copied from designer.bat to be tested here (so please check, it might be out of sync)
+rem - code is copied from pmd.bat to be tested here (so please check, it might be out of sync)
 rem - mostly the function "determine_java_version" is tested here
-rem - just run it with "designertest.bat" and look at the output
+rem - just run it with "pmd.bat" and look at the output
 rem - test cases are at the end of this script
 rem
 


### PR DESCRIPTION
## Describe the PR

- having quotes or spaces in path names separated by ";" (such as CLASSPATH) is tricky. Checking whether there is a value if `if [%CLASSPATH%]` requires quotes, e.g. `if ["%CLASSPATH%"]...`, as otherwise the ";" is executed, which is a delimiter and end the if statement in the middle. But having surrounding quotes now creates a problem, if the CLASSPATH itself starts with a quote... because double quotes (`""`) escapes the quote and then you have one quote character less and a syntax error...
  - but it's easier to just check for the existence of the variable with `if defined CLASSPATH`
- added `setlocal` to avoid creating any environment variables
- using `rem` for comments now everywhere. The double colon theoretically only works at the very start of the line and not in the middle (after indentation)
- added a check whether java exists. This needs to actually call java to determine, whether it is found in the path. [WHERE](https://ss64.com/nt/where.html) didn't work for me, as my PATH has quotes in it (it is `set PATH="C:\Users\andreas\openjdk\jdk-11.0.13+8"\bin;%PATH%`).
- remove the "pause" commands. End the script with "exit /b 1" instead: this just ends the batch script and not cmd.exe and also sets the error code to 1

## Related issues

- Fixes #4482

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

