### PR TITLE
[plsql] Fix ignored WITH clause for SELECT INTO statements

### DIFF
--- a/pmd-plsql/etc/grammar/PLSQL.jjt
+++ b/pmd-plsql/etc/grammar/PLSQL.jjt
@@ -1279,6 +1279,7 @@ void AbstractSelectStatement(AbstractSelectStatement node) #void :
 ASTSelectIntoStatement SelectIntoStatement() :
 {}
 {
+    [ WithClause() ]  // Although undocumented, WITH works with SELECT INTO !
     AbstractSelectStatement(jjtThis)
     SelectList()
     ( IntoClause() | BulkCollectIntoClause() )
@@ -2330,11 +2331,11 @@ ASTUnlabelledStatement UnlabelledStatement()  :
 {}
 {
        (
-       // small optimization: SelectIntoStatement and SelectStatement both begin with SELECT
+       // small optimization: SelectIntoStatement and SelectStatement both begin with WITH or SELECT
        // but to distinguish the two, a complete lookahead of SelectIntoStatement needs to be parsed.
        // Using a lookahead of a single token first avoids this the syntatic lookahead for all other choices
        // not related to SELECT statements.
-       LOOKAHEAD(<SELECT>) (
+       LOOKAHEAD(<WITH>|<SELECT>) (
             LOOKAHEAD(SelectIntoStatement()) SelectIntoStatement() ";" |
             SelectStatement() ";"
        ) |

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/WithClauseTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/WithClauseTest.java
@@ -1,0 +1,39 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.plsql.ast;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import net.sourceforge.pmd.lang.plsql.AbstractPLSQLParserTst;
+
+class WithClauseTest extends AbstractPLSQLParserTst {
+
+    @Test
+    void testSelect() {
+        ASTInput input = plsql.parseResource("WithClause.pls");
+
+        List<ASTSelectStatement> selectStatements = input.descendants(ASTSelectStatement.class).toList();
+        assertEquals(1, selectStatements.size());
+
+        assertNotNull(selectStatements.get(0).descendants(ASTWithClause.class).first());
+        assertNotNull(selectStatements.get(0).descendants(ASTSelectList.class).first());
+    }
+
+    @Test
+    void testSelectInto() {
+        ASTInput input = plsql.parseResource("WithClause.pls");
+
+        List<ASTSelectIntoStatement> selectStatements = input.descendants(ASTSelectIntoStatement.class).toList();
+        assertEquals(1, selectStatements.size());
+
+        assertNotNull(selectStatements.get(0).descendants(ASTWithClause.class).first());
+        assertNotNull(selectStatements.get(0).descendants(ASTSelectList.class).first());
+    }
+}

--- a/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/WithClause.pls
+++ b/pmd-plsql/src/test/resources/net/sourceforge/pmd/lang/plsql/ast/WithClause.pls
@@ -1,0 +1,17 @@
+--
+-- WITH Clause
+--
+
+BEGIN
+
+  WITH titles as ( SELECT * FROM academic_titles )
+  SELECT adt.adt_id
+    FROM titles adt;
+
+  WITH titles as ( SELECT * FROM academic_titles )
+  SELECT adt.adt_id
+    INTO v_adt_id
+    FROM titles adt;
+
+END;
+/


### PR DESCRIPTION
## Describe the PR

- WITH clauses were ignored because of missing lookahead. 
- Also added WITH clause support for SELECT INTO statements which actually works although not being documented.

## Related issues

- none that I know

- Fixes #4820 

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

