### PR TITLE
Use explicit encoding in ruleset xml files

### DIFF
--- a/.ci/files/all-regression-rules.xml
+++ b/.ci/files/all-regression-rules.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="All Regression Rules" 
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-apex/src/main/resources/category/apex/bestpractices.xml
+++ b/pmd-apex/src/main/resources/category/apex/bestpractices.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Best Practices"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-apex/src/main/resources/category/apex/codestyle.xml
+++ b/pmd-apex/src/main/resources/category/apex/codestyle.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Code Style"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-apex/src/main/resources/category/apex/design.xml
+++ b/pmd-apex/src/main/resources/category/apex/design.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Design"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-apex/src/main/resources/category/apex/documentation.xml
+++ b/pmd-apex/src/main/resources/category/apex/documentation.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Documentation"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-apex/src/main/resources/category/apex/errorprone.xml
+++ b/pmd-apex/src/main/resources/category/apex/errorprone.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Error Prone"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-apex/src/main/resources/category/apex/multithreading.xml
+++ b/pmd-apex/src/main/resources/category/apex/multithreading.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Multithreading"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-apex/src/main/resources/category/apex/performance.xml
+++ b/pmd-apex/src/main/resources/category/apex/performance.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Performance"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-apex/src/main/resources/category/apex/security.xml
+++ b/pmd-apex/src/main/resources/category/apex/security.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Security"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/DefaultRulesetTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/DefaultRulesetTest.java
@@ -9,12 +9,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
+import net.sourceforge.pmd.AbstractRuleSetFactoryTest;
 import net.sourceforge.pmd.RuleSet;
 import net.sourceforge.pmd.RuleSetLoader;
 
 import com.github.stefanbirkner.systemlambda.SystemLambda;
 
 class DefaultRulesetTest {
+    private static final String QUICKSTART_RULESET = "rulesets/apex/quickstart.xml";
 
     @Test
     void loadDefaultRuleset() {
@@ -25,10 +27,15 @@ class DefaultRulesetTest {
     @Test
     void loadQuickstartRuleset() throws Exception {
         String log = SystemLambda.tapSystemErr(() -> {
-            RuleSet ruleset = rulesetLoader().loadFromResource("rulesets/apex/quickstart.xml");
+            RuleSet ruleset = rulesetLoader().loadFromResource(QUICKSTART_RULESET);
             assertNotNull(ruleset);
         });
         assertTrue(log.isEmpty(), "No Logging expected");
+    }
+
+    @Test
+    void correctEncoding() throws Exception {
+        assertTrue(AbstractRuleSetFactoryTest.hasCorrectEncoding(QUICKSTART_RULESET));
     }
 
     private RuleSetLoader rulesetLoader() {

--- a/pmd-core/src/main/resources/rulesets/internal/all-ecmascript.xml
+++ b/pmd-core/src/main/resources/rulesets/internal/all-ecmascript.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="All ECMAScript Rules" 
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/internal/all-java.xml
+++ b/pmd-core/src/main/resources/rulesets/internal/all-java.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="All Java Rules" 
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/33.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/33.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="33"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/34.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/34.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="34"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/35.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/35.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="35"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/36.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/36.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="36"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/37-jsp.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/37-jsp.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="37"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/37.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/37.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="37"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/38.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/38.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="38"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/39.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/39.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="39"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/40rc1.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/40rc1.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="40rc1"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/41.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/41.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="41"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/42.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/42.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="42"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/50.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/50.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="50"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/501.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/501.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="501"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/510.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/510.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="510"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/512.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/512.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="512"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/520.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/520.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="520"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/540.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/540.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="540"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/550.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/550.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="550"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/551.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/551.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="551"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/552.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/552.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="552"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/553.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/553.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="553"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/554.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/554.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="554"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/560.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/560.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="560"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/580.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/580.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="580"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/600.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/600.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="600"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/6100.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6100.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="6100"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/6110.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6110.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="6110"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/6120.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6120.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="6120"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/6130.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6130.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="6130"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/6150.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6150.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="6150"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/6160.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6160.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="6160"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/6180.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6180.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="6180"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/620.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/620.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="620"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/6220.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6220.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="6220"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/6230.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6230.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="6230"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/6240.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6240.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="6240"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/6250.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6250.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="6250"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/6260.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6260.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="6260"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/6270.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6270.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="6270"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/6290.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6290.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="6290"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/630.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/630.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="630"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/6310.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6310.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="6310"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/6340.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6340.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="6340"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/6350.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6350.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="6350"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/6360.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6360.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="6360"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/6370.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6370.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="6370"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/640.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/640.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="640"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/6400.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6400.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="6400"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/6420.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6420.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="6420"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/6450.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6450.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="6450"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/6460.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6460.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="6460"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/650.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/650.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="650"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/6510.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6510.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="6510"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/6520.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/6520.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="6520"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/660.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/660.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="660"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/670.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/670.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="670"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/680.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/680.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="680"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/690.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/690.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="690"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-core/src/main/resources/rulesets/releases/700.xml
+++ b/pmd-core/src/main/resources/rulesets/releases/700.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="700"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-html/src/main/resources/category/html/bestpractices.xml
+++ b/pmd-html/src/main/resources/category/html/bestpractices.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Best Practices"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-html/src/main/resources/category/html/codestyle.xml
+++ b/pmd-html/src/main/resources/category/html/codestyle.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Code Style"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-html/src/main/resources/category/html/design.xml
+++ b/pmd-html/src/main/resources/category/html/design.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Design"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-html/src/main/resources/category/html/documentation.xml
+++ b/pmd-html/src/main/resources/category/html/documentation.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Documentation"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-html/src/main/resources/category/html/errorprone.xml
+++ b/pmd-html/src/main/resources/category/html/errorprone.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Error Prone"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-html/src/main/resources/category/html/multithreading.xml
+++ b/pmd-html/src/main/resources/category/html/multithreading.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Multithreading"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-html/src/main/resources/category/html/performance.xml
+++ b/pmd-html/src/main/resources/category/html/performance.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Performance"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-html/src/main/resources/category/html/security.xml
+++ b/pmd-html/src/main/resources/category/html/security.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Security"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Best Practices"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Code Style"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Design"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-java/src/main/resources/category/java/documentation.xml
+++ b/pmd-java/src/main/resources/category/java/documentation.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Documentation"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Error Prone"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-java/src/main/resources/category/java/multithreading.xml
+++ b/pmd-java/src/main/resources/category/java/multithreading.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Multithreading"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Performance"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-java/src/main/resources/category/java/security.xml
+++ b/pmd-java/src/main/resources/category/java/security.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Security" xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/pmd-java/src/main/resources/rulesets/java/quickstart.xml
+++ b/pmd-java/src/main/resources/rulesets/java/quickstart.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <ruleset name="quickstart"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/QuickstartRulesetTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/QuickstartRulesetTest.java
@@ -9,20 +9,27 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
+import net.sourceforge.pmd.AbstractRuleSetFactoryTest;
 import net.sourceforge.pmd.RuleSet;
 import net.sourceforge.pmd.RuleSetLoader;
 
 import com.github.stefanbirkner.systemlambda.SystemLambda;
 
 class QuickstartRulesetTest {
+    private static final String QUICKSTART_RULESET = "rulesets/java/quickstart.xml";
 
     @Test
     void noDeprecations() throws Exception {
         RuleSetLoader ruleSetLoader = new RuleSetLoader().enableCompatibility(false);
         String errorOutput = SystemLambda.tapSystemErr(() -> {
-            RuleSet quickstart = ruleSetLoader.loadFromResource("rulesets/java/quickstart.xml");
+            RuleSet quickstart = ruleSetLoader.loadFromResource(QUICKSTART_RULESET);
             assertFalse(quickstart.getRules().isEmpty());
         });
         assertTrue(errorOutput.isEmpty());
+    }
+
+    @Test
+    void correctEncoding() throws Exception {
+        assertTrue(AbstractRuleSetFactoryTest.hasCorrectEncoding(QUICKSTART_RULESET));
     }
 }

--- a/pmd-javascript/src/main/resources/category/ecmascript/bestpractices.xml
+++ b/pmd-javascript/src/main/resources/category/ecmascript/bestpractices.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Best Practices"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-javascript/src/main/resources/category/ecmascript/codestyle.xml
+++ b/pmd-javascript/src/main/resources/category/ecmascript/codestyle.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Code Style"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-javascript/src/main/resources/category/ecmascript/design.xml
+++ b/pmd-javascript/src/main/resources/category/ecmascript/design.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Design"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-javascript/src/main/resources/category/ecmascript/documentation.xml
+++ b/pmd-javascript/src/main/resources/category/ecmascript/documentation.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Documentation"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-javascript/src/main/resources/category/ecmascript/errorprone.xml
+++ b/pmd-javascript/src/main/resources/category/ecmascript/errorprone.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Error Prone"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-javascript/src/main/resources/category/ecmascript/multithreading.xml
+++ b/pmd-javascript/src/main/resources/category/ecmascript/multithreading.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Multithreading"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-javascript/src/main/resources/category/ecmascript/performance.xml
+++ b/pmd-javascript/src/main/resources/category/ecmascript/performance.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Performance"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-javascript/src/main/resources/category/ecmascript/security.xml
+++ b/pmd-javascript/src/main/resources/category/ecmascript/security.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Security"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-jsp/src/main/resources/category/jsp/bestpractices.xml
+++ b/pmd-jsp/src/main/resources/category/jsp/bestpractices.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Best Practices"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-jsp/src/main/resources/category/jsp/codestyle.xml
+++ b/pmd-jsp/src/main/resources/category/jsp/codestyle.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Code Style"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-jsp/src/main/resources/category/jsp/design.xml
+++ b/pmd-jsp/src/main/resources/category/jsp/design.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Design"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-jsp/src/main/resources/category/jsp/documentation.xml
+++ b/pmd-jsp/src/main/resources/category/jsp/documentation.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Documentation"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-jsp/src/main/resources/category/jsp/errorprone.xml
+++ b/pmd-jsp/src/main/resources/category/jsp/errorprone.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Error Prone"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-jsp/src/main/resources/category/jsp/multithreading.xml
+++ b/pmd-jsp/src/main/resources/category/jsp/multithreading.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Multithreading"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-jsp/src/main/resources/category/jsp/performance.xml
+++ b/pmd-jsp/src/main/resources/category/jsp/performance.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Performance"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-jsp/src/main/resources/category/jsp/security.xml
+++ b/pmd-jsp/src/main/resources/category/jsp/security.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Security"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-kotlin/src/main/resources/category/kotlin/bestpractices.xml
+++ b/pmd-kotlin/src/main/resources/category/kotlin/bestpractices.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Best Practices"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-kotlin/src/main/resources/category/kotlin/errorprone.xml
+++ b/pmd-kotlin/src/main/resources/category/kotlin/errorprone.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Error Prone"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-modelica/src/main/resources/category/modelica/bestpractices.xml
+++ b/pmd-modelica/src/main/resources/category/modelica/bestpractices.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Best Practices"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-plsql/src/main/resources/category/plsql/bestpractices.xml
+++ b/pmd-plsql/src/main/resources/category/plsql/bestpractices.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Best Practices"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-plsql/src/main/resources/category/plsql/codestyle.xml
+++ b/pmd-plsql/src/main/resources/category/plsql/codestyle.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Code Style"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-plsql/src/main/resources/category/plsql/design.xml
+++ b/pmd-plsql/src/main/resources/category/plsql/design.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Design"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-plsql/src/main/resources/category/plsql/documentation.xml
+++ b/pmd-plsql/src/main/resources/category/plsql/documentation.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Documentation"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-plsql/src/main/resources/category/plsql/errorprone.xml
+++ b/pmd-plsql/src/main/resources/category/plsql/errorprone.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Error Prone"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-plsql/src/main/resources/category/plsql/multithreading.xml
+++ b/pmd-plsql/src/main/resources/category/plsql/multithreading.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Multithreading"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-plsql/src/main/resources/category/plsql/performance.xml
+++ b/pmd-plsql/src/main/resources/category/plsql/performance.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Performance"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-plsql/src/main/resources/category/plsql/security.xml
+++ b/pmd-plsql/src/main/resources/category/plsql/security.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Security"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-scala-modules/pmd-scala-common/src/main/resources/category/scala/bestpractices.xml
+++ b/pmd-scala-modules/pmd-scala-common/src/main/resources/category/scala/bestpractices.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Best Practices"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-scala-modules/pmd-scala-common/src/main/resources/category/scala/codestyle.xml
+++ b/pmd-scala-modules/pmd-scala-common/src/main/resources/category/scala/codestyle.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Code Style"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-scala-modules/pmd-scala-common/src/main/resources/category/scala/design.xml
+++ b/pmd-scala-modules/pmd-scala-common/src/main/resources/category/scala/design.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Design"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-scala-modules/pmd-scala-common/src/main/resources/category/scala/documentation.xml
+++ b/pmd-scala-modules/pmd-scala-common/src/main/resources/category/scala/documentation.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Documentation"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-scala-modules/pmd-scala-common/src/main/resources/category/scala/errorprone.xml
+++ b/pmd-scala-modules/pmd-scala-common/src/main/resources/category/scala/errorprone.xml
@@ -1,13 +1,11 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Error Prone"
-	xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+         xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
 
-	<description>
+    <description>
 Rules to detect constructs that are either broken, extremely confusing or prone to runtime errors.
     </description>
-
-
 </ruleset>

--- a/pmd-scala-modules/pmd-scala-common/src/main/resources/category/scala/multithreading.xml
+++ b/pmd-scala-modules/pmd-scala-common/src/main/resources/category/scala/multithreading.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Multithreading"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-scala-modules/pmd-scala-common/src/main/resources/category/scala/performance.xml
+++ b/pmd-scala-modules/pmd-scala-common/src/main/resources/category/scala/performance.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Performance"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-scala-modules/pmd-scala-common/src/main/resources/category/scala/security.xml
+++ b/pmd-scala-modules/pmd-scala-common/src/main/resources/category/scala/security.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Security"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-swift/src/main/resources/category/swift/bestpractices.xml
+++ b/pmd-swift/src/main/resources/category/swift/bestpractices.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Best Practices"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-swift/src/main/resources/category/swift/codestyle.xml
+++ b/pmd-swift/src/main/resources/category/swift/codestyle.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Code Style"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-swift/src/main/resources/category/swift/design.xml
+++ b/pmd-swift/src/main/resources/category/swift/design.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Design"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-swift/src/main/resources/category/swift/documentation.xml
+++ b/pmd-swift/src/main/resources/category/swift/documentation.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Documentation"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-swift/src/main/resources/category/swift/errorprone.xml
+++ b/pmd-swift/src/main/resources/category/swift/errorprone.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Error Prone"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-swift/src/main/resources/category/swift/multithreading.xml
+++ b/pmd-swift/src/main/resources/category/swift/multithreading.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Multithreading"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-swift/src/main/resources/category/swift/performance.xml
+++ b/pmd-swift/src/main/resources/category/swift/performance.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Performance"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-swift/src/main/resources/category/swift/security.xml
+++ b/pmd-swift/src/main/resources/category/swift/security.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Security" xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/pmd-test/src/main/java/net/sourceforge/pmd/AbstractRuleSetFactoryTest.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/AbstractRuleSetFactoryTest.java
@@ -16,6 +16,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -230,6 +231,36 @@ public abstract class AbstractRuleSetFactoryTest {
         assertTrue(allValid, "All XML must parse without producing validation messages.");
     }
 
+    @Test
+    void verifyCorrectXmlEncoding() throws Exception {
+        boolean allValid = true;
+        List<String> ruleSetFileNames = getRuleSetFileNames();
+        StringBuilder messages = new StringBuilder();
+        for (String fileName : ruleSetFileNames) {
+            boolean valid = hasCorrectEncoding(fileName);
+            allValid = allValid && valid;
+            if (!valid) {
+                messages.append("RuleSet ")
+                        .append(fileName)
+                        .append(" is missing XML encoding or not using UTF8\n");
+            }
+        }
+        assertTrue(allValid, "All XML must use correct XML encoding\n" + messages);
+    }
+
+    public static boolean hasCorrectEncoding(String fileName) throws IOException {
+        try (InputStream inputStream = loadResourceAsStream(fileName)) {
+            // first bytes must be:
+            byte[] expectedBytes = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>".getBytes(StandardCharsets.UTF_8);
+            byte[] bytes = new byte[expectedBytes.length];
+            int count = inputStream.read(bytes);
+            if (count != expectedBytes.length || !Arrays.equals(expectedBytes, bytes)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     /**
      * Verifies that all rulesets are valid XML according to the DTD.
      *
@@ -381,8 +412,8 @@ public abstract class AbstractRuleSetFactoryTest {
         }
     }
 
-    private InputStream loadResourceAsStream(String resource) {
-        return getClass().getClassLoader().getResourceAsStream(resource);
+    private static InputStream loadResourceAsStream(String resource) {
+        return AbstractRuleSetFactoryTest.class.getClassLoader().getResourceAsStream(resource);
     }
 
     private void testRuleSet(String fileName) throws IOException, SAXException {

--- a/pmd-visualforce/src/main/resources/category/vf/bestpractices.xml
+++ b/pmd-visualforce/src/main/resources/category/vf/bestpractices.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Best Practices"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-visualforce/src/main/resources/category/vf/codestyle.xml
+++ b/pmd-visualforce/src/main/resources/category/vf/codestyle.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Code Style"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-visualforce/src/main/resources/category/vf/design.xml
+++ b/pmd-visualforce/src/main/resources/category/vf/design.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Design"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-visualforce/src/main/resources/category/vf/documentation.xml
+++ b/pmd-visualforce/src/main/resources/category/vf/documentation.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Documentation"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-visualforce/src/main/resources/category/vf/errorprone.xml
+++ b/pmd-visualforce/src/main/resources/category/vf/errorprone.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Error Prone"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-visualforce/src/main/resources/category/vf/multithreading.xml
+++ b/pmd-visualforce/src/main/resources/category/vf/multithreading.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Multithreading"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-visualforce/src/main/resources/category/vf/performance.xml
+++ b/pmd-visualforce/src/main/resources/category/vf/performance.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Performance"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-visualforce/src/main/resources/category/vf/security.xml
+++ b/pmd-visualforce/src/main/resources/category/vf/security.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Security"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-vm/src/main/resources/category/vm/bestpractices.xml
+++ b/pmd-vm/src/main/resources/category/vm/bestpractices.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Best Practices"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-vm/src/main/resources/category/vm/codestyle.xml
+++ b/pmd-vm/src/main/resources/category/vm/codestyle.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Code Style"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-vm/src/main/resources/category/vm/design.xml
+++ b/pmd-vm/src/main/resources/category/vm/design.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Design"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-vm/src/main/resources/category/vm/documentation.xml
+++ b/pmd-vm/src/main/resources/category/vm/documentation.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Documentation"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-vm/src/main/resources/category/vm/errorprone.xml
+++ b/pmd-vm/src/main/resources/category/vm/errorprone.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Error Prone"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-vm/src/main/resources/category/vm/multithreading.xml
+++ b/pmd-vm/src/main/resources/category/vm/multithreading.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Multithreading"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-vm/src/main/resources/category/vm/performance.xml
+++ b/pmd-vm/src/main/resources/category/vm/performance.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Performance"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-vm/src/main/resources/category/vm/security.xml
+++ b/pmd-vm/src/main/resources/category/vm/security.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Security"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/pom/bestpractices.xml
+++ b/pmd-xml/src/main/resources/category/pom/bestpractices.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Best Practices"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/pom/codestyle.xml
+++ b/pmd-xml/src/main/resources/category/pom/codestyle.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Code Style"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/pom/design.xml
+++ b/pmd-xml/src/main/resources/category/pom/design.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Design"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/pom/documentation.xml
+++ b/pmd-xml/src/main/resources/category/pom/documentation.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Documentation"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/pom/errorprone.xml
+++ b/pmd-xml/src/main/resources/category/pom/errorprone.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Error Prone"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/pom/multithreading.xml
+++ b/pmd-xml/src/main/resources/category/pom/multithreading.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Multithreading"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/pom/performance.xml
+++ b/pmd-xml/src/main/resources/category/pom/performance.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Performance"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/pom/security.xml
+++ b/pmd-xml/src/main/resources/category/pom/security.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Security"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/wsdl/bestpractices.xml
+++ b/pmd-xml/src/main/resources/category/wsdl/bestpractices.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Best Practices"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/wsdl/codestyle.xml
+++ b/pmd-xml/src/main/resources/category/wsdl/codestyle.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Code Style"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/wsdl/design.xml
+++ b/pmd-xml/src/main/resources/category/wsdl/design.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Design"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/wsdl/documentation.xml
+++ b/pmd-xml/src/main/resources/category/wsdl/documentation.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Documentation"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/wsdl/errorprone.xml
+++ b/pmd-xml/src/main/resources/category/wsdl/errorprone.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Error Prone"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/wsdl/multithreading.xml
+++ b/pmd-xml/src/main/resources/category/wsdl/multithreading.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Multithreading"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/wsdl/performance.xml
+++ b/pmd-xml/src/main/resources/category/wsdl/performance.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Performance"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/wsdl/security.xml
+++ b/pmd-xml/src/main/resources/category/wsdl/security.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Security"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/xml/bestpractices.xml
+++ b/pmd-xml/src/main/resources/category/xml/bestpractices.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Best Practices"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/xml/codestyle.xml
+++ b/pmd-xml/src/main/resources/category/xml/codestyle.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Code Style"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/xml/design.xml
+++ b/pmd-xml/src/main/resources/category/xml/design.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Design"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/xml/documentation.xml
+++ b/pmd-xml/src/main/resources/category/xml/documentation.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Documentation"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/xml/errorprone.xml
+++ b/pmd-xml/src/main/resources/category/xml/errorprone.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Error Prone"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/xml/multithreading.xml
+++ b/pmd-xml/src/main/resources/category/xml/multithreading.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Multithreading"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/xml/performance.xml
+++ b/pmd-xml/src/main/resources/category/xml/performance.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Performance"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/xml/security.xml
+++ b/pmd-xml/src/main/resources/category/xml/security.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Security"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/xsl/bestpractices.xml
+++ b/pmd-xml/src/main/resources/category/xsl/bestpractices.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Best Practices"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/xsl/codestyle.xml
+++ b/pmd-xml/src/main/resources/category/xsl/codestyle.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Code Style"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/xsl/design.xml
+++ b/pmd-xml/src/main/resources/category/xsl/design.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Design"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/xsl/documentation.xml
+++ b/pmd-xml/src/main/resources/category/xsl/documentation.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Documentation"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/xsl/errorprone.xml
+++ b/pmd-xml/src/main/resources/category/xsl/errorprone.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Error Prone"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/xsl/multithreading.xml
+++ b/pmd-xml/src/main/resources/category/xsl/multithreading.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Multithreading"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/xsl/performance.xml
+++ b/pmd-xml/src/main/resources/category/xsl/performance.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Performance"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"

--- a/pmd-xml/src/main/resources/category/xsl/security.xml
+++ b/pmd-xml/src/main/resources/category/xsl/security.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 
 <ruleset name="Security"
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"


### PR DESCRIPTION
## Describe the PR

Just a minor tweak I noticed recently. It's better to explicitly state the encoding, that is used. This avoids confusion.

This change also adds tests to ensure, that the encoding for the category ruleset files is UTF-8.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

