### PR TITLE
[java] Doc: Fix references AutoClosable -> AutoCloseable

### DIFF
--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -977,7 +977,7 @@ Ensure that resources (like `java.sql.Connection`, `java.sql.Statement`, and `ja
 and any subtype of `java.lang.AutoCloseable`) are always closed after use.
 Failing to do so might result in resource leaks.
 
-Note: It suffices to configure the super type, e.g. `java.lang.AutoClosable`, so that this rule automatically triggers
+Note: It suffices to configure the super type, e.g. `java.lang.AutoCloseable`, so that this rule automatically triggers
 on any subtype (e.g. `java.io.FileInputStream`). Additionally specifying `java.sql.Connection` helps in detecting
 the types, if the type resolution / auxclasspath is not correctly setup.
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UseTryWithResources.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UseTryWithResources.xml
@@ -182,13 +182,13 @@ public class TryWithResources {
         <code><![CDATA[
 public class TryWithResources {
     public void run() {
-        var noAutoclosable = new Object() {
+        var noAutoCloseable = new Object() {
             public void close() {}
         };
         try {
-            System.out.println(noAutocloseable);
+            System.out.println(noAutoCloseable);
         } finally {
-            noAutoclosable.close();
+            noAutoCloseable.close();
         }
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
@@ -1133,7 +1133,7 @@ public class CloseResourceJMS {
     </test-code>
 
     <test-code>
-        <description>CloseResource for closable - ignored if the types do not contain AutoClosable</description>
+        <description>CloseResource for closable - ignored if the types do not contain AutoCloseable</description>
         <rule-property name="types">java.sql.Connection,java.sql.Statement,java.sql.ResultSet</rule-property>
         <expected-problems>0</expected-problems>
         <code><![CDATA[


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

I believe "closable" and "closeable" could be used interchangeably - however, the proper spelling for the Java interface is `AutoCloseable`.

This PR fixes docs and code snippets that refer/allude to the AutoCloseable interface. 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

