### PR TITLE
[java] Fix #4457: false negative about OverrideBothEqualsAndHashcode

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/JavaAstUtils.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/JavaAstUtils.java
@@ -676,6 +676,19 @@ public final class JavaAstUtils {
             && !node.isStatic();
     }
 
+    public static boolean isEqualsMethod(ASTMethodDeclaration node) {
+        return "equals".equals(node.getName())
+            && node.getArity() == 1
+            && node.getFormalParameters().get(0).getTypeMirror().isTop()
+            && !node.isStatic();
+    }
+
+    public static boolean isHashCodeMethod(ASTMethodDeclaration node) {
+        return "hashCode".equals(node.getName())
+            && node.getArity() == 0
+            && !node.isStatic();
+    }
+
     public static boolean isArrayLengthFieldAccess(ASTExpression node) {
         if (node instanceof ASTFieldAccess) {
             ASTFieldAccess field = (ASTFieldAccess) node;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/OverrideBothEqualsAndHashcodeRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/OverrideBothEqualsAndHashcodeRule.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 
 import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.java.ast.ASTAnonymousClassDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTImplementsList;
@@ -25,6 +26,25 @@ public class OverrideBothEqualsAndHashcodeRule extends AbstractJavaRule {
 
     @Override
     public Object visit(ASTClassOrInterfaceDeclaration node, Object data) {
+        if (node.isInterface()) {
+            return data;
+        }
+        super.visit(node, data);
+        if (!implementsComparable && containsEquals ^ containsHashCode) {
+            if (nodeFound == null) {
+                nodeFound = node;
+            }
+            addViolation(data, nodeFound);
+        }
+        implementsComparable = false;
+        containsEquals = false;
+        containsHashCode = false;
+        nodeFound = null;
+        return data;
+    }
+
+    @Override
+    public Object visit(ASTAnonymousClassDeclaration node, Object data) {
         if (node.isInterface()) {
             return data;
         }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/OverrideBothEqualsAndHashcode.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/OverrideBothEqualsAndHashcode.xml
@@ -180,4 +180,23 @@ public class Foo implements Runnable {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description> [java]A false negative about OverrideBothEqualsAndHashcode #4457 </description>
+        <expected-problems>2</expected-problems>
+        <code><![CDATA[
+public class Foo {
+  public class B {
+      Object o = new Object() {
+          public boolean equals(Object other) {   // report no warning
+              return false;
+          }
+      };
+      public int hashCode() {
+          return 1;
+      }
+  }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/OverrideBothEqualsAndHashcode.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/OverrideBothEqualsAndHashcode.xml
@@ -199,4 +199,15 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>Support records</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+            public record Foo(int x) {
+                    public int hashCode() {
+                        return 1;
+                    }
+            }
+            ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

This PR consider the `AnonymousClass`.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #4457
- Fixes #4546 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

