### PR TITLE
[apex] Fix NcssMethodCount message

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/NcssMethodCountRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/NcssMethodCountRule.java
@@ -29,4 +29,9 @@ public class NcssMethodCountRule extends AbstractNcssCountRule<ASTMethod> {
     protected boolean isIgnored(ASTMethod node) {
         return node.isConstructor();
     }
+
+    @Override
+    protected Object[] getViolationParameters(ASTMethod node, int metric) {
+        return new Object[]{ node.getImage(), metric };
+    }
 }

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/xml/NcssMethodCount.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/xml/NcssMethodCount.xml
@@ -70,6 +70,9 @@ public class Foo {
         <description>long method</description>
         <rule-property name="minimum">13</rule-property>
         <expected-problems>1</expected-problems>
+        <expected-messages>
+            <message>The method 'foo()' has an NCSS line count of 13</message>
+        </expected-messages>
         <code-ref id="long-method"/>
     </test-code>
 


### PR DESCRIPTION
## Describe the PR

* Small bugfix: The reported message of rule [NcssMethodCount](https://docs.pmd-code.org/latest/pmd_rules_apex_design.html#ncssmethodcount) doesn't contain the correct information:

Wrong:
```
The method '68()' has an NCSS line count of {1}
```

Should be:
```
The method 'start()' has an NCSS line count of 68
```

## Related issues

- Found in https://chunk.io/pmd/9ba3a41020364534a828c66631585431/diff/Schedul-o-matic-9000/index.html#section-violations

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

