### PR TITLE
[java] Fix #4456: A false positive about FinalFieldCouldBeStatic and UtilityClass

### DIFF
--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -808,6 +808,7 @@ in each object at runtime.
 //FieldDeclaration
     [pmd-java:modifiers() = 'final']
     [not(pmd-java:modifiers() = 'static')]
+    [not(./ancestor::ClassOrInterfaceDeclaration[1][pmd-java:hasAnnotation('lombok.experimental.UtilityClass')])]
     [not(.//Annotation[pmd-java:typeIs('lombok.Builder.Default')])]
     /VariableDeclarator[*[pmd-java:nodeIs('Literal')]
          or VariableAccess[@Name = //FieldDeclaration[pmd-java:modifiers() = 'static']/VariableDeclarator/VariableDeclaratorId/@Name]

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/FinalFieldCouldBeStatic.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/FinalFieldCouldBeStatic.xml
@@ -265,4 +265,17 @@ class foo {
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description> [java]A false positive about FinalFieldCouldBeStatic and UtilityClass #4456 </description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import lombok.experimental.UtilityClass;
+@UtilityClass
+public class Test {
+    public final String BAR = "42";  //  report a warning
+}
+]]></code>
+    </test-code>
+
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
This PR excludes annotation `UtilityClass`

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #4456

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

