### PR TITLE
Fix deprecated API usage

### DIFF
--- a/pmd-ant/src/main/java/net/sourceforge/pmd/ant/SourceLanguage.java
+++ b/pmd-ant/src/main/java/net/sourceforge/pmd/ant/SourceLanguage.java
@@ -22,7 +22,7 @@ public class SourceLanguage {
         this.version = version;
     }
 
-    /** This actually corresponds to a {@link Language#getTerseName()}. */
+    /** This actually corresponds to {@link Language#getId()}. */
     public String getName() {
         return name;
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/BaseAntlrNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/BaseAntlrNode.java
@@ -72,7 +72,7 @@ public abstract class BaseAntlrNode<A extends AntlrToPmdParseTreeAdapter<N>, N e
     @Override
     public TextRegion getTextRegion() {
         return TextRegion.fromBothOffsets(getFirstAntlrToken().getStartIndex(),
-                                          getFirstAntlrToken().getStopIndex());
+                                          getLastAntlrToken().getStopIndex() + 1);
     }
 
     void setIndexInParent(int indexInParent) {

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleDocGenerator.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/docs/RuleDocGenerator.java
@@ -175,7 +175,7 @@ public class RuleDocGenerator {
      */
     private void generateLanguageIndex(Map<Language, List<RuleSet>> rulesets, Map<Language, List<RuleSet>> sortedAdditionalRulesets) throws IOException {
         for (Map.Entry<Language, List<RuleSet>> entry : rulesets.entrySet()) {
-            String languageTersename = entry.getKey().getTerseName();
+            String languageTersename = entry.getKey().getId();
             String filename = LANGUAGE_INDEX_FILENAME_PATTERN
                     .replace("${language.tersename}", languageTersename);
             Path path = getAbsoluteOutputPath(filename);
@@ -327,7 +327,7 @@ public class RuleDocGenerator {
     private void generateRuleSetIndex(Map<Language, List<RuleSet>> rulesets) throws IOException {
         for (Map.Entry<Language, List<RuleSet>> entry : rulesets.entrySet()) {
             Language language = entry.getKey();
-            String languageTersename = language.getTerseName();
+            String languageTersename = language.getId();
             String languageName = language.getName();
             for (RuleSet ruleset : entry.getValue()) {
                 String rulesetFilename = RuleSetUtils.getRuleSetFilename(ruleset);

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/docs/SidebarGenerator.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/docs/SidebarGenerator.java
@@ -72,14 +72,14 @@ public class SidebarGenerator {
             Map<String, Object> ruleIndexSubfolderItem = new LinkedHashMap<>();
             ruleIndexSubfolderItem.put("title", "Index");
             ruleIndexSubfolderItem.put("output", "web, pdf");
-            ruleIndexSubfolderItem.put("url", "/pmd_rules_" + entry.getKey().getTerseName() + ".html");
+            ruleIndexSubfolderItem.put("url", "/pmd_rules_" + entry.getKey().getId() + ".html");
             subfolderitems.add(ruleIndexSubfolderItem);
 
             for (RuleSet ruleset : entry.getValue()) {
                 Map<String, Object> subfolderitem = new LinkedHashMap<>();
                 subfolderitem.put("title", ruleset.getName());
                 subfolderitem.put("output", "web, pdf");
-                subfolderitem.put("url", "/pmd_rules_" + entry.getKey().getTerseName() + "_" + RuleSetUtils.getRuleSetFilename(ruleset) + ".html");
+                subfolderitem.put("url", "/pmd_rules_" + entry.getKey().getId() + "_" + RuleSetUtils.getRuleSetFilename(ruleset) + ".html");
                 subfolderitems.add(subfolderitem);
             }
 

--- a/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/HtmlXPathRuleTest.java
+++ b/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/HtmlXPathRuleTest.java
@@ -57,14 +57,14 @@ class HtmlXPathRuleTest {
     @Test
     void verifyTextNodeName() {
         ASTHtmlDocument document = HtmlParsingHelper.DEFAULT.parse("<p>foobar</p>");
-        ASTHtmlTextNode textNode = document.getFirstDescendantOfType(ASTHtmlTextNode.class);
+        ASTHtmlTextNode textNode = document.descendants(ASTHtmlTextNode.class).first();
         assertEquals("#text", textNode.getXPathNodeName());
     }
 
     @Test
     void verifyCommentNodeName() {
         ASTHtmlDocument document = HtmlParsingHelper.DEFAULT.parse("<p><!-- a comment --></p>");
-        ASTHtmlComment comment = document.getFirstDescendantOfType(ASTHtmlComment.class);
+        ASTHtmlComment comment = document.descendants(ASTHtmlComment.class).first();
         assertEquals("#comment", comment.getXPathNodeName());
     }
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/EcmascriptTreeBuilder.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/EcmascriptTreeBuilder.java
@@ -241,7 +241,7 @@ final class EcmascriptTreeBuilder implements NodeVisitor {
 
             // This will fetch the localized message
             // See https://github.com/pmd/pmd/issues/384
-            String trailingCommaLocalizedMessage = ScriptRuntime.getMessage0("msg.extra.trailing.comma");
+            String trailingCommaLocalizedMessage = ScriptRuntime.getMessageById("msg.extra.trailing.comma");
 
             for (ParseProblem parseProblem : parseProblems) {
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/rule/AbstractEcmascriptRule.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/rule/AbstractEcmascriptRule.java
@@ -6,15 +6,21 @@ package net.sourceforge.pmd.lang.ecmascript.rule;
 
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.ecmascript.ast.EcmascriptParserVisitor;
+import net.sourceforge.pmd.lang.ecmascript.ast.EcmascriptVisitor;
 import net.sourceforge.pmd.lang.rule.AbstractRule;
 
 
 public abstract class AbstractEcmascriptRule extends AbstractRule
-        implements EcmascriptParserVisitor {
+        implements EcmascriptVisitor<Object, Object> {
 
     @Override
     public void apply(Node target, RuleContext ctx) {
         target.acceptVisitor(this, ctx);
+    }
+
+    @Override
+    public Object visitNode(Node node, Object param) {
+        node.children().forEach(c -> c.acceptVisitor(this, param));
+        return param;
     }
 }

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/rule/bestpractices/ConsistentReturnRule.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/rule/bestpractices/ConsistentReturnRule.java
@@ -4,31 +4,32 @@
 
 package net.sourceforge.pmd.lang.ecmascript.rule.bestpractices;
 
-import java.util.List;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import net.sourceforge.pmd.lang.ecmascript.ast.ASTFunctionNode;
 import net.sourceforge.pmd.lang.ecmascript.ast.ASTReturnStatement;
 import net.sourceforge.pmd.lang.ecmascript.rule.AbstractEcmascriptRule;
+import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
 
 public class ConsistentReturnRule extends AbstractEcmascriptRule {
 
-    public ConsistentReturnRule() {
-        addRuleChainVisit(ASTFunctionNode.class);
+    @Override
+    protected @NonNull RuleTargetSelector buildTargetSelector() {
+        return RuleTargetSelector.forTypes(ASTFunctionNode.class);
     }
 
     @Override
     public Object visit(ASTFunctionNode functionNode, Object data) {
-        List<ASTReturnStatement> returnStatements = functionNode.findDescendantsOfType(ASTReturnStatement.class);
         Boolean hasResult = null;
-        for (ASTReturnStatement returnStatement : returnStatements) {
+        for (ASTReturnStatement returnStatement : functionNode.descendants(ASTReturnStatement.class)) {
             // Return for this function?
-            if (functionNode == returnStatement.getFirstParentOfType(ASTFunctionNode.class)) {
+            if (functionNode == returnStatement.ancestors(ASTFunctionNode.class).first()) {
                 if (hasResult == null) {
-                    hasResult = Boolean.valueOf(returnStatement.hasResult());
+                    hasResult = returnStatement.hasResult();
                 } else {
                     // Return has different result from previous return?
-                    if (hasResult.booleanValue() != returnStatement.hasResult()) {
-                        addViolation(data, functionNode);
+                    if (hasResult != returnStatement.hasResult()) {
+                        asCtx(data).addViolation(functionNode);
                         break;
                     }
                 }

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/ReportTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/ReportTest.java
@@ -20,7 +20,7 @@ class ReportTest extends EcmascriptParserTestBase {
         Rule rule = new AbstractEcmascriptRule() {
             @Override
             public Object visit(ASTFunctionNode node, Object data) {
-                addViolationWithMessage(data, node, "Test");
+                asCtx(data).addViolationWithMessage(node, "Test");
                 return data;
             }
         };

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTFunctionNodeTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTFunctionNodeTest.java
@@ -14,7 +14,7 @@ class ASTFunctionNodeTest extends EcmascriptParserTestBase {
     @Test
     void testGetBody() {
         ASTAstRoot node = js.parse("function foo() { var a = 'a'; }");
-        ASTFunctionNode fn = node.getFirstDescendantOfType(ASTFunctionNode.class);
+        ASTFunctionNode fn = node.descendants(ASTFunctionNode.class).first();
         assertFalse(fn.isClosure());
         EcmascriptNode<?> body = fn.getBody();
         assertTrue(body instanceof ASTBlock);
@@ -23,7 +23,7 @@ class ASTFunctionNodeTest extends EcmascriptParserTestBase {
     @Test
     void testGetBodyFunctionClosureExpression() {
         ASTAstRoot node = js.parse("(function(x) x*x)");
-        ASTFunctionNode fn = node.getFirstDescendantOfType(ASTFunctionNode.class);
+        ASTFunctionNode fn = node.descendants(ASTFunctionNode.class).first();
         assertTrue(fn.isClosure());
         EcmascriptNode<?> body = fn.getBody();
         assertTrue(body instanceof ASTBlock);

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTTryStatementTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTTryStatementTest.java
@@ -23,7 +23,7 @@ class ASTTryStatementTest extends EcmascriptParserTestBase {
 
     private ASTTryStatement getTryStmt(String js) {
         EcmascriptNode<AstRoot> node = this.js.parse(js);
-        List<ASTTryStatement> trys = node.findDescendantsOfType(ASTTryStatement.class);
+        List<ASTTryStatement> trys = node.descendants(ASTTryStatement.class).toList();
         assertEquals(1, trys.size());
         ASTTryStatement tryStmt = trys.get(0);
         return tryStmt;

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/EcmascriptParserTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/EcmascriptParserTest.java
@@ -34,13 +34,13 @@ class EcmascriptParserTest extends EcmascriptParserTestBase {
         assertEquals(3, node.getEndLine());
         assertEquals(2, node.getEndColumn());
 
-        Node child = node.getFirstChildOfType(ASTFunctionNode.class);
+        Node child = node.firstChild(ASTFunctionNode.class);
         assertEquals(1, child.getBeginLine());
         assertEquals(1, child.getBeginColumn());
         assertEquals(3, child.getEndLine());
         assertEquals(2, child.getEndColumn());
 
-        child = node.getFirstDescendantOfType(ASTFunctionCall.class);
+        child = node.descendants(ASTFunctionCall.class).first();
         assertEquals(2, child.getBeginLine());
         assertEquals(3, child.getBeginColumn());
         assertEquals(2, child.getEndLine());
@@ -63,7 +63,7 @@ class EcmascriptParserTest extends EcmascriptParserTestBase {
         class MyEcmascriptRule extends AbstractEcmascriptRule {
 
             public Object visit(ASTScope node, Object data) {
-                addViolationWithMessage(data, node, "Scope from " + node.getBeginLine() + " to " + node.getEndLine());
+                asCtx(data).addViolationWithMessage(node, "Scope from " + node.getBeginLine() + " to " + node.getEndLine());
                 return super.visit(node, data);
             }
         }
@@ -83,7 +83,7 @@ class EcmascriptParserTest extends EcmascriptParserTestBase {
     @Test
     void testArrayAccess() {
         EcmascriptNode<AstRoot> node = js.parse("function a() { b['a'] = 1; c[1] = 2; }");
-        List<ASTElementGet> arrays = node.findDescendantsOfType(ASTElementGet.class);
+        List<ASTElementGet> arrays = node.descendants(ASTElementGet.class).toList();
         assertEquals("b", arrays.get(0).getTarget().getImage());
         assertEquals("a", arrays.get(0).getElement().getImage());
         assertEquals("c", arrays.get(1).getTarget().getImage());
@@ -100,7 +100,7 @@ class EcmascriptParserTest extends EcmascriptParserTestBase {
             "function test(){\n" + "  a();      // OK\n" + "  b.c();    // OK\n" + "  d[0]();   // OK\n"
                 + "  e[0].f(); // OK\n" + "  y.z[0](); // FAIL ==> java.lang.NullPointerException\n" + "}");
 
-        List<ASTFunctionCall> calls = rootNode.findDescendantsOfType(ASTFunctionCall.class);
+        List<ASTFunctionCall> calls = rootNode.descendants(ASTFunctionCall.class).toList();
         List<String> results = new ArrayList<>();
         for (ASTFunctionCall f : calls) {
             Node node = f.getTarget();
@@ -132,7 +132,7 @@ class EcmascriptParserTest extends EcmascriptParserTestBase {
     @Test
     void testCaseAsIdentifier() {
         ASTAstRoot rootNode = js.parse("function f(a){\n" + "    a.case.flag = 1;\n" + "    return;\n" + "}");
-        ASTBlock block = rootNode.getFirstDescendantOfType(ASTBlock.class);
+        ASTBlock block = rootNode.descendants(ASTBlock.class).first();
         assertFalse(block.getChild(0) instanceof ASTEmptyExpression);
         assertTrue(block.getChild(0) instanceof ASTExpressionStatement);
         assertTrue(block.getChild(0).getChild(0) instanceof ASTAssignment);
@@ -164,7 +164,7 @@ class EcmascriptParserTest extends EcmascriptParserTestBase {
         ASTAstRoot rootNode = js.parse("function f(matchFn, fieldval, n){\n"
                                            + "    return (matchFn)?(matcharray = eval(matchFn+\"('\"+fieldval+\"','\"+n.id+\"')\")):void(0);\n"
                                            + "}\n");
-        ASTUnaryExpression unary = rootNode.getFirstDescendantOfType(ASTUnaryExpression.class);
+        ASTUnaryExpression unary = rootNode.descendants(ASTUnaryExpression.class).first();
         assertEquals("void", unary.getImage());
     }
 
@@ -176,7 +176,7 @@ class EcmascriptParserTest extends EcmascriptParserTestBase {
         ASTAstRoot rootNode = js.parse("function f() { var x = 2; x ^= 2; x &= 2; x |= 2; "
                                            + "x &&= true; x ||= false; x *= 2; x /= 2; x %= 2; x += 2; x -= 2; "
                                            + "x <<= 2; x >>= 2; x >>>= 2; }");
-        ASTAssignment infix = rootNode.getFirstDescendantOfType(ASTAssignment.class);
+        ASTAssignment infix = rootNode.descendants(ASTAssignment.class).first();
         assertEquals("^=", infix.getImage());
     }
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/TrailingCommaTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/TrailingCommaTest.java
@@ -29,7 +29,7 @@ class TrailingCommaTest extends EcmascriptParserTestBase {
 
     private void testTrailingComma() {
         ASTAstRoot node = js.parse("x = {a : 1, };\n");
-        ASTObjectLiteral fn = node.getFirstDescendantOfType(ASTObjectLiteral.class);
+        ASTObjectLiteral fn = node.descendants(ASTObjectLiteral.class).first();
         assertTrue(fn.isTrailingComma());
     }
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/AbstractJspRule.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/AbstractJspRule.java
@@ -6,13 +6,19 @@ package net.sourceforge.pmd.lang.jsp.rule;
 
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.jsp.ast.JspParserVisitor;
+import net.sourceforge.pmd.lang.jsp.ast.JspVisitor;
 import net.sourceforge.pmd.lang.rule.AbstractRule;
 
-public abstract class AbstractJspRule extends AbstractRule implements JspParserVisitor {
+public abstract class AbstractJspRule extends AbstractRule implements JspVisitor<Object, Object> {
 
     @Override
     public void apply(Node target, RuleContext ctx) {
         target.acceptVisitor(this, ctx);
+    }
+
+    @Override
+    public Object visitNode(Node node, Object param) {
+        node.children().forEach(c -> c.acceptVisitor(this, param));
+        return param;
     }
 }

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/codestyle/DuplicateJspImportsRule.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/codestyle/DuplicateJspImportsRule.java
@@ -33,7 +33,7 @@ public class DuplicateJspImportsRule extends AbstractJspRule {
         for (int ix = 0; ix < count; ix++) {
             String token = st.nextToken();
             if (imports.contains(token)) {
-                addViolation(data, node, node.getImage());
+                asCtx(data).addViolation(node, node.getImage());
             } else {
                 imports.add(token);
             }

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/design/NoInlineStyleInformationRule.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/design/NoInlineStyleInformationRule.java
@@ -45,7 +45,7 @@ public class NoInlineStyleInformationRule extends AbstractJspRule {
     @Override
     public Object visit(ASTAttribute node, Object data) {
         if (isStyleAttribute(node)) {
-            addViolation(data, node);
+            asCtx(data).addViolation(node);
         }
 
         return super.visit(node, data);
@@ -54,7 +54,7 @@ public class NoInlineStyleInformationRule extends AbstractJspRule {
     @Override
     public Object visit(ASTElement node, Object data) {
         if (isStyleElement(node)) {
-            addViolation(data, node);
+            asCtx(data).addViolation(node);
         }
 
         return super.visit(node, data);

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/security/NoUnsanitizedJSPExpressionRule.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/security/NoUnsanitizedJSPExpressionRule.java
@@ -18,14 +18,14 @@ public class NoUnsanitizedJSPExpressionRule extends AbstractJspRule {
     @Override
     public Object visit(ASTElExpression node, Object data) {
         if (elOutsideTaglib(node)) {
-            addViolation(data, node);
+            asCtx(data).addViolation(node);
         }
 
         return super.visit(node, data);
     }
 
     private boolean elOutsideTaglib(ASTElExpression node) {
-        ASTElement parentASTElement = node.getFirstParentOfType(ASTElement.class);
+        ASTElement parentASTElement = node.ancestors(ASTElement.class).first();
 
         boolean elInTaglib = parentASTElement != null && parentASTElement.getName() != null
                 && parentASTElement.getName().contains(":");

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/JspDocStyleTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/JspDocStyleTest.java
@@ -40,7 +40,7 @@ class JspDocStyleTest extends AbstractJspNodesTst {
     void testElementAttributeAndNamespace() {
         ASTCompilationUnit root = jsp.parse(TEST_ELEMENT_AND_NAMESPACE);
 
-        List<ASTElement> elementNodes = root.findDescendantsOfType(ASTElement.class);
+        List<ASTElement> elementNodes = root.descendants(ASTElement.class).toList();
         assertEquals(1, elementNodes.size(), "One element node expected!");
         ASTElement element = elementNodes.get(0);
         assertEquals("h:html", element.getName(), "Correct name expected!");
@@ -49,7 +49,7 @@ class JspDocStyleTest extends AbstractJspNodesTst {
         assertEquals("h", element.getNamespacePrefix(), "Correct namespace prefix of element expected!");
         assertEquals("html", element.getLocalName(), "Correct local name of element expected!");
 
-        List<ASTAttribute> attributeNodes = root.findDescendantsOfType(ASTAttribute.class);
+        List<ASTAttribute> attributeNodes = root.descendants(ASTAttribute.class).toList();
         assertEquals(1, attributeNodes.size(), "One attribute node expected!");
         ASTAttribute attribute = attributeNodes.get(0);
         assertEquals("MyNsPrefix:MyAttr", attribute.getName(), "Correct name expected!");
@@ -68,21 +68,21 @@ class JspDocStyleTest extends AbstractJspNodesTst {
     void testAttributeValueContainingHash() {
         ASTCompilationUnit root = jsp.parse(TEST_ATTRIBUTE_VALUE_CONTAINING_HASH);
 
-        List<ASTAttribute> attrsList = root.findDescendantsOfType(ASTAttribute.class);
+        List<ASTAttribute> attrsList = root.descendants(ASTAttribute.class).toList();
         assertEquals(3, attrsList.size(), "Three attributes expected!");
 
         ASTAttribute attr = attrsList.get(0);
 
         assertEquals("something", attr.getName(), "Correct attribute name expected!");
-        assertEquals("#yes#", attr.getFirstDescendantOfType(ASTAttributeValue.class).getImage(), "Correct attribute value expected!");
+        assertEquals("#yes#", attr.descendants(ASTAttributeValue.class).first().getImage(), "Correct attribute value expected!");
 
         attr = attrsList.get(1);
         assertEquals("foo", attr.getName(), "Correct attribute name expected!");
-        assertEquals("CREATE", attr.getFirstDescendantOfType(ASTAttributeValue.class).getImage(), "Correct attribute value expected!");
+        assertEquals("CREATE", attr.descendants(ASTAttributeValue.class).first().getImage(), "Correct attribute value expected!");
 
         attr = attrsList.get(2);
         assertEquals("href", attr.getName(), "Correct attribute name expected!");
-        assertEquals("#", attr.getFirstDescendantOfType(ASTAttributeValue.class).getImage(), "Correct attribute value expected!");
+        assertEquals("#", attr.descendants(ASTAttributeValue.class).first().getImage(), "Correct attribute value expected!");
     }
 
     /**
@@ -104,12 +104,12 @@ class JspDocStyleTest extends AbstractJspNodesTst {
     void testDoctype() {
         ASTCompilationUnit root = jsp.parse(TEST_DOCTYPE);
 
-        List<ASTDoctypeDeclaration> docTypeDeclarations = root.findDescendantsOfType(ASTDoctypeDeclaration.class);
+        List<ASTDoctypeDeclaration> docTypeDeclarations = root.descendants(ASTDoctypeDeclaration.class).toList();
         assertEquals(1, docTypeDeclarations.size(), "One doctype declaration expected!");
         ASTDoctypeDeclaration docTypeDecl = docTypeDeclarations.iterator().next();
         assertEquals("html", docTypeDecl.getName(), "Correct doctype-name expected!");
 
-        List<ASTDoctypeExternalId> externalIds = root.findDescendantsOfType(ASTDoctypeExternalId.class);
+        List<ASTDoctypeExternalId> externalIds = root.descendants(ASTDoctypeExternalId.class).toList();
         assertEquals(1, externalIds.size(), "One doctype external id expected!");
         ASTDoctypeExternalId externalId = externalIds.iterator().next();
         assertEquals("-//W3C//DTD XHTML 1.1//EN", externalId.getPublicId(), "Correct external public id expected!");
@@ -149,7 +149,7 @@ class JspDocStyleTest extends AbstractJspNodesTst {
         List<ASTHtmlScript> scripts = jsp.getNodes(ASTHtmlScript.class, TEST_IMPORT_JAVASCRIPT);
         assertEquals(1, scripts.size(), "One script expected!");
         ASTHtmlScript script = scripts.iterator().next();
-        List<ASTAttributeValue> value = script.findDescendantsOfType(ASTAttributeValue.class);
+        List<ASTAttributeValue> value = script.descendants(ASTAttributeValue.class).toList();
         assertEquals("filename.js", value.get(0).getImage());
     }
 
@@ -162,7 +162,7 @@ class JspDocStyleTest extends AbstractJspNodesTst {
         assertEquals(1, scripts.size(), "One script expected!");
         ASTHtmlScript script = scripts.iterator().next();
         assertEquals("Script!", script.getImage(), "Correct script content expected!");
-        List<ASTAttributeValue> attrs = script.findDescendantsOfType(ASTAttributeValue.class);
+        List<ASTAttributeValue> attrs = script.descendants(ASTAttributeValue.class).toList();
         assertEquals("text/javascript", attrs.get(0).getImage());
     }
 

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/JspPageStyleTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/ast/JspPageStyleTest.java
@@ -30,12 +30,12 @@ class JspPageStyleTest extends AbstractJspNodesTst {
     void testDirective() {
         ASTCompilationUnit root = jsp.parse(JSP_DIRECTIVE);
 
-        List<ASTJspDirective> directives = root.findDescendantsOfType(ASTJspDirective.class);
+        List<ASTJspDirective> directives = root.descendants(ASTJspDirective.class).toList();
         assertEquals(1, directives.size(), "One directive expected!");
         ASTJspDirective directive = directives.iterator().next();
         assertEquals("page", directive.getName(), "Correct directive name expected!");
 
-        List<ASTJspDirectiveAttribute> directiveAttrs = root.findDescendantsOfType(ASTJspDirectiveAttribute.class);
+        List<ASTJspDirectiveAttribute> directiveAttrs = root.descendants(ASTJspDirectiveAttribute.class).toList();
         assertEquals(2, directiveAttrs.size(), "Two directive attributes expected!");
 
         ASTJspDirectiveAttribute attr = directiveAttrs.get(0);

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTClassDefinition.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTClassDefinition.java
@@ -16,11 +16,11 @@ public class ASTClassDefinition extends AbstractModelicaNode {
     }
 
     public boolean isPartial() {
-        return prefixes.getFirstChildOfType(ASTPartialClause.class) != null;
+        return prefixes.firstChild(ASTPartialClause.class) != null;
     }
 
     public boolean isEncapsulated() {
-        return getFirstChildOfType(ASTEncapsulatedClause.class) != null;
+        return firstChild(ASTEncapsulatedClause.class) != null;
     }
 
     public ModelicaClassSpecialization getSpecialization() {
@@ -32,7 +32,7 @@ public class ASTClassDefinition extends AbstractModelicaNode {
     }
 
     private void checkSpecialization(Class<? extends ModelicaNode> clauseClass, ModelicaClassSpecialization restriction) {
-        if (prefixes.getFirstChildOfType(clauseClass) != null) {
+        if (prefixes.firstChild(clauseClass) != null) {
             assert specialization == null;
             specialization = restriction;
         }
@@ -49,10 +49,10 @@ public class ASTClassDefinition extends AbstractModelicaNode {
         checkSpecialization(ASTTypeClause.class, ModelicaClassSpecialization.TYPE);
         checkSpecialization(ASTPackageClause.class, ModelicaClassSpecialization.PACKAGE);
         checkSpecialization(ASTOperatorClause.class, ModelicaClassSpecialization.OPERATOR);
-        ASTFunctionClause functionOrNull = prefixes.getFirstChildOfType(ASTFunctionClause.class);
+        ASTFunctionClause functionOrNull = prefixes.firstChild(ASTFunctionClause.class);
         if (functionOrNull != null) {
-            boolean isPure = functionOrNull.getFirstChildOfType(ASTPureClause.class) != null;
-            boolean isOperator = functionOrNull.getFirstChildOfType(ASTOperatorClause.class) != null;
+            boolean isPure = functionOrNull.firstChild(ASTPureClause.class) != null;
+            boolean isOperator = functionOrNull.firstChild(ASTOperatorClause.class) != null;
             assert specialization == null;
             specialization = ModelicaClassSpecialization.getFunctionSpecialization(isPure, isOperator);
         }
@@ -62,8 +62,8 @@ public class ASTClassDefinition extends AbstractModelicaNode {
     @Override
     public void jjtClose() {
         super.jjtClose();
-        prefixes = getFirstChildOfType(ASTClassPrefixes.class);
-        specifier = getFirstChildOfType(ASTClassSpecifier.class).getFirstChildOfType(ModelicaClassSpecifierNode.class);
+        prefixes = firstChild(ASTClassPrefixes.class);
+        specifier = firstChild(ASTClassSpecifier.class).firstChild(ModelicaClassSpecifierNode.class);
         detectSpecialization();
     }
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTComponentReference.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTComponentReference.java
@@ -66,7 +66,7 @@ public final class ASTComponentReference extends AbstractModelicaNode implements
 
         nameComponentsWithoutSubscripts = new String[getNumChildren()];
         for (int i = 0; i < nameComponentsWithoutSubscripts.length; ++i) {
-            String name = getChild(i).getFirstChildOfType(ASTSimpleName.class).getImage();
+            String name = getChild(i).firstChild(ASTSimpleName.class).getImage();
             nameComponentsWithoutSubscripts[i] = name;
         }
     }

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTExtendingLongClassSpecifier.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTExtendingLongClassSpecifier.java
@@ -19,7 +19,7 @@ public final class ASTExtendingLongClassSpecifier extends AbstractModelicaClassS
     @Override
     public void populateExtendsAndImports(ModelicaClassType classTypeDeclaration) {
         super.populateExtendsAndImports(classTypeDeclaration);
-        pushExtendsAndImports(classTypeDeclaration, getFirstChildOfType(ASTComposition.class));
+        pushExtendsAndImports(classTypeDeclaration, firstChild(ASTComposition.class));
         // TODO
     }
 }

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTMultipleDefinitionImportClause.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTMultipleDefinitionImportClause.java
@@ -32,8 +32,8 @@ public final class ASTMultipleDefinitionImportClause extends AbstractModelicaImp
     @Override
     public void jjtClose() {
         super.jjtClose();
-        importFrom = getFirstChildOfType(ASTName.class);
-        ASTImportList importList = getFirstChildOfType(ASTImportList.class);
+        importFrom = firstChild(ASTName.class);
+        ASTImportList importList = firstChild(ASTImportList.class);
         for (int i = 0; i < importList.getNumChildren(); ++i) {
             ASTSimpleName namePart = (ASTSimpleName) importList.getChild(i);
             importedNames.add(namePart.getImage());

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTRenamingImportClause.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTRenamingImportClause.java
@@ -27,8 +27,8 @@ public final class ASTRenamingImportClause extends AbstractModelicaImportClause 
     public void jjtClose() {
         super.jjtClose();
 
-        importWhat = getFirstChildOfType(ASTName.class);
-        renamedTo = getFirstChildOfType(ASTSimpleName.class).getImage();
+        importWhat = firstChild(ASTName.class);
+        renamedTo = firstChild(ASTSimpleName.class).getImage();
     }
 
     @Override

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTSimpleLongClassSpecifier.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTSimpleLongClassSpecifier.java
@@ -19,6 +19,6 @@ public final class ASTSimpleLongClassSpecifier extends AbstractModelicaClassSpec
     @Override
     void populateExtendsAndImports(ModelicaClassType classTypeDeclaration) {
         super.populateExtendsAndImports(classTypeDeclaration);
-        pushExtendsAndImports(classTypeDeclaration, getFirstChildOfType(ASTComposition.class));
+        pushExtendsAndImports(classTypeDeclaration, firstChild(ASTComposition.class));
     }
 }

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTSimpleShortClassSpecifier.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTSimpleShortClassSpecifier.java
@@ -23,7 +23,7 @@ public final class ASTSimpleShortClassSpecifier extends AbstractModelicaClassSpe
         InternalModelicaResolverApi.addExtendToClass(
                 classTypeDeclaration,
                 Visibility.UNSPEC,
-                getFirstChildOfType(ASTName.class).getCompositeName()
+                firstChild(ASTName.class).getCompositeName()
         );
     }
 }

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTSingleDefinitionImportClause.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTSingleDefinitionImportClause.java
@@ -27,7 +27,7 @@ public class ASTSingleDefinitionImportClause extends AbstractModelicaImportClaus
     public void jjtClose() {
         super.jjtClose();
 
-        importWhat = getFirstChildOfType(ASTName.class);
+        importWhat = firstChild(ASTName.class);
         importedName = importWhat.getChild(importWhat.getNumChildren() - 1).getImage();
     }
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTUnqualifiedImportClause.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTUnqualifiedImportClause.java
@@ -29,7 +29,7 @@ public final class ASTUnqualifiedImportClause extends AbstractModelicaImportClau
     public void jjtClose() {
         super.jjtClose();
 
-        importFromWhere = getFirstChildOfType(ASTName.class);
+        importFromWhere = firstChild(ASTName.class);
     }
 
     @Override

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTWithinClause.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTWithinClause.java
@@ -18,7 +18,7 @@ public final class ASTWithinClause extends AbstractModelicaNode {
     public void jjtClose() {
         super.jjtClose();
 
-        ASTName name = getFirstChildOfType(ASTName.class);
+        ASTName name = firstChild(ASTName.class);
         if (name != null) {
             setImage(name.getImage());
         } else {

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/AbstractModelicaClassSpecifierNode.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/AbstractModelicaClassSpecifierNode.java
@@ -18,7 +18,7 @@ abstract class AbstractModelicaClassSpecifierNode extends AbstractModelicaNode i
     @Override
     public void jjtClose() {
         super.jjtClose();
-        setImage(getFirstChildOfType(ASTSimpleName.class).getImage());
+        setImage(firstChild(ASTSimpleName.class).getImage());
     }
 
     /**
@@ -37,14 +37,14 @@ abstract class AbstractModelicaClassSpecifierNode extends AbstractModelicaNode i
                 InternalModelicaResolverApi.addExtendToClass(
                         classTypeDeclaration,
                         listNode.getVisibility(),
-                        child.getFirstChildOfType(ASTName.class).getCompositeName()
+                        child.firstChild(ASTName.class).getCompositeName()
                 );
             }
             if (child instanceof ASTImportClause) {
                 InternalModelicaResolverApi.addImportToClass(
                         classTypeDeclaration,
                         listNode.getVisibility(),
-                        child.getFirstChildOfType(ModelicaImportClause.class)
+                        child.firstChild(ModelicaImportClause.class)
                 );
             }
         }

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaComponentDeclaration.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaComponentDeclaration.java
@@ -83,14 +83,14 @@ public class ModelicaComponentDeclaration extends AbstractModelicaDeclaration im
     private final ASTConditionAttribute condition;
 
     public ModelicaComponentDeclaration(ASTComponentDeclaration node) {
-        declarationName = node.getFirstChildOfType(ASTDeclaration.class).getFirstChildOfType(ASTSimpleName.class).getImage();
-        condition = node.getFirstChildOfType(ASTConditionAttribute.class);
-        ASTComponentClause declarationRoot = node.getFirstParentOfType(ASTComponentClause.class);
-        ASTTypePrefix prefixes = declarationRoot.getFirstChildOfType(ASTTypePrefix.class);
+        declarationName = node.firstChild(ASTDeclaration.class).firstChild(ASTSimpleName.class).getImage();
+        condition = node.firstChild(ASTConditionAttribute.class);
+        ASTComponentClause declarationRoot = node.ancestors(ASTComponentClause.class).first();
+        ASTTypePrefix prefixes = declarationRoot.firstChild(ASTTypePrefix.class);
         parseTypePrefix(prefixes);
         typeName = declarationRoot
-                .getFirstChildOfType(ASTTypeSpecifier.class)
-                .getFirstChildOfType(ASTName.class);
+                .firstChild(ASTTypeSpecifier.class)
+                .firstChild(ASTName.class);
     }
 
     void setContainingScope(ModelicaClassScope scope) {
@@ -103,27 +103,27 @@ public class ModelicaComponentDeclaration extends AbstractModelicaDeclaration im
     }
 
     private void parseTypePrefix(ASTTypePrefix prefix) {
-        if (prefix.getFirstChildOfType(ASTFlowClause.class) != null) {
+        if (prefix.firstChild(ASTFlowClause.class) != null) {
             kind = ComponentKind.FLOW;
-        } else if (prefix.getFirstChildOfType(ASTStreamClause.class) != null) {
+        } else if (prefix.firstChild(ASTStreamClause.class) != null) {
             kind = ComponentKind.STREAM;
         } else {
             kind = ComponentKind.NOTHING_SPECIAL;
         }
 
-        if (prefix.getFirstChildOfType(ASTDiscreteClause.class) != null) {
+        if (prefix.firstChild(ASTDiscreteClause.class) != null) {
             variability = ComponentVariability.DISCRETE;
-        } else if (prefix.getFirstChildOfType(ASTParameterClause.class) != null) {
+        } else if (prefix.firstChild(ASTParameterClause.class) != null) {
             variability = ComponentVariability.PARAMETER;
-        } else if (prefix.getFirstChildOfType(ASTConstantClause.class) != null) {
+        } else if (prefix.firstChild(ASTConstantClause.class) != null) {
             variability = ComponentVariability.CONSTANT;
         } else {
             variability = ComponentVariability.CONTINUOUS;
         }
 
-        if (prefix.getFirstChildOfType(ASTInputClause.class) != null) {
+        if (prefix.firstChild(ASTInputClause.class) != null) {
             causality = ComponentCausality.INPUT;
-        } else if (prefix.getFirstChildOfType(ASTOutputClause.class) != null) {
+        } else if (prefix.firstChild(ASTOutputClause.class) != null) {
             causality = ComponentCausality.OUTPUT;
         } else {
             causality = ComponentCausality.ACAUSAL;

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ScopeAndDeclarationFinder.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/resolver/ScopeAndDeclarationFinder.java
@@ -12,9 +12,9 @@ import net.sourceforge.pmd.lang.modelica.ast.ASTComponentDeclaration;
 import net.sourceforge.pmd.lang.modelica.ast.ASTStoredDefinition;
 import net.sourceforge.pmd.lang.modelica.ast.InternalModelicaNodeApi;
 import net.sourceforge.pmd.lang.modelica.ast.ModelicaNode;
-import net.sourceforge.pmd.lang.modelica.ast.ModelicaParserVisitorAdapter;
+import net.sourceforge.pmd.lang.modelica.ast.ModelicaVisitorBase;
 
-class ScopeAndDeclarationFinder extends ModelicaParserVisitorAdapter {
+class ScopeAndDeclarationFinder extends ModelicaVisitorBase<Object, Object> {
     private final Deque<AbstractModelicaScope> scopes = new ArrayDeque<>();
 
     ScopeAndDeclarationFinder() {

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/AbstractModelicaRule.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/AbstractModelicaRule.java
@@ -6,17 +6,22 @@ package net.sourceforge.pmd.lang.modelica.rule;
 
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.ast.Node;
-import net.sourceforge.pmd.lang.modelica.ast.ModelicaParserVisitor;
+import net.sourceforge.pmd.lang.modelica.ast.ModelicaVisitor;
 import net.sourceforge.pmd.lang.rule.AbstractRule;
 
 /**
  * Base class for rules for Modelica language.
  */
-public abstract class AbstractModelicaRule extends AbstractRule implements ModelicaParserVisitor {
+public abstract class AbstractModelicaRule extends AbstractRule implements ModelicaVisitor<Object, Object> {
 
     @Override
     public void apply(Node target, RuleContext ctx) {
         target.acceptVisitor(this, ctx);
     }
 
+    @Override
+    public Object visitNode(Node node, Object param) {
+        node.children().forEach(c -> c.acceptVisitor(this, param));
+        return param;
+    }
 }

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/AmbiguousResolutionRule.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/AmbiguousResolutionRule.java
@@ -8,6 +8,7 @@ package net.sourceforge.pmd.lang.modelica.rule;
 /**
  * @deprecated Use {@link net.sourceforge.pmd.lang.modelica.rule.bestpractices.AmbiguousResolutionRule}
  */
+@Deprecated
 public class AmbiguousResolutionRule extends net.sourceforge.pmd.lang.modelica.rule.bestpractices.AmbiguousResolutionRule {
 
 }

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/bestpractices/AmbiguousResolutionRule.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/bestpractices/AmbiguousResolutionRule.java
@@ -20,7 +20,7 @@ public class AmbiguousResolutionRule extends AbstractModelicaRule {
                 sb.append(candidate.getDescriptiveName());
                 sb.append(", ");
             }
-            addViolation(data, node, sb.substring(0, sb.length() - 2));
+            asCtx(data).addViolation(node, sb.substring(0, sb.length() - 2));
         }
         return super.visit(node, data);
     }

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/bestpractices/ConnectUsingNonConnectorRule.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/bestpractices/ConnectUsingNonConnectorRule.java
@@ -26,14 +26,14 @@ public class ConnectUsingNonConnectorRule extends AbstractModelicaRule {
                         ModelicaClassType classDecl = (ModelicaClassType) componentTypes.getBestCandidates().get(0);
                         ModelicaClassSpecialization restriction = classDecl.getSpecialization();
                         if (!classDecl.isConnectorLike()) {
-                            addViolation(data, ref, restriction.toString());
+                            asCtx(data).addViolation(ref, restriction.toString());
                         }
                     } else {
-                        addViolation(data, ref, firstDecl.getDescriptiveName());
+                        asCtx(data).addViolation(ref, firstDecl.getDescriptiveName());
                     }
                 }
             } else {
-                addViolation(data, ref, firstDecl.getDescriptiveName());
+                asCtx(data).addViolation(ref, firstDecl.getDescriptiveName());
             }
         }
     }

--- a/pmd-modelica/src/test/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaResolverTest.java
+++ b/pmd-modelica/src/test/java/net/sourceforge/pmd/lang/modelica/resolver/ModelicaResolverTest.java
@@ -19,13 +19,13 @@ import net.sourceforge.pmd.lang.modelica.ast.ASTExtendsClause;
 import net.sourceforge.pmd.lang.modelica.ast.ASTStoredDefinition;
 import net.sourceforge.pmd.lang.modelica.ast.ModelicaClassSpecifierNode;
 import net.sourceforge.pmd.lang.modelica.ast.ModelicaNode;
-import net.sourceforge.pmd.lang.modelica.ast.ModelicaParserVisitorAdapter;
+import net.sourceforge.pmd.lang.modelica.ast.ModelicaVisitorBase;
 
 class ModelicaResolverTest {
 
     private final ModelicaParsingHelper modelica = ModelicaParsingHelper.DEFAULT;
 
-    private static class NodeFinder extends ModelicaParserVisitorAdapter {
+    private static class NodeFinder extends ModelicaVisitorBase<Object, Object> {
         private ModelicaNode result;
         private Class<?> nodeClass;
         private String nodeName;
@@ -153,7 +153,7 @@ class ModelicaResolverTest {
 
         ASTStoredDefinition ast = modelica.parse(contents);
 
-        List<ASTExtendsClause> extendsClauses = ast.findDescendantsOfType(ASTExtendsClause.class);
+        List<ASTExtendsClause> extendsClauses = ast.descendants(ASTExtendsClause.class).toList();
         assertEquals(1, extendsClauses.size());
         ASTExtendsClause extendsB = extendsClauses.get(0);
         assertEquals("#ROOT#FILE#Class:Test#Class:A", ((AbstractModelicaScope) extendsB.getMostSpecificScope()).getNestingRepresentation());

--- a/pmd-objectivec/etc/grammar/ObjectiveC.jj
+++ b/pmd-objectivec/etc/grammar/ObjectiveC.jj
@@ -794,8 +794,8 @@ void PossibleCocoaType() : { Token t; }
   t = <POSSIBLE_COCOA_TYPE>
   {
      if (verbose)
-        System.out.println("WARNING: Adding typedef on possible Cocoa type " + t.image + " at line number " + t.beginLine + ", column number " + t.beginColumn);
-     addType(t.image);
+        System.out.println("WARNING: Adding typedef on possible Cocoa type " + t.getImage() + " at " + t.getReportLocation().startPosToString());
+     addType(t.getImage());
   }
 }
 
@@ -804,8 +804,8 @@ void PossibleCoreType() : { Token t; }
   t = <POSSIBLE_CORE_TYPE>
   {
      if (verbose)
-         System.out.println("WARNING: Adding typedef on possible CoreFoundation type " + t.image + " at line number " + t.beginLine + ", column number " + t.beginColumn);
-     addType(t.image);
+         System.out.println("WARNING: Adding typedef on possible CoreFoundation type " + t.getImage() + " at " + t.getReportLocation().startPosToString());
+     addType(t.getImage());
   }
 }
 
@@ -814,8 +814,8 @@ void PossibleUnknownType() : { Token t; }
   t = <IDENT>
   {
      if (verbose)
-        System.out.println("WARNING: Adding typedef on unknown identifier " + t.image + " at line number " + t.beginLine + ", column number " + t.beginColumn);
-     addType(t.image);
+        System.out.println("WARNING: Adding typedef on unknown identifier " + t.getImage() + " at " + t.getReportLocation().startPosToString());
+     addType(t.getImage());
   }
 }
 
@@ -948,7 +948,7 @@ void DirectDeclarator() : { Token t;}
   ( t =  ObjCIDENT()
 
   { if(!(typedefParsingStack.empty()) && ((Boolean)typedefParsingStack.peek()).booleanValue()){
-        addType(t.image);
+        addType(t.getImage());
     }
   }
    | LOOKAHEAD(3) "(" Declarator() ")" )

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/rule/ScalaRule.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/rule/ScalaRule.java
@@ -7,7 +7,6 @@ package net.sourceforge.pmd.lang.scala.rule;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.rule.AbstractRule;
-import net.sourceforge.pmd.lang.scala.ast.ScalaNode;
 import net.sourceforge.pmd.lang.scala.ast.ScalaParserVisitor;
 
 /**
@@ -18,7 +17,7 @@ public class ScalaRule extends AbstractRule implements ScalaParserVisitor<RuleCo
 
     @Override
     public void apply(Node target, RuleContext ctx) {
-        ((ScalaNode<?>) target).accept(this, ctx);
+        target.acceptVisitor(this, ctx);
     }
 
     @Override

--- a/pmd-scala-modules/pmd-scala-common/src/test/java/net/sourceforge/pmd/lang/scala/rule/ScalaRuleTest.java
+++ b/pmd-scala-modules/pmd-scala-common/src/test/java/net/sourceforge/pmd/lang/scala/rule/ScalaRuleTest.java
@@ -47,12 +47,12 @@ class ScalaRuleTest extends BaseScalaTest {
             }
 
             @Override
-            public RuleContext visit(ASTTermApply node, RuleContext data) {
-                ASTTermName child = node.getFirstChildOfType(ASTTermName.class);
+            public RuleContext visit(ASTTermApply node, RuleContext ruleContext) {
+                ASTTermName child = node.firstChild(ASTTermName.class);
                 if (child != null && child.hasImageEqualTo("println")) {
-                    addViolation(data, node);
+                    ruleContext.addViolation(node);
                 }
-                return data;
+                return ruleContext;
             }
         };
         Report report = scala.executeRuleOnResource(rule, SCALA_TEST);

--- a/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/rule/bestpractices/UnavailableFunctionRule.java
+++ b/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/rule/bestpractices/UnavailableFunctionRule.java
@@ -5,8 +5,14 @@
 package net.sourceforge.pmd.lang.swift.rule.bestpractices;
 
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import net.sourceforge.pmd.RuleContext;
+import net.sourceforge.pmd.lang.document.Chars;
+import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
 import net.sourceforge.pmd.lang.swift.ast.SwiftParser.SwAttribute;
 import net.sourceforge.pmd.lang.swift.ast.SwiftParser.SwAttributes;
 import net.sourceforge.pmd.lang.swift.ast.SwiftParser.SwCodeBlock;
@@ -19,13 +25,12 @@ import net.sourceforge.pmd.lang.swift.rule.AbstractSwiftRule;
 
 public class UnavailableFunctionRule extends AbstractSwiftRule {
 
-    private static final String AVAILABLE_UNAVAILABLE = "@available(*,unavailable)";
+    private static final Pattern AVAILABLE_UNAVAILABLE = Pattern.compile("^\\s*@available\\s*\\(\\s*\\*\\s*,\\s*unavailable\\s*\\)\\s*$", Pattern.CASE_INSENSITIVE);
     private static final String FATAL_ERROR = "fatalError";
 
-    public UnavailableFunctionRule() {
-        super();
-        addRuleChainVisit(SwFunctionDeclaration.class);
-        addRuleChainVisit(SwInitializerDeclaration.class);
+    @Override
+    protected @NonNull RuleTargetSelector buildTargetSelector() {
+        return RuleTargetSelector.forTypes(SwFunctionDeclaration.class, SwInitializerDeclaration.class);
     }
 
     @Override
@@ -41,7 +46,7 @@ public class UnavailableFunctionRule extends AbstractSwiftRule {
                 if (shouldIncludeUnavailableModifier(ctx.functionBody().codeBlock())) {
                     final SwAttributes attributes = ctx.functionHead().attributes();
                     if (attributes == null || !hasUnavailableModifier(attributes.attribute())) {
-                        addViolation(ruleCtx, ctx);
+                        ruleCtx.addViolation(ctx);
                     }
                 }
 
@@ -57,7 +62,7 @@ public class UnavailableFunctionRule extends AbstractSwiftRule {
                 if (shouldIncludeUnavailableModifier(ctx.initializerBody().codeBlock())) {
                     final SwAttributes attributes = ctx.initializerHead().attributes();
                     if (attributes == null || !hasUnavailableModifier(attributes.attribute())) {
-                        addViolation(ruleCtx, ctx);
+                        ruleCtx.addViolation(ctx);
                     }
                 }
 
@@ -75,7 +80,12 @@ public class UnavailableFunctionRule extends AbstractSwiftRule {
             }
 
             private boolean hasUnavailableModifier(final List<SwAttribute> attributes) {
-                return attributes.stream().anyMatch(atr -> AVAILABLE_UNAVAILABLE.equals(atr.joinTokenText()));
+                return attributes.stream().anyMatch(attr -> {
+                        Chars text = attr.getTextDocument().sliceTranslatedText(attr.getTextRegion());
+                        Matcher matcher = AVAILABLE_UNAVAILABLE.matcher(text);
+                        return matcher.matches();
+                    }
+                );
             }
         };
     }

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/AbstractVmRule.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/AbstractVmRule.java
@@ -7,12 +7,18 @@ package net.sourceforge.pmd.lang.vm.rule;
 import net.sourceforge.pmd.RuleContext;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.rule.AbstractRule;
-import net.sourceforge.pmd.lang.vm.ast.VmParserVisitor;
+import net.sourceforge.pmd.lang.vm.ast.VmVisitor;
 
-public abstract class AbstractVmRule extends AbstractRule implements VmParserVisitor {
+public abstract class AbstractVmRule extends AbstractRule implements VmVisitor<Object, Object> {
 
     @Override
     public void apply(Node target, RuleContext ctx) {
         target.acceptVisitor(this, ctx);
+    }
+
+    @Override
+    public Object visitNode(Node node, Object param) {
+        node.children().forEach(it -> it.acceptVisitor(this, param));
+        return param;
     }
 }

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/bestpractices/AvoidReassigningParametersRule.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/bestpractices/AvoidReassigningParametersRule.java
@@ -5,7 +5,6 @@
 package net.sourceforge.pmd.lang.vm.rule.bestpractices;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import net.sourceforge.pmd.lang.vm.ast.ASTDirective;
@@ -19,15 +18,13 @@ public class AvoidReassigningParametersRule extends AbstractVmRule {
     public Object visit(final ASTDirective node, final Object data) {
         if ("macro".equals(node.getDirectiveName())) {
             final Set<String> paramNames = new HashSet<>();
-            final List<ASTReference> params = node.findChildrenOfType(ASTReference.class);
-            for (final ASTReference param : params) {
+            for (final ASTReference param : node.children(ASTReference.class)) {
                 paramNames.add(param.getFirstToken().getImage());
             }
-            final List<ASTSetDirective> assignments = node.findDescendantsOfType(ASTSetDirective.class);
-            for (final ASTSetDirective assignment : assignments) {
-                final ASTReference ref = assignment.getFirstChildOfType(ASTReference.class);
+            for (final ASTSetDirective assignment : node.descendants(ASTSetDirective.class)) {
+                final ASTReference ref = assignment.firstChild(ASTReference.class);
                 if (ref != null && paramNames.contains(ref.getFirstToken().getImage())) {
-                    addViolation(data, node, ref.getFirstToken().getImage());
+                    asCtx(data).addViolation(node, ref.getFirstToken().getImage());
                 }
             }
         }

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/bestpractices/UnusedMacroParameterRule.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/bestpractices/UnusedMacroParameterRule.java
@@ -5,7 +5,6 @@
 package net.sourceforge.pmd.lang.vm.rule.bestpractices;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import net.sourceforge.pmd.lang.vm.ast.ASTBlock;
@@ -20,22 +19,21 @@ public class UnusedMacroParameterRule extends AbstractVmRule {
     public Object visit(final ASTDirective node, final Object data) {
         if ("macro".equals(node.getDirectiveName())) {
             final Set<String> paramNames = new HashSet<>();
-            final List<ASTReference> params = node.findChildrenOfType(ASTReference.class);
-            for (final ASTReference param : params) {
+            for (final ASTReference param : node.children(ASTReference.class)) {
                 paramNames.add(param.literal());
             }
-            final ASTBlock macroBlock = node.getFirstChildOfType(ASTBlock.class);
+            final ASTBlock macroBlock = node.firstChild(ASTBlock.class);
             if (macroBlock != null) {
-                for (final ASTReference referenceInMacro : macroBlock.findDescendantsOfType(ASTReference.class)) {
+                for (final ASTReference referenceInMacro : macroBlock.descendants(ASTReference.class)) {
                     checkForParameter(paramNames, referenceInMacro.literal());
                 }
-                for (final ASTStringLiteral literalInMacro : macroBlock.findDescendantsOfType(ASTStringLiteral.class)) {
+                for (final ASTStringLiteral literalInMacro : macroBlock.descendants(ASTStringLiteral.class)) {
                     final String text = literalInMacro.literal();
                     checkForParameter(paramNames, text);
                 }
             }
             if (!paramNames.isEmpty()) {
-                addViolation(data, node, paramNames.toString());
+                asCtx(data).addViolation(node, paramNames.toString());
             }
         }
         return super.visit(node, data);

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/design/AvoidDeeplyNestedIfStmtsRule.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/design/AvoidDeeplyNestedIfStmtsRule.java
@@ -50,7 +50,7 @@ public class AvoidDeeplyNestedIfStmtsRule extends AbstractVmRule {
         depth++;
         super.visitVmNode(node, data);
         if (depth == depthLimit) {
-            addViolation(data, node);
+            asCtx(data).addViolation(node);
         }
         depth--;
         return data;

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/design/CollapsibleIfStatementsRule.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/design/CollapsibleIfStatementsRule.java
@@ -26,16 +26,16 @@ public class CollapsibleIfStatementsRule extends AbstractVmRule {
     @Override
     public Object visit(final ASTElseIfStatement node, final Object data) {
         // verify that this elseif doesn't have any siblings
-        if (node.getParent().findChildrenOfType(ASTElseIfStatement.class).size() == 1) {
+        if (node.getParent().children(ASTElseIfStatement.class).count() == 1) {
             handleIfElseIf(node, data);
         }
         return super.visit(node, data);
     }
 
     private void handleIfElseIf(final VmNode node, final Object data) {
-        if (node.getFirstChildOfType(ASTElseStatement.class) == null
-                && node.getFirstChildOfType(ASTElseIfStatement.class) == null) {
-            final ASTBlock ifBlock = node.getFirstChildOfType(ASTBlock.class);
+        if (node.firstChild(ASTElseStatement.class) == null
+                && node.firstChild(ASTElseIfStatement.class) == null) {
+            final ASTBlock ifBlock = node.firstChild(ASTBlock.class);
             boolean violationFound = false;
             int ifCounter = 0;
             for (int i = 0; i < ifBlock.getNumChildren(); i++) {
@@ -66,14 +66,14 @@ public class CollapsibleIfStatementsRule extends AbstractVmRule {
                 }
             }
             if (violationFound && ifCounter == 1) {
-                addViolation(data, node);
+                asCtx(data).addViolation(node);
             }
         }
     }
 
     private boolean hasElseOrElseIf(final Node parentIfNode) {
-        return parentIfNode.getFirstChildOfType(ASTElseStatement.class) != null
-                || parentIfNode.getFirstChildOfType(ASTElseIfStatement.class) != null;
+        return parentIfNode.firstChild(ASTElseStatement.class) != null
+                || parentIfNode.firstChild(ASTElseIfStatement.class) != null;
     }
 
 }

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/design/ExcessiveTemplateLengthRule.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/design/ExcessiveTemplateLengthRule.java
@@ -6,6 +6,9 @@ package net.sourceforge.pmd.lang.vm.rule.design;
 
 import static net.sourceforge.pmd.properties.NumericConstraints.positive;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
 import net.sourceforge.pmd.lang.rule.internal.CommonPropertyDescriptors;
 import net.sourceforge.pmd.lang.vm.ast.ASTTemplate;
 import net.sourceforge.pmd.lang.vm.rule.AbstractVmRule;
@@ -22,14 +25,18 @@ public class ExcessiveTemplateLengthRule extends AbstractVmRule {
 
     public ExcessiveTemplateLengthRule() {
         definePropertyDescriptor(REPORT_LEVEL);
-        addRuleChainVisit(ASTTemplate.class);
+    }
+
+    @Override
+    protected @NonNull RuleTargetSelector buildTargetSelector() {
+        return RuleTargetSelector.forTypes(ASTTemplate.class);
     }
 
     @Override
     public Object visit(final ASTTemplate node, final Object data) {
 
         if (node.getEndLine() - node.getBeginLine() >= getProperty(REPORT_LEVEL)) {
-            addViolation(data, node);
+            asCtx(data).addViolation(node);
         }
         return data;
     }

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/design/NoInlineJavaScriptRule.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/design/NoInlineJavaScriptRule.java
@@ -20,7 +20,7 @@ public class NoInlineJavaScriptRule extends AbstractVmRule {
         while (matcher.find()) {
             final String currentMatch = matcher.group();
             if (!SRC_PATTERN.matcher(currentMatch).find()) {
-                addViolation(data, node);
+                asCtx(data).addViolation(node);
             }
         }
         return super.visit(node, data);

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/errorprone/EmptyForeachStmtRule.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/errorprone/EmptyForeachStmtRule.java
@@ -12,8 +12,8 @@ public class EmptyForeachStmtRule extends AbstractVmRule {
 
     @Override
     public Object visit(final ASTForeachStatement node, final Object data) {
-        if (node.getFirstChildOfType(ASTBlock.class).isEmpty()) {
-            addViolation(data, node);
+        if (node.firstChild(ASTBlock.class).isEmpty()) {
+            asCtx(data).addViolation(node);
         }
         return super.visit(node, data);
     }

--- a/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/errorprone/EmptyIfStmtRule.java
+++ b/pmd-vm/src/main/java/net/sourceforge/pmd/lang/vm/rule/errorprone/EmptyIfStmtRule.java
@@ -31,8 +31,8 @@ public class EmptyIfStmtRule extends AbstractVmRule {
     }
 
     private void handleIf(final VmNode node, final Object data) {
-        if (node.getFirstChildOfType(ASTBlock.class).isEmpty()) {
-            addViolation(data, node);
+        if (node.firstChild(ASTBlock.class).isEmpty()) {
+            asCtx(data).addViolation(node);
         }
     }
 }


### PR DESCRIPTION
## Describe the PR

* Fixes deprecated API usage so that we can delete this on core.
* Fixes in pmd-doc, html, javascript, jsp, modelica, objectivec, scala, swift, vm
* Also fixes a small bug in core/BaseAntlrNode::getTextRegion (which I used in swift).

## Related issues

- None

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

