### PR TITLE
[core] Fix flaky SummaryHTMLRenderer

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/SummaryHTMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/SummaryHTMLRenderer.java
@@ -5,7 +5,7 @@
 package net.sourceforge.pmd.renderers;
 
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -74,7 +74,7 @@ public class SummaryHTMLRenderer extends AbstractAccumulatingRenderer {
     }
 
     private static Map<String, MutableInt> getSummary(Report report) {
-        Map<String, MutableInt> summary = new HashMap<>();
+        Map<String, MutableInt> summary = new LinkedHashMap<>();
         for (RuleViolation rv : report.getViolations()) {
             String name = rv.getRule().getName();
             MutableInt count = summary.get(name);

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/SummaryHTMLRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/SummaryHTMLRendererTest.java
@@ -69,8 +69,8 @@ class SummaryHTMLRendererTest extends AbstractRendererTest {
         return "<html><head><title>PMD</title></head><body>" + EOL + "<center><h2>Summary</h2></center>" + EOL
                 + "<table align=\"center\" cellspacing=\"0\" cellpadding=\"3\">" + EOL
                 + "<tr><th>Rule name</th><th>Number of violations</th></tr>" + EOL
-                + "<tr><td>Boo</td><td align=center>1</td></tr>" + EOL
-                + "<tr><td>Foo</td><td align=center>1</td></tr>" + EOL + "</table>" + EOL
+                + "<tr><td>Foo</td><td align=center>1</td></tr>" + EOL
+                + "<tr><td>Boo</td><td align=center>1</td></tr>" + EOL + "</table>" + EOL
                 + "<center><h2>Detail</h2></center><table align=\"center\" cellspacing=\"0\" cellpadding=\"3\"><tr>"
                 + EOL
                 + "<center><h3>PMD report</h3></center><center><h3>Problems found</h3></center><table align=\"center\" cellspacing=\"0\" cellpadding=\"3\"><tr>"


### PR DESCRIPTION
## Describe the PR

The test `SummaryHTMLRendererTest.testRendererMultiple` assumes a particular order for the keys stored in `summary` map. 
The following lines of code in `renderSummary` function may return any random field ordering. This might cause inconsistent output rendering and results in the unit test being flaky.
https://github.com/pmd/pmd/blob/bdc08e44fd92380d59cdc50cf9d8dd36e537c369/pmd-core/src/main/java/net/sourceforge/pmd/renderers/SummaryHTMLRenderer.java#L64-L72
Changing the HashMap to LinkedHashMap, makes the output consistent and fixes the flaky test. There might be other possible fixes like, changing the test code such that, the tests expects and passes for both the orderings.

## Steps to reproduce the flaky test
Setup the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool in your repo and run
```
mvn -pl pmd-core -Dtest=net.sourceforge.pmd.renderers.SummaryHTMLRendererTest#testRendererMultiple
```
**Error Message**
```html
net.sourceforge.pmd.renderers.SummaryHTMLRendererTest.testRendererMultiple  Time elapsed: 0.002 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: 
expected: <<html><head><title>PMD</title></head><body>
<center><h2>Summary</h2></center>
<table align="center" cellspacing="0" cellpadding="3">
<tr><th>Rule name</th><th>Number of violations</th></tr>
<tr><td>Boo</td><td align=center>1</td></tr>
<tr><td>Foo</td><td align=center>1</td></tr>
</table>
<center><h2>Detail</h2></center><table align="center" cellspacing="0" cellpadding="3"><tr>
<center><h3>PMD report</h3></center><center><h3>Problems found</h3></center><table align="center" cellspacing="0" cellpadding="3"><tr>
<th>#</th><th>File</th><th>Line</th><th>Problem</th></tr>
<tr bgcolor="lightgrey"> 
<td align="center">1</td>
<td width="*%"><a href="link_prefixnotAvailable.html#line_prefix1">notAvailable</a></td>
<td align="center" width="5%">1</td>
<td width="*">blah</td>
</tr>
<tr> 
<td align="center">2</td>
<td width="*%"><a href="link_prefixnotAvailable.html#line_prefix1">notAvailable</a></td>
<td align="center" width="5%">1</td>
<td width="*">blah</td>
</tr>
</table></tr></table></body></html>
> but was: <<html><head><title>PMD</title></head><body>
<center><h2>Summary</h2></center>
<table align="center" cellspacing="0" cellpadding="3">
<tr><th>Rule name</th><th>Number of violations</th></tr>
<tr><td>Foo</td><td align=center>1</td></tr>
<tr><td>Boo</td><td align=center>1</td></tr>
</table>
<center><h2>Detail</h2></center><table align="center" cellspacing="0" cellpadding="3"><tr>
<center><h3>PMD report</h3></center><center><h3>Problems found</h3></center><table align="center" cellspacing="0" cellpadding="3"><tr>
<th>#</th><th>File</th><th>Line</th><th>Problem</th></tr>
<tr bgcolor="lightgrey"> 
<td align="center">1</td>
<td width="*%"><a href="link_prefixnotAvailable.html#line_prefix1">notAvailable</a></td>
<td align="center" width="5%">1</td>
<td width="*">blah</td>
</tr>
<tr> 
<td align="center">2</td>
<td width="*%"><a href="link_prefixnotAvailable.html#line_prefix1">notAvailable</a></td>
<td align="center" width="5%">1</td>
<td width="*">blah</td>
</tr>
</table></tr></table></body></html>
>
```

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

