### PR TITLE
[apex] Add SObjectType and SObjectField to list of injectable SOQL variable types

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.apex.rule.security;
 
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -35,12 +37,12 @@ import net.sourceforge.pmd.lang.apex.rule.internal.Helper;
  *
  */
 public class ApexSOQLInjectionRule extends AbstractApexRule {
-    private static final String DOUBLE = "double";
-    private static final String LONG = "long";
-    private static final String DECIMAL = "decimal";
-    private static final String BOOLEAN = "boolean";
-    private static final String ID = "id";
-    private static final String INTEGER = "integer";
+    private static final Set<String> SAFE_VARIABLE_TYPES = Collections.unmodifiableSet(
+        new HashSet<>(Arrays.asList(
+            "double", "long", "decimal", "boolean", "id", "integer",
+            "sobjecttype", "schema.sobjecttype", "sobjectfield", "schema.sobjectfield"
+        )));
+    
     private static final String JOIN = "join";
     private static final String ESCAPE_SINGLE_QUOTES = "escapeSingleQuotes";
     private static final String STRING = "String";
@@ -108,23 +110,16 @@ public class ApexSOQLInjectionRule extends AbstractApexRule {
         return Helper.isMethodName(m, DATABASE, QUERY) || Helper.isMethodName(m, DATABASE, COUNT_QUERY);
     }
 
+    private boolean isSafeVariableType(String typeName) {
+        return SAFE_VARIABLE_TYPES.contains(typeName.toLowerCase(Locale.ROOT));
+    }
+
     private void findSafeVariablesInSignature(ASTMethod m) {
         for (ASTParameter p : m.findChildrenOfType(ASTParameter.class)) {
-            switch (p.getType().toLowerCase(Locale.ROOT)) {
-            case ID:
-            case INTEGER:
-            case BOOLEAN:
-            case DECIMAL:
-            case LONG:
-            case DOUBLE:
+            if (isSafeVariableType(p.getType())) {
                 safeVariables.add(Helper.getFQVariableName(p));
-                break;
-            default:
-                break;
             }
-
         }
-
     }
 
     private void findSanitizedVariables(ApexNode<?> node) {
@@ -159,17 +154,8 @@ public class ApexSOQLInjectionRule extends AbstractApexRule {
         }
 
         if (node instanceof ASTVariableDeclaration) {
-            switch (((ASTVariableDeclaration) node).getType().toLowerCase(Locale.ROOT)) {
-            case INTEGER:
-            case ID:
-            case BOOLEAN:
-            case DECIMAL:
-            case LONG:
-            case DOUBLE:
+            if (isSafeVariableType(((ASTVariableDeclaration) node).getType())) {
                 safeVariables.add(Helper.getFQVariableName(left));
-                break;
-            default:
-                break;
             }
         }
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
@@ -39,7 +39,7 @@ import net.sourceforge.pmd.lang.apex.rule.internal.Helper;
  */
 public class ApexSOQLInjectionRule extends AbstractApexRule {
     private static final Set<String> SAFE_VARIABLE_TYPES = 
-    	Collections.unmodifiableSet(Stream.of(
+        Collections.unmodifiableSet(Stream.of(
             "double", "long", "decimal", "boolean", "id", "integer",
             "sobjecttype", "schema.sobjecttype", "sobjectfield", "schema.sobjectfield"
         ).collect(Collectors.toSet()));

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/security/ApexSOQLInjectionRule.java
@@ -4,7 +4,6 @@
 
 package net.sourceforge.pmd.lang.apex.rule.security;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -13,6 +12,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTAssignmentExpression;
 import net.sourceforge.pmd.lang.apex.ast.ASTBinaryExpression;
@@ -37,11 +38,11 @@ import net.sourceforge.pmd.lang.apex.rule.internal.Helper;
  *
  */
 public class ApexSOQLInjectionRule extends AbstractApexRule {
-    private static final Set<String> SAFE_VARIABLE_TYPES = Collections.unmodifiableSet(
-        new HashSet<>(Arrays.asList(
+    private static final Set<String> SAFE_VARIABLE_TYPES = 
+    	Collections.unmodifiableSet(Stream.of(
             "double", "long", "decimal", "boolean", "id", "integer",
             "sobjecttype", "schema.sobjecttype", "sobjectfield", "schema.sobjectfield"
-        )));
+        ).collect(Collectors.toSet()));
     
     private static final String JOIN = "join";
     private static final String ESCAPE_SINGLE_QUOTES = "escapeSingleQuotes";

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSOQLInjection.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSOQLInjection.xml
@@ -91,22 +91,6 @@ public with sharing class Foo {
     </test-code>
 
     <test-code>
-        <description>SObjectType and Field as constants are safe to use in SOQL query string building</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-public with sharing class Foo {
-    private static final SObjectType TYPE = getSObjectType();
-    private static final SObjectField FIELD = getSObjectField();
-
-    public void getUniqueValues() {
-        String query = 'SELECT ' + FIELD + ' FROM ' + TYPE;
-        Database.query(query);
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
         <description>Schema.SObjectType and Field as parameters are safe to use in SOQL query string building</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
@@ -128,22 +112,6 @@ public with sharing class Foo {
         Schema.SObjectType type = getSObjectType();
         Schema.SObjectField field = getSObjectField();
         String query = 'SELECT ' + field + ' FROM ' + type;
-        Database.query(query);
-    }
-}
-        ]]></code>
-    </test-code>
-
-    <test-code>
-        <description>Schema.SObjectType and Field as constants are safe to use in SOQL query string building</description>
-        <expected-problems>0</expected-problems>
-        <code><![CDATA[
-public with sharing class Foo {
-    private static final Schema.SObjectType TYPE = getSObjectType();
-    private static final Schema.SObjectField FIELD = getSObjectField();
-
-    public void getUniqueValues() {
-        String query = 'SELECT ' + FIELD + ' FROM ' + TYPE;
         Database.query(query);
     }
 }

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSOQLInjection.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/security/xml/ApexSOQLInjection.xml
@@ -63,6 +63,94 @@ public class Foo {
     </test-code>
 
     <test-code>
+        <description>SObjectType and Field as parameters are safe to use in SOQL query string building</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public with sharing class Foo {
+    public void getUniqueValues(SObjectType type, SObjectField field) {
+        String query = 'SELECT ' + field + ' FROM ' + type;
+        Database.query(query);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>SObjectType and Field as variables are safe to use in SOQL query string building</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public with sharing class Foo {
+    public void getUniqueValues() {
+        SObjectType type = getSObjectType();
+        SObjectField field = getSObjectField();
+        String query = 'SELECT ' + field + ' FROM ' + type;
+        Database.query(query);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>SObjectType and Field as constants are safe to use in SOQL query string building</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public with sharing class Foo {
+    private static final SObjectType TYPE = getSObjectType();
+    private static final SObjectField FIELD = getSObjectField();
+
+    public void getUniqueValues() {
+        String query = 'SELECT ' + FIELD + ' FROM ' + TYPE;
+        Database.query(query);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Schema.SObjectType and Field as parameters are safe to use in SOQL query string building</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public with sharing class Foo {
+    public void getUniqueValues(Schema.SObjectType type, Schema.SObjectField field) {
+        String query = 'SELECT ' + field + ' FROM ' + type;
+        Database.query(query);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Schema.SObjectType and Field as variables are safe to use in SOQL query string building</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public with sharing class Foo {
+    public void getUniqueValues() {
+        Schema.SObjectType type = getSObjectType();
+        Schema.SObjectField field = getSObjectField();
+        String query = 'SELECT ' + field + ' FROM ' + type;
+        Database.query(query);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Schema.SObjectType and Field as constants are safe to use in SOQL query string building</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public with sharing class Foo {
+    private static final Schema.SObjectType TYPE = getSObjectType();
+    private static final Schema.SObjectField FIELD = getSObjectField();
+
+    public void getUniqueValues() {
+        String query = 'SELECT ' + FIELD + ' FROM ' + TYPE;
+        Database.query(query);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>Safe SOQL + merged variable from a literal</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[


### PR DESCRIPTION
…types

## Describe the PR

Recognise variables declared as SObjectField and SObjecType as safe for insertion into SOQL statements. These are Table and Field tokens and resolve to the safe name for their respective artefacts when inserted into a string.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #4646 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

