### PR TITLE
[core] Fix flaky LatticeRelationTest

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/GraphUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/GraphUtil.java
@@ -43,7 +43,10 @@ public final class GraphUtil {
         StringBuilder sb = new StringBuilder("strict digraph {\n");
         Map<V, String> ids = new HashMap<>();
         int i = 0;
-        for (V node : vertices) {
+        List<V> vertexList = new ArrayList<>();
+        vertexList.addAll(vertices);
+        vertexList.sort(Comparator.comparing(Object::toString)); // for reproducibility in tests
+        for (V node : vertexList) {
             String id = "n" + i++;
             ids.put(node, id);
             sb.append(id)
@@ -56,7 +59,7 @@ public final class GraphUtil {
 
         List<String> edges = new ArrayList<>();
 
-        for (V node : vertices) {
+        for (V node : vertexList) {
             // edges
             String id = ids.get(node);
             for (V succ : successorFun.apply(node)) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/GraphUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/GraphUtil.java
@@ -43,8 +43,7 @@ public final class GraphUtil {
         StringBuilder sb = new StringBuilder("strict digraph {\n");
         Map<V, String> ids = new HashMap<>();
         int i = 0;
-        List<V> vertexList = new ArrayList<>();
-        vertexList.addAll(vertices);
+        List<V> vertexList = new ArrayList<>(vertices);
         vertexList.sort(Comparator.comparing(Object::toString)); // for reproducibility in tests
         for (V node : vertexList) {
             String id = "n" + i++;

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/internal/LatticeRelationTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/internal/LatticeRelationTest.java
@@ -279,15 +279,15 @@ class LatticeRelationTest {
         // all {1}, {2}, and { } are query nodes, not {1,2}
 
         assertEquals("strict digraph {\n"
-                         + "n0 [ shape=box, color=green, label=\"[]\" ];\n"
+                         + "n0 [ shape=box, color=black, label=\"[1, 2]\" ];\n"
                          + "n1 [ shape=box, color=green, label=\"[1]\" ];\n"
                          + "n2 [ shape=box, color=green, label=\"[2]\" ];\n"
-                         + "n3 [ shape=box, color=black, label=\"[1, 2]\" ];\n"
-                         + "n1 -> n0;\n" // {1}   -> { }
-                         + "n2 -> n0;\n" // {2}   -> { }
-                         + "n3 -> n0;\n" // {1,2} -> { }
-                         + "n3 -> n1;\n" // {1,2} -> {1}
-                         + "n3 -> n2;\n" // {1,2} -> {2}
+                         + "n3 [ shape=box, color=green, label=\"[]\" ];\n"
+                         + "n0 -> n1;\n" // {1}   -> { }
+                         + "n0 -> n2;\n" // {2}   -> { }
+                         + "n0 -> n3;\n" // {1,2} -> { }
+                         + "n1 -> n3;\n" // {1,2} -> {1}
+                         + "n2 -> n3;\n" // {1,2} -> {2}
                          + "}", lattice.toString());
     }
 


### PR DESCRIPTION
## Describe the PR
**Problem**
The `LatticeRelationTest.testToString` is detected as flaky. The following lines of code iterate over `vertices` which is of Type Set.
https://github.com/pmd/pmd/blob/f030d7f8d77cf3f943e4ef2a6fe3d7d01ee26c66/pmd-core/src/main/java/net/sourceforge/pmd/util/GraphUtil.java#L46
https://github.com/pmd/pmd/blob/f030d7f8d77cf3f943e4ef2a6fe3d7d01ee26c66/pmd-core/src/main/java/net/sourceforge/pmd/util/GraphUtil.java#L59
Java does not iterate over elements of a set in a particular order. This causes the output `toString` function to be non-deterministic and results in the `LatticeRelationTest.testToString` to be flaky. 
**Solution**
I have modified the code such that we iterate over a sorted list of `Vertex` objects. This results in the `toString` output being deterministic. I had to modify the expected string in the test assertion to account for the sorting.
Another possible fix would be to modify the test itself and change the `assert` to expect multiple different string ordering values. 

## Steps to reproduce the flaky test
Setup the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool and run
```
mvn -pl pmd-core edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=net.sourceforge.pmd.lang.rule.internal.LatticeRelationTest#testToString
```
**Error Message**
```javascript
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.077 s <<< FAILURE! - in net.sourceforge.pmd.lang.rule.internal.LatticeRelationTest
[ERROR] net.sourceforge.pmd.lang.rule.internal.LatticeRelationTest.testToString  Time elapsed: 0.047 s  <<< FAILURE!
org.opentest4j.AssertionFailedError: 
expected: <strict digraph {
n0 [ shape=box, color=green, label="[]" ];
n1 [ shape=box, color=green, label="[1]" ];
n2 [ shape=box, color=green, label="[2]" ];
n3 [ shape=box, color=black, label="[1, 2]" ];
n1 -> n0;
n2 -> n0;
n3 -> n0;
n3 -> n1;
n3 -> n2;
}> but was: <strict digraph {
n0 [ shape=box, color=green, label="[2]" ];
n1 [ shape=box, color=green, label="[]" ];
n2 [ shape=box, color=black, label="[1, 2]" ];
n3 [ shape=box, color=green, label="[1]" ];
n0 -> n1;
n2 -> n0;
n2 -> n1;
n2 -> n3;
n3 -> n1;
}>
```


## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [X] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

