### PR TITLE
[java] EmptyControlStatementRule: Add allowCommentedBlocks property

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/EmptyControlStatementRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/EmptyControlStatementRule.java
@@ -21,13 +21,25 @@ import net.sourceforge.pmd.lang.java.ast.ASTWhileStatement;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
 
 public class EmptyControlStatementRule extends AbstractJavaRulechainRule {
+
+    private static final PropertyDescriptor<Boolean> ALLOW_COMMENTED_BLOCKS
+            = PropertyFactory.booleanProperty("allowCommentedBlocks")
+            .desc("Option for allowing empty but commented blocks. This is useful where a developer "
+                    + "wants to have the code structure and explain why a condition does not require "
+                    + "logic or to hold TODO comments for future work.")
+            .defaultValue(Boolean.FALSE)
+            .build();
 
     public EmptyControlStatementRule() {
         super(ASTFinallyClause.class, ASTSynchronizedStatement.class, ASTTryStatement.class, ASTDoStatement.class,
                 ASTBlock.class, ASTForStatement.class, ASTForeachStatement.class, ASTWhileStatement.class,
                 ASTIfStatement.class, ASTSwitchStatement.class, ASTInitializer.class);
+
+        definePropertyDescriptor(ALLOW_COMMENTED_BLOCKS);
     }
 
     @Override
@@ -145,7 +157,9 @@ public class EmptyControlStatementRule extends AbstractJavaRulechainRule {
     }
 
     private boolean isEmpty(JavaNode node) {
-        return node instanceof ASTBlock && node.getNumChildren() == 0
+        boolean allowCommentedBlocks = getProperty(ALLOW_COMMENTED_BLOCKS);
+
+        return (node instanceof ASTBlock && node.getNumChildren() == 0 && !(((ASTBlock) node).containsComment() && allowCommentedBlocks))
             || node instanceof ASTEmptyStatement;
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/EmptyControlStatement.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/EmptyControlStatement.xml
@@ -228,7 +228,7 @@
             }
             ]]></code>
     </test-code>
-    
+
     <test-code>
         <description>empty initializer failure case (non static)</description>
         <expected-problems>1</expected-problems>
@@ -502,7 +502,8 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>empty if statement with comment</description>
+        <description>empty if statement with comment, disallow commented block</description>
+        <rule-property name="allowCommentedBlocks">false</rule-property>
         <expected-problems>1</expected-problems>
         <expected-messages>
             <message>Empty if statement</message>
@@ -516,5 +517,21 @@ public class Foo {
     }
 }
         ]]></code>
+
+    </test-code>
+    <test-code>
+        <description>empty if statement with comment, allow commented block</description>
+        <rule-property name="allowCommentedBlocks">true</rule-property>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void bar(int x) {
+        if (x == 0) {
+            // empty!
+        }
+    }
+}
+        ]]></code>
+
     </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

**Rule**: [EmptyControlStatement](https://docs.pmd-code.org/latest/pmd_rules_java_codestyle.html#emptycontrolstatement)

Adds a property to EmptyControlStatementRule to allow empty block containing comments.  It may be good to be able to explain why a condition does not require logic.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

