### PR TITLE
[pom] Properly navigate dependencyManagement node

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -25,6 +25,8 @@ This is a {{ site.pmd.release_type }} release.
   * [#3845](https://github.com/pmd/pmd/issues/3845): \[java] InsufficientStringBufferDeclaration should consider literal expression
   * [#4874](https://github.com/pmd/pmd/issues/4874): \[java] StringInstantiation: False-positive when using `new String(charArray)`
   * [#4886](https://github.com/pmd/pmd/issues/4886): \[java] BigIntegerInstantiation: False Positive with Java 17 and BigDecimal.TWO
+* pom-errorprone
+  * [#4388](https://github.com/pmd/pmd/issues/4388): \[pom] InvalidDependencyTypes doesn't consider dependencies at all
 
 ### 🚨 API Changes
 

--- a/pmd-xml/src/main/resources/category/pom/errorprone.xml
+++ b/pmd-xml/src/main/resources/category/pom/errorprone.xml
@@ -26,7 +26,7 @@ The following types are considered valid: pom, jar, maven-plugin, ejb, war, ear,
             <property name="xpath">
                 <value>
 <![CDATA[
-//dependencyManagement/dependency/type/text[not(@Text = $validTypes)]
+//dependencyManagement/dependencies/dependency/type/text[not(@Text = $validTypes)]
 ]]>
                 </value>
             </property>

--- a/pmd-xml/src/test/resources/net/sourceforge/pmd/lang/xml/pom/rule/errorprone/xml/InvalidDependencyTypes.xml
+++ b/pmd-xml/src/test/resources/net/sourceforge/pmd/lang/xml/pom/rule/errorprone/xml/InvalidDependencyTypes.xml
@@ -15,13 +15,15 @@
     <version>1.0.0-SNAPSHOT</version>
 
     <dependencyManagement>
-        <dependency>
-            <groupId>org.jboss.arquillian</groupId>
-            <artifactId>arquillian-bom</artifactId>
-            <version>${arquillian.version}</version>
-            <type>pom</type>
-            <scope>import</scope>
-        </dependency>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>${arquillian.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
     </dependencyManagement>
 </project>
         ]]></code>
@@ -38,13 +40,15 @@
     <version>1.0.0-SNAPSHOT</version>
 
     <dependencyManagement>
-        <dependency>
-            <groupId>org.jboss.arquillian</groupId>
-            <artifactId>arquillian-bom</artifactId>
-            <version>${arquillian.version}</version>
-            <type>bom</type>
-            <scope>import</scope>
-        </dependency>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>${arquillian.version}</version>
+                <type>bom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
     </dependencyManagement>
 </project>
         ]]></code>
@@ -62,13 +66,15 @@
     <version>1.0.0-SNAPSHOT</version>
 
     <dependencyManagement>
-        <dependency>
-            <groupId>org.jboss.arquillian</groupId>
-            <artifactId>arquillian-bom</artifactId>
-            <version>${arquillian.version}</version>
-            <type>bom</type>
-            <scope>import</scope>
-        </dependency>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>${arquillian.version}</version>
+                <type>bom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
     </dependencyManagement>
 </project>
         ]]></code>


### PR DESCRIPTION
## Describe the PR

The XPath (and even tests! 😱) would assume that `<dependency>` was a direct child of `<dependencyManagement>`, but in truth, there is a `<dependencies>` intermediate node.

## Related issues

- Fixes #4388

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

