### PR TITLE
[java] Fix #4578 - CommentDefaultAccessModifier comment needs to be before annotation if present

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -45,6 +45,8 @@ The remaining section describes the complete release notes for 7.0.0.
   * [#4582](https://github.com/pmd/pmd/issues/4582): \[dist] Download link broken
 * java
   * [#4401](https://github.com/pmd/pmd/issues/4401): \[java] PMD 7 fails to build under Java 19
+* java-codestyle
+  * [#4578](https://github.com/pmd/pmd/issues/4578): \[java] CommentDefaultAccessModifier comment needs to be before annotation if present
 
 #### API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaComment.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaComment.java
@@ -132,8 +132,9 @@ public class JavaComment implements Reportable {
         return line.subSequence(subseqFrom, line.length()).trim();
     }
 
-    private static Stream<JavaccToken> getSpecialCommentsIn(JjtreeNode<?> node) {
-        return GenericToken.streamRange(node.getFirstToken(), node.getLastToken())
+    private static Stream<JavaccToken> getSpecialTokensIn(JjtreeNode<?> node) {
+        // Consider one more token to include also comments immediately after the node
+        return GenericToken.streamRange(node.getFirstToken(), node.getLastToken().getNext())
                            .flatMap(it -> IteratorUtil.toStream(GenericToken.previousSpecials(it).iterator()));
     }
 
@@ -141,7 +142,7 @@ public class JavaComment implements Reportable {
         if (node instanceof AccessNode) {
             node = ((AccessNode) node).getModifiers();
         }
-        return getSpecialCommentsIn(node).filter(JavaComment::isComment)
+        return getSpecialTokensIn(node).filter(JavaComment::isComment)
                                          .map(JavaComment::toComment);
     }
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/CommentDefaultAccessModifier.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/CommentDefaultAccessModifier.xml
@@ -567,4 +567,20 @@ class C {
 }
         ]]></code>
     </test-code>
+    
+    <test-code>
+        <description>#4578 failure with comment after annotation</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Test {
+    @SuppressWarnings("")
+    /* package */ void test1() {
+    }
+
+    /* package */ @SuppressWarnings("")
+    void test2() {
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
- Fixes #4578 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

