### PR TITLE
[core] Undeprecate PropertySource::dysfunctionReason in PMD 7

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertySource.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertySource.java
@@ -145,10 +145,7 @@ public interface PropertySource {
      * between values. Returns null if the receiver is ok.
      *
      * @return String
-     *
-     * @deprecated PMD 7 will introduce another mechanism to report dysfunctional rules better.
      */
-    @Deprecated
     default String dysfunctionReason() {
         return null;
     }


### PR DESCRIPTION
## Describe the PR

An alternative implementation is not ready for PMD 7, so I'm undoing this deprecation.
In PMD 6.55.0, this is not deprecated.
It is used in `net.sourceforge.pmd.PmdAnalysis#removeBrokenRules`

The related issues are:

## Related issues

* #3868
* #3901

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

