### PR TITLE
[java] Fix #4268: CommentDefaultAccessModifier - false positive with TestNG's @Test annotation 

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/CommentDefaultAccessModifierRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/CommentDefaultAccessModifierRule.java
@@ -61,7 +61,8 @@ public class CommentDefaultAccessModifierRule extends AbstractJavaRulechainRule 
             "org.junit.jupiter.api.BeforeEach",
             "org.junit.jupiter.api.BeforeAll",
             "org.junit.jupiter.api.AfterEach",
-            "org.junit.jupiter.api.AfterAll"
+            "org.junit.jupiter.api.AfterAll",
+            "org.testng.annotations.Test"
         );
 
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/CommentDefaultAccessModifier.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/CommentDefaultAccessModifier.xml
@@ -514,4 +514,18 @@ class Test { // missing
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description> [java] CommentDefaultAccessModifier - false positive with TestNG's @Test annotation #4268 </description>
+        <rule-property name="checkTopLevelTypes">true</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.testng.annotations.Test;
+public class C {
+    @Test
+    void foo() {
+        synchronized (this) {}
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
This PR excludes `org.testng.annotations.Test`.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #4268 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

