### PR TITLE
Make PMD buildable with java 21

### DIFF
--- a/pmd-core/src/test/java/net/sourceforge/pmd/PmdAnalysisTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/PmdAnalysisTest.java
@@ -32,6 +32,7 @@ import net.sourceforge.pmd.lang.document.FileId;
 import net.sourceforge.pmd.lang.document.SimpleTestTextFile;
 import net.sourceforge.pmd.lang.rule.AbstractRule;
 import net.sourceforge.pmd.renderers.Renderer;
+import net.sourceforge.pmd.renderers.TextRenderer;
 import net.sourceforge.pmd.reporting.ReportStats;
 import net.sourceforge.pmd.util.log.MessageReporter;
 
@@ -54,7 +55,7 @@ class PmdAnalysisTest {
     void testRendererInteractions() throws IOException {
         PMDConfiguration config = new PMDConfiguration();
         config.addInputPath(Paths.get("sample-source/dummy"));
-        Renderer renderer = spy(Renderer.class);
+        Renderer renderer = spy(new TextRenderer());
         try (PmdAnalysis pmd = PmdAnalysis.create(config)) {
             pmd.addRenderer(renderer);
             verify(renderer, never()).start();

--- a/pmd-core/src/test/java/net/sourceforge/pmd/PmdAnalysisTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/PmdAnalysisTest.java
@@ -32,7 +32,6 @@ import net.sourceforge.pmd.lang.document.FileId;
 import net.sourceforge.pmd.lang.document.SimpleTestTextFile;
 import net.sourceforge.pmd.lang.rule.AbstractRule;
 import net.sourceforge.pmd.renderers.Renderer;
-import net.sourceforge.pmd.renderers.TextRenderer;
 import net.sourceforge.pmd.reporting.ReportStats;
 import net.sourceforge.pmd.util.log.MessageReporter;
 
@@ -55,7 +54,7 @@ class PmdAnalysisTest {
     void testRendererInteractions() throws IOException {
         PMDConfiguration config = new PMDConfiguration();
         config.addInputPath(Paths.get("sample-source/dummy"));
-        Renderer renderer = spy(new TextRenderer());
+        Renderer renderer = spy(Renderer.class);
         try (PmdAnalysis pmd = PmdAnalysis.create(config)) {
             pmd.addRenderer(renderer);
             verify(renderer, never()).start();

--- a/pom.xml
+++ b/pom.xml
@@ -835,6 +835,23 @@
                 <scope>test</scope>
             </dependency>
 
+            <!-- byte-buddy is used by mockito.
+                 Using a newer version than the one from mockito 4.11.0 for Java 21 compatibility
+                 At least byte-buddy 1.14.3 is required for Java 21.
+            -->
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy</artifactId>
+                <version>1.14.9</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>net.bytebuddy</groupId>
+                <artifactId>byte-buddy-agent</artifactId>
+                <version>1.14.9</version>
+                <scope>test</scope>
+            </dependency>
+
             <dependency>
                 <groupId>com.github.tomakehurst</groupId>
                 <artifactId>wiremock-jre8</artifactId>


### PR DESCRIPTION
This is the only change needed, so that PMD builds with java21. This seems to be a bug in mockito (see https://github.com/mockito/mockito/issues/3121) but we seem to use this edge case only here. So I opted to go the simple way...

(mockito fails to call the default method `newListener()` on interface `Renderer`).