### PR TITLE
[core] Restore behavior with thread=1 setting

### DIFF
--- a/.ci/inc/regression-tester.inc
+++ b/.ci/inc/regression-tester.inc
@@ -50,6 +50,7 @@ function regression_tester_uploadBaseline() {
         --patch-branch "${baseline_branch}" \
         --patch-config ./pmd/.ci/files/all-regression-rules.xml \
         --list-of-project ./pmd/.ci/files/project-list.xml --html-flag \
+        --threads "$(nproc)" \
         --error-recovery
     pushd target/reports || { echo "Directory 'target/reports' doesn't exist"; exit 1; }
     BRANCH_FILENAME="${baseline_branch/\//_}"

--- a/Dangerfile
+++ b/Dangerfile
@@ -2,6 +2,7 @@ require 'pmdtester'
 require 'time'
 require 'logger'
 require 'fileutils'
+require 'etc'
 
 @logger = Logger.new(STDOUT)
 
@@ -16,6 +17,7 @@ def get_args(base_branch, autogen = TRUE, patch_config = './pmd/.ci/files/all-re
    '--keep-reports',
    '--error-recovery',
    '--baseline-download-url', 'https://pmd-code.org/pmd-regression-tester/',
+   '--threads', Etc.nprocessors.to_s,
    # '--debug',
    ]
 end

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/AbstractPMDProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/AbstractPMDProcessor.java
@@ -34,10 +34,12 @@ abstract class AbstractPMDProcessor implements AutoCloseable {
 
     /**
      * Returns a new file processor. The strategy used for threading is
-     * determined by {@link AnalysisTask#getThreads()}.
+     * determined by {@link AnalysisTask#getThreadCount()}.
+     * <p>Note: Only {@code 0} threads disables multi-thread processing. See the CLI documentation
+     * for parameter {@code --threads}.</p>
      */
     public static AbstractPMDProcessor newFileProcessor(AnalysisTask analysisTask) {
-        return analysisTask.getThreadCount() > 1
+        return analysisTask.getThreadCount() > 0
                ? new MultiThreadProcessor(analysisTask)
                : new MonoThreadProcessor(analysisTask);
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/impl/AbstractPMDProcessorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/impl/AbstractPMDProcessorTest.java
@@ -1,0 +1,27 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.impl;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.junit.jupiter.api.Test;
+
+import net.sourceforge.pmd.lang.LanguageProcessor;
+
+class AbstractPMDProcessorTest {
+    @Test
+    void shouldUseMonoThreadProcessorForZeroOnly() {
+        AbstractPMDProcessor processor = AbstractPMDProcessor.newFileProcessor(createTask(0));
+        assertSame(MonoThreadProcessor.class, processor.getClass());
+
+        processor = AbstractPMDProcessor.newFileProcessor(createTask(1));
+        assertSame(MultiThreadProcessor.class, processor.getClass());
+    }
+
+    private LanguageProcessor.AnalysisTask createTask(int threads) {
+        LanguageProcessor.AnalysisTask task = new LanguageProcessor.AnalysisTask(null, null, null, threads, null, null, null);
+        return task;
+    }
+}

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/impl/MultiThreadProcessorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/impl/MultiThreadProcessorTest.java
@@ -2,7 +2,7 @@
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
-package net.sourceforge.pmd.processor;
+package net.sourceforge.pmd.lang.impl;
 
 import static net.sourceforge.pmd.util.CollectionUtil.listOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -31,6 +31,7 @@ class MultiThreadProcessorTest {
     PmdAnalysis setupForTest(final String ruleset) {
         PMDConfiguration configuration = new PMDConfiguration();
         configuration.setThreads(2);
+        configuration.setIgnoreIncrementalAnalysis(true);
         PmdAnalysis pmd = PmdAnalysis.create(configuration);
         LanguageVersion lv = DummyLanguageModule.getInstance().getDefaultVersion();
         pmd.files().addFile(TextFile.forCharSeq("abc", "file1-violation.dummy", lv));
@@ -47,7 +48,7 @@ class MultiThreadProcessorTest {
         return pmd;
     }
 
-    // Dysfunctional rules are pruned upstream of the processor.
+    // TODO: Dysfunctional rules are pruned upstream of the processor.
     //
     //    @Test
     //    void testRulesDysnfunctionalLog() throws Exception {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/processor/GlobalListenerTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/processor/GlobalListenerTest.java
@@ -124,7 +124,7 @@ class GlobalListenerTest {
         PMDConfiguration config = new PMDConfiguration();
         config.setAnalysisCache(new NoopAnalysisCache());
         config.setIgnoreIncrementalAnalysis(true);
-        config.setThreads(1);
+        config.setThreads(0); // no multithreading for this test
         return config;
     }
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/processor/PmdRunnableTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/processor/PmdRunnableTest.java
@@ -65,8 +65,8 @@ class PmdRunnableTest {
         reporter = mock(MessageReporter.class);
         configuration.setReporter(reporter);
         // exceptions thrown on a worker thread are not thrown by the main thread,
-        // so this test only makes sense with one thread
-        configuration.setThreads(1);
+        // so this test only makes sense without separate threads
+        configuration.setThreads(0);
     }
 
 

--- a/pmd-core/src/test/resources/rulesets/MultiThreadProcessorTest/basic.xml
+++ b/pmd-core/src/test/resources/rulesets/MultiThreadProcessorTest/basic.xml
@@ -6,7 +6,7 @@
   Ruleset used by test RuleSetReferenceIdTest
   </description>
 
-    <rule name="NotThreadSafeRule" language="dummy" since="1.0" message="Not thread safe" class="net.sourceforge.pmd.processor.MultiThreadProcessorTest$NotThreadSafeRule"
+    <rule name="NotThreadSafeRule" language="dummy" since="1.0" message="Not thread safe" class="net.sourceforge.pmd.lang.impl.MultiThreadProcessorTest$NotThreadSafeRule"
         externalInfoUrl="foo">
         <description>Foo</description>
         <priority>3</priority>

--- a/pmd-core/src/test/resources/rulesets/MultiThreadProcessorTest/dysfunctional.xml
+++ b/pmd-core/src/test/resources/rulesets/MultiThreadProcessorTest/dysfunctional.xml
@@ -6,7 +6,7 @@
   Ruleset used by test MultiThreadProcessorTest
   </description>
 
-    <rule name="DysfunctionalRule" language="dummy" since="1.0" message="dysfunctional rule" class="net.sourceforge.pmd.processor.MultiThreadProcessorTest$DysfunctionalRule"
+    <rule name="DysfunctionalRule" language="dummy" since="1.0" message="dysfunctional rule" class="net.sourceforge.pmd.lang.impl.MultiThreadProcessorTest$DysfunctionalRule"
         externalInfoUrl="foo">
         <description>Dysfunctional</description>
         <priority>3</priority>

--- a/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/BaseParsingHelper.kt
+++ b/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/BaseParsingHelper.kt
@@ -233,7 +233,7 @@ abstract class BaseParsingHelper<Self : BaseParsingHelper<Self, T>, T : RootNode
             suppressMarker = params.suppressMarker
             forceLanguageVersion = defaultVersion
             isIgnoreIncrementalAnalysis = true
-            threads = 1
+            threads = 0 // don't use separate threads for rule execution
         }
 
         return PmdAnalysis.create(config).use { pmd ->

--- a/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/testframework/RuleTst.java
@@ -226,7 +226,7 @@ public abstract class RuleTst {
         PMDConfiguration configuration = new PMDConfiguration();
         configuration.setIgnoreIncrementalAnalysis(true);
         configuration.setDefaultLanguageVersion(languageVersion);
-        configuration.setThreads(1);
+        configuration.setThreads(0); // don't use separate threads
         configuration.prependAuxClasspath(".");
 
         try (PmdAnalysis pmd = PmdAnalysis.create(configuration)) {


### PR DESCRIPTION
## Describe the PR

Found this while upgrading the manual integration tests (see https://github.com/pmd/pmd-regression-tester/pull/119): The errors where different when comparing to the baseline - but only the stacktrace. I could see, that the stacktraces are either from the main thread (including PmdCli) or from a worker thread (then they are shorter).
As we didn't specify the thread count for the regression tester baseline, it should be the default, which is "1" - and that should actually run the MultiThreadProcessor. Only with thread count=0 we should use MonoThreadProcessor. See the [CLI documentation](https://docs.pmd-code.org/latest/pmd_userdocs_cli_reference.html) on threads:

> Sets the number of threads used by PMD. Set threads to 0 to disable multi-threading processing.

Keeping to this behavior, it should make the error stacktraces more comparable regardless whether you run it with 4 threads or only with 1.
See also the old impl: https://github.com/pmd/pmd/blob/ef3455348603aa25f86894b9930f05f141f44d20/pmd-core/src/main/java/net/sourceforge/pmd/PmdAnalysis.java#L309

Additionally, I took the chance to set the threads now when creating the baseline or running regression tester. Maybe it makes it a bit faster (don't know, how powerful the GitHub action instance runners are).

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

