### PR TITLE
[java] CloseResource should treat parameters as external even if casted when assigned to a local variable

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -21,6 +21,8 @@ This is a {{ site.pmd.release_type }} release.
   * [#4881](https://github.com/pmd/pmd/issues/4881): \[java] ClassNamingConventions: interfaces are identified as abstract classes (regression in 7.0.0)
 * java-design
   * [#4873](https://github.com/pmd/pmd/issues/4873): \[java] AvoidCatchingGenericException: Can no longer suppress on the exception itself
+* java-errorprone
+  * [#2056](https://github.com/pmd/pmd/issues/2056): \[java] CloseResource false-positive with URLClassLoader in cast expression
 * java-performance
   * [#3845](https://github.com/pmd/pmd/issues/3845): \[java] InsufficientStringBufferDeclaration should consider literal expression
   * [#4874](https://github.com/pmd/pmd/issues/4874): \[java] StringInstantiation: False-positive when using `new String(charArray)`

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
@@ -20,6 +20,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignableExpr.ASTNamedReferenceExpr;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignmentExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTBlock;
+import net.sourceforge.pmd.lang.java.ast.ASTCastExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTExecutableDeclaration;
@@ -340,8 +341,13 @@ public class CloseResourceRule extends AbstractJavaRule {
         if (wrappedVarName != null) {
             ASTFormalParameters methodParams = method.getFormalParameters();
             for (ASTFormalParameter param : methodParams) {
-                if ((isResourceTypeOrSubtype(param) || wrappedVarName.getParent() instanceof ASTVariableDeclarator
-                        || wrappedVarName.getParent() instanceof ASTAssignmentExpression)
+                // get the parent node where it's used (no casts)
+                Node parentUse = wrappedVarName.getParent();
+                if (parentUse instanceof ASTCastExpression) {
+                    parentUse = parentUse.getParent();
+                }
+                if ((isResourceTypeOrSubtype(param) || parentUse instanceof ASTVariableDeclarator
+                        || parentUse instanceof ASTAssignmentExpression)
                     && JavaAstUtils.isReferenceToVar(wrappedVarName, param.getVarId().getSymbol())) {
                     return true;
                 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
@@ -2029,4 +2029,22 @@ public class LocalVariableTypeInference {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Parameters don't need to be closed even if casted #2056</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.net.URLClassLoader;
+
+public class CastedParameter {
+
+    public void checkValidity(ClassLoader auxclassPathClassLoader) {
+        if (auxclassPathClassLoader instanceof URLClassLoader) {
+            final URLClassLoader urlClassLoader = (URLClassLoader) auxclassPathClassLoader;
+            // doesn't need to be closed, it's still a paramter…
+        }
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

The rule allows for resources being passed as parameters to not be closed, even when copied to another variable or wrapped in another instance. However, those checks fail when it's a simple cast being used.

## Related issues

- Fixes #2056 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

