### PR TITLE
[java] Compute literal expressions for InsufficientStringBufferDeclaration

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -18,6 +18,7 @@ This is a {{ site.pmd.release_type }} release.
 * java-codestyle
   * [#4881](https://github.com/pmd/pmd/issues/4881): \[java] ClassNamingConventions: interfaces are identified as abstract classes (regression in 7.0.0)
 * java-performance
+  * [#3845](https://github.com/pmd/pmd/issues/3845): \[java] InsufficientStringBufferDeclaration should consider literal expression
   * [#4874](https://github.com/pmd/pmd/issues/4874): \[java] StringInstantiation: False-positive when using `new String(charArray)`
 
 ### 🚨 API Changes

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
@@ -250,17 +250,26 @@ public class InsufficientStringBufferDeclarationRule extends AbstractJavaRulecha
             public Void visit(ASTInfixExpression node, MutableInt data) {
                 MutableInt temp = new MutableInt(-1);
 
-                if (BinaryOp.ADD.equals(node.getOperator())) {
-                    data.setValue(0);
-                    node.getLeftOperand().acceptVisitor(this, temp);
-                    data.add(temp.getValue());
-                    node.getRightOperand().acceptVisitor(this, temp);
-                    data.add(temp.getValue());
-                } else if (BinaryOp.MUL.equals(node.getOperator())) {
-                    node.getLeftOperand().acceptVisitor(this, temp);
-                    data.setValue(temp.getValue());
-                    node.getRightOperand().acceptVisitor(this, temp);
-                    data.setValue(data.getValue() * temp.getValue());
+                node.getLeftOperand().acceptVisitor(this, temp);
+                data.setValue(temp.getValue());
+                node.getRightOperand().acceptVisitor(this, temp);
+
+                switch (node.getOperator()) {
+                    case ADD:
+                        data.add(temp.getValue());
+                        break;
+
+                    case SUB:
+                        data.subtract(temp.getValue());
+                        break;
+
+                    case MUL:
+                        data.setValue(data.getValue() * temp.getValue());
+                        break;
+
+                    case DIV:
+                        data.setValue(data.getValue() / temp.getValue());
+                        break;
                 }
 
                 return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
@@ -225,8 +225,11 @@ public class InsufficientStringBufferDeclarationRule extends AbstractJavaRulecha
         ASTConstructorCall constructorCall = (ASTConstructorCall) possibleConstructorCall;
         if (constructorCall.getArguments().size() == 1) {
             ASTExpression argument = constructorCall.getArguments().get(0);
-            if (argument instanceof ASTStringLiteral) {
-                int stringLength = ((ASTStringLiteral) argument).length();
+            if (TypeTestUtil.isA(String.class, argument)) {
+                if (argument.getConstValue() == null) {
+                    return state;
+                }
+                int stringLength = ((String) argument.getConstValue()).length();
                 return new State(variable, constructorCall, DEFAULT_BUFFER_SIZE + stringLength, stringLength + state.anticipatedLength);
             } else {
                 return new State(variable, constructorCall, calculateExpression(argument), state.anticipatedLength);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
@@ -44,7 +44,6 @@ import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
  */
 public class InsufficientStringBufferDeclarationRule extends AbstractJavaRulechainRule {
 
-
     private static final int DEFAULT_BUFFER_SIZE = 16;
 
     public InsufficientStringBufferDeclarationRule() {
@@ -269,6 +268,10 @@ public class InsufficientStringBufferDeclarationRule extends AbstractJavaRulecha
 
                     case DIV:
                         data.setValue(data.getValue() / temp.getValue());
+                        break;
+
+                    default:
+                        data.setValue(0);
                         break;
                 }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
@@ -241,7 +241,7 @@ public class InsufficientStringBufferDeclarationRule extends AbstractJavaRulecha
         return new State(variable, constructorCall, DEFAULT_BUFFER_SIZE, state.anticipatedLength);
     }
 
-    private static class MutableOptionalInt {
+    private final static class MutableOptionalInt {
         @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
         OptionalInt val = OptionalInt.empty();
     }
@@ -263,7 +263,6 @@ public class InsufficientStringBufferDeclarationRule extends AbstractJavaRulecha
                     return null;
                 }
 
-                OptionalInt ret;
                 switch (node.getOperator()) {
                     case ADD:
                         data.val = OptionalInt.of(left.val.getAsInt() + right.val.getAsInt());

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InsufficientStringBufferDeclarationRule.java
@@ -271,7 +271,7 @@ public class InsufficientStringBufferDeclarationRule extends AbstractJavaRulecha
                         break;
 
                     default:
-                        data.setValue(0);
+                        data.setValue(-1);
                         break;
                 }
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/InsufficientStringBufferDeclaration.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/InsufficientStringBufferDeclaration.xml
@@ -1360,4 +1360,19 @@ public class InsufficientStringBufferDeclarationNPE {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[java] InsufficientStringBufferDeclaration should consider literal expression #3845</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class LiteralExpression {
+    public void bar() {
+        StringBuffer sb = new StringBuffer(1 + 2 - 1);  // Should report a warning at this line
+        sb.append('a');
+        sb.append('a');
+        sb.append('a');
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/InsufficientStringBufferDeclaration.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/InsufficientStringBufferDeclaration.xml
@@ -1391,4 +1391,32 @@ public class LiteralExpression {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Properly handle constant string expressions</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class LiteralExpression {
+    public String bar() {
+        StringBuilder sb = new StringBuilder(
+				"<!doctype html>\n" +
+				"<html><head>\n" +
+				"  <meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\" />\n" +
+				"  <meta http-equiv=\"Content-Type\" content=\"text/html; charset=UTF-8\" />\n" +
+				"</head><body><h2>Don't panic!</h2>\n" +
+				"  <script>\n" +
+				"    document.domain = document.domain;\n" +
+				"    var c = parent.%s;\n" +
+				"    c.start();\n" +
+				"    function p(d) {c.message(d);};\n" +
+				"    window.onload = function() {c.stop();};\n" +
+				"  </script>"
+				);
+
+        sb.append("this string is longer than 16 characters");
+		return sb.toString();
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/InsufficientStringBufferDeclaration.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/InsufficientStringBufferDeclaration.xml
@@ -1375,4 +1375,20 @@ public class LiteralExpression {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Properly handle constant variable references</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class LiteralExpression {
+    private static final int MIN_LENGTH = 1;
+    public void bar() {
+        StringBuffer sb = new StringBuffer(MIN_LENGTH + 1);  // Should report a warning at this line
+        sb.append('a');
+        sb.append('a');
+        sb.append('a');
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Handle other operation types when computing initial buffer size.

## Related issues

- Fixes #3845 

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

