### PR TITLE
[core] Improve AssertionUtil messages

### DIFF
--- a/pmd-compat6/src/main/java/net/sourceforge/pmd/PmdAnalysis.java
+++ b/pmd-compat6/src/main/java/net/sourceforge/pmd/PmdAnalysis.java
@@ -474,7 +474,7 @@ public final class PmdAnalysis implements AutoCloseable {
             } catch (Exception ioe) {
                 // close listeners so far, throw their close exception or the ioe
                 IOUtil.ensureClosed(rendererListeners, ioe);
-                throw AssertionUtil.shouldNotReachHere("ensureClosed should have thrown");
+                throw AssertionUtil.shouldNotReachHere("ensureClosed should have thrown", ioe);
             }
         }
         return GlobalAnalysisListener.tee(rendererListeners);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PmdAnalysis.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PmdAnalysis.java
@@ -477,7 +477,7 @@ public final class PmdAnalysis implements AutoCloseable {
             } catch (Exception ioe) {
                 // close listeners so far, throw their close exception or the ioe
                 IOUtil.ensureClosed(rendererListeners, ioe);
-                throw AssertionUtil.shouldNotReachHere("ensureClosed should have thrown");
+                throw AssertionUtil.shouldNotReachHere("ensureClosed should have thrown", ioe);
             }
         }
         return GlobalAnalysisListener.tee(rendererListeners);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/impl/AttributeAxisIterator.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/impl/AttributeAxisIterator.java
@@ -89,7 +89,7 @@ public class AttributeAxisIterator implements Iterator<Attribute> {
                          try {
                              return new MethodWrapper(m, nodeClass);
                          } catch (ReflectiveOperationException e) {
-                             throw AssertionUtil.shouldNotReachHere("Method should be accessible " + e);
+                             throw AssertionUtil.shouldNotReachHere("Method '" + m + "' should be accessible, but: " + e, e);
                          }
                      })
                      .collect(Collectors.toList());

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/AssertionUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/AssertionUtil.java
@@ -213,10 +213,14 @@ public final class AssertionUtil {
     }
 
     public static @NonNull AssertionError shouldNotReachHere(String message) {
+        return shouldNotReachHere(message, null);
+    }
+
+    public static @NonNull AssertionError shouldNotReachHere(String message, Throwable cause) {
         String prefix = "This should be unreachable";
         message = StringUtils.isBlank(message) ? prefix
                                                : prefix + ": " + message;
-        return new AssertionError(message);
+        return new AssertionError(message, cause);
     }
 
     public static @NonNull ContextedAssertionError contexted(AssertionError e) {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/impl/AttributeAxisIteratorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/impl/AttributeAxisIteratorTest.java
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.rule.xpath.impl;
 
 import static net.sourceforge.pmd.util.CollectionUtil.setOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import net.sourceforge.pmd.lang.ast.DummyNode;
 import net.sourceforge.pmd.lang.ast.Node;
 import net.sourceforge.pmd.lang.rule.xpath.Attribute;
+import net.sourceforge.pmd.lang.rule.xpath.impl.dummyast.ConcreteNode;
 import net.sourceforge.pmd.util.CollectionUtil;
 
 
@@ -61,6 +63,20 @@ class AttributeAxisIteratorTest {
         AttributeAxisIterator it = new AttributeAxisIterator(dummyNode);
 
         assertEquals(DEFAULT_ATTRS, toMap(it).keySet());
+    }
+
+    /**
+     * Exercises the case described in
+     * <a href="https://github.com/pmd/pmd/issues/4885">[java] AssertionError: Method should be accessible #4885</a>.
+     */
+    @Test
+    void accessPublicMethodWithAPackagePrivateImplementationInSuperclass() {
+        final String ATTRIBUTE_NAME = "Value";
+        ConcreteNode node = new ConcreteNode();
+        AttributeAxisIterator it = new AttributeAxisIterator(node);
+        Map<String, Attribute> attributes = toMap(it);
+        assertTrue(attributes.containsKey(ATTRIBUTE_NAME));
+        assertEquals("actual_value", attributes.get(ATTRIBUTE_NAME).getValue().toString());
     }
 
     private Map<String, Attribute> toMap(AttributeAxisIterator it) {

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/impl/dummyast/AbstractNode.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/impl/dummyast/AbstractNode.java
@@ -1,0 +1,23 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.rule.xpath.impl.dummyast;
+
+import net.sourceforge.pmd.lang.ast.DummyNode;
+import net.sourceforge.pmd.lang.document.Chars;
+
+// This class is package private
+// and provides the implementation for getValue(). This
+// class is the DeclaringClass for that method.
+class AbstractNode extends DummyNode implements ValueNode {
+
+    AbstractNode() {
+
+    }
+
+    @Override
+    public final Chars getValue() {
+        return Chars.wrap("actual_value");
+    }
+}

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/impl/dummyast/ConcreteNode.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/impl/dummyast/ConcreteNode.java
@@ -1,0 +1,8 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.rule.xpath.impl.dummyast;
+
+public final class ConcreteNode extends AbstractNode implements ValueNode {
+}

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/impl/dummyast/ValueNode.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/impl/dummyast/ValueNode.java
@@ -1,0 +1,16 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.rule.xpath.impl.dummyast;
+
+import net.sourceforge.pmd.lang.document.Chars;
+
+/**
+ * This interface is implemented by both AbstractNode and ConcreteNode.
+ * <p>This is similar to the case in pmd-java, where ASTLiteral is implemented
+ * by both ASTStringLiteral (and others) and AbstractLiteral.</p>
+ */
+public interface ValueNode {
+    Chars getValue();
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ConstantFolder.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ConstantFolder.java
@@ -365,7 +365,7 @@ final strictfp class ConstantFolder extends JavaVisitorBase<Void, Object> {
             return null;
         }
         default:
-            throw AssertionUtil.shouldNotReachHere("Unknown operator in " + node);
+            throw AssertionUtil.shouldNotReachHere("Unknown operator '" + node.getOperator() + "' in " + node);
         }
     }
 
@@ -502,7 +502,7 @@ final strictfp class ConstantFolder extends JavaVisitorBase<Void, Object> {
             case DOUBLE:
                 return doubleValue(v);
             default:
-                throw AssertionUtil.shouldNotReachHere("exhaustive enum");
+                throw AssertionUtil.shouldNotReachHere("exhaustive enum: " + target);
             }
         }
         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/InternalApiBridge.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/InternalApiBridge.java
@@ -132,7 +132,7 @@ public final class InternalApiBridge {
         } else if (node instanceof ASTLambdaExpression) {
             ((ASTLambdaExpression) node).setFunctionalMethod(methodType);
         } else {
-            throw AssertionUtil.shouldNotReachHere("" + node);
+            throw AssertionUtil.shouldNotReachHere("FunctionalExpression is not handled: " + node);
         }
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryFullyQualifiedNameRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryFullyQualifiedNameRule.java
@@ -249,7 +249,7 @@ public class UnnecessaryFullyQualifiedNameRule extends AbstractJavaRulechainRule
         case ENCLOSING_TYPE:
             return "declared in an enclosing type";
         default:
-            throw AssertionUtil.shouldNotReachHere("unknown constant" + scopeInfo);
+            throw AssertionUtil.shouldNotReachHere("unknown constant ScopeInfo: " + scopeInfo);
         }
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NcssCountRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NcssCountRule.java
@@ -81,7 +81,7 @@ public final class NcssCountRule extends AbstractJavaRulechainRule {
         } else if (node instanceof ASTExecutableDeclaration) {
             visitMethod((ASTExecutableDeclaration) node, methodReportLevel, ncssOptions, (RuleContext) data);
         } else {
-            throw AssertionUtil.shouldNotReachHere("unreachable");
+            throw AssertionUtil.shouldNotReachHere("node is not handled: " + node);
         }
         return data;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/AbruptCompletionAnalysis.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/AbruptCompletionAnalysis.java
@@ -105,7 +105,7 @@ final class AbruptCompletionAnalysis {
 
         @Override
         public Boolean visitJavaNode(JavaNode node, SubtreeState data) {
-            throw AssertionUtil.shouldNotReachHere("Cannot visit non-statements");
+            throw AssertionUtil.shouldNotReachHere("Cannot visit non-statements: " + node);
         }
 
         @Override
@@ -214,7 +214,7 @@ final class AbruptCompletionAnalysis {
                     branchCompletesNormally = blockCanCompleteNormally(statements, branchState)
                         || branchState.containsBreak(node);
                 } else {
-                    throw AssertionUtil.shouldNotReachHere("Not a branch type :" + branch);
+                    throw AssertionUtil.shouldNotReachHere("Not a branch type: " + branch);
                 }
 
                 if (isExhaustive && first) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/JavaResolvers.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/JavaResolvers.java
@@ -444,8 +444,8 @@ public final class JavaResolvers {
         case 0:
             return sym.getPackageName().equals(packageName);
         default:
-            // fixme this is reachable for invalid declarations, like a private field of an interface
-            throw AssertionUtil.shouldNotReachHere(Modifier.toString(sym.getModifiers()));
+            // TODO this is reachable for invalid declarations, like a private field of an interface
+            throw AssertionUtil.shouldNotReachHere("private field of an interface? " + sym + ", modifiers: " + Modifier.toString(sym.getModifiers()));
         }
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ast/internal/PolyResolution.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ast/internal/PolyResolution.java
@@ -176,7 +176,7 @@ public final class PolyResolution {
                         List<JTypeMirror> branches = ((ASTSwitchExpression) e).getYieldExpressions().toList(TypeNode::getTypeMirror);
                         return computeStandaloneConditionalType(ts, branches);
                     } else {
-                        throw AssertionUtil.shouldNotReachHere("ConditionalMirrorImpl returns non-null for conditionals");
+                        throw AssertionUtil.shouldNotReachHere("ConditionalMirrorImpl returns non-null for conditionals: " + e);
                     }
                 }
                 return ts.ERROR;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/JavaExprMirrors.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/JavaExprMirrors.java
@@ -109,7 +109,7 @@ public final class JavaExprMirrors {
         } else if (e instanceof ASTEnumConstant) {
             return new EnumCtorInvocMirror(this, (ASTEnumConstant) e, parent, subexprMaker);
         }
-        throw AssertionUtil.shouldNotReachHere("" + e);
+        throw AssertionUtil.shouldNotReachHere("Unhandled InvocationNode:" + e);
     }
 
 
@@ -124,7 +124,7 @@ public final class JavaExprMirrors {
         } else if (e instanceof ASTSwitchExpression) {
             return new SwitchMirror(this, (ASTSwitchExpression) e, true, null, defaultMirrorMaker());
         }
-        throw AssertionUtil.shouldNotReachHere("" + e);
+        throw AssertionUtil.shouldNotReachHere("Unhandled expression: " + e);
     }
 
     /**
@@ -136,7 +136,7 @@ public final class JavaExprMirrors {
         } else if (e instanceof ASTSwitchExpression) {
             return new SwitchMirror(this, (ASTSwitchExpression) e, false, null, defaultMirrorMaker());
         }
-        throw AssertionUtil.shouldNotReachHere("" + e);
+        throw AssertionUtil.shouldNotReachHere("Unhandled expression: " + e);
     }
 
     public FunctionalExprMirror getTopLevelFunctionalMirror(ASTExpression e) {
@@ -149,7 +149,7 @@ public final class JavaExprMirrors {
         } else if (e instanceof ASTMethodReference) {
             return new MethodRefMirrorImpl(this, (ASTMethodReference) e, parent, subexprMaker);
         }
-        throw AssertionUtil.shouldNotReachHere("" + e);
+        throw AssertionUtil.shouldNotReachHere("Unhandled expression: " + e);
     }
 
 


### PR DESCRIPTION
## Describe the PR

We sometimes don't give much info, when we reach an assertion.
Especially for #4885, we don't preserve the original exception.
I've updated a couple of places, where we throw `AssertionUtil.shouldNotReachHere`.


## Related issues

- Ref #4885
  - added a simple test case. At least, we exercise the code path, but the problem is not reproducible.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

