### PR TITLE
[core] Undeprecate Node::getImage() in PMD 7

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotation.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotation.java
@@ -23,9 +23,8 @@ public final class ASTAnnotation extends AbstractApexNode<Annotation> {
     }
 
     @Override
-    @Deprecated
     public String getImage() {
-        return node.getType().getApexName();
+        return getName();
     }
 
     public boolean isResolved() {

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotationParameter.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotationParameter.java
@@ -38,7 +38,6 @@ public final class ASTAnnotationParameter extends AbstractApexNode<AnnotationPar
     }
 
     @Override
-    @Deprecated
     public String getImage() {
         return getValue();
     }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/BaseApexClass.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/BaseApexClass.java
@@ -4,8 +4,6 @@
 
 package net.sourceforge.pmd.lang.apex.ast;
 
-import net.sourceforge.pmd.annotation.DeprecatedUntil700;
-
 import apex.jorje.semantic.ast.compilation.Compilation;
 
 abstract class BaseApexClass<T extends Compilation> extends AbstractApexNode<T> implements ASTUserClassOrInterface<T> {
@@ -21,12 +19,7 @@ abstract class BaseApexClass<T extends Compilation> extends AbstractApexNode<T> 
         return true;
     }
 
-    /**
-     * @deprecated Use {@link #getSimpleName()}
-     */
     @Override
-    @Deprecated
-    @DeprecatedUntil700
     public String getImage() {
         return getSimpleName();
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/Node.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/Node.java
@@ -72,11 +72,12 @@ public interface Node extends Reportable {
      * node. This is usually an identifier, but you should check that using the Designer. On most nodes though, this
      * method returns {@code null}.
      *
-     * @deprecated Should be replaced with methods that have more specific
-     *     names in node classes.
+     * <p><strong>Note:</strong>
+     * This method will be deprecated in the future (<a href="https://github.com/pmd/pmd/issues/4787">#4787</a>).
+     * It will be replaced with methods that have more specific names in node classes. In some cases, there
+     * are already alternatives available that should be used.</p>
      */
-    @Deprecated
-    @DeprecatedUntil700
+    // @Deprecated // todo deprecate (#4787)
     default String getImage() {
         return null;
     }
@@ -85,12 +86,13 @@ public interface Node extends Reportable {
     /**
      * Returns true if this node's image is equal to the given string.
      *
+     * <p><strong>Note:</strong>
+     * This method will be deprecated in the future (<a href="https://github.com/pmd/pmd/issues/4787">#4787</a>).
+     * See {@link #getImage()}.
+     * </p>
      * @param image The image to check
-     *
-     * @deprecated See {@link #getImage()}
      */
-    @Deprecated
-    @DeprecatedUntil700
+    // @Deprecated // todo deprecate (#4787)
     default boolean hasImageEqualTo(String image) {
         return Objects.equals(getImage(), image);
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/AbstractJjtreeNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/AbstractJjtreeNode.java
@@ -38,7 +38,7 @@ public abstract class AbstractJjtreeNode<B extends AbstractJjtreeNode<B, N>, N e
     }
 
     @Override
-    // @Deprecated // todo deprecate, will change tree dump tests
+    // @Deprecated // todo deprecate, will change tree dump tests (#4787)
     public String getImage() {
         return image;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnyTypeDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnyTypeDeclaration.java
@@ -69,7 +69,7 @@ public interface ASTAnyTypeDeclaration
     /**
      * @deprecated Use {@link #getSimpleName()}
      */
-    @Deprecated
+    @Deprecated // note: already deprecated in 6.55.0
     @DeprecatedAttribute(replaceWith = "@SimpleName")
     @Override
     String getImage();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclaratorId.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableDeclaratorId.java
@@ -112,7 +112,7 @@ public final class ASTVariableDeclaratorId extends AbstractTypedSymbolDeclarator
      */
     @Override
     @DeprecatedAttribute(replaceWith = "@Name")
-    @Deprecated
+    @Deprecated // note: already deprecated in 6.55.0
     public String getImage() {
         return getName();
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractAnyTypeDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractAnyTypeDeclaration.java
@@ -40,7 +40,7 @@ abstract class AbstractAnyTypeDeclaration extends AbstractTypedSymbolDeclarator<
     /**
      * @deprecated Use {@link #getSimpleName()}
      */
-    @Deprecated
+    @Deprecated // note: already deprecated in 6.55.0
     @DeprecatedAttribute(replaceWith = "@SimpleName")
     @Override
     public String getImage() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaComment.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaComment.java
@@ -42,7 +42,7 @@ public class JavaComment implements Reportable {
      */
     @Deprecated
     public String getImage() {
-        return getToken().getImage();
+        return getText().toString();
     }
 
     /** The token underlying this comment. */


### PR DESCRIPTION
## Describe the PR

-> see https://github.com/pmd/pmd/pull/4768#issuecomment-1855906004

This will undeprecate Node::getImage. We can then finish this in 7.x and 8.
See #4787 for the plan forward.

## Related issues

- Relates #4787

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

