### PR TITLE
Fix #4791 Error caused by space in JDK path

### DIFF
--- a/pmd-dist/src/main/resources/scripts/pmd.bat
+++ b/pmd-dist/src/main/resources/scripts/pmd.bat
@@ -1,7 +1,7 @@
 @echo off
 rem make all variables local to not add new global environment variables to the current cmd session
 setlocal
-set TOPDIR="%~dp0.."
+set TOPDIR=%~dp0..
 set OPTS=
 set COMMAND=%1
 set MAIN_CLASS=net.sourceforge.pmd.cli.PmdCli

--- a/pmd-dist/src/main/resources/scripts/pmd.bat
+++ b/pmd-dist/src/main/resources/scripts/pmd.bat
@@ -76,4 +76,4 @@ if defined CLASSPATH (
     set pmd_classpath=%CLASSPATH%;%pmd_classpath%
 )
 
-java %PMD_JAVA_OPTS% %jreopts% -classpath %pmd_classpath% %OPTS% %MAIN_CLASS% %*
+java %PMD_JAVA_OPTS% %jreopts% -classpath "%pmd_classpath%" %OPTS% %MAIN_CLASS% %*


### PR DESCRIPTION
## Describe the PR

Hi, thanks for your reply! I tried and found that it's because that `%pmd_classpath%` is without quotation marks. 

## Related issues

- Fixes #4791


## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

