### PR TITLE
Fix kotlin compiler warnings

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexTreeBuilder.kt
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexTreeBuilder.kt
@@ -76,10 +76,9 @@ import com.google.summit.ast.statement.WhileLoopStatement
 
 import kotlin.reflect.KClass
 
-@Suppress("DEPRECATION")
-class ApexTreeBuilder(val task: ParserTask, val proc: ApexLanguageProcessor) {
-    private val sourceCode = task.getTextDocument()
-    private val commentBuilder = ApexCommentBuilder(sourceCode, proc.getProperties().getSuppressMarker())
+class ApexTreeBuilder(private val task: ParserTask, private val proc: ApexLanguageProcessor) {
+    private val sourceCode = task.textDocument
+    private val commentBuilder = ApexCommentBuilder(sourceCode, proc.properties.suppressMarker)
 
     /** Builds and returns an [ASTApexFile] corresponding to the given [CompilationUnit]. */
     fun buildTree(compilationUnit: CompilationUnit): ASTApexFile {
@@ -87,7 +86,7 @@ class ApexTreeBuilder(val task: ParserTask, val proc: ApexLanguageProcessor) {
         val baseClass =
             build(compilationUnit, parent = null) as? BaseApexClass<*>
                 ?: throw ParseException("Unable to build tree")
-        val result = ASTApexFile(task, compilationUnit, commentBuilder.getSuppressMap(), proc)
+        val result = ASTApexFile(task, compilationUnit, commentBuilder.suppressMap, proc)
         baseClass.setParent(result)
 
         // Post-processing passes
@@ -759,8 +758,8 @@ class ApexTreeBuilder(val task: ParserTask, val proc: ApexLanguageProcessor) {
         }
       }
 
-      for(i in 0..node.getNumChildren()-1) {
-        node.setChild(children.get(i) as AbstractApexNode, i)
+      for(i in 0 until node.getNumChildren()) {
+        node.setChild(children[i] as AbstractApexNode, i)
       }
     }
 
@@ -794,12 +793,10 @@ class ApexTreeBuilder(val task: ParserTask, val proc: ApexLanguageProcessor) {
     }
 
     /**
-     * If [parent] is not null, adds this [ApexNode] as a [child][ApexNode.jjtAddChild] and sets
-     * [parent] as the [parent][ApexNode.jjtSetParent].
+     * If [parent] is not null, adds this [ApexNode] as a [child][AbstractApexNode.addChild] and sets
+     * [parent] as the [parent][AbstractApexNode.setParent].
      */
     private fun AbstractApexNode.setParent(parent: AbstractApexNode?) {
-        if (parent != null) {
-            parent.addChild(this, parent.numChildren)
-        }
+        parent?.addChild(this, parent.numChildren)
     }
 }

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTCastExpressionTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTCastExpressionTest.kt
@@ -7,7 +7,6 @@ package net.sourceforge.pmd.lang.java.ast
 import net.sourceforge.pmd.lang.ast.test.shouldBe
 import net.sourceforge.pmd.lang.java.ast.JavaVersion.Companion.Earliest
 import net.sourceforge.pmd.lang.java.ast.JavaVersion.Companion.Latest
-import net.sourceforge.pmd.lang.java.ast.ExpressionParsingCtx
 import net.sourceforge.pmd.lang.java.types.JPrimitiveType.PrimitiveTypeKind.*
 
 class ASTCastExpressionTest : ParserTestSpec({

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTFieldAccessTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTFieldAccessTest.kt
@@ -4,7 +4,6 @@
 
 package net.sourceforge.pmd.lang.java.ast
 
-import io.kotest.matchers.shouldBe
 import net.sourceforge.pmd.lang.ast.test.shouldBe
 
 /**
@@ -12,7 +11,7 @@ import net.sourceforge.pmd.lang.ast.test.shouldBe
  */
 class ASTFieldAccessTest : ParserTestSpec({
 
-    parserTest("Field access exprs") {
+    parserTest("Field access expressions") {
 
         inContext(ExpressionParsingCtx) {
 

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTMethodCallTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTMethodCallTest.kt
@@ -13,7 +13,7 @@ import net.sourceforge.pmd.lang.ast.test.shouldBe
 class ASTMethodCallTest : ParserTestSpec({
 
 
-    parserTest("Method call exprs") {
+    parserTest("Method call expressions") {
 
         inContext(ExpressionParsingCtx) {
 

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTMethodDeclarationTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTMethodDeclarationTest.kt
@@ -138,7 +138,7 @@ class ASTMethodDeclarationTest : ParserTestSpec({
             }
         }
 
-        // default abstract is an invalid combination of modifiers so we won't encounter it in real analysis
+        // default abstract is an invalid combination of modifiers, so we won't encounter it in real analysis
     }
 
     parserTest("Throws list") {

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTPatternTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTPatternTest.kt
@@ -5,7 +5,6 @@
 package net.sourceforge.pmd.lang.java.ast
 
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNot
 import net.sourceforge.pmd.lang.java.ast.JavaVersion.J16
 import java.io.IOException
 

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTSuperExpressionTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTSuperExpressionTest.kt
@@ -31,7 +31,7 @@ class ASTSuperExpressionTest : ParserTestSpec({
             // a method call, field access, or method reference
             "super" shouldNot parse()
 
-            // type arguments and annots are disallowed on the qualifier
+            // type arguments and annotations are disallowed on the qualifier
             "T.B<C>.super::foo" shouldNot parse()
             "T.B<C>.super.foo()" shouldNot parse()
             "T.@F B.super.foo()" shouldNot parse()

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTThisExpressionTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTThisExpressionTest.kt
@@ -47,7 +47,7 @@ class ASTThisExpressionTest : ParserTestSpec({
     parserTest("Neg cases") {
         inContext(ExpressionParsingCtx) {
 
-            // type arguments and annots are disallowed on the qualifier
+            // type arguments and annotations are disallowed on the qualifier
             "T.B<C>.this" shouldNot parse()
             "T.@F B.this" shouldNot parse()
         }

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTTypeTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTTypeTest.kt
@@ -59,9 +59,9 @@ class ASTTypeTest : ParserTestSpec({
         // So @B binds to "java"
         // If the annotation is not applicable to TYPE_USE then it doesn't compile
 
-        // this happens in type context, eg in a cast, or in an extends list
+        // this happens in type context, e.g. in a cast, or in an extends list
 
-        // TYPE_USE annotations are prohibited eg before a declaration
+        // TYPE_USE annotations are prohibited e.g. before a declaration
 
         inContext(TypeParsingCtx) {
 

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTUnaryExpressionTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ASTUnaryExpressionTest.kt
@@ -84,7 +84,7 @@ class ASTUnaryExpressionTest : ParserTestSpec({
 
     parserTest("Unary expression ambiguity corner cases") {
 
-        // the following cases test ambiguity between cast of unary, and eg parenthesized additive expr
+        // the following cases test ambiguity between cast of unary, and e.g. parenthesized additive expr
 
         // see https://docs.oracle.com/javase/specs/jls/se9/html/jls-15.html#jls-UnaryExpressionNotPlusMinus
         // comments about ambiguity are below grammar

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/Java11Test.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/Java11Test.kt
@@ -4,9 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.ast
 
-import io.kotest.matchers.shouldBe
 import net.sourceforge.pmd.lang.ast.test.shouldBe
-import net.sourceforge.pmd.lang.java.ast.*
 import net.sourceforge.pmd.lang.java.ast.JavaVersion.*
 import net.sourceforge.pmd.lang.java.ast.JavaVersion.Companion.Latest
 

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/NodeParsingCtx.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/NodeParsingCtx.kt
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.java.ast
 
 import net.sourceforge.pmd.lang.ast.Node
+import net.sourceforge.pmd.lang.ast.ParseException
 import net.sourceforge.pmd.lang.java.JavaParsingHelper
 
 /**
@@ -139,7 +140,7 @@ $construct
     }
 
     override fun retrieveNode(acu: ASTCompilationUnit): ASTBodyDeclaration =
-            acu.typeDeclarations.firstOrThrow().getDeclarations().firstOrThrow()
+            acu.typeDeclarations.firstOrThrow().declarations.firstOrThrow()
 }
 
 object TopLevelTypeDeclarationParsingCtx : NodeParsingCtx<ASTTypeDeclaration>("top-level declaration") {

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ParenthesesTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ParenthesesTest.kt
@@ -73,7 +73,7 @@ class ParenthesesTest : ParserTestSpec({
                                 it::getParenthesisDepth shouldBe 2
                                 it::isParenthesized shouldBe true
 
-                                it.tokenList().map { it.image } shouldBe listOf("(", "(", "a", ")", ")")
+                                it.tokenList().map { token -> token.image } shouldBe listOf("(", "(", "a", ")", ")")
                             }
                         }
                     }
@@ -95,7 +95,7 @@ class ParenthesesTest : ParserTestSpec({
                                 it::getParenthesisDepth shouldBe 1
                                 it::isParenthesized shouldBe true
 
-                                it.tokenList().map { it.image } shouldBe listOf("(", "a", ")")
+                                it.tokenList().map { token -> token.image } shouldBe listOf("(", "a", ")")
                             }
                         }
                     }

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/TestExtensions.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/TestExtensions.kt
@@ -256,8 +256,8 @@ fun TreeNodeWrapper<Node, *>.returnStatement(contents: ValuedNodeSpec<ASTReturnS
 
 fun TreeNodeWrapper<Node, *>.forLoop(body: ValuedNodeSpec<ASTForStatement, ASTStatement?> = { null }) =
         child<ASTForStatement> {
-            val body = body()
-            if (body != null) it::getBody shouldBe body
+            val expectedBody = body()
+            if (expectedBody != null) it::getBody shouldBe expectedBody
             else unspecifiedChildren(it.numChildren)
         }
 
@@ -280,22 +280,22 @@ fun TreeNodeWrapper<Node, *>.statementExprList(body: NodeSpec<ASTStatementExpres
 
 fun TreeNodeWrapper<Node, *>.foreachLoop(body: ValuedNodeSpec<ASTForeachStatement, ASTStatement?> = { null }) =
         child<ASTForeachStatement> {
-            val body = body()
-            if (body != null) it::getBody shouldBe body
+            val expectedBody = body()
+            if (expectedBody != null) it::getBody shouldBe expectedBody
             else unspecifiedChildren(it.numChildren)
         }
 
 fun TreeNodeWrapper<Node, *>.doLoop(body: ValuedNodeSpec<ASTDoStatement, ASTStatement?> = { null }) =
         child<ASTDoStatement> {
-            val body = body()
-            if (body != null) it::getBody shouldBe body
+            val expectedBody = body()
+            if (expectedBody != null) it::getBody shouldBe expectedBody
             else unspecifiedChildren(it.numChildren)
         }
 
 fun TreeNodeWrapper<Node, *>.whileLoop(body: ValuedNodeSpec<ASTWhileStatement, ASTStatement?> = { null }) =
         child<ASTWhileStatement> {
-            val body = body()
-            if (body != null) it::getBody shouldBe body
+            val expectedBody = body()
+            if (expectedBody != null) it::getBody shouldBe expectedBody
             else unspecifiedChildren(it.numChildren)
         }
 
@@ -398,7 +398,7 @@ fun TreeNodeWrapper<Node, *>.unionType(contents: NodeSpec<ASTUnionType> = EmptyA
             contents()
         }
 
-fun TreeNodeWrapper<Node, *>.voidType() = child<ASTVoidType>() {}
+fun TreeNodeWrapper<Node, *>.voidType() = child<ASTVoidType> {}
 
 
 fun TreeNodeWrapper<Node, *>.typeExpr(contents: ValuedNodeSpec<ASTTypeExpression, ASTType>) =
@@ -425,7 +425,7 @@ fun TreeNodeWrapper<Node, *>.arrayType(contents: NodeSpec<ASTArrayType> = EmptyA
 fun TreeNodeWrapper<Node, *>.primitiveType(type: PrimitiveTypeKind, assertions: NodeSpec<ASTPrimitiveType> = EmptyAssertions) =
         child<ASTPrimitiveType> {
             it::getKind shouldBe type
-            PrettyPrintingUtil.prettyPrintType(it) shouldBe type.toString();
+            PrettyPrintingUtil.prettyPrintType(it) shouldBe type.toString()
             assertions()
         }
 
@@ -586,8 +586,8 @@ fun TreeNodeWrapper<Node, *>.switchStmt(assertions: NodeSpec<ASTSwitchStatement>
 
 fun TreeNodeWrapper<Node, *>.switchArrow(rhs: ValuedNodeSpec<ASTSwitchArrowBranch, ASTSwitchArrowRHS?> = { null }) =
         child<ASTSwitchArrowBranch> {
-            val rhs = rhs()
-            if (rhs != null) it::getRightHandSide shouldBe rhs
+            val expectedRhs = rhs()
+            if (expectedRhs != null) it::getRightHandSide shouldBe expectedRhs
             else unspecifiedChildren(2) // label + rhs
         }
 

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/TypeDisambiguationTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/TypeDisambiguationTest.kt
@@ -246,18 +246,18 @@ class TypeDisambiguationTest : ParserTestSpec({
 
         val outerUnresolved = m0.qualifier!!
         val outerT = outerUnresolved.typeMirror.shouldBeA<JClassType> {
-            it.symbol.shouldBeA<JClassSymbol> {
-                it::isUnresolved shouldBe true
-                it::getSimpleName shouldBe "OuterUnresolved"
+            it.symbol.shouldBeA<JClassSymbol> { classSymbol ->
+                classSymbol::isUnresolved shouldBe true
+                classSymbol::getSimpleName shouldBe "OuterUnresolved"
             }
         }
 
         val innerT = m0.typeMirror.shouldBeA<JClassType> {
             it::getEnclosingType shouldBe outerT
-            it.symbol.shouldBeA<JClassSymbol> {
-                it::isUnresolved shouldBe true
-                it::getSimpleName shouldBe "InnerUnresolved"
-                it.enclosingClass.shouldBeSameInstanceAs(outerT.symbol)
+            it.symbol.shouldBeA<JClassSymbol> { classSymbol ->
+                classSymbol::isUnresolved shouldBe true
+                classSymbol::getSimpleName shouldBe "InnerUnresolved"
+                classSymbol.enclosingClass.shouldBeSameInstanceAs(outerT.symbol)
             }
         }
 
@@ -314,7 +314,7 @@ class TypeDisambiguationTest : ParserTestSpec({
         // before all classes of the CU have been visited
         enableProcessing()
 
-        val acu = parser.parse("""
+        @Suppress("UNUSED_VARIABLE") val acu = parser.parse("""
 package p;
 import static p.Assert2.*;
 

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/UsageResolutionTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/UsageResolutionTest.kt
@@ -65,13 +65,13 @@ class UsageResolutionTest : ProcessorTestSpec({
         p::isRecordComponent shouldBe true
         p.localUsages.shouldHaveSize(2)
         p.localUsages[0].shouldBeA<ASTVariableAccess> {
-            it.referencedSym!!.shouldBeA<JFormalParamSymbol> {
-                it.tryGetNode() shouldBe p
+            it.referencedSym!!.shouldBeA<JFormalParamSymbol> { symbol ->
+                symbol.tryGetNode() shouldBe p
             }
         }
         p.localUsages[1].shouldBeA<ASTVariableAccess> {
-            it.referencedSym!!.shouldBeA<JFieldSymbol> {
-                it.tryGetNode() shouldBe p
+            it.referencedSym!!.shouldBeA<JFieldSymbol> { symbol ->
+                symbol.tryGetNode() shouldBe p
             }
         }
     }

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/VarDisambiguationTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/VarDisambiguationTest.kt
@@ -11,7 +11,6 @@ import net.sourceforge.pmd.lang.ast.test.shouldMatchN
 import net.sourceforge.pmd.lang.java.JavaParsingHelper
 import net.sourceforge.pmd.lang.java.symbols.JClassSymbol
 import net.sourceforge.pmd.lang.java.symbols.JTypeParameterSymbol
-import net.sourceforge.pmd.lang.java.symbols.table.internal.JavaSemanticErrors
 import net.sourceforge.pmd.lang.java.symbols.table.internal.JavaSemanticErrors.*
 
 class VarDisambiguationTest : ParserTestSpec({

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/AstSymbolTests.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/AstSymbolTests.kt
@@ -386,7 +386,7 @@ class AstSymbolTests : ParserTestSpec({
         val (canonCtor1, canonCtor2) = acu.descendants(ASTRecordComponentList::class.java).toList { it.symbol }
         val (auxCtor) = acu.descendants(ASTConstructorDeclaration::class.java).toList { it.symbol }
         val (xAccessor) = acu.descendants(ASTMethodDeclaration::class.java).toList { it.symbol }
-        val (xComp, yComp, x2Comp, y2Comp, x2Formal) = acu.descendants(ASTVariableId::class.java).toList { it.symbol }
+        val (xComp, yComp, _, y2Comp, _) = acu.descendants(ASTVariableId::class.java).toList { it.symbol }
 
 
         doTest("should reflect their modifiers") {
@@ -550,7 +550,7 @@ class AstSymbolTests : ParserTestSpec({
             }
 
             // all others are Runnable
-            (allAnons - anonsWithSuperClass).forEach {
+            (allAnons - anonsWithSuperClass.toSet()).forEach {
                 it::getSuperclass shouldBe it.typeSystem.OBJECT.symbol
                 it::getSuperInterfaces shouldBe listOf(it.typeSystem.getClassSymbol(Runnable::class.java))
             }

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/PrimitiveSymbolTests.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/PrimitiveSymbolTests.kt
@@ -17,7 +17,7 @@ import net.sourceforge.pmd.lang.java.types.testTypeSystem
  */
 class PrimitiveSymbolTests : WordSpec({
 
-    fun primitives(): List<JClassSymbol> = testTypeSystem.allPrimitives.map { it.symbol!! }
+    fun primitives(): List<JClassSymbol> = testTypeSystem.allPrimitives.map { it.symbol }
 
     "A primitive symbol" should {
 

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/ReflectedClassSymbolTests.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/ReflectedClassSymbolTests.kt
@@ -40,7 +40,7 @@ class ReflectedClassSymbolTests : IntelliMarker, WordSpec({
 
         "reflect its superinterfaces correctly" {
             TestClassesGen.forAllEqual {
-                classSym(it)!!.superInterfaces to it.interfaces.toList().map { classSym(it) }
+                classSym(it)!!.superInterfaces to it.interfaces.toList().map { clazz -> classSym(clazz) }
             }
         }
 

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/ReflectedFieldSymbolTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/ReflectedFieldSymbolTest.kt
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.java.symbols.internal
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.ints.shouldBeExactly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.property.arbitrary.filterNot
@@ -39,8 +40,8 @@ class ReflectedFieldSymbolTest : IntelliMarker, WordSpec({
         "reflect its modifiers properly" {
             TestClassesGen.filterNot { it.isArray }.forAllEqual {
                 Pair(
-                        classSym(it)!!.declaredFields.map { it.simpleName to it.modifiers },
-                        it.declaredFields.map { it.name to it.modifiers }
+                        classSym(it)!!.declaredFields.map { fieldSymbol -> fieldSymbol.simpleName to fieldSymbol.modifiers },
+                        it.declaredFields.map { field -> field.name to field.modifiers }
                 )
             }
         }
@@ -56,9 +57,14 @@ class ReflectedFieldSymbolTest : IntelliMarker, WordSpec({
         }
 
         "be unmodifiable" {
-            shouldThrow<UnsupportedOperationException> {
-                classSym(SomeFields::class.java)!!.getDeclaredField("foo")!!.declaredAnnotations.add(null)
-            }
+            val declaredAnnotations = classSym(SomeFields::class.java)!!.getDeclaredField("foo")!!.declaredAnnotations
+            declaredAnnotations.size shouldBeExactly 1
+            val annot = declaredAnnotations.first()
+            declaredAnnotations.plus(annot)
+            declaredAnnotations.size shouldBeExactly 1
+
+            // still unmodified
+            classSym(SomeFields::class.java)!!.getDeclaredField("foo")!!.declaredAnnotations.size shouldBeExactly 1
         }
     }
 

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/Utils.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/Utils.kt
@@ -8,7 +8,6 @@ import io.kotest.assertions.withClue
 import io.kotest.matchers.collections.haveSize
 import io.kotest.matchers.should
 import io.kotest.property.*
-import io.kotest.property.arbitrary.arbitrary
 import net.sourceforge.pmd.lang.java.symbols.JClassSymbol
 import net.sourceforge.pmd.lang.java.symbols.SymbolResolver
 import net.sourceforge.pmd.lang.java.types.testTypeSystem
@@ -80,7 +79,7 @@ object TestClassesGen : Arb<Class<*>>() {
                 return
             }
             val files = directory.listFiles()
-            for (file in files) {
+            for (file in files!!) {
                 if (file.isDirectory) {
                     assert(!file.name.contains("."))
                     findClasses(file, packageName + "." + file.name)

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/asm/BrokenClasspathTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/asm/BrokenClasspathTest.kt
@@ -59,7 +59,7 @@ class BrokenClasspathTest : FunSpec({
         // since we're loading things lazily this type hasn't tried to populate its superinterfaces
         val superItfType = ts.declaration(unresolvedItfSym) as JClassType
         val subclassType = ts.declaration(subclassSym) as JClassType
-        val (tvarC, tvarD) = subclassType.formalTypeParams
+        val (_, tvarD) = subclassType.formalTypeParams
 
         // and now since the super interface *type* is parameterized, we'll try to create SuperItf<D,D>
         // Except SuperItf is unresolved.

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/asm/SigParserTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/asm/SigParserTest.kt
@@ -7,9 +7,7 @@ package net.sourceforge.pmd.lang.java.symbols.internal.asm
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.assertions.withClue
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.Matcher
 import io.kotest.matchers.collections.shouldHaveSize
-import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import javasymbols.testdata.impls.SomeInnerClasses

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/table/internal/HeaderScopesTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/table/internal/HeaderScopesTest.kt
@@ -7,8 +7,6 @@
 package net.sourceforge.pmd.lang.java.symbols.table.internal
 
 import io.kotest.matchers.collections.*
-import io.kotest.matchers.maps.shouldBeEmpty
-import io.kotest.matchers.maps.shouldContain
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -252,8 +250,8 @@ class HeaderScopesTest : ProcessorTestSpec({
                 it.apply {
                     scopeTag shouldBe SINGLE_IMPORT
                     results should haveSize(2)
-                    results.forEach {
-                        it.symbol.enclosingClass.canonicalName shouldBe "javasymbols.testdata.StaticNameCollision"
+                    results.forEach { methodSig ->
+                        methodSig.symbol.enclosingClass.canonicalName shouldBe "javasymbols.testdata.StaticNameCollision"
                     }
                 }
 
@@ -261,8 +259,8 @@ class HeaderScopesTest : ProcessorTestSpec({
                 it.apply {
                     scopeTag shouldBe IMPORT_ON_DEMAND
                     results should haveSize(2)
-                    results.forEach {
-                        it.symbol.enclosingClass.canonicalName shouldBe "javasymbols.testdata.Statics"
+                    results.forEach { methodSig ->
+                        methodSig.symbol.enclosingClass.canonicalName shouldBe "javasymbols.testdata.Statics"
                     }
                 }
             }
@@ -276,8 +274,8 @@ class HeaderScopesTest : ProcessorTestSpec({
                 it.apply {
                     scopeTag shouldBe IMPORT_ON_DEMAND
                     results should haveSize(1)
-                    results.forEach {
-                        it.symbol.enclosingClass.canonicalName shouldBe "javasymbols.testdata.Statics"
+                    results.forEach { methodSig ->
+                        methodSig.symbol.enclosingClass.canonicalName shouldBe "javasymbols.testdata.Statics"
                     }
                 }
             }

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/table/internal/LocalTypeScopesTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/table/internal/LocalTypeScopesTest.kt
@@ -112,7 +112,7 @@ class LocalTypeScopesTest : ParserTestSpec({
             }
         """)
 
-        val (foo, inner, other) =
+        val (foo, inner, _) =
                 acu.descendants(ASTClassDeclaration::class.java).toList()
 
         val (insideFoo, insideInner, insideOther) =

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/table/internal/MemberInheritanceTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/table/internal/MemberInheritanceTest.kt
@@ -261,26 +261,26 @@ class MemberInheritanceTest : ParserTestSpec({
             }
         """)
 
-        val (t_Scratch, t_Inner) =
+        val (typeScratch, typeInner) =
                 acu.descendants(ASTClassDeclaration::class.java).toList { it.typeMirror }
 
         val insideFoo =
                 acu.descendants(ASTClassBody::class.java)
                     .crossFindBoundaries().get(2)!!
 
-        val `t_Scratch{String}Inner` = with (acu.typeDsl) {
-            t_Scratch[gen.t_String].selectInner(t_Inner.symbol, emptyList())
+        val `typeScratch{String}Inner` = with (acu.typeDsl) {
+            typeScratch[gen.t_String].selectInner(typeInner.symbol, emptyList())
         }
 
         insideFoo.symbolTable.types().resolve("Inner").shouldBeSingleton {
-            it.shouldBe(`t_Scratch{String}Inner`)
+            it.shouldBe(`typeScratch{String}Inner`)
         }
 
         val typeNode = acu.descendants(ASTClassType::class.java).first { it.simpleName == "Inner" }!!
 
         typeNode.shouldMatchN {
             classType("Inner") {
-                it shouldHaveType `t_Scratch{String}Inner`
+                it shouldHaveType `typeScratch{String}Inner`
             }
         }
 

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/table/internal/VarScopingTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/table/internal/VarScopingTest.kt
@@ -426,7 +426,7 @@ class VarScopingTest : ProcessorTestSpec({
 
         """.trimIndent())
 
-        val (_, t_SomeEnum) = acu.descendants(ASTTypeDeclaration::class.java).toList { it.typeMirror }
+        val (_, typeSomeEnum) = acu.descendants(ASTTypeDeclaration::class.java).toList { it.typeMirror }
 
         val (enumA, enumB) =
                 acu.descendants(ASTEnumDeclaration::class.java)
@@ -443,17 +443,17 @@ class VarScopingTest : ProcessorTestSpec({
 
         qualifiedA.referencedSym shouldBe enumA.symbol
         qualifiedA.referencedSym!!.tryGetNode() shouldBe enumA
-        qualifiedA shouldHaveType t_SomeEnum
+        qualifiedA shouldHaveType typeSomeEnum
 
         caseA.referencedSym shouldBe enumA.symbol
         caseA.referencedSym!!.tryGetNode() shouldBe enumA
-        caseA shouldHaveType t_SomeEnum
+        caseA shouldHaveType typeSomeEnum
 
         caseB.referencedSym shouldBe enumB.symbol
         caseB.referencedSym!!.tryGetNode() shouldBe enumB
-        caseB shouldHaveType t_SomeEnum
+        caseB shouldHaveType typeSomeEnum
 
-        e shouldHaveType t_SomeEnum
+        e shouldHaveType typeSomeEnum
 
         // symbol tables don't carry that info, this is documented on JSymbolTable#variables()
         caseB.symbolTable.variables().resolve("A").shouldBeEmpty()

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/ArraySymbolTests.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/ArraySymbolTests.kt
@@ -21,7 +21,7 @@ import net.sourceforge.pmd.lang.java.symbols.internal.getDeclaredMethods
  */
 class ArraySymbolTests : WordSpec({
 
-    val INT_SYM = testTypeSystem.getClassSymbol(java.lang.Integer.TYPE)
+    val INT_SYM = testTypeSystem.getClassSymbol(Integer.TYPE)
     val STRING_SYM = testTypeSystem.getClassSymbol(java.lang.String::class.java)
 
     fun makeArraySym(comp: JTypeDeclSymbol?) = ArraySymbolImpl(testTypeSystem, comp)

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/BoxingTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/BoxingTest.kt
@@ -10,7 +10,6 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.kotest.matchers.types.shouldBeSameInstanceAs
-import io.kotest.property.forAll
 import net.sourceforge.pmd.lang.java.symbols.internal.forAllEqual
 
 /**

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/CaptureTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/CaptureTest.kt
@@ -7,7 +7,6 @@ package net.sourceforge.pmd.lang.java.types
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import net.sourceforge.pmd.lang.java.symbols.JClassSymbol
 import net.sourceforge.pmd.lang.java.symbols.internal.asm.createUnresolvedAsmSymbol
 import net.sourceforge.pmd.lang.java.types.TypeConversion.*
 
@@ -58,7 +57,7 @@ class CaptureTest : FunSpec({
             }
 
             test("Capture of malformed types") {
-                val sym = ts.createUnresolvedAsmSymbol("does.not.Exist") as JClassSymbol
+                val sym = ts.createUnresolvedAsmSymbol("does.not.Exist")
 
                 val matcher = captureMatcher(`?` extends t_String).also {
                     capture(sym[t_String, `?` extends t_String]) shouldBe sym[t_String, it]

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/SubtypingTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/SubtypingTest.kt
@@ -15,7 +15,6 @@ import io.kotest.property.exhaustive.ints
 import io.kotest.property.forAll
 import net.sourceforge.pmd.lang.ast.test.shouldBeA
 import net.sourceforge.pmd.lang.java.ast.ParserTestCtx
-import net.sourceforge.pmd.lang.java.symbols.JClassSymbol
 import net.sourceforge.pmd.lang.java.symbols.internal.UnresolvedClassStore
 import net.sourceforge.pmd.lang.java.symbols.internal.asm.createUnresolvedAsmSymbol
 import net.sourceforge.pmd.lang.java.types.TypeConversion.*
@@ -157,10 +156,10 @@ class SubtypingTest : FunSpec({
 
             test("Test raw type is convertible to wildcard parameterized type without unchecked conversion") {
                 val `Class{String}` = Class::class[ts.STRING]
-                val `Class{?}` = Class::class[`?`]
+                val `Class{Wildcard}` = Class::class[`?`]
                 val Class = Class::class.raw
 
-                val `Comparable{?}` = java.lang.Comparable::class[`?`]
+                val `Comparable{Wildcard}` = java.lang.Comparable::class[`?`]
 
                 /*
                     Class raw = String.class;
@@ -179,15 +178,15 @@ class SubtypingTest : FunSpec({
 
 
                 `Class{String}` shouldBeSubtypeOf Class
-                `Class{?}` shouldBeSubtypeOf Class
+                `Class{Wildcard}` shouldBeSubtypeOf Class
 
-                `Class{String}` shouldBeSubtypeOf `Class{?}`
-                `Class{?}` shouldNotBeSubtypeOf `Class{String}`
+                `Class{String}` shouldBeSubtypeOf `Class{Wildcard}`
+                `Class{Wildcard}` shouldNotBeSubtypeOf `Class{String}`
 
-                assertSubtype(Class, `Class{?}`) { this == UNCHECKED_NO_WARNING }
+                assertSubtype(Class, `Class{Wildcard}`) { this == UNCHECKED_NO_WARNING }
                 Class shouldBeUncheckedSubtypeOf `Class{String}`
 
-                ts.STRING shouldBeSubtypeOf `Comparable{?}`
+                ts.STRING shouldBeSubtypeOf `Comparable{Wildcard}`
             }
 
             test("Test wildcard subtyping") {
@@ -319,7 +318,7 @@ class SubtypingTest : FunSpec({
             }
 
             test("Test non well-formed types") {
-                val sym = ts.createUnresolvedAsmSymbol("does.not.Exist") as JClassSymbol
+                val sym = ts.createUnresolvedAsmSymbol("does.not.Exist")
                 sym[t_String, t_String] shouldBeUnrelatedTo sym[t_String]
                 sym[t_String] shouldBeSubtypeOf sym[t_String]
                 sym[t_String] shouldBeSubtypeOf sym[`?` extends t_String] // containment

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TestUtilitiesForTypes.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TestUtilitiesForTypes.kt
@@ -8,7 +8,6 @@
 package net.sourceforge.pmd.lang.java.types
 
 import io.kotest.assertions.*
-import io.kotest.assertions.print.Printed
 import io.kotest.assertions.print.print
 import io.kotest.matchers.shouldBe
 import net.sourceforge.pmd.lang.ast.test.shouldBe
@@ -18,8 +17,8 @@ import net.sourceforge.pmd.lang.java.ast.*
 import net.sourceforge.pmd.lang.java.symbols.internal.asm.AsmSymbolResolver
 import net.sourceforge.pmd.lang.java.types.TypeOps.*
 import org.hamcrest.Description
+import java.util.stream.Collectors
 import kotlin.String
-import kotlin.streams.toList
 import kotlin.test.assertTrue
 
 /*
@@ -45,7 +44,7 @@ val TypeSystem.STRING get() = declaration(getClassSymbol(String::class.java)) as
 typealias TypePair = Pair<JTypeMirror, JTypeMirror>
 
 
-fun JTypeMirror.getMethodsByName(name: String) = streamMethods { it.simpleName == name }.toList()
+fun JTypeMirror.getMethodsByName(name: String): List<JMethodSig> = streamMethods { it.simpleName == name }.collect(Collectors.toList())
 
 fun JTypeMirror.shouldBeUnresolvedClass(canonicalName: String) =
     this.shouldBeA<JClassType> {
@@ -225,6 +224,7 @@ val JTypeMirror.isExlusiveIntersectionBound
 /**
  * Was added in java 12.
  */
+@Suppress("UNCHECKED_CAST")
 val <T> Class<T>.arrayType: Class<Array<T>>
     get() {
         val arr = java.lang.reflect.Array.newInstance(this, 0)

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeCreationDsl.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeCreationDsl.kt
@@ -7,7 +7,6 @@
 package net.sourceforge.pmd.lang.java.types
 
 import net.sourceforge.pmd.lang.java.ast.JavaNode
-import net.sourceforge.pmd.lang.java.ast.ParserTestSpec
 import net.sourceforge.pmd.lang.java.symbols.JClassSymbol
 import net.sourceforge.pmd.lang.java.symbols.SymbolicValue.SymAnnot
 import net.sourceforge.pmd.lang.java.symbols.internal.FakeSymAnnot
@@ -26,7 +25,7 @@ val JavaNode.typeDsl get() = TypeDslOf(this.typeSystem)
  * int[][]:                 int.toArray(2)
  * List<? extends Number>:  List::class[`?` extends Number::class]
  *
- * Use [typeDsl] (eg `with(node.typeDsl) { ... }`,
+ * Use [typeDsl] (eg `with(node.typeDsl) { ... }`),
  * or [TypeDslOf] (eg `with(TypeDslOf(ts)) { ... }`)
  *
  * to bring it into scope.
@@ -125,13 +124,14 @@ interface TypeDslMixin {
      *      List::class[`?` super String::class]
      *
      */
+    @Suppress("DANGEROUS_CHARACTERS")
     val `?`: WildcardDsl get() = WildcardDsl(ts)
 
 }
 
 
 /** See [TypeDslMixin.@A]. */
-val ParserTestSpec.GroupTestCtx.VersionedTestCtx.ImplicitNodeParsingCtx<*>.AnnotA
+val AnnotA
     get() = "@" + ClassWithTypeAnnotationsInside.A::class.java.canonicalName
 
 class TypeDslOf(override val ts: TypeSystem) : TypeDslMixin

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeEqualityTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeEqualityTest.kt
@@ -10,9 +10,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.property.checkAll
 import io.kotest.property.forAll
-import net.sourceforge.pmd.lang.java.symbols.JClassSymbol
 import net.sourceforge.pmd.lang.java.symbols.internal.asm.createUnresolvedAsmSymbol
-import net.sourceforge.pmd.lang.java.symbols.internal.forAllEqual
 
 /**
  * @author Clément Fournier
@@ -83,7 +81,7 @@ class TypeEqualityTest : FunSpec({
 
 
             test("Test non well-formed types") {
-                val sym = ts.createUnresolvedAsmSymbol("does.not.Exist") as JClassSymbol
+                val sym = ts.createUnresolvedAsmSymbol("does.not.Exist")
                 // not equal
                 sym[t_String, t_String] shouldNotBe sym[t_String]
                 sym[t_String] shouldNotBe sym[t_String, t_String]

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeGenerationUtil.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeGenerationUtil.kt
@@ -10,7 +10,9 @@ import io.kotest.property.Arb
 import io.kotest.property.Exhaustive
 import io.kotest.property.RandomSource
 import io.kotest.property.Sample
-import io.kotest.property.arbitrary.*
+import io.kotest.property.arbitrary.arbitrary
+import io.kotest.property.arbitrary.filter
+import io.kotest.property.arbitrary.pair
 import io.kotest.property.exhaustive.exhaustive
 import net.sourceforge.pmd.lang.java.JavaParsingHelper
 import net.sourceforge.pmd.lang.java.ast.ASTTypeParameter
@@ -18,8 +20,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTTypeParameters
 import net.sourceforge.pmd.lang.java.ast.ParserTestCtx
 import net.sourceforge.pmd.lang.java.symbols.internal.TestClassesGen
 import net.sourceforge.pmd.lang.java.symbols.internal.asm.createUnresolvedAsmSymbol
-import javax.lang.model.type.TypeMirror
-import kotlin.streams.toList
+import java.util.stream.Collectors
 
 
 val TypeSystem.primitiveGen: Exhaustive<JPrimitiveType> get() = exhaustive(this.allPrimitives.toList())
@@ -48,7 +49,7 @@ class RefTypeGenArb(val ts: TypeSystem) : Arb<JTypeMirror>() {
         // we exclude the null type because it's not ok as an array component
         ts.SERIALIZABLE,
         ts.CLONEABLE
-        );
+        )
 
     override fun edgecase(rs: RandomSource): JTypeMirror {
         return allEdgecases.random(rs.random)
@@ -105,7 +106,7 @@ class RefTypeGenArb(val ts: TypeSystem) : Arb<JTypeMirror>() {
 
 
 
-@Suppress("ObjectPropertyName", "MemberVisibilityCanBePrivate")
+@Suppress("MemberVisibilityCanBePrivate", "DANGEROUS_CHARACTERS")
 class RefTypeConstants(override val ts: TypeSystem) : TypeDslMixin {
 
     val t_String: JClassType                        get() = java.lang.String::class.decl
@@ -192,7 +193,7 @@ fun JavaParsingHelper.makeDummyTVars(vararg names: String): List<JTypeVar> {
             .toStream()
             .map {
                 it.typeMirror
-            }.toList()
+            }.collect(Collectors.toList())
 
 }
 

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypesFromReflectionTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypesFromReflectionTest.kt
@@ -90,6 +90,7 @@ class TypesFromReflectionTest : FunSpec({
         }
 
 
+        @Suppress("unused")
         private class GenericKlass<T>
 
         /**

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/ast/ConversionContextTests.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/ast/ConversionContextTests.kt
@@ -49,7 +49,7 @@ class ConversionContextTests : ProcessorTestSpec({
             }
         """)
 
-        val (ternary, _, num1, shortCast, num5) = acu.descendants(ASTExpression::class.java).toList()
+        val (ternary, _, num1, shortCast, _) = acu.descendants(ASTExpression::class.java).toList()
 
         spy.shouldBeOk {
             // ternary is in double assignment context
@@ -80,7 +80,7 @@ class ConversionContextTests : ProcessorTestSpec({
             }
         """)
 
-        val (ternary, _, integerCast, nullLit, num4) = acu.descendants(ASTExpression::class.java).toList()
+        val (ternary, _, integerCast, _, num4) = acu.descendants(ASTExpression::class.java).toList()
 
         spy.shouldBeOk {
             // ternary is in double assignment context

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/BranchingExprsTestCases.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/BranchingExprsTestCases.kt
@@ -4,7 +4,6 @@
 
 package net.sourceforge.pmd.lang.java.types.internal.infer
 
-import io.kotest.matchers.shouldBe
 import net.sourceforge.pmd.lang.ast.test.shouldBe
 import net.sourceforge.pmd.lang.ast.test.shouldMatchN
 import net.sourceforge.pmd.lang.java.ast.*

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/CaptureInferenceTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/CaptureInferenceTest.kt
@@ -476,7 +476,6 @@ public class SubClass<T> {
                 """.trimIndent()
         )
 
-        val cvar = acu.typeVar("C")
         val tvar = acu.typeVar("T")
 
         spy.shouldBeOk {

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/CtorInferenceTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/CtorInferenceTest.kt
@@ -215,7 +215,7 @@ class CtorInferenceTest : ProcessorTestSpec({
 
             """)
 
-        val (t_Outer, t_Inner, t_Scratch) = acu.declaredTypeSignatures()
+        val (t_Outer, t_Inner, _) = acu.declaredTypeSignatures()
 
         val (innerCtor) = acu.ctorDeclarations().toList()
         val (ctor) = acu.descendants(ASTExplicitConstructorInvocation::class.java).toList()
@@ -260,7 +260,7 @@ class CtorInferenceTest : ProcessorTestSpec({
             """)
 
 
-        val (t_Outer, t_Inner, t_Scratch) = acu.declaredTypeSignatures()
+        val (t_Outer, t_Inner, _) = acu.declaredTypeSignatures()
 
         val (innerCtor) = acu.ctorDeclarations().toList()
         val (ctor) = acu.descendants(ASTExplicitConstructorInvocation::class.java).toList()
@@ -335,7 +335,7 @@ class CtorInferenceTest : ProcessorTestSpec({
 
     parserTest("Mapping of type params doesn't fail") {
 
-        val (acu, spy) = parser.parseWithTypeInferenceSpy(
+        val (acu, _) = parser.parseWithTypeInferenceSpy(
             """
 
     class Gen<A,B> {

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/Java7InferenceTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/Java7InferenceTest.kt
@@ -193,7 +193,7 @@ class Java7InferenceTest : ProcessorTestSpec({
 
 })
 
-private fun TypeDslMixin.ctorInfersTo(
+private fun ctorInfersTo(
     call: ASTConstructorCall,
     inferredType: JClassType
 ) {
@@ -204,7 +204,7 @@ private fun TypeDslMixin.ctorInfersTo(
     )
 }
 
-private fun TypeDslMixin.methodInfersTo(call: ASTMethodCall, returnType: JClassType) {
+private fun methodInfersTo(call: ASTMethodCall, returnType: JClassType) {
     call.methodType.shouldMatchMethod(
         named = call.methodName,
         declaredIn = null, // not asserted

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/OverridingTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/OverridingTest.kt
@@ -10,7 +10,6 @@ import io.kotest.matchers.shouldBe
 import net.sourceforge.pmd.lang.java.ast.*
 import net.sourceforge.pmd.lang.java.types.*
 import net.sourceforge.pmd.util.OptionalBool
-import org.intellij.lang.annotations.Language
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/SpecialMethodsTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/SpecialMethodsTest.kt
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.java.types.internal.infer
 
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import net.sourceforge.pmd.lang.ast.test.shouldBeA
 import net.sourceforge.pmd.lang.ast.test.shouldMatchN
 import net.sourceforge.pmd.lang.java.ast.*
@@ -44,7 +45,7 @@ class SpecialMethodsTest : ProcessorTestSpec({
 
         val t_Scratch = acu.declaredTypeSignatures()[0]
         val kvar = acu.typeVar("K")
-        val (k, k2, raw, call) = acu.methodCalls().toList()
+        val (k, k2, _, call) = acu.methodCalls().toList()
 
         doTest("Test this::getClass") {
             spy.shouldBeOk {
@@ -137,7 +138,7 @@ class SpecialMethodsTest : ProcessorTestSpec({
 
         """.trimIndent())
 
-        val t_Scratch = acu.descendants(ASTTypeDeclaration::class.java).firstOrThrow().typeMirror
+        acu.descendants(ASTTypeDeclaration::class.java).firstOrThrow().typeMirror shouldNotBe null
 
         val call = acu.descendants(ASTMethodCall::class.java).firstOrThrow()
 

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/StandaloneTypesTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/StandaloneTypesTest.kt
@@ -8,10 +8,7 @@ package net.sourceforge.pmd.lang.java.types.internal.infer
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import io.kotest.property.arbitrary.filterNot
-import io.kotest.property.checkAll
 import net.sourceforge.pmd.lang.ast.test.shouldBe
-import net.sourceforge.pmd.lang.ast.test.shouldBeA
 import net.sourceforge.pmd.lang.ast.test.shouldMatchN
 import net.sourceforge.pmd.lang.java.ast.*
 import net.sourceforge.pmd.lang.java.ast.BinaryOp.*

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/StressTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/StressTest.kt
@@ -39,7 +39,7 @@ class StressTest : ProcessorTestSpec({
         fun TreeNodeWrapper<Node, out TypeNode>.typeIs(value: Boolean) {
             it.typeMirror.shouldBeA<JClassType> {
                 it.symbol.binaryName  shouldBe "net.sourceforge.pmd.lang.java.types.testdata.BoolLogic\$${value.toString()
-                    .replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }}"
+                    .replaceFirstChar { char -> if (char.isLowerCase()) char.titlecase(Locale.getDefault()) else char.toString() }}"
             }
         }
 

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/TypeAnnotationsInferenceTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/TypeAnnotationsInferenceTest.kt
@@ -8,8 +8,6 @@ package net.sourceforge.pmd.lang.java.types.internal.infer
 
 import net.sourceforge.pmd.lang.java.ast.*
 import net.sourceforge.pmd.lang.java.types.*
-import net.sourceforge.pmd.lang.java.types.internal.infer.TypeInferenceLogger.VerboseLogger
-import java.util.*
 
 /**
  */

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/TypeInferenceTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/TypeInferenceTest.kt
@@ -248,7 +248,7 @@ class Scratch<O> {
 }
         """.trimIndent())
 
-        val (t_I, t_C) = acu.declaredTypeSignatures()
+        val (_, t_C) = acu.declaredTypeSignatures()
         val tParam = acu.typeVariables().first { it.name == "T" }
 
         spy.shouldBeOk {

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/UnresolvedTypesRecoveryTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/UnresolvedTypesRecoveryTest.kt
@@ -261,7 +261,7 @@ class C {
         val (fooM, idM) = acu.descendants(ASTMethodDeclaration::class.java).toList { it.symbol }
 
         val t_Foo = fooM.getReturnType(Substitution.EMPTY).shouldBeUnresolvedClass("ooo.Foo")
-        val t_Bound = idM.typeParameters[0].upperBound.shouldBeUnresolvedClass("ooo.Bound")
+        idM.typeParameters[0].upperBound.shouldBeUnresolvedClass("ooo.Bound")
 
         val call = acu.descendants(ASTMethodCall::class.java).firstOrThrow()
 

--- a/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/cpd/test/CpdTextComparisonTest.kt
+++ b/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/cpd/test/CpdTextComparisonTest.kt
@@ -130,9 +130,9 @@ abstract class CpdTextComparisonTest(
 
     private fun StringBuilder.formatLine(escapedImage: String, bcol: Any, ecol: Any): StringBuilder {
         var colStart = length
-        colStart = append(Indent).append(escapedImage).padCol(colStart, Col0Width)
+        colStart = append(INDENT).append(escapedImage).padCol(colStart, COL_0_WIDTH)
         @Suppress("UNUSED_VALUE")
-        colStart = append(Indent).append(bcol).padCol(colStart, Col1Width)
+        colStart = append(INDENT).append(bcol).padCol(colStart, COL_1_WIDTH)
         return append(ecol)
     }
 
@@ -152,7 +152,7 @@ abstract class CpdTextComparisonTest(
                 .replace(Regex("\\u000D\\u000A|[\\u000A\\u000B\\u000C\\u000D\\u0085\\u2028\\u2029]"), "\\\\n")       // escape other newlines (normalizing), use \\R with java8+
                 .replace(Regex("[]\\[]"), "\\\\$0")   // escape []
 
-        var truncated = StringUtils.truncate(escaped, ImageSize)
+        var truncated = StringUtils.truncate(escaped, IMAGE_SIZE)
 
         if (truncated.endsWith('\\') && !truncated.endsWith("\\\\"))
             truncated = truncated.substring(0, truncated.length - 1) // cut inside an escape
@@ -176,10 +176,10 @@ abstract class CpdTextComparisonTest(
         CpdLexer.tokenize(cpdLexer, sourceCodeOf(fileData))
 
     private companion object {
-        const val Indent = "    "
-        const val Col0Width = 40
-        const val Col1Width = 10 + Indent.length
-        val ImageSize = Col0Width - Indent.length - 2 // -2 is for the "[]"
+        const val INDENT = "    "
+        const val COL_0_WIDTH = 40
+        const val COL_1_WIDTH = 10 + INDENT.length
+        const val IMAGE_SIZE = COL_0_WIDTH - INDENT.length - 2 // -2 is for the "[]"
     }
 }
 

--- a/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/NodeExtensions.kt
+++ b/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/NodeExtensions.kt
@@ -20,8 +20,6 @@ val TextAvailableNode.textStr: String
 infix fun TextAvailableNode.shouldHaveText(str: String) {
     this::textStr shouldBe str
 }
-inline fun <reified T : Node> Node.getDescendantsOfType(): List<T> = descendants(T::class.java).toList()
-inline fun <reified T : Node> Node.getFirstDescendantOfType(): T = descendants(T::class.java).firstOrThrow()
 
 fun Node.textOfReportLocation(): String? =
         reportLocation.regionInFile?.let(textDocument::sliceOriginalText)?.toString()

--- a/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/NodePrinters.kt
+++ b/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/NodePrinters.kt
@@ -27,10 +27,10 @@ val SimpleNodePrinter = TextTreeRenderer(true, -1)
 
 open class RelevantAttributePrinter : BaseNodeAttributePrinter() {
 
-    private val Ignored = setOf("BeginLine", "EndLine", "BeginColumn", "EndColumn", "FindBoundary", "SingleLine")
+    private val defaultIgnoredAttributes = setOf("BeginLine", "EndLine", "BeginColumn", "EndColumn", "FindBoundary", "SingleLine")
 
     override fun ignoreAttribute(node: Node, attribute: Attribute): Boolean =
-            Ignored.contains(attribute.name) || attribute.name == "Image" && attribute.value == null
+            defaultIgnoredAttributes.contains(attribute.name) || attribute.name == "Image" && attribute.value == null
 
 }
 
@@ -102,7 +102,7 @@ open class BaseNodeAttributePrinter : TextTreeRenderer(true, -1) {
         get() = this.javaClass.let {
             when {
                 it.isEnum -> it
-                else -> it.enclosingClass.takeIf { it.isEnum }
+                else -> it.enclosingClass.takeIf { clazz -> clazz.isEnum }
                         ?: throw IllegalStateException()
             }
         }

--- a/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/TestUtils.kt
+++ b/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/TestUtils.kt
@@ -12,6 +12,7 @@ import net.sourceforge.pmd.reporting.Report
 import net.sourceforge.pmd.reporting.RuleViolation
 import net.sourceforge.pmd.lang.ast.Node
 import net.sourceforge.pmd.lang.document.Chars
+import java.util.*
 import kotlin.reflect.KCallable
 import kotlin.reflect.jvm.isAccessible
 import kotlin.test.assertEquals
@@ -29,9 +30,9 @@ infix fun <N, V : N> KCallable<N>.shouldEqual(expected: V?) =
             n.should(equalityMatcher(v) as Matcher<N>)
         }
 
-private fun <N, V> assertWrapper(callable: KCallable<N>, right: V, asserter: (N, V) -> Unit) {
+private fun <N, V> assertWrapper(callable: KCallable<N>, expected: V, asserter: (N, V) -> Unit) {
 
-    fun formatName() = "::" + callable.name.removePrefix("get").decapitalize()
+    fun formatName() = "::" + callable.name.removePrefix("get").replaceFirstChar { it.lowercase(Locale.getDefault()) }
 
     val value: N = try {
         callable.isAccessible = true
@@ -41,7 +42,7 @@ private fun <N, V> assertWrapper(callable: KCallable<N>, right: V, asserter: (N,
     }
 
     try {
-        asserter(value, right)
+        asserter(value, expected)
     } catch (e: AssertionError) {
 
         if (e.message?.contains("expected:") == true) {

--- a/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/test/BaseTextComparisonTest.kt
+++ b/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/test/BaseTextComparisonTest.kt
@@ -31,8 +31,8 @@ abstract class BaseTextComparisonTest {
     data class FileData(val fileName: FileId, val fileText:String)
 
     /**
-     * Executes the test. The test files are looked up using the [parser].
-     * The reference test file must be named [fileBaseName] + [ExpectedExt].
+     * Executes the test. The test files are looked up using the [resourceLoader].
+     * The reference test file must be named [fileBaseName] + [EXPECTED_EXTENSION].
      * The source file to parse must be named [fileBaseName] + [extensionIncludingDot].
      *
      * @param transformTextContent Function that maps the contents of the source file to the
@@ -41,7 +41,7 @@ abstract class BaseTextComparisonTest {
     internal fun doTest(fileBaseName: String,
                         expectedSuffix: String = "",
                         transformTextContent: (FileData) -> String) {
-        val expectedFile = findTestFile(resourceLoader, "${resourcePrefix}/$fileBaseName$expectedSuffix$ExpectedExt").toFile()
+        val expectedFile = findTestFile(resourceLoader, "${resourcePrefix}/$fileBaseName$expectedSuffix$EXPECTED_EXTENSION").toFile()
 
         val actual = transformTextContent(sourceText(fileBaseName))
 
@@ -97,7 +97,7 @@ abstract class BaseTextComparisonTest {
     }
 
     companion object {
-        const val ExpectedExt = ".txt"
+        const val EXPECTED_EXTENSION = ".txt"
 
     }
 


### PR DESCRIPTION
## Describe the PR

Some cleanups

```
2024-03-01T11:55:46.4583223Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/TestExtensions.kt: (259, 17) Name shadowed: body
2024-03-01T11:55:46.4647576Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/TestExtensions.kt: (283, 17) Name shadowed: body
2024-03-01T11:55:46.4657489Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/TestExtensions.kt: (290, 17) Name shadowed: body
2024-03-01T11:55:46.4660365Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/TestExtensions.kt: (297, 17) Name shadowed: body
2024-03-01T11:55:46.4663125Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/TestExtensions.kt: (589, 17) Name shadowed: rhs
2024-03-01T11:55:46.4666113Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/TypeDisambiguationTest.kt: (317, 13) Variable 'acu' is never used
2024-03-01T11:55:46.4669391Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/AstSymbolTests.kt: (389, 28) Variable 'x2Comp' is never used
2024-03-01T11:55:46.4746019Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/AstSymbolTests.kt: (389, 44) Variable 'x2Formal' is never used
2024-03-01T11:55:46.4751208Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/PrimitiveSymbolTests.kt: (20, 88) Unnecessary non-null assertion (!!) on a non-null receiver of type JClassSymbol
2024-03-01T11:55:46.4756514Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/ReflectedFieldSymbolTest.kt: (60, 98) 'add(E!): Boolean' is deprecated. Deprecated in Java
2024-03-01T11:55:46.4761838Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/asm/BrokenClasspathTest.kt: (62, 14) Variable 'tvarC' is never used
2024-03-01T11:55:46.4766830Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/table/internal/LocalTypeScopesTest.kt: (115, 26) Variable 'other' is never used
2024-03-01T11:55:46.4771112Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/CaptureTest.kt: (61, 74) No cast needed
2024-03-01T11:55:46.4775373Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/SubtypingTest.kt: (160, 21) Name contains characters which can cause problems on Windows: ?
2024-03-01T11:55:46.4780081Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/SubtypingTest.kt: (163, 21) Name contains characters which can cause problems on Windows: ?
2024-03-01T11:55:46.4783626Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/SubtypingTest.kt: (322, 74) No cast needed
2024-03-01T11:55:46.4786981Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TestUtilitiesForTypes.kt: (231, 32) Unchecked cast: Class<out Any!> to Class<Array<T>>
2024-03-01T11:55:46.4795166Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeCreationDsl.kt: (128, 9) Name contains characters which can cause problems on Windows: ?
2024-03-01T11:55:46.4798362Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeEqualityTest.kt: (86, 74) No cast needed
2024-03-01T11:55:46.4801474Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeGenerationUtil.kt: (125, 9) Name contains characters which can cause problems on Windows: ?
2024-03-01T11:55:46.4805293Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeGenerationUtil.kt: (137, 9) Name contains characters which can cause problems on Windows: ?
2024-03-01T11:55:46.4808918Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeGenerationUtil.kt: (138, 9) Name contains characters which can cause problems on Windows: ?
2024-03-01T11:55:46.4812539Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeGenerationUtil.kt: (139, 9) Name contains characters which can cause problems on Windows: ?
2024-03-01T11:55:46.4981285Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeGenerationUtil.kt: (140, 9) Name contains characters which can cause problems on Windows: ?
2024-03-01T11:55:46.4986358Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeGenerationUtil.kt: (141, 9) Name contains characters which can cause problems on Windows: ?
2024-03-01T11:55:46.4991264Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/ast/ConversionContextTests.kt: (52, 43) Variable 'num5' is never used
2024-03-01T11:55:46.4995803Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/ast/ConversionContextTests.kt: (83, 39) Variable 'nullLit' is never used
2024-03-01T11:55:46.5000473Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/CaptureInferenceTest.kt: (479, 13) Variable 'cvar' is never used
2024-03-01T11:55:46.5005524Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/CtorInferenceTest.kt: (218, 32) Variable 't_Scratch' is never used
2024-03-01T11:55:46.5010256Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/CtorInferenceTest.kt: (263, 32) Variable 't_Scratch' is never used
2024-03-01T11:55:46.5015377Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/CtorInferenceTest.kt: (338, 19) Variable 'spy' is never used
2024-03-01T11:55:46.5020084Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/SpecialMethodsTest.kt: (47, 21) Variable 'raw' is never used
2024-03-01T11:55:46.5024873Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/SpecialMethodsTest.kt: (140, 13) Variable 't_Scratch' is never used
2024-03-01T11:55:46.5029668Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/TypeInferenceTest.kt: (251, 14) Variable 't_I' is never used
2024-03-01T11:55:46.5034550Z [WARNING] /home/runner/work/pmd/pmd/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/UnresolvedTypesRecoveryTest.kt: (264, 13) Variable 't_Bound' is never used
```

This one, I didn't fix - it's very weird...

```
2024-03-01T11:52:20.9554721Z [WARNING] /home/runner/work/pmd/pmd/pmd-lang-test/src/main/kotlin/net/sourceforge/pmd/lang/ast/test/TestUtils.kt: (29, 41) Unchecked cast: Matcher<V?> to Matcher<N>
```


## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

