### PR TITLE
[java] Make allowExceptionNameRegex a Regex

### DIFF
--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -1465,7 +1465,7 @@ or reported.
                 </value>
             </property>
             <property name="allowCommentedBlocks" type="Boolean" description="Empty blocks containing comments will be skipped" value="false"/>
-            <property name="allowExceptionNameRegex" type="String" description="Empty blocks catching exceptions with names matching this regular expression will be skipped" value="^(ignored|expected)$"/>
+            <property name="allowExceptionNameRegex" type="Regex" description="Empty blocks catching exceptions with names matching this regular expression will be skipped" value="^(ignored|expected)$"/>
         </properties>
         <example>
 <![CDATA[


### PR DESCRIPTION
## Describe the PR

This is the last regex property not using `PropertyDescriptor<Pattern>` underneath.

## Related issues

Fixes #1027 

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

