### PR TITLE
[core] Fix loading language properties from env vars

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageProcessorRegistry.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageProcessorRegistry.java
@@ -117,6 +117,14 @@ public final class LanguageProcessorRegistry implements AutoCloseable {
     public static LanguageProcessorRegistry create(LanguageRegistry registry,
                                                    Map<Language, LanguagePropertyBundle> languageProperties,
                                                    MessageReporter messageReporter) {
+        return create(registry, languageProperties, messageReporter, System.getenv());
+    }
+
+    // overload for testing to allow mocking the system env vars.
+    static LanguageProcessorRegistry create(LanguageRegistry registry,
+                                            Map<Language, LanguagePropertyBundle> languageProperties,
+                                            MessageReporter messageReporter,
+                                            Map<String, String> env) {
         Set<LanguageProcessor> processors = new HashSet<>();
         for (Language language : registry) {
             LanguagePropertyBundle properties = languageProperties.getOrDefault(language, language.newPropertyBundle());
@@ -126,7 +134,7 @@ public final class LanguageProcessorRegistry implements AutoCloseable {
 
             try {
                 //
-                readLanguagePropertiesFromEnv(properties, messageReporter);
+                readLanguagePropertiesFromEnv(properties, messageReporter, env);
 
                 processors.add(language.createProcessor(properties));
             } catch (IllegalArgumentException e) {
@@ -182,11 +190,11 @@ public final class LanguageProcessorRegistry implements AutoCloseable {
         }
     }
 
-    private static void readLanguagePropertiesFromEnv(LanguagePropertyBundle props, MessageReporter reporter) {
+    private static void readLanguagePropertiesFromEnv(LanguagePropertyBundle props, MessageReporter reporter, Map<String, String> env) {
         for (PropertyDescriptor<?> propertyDescriptor : props.getPropertyDescriptors()) {
 
             String envVarName = getEnvironmentVariableName(props.getLanguage(), propertyDescriptor);
-            String propertyValue = System.getenv(envVarName);
+            String propertyValue = env.get(envVarName);
 
             if (propertyValue != null) {
                 if (props.isPropertyOverridden(propertyDescriptor)) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/StringUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/StringUtil.java
@@ -516,7 +516,7 @@ public final class StringUtil {
 
             @Override
             String joinWords(List<String> words) {
-                return words.stream().map(s -> s.toLowerCase(Locale.ROOT)).collect(Collectors.joining("_"));
+                return words.stream().map(s -> s.toUpperCase(Locale.ROOT)).collect(Collectors.joining("_"));
             }
         },
         /** camelCase. */

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/LanguageProcessorRegistryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/LanguageProcessorRegistryTest.java
@@ -1,0 +1,51 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.util.log.MessageReporter;
+
+class LanguageProcessorRegistryTest {
+    @Test
+    void loadEnvironmentVariables() throws Exception {
+        Map<String, String> env = new HashMap<>();
+        env.put("PMD_DUMMY_ROOT_DIRECTORY", "theValue");
+
+        Language dummyLanguage = DummyLanguageModule.getInstance().getDefaultVersion().getLanguage();
+        LanguageRegistry languageRegistry = LanguageRegistry.singleton(dummyLanguage);
+
+        Map<Language, LanguagePropertyBundle> languageProperties = new HashMap<>();
+        DummyLanguagePropertyBundle bundle = new DummyLanguagePropertyBundle(dummyLanguage);
+        languageProperties.put(dummyLanguage, bundle);
+
+        try (LanguageProcessorRegistry ignored = LanguageProcessorRegistry.create(languageRegistry, languageProperties, MessageReporter.quiet(), env)) {
+            assertEquals("theValue", bundle.getRootDirectory());
+        }
+    }
+
+    private static class DummyLanguagePropertyBundle extends LanguagePropertyBundle {
+        private static final PropertyDescriptor<String> ROOT_DIRECTORY = PropertyFactory.stringProperty("rootDirectory")
+                .desc("Test")
+                .defaultValue("")
+                .build();
+
+        DummyLanguagePropertyBundle(Language language) {
+            super(language);
+            definePropertyDescriptor(ROOT_DIRECTORY);
+        }
+
+        public String getRootDirectory() {
+            return getProperty(ROOT_DIRECTORY);
+        }
+    }
+}

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/StringUtilTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/StringUtilTest.java
@@ -8,9 +8,14 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.stream.Stream;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import net.sourceforge.pmd.lang.document.Chars;
+import net.sourceforge.pmd.util.StringUtil.CaseConvention;
 
 class StringUtilTest {
 
@@ -91,4 +96,102 @@ class StringUtilTest {
         assertEquals("abc", StringUtil.substringAfterLast("abc", '.'));
     }
 
+    @Test
+    void caseConventionCamelCaseToScreamingSnake() {
+        assertEquals("rootDirectory", CaseConvention.SCREAMING_SNAKE_CASE.convertTo(CaseConvention.CAMEL_CASE, "ROOT_DIRECTORY"));
+        assertEquals("ROOT_DIRECTORY", CaseConvention.CAMEL_CASE.convertTo(CaseConvention.SCREAMING_SNAKE_CASE, "rootDirectory"));
+    }
+
+    @ParameterizedTest
+    @MethodSource
+    void caseConventionConvertTo(CaseConventionConversionTestData data) {
+        assertEquals(data.expected, data.from.convertTo(data.to, data.source));
+    }
+
+    private static Stream<CaseConventionConversionTestData> caseConventionConvertTo() {
+        return Stream.of(
+                new CaseConventionConversionTestData(
+                        CaseConvention.CAMEL_CASE,
+                        CaseConvention.SCREAMING_SNAKE_CASE,
+                        "camelCase",
+                        "CAMEL_CASE"),
+                new CaseConventionConversionTestData(
+                        CaseConvention.CAMEL_CASE,
+                        CaseConvention.PASCAL_CASE,
+                        "camelCase",
+                        "CamelCase"),
+                new CaseConventionConversionTestData(
+                        CaseConvention.CAMEL_CASE,
+                        CaseConvention.SPACE_SEPARATED,
+                        "camelCase",
+                        "camel case"),
+
+                new CaseConventionConversionTestData(
+                        CaseConvention.SCREAMING_SNAKE_CASE,
+                        CaseConvention.CAMEL_CASE,
+                        "SCREAMING_SNAKE_CASE",
+                        "screamingSnakeCase"),
+                new CaseConventionConversionTestData(
+                        CaseConvention.SCREAMING_SNAKE_CASE,
+                        CaseConvention.PASCAL_CASE,
+                        "SCREAMING_SNAKE_CASE",
+                        "ScreamingSnakeCase"),
+                new CaseConventionConversionTestData(
+                        CaseConvention.SCREAMING_SNAKE_CASE,
+                        CaseConvention.SPACE_SEPARATED,
+                        "SCREAMING_SNAKE_CASE",
+                        "screaming snake case"),
+
+                new CaseConventionConversionTestData(
+                        CaseConvention.PASCAL_CASE,
+                        CaseConvention.CAMEL_CASE,
+                        "PascalCase",
+                        "pascalCase"),
+                new CaseConventionConversionTestData(
+                        CaseConvention.PASCAL_CASE,
+                        CaseConvention.SCREAMING_SNAKE_CASE,
+                        "PascalCase",
+                        "PASCAL_CASE"),
+                new CaseConventionConversionTestData(
+                        CaseConvention.PASCAL_CASE,
+                        CaseConvention.SPACE_SEPARATED,
+                        "PascalCase",
+                        "pascal case"),
+
+                new CaseConventionConversionTestData(
+                        CaseConvention.SPACE_SEPARATED,
+                        CaseConvention.CAMEL_CASE,
+                        "space separated",
+                        "spaceSeparated"),
+                new CaseConventionConversionTestData(
+                        CaseConvention.SPACE_SEPARATED,
+                        CaseConvention.SCREAMING_SNAKE_CASE,
+                        "space separated",
+                        "SPACE_SEPARATED"),
+                new CaseConventionConversionTestData(
+                        CaseConvention.SPACE_SEPARATED,
+                        CaseConvention.PASCAL_CASE,
+                        "space separated",
+                        "SpaceSeparated")
+        );
+    }
+
+    private static class CaseConventionConversionTestData {
+        CaseConvention from;
+        CaseConvention to;
+        String source;
+        String expected;
+
+        CaseConventionConversionTestData(CaseConvention from, CaseConvention to, String source, String expected) {
+            this.from = from;
+            this.to = to;
+            this.source = source;
+            this.expected = expected;
+        }
+
+        @Override
+        public String toString() {
+            return source + "(" + from.name() + "->" + to.name() + ")=" + expected;
+        }
+    }
 }


### PR DESCRIPTION
## Describe the PR

The environment variables should be uppercase as documented.

Found this while reproducing #4453 when trying to set "PMD_APEX_ROOT_DIRECTORY" which didn't have any effect. I needed to use "PMD_APEX_root_directory" to make it working.


## Related issues

- Refs #2518 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

