### PR TITLE
Fixes NoSuchMethodError on processing errors in pmd-compat6

### DIFF
--- a/pmd-compat6/src/it/pmd-for-java/exception_ruleset.xml
+++ b/pmd-compat6/src/it/pmd-for-java/exception_ruleset.xml
@@ -1,0 +1,16 @@
+<ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0" name="Exception throwing ruleset">
+    <description/>
+    <rule name="ExceptionThrowingRule"
+          language="java"
+          class="net.sourceforge.pmd.lang.rule.XPathRule">
+        <description>Use this rule to produce a processing error.</description>
+        <priority>3</priority>
+        <properties>
+            <property name="xpath">
+                <value><![CDATA[
+error()
+            ]]></value></property>
+        </properties>
+    </rule>
+</ruleset>
+

--- a/pmd-compat6/src/it/pmd-for-java/pom.xml
+++ b/pmd-compat6/src/it/pmd-for-java/pom.xml
@@ -30,8 +30,12 @@
                 </executions>
                 <configuration>
                     <printFailingErrors>true</printFailingErrors>
-                    <skipPmdError>false</skipPmdError>
+                    <skipPmdError>true</skipPmdError> <!-- we want to capture processing errors -->
                     <minimumTokens>5</minimumTokens>
+                    <rulesets>
+                        <ruleset>/rulesets/java/maven-pmd-plugin-default.xml</ruleset>
+                        <ruleset>${project.basedir}/exception_ruleset.xml</ruleset>
+                    </rulesets>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/pmd-compat6/src/it/pmd-for-java/verify.bsh
+++ b/pmd-compat6/src/it/pmd-for-java/verify.bsh
@@ -51,3 +51,7 @@ String textReport = readFile(pmdTextReport);
 if (!textReport.contains(mainFile + ":5:\tUnusedLocalVariable")) {
     throw new RuntimeException("Expected violation has not been reported in TXT");
 }
+
+if (!pmdXml.contains("<error filename=\"" + mainFile.getAbsolutePath()) || !pmdXml.contains(mainFile + "\" msg=\"PmdXPathException")) {
+    throw new RuntimeException("Processing error has not been reported");
+}

--- a/pmd-compat6/src/it/pmd-for-java/verify.bsh
+++ b/pmd-compat6/src/it/pmd-for-java/verify.bsh
@@ -29,9 +29,12 @@ String pmdXml = readFile(pmdXmlReport);
 if (!pmdXml.contains("<violation beginline=\"5\" endline=\"5\" begincolumn=\"16\" endcolumn=\"37\" rule=\"UnusedLocalVariable\" ruleset=\"Best Practices\" package=\"org.example\" class=\"Main\" method=\"main\" variable=\"thisIsAUnusedLocalVar\"")) {
     throw new RuntimeException("Expected violation has not been reported");
 }
-File mainFile = new File("pmd-for-java/src/main/java/org/example/Main.java");
+File mainFile = new File(basedir, "src/main/java/org/example/Main.java");
 if (!pmdXml.contains(mainFile + "\">")) {
     throw new RuntimeException("Expected violation has not been reported");
+}
+if (!pmdXml.contains("<error filename=\"" + mainFile.getAbsolutePath()) || !pmdXml.contains(mainFile + "\" msg=\"PmdXPathException")) {
+    throw new RuntimeException("Processing error has not been reported");
 }
 
 File pmdCsvReport = new File(basedir, "target/pmd.csv");
@@ -50,8 +53,4 @@ if (!pmdTextReport.exists()) {
 String textReport = readFile(pmdTextReport);
 if (!textReport.contains(mainFile + ":5:\tUnusedLocalVariable")) {
     throw new RuntimeException("Expected violation has not been reported in TXT");
-}
-
-if (!pmdXml.contains("<error filename=\"" + mainFile.getAbsolutePath()) || !pmdXml.contains(mainFile + "\" msg=\"PmdXPathException")) {
-    throw new RuntimeException("Processing error has not been reported");
 }

--- a/pmd-compat6/src/main/java/net/sourceforge/pmd/Report.java
+++ b/pmd-compat6/src/main/java/net/sourceforge/pmd/Report.java
@@ -143,6 +143,11 @@ public final class Report {
         public Throwable getError() {
             return error;
         }
+
+        // ------------------- compat extensions --------------------
+        public String getFile() {
+            return file.getAbsolutePath();
+        }
     }
 
     /**


### PR DESCRIPTION
## Describe the PR

When a processing error occurs while using pmd-compat6 (rc4) then a NoSuchMethodError is thrown:

`[ERROR] Failed to execute goal org.apache.maven.plugins:maven-pmd-plugin:3.21.2:pmd (default-cli) on project flexpay-reflectdb: Execution default-cli of goal org.apache.maven.plugins:maven-pmd-plugin:3.21.2:pmd failed: An API incompatibility was encountered while executing org.apache.maven.plugins:maven-pmd-plugin:3.21.2:pmd: java.lang.NoSuchMethodError: 'java.lang.String net.sourceforge.pmd.Report$ProcessingError.getFile()'`

This PR implements the missing getFile() method.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

