### PR TITLE
[ci] Introduce a two-step release process

### DIFF
--- a/do-release.sh
+++ b/do-release.sh
@@ -244,6 +244,7 @@ echo "    <https://repo.maven.apache.org/maven2/net/sourceforge/pmd/pmd/maven-me
 echo
 echo
 echo "Then proceed with releasing pmd-designer..."
+echo "<https://github.com/pmd/pmd-designer/blob/master/releasing.md>"
 echo
 echo "Press enter to continue when pmd-designer is available in maven-central..."
 echo "<https://repo.maven.apache.org/maven2/net/sourceforge/pmd/pmd-ui/maven-metadata.xml>."

--- a/do-release.sh
+++ b/do-release.sh
@@ -101,8 +101,8 @@ echo "    the new release based on the release notes. Also add any deprecated ru
 echo
 echo "*   Update **../pmd.github.io/_config.yml** to mention the new release"
 echo
-echo "*   Update property \`pmd-designer.version\` in **pom.xml** to reference the latest pmd-designer release"
-echo "    See <https://search.maven.org/search?q=g:net.sourceforge.pmd%20AND%20a:pmd-ui&core=gav> for the available releases."
+echo "*   Update property \`pmd-designer.version\` in **pom.xml** to reference the version, that will be released"
+echo "    later in this process."
 echo
 echo "Press enter to continue..."
 read -r
@@ -170,8 +170,8 @@ git commit -a -m "Prepare pmd release ${RELEASE_VERSION}"
     -DreleaseVersion="${RELEASE_VERSION}" \
     -DdevelopmentVersion="${DEVELOPMENT_VERSION}" \
     -DscmCommentPrefix="[release] " \
-    -Pgenerate-rule-docs
-
+    -Darguments='-Pgenerate-rule-docs,!cli-dist' \
+    '-Pgenerate-rule-docs,!cli-dist'
 
 echo
 echo "Tag has been pushed.... now check github actions: <https://github.com/pmd/pmd/actions>"
@@ -235,14 +235,45 @@ EOF
 git commit -a -m "Prepare next development version [skip ci]"
 git push origin "${CURRENT_BRANCH}"
 ./mvnw -B release:clean
+
 echo
+echo
+echo
+echo "*   Wait until the new version is synced to maven central and appears as latest version in"
+echo "    <https://repo.maven.apache.org/maven2/net/sourceforge/pmd/pmd/maven-metadata.xml>."
+echo
+echo
+echo "Then proceed with releasing pmd-designer..."
+echo
+echo "Press enter to continue when pmd-designer is available in maven-central..."
+echo "<https://repo.maven.apache.org/maven2/net/sourceforge/pmd/pmd-ui/maven-metadata.xml>."
+read -r
+
+echo
+echo "Continuing with release of pmd-cli and pmd-dist..."
+git checkout "pmd_releases/${RELEASE_VERSION}"
+./mvnw versions:update-parent -DparentVersion="${RELEASE_VERSION}" -DskipResolution=true -DgenerateBackupPoms=false -pl pmd-cli,pmd-dist
+git add pmd-cli/pom.xml pmd-dist/pom.xml
+git commit -m "[release] prepare release pmd_releases/${RELEASE_VERSION}-dist"
+git tag -m "[release] copy for tag pmd_releases/${RELEASE_VERSION}-dist" "pmd_releases/${RELEASE_VERSION}-dist"
+git push origin tag "pmd_releases/${RELEASE_VERSION}-dist"
+git checkout master
+# make sure parent reference is correct
+./mvnw versions:update-parent -DparentVersion="${DEVELOPMENT_VERSION}" -DskipResolution=true -DgenerateBackupPoms=false -pl pmd-cli,pmd-dist
+git add pmd-cli/pom.xml pmd-dist/pom.xml
+changes=$(git status --porcelain 2>/dev/null| grep -c -E "^[AMDRC]")
+if [ "$changes" -gt 0 ]; then
+    git commit -m "Prepare next development version [skip ci]"
+    git push origin "${CURRENT_BRANCH}"
+fi
+
+echo
+echo "Second tag 'pmd_releases/${RELEASE_VERSION}-dist' has been pushed ... now check github actions: <https://github.com/pmd/pmd/actions>"
 echo
 echo
 echo "Verify the new release on github: <https://github.com/pmd/pmd/releases/tag/pmd_releases/${RELEASE_VERSION}>"
 echo "and the news entry at <https://sourceforge.net/p/pmd/news/>"
 echo
-echo "*   Wait until the new version is synced to maven central and appears as latest version in"
-echo "    <https://repo.maven.apache.org/maven2/net/sourceforge/pmd/pmd/maven-metadata.xml>."
 echo "*   Send out an announcement mail to the mailing list:"
 echo
 echo "To: PMD Developers List <pmd-devel@lists.sourceforge.net>"

--- a/pmd-doc/pom.xml
+++ b/pmd-doc/pom.xml
@@ -74,8 +74,9 @@
     <dependencies>
         <dependency>
             <groupId>net.sourceforge.pmd</groupId>
-            <artifactId>pmd-dist</artifactId>
+            <artifactId>pmd-languages-deps</artifactId>
             <version>${project.version}</version>
+            <type>pom</type>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1150,18 +1150,27 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>cli-dist</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>pmd-cli</module>
+                <module>pmd-dist</module>
+            </modules>
+        </profile>
     </profiles>
 
     <modules>
         <module>pmd-apex-jorje</module>
         <module>pmd-apex</module>
-        <module>pmd-cli</module>
         <module>pmd-coco</module>
         <module>pmd-core</module>
         <module>pmd-cpp</module>
         <module>pmd-cs</module>
         <module>pmd-dart</module>
-        <module>pmd-dist</module>
         <module>pmd-doc</module>
         <module>pmd-fortran</module>
         <module>pmd-gherkin</module>


### PR DESCRIPTION
1. Release all modules except pmd-cli and pmd-dist
2. Release pmd-cli and pmd-dist

This allows to release pmd-designer in between.

This addresses #4446 in a hackish way, which might even work :crossed_fingers: 
I think, we should keep #4446 open because doing a release in two steps would be really simpler, if we move pmd-cli and pmd-dist somewhere else.

Anyway, I'll try out this solution tomorrow for the 7.0.0-rc4 release.