### PR TITLE
[java] Make LawOfDemeter results deterministic

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LawOfDemeterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LawOfDemeterRule.java
@@ -14,6 +14,7 @@ import static net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil.isGetterC
 import static net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil.isNullChecked;
 import static net.sourceforge.pmd.properties.constraints.NumericConstraints.positive;
 
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -301,7 +302,11 @@ public class LawOfDemeterRule extends AbstractJavaRule {
 
         // note this max could be changed to min to get a more conservative
         // strategy, trading recall for precision. maybe make that configurable
-        return reaching.getReaching().stream().mapToInt(this::foreignDegree).max().orElse(TRUSTED);
+        return reaching.getReaching().stream()
+                // sort the assignments to have a deterministic result. We need to call #foreignDegree always
+                // in the same order, to get the same computed degrees.
+                .sorted(Comparator.comparing(AssignmentEntry::getLocation, Node.COORDS_COMPARATOR).reversed())
+                .mapToInt(this::foreignDegree).max().orElse(TRUSTED);
     }
 
     private int fieldAccessDegree(ASTNamedReferenceExpr expr) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LawOfDemeterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LawOfDemeterRule.java
@@ -305,7 +305,7 @@ public class LawOfDemeterRule extends AbstractJavaRule {
         return reaching.getReaching().stream()
                 // sort the assignments to have a deterministic result. We need to call #foreignDegree always
                 // in the same order, to get the same computed degrees.
-                .sorted(Comparator.comparing(AssignmentEntry::getLocation, Node.COORDS_COMPARATOR).reversed())
+                .sorted(Comparator.comparing(AssignmentEntry::getLocation, Node.COORDS_COMPARATOR))
                 .mapToInt(this::foreignDegree).max().orElse(TRUSTED);
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LawOfDemeterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LawOfDemeterRule.java
@@ -14,7 +14,6 @@ import static net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil.isGetterC
 import static net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil.isNullChecked;
 import static net.sourceforge.pmd.properties.constraints.NumericConstraints.positive;
 
-import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -303,9 +302,6 @@ public class LawOfDemeterRule extends AbstractJavaRule {
         // note this max could be changed to min to get a more conservative
         // strategy, trading recall for precision. maybe make that configurable
         return reaching.getReaching().stream()
-                // sort the assignments to have a deterministic result. We need to call #foreignDegree always
-                // in the same order, to get the same computed degrees.
-                .sorted(Comparator.comparing(AssignmentEntry::getLocation, Node::compareLocation))
                 .mapToInt(this::foreignDegree).max().orElse(TRUSTED);
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LawOfDemeterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LawOfDemeterRule.java
@@ -305,7 +305,7 @@ public class LawOfDemeterRule extends AbstractJavaRule {
         return reaching.getReaching().stream()
                 // sort the assignments to have a deterministic result. We need to call #foreignDegree always
                 // in the same order, to get the same computed degrees.
-                .sorted(Comparator.comparing(AssignmentEntry::getLocation, Node.COORDS_COMPARATOR))
+                .sorted(Comparator.comparing(AssignmentEntry::getLocation, Node::compareLocation))
                 .mapToInt(this::foreignDegree).max().orElse(TRUSTED);
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/DataflowPass.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/DataflowPass.java
@@ -8,8 +8,8 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Deque;
-import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -212,7 +212,7 @@ public final class DataflowPass {
             this.containsInitialFieldValue |= reaching.containsInitialFieldValue;
             this.isNotFullyKnown |= reaching.isNotFullyKnown;
             if (this.reaching.isEmpty()) { // unmodifiable
-                this.reaching = new HashSet<>(reaching.reaching);
+                this.reaching = new LinkedHashSet<>(reaching.reaching);
             } else {
                 this.reaching.addAll(reaching.reaching);
             }
@@ -234,8 +234,8 @@ public final class DataflowPass {
 
 
         DataflowResult() {
-            this.unusedAssignments = new HashSet<>();
-            this.killRecord = new HashMap<>();
+            this.unusedAssignments = new LinkedHashSet<>();
+            this.killRecord = new LinkedHashMap<>();
         }
 
         /**
@@ -360,7 +360,7 @@ public final class DataflowPass {
             // next iteration
 
             SpanInfo state = data;
-            Set<ASTVariableDeclaratorId> localsToKill = new HashSet<>();
+            Set<ASTVariableDeclaratorId> localsToKill = new LinkedHashSet<>();
 
             for (JavaNode child : node.children()) {
                 // each output is passed as input to the next (most relevant for blocks)
@@ -1060,9 +1060,9 @@ public final class DataflowPass {
         }
 
         private GlobalAlgoState() {
-            this(new HashSet<>(),
-                 new HashSet<>(),
-                 new HashMap<>());
+            this(new LinkedHashSet<>(),
+                 new LinkedHashSet<>(),
+                 new LinkedHashMap<>());
         }
     }
 
@@ -1081,7 +1081,7 @@ public final class DataflowPass {
             if (other == this) { // NOPMD #3205
                 return this;
             }
-            Set<AssignmentEntry> merged = new HashSet<>(reachingDefs.size() + other.reachingDefs.size());
+            Set<AssignmentEntry> merged = new LinkedHashSet<>(reachingDefs.size() + other.reachingDefs.size());
             merged.addAll(reachingDefs);
             merged.addAll(other.reachingDefs);
             return new VarLocalInfo(merged);
@@ -1123,7 +1123,7 @@ public final class DataflowPass {
         private OptionalBool hasCompletedAbruptly = OptionalBool.NO;
 
         private SpanInfo(GlobalAlgoState global) {
-            this(null, global, new HashMap<>());
+            this(null, global, new LinkedHashMap<>());
         }
 
         private SpanInfo(SpanInfo parent,
@@ -1163,7 +1163,7 @@ public final class DataflowPass {
                         continue;
                     }
 
-                    global.killRecord.computeIfAbsent(killed, k -> new HashSet<>(1))
+                    global.killRecord.computeIfAbsent(killed, k -> new LinkedHashSet<>(1))
                                      .add(entry);
                 }
             }
@@ -1202,7 +1202,7 @@ public final class DataflowPass {
             if (info != null) {
                 global.usedAssignments.addAll(info.reachingDefs);
                 if (reachingDefSink != null) {
-                    ReachingDefinitionSet reaching = new ReachingDefinitionSet(new HashSet<>(info.reachingDefs));
+                    ReachingDefinitionSet reaching = new ReachingDefinitionSet(new LinkedHashSet<>(info.reachingDefs));
                     // need to merge into previous to account for cyclic control flow
                     reachingDefSink.getUserMap().compute(REACHING_DEFS, current -> {
                         if (current != null) {
@@ -1256,12 +1256,12 @@ public final class DataflowPass {
         }
 
         SpanInfo forkEmpty() {
-            return doFork(this, new HashMap<>());
+            return doFork(this, new LinkedHashMap<>());
         }
 
 
         SpanInfo forkEmptyNonLocal() {
-            return doFork(null, new HashMap<>());
+            return doFork(null, new LinkedHashMap<>());
         }
 
         SpanInfo forkCapturingNonLocal() {
@@ -1269,7 +1269,7 @@ public final class DataflowPass {
         }
 
         private Map<JVariableSymbol, VarLocalInfo> copyTable() {
-            return new HashMap<>(this.symtable);
+            return new LinkedHashMap<>(this.symtable);
         }
 
         private SpanInfo doFork(/*nullable*/ SpanInfo parent, Map<JVariableSymbol, VarLocalInfo> reaching) {
@@ -1377,7 +1377,7 @@ public final class DataflowPass {
     static class TargetStack {
 
         final Deque<SpanInfo> unnamedTargets = new ArrayDeque<>();
-        final Map<String, SpanInfo> namedTargets = new HashMap<>();
+        final Map<String, SpanInfo> namedTargets = new LinkedHashMap<>();
 
 
         void push(SpanInfo state) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/LawOfDemeter.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/LawOfDemeter.xml
@@ -1194,8 +1194,8 @@ public final class ControlEvent {
         <expected-problems>2</expected-problems>
         <expected-linenumbers>15,17</expected-linenumbers>
         <expected-messages>
-            <message>Access to field `left` on foreign value `p` (degree 1)</message>
-            <message>Access to field `right` on foreign value `p` (degree 2)</message>
+            <message>Access to field `left` on foreign value `p` (degree 2)</message>
+            <message>Access to field `right` on foreign value `p` (degree 1)</message>
         </expected-messages>
         <code><![CDATA[
 class LawOfDemeterFields {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/LawOfDemeter.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/LawOfDemeter.xml
@@ -1188,4 +1188,40 @@ public final class ControlEvent {
             }
             ]]></code>
     </test-code>
+
+    <test-code>
+        <description>conditional self assignment of fields</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>15,17</expected-linenumbers>
+        <expected-messages>
+            <message>Access to field `left` on foreign value `p` (degree 1)</message>
+            <message>Access to field `right` on foreign value `p` (degree 2)</message>
+        </expected-messages>
+        <code><![CDATA[
+class LawOfDemeterFields {
+    static class Entry {
+        Entry left;
+        Entry right;
+        Integer value;
+    }
+
+    private Entry root;
+
+    Entry find(Integer i) {
+        Entry p = root;
+        while (p != null) {
+            int cmp = p.value.compareTo(i);
+            if (cmp < 0) {
+                p = p.left; // law of demeter: degree 1
+            } else if (cpm > 0) {
+                p = p.right; // law of demeter: degree 2
+            } else {
+                return p;
+            }
+        }
+        return null;
+    }
+}
+]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/LawOfDemeter.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/LawOfDemeter.xml
@@ -1194,8 +1194,8 @@ public final class ControlEvent {
         <expected-problems>2</expected-problems>
         <expected-linenumbers>15,17</expected-linenumbers>
         <expected-messages>
-            <message>Access to field `left` on foreign value `p` (degree 2)</message>
-            <message>Access to field `right` on foreign value `p` (degree 1)</message>
+            <message>Access to field `left` on foreign value `p` (degree 1)</message>
+            <message>Access to field `right` on foreign value `p` (degree 2)</message>
         </expected-messages>
         <code><![CDATA[
 class LawOfDemeterFields {


### PR DESCRIPTION
## Describe the PR

I believe, this should fix the spurious differing results in the regression tester. At least, I could reproduce on first try the problem when reversing the order of the reaching assignments.

That should then make the test-case-3 of https://github.com/pmd/pmd-regression-tester/pull/119 happy.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

