### PR TITLE
[core] Remove support for deprecated rule set references notation

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -105,6 +105,7 @@ in the Migration Guide.
   * [#4723](https://github.com/pmd/pmd/issues/4723): \[cli] Launch fails for "bash pmd"
 * core
   * [#1027](https://github.com/pmd/pmd/issues/1027): \[core] Apply the new PropertyDescriptor&lt;Pattern&gt; type where applicable
+  * [#4313](https://github.com/pmd/pmd/issues/4313): \[core] Remove support for &lt;lang&gt;-&lt;ruleset&gt; hyphen notation for ruleset references
   * [#4674](https://github.com/pmd/pmd/issues/4674): \[core] WARNING: Illegal reflective access by org.codehaus.groovy.reflection.CachedClass
   * [#4750](https://github.com/pmd/pmd/pull/4750):   \[core] Fix flaky SummaryHTMLRenderer
 * doc
@@ -561,6 +562,7 @@ See also [Detailed Release Notes for PMD 7]({{ baseurl }}pmd_release_notes_pmd7.
     * [#4204](https://github.com/pmd/pmd/issues/4204): \[core] Provide a CpdAnalysis class as a programmatic entry point into CPD
     * [#4301](https://github.com/pmd/pmd/issues/4301): \[core] Remove deprecated property concrete classes
     * [#4302](https://github.com/pmd/pmd/issues/4302): \[core] Migrate Property Framework API to Java 8
+    * [#4313](https://github.com/pmd/pmd/issues/4313): \[core] Remove support for &lt;lang&gt;-&lt;ruleset&gt; hyphen notation for ruleset references
     * [#4323](https://github.com/pmd/pmd/issues/4323): \[core] Refactor CPD integration
     * [#4353](https://github.com/pmd/pmd/pull/4353):   \[core] Micro optimizations for Node API
     * [#4365](https://github.com/pmd/pmd/pull/4365):   \[core] Improve benchmarking

--- a/pmd-cli/src/test/java/net/sourceforge/pmd/cli/PmdCliTest.java
+++ b/pmd-cli/src/test/java/net/sourceforge/pmd/cli/PmdCliTest.java
@@ -210,12 +210,6 @@ class PmdCliTest extends BaseCliTest {
     }
 
     @Test
-    void testDeprecatedRulesetSyntaxOnCommandLine() throws Exception {
-        CliExecutionResult result = runCli(VIOLATIONS_FOUND, "--dir", srcDir.toString(), "--rulesets", "dummy-basic");
-        result.checkStdErr(containsString("Ruleset reference 'dummy-basic' uses a deprecated form, use 'rulesets/dummy/basic.xml' instead"));
-    }
-
-    @Test
     void testReportToStdoutNotClosing() throws Exception {
         PrintStream originalOut = System.out;
         PrintStream out = new PrintStream(new FilterOutputStream(originalOut) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetReferenceId.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/RuleSetReferenceId.java
@@ -4,75 +4,93 @@
 
 package net.sourceforge.pmd;
 
-import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
+import java.util.Locale;
 
 import org.apache.commons.lang3.StringUtils;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.sourceforge.pmd.annotation.InternalApi;
 import net.sourceforge.pmd.util.ResourceLoader;
-import net.sourceforge.pmd.util.log.MessageReporter;
 
 /**
- * This class is used to parse a RuleSet reference value. Most commonly used for
+ * This class is used to reference either a complete ruleset with all rules or to reference a single rule
+ * within a rule set.
+ *
+ * <p>A {@link RuleSetReferenceId} is said to be "absolute" if it knows about the ruleset it references.
+ * It is "relative", if only the name of the referenced rule is known. In that case, the {@link RuleSetReferenceId}
+ * needs to be paired with an absolute reference.
+ *
+ * <p>This class can parse reference values from string. Most commonly used for
  * specifying a RuleSet to process, or in a Rule 'ref' attribute value in the
- * RuleSet XML. The RuleSet reference can refer to either an external RuleSet or
+ * RuleSet XML. The RuleSet reference can refer to either a specific RuleSet file or
  * the current RuleSet when used as a Rule 'ref' attribute value. An individual
- * Rule in the RuleSet can be indicated.
+ * Rule in the RuleSet can be selected.
  *
- * For an external RuleSet, referring to the entire RuleSet, the format is
- * <i>ruleSetName</i>, where the RuleSet name is either a resource file path to
- * a RuleSet that ends with <code>'.xml'</code>, or a simple RuleSet name.
+ * <p>For referring an entire RuleSet, the format is
+ * <i>ruleSetName</i>, where the ruleSetName is a resource file path, a classpath or a URL
+ * that ends with <code>'.xml'</code>.
  *
- * A simple RuleSet name, is one which contains no path separators, and either
- * contains a '-' or is entirely numeric release number. A simple name of the
- * form <code>[language]-[name]</code> is short for the full RuleSet name
- * <code>rulesets/[language]/[name].xml</code>. A numeric release simple name of
- * the form <code>[release]</code> is short for the full PMD Release RuleSet
- * name <code>rulesets/releases/[release].xml</code>.
+ * <p>Referring to a single Rule, the format is
+ * <i>ruleSetName/ruleName</i>, where the ruleSetName is as described above. A
+ * Rule with the <i>ruleName</i> should exist in the referenced RuleSet.
  *
- * For an external RuleSet, referring to a single Rule, the format is
- * <i>ruleSetName/ruleName</i>, where the RuleSet name is as described above. A
- * Rule with the <i>ruleName</i> should exist in this external RuleSet.
- *
- * For the current RuleSet, the format is <i>ruleName</i>, where the Rule name
- * is not RuleSet name (i.e. contains no path separators, '-' or '.xml' in it,
- * and is not all numeric). A Rule with the <i>ruleName</i> should exist in the
- * current RuleSet.
+ * <p>For the current RuleSet, the format is <i>ruleName</i>, where the Rule name
+ * is not RuleSet name (i.e. contains no path separators or '.xml' in it).
+ * A Rule with the <i>ruleName</i> should exist in the current RuleSet.
  *
  * <table>
- * <caption>Examples</caption> <thead>
+ * <caption>Examples</caption>
+ * <thead>
  * <tr>
- * <th>String</th>
- * <th>RuleSet file name</th>
- * <th>Rule</th>
+ *     <th>String</th>
+ *     <th>RuleSet file name</th>
+ *     <th>Rule</th>
  * </tr>
- * </thead> <tbody>
+ * </thead>
+ * <tbody>
  * <tr>
- * <td>rulesets/java/basic.xml</td>
- * <td>rulesets/java/basic.xml</td>
- * <td>all</td>
- * </tr>
- * <tr>
- * <td>rulesets/java/basic.xml/EmptyCatchBlock</td>
- * <td>rulesets/java/basic.xml</td>
- * <td>EmptyCatchBlock</td>
+ *     <td>rulesets/java/basic.xml</td>
+ *     <td>rulesets/java/basic.xml</td>
+ *     <td>null (all rules)</td>
  * </tr>
  * <tr>
- * <td>EmptyCatchBlock</td>
- * <td>null</td>
- * <td>EmptyCatchBlock</td>
+ *     <td>rulesets/java/basic.xml/EmptyCatchBlock</td>
+ *     <td>rulesets/java/basic.xml</td>
+ *     <td>EmptyCatchBlock</td>
+ * </tr>
+ * <tr>
+ *     <td>EmptyCatchBlock</td>
+ *     <td>null (current rule set)</td>
+ *     <td>EmptyCatchBlock</td>
+ * </tr>
+ * <tr>
+ *     <td>https://raw.githubusercontent.com/pmd/pmd/master/<wbr />pmd-java/src/main/resources/<wbr />rulesets/java/quickstart.xml/ConstantsInInterface</td>
+ *     <td>https://raw.githubusercontent.com/pmd/pmd/master/<wbr />pmd-java/src/main/resources/<wbr />rulesets/java/quickstart.xml</td>
+ *     <td>ConstantsInInterface</td>
+ * </tr>
+ * <tr>
+ *     <td>https://example.org/ruleset/MyRule</td>
+ *     <td>https://example.org/ruleset/MyRule</td>
+ *     <td>null (all rules, see note below)</td>
+ * </tr>
+ * <tr>
+ *     <td>https://example.org/ruleset.xml/MyRule</td>
+ *     <td>https://example.org/ruleset.xml</td>
+ *     <td>MyRule (see note below)</td>
  * </tr>
  * </tbody>
  * </table>
+ *
+ * <p>Note: When specifying a URL, the URL won't be checked until the ruleset is actually loaded. This might result
+ * in ambiguity in the following cases: if "https://example.org/ruleset/MyRule" will be interpreted as reference
+ * to a rulesets and all rules are referenced. To avoid this ambiguity, rulesets should always use the extension ".xml",
+ * e.g. "https://example.org/ruleset.xml/MyRule".
  *
  * @deprecated This is part of the internals of the {@link RuleSetLoader}.
  */
@@ -80,244 +98,111 @@ import net.sourceforge.pmd.util.log.MessageReporter;
 @InternalApi
 public class RuleSetReferenceId {
 
-    // todo this class has issues... What is even an "external" ruleset?
-    //  terminology and API should be clarified.
+    // might be a file path, classpath or URI. Can be null.
+    private final @Nullable String ruleSetReference;
+    // referenced rule within the ruleSet. Can be null.
+    private final @Nullable String ruleName;
 
-    private final boolean external;
-    private final String ruleSetFileName;
-    private final boolean allRules;
-    private final String ruleName;
-    private final RuleSetReferenceId externalRuleSetReferenceId;
+    private final @NonNull String originalRef;
 
-    private final String originalRef;
+
+    // Helper constructor, that does not parse the ruleSetReference string
+    private RuleSetReferenceId(final String ruleSetReference, final String ruleName) {
+        this.ruleSetReference = ruleSetReference;
+        this.ruleName = ruleName;
+        this.originalRef = ruleSetReference;
+    }
 
     /**
-     * Construct a RuleSetReferenceId for the given single ID string.
+     * Construct a RuleSetReferenceId for the given single reference string.
      *
-     * @param id
-     *            The id string.
+     * @param reference
+     *            The reference string.
      * @throws IllegalArgumentException
      *             If the ID contains a comma character.
      */
-    public RuleSetReferenceId(final String id) {
-
-        this(id, null, null);
-    }
-
-    private RuleSetReferenceId(final String ruleSetFileName, boolean external, String ruleName, RuleSetReferenceId externalRuleSetReferenceId) {
-        this.ruleSetFileName = Objects.requireNonNull(ruleSetFileName);
-        this.originalRef = ruleName == null ? ruleSetFileName : ruleSetFileName + "/" + ruleName;
-        this.allRules = ruleName == null;
-        this.external = external;
-        this.ruleName = ruleName;
-        this.externalRuleSetReferenceId = externalRuleSetReferenceId;
+    public RuleSetReferenceId(final String reference) {
+        this(reference, (RuleSetReferenceId) null);
     }
 
     /**
      * Construct a RuleSetReferenceId for the given single ID string. If an
-     * external RuleSetReferenceId is given, the ID must refer to a non-external
-     * Rule. The external RuleSetReferenceId will be responsible for producing
-     * the InputStream containing the Rule.
+     * absolute RuleSetReferenceId is given, the ID must refer to a simple
+     * Rule. The rule will be resolved within the given absolute RuleSetReference.
      *
      * @param id                         The id string.
-     * @param externalRuleSetReferenceId A RuleSetReferenceId to associate with this new instance.
+     * @param absoluteRuleSetReferenceId A RuleSetReferenceId to associate with this new instance.
      *
      * @throws IllegalArgumentException If the ID contains a comma character.
-     * @throws IllegalArgumentException If external RuleSetReferenceId is not external.
-     * @throws IllegalArgumentException If the ID is not Rule reference when there is an external
-     *                                  RuleSetReferenceId.
+     * @throws IllegalArgumentException If absolute RuleSetReferenceId is not absolute.
+     * @throws IllegalArgumentException If the ID is not Rule reference when there is an absoluteRuleSetReferenceId
      */
-    public RuleSetReferenceId(final String id, final RuleSetReferenceId externalRuleSetReferenceId) {
-        this(id, externalRuleSetReferenceId, null);
-    }
+    public RuleSetReferenceId(final String id, final RuleSetReferenceId absoluteRuleSetReferenceId) {
+        this.originalRef = StringUtils.trim(id);
 
-    /**
-     * Construct a RuleSetReferenceId for the given single ID string. If an
-     * external RuleSetReferenceId is given, the ID must refer to a non-external
-     * Rule. The external RuleSetReferenceId will be responsible for producing
-     * the InputStream containing the Rule.
-     *
-     * @param id                         The id string.
-     * @param externalRuleSetReferenceId A RuleSetReferenceId to associate with this new instance.
-     *
-     * @throws IllegalArgumentException If the ID contains a comma character.
-     * @throws IllegalArgumentException If external RuleSetReferenceId is not external.
-     * @throws IllegalArgumentException If the ID is not Rule reference when there is an external
-     *                                  RuleSetReferenceId.
-     */
-    RuleSetReferenceId(final String id,
-                       final RuleSetReferenceId externalRuleSetReferenceId,
-                       final @Nullable MessageReporter err) {
-        this.originalRef = id;
-
-        if (externalRuleSetReferenceId != null && !externalRuleSetReferenceId.isExternal()) {
-            throw new IllegalArgumentException("Cannot pair with non-external <" + externalRuleSetReferenceId + ">.");
-        }
-
-        if (id != null && id.indexOf(',') >= 0) {
+        if (originalRef != null && originalRef.indexOf(',') >= 0) {
             throw new IllegalArgumentException(
                     "A single RuleSetReferenceId cannot contain ',' (comma) characters: " + id);
         }
+        if (absoluteRuleSetReferenceId != null && !absoluteRuleSetReferenceId.isAbsolute()) {
+            throw new IllegalArgumentException("Cannot pair with relative <" + absoluteRuleSetReferenceId + ">.");
+        }
+        if (isFullRuleSetName(originalRef) && absoluteRuleSetReferenceId != null) {
+            throw new IllegalArgumentException(
+                    "Cannot pair absolute <" + originalRef + "> with absolute <" + absoluteRuleSetReferenceId + ">.");
+        }
+        if (originalRef == null && absoluteRuleSetReferenceId == null) {
+            throw new IllegalArgumentException("Either ID or absoluteRuleSetReferenceId is required");
+        }
 
-        // Damn this parsing sucks, but my brain is just not working to let me
-        // write a simpler scheme.
+        // try to split originalRef into ruleset and rule
+        String tempRuleName = getRuleName(originalRef);
+        String tempRuleSetReference = tempRuleName == null
+                ? null
+                : originalRef.substring(0, originalRef.length() - tempRuleName.length() - 1);
+        if (isFullRuleSetName(tempRuleSetReference) && absoluteRuleSetReferenceId != null) {
+            throw new IllegalArgumentException(
+                    "Cannot pair absolute <" + originalRef + "> with absolute <" + absoluteRuleSetReferenceId + ">.");
+        }
 
-        if (isValidUrl(id)) {
-            // A full RuleSet name
-            external = true;
-            ruleSetFileName = StringUtils.strip(id);
-            allRules = true;
-            ruleName = null;
-        } else if (isFullRuleSetName(id)) {
-            // A full RuleSet name
-            external = true;
-            ruleSetFileName = id;
-            allRules = true;
+        if (absoluteRuleSetReferenceId != null && absoluteRuleSetReferenceId.isAbsolute()) {
+            // referencing a rule within another ruleset
+            ruleSetReference = absoluteRuleSetReferenceId.getRuleSetFileName();
+            ruleName = originalRef;
+        } else if (isFullRuleSetName(originalRef)) {
+            // A full RuleSet name - ends with .xml
+            ruleSetReference = originalRef;
             ruleName = null;
         } else {
-            String tempRuleName = getRuleName(id);
-            String tempRuleSetFileName = tempRuleName != null && id != null
-                                         ? id.substring(0, id.length() - tempRuleName.length() - 1) : id;
-
-            if (isValidUrl(tempRuleSetFileName)) {
-                // remaining part is a xml ruleset file, so the tempRuleName is
-                // probably a real rule name
-                external = true;
-                ruleSetFileName = StringUtils.strip(tempRuleSetFileName);
-                ruleName = StringUtils.strip(tempRuleName);
-                allRules = tempRuleName == null;
-            } else if (isHttpUrl(id)) {
-                // it's a url, we can't determine whether it's a full ruleset or
-                // a single rule - so falling back to
-                // a full RuleSet name
-                external = true;
-                ruleSetFileName = StringUtils.strip(id);
-                allRules = true;
-                ruleName = null;
-            } else if (isFullRuleSetName(tempRuleSetFileName)) {
-                // remaining part is a xml ruleset file, so the tempRuleName is
-                // probably a real rule name
-                external = true;
-                ruleSetFileName = tempRuleSetFileName;
+            if (isFullRuleSetName(tempRuleSetReference)) {
+                // only interpret last part as rule name, if the remaining part is a full ruleset name (ending in .xml)
+                ruleSetReference = tempRuleSetReference;
                 ruleName = tempRuleName;
-                allRules = tempRuleName == null;
+            } else if (originalRef.indexOf('/') == -1 && originalRef.indexOf('\\') == -1) {
+                // it's a simple name, assume we only reference a rule name here
+                ruleSetReference = null;
+                ruleName = originalRef;
             } else {
-                // resolve the ruleset name - it's maybe a built in ruleset
-                String expandedRuleset = resolveDeprecatedBuiltInRulesetShorthand(tempRuleSetFileName);
-                String builtinRuleSet = expandedRuleset == null ? tempRuleSetFileName : expandedRuleset;
-                if (checkRulesetExists(builtinRuleSet)) {
-                    if (expandedRuleset != null && err != null) {
-                        err.warn(
-                            "Ruleset reference ''{0}'' uses a deprecated form, use ''{1}'' instead",
-                            tempRuleSetFileName, builtinRuleSet
-                        );
-                    }
-
-                    external = true;
-                    ruleSetFileName = builtinRuleSet;
-                    ruleName = tempRuleName;
-                    allRules = tempRuleName == null;
-                } else {
-                    // well, we didn't find the ruleset, so it's probably not a
-                    // internal ruleset.
-                    // at this time, we don't know, whether the tempRuleName is
-                    // a name of the rule
-                    // or the file name of the ruleset file.
-                    // It is assumed, that tempRuleName is actually the filename
-                    // of the ruleset,
-                    // if there are more separator characters in the remaining
-                    // ruleset filename (tempRuleSetFileName).
-                    // This means, the only reliable way to specify single rules
-                    // within a custom rulesest file is
-                    // only possible, if the ruleset file has a .xml file
-                    // extension.
-                    if (tempRuleSetFileName == null || tempRuleSetFileName.contains(File.separator)) {
-                        external = true;
-                        ruleSetFileName = id;
-                        ruleName = null;
-                        allRules = true;
-                    } else {
-                        external = externalRuleSetReferenceId != null && externalRuleSetReferenceId.isExternal();
-                        ruleSetFileName = externalRuleSetReferenceId != null
-                                ? externalRuleSetReferenceId.getRuleSetFileName() : null;
-                        ruleName = id;
-                        allRules = false;
-                    }
-                }
+                // in any other case, the name is more complex, likely a URI or something
+                // assuming a complete ruleset reference
+                ruleSetReference = originalRef;
+                ruleName = null;
             }
         }
-
-        if (this.external && this.ruleName != null && !this.ruleName.equals(id) && externalRuleSetReferenceId != null) {
-            throw new IllegalArgumentException(
-                    "Cannot pair external <" + this + "> with external <" + externalRuleSetReferenceId + ">.");
-        }
-        this.externalRuleSetReferenceId = externalRuleSetReferenceId;
     }
 
     @Nullable RuleSetReferenceId getParentRulesetIfThisIsARule() {
         if (ruleName == null) {
             return null;
         }
-        return new RuleSetReferenceId(
-            ruleSetFileName,
-            external,
-            null,
-
-            null
-        );
+        return new RuleSetReferenceId(ruleSetReference, (String) null);
     }
 
-    /**
-     * Tries to load the given ruleset.
-     *
-     * @param name
-     *            the ruleset name
-     * @return <code>true</code> if the ruleset could be loaded,
-     *         <code>false</code> otherwise.
-     */
-    private boolean checkRulesetExists(final String name) {
-        boolean resourceFound = false;
-        if (name != null) {
-            try (InputStream ignored = new ResourceLoader().loadClassPathResourceAsStreamOrThrow(name)) {
-                resourceFound = true;
-            } catch (Exception ignored) {
-                // ignored
-            }
-        }
-        return resourceFound;
-    }
-
-    /**
-     * Assumes that the ruleset name given is e.g. "java-basic". Then it will
-     * return the full classpath name for the ruleset, in this example it would
-     * return "rulesets/java/basic.xml".
-     *
-     * @param name
-     *            the ruleset name
-     * @return the full classpath to the ruleset
-     */
-    private String resolveDeprecatedBuiltInRulesetShorthand(final String name) {
-        if (name == null) {
-            return null;
-        }
-        // Likely a simple RuleSet name
-        int index = name.indexOf('-');
-        if (index > 0) {
-            // Standard short name
-            return "rulesets/" + name.substring(0, index) + '/' + name.substring(index + 1) + ".xml";
-        }
-        // A release RuleSet?
-        if (name.matches("[0-9]+.*")) {
-            return "rulesets/releases/" + name + ".xml";
-        }
-        // Appears to be a non-standard RuleSet name
-        return null;
-    }
 
     /**
      * Extracts the rule name out of a ruleset path. E.g. for
      * "/my/ruleset.xml/MyRule" it would return "MyRule". If no single rule is
-     * specified, <code>null</code> is returned.
+     * specified (in other words: no separated last path name part), {@code null} is returned.
      *
      * @param rulesetName
      *            the full rule set path
@@ -336,34 +221,8 @@ public class RuleSetReferenceId {
         return result;
     }
 
-    private static boolean isHttpUrl(String name) {
-        String stripped = StringUtils.strip(name);
-        return stripped != null && (stripped.startsWith("http://") || stripped.startsWith("https://"));
-    }
-
-    private static boolean isValidUrl(String name) {
-        if (isHttpUrl(name)) {
-            String url = StringUtils.strip(name);
-            try {
-                // FIXME : Do we really need to perform a request? if it's a url we should treat it as one even if the server is down
-                HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
-                connection.setRequestMethod("HEAD");
-                connection.setConnectTimeout(ResourceLoader.TIMEOUT);
-                connection.setReadTimeout(ResourceLoader.TIMEOUT);
-                int responseCode = connection.getResponseCode();
-                if (responseCode == 200) {
-                    return true;
-                }
-            } catch (IOException e) {
-                return false;
-            }
-        }
-        return false;
-    }
-
     private static boolean isFullRuleSetName(String name) {
-
-        return name != null && name.endsWith(".xml");
+        return name != null && name.toLowerCase(Locale.ROOT).endsWith(".xml");
     }
 
     /**
@@ -376,19 +235,14 @@ public class RuleSetReferenceId {
      */
     // TODO deprecate and remove
     public static List<RuleSetReferenceId> parse(String referenceString) {
-        return parse(referenceString, null);
-    }
-
-    static List<RuleSetReferenceId> parse(String referenceString,
-                                          MessageReporter err) {
         List<RuleSetReferenceId> references = new ArrayList<>();
         if (referenceString != null && referenceString.trim().length() > 0) {
 
             if (referenceString.indexOf(',') == -1) {
-                references.add(new RuleSetReferenceId(referenceString, null, err));
+                references.add(new RuleSetReferenceId(referenceString));
             } else {
                 for (String name : referenceString.split(",")) {
-                    references.add(new RuleSetReferenceId(name.trim(), null, err));
+                    references.add(new RuleSetReferenceId(name.trim()));
                 }
             }
         }
@@ -396,13 +250,13 @@ public class RuleSetReferenceId {
     }
 
     /**
-     * Is this an external RuleSet reference?
+     * Does this {@link RuleSetReferenceId} contain a reference to a ruleset. That means, it either
+     * references all rules with the ruleset or a specific rule. But in any case, the ruleset is known.
      *
-     * @return <code>true</code> if this is an external reference,
-     *     <code>false</code> otherwise.
+     * @return {@code true} if the ruleset is known, {@code false} when only the rule name is known.
      */
-    public boolean isExternal() {
-        return external;
+    public boolean isAbsolute() {
+        return ruleSetReference != null;
     }
 
     /**
@@ -412,17 +266,17 @@ public class RuleSetReferenceId {
      *         <code>false</code> otherwise.
      */
     public boolean isAllRules() {
-        return allRules;
+        return ruleName == null;
     }
 
     /**
      * Get the RuleSet file name.
      *
-     * @return The RuleSet file name if this is an external reference,
+     * @return The RuleSet file name if this is an absolute reference,
      *         <code>null</code> otherwise.
      */
     public String getRuleSetFileName() {
-        return ruleSetFileName;
+        return ruleSetReference;
     }
 
     /**
@@ -437,25 +291,19 @@ public class RuleSetReferenceId {
     /**
      * Try to load the RuleSet resource with the specified ResourceLoader. Multiple
      * attempts to get independent InputStream instances may be made, so
-     * subclasses must ensure they support this behavior. Delegates to an
-     * external RuleSetReferenceId if there is one associated with this
-     * instance.
+     * subclasses must ensure they support this behavior.
      *
      * @param rl The {@link ResourceLoader} to use.
      * @return An InputStream to that resource.
      */
     public InputStream getInputStream(final ResourceLoader rl) throws IOException {
-        if (externalRuleSetReferenceId == null) {
-            if (StringUtils.isBlank(ruleSetFileName)) {
-                throw notFoundException();
-            }
-            try {
-                return rl.loadResourceAsStream(ruleSetFileName);
-            } catch (FileNotFoundException ignored) {
-                throw notFoundException();
-            }
-        } else {
-            return externalRuleSetReferenceId.getInputStream(rl);
+        if (!isAbsolute()) {
+            throw new IllegalArgumentException("Cannot resolve rule/ruleset reference '" + this + "' - reference is not absolute");
+        }
+        try {
+            return rl.loadResourceAsStream(ruleSetReference);
+        } catch (FileNotFoundException ignored) {
+            throw notFoundException();
         }
     }
 
@@ -469,28 +317,28 @@ public class RuleSetReferenceId {
      * Return the String form of this Rule reference.
      *
      * @return Return the String form of this Rule reference, which is
-     *         <i>ruleSetFileName</i> for all Rule external references,
-     *         <i>ruleSetFileName/ruleName</i>, for a single Rule external
+     *         <i>ruleSetFileName</i> for all Rule absolute references,
+     *         <i>ruleSetFileName/ruleName</i>, for a single Rule absolute
      *         references, or <i>ruleName</i> otherwise.
-     *
-     * @deprecated Do not rely on the format of this method, it may be changed in PMD 7.
+     */
+    public String toNormalizedReference() {
+        if (isAbsolute()) {
+            if (isAllRules()) {
+                return ruleSetReference;
+            } else {
+                return ruleSetReference + '/' + ruleName;
+            }
+        } else {
+            return ruleName;
+        }
+    }
+
+    /**
+     * String representation of this reference. Do not rely on the format of this method,
+     * instead use {@link #toNormalizedReference()}.
      */
     @Override
-    @Deprecated
     public String toString() {
-        if (ruleSetFileName != null) {
-            if (allRules) {
-                return ruleSetFileName;
-            } else {
-                return ruleSetFileName + '/' + ruleName;
-            }
-
-        } else {
-            if (allRules) {
-                return "anonymous all Rule";
-            } else {
-                return ruleName;
-            }
-        }
+        return toNormalizedReference();
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/ResourceLoader.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/ResourceLoader.java
@@ -56,9 +56,9 @@ public class ResourceLoader {
     }
 
     /**
-     * Attempts to load the resource from file, a URL or the claspath
-     * <p>
-     * Caller is responsible for closing the {@link InputStream}.
+     * Attempts to load the resource from file, a URL or the classpath.
+     *
+     * <p>Caller is responsible for closing the {@link InputStream}.
      *
      * @param name The resource to attempt and load
      *
@@ -77,7 +77,7 @@ public class ResourceLoader {
             }
         }
 
-        // Maybe it's a url?
+        // Maybe it's a URL?
         try {
             final HttpURLConnection connection = (HttpURLConnection) new URL(name).openConnection();
             connection.setConnectTimeout(TIMEOUT);

--- a/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/RuleSetFactoryTest.java
@@ -265,7 +265,7 @@ class RuleSetFactoryTest extends RulesetFactoryTestBase {
     @Test
     void testRuleSetWithDeprecatedRenamedRuleForDoc() {
         RuleSetLoader loader = new RuleSetLoader().includeDeprecatedRuleReferences(true);
-        RuleSet rs = loader.loadFromString("",
+        RuleSet rs = loader.loadFromString("ruleset.xml",
                                            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" + "<ruleset name=\"test\">\n"
                                                + "  <description>ruleset desc</description>\n"
                                                + "     <rule deprecated=\"true\" ref=\"NewName\" name=\"OldName\"/>"
@@ -528,38 +528,38 @@ class RuleSetFactoryTest extends RulesetFactoryTestBase {
         RuleSetLoader config = new RuleSetLoader().warnDeprecated(false).enableCompatibility(true);
 
         RuleSetLoader rulesetLoader = config.filterAbovePriority(RulePriority.LOW);
-        RuleSet ruleSet = rulesetLoader.loadFromString("", REF_INTERNAL_TO_INTERNAL_CHAIN);
+        RuleSet ruleSet = rulesetLoader.loadFromString("ruleset.xml", REF_INTERNAL_TO_INTERNAL_CHAIN);
         assertEquals(3, ruleSet.getRules().size(), "Number of Rules");
         assertNotNull(ruleSet.getRuleByName("MockRuleName"));
         assertNotNull(ruleSet.getRuleByName("MockRuleNameRef"));
         assertNotNull(ruleSet.getRuleByName("MockRuleNameRefRef"));
 
         rulesetLoader = config.filterAbovePriority(RulePriority.MEDIUM_HIGH);
-        ruleSet = rulesetLoader.loadFromString("", REF_INTERNAL_TO_INTERNAL_CHAIN);
+        ruleSet = rulesetLoader.loadFromString("ruleset.xml", REF_INTERNAL_TO_INTERNAL_CHAIN);
         assertEquals(2, ruleSet.getRules().size(), "Number of Rules");
         assertNotNull(ruleSet.getRuleByName("MockRuleNameRef"));
         assertNotNull(ruleSet.getRuleByName("MockRuleNameRefRef"));
 
         rulesetLoader = config.filterAbovePriority(RulePriority.HIGH);
-        ruleSet = rulesetLoader.loadFromString("", REF_INTERNAL_TO_INTERNAL_CHAIN);
+        ruleSet = rulesetLoader.loadFromString("ruleset.xml", REF_INTERNAL_TO_INTERNAL_CHAIN);
         assertEquals(1, ruleSet.getRules().size(), "Number of Rules");
         assertNotNull(ruleSet.getRuleByName("MockRuleNameRefRef"));
 
         rulesetLoader = config.filterAbovePriority(RulePriority.LOW);
-        ruleSet = rulesetLoader.loadFromString("", REF_INTERNAL_TO_EXTERNAL_CHAIN);
+        ruleSet = rulesetLoader.loadFromString("ruleset.xml", REF_INTERNAL_TO_EXTERNAL_CHAIN);
         assertEquals(3, ruleSet.getRules().size(), "Number of Rules");
         assertNotNull(ruleSet.getRuleByName("ExternalRefRuleName"));
         assertNotNull(ruleSet.getRuleByName("ExternalRefRuleNameRef"));
         assertNotNull(ruleSet.getRuleByName("ExternalRefRuleNameRefRef"));
 
         rulesetLoader = config.filterAbovePriority(RulePriority.MEDIUM_HIGH);
-        ruleSet = rulesetLoader.loadFromString("", REF_INTERNAL_TO_EXTERNAL_CHAIN);
+        ruleSet = rulesetLoader.loadFromString("ruleset.xml", REF_INTERNAL_TO_EXTERNAL_CHAIN);
         assertEquals(2, ruleSet.getRules().size(), "Number of Rules");
         assertNotNull(ruleSet.getRuleByName("ExternalRefRuleNameRef"));
         assertNotNull(ruleSet.getRuleByName("ExternalRefRuleNameRefRef"));
 
         rulesetLoader = config.filterAbovePriority(RulePriority.HIGH);
-        ruleSet = rulesetLoader.loadFromString("", REF_INTERNAL_TO_EXTERNAL_CHAIN);
+        ruleSet = rulesetLoader.loadFromString("ruleset.xml", REF_INTERNAL_TO_EXTERNAL_CHAIN);
         assertEquals(1, ruleSet.getRules().size(), "Number of Rules");
         assertNotNull(ruleSet.getRuleByName("ExternalRefRuleNameRefRef"));
     }
@@ -625,9 +625,9 @@ class RuleSetFactoryTest extends RulesetFactoryTestBase {
     @Test
     void testSetPriority() {
         RuleSetLoader rulesetLoader = new RuleSetLoader().filterAbovePriority(RulePriority.MEDIUM_HIGH).warnDeprecated(false);
-        assertEquals(0, rulesetLoader.loadFromString("", SINGLE_RULE).size());
+        assertEquals(0, rulesetLoader.loadFromString("ruleset.xml", SINGLE_RULE).size());
         rulesetLoader = new RuleSetLoader().filterAbovePriority(RulePriority.MEDIUM_LOW).warnDeprecated(false);
-        assertEquals(1, rulesetLoader.loadFromString("", SINGLE_RULE).size());
+        assertEquals(1, rulesetLoader.loadFromString("ruleset.xml", SINGLE_RULE).size());
     }
 
     @Test
@@ -975,20 +975,6 @@ class RuleSetFactoryTest extends RulesetFactoryTestBase {
                         + "  </ruleset>\n"
         );
         verifyFoundAWarningWithMessage(containing("RuleSet description is missing."));
-    }
-
-    @Test
-    void testDeprecatedRulesetReferenceProducesWarning() throws Exception {
-        String log = SystemLambda.tapSystemErr(
-            () -> loadRuleSetWithDeprecationWarnings(
-                rulesetXml(
-                    ruleRef("dummy-basic")
-                )));
-        System.out.println(log);
-
-        verifyFoundAWarningWithMessage(containing(
-            "Ruleset reference 'dummy-basic' uses a deprecated form, use 'rulesets/dummy/basic.xml' instead"
-        ));
     }
 
     private static final String REF_OVERRIDE_ORIGINAL_NAME = "<?xml version=\"1.0\"?>\n"

--- a/pmd-test/src/main/java/net/sourceforge/pmd/AbstractRuleSetFactoryTest.java
+++ b/pmd-test/src/main/java/net/sourceforge/pmd/AbstractRuleSetFactoryTest.java
@@ -460,7 +460,7 @@ public abstract class AbstractRuleSetFactoryTest {
 
         // Read RuleSet from XML, first time
         RuleSetLoader loader = new RuleSetLoader();
-        RuleSet ruleSet2 = loader.loadFromString("", xml2);
+        RuleSet ruleSet2 = loader.loadFromString("readRuleSet1.xml", xml2);
 
         // Do write/read a 2nd time, just to be sure
 
@@ -473,7 +473,7 @@ public abstract class AbstractRuleSetFactoryTest {
         // System.out.println("xml3: " + xml3);
 
         // Read RuleSet from XML, second time
-        RuleSet ruleSet3 = loader.loadFromString("", xml3);
+        RuleSet ruleSet3 = loader.loadFromString("readRuleSet2.xml", xml3);
 
         // The 2 written XMLs should all be valid w.r.t Schema/DTD
         assertTrue(validateAgainstSchema(new ByteArrayInputStream(xml2.getBytes())),


### PR DESCRIPTION
## Describe the PR

The old notation <lang>-<ruleset> is not supported anymore. It is now interpreted as a ruleset reference without a ruleset and just referencing a single rule. Also the release number notation is not supported anymore.

Since RuleSetReferenceId is Internal+Deprecated, no API changes. Clarified External/Internal: A RuleSetReference is either absolute (RuleSet is known) or relative (RuleSet is not known).

## Related issues

- Fixes #4313

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)
