### PR TITLE
[java] Fix #4458: A false positive about RedundantFieldInitializer and @Value

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/RedundantFieldInitializerRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/RedundantFieldInitializerRule.java
@@ -4,6 +4,10 @@
 
 package net.sourceforge.pmd.lang.java.rule.performance;
 
+import static net.sourceforge.pmd.util.CollectionUtil.setOf;
+
+import java.util.Set;
+
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldAccess;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
@@ -12,6 +16,9 @@ import net.sourceforge.pmd.lang.java.ast.ASTVariableDeclaratorId;
 import net.sourceforge.pmd.lang.java.ast.JModifier;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+
+
+
 
 /**
  * Detects redundant field initializers, i.e. the field initializer expressions
@@ -22,13 +29,18 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
  */
 public class RedundantFieldInitializerRule extends AbstractJavaRulechainRule {
 
+    private static final Set<String> MAKE_FIELD_FINAL_CLASS_ANNOT =
+        setOf(
+                "lombok.Value"
+        );
+
     public RedundantFieldInitializerRule() {
         super(ASTFieldDeclaration.class);
     }
 
     @Override
     public Object visit(ASTFieldDeclaration fieldDeclaration, Object data) {
-        if (!fieldDeclaration.hasModifiers(JModifier.FINAL)) {
+        if (!fieldDeclaration.hasModifiers(JModifier.FINAL) && !JavaAstUtils.hasAnyAnnotation(fieldDeclaration.getEnclosingType(), MAKE_FIELD_FINAL_CLASS_ANNOT)) {
             for (ASTVariableDeclaratorId varId : fieldDeclaration.getVarIds()) {
                 ASTExpression init = varId.getInitializer();
                 if (init != null) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/RedundantFieldInitializer.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/RedundantFieldInitializer.xml
@@ -1481,4 +1481,16 @@ class O {
             }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description> [java]A false positive about RedundantFieldInitializer and @Value #4458 </description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import lombok.Value;
+@Value
+public class Test {
+    String bar = null;   // report a warning
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
This PR add an annotation whitelist to exclude `@Value`

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #4458

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

