### PR TITLE
[java] fix: remove delimiter attribute from ruleset category/java/errorprone.xml

### DIFF
--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -1036,7 +1036,7 @@ in the `typesThatCompareByReference` property.
         <priority>3</priority>
         <properties>
             <property name="version" value="2.0"/>
-            <property name="typesThatCompareByReference" type="List[String]" delimiter="," description="List of canonical type names for which reference comparison is allowed.">
+            <property name="typesThatCompareByReference" type="List[String]" description="List of canonical type names for which reference comparison is allowed.">
                 <value>java.lang.Enum,java.lang.Class</value>
             </property>
             <property name="xpath">
@@ -2350,7 +2350,7 @@ See the property `annotations`.
         </description>
         <priority>3</priority>
         <properties>
-            <property name="annotations" type="List[String]" delimiter="," value="org.springframework.beans.factory.annotation.Autowired,javax.inject.Inject,com.google.inject.Inject" description="If a constructor is annotated with one of these annotations, then the class is ignored."/>
+            <property name="annotations" type="List[String]" value="org.springframework.beans.factory.annotation.Autowired,javax.inject.Inject,com.google.inject.Inject" description="If a constructor is annotated with one of these annotations, then the class is ignored."/>
             <property name="xpath">
                 <value>
 <![CDATA[


### PR DESCRIPTION
## Describe the PR

When using `category/java/errorprone.xml` ruleset with PMD 7.0.0-rc4 I'm getting these warnings:

```
Warning at category/java/errorprone.xml:1039:78
 1037|         <properties>
 1038|             <property name="version" value="2.0"/>
 1039|             <property name="typesThatCompareByReference" type="List[String]" delimiter="," description="List of canonical type names for which reference comparison is allowed.">
                                                                                    ^^^^^^^^^ Delimiter attribute is not supported anymore, values are always comma-separated.

 1040|                 <value>java.lang.Enum,java.lang.Class</value>
 1041|             </property>
Warning at category/java/errorprone.xml:2353:62
 2351|         <priority>3</priority>
 2352|         <properties>
 2353|             <property name="annotations" type="List[String]" delimiter="," value="org.springframework.beans.factory.annotation.Autowired,javax.inject.Inject,com.google.inject.Inject" description="If a constructor is annotated with one of these annotations, then the class is ignored."/>
                                                                    ^^^^^^^^^ Delimiter attribute is not supported anymore, values are always comma-separated.

 2354|             <property name="xpath">
 2355|                 <value>
 ```

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

None.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

