### PR TITLE
[core] Resurrect removed methods/classes for maven-pmd-plugin compat

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/Report.java
@@ -137,6 +137,11 @@ public final class Report {
             return file;
         }
 
+        @Deprecated
+        public String getFile() {
+            return getFileId().getAbsolutePath();
+        }
+
         public Throwable getError() {
             return error;
         }
@@ -388,6 +393,12 @@ public final class Report {
         copy.errors.addAll(errors);
         copy.configErrors.addAll(configErrors);
         return copy;
+    }
+
+    @Experimental
+    @Deprecated
+    public Report filterViolations(net.sourceforge.pmd.util.Predicate<RuleViolation> filter) {
+        return filterViolations((Predicate<RuleViolation>) filter);
     }
 
     /**

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleViolation.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleViolation.java
@@ -87,6 +87,11 @@ public interface RuleViolation {
         return getLocation().getFileId();
     }
 
+    @Deprecated
+    default String getFilename() {
+        return getFileId().getAbsolutePath();
+    }
+
     /**
      * Get the begin line number in the source file in which this violation was
      * identified.

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/XMLRenderer.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.cpd;
 import java.io.IOException;
 import java.io.Writer;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import javax.xml.parsers.DocumentBuilder;
@@ -22,6 +23,7 @@ import javax.xml.transform.stream.StreamResult;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+import net.sourceforge.pmd.cpd.renderer.CPDRenderer;
 import net.sourceforge.pmd.cpd.renderer.CPDReportRenderer;
 import net.sourceforge.pmd.util.StringUtil;
 
@@ -30,7 +32,7 @@ import net.sourceforge.pmd.util.StringUtil;
  * @author Romain Pelisse - javax.xml implementation
  *
  */
-public final class XMLRenderer implements CPDReportRenderer {
+public final class XMLRenderer implements CPDReportRenderer, CPDRenderer {
 
     private String encoding;
 
@@ -89,6 +91,22 @@ public final class XMLRenderer implements CPDReportRenderer {
         }
     }
 
+    @Override
+    @Deprecated
+    public void render(Iterator<Match> matches, Writer writer) throws IOException {
+        Document doc = createDocument();
+        Element root = doc.createElement("pmd-cpd");
+        doc.appendChild(root);
+
+        Match match;
+        while (matches.hasNext()) {
+            match = matches.next();
+            root.appendChild(addCodeSnippet(doc,
+                                            addFilesToDuplicationElement(doc, createDuplicationElement(doc, match), match), match));
+        }
+        dumpDocToWriter(doc, writer);
+        writer.flush();
+    }
 
     @Override
     public void render(final CPDReport report, final Writer writer) throws IOException {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/renderer/CPDRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/renderer/CPDRenderer.java
@@ -1,0 +1,16 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.cpd.renderer;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Iterator;
+
+import net.sourceforge.pmd.cpd.Match;
+
+@Deprecated
+public interface CPDRenderer {
+    void render(Iterator<Match> matches, Writer writer) throws IOException;
+}

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/Predicate.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/Predicate.java
@@ -13,7 +13,6 @@ import net.sourceforge.pmd.annotation.Experimental;
  */
 // TODO java8 - replace with java.util.function.Predicate
 @Experimental
-public interface Predicate<T> {
-
-    boolean test(T t);
+@FunctionalInterface
+public interface Predicate<T> extends java.util.function.Predicate<T> {
 }


### PR DESCRIPTION
maven-pmd-plugin 3.21.0 is the latest version of the plugin, which unfortunately does no longer support PMD 7.0.0-SNAPSHOT, since some API that is used by the plugin is no longer available.

This prevents testing new PMD version in existing projects that make use of the Maven plugin.

Resurrect the removed API to re-enable compatibility with the plugin, adding `@Deprecated` where appropriate.

- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
