### PR TITLE
[java] Fix #4493: false-positive about MissingStaticMethodInNonInstantiatableClass and @Inject

### DIFF
--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2349,7 +2349,7 @@ See the property `annotations`.
         </description>
         <priority>3</priority>
         <properties>
-            <property name="annotations" type="List[String]" delimiter="," value="org.springframework.beans.factory.annotation.Autowired,javax.inject.Inject" description="If a constructor is annotated with one of these annotations, then the class is ignored."/>
+            <property name="annotations" type="List[String]" delimiter="," value="org.springframework.beans.factory.annotation.Autowired,javax.inject.Inject,com.google.inject.Inject" description="If a constructor is annotated with one of these annotations, then the class is ignored."/>
             <property name="xpath">
                 <value>
 <![CDATA[

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/MissingStaticMethodInNonInstantiatableClass.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/MissingStaticMethodInNonInstantiatableClass.xml
@@ -576,4 +576,21 @@ public final class TestPrivateClassWithFactory implements GenericTest {
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#4493:[java]false-positive about MissingStaticMethodInNonInstantiatableClass and @Inject </description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import com.google.inject.Inject;
+public class Foo {  
+   @Inject
+   private Foo() {}
+}
+
+public class Bar extends Foo {
+   public Bar() {}
+}
+]]></code>
+    </test-code>
+
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
This PR excludes `com.google.inject.Inject` which cause FP.
## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #4493

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

