### PR TITLE
Add how to programmatically access report

### DIFF
--- a/docs/pages/pmd/userdocs/tools/java-api.md
+++ b/docs/pages/pmd/userdocs/tools/java-api.md
@@ -212,4 +212,5 @@ public class PmdExample2 {
 }
 ```
 
+If you would like to process the report programmatically instead of writing it to a file, replace the call to `pmd.performAnalysis()` with `Report report = pmd.performAnalysisAndCollectReport()`.
 


### PR DESCRIPTION
## Describe the PR

The existing page is very good but did not communicate that there is a way to get programmatic access to the report instead of rendering it to a file.

## Related issues

I proposed an unnecessarily complicated workaround before I learned about `performAnalysisAndCollectReport()`. #4574 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

