### PR TITLE
[java] Fix #4602 - unnecessaryimport FPs

### DIFF
--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1684,6 +1684,10 @@ public class Foo {
             Reports import statements that can be removed. They are either unused,
             duplicated, or the members they import are already implicitly in scope,
             because they're in java.lang, or the current package.
+
+            If some imports cannot be resolved, for instance because you run PMD with
+            an incomplete auxiliary classpath, some imports may be conservatively marked
+            as used even if they're not to avoid false positives.
         </description>
         <priority>4</priority>
         <example>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryImport.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryImport.xml
@@ -1195,4 +1195,46 @@ public class Example {
 }
 ]]></code>
     </test-code>
+    <test-code>
+        <description>FP with unknown symbols</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import static something.Foo.*;
+
+public class Example {
+    public Set<String> sample() {
+        foo();
+    }
+}
+]]></code>
+    </test-code>
+    <test-code>
+        <description>FP with unknown symbols 2</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            import static something.Foo.foo;
+
+            public class Example {
+                public Set<String> sample() {
+                    foo(x);
+                }
+            }
+            ]]></code>
+    </test-code>
+    <test-code>
+        <description>FP with unknown symbols 3</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>1</expected-linenumbers>
+        <code><![CDATA[
+            import static something.Foo.bar;
+            import static something.Bar.*; // this is marked as not unnecessary
+            import static something.Other.*; // this is marked as not unnecessary
+
+            public class Example {
+                public Set<String> sample() {
+                    foo(x);
+                }
+            }
+            ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
UnnecessaryImport was written with compilable code in mind. In invalid code, or code we do not know is valid because of missing aux classpath, it currently tends to FP which is not user-friendly. This implements a better strategy for when we can't resolve some names.


## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #4602
- fix #4785

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

