### PR TITLE
[doc] Fix typo: missing closing quotation mark after CPD-END

### DIFF
--- a/docs/pages/pmd/userdocs/cpd/cpd.md
+++ b/docs/pages/pmd/userdocs/cpd/cpd.md
@@ -457,7 +457,7 @@ public Object someParameterizedFactoryMethod(int x) throws Exception {
     // any code here will be ignored for the duplication detection
 }
 //disable suppression
-@SuppressWarnings("CPD-END)
+@SuppressWarnings("CPD-END")
 public void nextMethod() {
 }
 ```


### PR DESCRIPTION
## Describe the PR

Fixes a small typo: there was a missing quotation mark after `CPD-END` in the provided example.
