### PR TITLE
Fix javadoc/dokka configuration

### DIFF
--- a/pmd-ant/pom.xml
+++ b/pmd-ant/pom.xml
@@ -15,6 +15,24 @@
     <name>PMD Ant Integration</name>
     <description>Apache Ant integration for PMD.</description>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <!-- overrides the configuration from parent pom: we only have pmd-core yet -->
+                    <offlineLinks combine.self="override">
+                        <offlineLink>
+                            <location>${project.basedir}/../pmd-core/target/apidocs</location>
+                            <url>../../pmd-core/${project.version}</url>
+                        </offlineLink>
+                    </offlineLinks>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <dependency>
             <groupId>net.sourceforge.pmd</groupId>

--- a/pmd-core/pom.xml
+++ b/pmd-core/pom.xml
@@ -33,6 +33,15 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <!-- overrides the configuration from parent pom: we have here no offline links yet -->
+                    <offlineLinks combine.self="override"></offlineLinks>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/pmd-lang-test/pom.xml
+++ b/pmd-lang-test/pom.xml
@@ -45,6 +45,19 @@
             <plugin>
                 <groupId>org.jetbrains.dokka</groupId>
                 <artifactId>dokka-maven-plugin</artifactId>
+                <configuration>
+                    <!-- overrides the configuration from parent pom: we have here only pmd-core and pmd-test available -->
+                    <externalDocumentationLinks combine.self="override">
+                        <link>
+                            <url>https://docs.pmd-code.org/apidocs/pmd-core/${project.version}/</url>
+                            <packageListUrl>file://${project.basedir}/../pmd-core/target/apidocs/element-list</packageListUrl>
+                        </link>
+                        <link>
+                            <url>https://docs.pmd-code.org/apidocs/pmd-test/${project.version}/</url>
+                            <packageListUrl>file://${project.basedir}/../pmd-test/target/apidocs/element-list</packageListUrl>
+                        </link>
+                    </externalDocumentationLinks>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pmd-test-schema/pom.xml
+++ b/pmd-test-schema/pom.xml
@@ -19,6 +19,23 @@
         <java.version>8</java.version>
     </properties>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <!-- overrides the configuration from parent pom: we only have pmd-core yet -->
+                    <offlineLinks combine.self="override">
+                        <offlineLink>
+                            <location>${project.basedir}/../pmd-core/target/apidocs</location>
+                            <url>../../pmd-core/${project.version}</url>
+                        </offlineLink>
+                    </offlineLinks>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
     <dependencies>
         <dependency>

--- a/pmd-test/pom.xml
+++ b/pmd-test/pom.xml
@@ -16,6 +16,24 @@
         <java.version>8</java.version>
     </properties>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <!-- overrides the configuration from parent pom: we only have pmd-core yet -->
+                    <offlineLinks combine.self="override">
+                        <offlineLink>
+                            <location>${project.basedir}/../pmd-core/target/apidocs</location>
+                            <url>../../pmd-core/${project.version}</url>
+                        </offlineLink>
+                    </offlineLinks>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
          <!--
              hamcrest and junit are scope compile,

--- a/pom.xml
+++ b/pom.xml
@@ -375,17 +375,16 @@
                         <detectOfflineLinks>false</detectOfflineLinks>
                         <offlineLinks>
                             <offlineLink>
-                                <location>${project.basedir}/../pmd-lang-test/target/dokkaJavadocJar</location>
-                                <url>../../pmd-lang-test/${project.version}</url>
+                                <location>${project.basedir}/../pmd-core/target/apidocs</location>
+                                <url>../../pmd-core/${project.version}</url>
                             </offlineLink>
                             <offlineLink>
                                 <location>${project.basedir}/../pmd-test/target/apidocs</location>
                                 <url>../../pmd-test/${project.version}</url>
                             </offlineLink>
-                            <!-- core needs to be last, because the package "net.sourceforge.pmd.lang" is both in pmd-core and pmd-test -->
                             <offlineLink>
-                                <location>${project.basedir}/../pmd-core/target/apidocs</location>
-                                <url>../../pmd-core/${project.version}</url>
+                                <location>${project.basedir}/../pmd-lang-test/target/dokkaJavadocJar</location>
+                                <url>../../pmd-lang-test/${project.version}</url>
                             </offlineLink>
                         </offlineLinks>
                     </configuration>
@@ -397,6 +396,20 @@
                     <version>${dokka.version}</version>
                     <configuration>
                         <skip>${dokka.skip}</skip>
+                        <externalDocumentationLinks>
+                            <link>
+                                <url>https://docs.pmd-code.org/apidocs/pmd-core/${project.version}/</url>
+                                <packageListUrl>file://${project.basedir}/../pmd-core/target/apidocs/element-list</packageListUrl>
+                            </link>
+                            <link>
+                                <url>https://docs.pmd-code.org/apidocs/pmd-test/${project.version}/</url>
+                                <packageListUrl>file://${project.basedir}/../pmd-test/target/apidocs/element-list</packageListUrl>
+                            </link>
+                            <link>
+                                <url>https://docs.pmd-code.org/apidocs/pmd-lang-test/${project.version}/</url>
+                                <packageListUrl>file:///${project.basedir}/../pmd-lang-test/target/dokkaJavadocJar/element-list</packageListUrl>
+                            </link>
+                        </externalDocumentationLinks>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
## Describe the PR

This gets rid of the following errors during building:

```
[INFO] --- javadoc:3.4.1:jar (attach-javadocs) @ pmd-core ---
[ERROR] The given File link: /home/andreas/PMD/source/pmd/pmd-core/../pmd-lang-test/target/dokkaJavadocJar is not a dir.
[ERROR] Error fetching link: /home/andreas/PMD/source/pmd/pmd-core/../pmd-lang-test/target/dokkaJavadocJar. Ignored it.
[ERROR] The given File link: /home/andreas/PMD/source/pmd/pmd-core/../pmd-test/target/apidocs is not a dir.
[ERROR] Error fetching link: /home/andreas/PMD/source/pmd/pmd-core/../pmd-test/target/apidocs. Ignored it.
[ERROR] Error fetching link: /home/andreas/PMD/source/pmd/pmd-core/../pmd-core/target/apidocs. Ignored it.
[INFO] No previous run data found, generating javadoc.

[INFO] --- javadoc:3.4.1:jar (attach-javadocs) @ pmd-test-schema ---
[ERROR] The given File link: /home/andreas/PMD/source/pmd/pmd-test-schema/../pmd-lang-test/target/dokkaJavadocJar is not a dir.
[ERROR] Error fetching link: /home/andreas/PMD/source/pmd/pmd-test-schema/../pmd-lang-test/target/dokkaJavadocJar. Ignored it.
[ERROR] The given File link: /home/andreas/PMD/source/pmd/pmd-test-schema/../pmd-test/target/apidocs is not a dir.
[ERROR] Error fetching link: /home/andreas/PMD/source/pmd/pmd-test-schema/../pmd-test/target/apidocs. Ignored it.
[INFO] No previous run data found, generating javadoc.

[INFO] --- javadoc:3.4.1:jar (attach-javadocs) @ pmd-ant ---
[ERROR] The given File link: /home/andreas/PMD/source/pmd/pmd-ant/../pmd-lang-test/target/dokkaJavadocJar is not a dir.
[ERROR] Error fetching link: /home/andreas/PMD/source/pmd/pmd-ant/../pmd-lang-test/target/dokkaJavadocJar. Ignored it.
[ERROR] The given File link: /home/andreas/PMD/source/pmd/pmd-ant/../pmd-test/target/apidocs is not a dir.
[ERROR] Error fetching link: /home/andreas/PMD/source/pmd/pmd-ant/../pmd-test/target/apidocs. Ignored it.
[INFO] No previous run data found, generating javadoc.

[INFO] --- javadoc:3.4.1:jar (attach-javadocs) @ pmd-test ---
[ERROR] The given File link: /home/andreas/PMD/source/pmd/pmd-test/../pmd-lang-test/target/dokkaJavadocJar is not a dir.
[ERROR] Error fetching link: /home/andreas/PMD/source/pmd/pmd-test/../pmd-lang-test/target/dokkaJavadocJar. Ignored it.
[ERROR] Error fetching link: /home/andreas/PMD/source/pmd/pmd-test/../pmd-test/target/apidocs. Ignored it.
[INFO] No previous run data found, generating javadoc.
```

It also add working links to the dokka generated javadoc. Unfortunately we need to provide absolute URLs there for externalDocumentationLinks... relative URLs seem not to be supported.
Note: Didn't try a newer dokka version, we use 1.7.20, which is not the latest.


## Related issues

- none

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

