### PR TITLE
[java] Fix #4510: A false positive about ConstructorCallsOverridableMethod and @Value

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConstructorCallsOverridableMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConstructorCallsOverridableMethodRule.java
@@ -4,11 +4,14 @@
 
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 
+import static net.sourceforge.pmd.util.CollectionUtil.setOf;
+
 import java.lang.reflect.Modifier;
 import java.util.Deque;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -28,6 +31,7 @@ import net.sourceforge.pmd.lang.java.symbols.JExecutableSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JMethodSymbol;
 import net.sourceforge.pmd.lang.java.types.JMethodSig;
 import net.sourceforge.pmd.lang.java.types.OverloadSelectionResult;
+
 
 /**
  * Searches through all methods and constructors called from constructors. It
@@ -54,6 +58,11 @@ public final class ConstructorCallsOverridableMethodRule extends AbstractJavaRul
 
     private static final Deque<JMethodSymbol> EMPTY_STACK = new LinkedList<>();
 
+    private static final Set<String> MAKE_FIELD_FINAL_CLASS_ANNOT =
+        setOf(
+            "lombok.Value"
+        );
+
     public ConstructorCallsOverridableMethodRule() {
         super(ASTConstructorDeclaration.class);
     }
@@ -66,7 +75,7 @@ public final class ConstructorCallsOverridableMethodRule extends AbstractJavaRul
 
     @Override
     public Object visit(ASTConstructorDeclaration node, Object data) {
-        if (node.getEnclosingType().isFinal()) {
+        if (node.getEnclosingType().isFinal() || JavaAstUtils.hasAnyAnnotation(node.getEnclosingType(), MAKE_FIELD_FINAL_CLASS_ANNOT)) {
             return null; // then cannot be overridden
         }
         for (ASTMethodCall call : node.getBody().descendants(ASTMethodCall.class)) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ConstructorCallsOverridableMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ConstructorCallsOverridableMethod.xml
@@ -616,4 +616,19 @@ public class MyTimestamp {
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description> [java]A false positive about ConstructorCallsOverridableMethod and @Value #4510 </description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import lombok.Value;
+@Value
+class Foo1 {
+    public Foo1(String bar) {
+        bar();  //  report a warning
+    }
+    public void bar() {}
+}
+]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

This PR add an whitelist to excludes `@Value`

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #4510

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

