### PR TITLE
[apex] EmptyCatchBlock: Fix FP with doc comments

### DIFF
--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/xml/EmptyCatchBlock.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/xml/EmptyCatchBlock.xml
@@ -297,27 +297,27 @@ private class FunctionalityTest {
         ///////////////////////////////
         try {
         } catch (Exception e) {
-          /** NOK: doc comment inside of empty catch block; should be reported */
+          /** OK: doc comment inside of empty catch block; should be reported */
         }
 
         try {
         } catch (Exception e) {
-          /** NOK: doc comment inside of empty catch block;
+          /** OK: doc comment inside of empty catch block;
            * multiple lines
            * should be reported
            */
         }
 
         try {
-        } catch (Exception e) { /** NOK: doc comment inside of empty catch block, same line as begin; should be reported */
+        } catch (Exception e) { /** OK: doc comment inside of empty catch block, same line as begin; should be reported */
         }
 
         try {
         } catch (Exception e) {
-        /** NOK: doc comment inside of empty catch block, same line as end; should be reported */ }
+        /** OK: doc comment inside of empty catch block, same line as end; should be reported */ }
 
         try {
-        } catch (Exception e) { /** NOK: doc comment inside catch block, same line as begin/end; should be reported */ }
+        } catch (Exception e) { /** OK: doc comment inside catch block, same line as begin/end; should be reported */ }
     }
 }
     ]]></code-fragment>
@@ -333,8 +333,8 @@ private class FunctionalityTest {
     <test-code>
         <description>#3569 - Verify use of allowCommentedBlocks=true, binary search boundaries verification</description>
         <rule-property name="allowCommentedBlocks">true</rule-property>
-        <expected-problems>9</expected-problems>
-        <expected-linenumbers>19,23,54,58,65,70,78,82,86</expected-linenumbers>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>19,23,54,58</expected-linenumbers>
         <code-ref id="with-comments"/>
     </test-code>
 </test-data>


### PR DESCRIPTION
I don't remember why they were special cased, but it seems that removing the exception does not break anything and it is more regular than before.

## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #3953

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

