### PR TITLE
#1831 resolved the issue

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/DetachedTestCaseRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/DetachedTestCaseRule.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 
 import net.sourceforge.pmd.lang.ast.NodeStream;
+
 import net.sourceforge.pmd.lang.java.ast.ASTClassOrInterfaceDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.JModifier;
@@ -24,7 +25,7 @@ public class DetachedTestCaseRule extends AbstractJavaRulechainRule {
             // looks like a test case
             methods.filter(m -> m.getArity() == 0
                        && m.isVoid()
-                       && !m.getModifiers().hasAny(JModifier.STATIC, JModifier.PRIVATE, JModifier.PROTECTED))
+                       && !m.getModifiers().hasAny(JModifier.STATIC, JModifier.PRIVATE, JModifier.PROTECTED, JModifier.ABSTRACT))
                    // the method itself has no annotation
                    .filter(it -> it.getDeclaredAnnotations().isEmpty())
                    .forEach(m -> addViolation(data, m));


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

Abstract methods should not have body and therefore we should not be doing anything inside them rather implementation is done at the child level. In the DetachedTestCaseRule added the filter condition to exclude all
abstract methods from getting evaluated under this rule. 


## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #

## Ready?
I have run the mvn compile package command and executed the pmd checks on a test java class
and it ignored the abstract methods
 
<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

