### PR TITLE
[apex] Add rule test for UnusedMethod

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -43,6 +43,8 @@ The remaining section describes the complete release notes for 7.0.0.
 
 * miscellaneous
   * [#4582](https://github.com/pmd/pmd/issues/4582): \[dist] Download link broken
+* apex
+  * [#4453](https://github.com/pmd/pmd/issues/4453): \[apex] \[7.0-rc1] Exception while initializing Apexlink (Index 34812 out of bounds for length 34812)
 * apex-design
   * [#4596](https://github.com/pmd/pmd/issues/4596): \[apex] ExcessivePublicCount ignores properties
 * java
@@ -401,6 +403,7 @@ Language specific fixes:
     * [#1750](https://github.com/pmd/pmd/pull/1750):   \[apex] Remove apex statistical rules
     * [#2836](https://github.com/pmd/pmd/pull/2836):   \[apex] Remove Apex ProjectMirror
     * [#4427](https://github.com/pmd/pmd/issues/4427): \[apex] ApexBadCrypto test failing to detect inline code
+    * [#4453](https://github.com/pmd/pmd/issues/4453): \[apex] \[7.0-rc1] Exception while initializing Apexlink (Index 34812 out of bounds for length 34812)
 * apex-design
     * [#2667](https://github.com/pmd/pmd/issues/2667): \[apex] Integrate nawforce/ApexLink to build robust Unused rule
     * [#4509](https://github.com/pmd/pmd/issues/4509): \[apex] ExcessivePublicCount doesn't consider inner classes correctly

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/UnusedMethodRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/UnusedMethodRule.java
@@ -11,6 +11,9 @@ public class UnusedMethodRule extends AbstractApexRule {
 
     @Override
     public Object visit(ASTMethod node, Object data) {
+        if (node.isSynthetic()) {
+            return data;
+        }
 
         // Check if any 'Unused' Issues align with this method
         node.getRoot().getGlobalIssues().stream()

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/UnusedMethodTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/UnusedMethodTest.java
@@ -1,0 +1,64 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.rule.design;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+
+import net.sourceforge.pmd.PMDConfiguration;
+import net.sourceforge.pmd.PmdAnalysis;
+import net.sourceforge.pmd.Report;
+import net.sourceforge.pmd.Rule;
+import net.sourceforge.pmd.RuleSet;
+import net.sourceforge.pmd.RuleSetLoader;
+import net.sourceforge.pmd.RuleViolation;
+import net.sourceforge.pmd.lang.Language;
+import net.sourceforge.pmd.lang.LanguageVersion;
+import net.sourceforge.pmd.lang.apex.ApexLanguageModule;
+import net.sourceforge.pmd.lang.apex.ApexLanguageProperties;
+import net.sourceforge.pmd.reporting.GlobalAnalysisListener;
+
+class UnusedMethodTest {
+
+    @Test
+    void findUnusedMethodsWithSfdxProject() throws Exception {
+        Path testProjectDir = Paths.get("src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/UnusedMethod/project1");
+        Report report = runRule(testProjectDir);
+        assertEquals(1, report.getViolations().size());
+        assertViolation(report.getViolations().get(0), "Foo.cls", 6);
+    }
+
+    private void assertViolation(RuleViolation violation, String fileName, int lineNumber) {
+        assertEquals("Foo.cls", violation.getFileId().getFileName());
+        assertEquals(6, violation.getBeginLine()); // line 6 is method unusedMethod()
+    }
+
+    private Report runRule(Path testProjectDir) throws IOException {
+        Language apexLanguage = ApexLanguageModule.getInstance();
+        LanguageVersion languageVersion = apexLanguage.getDefaultVersion();
+        PMDConfiguration configuration = new PMDConfiguration();
+        configuration.setIgnoreIncrementalAnalysis(true);
+        configuration.setDefaultLanguageVersion(languageVersion);
+        configuration.setThreads(0); // don't use separate threads
+        configuration.prependAuxClasspath(".");
+
+        configuration.getLanguageProperties(apexLanguage).setProperty(ApexLanguageProperties.MULTIFILE_DIRECTORY, testProjectDir.toString());
+
+        RuleSet parsedRset = new RuleSetLoader().warnDeprecated(false).loadFromResource("category/apex/design.xml");
+        Rule rule = parsedRset.getRuleByName("UnusedMethod");
+
+        try (PmdAnalysis pmd = PmdAnalysis.create(configuration)) {
+            pmd.files().addDirectory(testProjectDir);
+            pmd.addRuleSet(RuleSet.forSingleRule(rule));
+            pmd.addListener(GlobalAnalysisListener.exceptionThrower());
+            return pmd.performAnalysisAndCollectReport();
+        }
+    }
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/UnusedMethod/project1/sfdx-project.json
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/UnusedMethod/project1/sfdx-project.json
@@ -4,5 +4,6 @@
       "path": "src",
       "default": true
     }
-  ]
+  ],
+  "namespace": "foo_ns"
 }

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/UnusedMethod/project1/sfdx-project.json
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/UnusedMethod/project1/sfdx-project.json
@@ -1,0 +1,8 @@
+{
+  "packageDirectories": [
+    {
+      "path": "src",
+      "default": true
+    }
+  ]
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/UnusedMethod/project1/src/Foo.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/UnusedMethod/project1/src/Foo.cls
@@ -1,0 +1,13 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+public class Foo {
+    public void unusedMethod() {
+        // ääää // at least 4 umlauts are required in order to
+        // reproduce the ArrayIndexOutOfBoundsException
+        Integer a;
+        // note: there should be no additional characters
+        // after this method, only the two closing brackets
+    }
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/UnusedMethod/project1/src/Foo.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/UnusedMethod/project1/src/Foo.cls
@@ -3,10 +3,15 @@
  */
 
 public class Foo {
+    // this method is needed, otherwise the whole class is considered as unused, as it would contain
+    // then only one unused method.
+    private void other() {}
+
     public void unusedMethod() {
         // ääää // at least 4 umlauts are required in order to
-        // reproduce the ArrayIndexOutOfBoundsException
-        Integer a;
+        // reproduce the ArrayIndexOutOfBoundsException (#4453)
+        // up to 7.0.0-rc3 with export PMD_JAVA_OPTS="-Dfile.encoding=ISO-8859-15" (e.g. platform encoding is not UTF-8)
+        other();
         // note: there should be no additional characters
         // after this method, only the two closing brackets
     }


### PR DESCRIPTION
## Describe the PR

* This adds a unit test to verify the rule [UnusedMethod](https://docs.pmd-code.org/latest/pmd_rules_apex_design.html#unusedmethod) actually works.
* This is important, as that actually tests the integration with apexlink

I could now confirm, that #4453 is indeed fixed by the update of apexlink (#4528) - since apexlink now hardcoded uses always UTF-8 - for both itself and when creating a antlr char stream (see https://github.com/nawforce/apex-link/blob/7688adcb7a2d7f8aa28d0618ffb2a3aa81151858/pkgforce/jvm/src/main/scala/com/nawforce/runtime/parsers/SourceData.scala#L55-L59 )

I couldn't create a unit test to reproduce #4453, since that would have involved changed the default charset in java in a running vm which is not possible.

But I manually verified, that #4453 is now fixed.


## Related issues

- Fixes #4453

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

