### PR TITLE
[cli] Launch script fails if run via "bash pmd"

### DIFF
--- a/pmd-dist/src/main/resources/scripts/pmd
+++ b/pmd-dist/src/main/resources/scripts/pmd
@@ -52,7 +52,7 @@ set_lib_dir() {
     if [ -L "$0" ]; then
       local script_real_loc=$(readlink "$0")
     else
-      local script_real_loc=$0
+      local script_real_loc=${BASH_SOURCE[0]}
     fi
     local script_dir=$(dirname "${script_real_loc}")
 

--- a/pmd-dist/src/main/resources/scripts/pmd
+++ b/pmd-dist/src/main/resources/scripts/pmd
@@ -52,7 +52,7 @@ set_lib_dir() {
     if [ -L "$0" ]; then
       local script_real_loc=$(readlink "$0")
     else
-      local script_real_loc=${BASH_SOURCE[0]}
+      local script_real_loc=${BASH_SOURCE[0]:-${(%):-%x}}
     fi
     local script_dir=$(dirname "${script_real_loc}")
 


### PR DESCRIPTION
If run.sh is launched via 'bin/bash run.sh', when run.sh is not in the local directory (i.e., accessed via path env var), it thinks it runs in the local directory.
This change makes sure that all cases are covered.
Tested on local Ubuntu 22.04 and similar Docker container running on Jenkins.

- Fixes #4723
