### PR TITLE
[core] Deal with errors from threads in multithreading mode

### DIFF
--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/impl/AbstractPMDProcessorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/impl/AbstractPMDProcessorTest.java
@@ -4,24 +4,136 @@
 
 package net.sourceforge.pmd.lang.impl;
 
+import static net.sourceforge.pmd.util.CollectionUtil.listOf;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
+import net.sourceforge.pmd.PMDConfiguration;
+import net.sourceforge.pmd.PmdAnalysis;
+import net.sourceforge.pmd.Report;
+import net.sourceforge.pmd.RuleContext;
+import net.sourceforge.pmd.RuleSet;
+import net.sourceforge.pmd.RuleViolation;
+import net.sourceforge.pmd.lang.DummyLanguageModule;
 import net.sourceforge.pmd.lang.LanguageProcessor;
+import net.sourceforge.pmd.lang.LanguageVersion;
+import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.document.FileId;
+import net.sourceforge.pmd.lang.document.TextFile;
+import net.sourceforge.pmd.lang.rule.AbstractRule;
+import net.sourceforge.pmd.reporting.FileAnalysisListener;
+import net.sourceforge.pmd.reporting.GlobalAnalysisListener;
+import net.sourceforge.pmd.util.log.MessageReporter;
 
-class AbstractPMDProcessorTest {
+abstract class AbstractPMDProcessorTest {
+    protected SimpleReportListener reportListener;
+
+    protected MessageReporter reporter;
+
+    protected abstract int getThreads();
+
+    protected abstract Class<? extends AbstractPMDProcessor> getExpectedImplementation();
+
     @Test
-    void shouldUseMonoThreadProcessorForZeroOnly() {
-        AbstractPMDProcessor processor = AbstractPMDProcessor.newFileProcessor(createTask(0));
-        assertSame(MonoThreadProcessor.class, processor.getClass());
-
-        processor = AbstractPMDProcessor.newFileProcessor(createTask(1));
-        assertSame(MultiThreadProcessor.class, processor.getClass());
+    void shouldUseCorrectProcessorImpl() {
+        try (AbstractPMDProcessor processor = AbstractPMDProcessor.newFileProcessor(createTask(getThreads()))) {
+            assertSame(getExpectedImplementation(), processor.getClass());
+        }
     }
 
     private LanguageProcessor.AnalysisTask createTask(int threads) {
-        LanguageProcessor.AnalysisTask task = new LanguageProcessor.AnalysisTask(null, null, null, threads, null, null, null);
-        return task;
+        return new LanguageProcessor.AnalysisTask(null, null, null, threads, null, null, null);
+    }
+
+    @Test
+    void exceptionsShouldBeLogged() {
+        try (PmdAnalysis pmd = createPmdAnalysis()) {
+            pmd.addRuleSet(RuleSet.forSingleRule(new RuleThatThrowsException()));
+            pmd.performAnalysis();
+        }
+
+        assertEquals(2, reportListener.files.get());
+        assertEquals(2, reportListener.errors.get());
+        // exceptions are reported as processing errors
+        Mockito.verifyNoInteractions(reporter);
+    }
+
+    protected PmdAnalysis createPmdAnalysis() {
+        PMDConfiguration configuration = new PMDConfiguration();
+        configuration.setThreads(getThreads());
+        configuration.setIgnoreIncrementalAnalysis(true);
+        reporter = Mockito.spy(configuration.getReporter());
+        configuration.setReporter(reporter);
+
+        PmdAnalysis pmd = PmdAnalysis.create(configuration);
+        LanguageVersion lv = DummyLanguageModule.getInstance().getDefaultVersion();
+        pmd.files().addFile(TextFile.forCharSeq("abc", FileId.fromPathLikeString("file1-violation.dummy"), lv));
+        pmd.files().addFile(TextFile.forCharSeq("DEF", FileId.fromPathLikeString("file2-foo.dummy"), lv));
+
+        reportListener = new SimpleReportListener();
+        GlobalAnalysisListener listener = GlobalAnalysisListener.tee(listOf(
+                new Report.GlobalReportBuilderListener(),
+                reportListener
+        ));
+
+
+        pmd.addListener(listener);
+        return pmd;
+    }
+
+    protected static class RuleThatThrowsException extends AbstractRule {
+        RuleThatThrowsException() {
+            setLanguage(DummyLanguageModule.getInstance().getDefaultVersion().getLanguage());
+        }
+
+        @Override
+        public void apply(Node target, RuleContext ctx) {
+            throw new RuntimeException("test exception");
+        }
+    }
+
+    protected static class RuleThatThrowsError extends AbstractRule {
+        RuleThatThrowsError() {
+            setLanguage(DummyLanguageModule.getInstance().getDefaultVersion().getLanguage());
+        }
+
+        @Override
+        public void apply(Node target, RuleContext ctx) {
+            throw new Error("test error");
+        }
+    }
+
+    protected static class SimpleReportListener implements GlobalAnalysisListener {
+
+        public AtomicInteger violations = new AtomicInteger(0);
+        public AtomicInteger files = new AtomicInteger(0);
+        public AtomicInteger errors = new AtomicInteger(0);
+
+        @Override
+        public FileAnalysisListener startFileAnalysis(TextFile file) {
+            files.incrementAndGet();
+
+            return new FileAnalysisListener() {
+                @Override
+                public void onRuleViolation(RuleViolation violation) {
+                    violations.incrementAndGet();
+                }
+
+                @Override
+                public void onError(Report.ProcessingError error) {
+                    errors.incrementAndGet();
+                }
+            };
+        }
+
+        @Override
+        public void close() throws Exception {
+
+        }
     }
 }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/impl/MonoThreadProcessorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/impl/MonoThreadProcessorTest.java
@@ -1,0 +1,43 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import net.sourceforge.pmd.PmdAnalysis;
+import net.sourceforge.pmd.RuleSet;
+
+class MonoThreadProcessorTest extends AbstractPMDProcessorTest {
+
+    @Override
+    protected int getThreads() {
+        return 0;
+    }
+
+    @Override
+    protected Class<? extends AbstractPMDProcessor> getExpectedImplementation() {
+        return MonoThreadProcessor.class;
+    }
+
+    @Test
+    void errorsShouldBeThrown() {
+        try (PmdAnalysis pmd = createPmdAnalysis()) {
+            pmd.addRuleSet(RuleSet.forSingleRule(new RuleThatThrowsError()));
+            Error exception = assertThrows(Error.class, pmd::performAnalysis);
+            assertEquals("test error", exception.getMessage());
+        }
+
+        // in mono thread, files are processed one after another.
+        // in case of error, we abort at the first error, so in this test case
+        // we abort at the first file, so only 1 file is processed.
+        assertEquals(1, reportListener.files.get());
+        // in mono thread, the error just falls through, we don't additionally catch and log it.
+        Mockito.verifyNoInteractions(reporter);
+    }
+}

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/impl/MultiThreadProcessorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/impl/MultiThreadProcessorTest.java
@@ -4,49 +4,59 @@
 
 package net.sourceforge.pmd.lang.impl;
 
-import static net.sourceforge.pmd.util.CollectionUtil.listOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
-import net.sourceforge.pmd.PMDConfiguration;
 import net.sourceforge.pmd.PmdAnalysis;
-import net.sourceforge.pmd.Report.GlobalReportBuilderListener;
 import net.sourceforge.pmd.RuleContext;
-import net.sourceforge.pmd.RuleViolation;
-import net.sourceforge.pmd.lang.DummyLanguageModule;
-import net.sourceforge.pmd.lang.LanguageVersion;
+import net.sourceforge.pmd.RuleSet;
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.document.FileId;
-import net.sourceforge.pmd.lang.document.TextFile;
 import net.sourceforge.pmd.lang.rule.AbstractRule;
-import net.sourceforge.pmd.reporting.FileAnalysisListener;
-import net.sourceforge.pmd.reporting.GlobalAnalysisListener;
 
-class MultiThreadProcessorTest {
+class MultiThreadProcessorTest extends AbstractPMDProcessorTest {
 
-    private SimpleReportListener reportListener;
+    @Override
+    protected int getThreads() {
+        return 2;
+    }
 
-    PmdAnalysis setupForTest(final String ruleset) {
-        PMDConfiguration configuration = new PMDConfiguration();
-        configuration.setThreads(2);
-        configuration.setIgnoreIncrementalAnalysis(true);
-        PmdAnalysis pmd = PmdAnalysis.create(configuration);
-        LanguageVersion lv = DummyLanguageModule.getInstance().getDefaultVersion();
-        pmd.files().addFile(TextFile.forCharSeq("abc", FileId.fromPathLikeString("file1-violation.dummy"), lv));
-        pmd.files().addFile(TextFile.forCharSeq("DEF", FileId.fromPathLikeString("file2-foo.dummy"), lv));
+    @Override
+    protected Class<? extends AbstractPMDProcessor> getExpectedImplementation() {
+        return MultiThreadProcessor.class;
+    }
 
-        reportListener = new SimpleReportListener();
-        GlobalAnalysisListener listener = GlobalAnalysisListener.tee(listOf(
-            new GlobalReportBuilderListener(),
-            reportListener
-        ));
-
-        pmd.addListener(listener);
+    private PmdAnalysis createPmdAnalysis(final String ruleset) {
+        PmdAnalysis pmd = createPmdAnalysis();
         pmd.addRuleSet(pmd.newRuleSetLoader().loadFromResource(ruleset));
         return pmd;
+    }
+
+    @Test
+    void errorsShouldBeThrown() {
+        // in multithreading mode, the errors are detected when closing PmdAnalysis
+        Error error = assertThrows(Error.class, () -> {
+            try (PmdAnalysis pmd = createPmdAnalysis()) {
+                pmd.addRuleSet(RuleSet.forSingleRule(new RuleThatThrowsError()));
+                pmd.performAnalysis();
+            }
+        });
+        assertEquals("test error", error.getMessage());
+
+        // in multithreading mode, all files are started but eventually fail
+        // depending on how many tasks have been started before getting the first results
+        // we might have started only one file analysis or more. But we rethrow
+        // the error on the first.
+        assertTrue(reportListener.files.get() >= 1);
+        // we report the first error
+        Mockito.verify(reporter).error(Mockito.eq("Unknown error occurred while executing a PmdRunnable: {0}"),
+                Mockito.eq("java.lang.Error: test error"),
+                Mockito.any(Error.class));
     }
 
     // TODO: Dysfunctional rules are pruned upstream of the processor.
@@ -71,7 +81,7 @@ class MultiThreadProcessorTest {
 
     @Test
     void testRulesThreadSafety() throws Exception {
-        try (PmdAnalysis pmd = setupForTest("rulesets/MultiThreadProcessorTest/basic.xml")) {
+        try (PmdAnalysis pmd = createPmdAnalysis("rulesets/MultiThreadProcessorTest/basic.xml")) {
             pmd.performAnalysis();
         }
 
@@ -130,23 +140,4 @@ class MultiThreadProcessorTest {
         }
     }
 
-    private static class SimpleReportListener implements GlobalAnalysisListener {
-
-        public AtomicInteger violations = new AtomicInteger(0);
-        
-        @Override
-        public FileAnalysisListener startFileAnalysis(TextFile file) {
-            return new FileAnalysisListener() {
-                @Override
-                public void onRuleViolation(RuleViolation violation) {
-                    violations.incrementAndGet();
-                }
-            };
-        }
-
-        @Override
-        public void close() throws Exception {
-
-        }
-    }
 }


### PR DESCRIPTION
## Describe the PR

If an error occurs in multithreading mode, PMD now rethrows this. Such errors indicate a serious problem like incomplete runtime classpath of PMD or other
VM error (out of memory) that shouldn't be swallowed.

When working on #4605 I once had an incomplete runtime classpath (I think guava was missing which jorje needs). The result was, that I didn't see any errors at all, even not with `--debug`. PMD ran fine, but Apex just didn't find anything yet. The fact, that no Apex violations were found was caught by the integration test. But it's not good, if an error is not printed at least to the console.

The solution in this PR is the most basic and could be improved it any thinkable way - but this change at least should be enough to see some errors.

Note: This is not about runtime exceptions or something like that - these are already collected in the report as processing errors.

- [x] TODO: verify this PR together with #4605, when running PMD and deleting guava-xxx.jar from lib/.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

