### PR TITLE
Bump pmd-designer from 7.0.0-rc1 to 7.0.0-SNAPSHOT

### DIFF
--- a/pmd-dist/pom.xml
+++ b/pmd-dist/pom.xml
@@ -168,13 +168,6 @@
             <artifactId>commons-lang3</artifactId>
         </dependency>
 
-        <!-- needed for pmd-designer 7.0.0-rc1 -->
-        <dependency>
-            <groupId>com.beust</groupId>
-            <artifactId>jcommander</artifactId>
-            <version>1.48</version>
-        </dependency>
-
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
 
         <pmd.build-tools.version>22-SNAPSHOT</pmd.build-tools.version>
 
-        <pmd-designer.version>7.0.0-rc1</pmd-designer.version>
+        <pmd-designer.version>7.0.0-SNAPSHOT</pmd-designer.version>
         <javacc.jar>${settings.localRepository}/net/java/dev/javacc/javacc/${javacc.version}/javacc-${javacc.version}.jar</javacc.jar>
         <javacc.outputDirectory>${project.build.directory}/generated-sources/javacc</javacc.outputDirectory>
         <javacc.ant.wrapper>${project.basedir}/../javacc-wrapper.xml</javacc.ant.wrapper>


### PR DESCRIPTION
Also remove jcommander, this is not needed anymore.

This partly resolves #4691, as the new pmd-designer doesn't contain commons-io anymore (see pmd/pmd-designer#74).

This also makes the designer workable again in the current SNAPSHOT of PMD.

