### PR TITLE
[java] Fix #4455: A false positive about FieldNamingConventions and UtilityClass

### DIFF
--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/FieldNamingConventions.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/FieldNamingConventions.xml
@@ -217,4 +217,20 @@ public class MyException {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description> [java]A false positive about FieldNamingConventions and UtilityClass #4455 </description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import lombok.experimental.UtilityClass;
+public  class Foo {
+    @UtilityClass
+    public class Test1 {
+        private final String FINAL_F = "final_field";  // report a warning
+    }
+    public class Test2 {
+        private static final String FINAL_F = "final_field";  // report no warning
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/FieldNamingConventions.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/FieldNamingConventions.xml
@@ -225,7 +225,7 @@ import lombok.experimental.UtilityClass;
 public  class Foo {
     @UtilityClass
     public class Test1 {
-        private final String FINAL_F = "final_field";  // report a warning
+        private final String FINAL_F = "final_field";  // should not report a warning
     }
     public class Test2 {
         private static final String FINAL_F = "final_field";  // report no warning


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
This PR adds an annotation whitelist to exclude `UtilityClass`.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #4455

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

