### PR TITLE
[java] Fix #4487: A false-positive about UnnecessaryConstructor and @Inject and @Autowired

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryConstructorRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryConstructorRule.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.lang.java.rule.codestyle;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryConstructorRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryConstructorRule.java
@@ -36,7 +36,8 @@ public class UnnecessaryConstructorRule extends AbstractIgnoredAnnotationRule {
     @Override
     protected Collection<String> defaultSuppressionAnnotations() {
         return Arrays.asList("javax.inject.Inject",
-                "com.google.inject.Inject");
+                "com.google.inject.Inject",
+                "org.springframework.beans.factory.annotation.Autowired");
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryConstructorRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryConstructorRule.java
@@ -4,6 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -35,7 +36,8 @@ public class UnnecessaryConstructorRule extends AbstractIgnoredAnnotationRule {
 
     @Override
     protected Collection<String> defaultSuppressionAnnotations() {
-        return Collections.singletonList("javax.inject.Inject");
+        return Arrays.asList("javax.inject.Inject",
+                "com.google.inject.Inject");
     }
 
     @Override

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryConstructor.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryConstructor.xml
@@ -218,11 +218,16 @@ public class Foo {
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 import com.google.inject.Inject;
+import org.springframework.beans.factory.annotation.Autowired;
 public class Foo {
     private Foo() {}
 }
 public class Bar extends Foo {
     @Inject
+    public Bar() {}
+}
+public class Bar extends Foo {
+    @Autowired
     public Bar() {}
 }
         ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryConstructor.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryConstructor.xml
@@ -212,4 +212,19 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Issue #4487: [java]A false-positive about UnnecessaryConstructor and @Inject</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import com.google.inject.Inject;
+public class Foo {
+    private Foo() {}
+}
+public class Bar extends Foo {
+    @Inject
+    public Bar() {}
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
This PR excludes `com.google.inject.Inject` and `org.springframework.beans.factory.annotation.Autowired`  which cause FP.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #4487 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

