### PR TITLE
Bump wiremock from 2.33.2 to 2.35.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -838,7 +838,7 @@
             <dependency>
                 <groupId>com.github.tomakehurst</groupId>
                 <artifactId>wiremock-jre8</artifactId>
-                <version>2.33.2</version>
+                <version>2.35.1</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
* Fixes https://github.com/pmd/pmd/security/dependabot/48
* Fixes CVE-2023-41329
* Fixes https://github.com/advisories/GHSA-pmxq-pj47-j8j4
