### PR TITLE
fix #2305: do not apply UnnecessaryBlock for the ECMAScript (JavaScript) destructuring assignments

### DIFF
--- a/pmd-javascript/src/main/resources/category/ecmascript/codestyle.xml
+++ b/pmd-javascript/src/main/resources/category/ecmascript/codestyle.xml
@@ -225,10 +225,12 @@ be misleading.  Considering removing this unnecessary Block.
                 <value>
 <![CDATA[
 //Block[not(parent::FunctionNode or parent::IfStatement or parent::ForLoop or parent::ForInLoop
-    or parent::WhileLoop or parent::DoLoop or parent::TryStatement or parent::CatchClause)]
+    or parent::WhileLoop or parent::DoLoop or parent::TryStatement or parent::CatchClause)
+    and not(ancestor::VariableDeclarator) and not(ancestor::ImportDeclaration)]
 |
 //Scope[not(parent::FunctionNode or parent::IfStatement or parent::ForLoop or parent::ForInLoop
-    or parent::WhileLoop or parent::DoLoop or parent::TryStatement or parent::CatchClause)]
+    or parent::WhileLoop or parent::DoLoop or parent::TryStatement or parent::CatchClause)
+    and not(ancestor::VariableDeclarator) and not(ancestor::ImportDeclaration)]
 ]]>
                 </value>
             </property>

--- a/pmd-javascript/src/main/resources/category/ecmascript/codestyle.xml
+++ b/pmd-javascript/src/main/resources/category/ecmascript/codestyle.xml
@@ -224,13 +224,17 @@ be misleading.  Considering removing this unnecessary Block.
             <property name="xpath">
                 <value>
 <![CDATA[
-//Block[not(parent::FunctionNode or parent::IfStatement or parent::ForLoop or parent::ForInLoop or parent::ForOfLoop
-    or parent::WhileLoop or parent::DoLoop or parent::TryStatement or parent::CatchClause
-    or parent::VariableDeclarator or parent::ImportDeclaration)]
-|
-//Scope[not(parent::FunctionNode or parent::IfStatement or parent::ForLoop or parent::ForInLoop or parent::ForOfLoop
-    or parent::WhileLoop or parent::DoLoop or parent::TryStatement or parent::CatchClause
-    or parent::VariableDeclarator or parent::ImportDeclaration)]
+//(Block|Scope)
+    [not(
+        parent::FunctionNode or
+        parent::IfStatement or
+        parent::ForLoop or
+        parent::ForInLoop or
+        parent::WhileLoop or
+        parent::DoLoop or
+        parent::TryStatement or
+        parent::CatchClause 
+    )]
 ]]>
                 </value>
             </property>

--- a/pmd-javascript/src/main/resources/category/ecmascript/codestyle.xml
+++ b/pmd-javascript/src/main/resources/category/ecmascript/codestyle.xml
@@ -224,13 +224,13 @@ be misleading.  Considering removing this unnecessary Block.
             <property name="xpath">
                 <value>
 <![CDATA[
-//Block[not(parent::FunctionNode or parent::IfStatement or parent::ForLoop or parent::ForInLoop
-    or parent::WhileLoop or parent::DoLoop or parent::TryStatement or parent::CatchClause)
-    and not(ancestor::VariableDeclarator) and not(ancestor::ImportDeclaration)]
+//Block[not(parent::FunctionNode or parent::IfStatement or parent::ForLoop or parent::ForInLoop or parent::ForOfLoop
+    or parent::WhileLoop or parent::DoLoop or parent::TryStatement or parent::CatchClause
+    or parent::VariableDeclarator or parent::ImportDeclaration)]
 |
-//Scope[not(parent::FunctionNode or parent::IfStatement or parent::ForLoop or parent::ForInLoop
-    or parent::WhileLoop or parent::DoLoop or parent::TryStatement or parent::CatchClause)
-    and not(ancestor::VariableDeclarator) and not(ancestor::ImportDeclaration)]
+//Scope[not(parent::FunctionNode or parent::IfStatement or parent::ForLoop or parent::ForInLoop or parent::ForOfLoop
+    or parent::WhileLoop or parent::DoLoop or parent::TryStatement or parent::CatchClause
+    or parent::VariableDeclarator or parent::ImportDeclaration)]
 ]]>
                 </value>
             </property>

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/UnnecessaryBlockTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/UnnecessaryBlockTest.java
@@ -1,11 +1,32 @@
-/**
- * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
- */
-
 package net.sourceforge.pmd.lang.ecmascript.rule.codestyle;
 
 import net.sourceforge.pmd.testframework.PmdRuleTst;
 
-class UnnecessaryBlockTest extends PmdRuleTst {
-    // no additional unit tests
+public class UnnecessaryBlockTest extends PmdRuleTst {
+    @Override
+    public void setUp() {
+        // Set up any required configurations or resources before running the tests
+    }
+
+
+    public void testUnnecessaryBlockInImportStatement() {
+        String code = "import { foo } from 'bar';\n" +
+                      "{\n" +
+                      "    // Unnecessary block\n" +
+                      "}\n";
+
+        // Assert that the PMD rule does not flag the unnecessary block within import statement
+        addSourceCodeTest(code, 0);
+    }
+
+    public void testUnnecessaryBlockInDestructuringAssignment() {
+        String code = "const { a, b } = obj;\n" +
+                      "{\n" +
+                      "    // Unnecessary block\n" +
+                      "}\n";
+
+        // Assert that the PMD rule does not flag the unnecessary block within destructuring assignment
+        addSourceCodeTest(code, 0);
+    }
+
 }

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/UnnecessaryBlockTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/UnnecessaryBlockTest.java
@@ -1,7 +1,11 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
 package net.sourceforge.pmd.lang.ecmascript.rule.codestyle;
 
 import net.sourceforge.pmd.testframework.PmdRuleTst;
 
 public class UnnecessaryBlockTest extends PmdRuleTst {
-    
+    // no additional unit tests
 }

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/UnnecessaryBlockTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/UnnecessaryBlockTest.java
@@ -3,30 +3,5 @@ package net.sourceforge.pmd.lang.ecmascript.rule.codestyle;
 import net.sourceforge.pmd.testframework.PmdRuleTst;
 
 public class UnnecessaryBlockTest extends PmdRuleTst {
-    @Override
-    public void setUp() {
-        // Set up any required configurations or resources before running the tests
-    }
-
-
-    public void testUnnecessaryBlockInImportStatement() {
-        String code = "import { foo } from 'bar';\n" +
-                      "{\n" +
-                      "    // Unnecessary block\n" +
-                      "}\n";
-
-        // Assert that the PMD rule does not flag the unnecessary block within import statement
-        addSourceCodeTest(code, 0);
-    }
-
-    public void testUnnecessaryBlockInDestructuringAssignment() {
-        String code = "const { a, b } = obj;\n" +
-                      "{\n" +
-                      "    // Unnecessary block\n" +
-                      "}\n";
-
-        // Assert that the PMD rule does not flag the unnecessary block within destructuring assignment
-        addSourceCodeTest(code, 0);
-    }
-
+    
 }

--- a/pmd-javascript/src/test/resources/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/xml/UnnecessaryBlock.xml
+++ b/pmd-javascript/src/test/resources/net/sourceforge/pmd/lang/ecmascript/rule/codestyle/xml/UnnecessaryBlock.xml
@@ -43,6 +43,15 @@ for (var i in obj) {
     </test-code>
 
     <test-code>
+        <description>Ok, for of</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+for (let value of obj) {
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>Ok, while</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
@@ -190,6 +199,46 @@ try {
     {
     }
 }
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Ok, destructure assigments</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import {foo} from 'bar'
+
+const [a, b] = array;
+const [a, , b] = array;
+const [a = aDefault, b] = array;
+const [a, b, ...rest] = array;
+const [a, , b, ...rest] = array;
+const [a, b, ...{ pop, push }] = array;
+const [a, b, ...[c, d]] = array;
+
+const { a, b } = obj;
+const { a: a1, b: b1 } = obj;
+const { a: a1 = aDefault, b = bDefault } = obj;
+const { a, b, ...rest } = obj;
+const { a: a1, b: b1, ...rest } = obj;
+const { [key]: a } = obj;
+
+let a, b, a1, b1, c, d, rest, pop, push;
+[a, b] = array;
+[a, , b] = array;
+[a = aDefault, b] = array;
+[a, b, ...rest] = array;
+[a, , b, ...rest] = array;
+[a, b, ...{ pop, push }] = array;
+[a, b, ...[c, d]] = array;
+
+({ a, b } = obj); // parentheses are required
+({ a: a1, b: b1 } = obj);
+({ a: a1 = aDefault, b = bDefault } = obj);
+({ a, b, ...rest } = obj);
+({ a: a1, b: b1, ...rest } = obj);
+
+function fn( ({arg}) ){ return arg}
         ]]></code>
     </test-code>
 </test-data>


### PR DESCRIPTION
This pull request addresses an issue with the PMD rule UnnecessaryBlock in ECMAScript (JavaScript) analysis. The original rule flagged unnecessary blocks in JavaScript code, including those within import statements and destructuring assignments.

Fixes #2305 

To improve the rule's accuracy and usability, this pull request modifies the PMD rule configuration to exclude unnecessary blocks within import statements and destructuring assignments. This refinement ensures that the rule focuses on identifying genuinely redundant blocks in JavaScript code, enhancing code quality without unnecessary noise.

Changes Made:

Updated the XPath expression in the PMD rule to exclude unnecessary blocks within import statements and destructuring assignments.
Added conditions to the XPath expression to exclude blocks within relevant ECMAScript syntax constructs.

Testing:

Added test code to the `UnnecessaryBlock.xml` 
And `mvn test` runs ok

Impact:

Enhances the accuracy of the PMD rule UnnecessaryBlock in ECMAScript analysis.
Improves the user experience by reducing false positives and noise in code analysis results.
Ensures consistent and reliable identification of unnecessary blocks in JavaScript code.
