### PR TITLE
[java] Fix pretty printing for some exprs

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/PrettyPrintingUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/PrettyPrintingUtil.java
@@ -7,21 +7,25 @@ package net.sourceforge.pmd.lang.java.ast.internal;
 import static net.sourceforge.pmd.util.AssertionUtil.shouldNotReachHere;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.sourceforge.pmd.lang.java.ast.ASTAmbiguousName;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotationTypeDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTArrayAccess;
 import net.sourceforge.pmd.lang.java.ast.ASTArrayType;
 import net.sourceforge.pmd.lang.java.ast.ASTCastExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTClassDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTClassLiteral;
 import net.sourceforge.pmd.lang.java.ast.ASTClassType;
+import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTEnumDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTExecutableDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldAccess;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTForInit;
 import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTFormalParameters;
 import net.sourceforge.pmd.lang.java.ast.ASTImportDeclaration;
@@ -30,6 +34,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTList;
 import net.sourceforge.pmd.lang.java.ast.ASTLiteral;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodReference;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimaryExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTPrimitiveType;
 import net.sourceforge.pmd.lang.java.ast.ASTRecordDeclaration;
@@ -122,10 +127,10 @@ public final class PrettyPrintingUtil {
             }
         } else if (t instanceof ASTUnionType) {
             CollectionUtil.joinOn(sb, ((ASTUnionType) t).getComponents(),
-                                  PrettyPrintingUtil::prettyPrintTypeNode, " | ");
+                PrettyPrintingUtil::prettyPrintTypeNode, " | ");
         } else if (t instanceof ASTIntersectionType) {
             CollectionUtil.joinOn(sb, ((ASTIntersectionType) t).getComponents(),
-                                  PrettyPrintingUtil::prettyPrintTypeNode, " & ");
+                PrettyPrintingUtil::prettyPrintTypeNode, " & ");
         } else if (t instanceof ASTAmbiguousName) {
             sb.append(((ASTAmbiguousName) t).getName());
         } else {
@@ -249,6 +254,7 @@ public final class PrettyPrintingUtil {
 
         @Override
         public Void visitJavaNode(JavaNode node, StringBuilder data) {
+            data.append("<<NOT_IMPLEMENTED: ").append(node).append(">>");
             return null; // don't recurse
         }
 
@@ -327,16 +333,38 @@ public final class PrettyPrintingUtil {
         }
 
         @Override
+        public Void visit(ASTAmbiguousName node, StringBuilder data) {
+            data.append(node.getName());
+            return null;
+        }
+
+        @Override
         public Void visit(ASTMethodCall node, StringBuilder sb) {
             addQualifier(node, sb);
+            ppTypeArgs(sb, node.getExplicitTypeArguments());
             sb.append(node.getMethodName());
-            if (node.getArguments().isEmpty()) {
+            ppArguments(sb, node.getArguments());
+            return null;
+        }
+
+        @Override
+        public Void visit(ASTConstructorCall node, StringBuilder sb) {
+            addQualifier(node, sb);
+            sb.append("new ");
+            ppTypeArgs(sb, node.getExplicitTypeArguments());
+            prettyPrintTypeNode(sb, node.getTypeNode());
+            ppArguments(sb, node.getArguments());
+            return null;
+        }
+
+        private void ppArguments(StringBuilder sb, ASTArgumentList arguments) {
+            if (arguments.isEmpty()) {
                 sb.append("()");
             } else {
                 final int argStart = sb.length();
                 sb.append('(');
                 boolean first = true;
-                for (ASTExpression arg : node.getArguments()) {
+                for (ASTExpression arg : arguments) {
                     if (sb.length() - argStart >= MAX_ARG_LENGTH) {
                         sb.append("...");
                         break;
@@ -348,18 +376,30 @@ public final class PrettyPrintingUtil {
                 }
                 sb.append(')');
             }
+        }
+
+        @Override
+        public Void visit(ASTMethodReference node, StringBuilder sb) {
+            ppMaybeInParens(sb, node.getQualifier());
+            sb.append("::");
+            ppTypeArgs(sb, node.getExplicitTypeArguments());
+            sb.append(node.getMethodName());
             return null;
+        }
+
+        private void ppMaybeInParens(StringBuilder sb, ASTExpression qualifier) {
+            if (!(qualifier instanceof ASTPrimaryExpression)) {
+                ppInParens(sb, qualifier);
+            } else {
+                qualifier.acceptVisitor(this, sb);
+            }
         }
 
 
         private void addQualifier(QualifiableExpression node, StringBuilder data) {
             ASTExpression qualifier = node.getQualifier();
             if (qualifier != null) {
-                if (!(qualifier instanceof ASTPrimaryExpression)) {
-                    ppInParens(data, qualifier);
-                } else {
-                    qualifier.acceptVisitor(this, data);
-                }
+                ppMaybeInParens(data, qualifier);
                 data.append('.');
             }
 
@@ -369,6 +409,20 @@ public final class PrettyPrintingUtil {
             data.append('(');
             qualifier.acceptVisitor(this, data);
             return data.append(')');
+        }
+
+
+        private void ppTypeArgs(StringBuilder data, @Nullable ASTTypeArguments targs) {
+            if (targs == null) {
+                return;
+            }
+            data.append('<');
+            prettyPrintTypeNode(data, targs.get(0));
+            for (int i = 1; i < targs.size(); i++) {
+                data.append(", ");
+                prettyPrintTypeNode(data, targs.get(i));
+            }
+            data.append('>');
         }
 
     }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/internal/PrettyPrintingUtilTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/internal/PrettyPrintingUtilTest.java
@@ -19,8 +19,10 @@ import org.junit.jupiter.api.Test;
 
 import net.sourceforge.pmd.lang.java.BaseParserTest;
 import net.sourceforge.pmd.lang.java.ast.ASTCompilationUnit;
+import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodReference;
 import net.sourceforge.pmd.util.StringUtil;
 
 class PrettyPrintingUtilTest extends BaseParserTest {
@@ -57,6 +59,30 @@ class PrettyPrintingUtilTest extends BaseParserTest {
         @NonNull ASTMethodCall m = root.descendants(ASTMethodCall.class).firstOrThrow();
 
         assertThat(prettyPrint(m), contentEquals("((Object) this).foo(12)"));
+    }
+
+    @Test
+    void ppMethodRef() {
+        ASTCompilationUnit root = java.parse("class A { { foo(ASTW::meth); } }");
+        @NonNull ASTMethodReference m = root.descendants(ASTMethodReference.class).firstOrThrow();
+
+        assertThat(prettyPrint(m), contentEquals("ASTW::meth"));
+    }
+
+    @Test
+    void ppCtorCall() {
+        ASTCompilationUnit root = java.parse("class A { { new Foo(1); } }");
+        @NonNull ASTConstructorCall m = root.descendants(ASTConstructorCall.class).firstOrThrow();
+
+        assertThat(prettyPrint(m), contentEquals("new Foo(1)"));
+    }
+
+    @Test
+    void ppMethodRefWithTyArgs() {
+        ASTCompilationUnit root = java.parse("class A { { foo(ASTW::<String>meth); } }");
+        @NonNull ASTMethodReference m = root.descendants(ASTMethodReference.class).firstOrThrow();
+
+        assertThat(prettyPrint(m), contentEquals("ASTW::<String>meth"));
     }
 
     private static Matcher<CharSequence> contentEquals(String str) {


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
The pretty printer is not implemented for all expression types and the behavior on these types is just to return the empty string. This makes some messages of eg LawOfDemeter confusing. This adds more implementations...

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- changes extracted from #4918 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

