### PR TITLE
[xml] Add MissingEncoding rule

### DIFF
--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/internal/XmlParserImpl.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/internal/XmlParserImpl.java
@@ -10,7 +10,6 @@ import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
-
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/internal/XmlParserImpl.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/internal/XmlParserImpl.java
@@ -8,6 +8,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -22,6 +23,9 @@ import org.xml.sax.SAXException;
 import net.sourceforge.pmd.lang.ast.AstInfo;
 import net.sourceforge.pmd.lang.ast.ParseException;
 import net.sourceforge.pmd.lang.ast.Parser.ParserTask;
+import net.sourceforge.pmd.lang.rule.xpath.Attribute;
+import net.sourceforge.pmd.lang.rule.xpath.NoAttribute;
+import net.sourceforge.pmd.lang.rule.xpath.impl.AttributeAxisIterator;
 import net.sourceforge.pmd.lang.ast.RootNode;
 import net.sourceforge.pmd.lang.xml.ast.XmlNode;
 
@@ -107,6 +111,31 @@ public final class XmlParserImpl {
         @Override
         public Document getNode() {
             return (Document) super.getNode();
+        }
+        
+        public String getXmlEncoding() {
+            return getNode().getXmlEncoding();
+        }
+        
+        public boolean isXmlStandalone() {
+            return getNode().getXmlStandalone();
+        }
+        
+        public String getXmlVersion() {
+            return getNode().getXmlVersion();
+        }
+
+        // Hide the image attribute
+        @NoAttribute
+        @Override
+        public String getImage() {
+            return super.getImage();
+        }
+        
+        @Override
+        public Iterator<Attribute> getXPathAttributesIterator() {
+            // Expose this node's attributes through reflection
+            return new AttributeAxisIterator(this);
         }
     }
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/internal/XmlParserImpl.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/internal/XmlParserImpl.java
@@ -10,6 +10,7 @@ import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -23,10 +24,10 @@ import org.xml.sax.SAXException;
 import net.sourceforge.pmd.lang.ast.AstInfo;
 import net.sourceforge.pmd.lang.ast.ParseException;
 import net.sourceforge.pmd.lang.ast.Parser.ParserTask;
+import net.sourceforge.pmd.lang.ast.RootNode;
 import net.sourceforge.pmd.lang.rule.xpath.Attribute;
 import net.sourceforge.pmd.lang.rule.xpath.NoAttribute;
 import net.sourceforge.pmd.lang.rule.xpath.impl.AttributeAxisIterator;
-import net.sourceforge.pmd.lang.ast.RootNode;
 import net.sourceforge.pmd.lang.xml.ast.XmlNode;
 
 public final class XmlParserImpl {

--- a/pmd-xml/src/main/resources/category/xml/bestpractices.xml
+++ b/pmd-xml/src/main/resources/category/xml/bestpractices.xml
@@ -8,4 +8,31 @@
     <description>
 Rules which enforce generally accepted best practices.
     </description>
+    
+    <rule name="MissingEncoding"
+      language="xml"
+      message="Set an explicit XML encoding in the XML declaration to ensure proper parsing"
+      class="net.sourceforge.pmd.lang.rule.XPathRule">
+       <description>
+          When the character encoding is missing from the XML declaration,
+          the parser may produce garbled text.
+    
+          This is completely dependent on how the parser is set up
+          and the content of the XML file, so it may be hard to reproduce.
+    
+          Providing an explicit encoding ensures  accurate and consistent
+          parsing.
+       </description>
+       <priority>3</priority>
+       <properties>
+          <property name="version" value="3.1"/>
+          <property name="xpath">
+             <value>
+    <![CDATA[
+    //document[@XmlEncoding = ""]
+    ]]>
+             </value>
+          </property>
+       </properties>
+    </rule>
 </ruleset>

--- a/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/rule/bestpractices/MissingEncodingTest.java
+++ b/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/rule/bestpractices/MissingEncodingTest.java
@@ -1,0 +1,11 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.xml.rule.bestpractices;
+
+import net.sourceforge.pmd.testframework.PmdRuleTst;
+
+class MissingEncodingTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-xml/src/test/resources/net/sourceforge/pmd/lang/xml/ast/testdata/bug1518.txt
+++ b/pmd-xml/src/test/resources/net/sourceforge/pmd/lang/xml/ast/testdata/bug1518.txt
@@ -1,4 +1,4 @@
-+- document[]
++- document[@XmlEncoding = "UTF-8", @XmlStandalone = false, @XmlVersion = "1.0"]
    +- deployment-plan[@global-variables = "false", @xmlns = "http://xmlns.oracle.com/weblogic/deployment-plan", @xmlns:xsi = "http://www.w3.org/2001/XMLSchema-instance", @xsi:schemaLocation = "http://xmlns.oracle.com/weblogic/deployment-plan http://xmlns.oracle.com/weblogic/deployment-plan/1.0/deployment-plan.xsd"]
       +- text[@Image = "\n    "]
       +- application-name[]

--- a/pmd-xml/src/test/resources/net/sourceforge/pmd/lang/xml/ast/testdata/sampleNs.txt
+++ b/pmd-xml/src/test/resources/net/sourceforge/pmd/lang/xml/ast/testdata/sampleNs.txt
@@ -1,4 +1,4 @@
-+- document[]
++- document[@XmlEncoding = null, @XmlStandalone = false, @XmlVersion = "1.0"]
    +- comment[]
    +- rootElement[]
    +- rootElement[]

--- a/pmd-xml/src/test/resources/net/sourceforge/pmd/lang/xml/ast/testdata/sampleXml.txt
+++ b/pmd-xml/src/test/resources/net/sourceforge/pmd/lang/xml/ast/testdata/sampleXml.txt
@@ -1,4 +1,4 @@
-+- document[]
++- document[@XmlEncoding = null, @XmlStandalone = false, @XmlVersion = "1.0"]
    +- pmd:rootElement[@xmlns:pmd = "http://pmd.sf.net"]
       +- text[@Image = "\n    "]
       +- comment[]

--- a/pmd-xml/src/test/resources/net/sourceforge/pmd/lang/xml/rule/bestpractices/xml/MissingEncoding.xml
+++ b/pmd-xml/src/test/resources/net/sourceforge/pmd/lang/xml/rule/bestpractices/xml/MissingEncoding.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+    <test-code>
+        <description>No XML Declaration</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+<root>
+    <child/>
+</root>
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>XML Declaration without encoding</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+<?xml version="1.0" ?>
+<root>
+    <child/>
+</root>
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>XML Declaration with UTF-8 encoding</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+<?xml version="1.0" encoding="UTF-8" ?>
+<root>
+    <child/>
+</root>
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>XML Declaration with ISO-8859-1 encoding</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+<?xml version="1.0" encoding="ISO-8859-1" ?>
+<root>
+    <child/>
+</root>
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>XML Declaration with UTF-8 encoding and standalone</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
+<root>
+    <child/>
+</root>
+        ]]></code>
+    </test-code>
+</test-data>


### PR DESCRIPTION
## Describe the PR

- Expose XML declaration attributes to the DOM
- Implement a rule enforcing the XML declaration includes an encoding

This implementation has a few constraints:
- Since the parser doesn't really expose the declaration, it's not possible to know if the declaration is present or not. The XML version will be declared as "1.0" in such scenarios, and "standalone" be reported as false (the default according to the XML standard)

## Related issues

This would allow us to remove the test from #4586 and instead add this rule to the dogfooding ruleset.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

