### PR TITLE
[core] Add japicmp

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -42,6 +42,11 @@ This is a {{ site.pmd.release_type }} release.
 
 ### 🚨 API Changes
 
+#### Deprecated methods
+
+* {%jdoc java::lang.java.rule.design.SingularFieldRule#mayBeSingular(java::lang.java.ast.ModifierOwner) %} has been deprecated for
+  removal. The method is only useful for the rule itself and shouldn't be used otherwise.
+
 ### ✨ External Contributions
 * [#4864](https://github.com/pmd/pmd/pull/4864): Fix #1084 \[Java] add extra assert method names to Junit rules - [Erwan Moutymbo](https://github.com/emouty) (@emouty)
 * [#4894](https://github.com/pmd/pmd/pull/4894): Fix #4791 Error caused by space in JDK path - [Scrates1](https://github.com/Scrates1) (@Scrates1)

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -21,6 +21,8 @@ This is a {{ site.pmd.release_type }} release.
   methods should be considered as valid verification methods. This allows to use custom mocking or assertion libraries.
 
 ### 🐛 Fixed Issues
+* core
+  * [#494](https://github.com/pmd/pmd/issues/494): \[core] Adopt JApiCmp to enforce control over API changes
 * cli
   * [#4791](https://github.com/pmd/pmd/issues/4791): \[cli] Could not find or load main class
 * java-bestpractices

--- a/pmd-ant/pom.xml
+++ b/pmd-ant/pom.xml
@@ -30,6 +30,18 @@
                     </offlineLinks>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+                <configuration>
+                    <parameter>
+                        <excludes combine.children="append">
+                            <exclude>net.sourceforge.pmd.ant.internal</exclude>
+                        </excludes>
+                    </parameter>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pmd-apex/pom.xml
+++ b/pmd-apex/pom.xml
@@ -55,6 +55,20 @@
                 <groupId>org.jetbrains.dokka</groupId>
                 <artifactId>dokka-maven-plugin</artifactId>
             </plugin>
+
+            <plugin>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+                <configuration>
+                    <parameter>
+                        <excludes combine.children="append">
+                            <exclude>net.sourceforge.pmd.lang.apex.internal</exclude>
+                            <exclude>net.sourceforge.pmd.lang.apex.metrics.internal</exclude>
+                            <exclude>net.sourceforge.pmd.lang.apex.rule.internal</exclude>
+                        </excludes>
+                    </parameter>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/pmd-cli/pom.xml
+++ b/pmd-cli/pom.xml
@@ -20,6 +20,21 @@
                     <suppressionsLocation>pmd-cli-checkstyle-suppressions.xml</suppressionsLocation>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+                <configuration>
+                    <parameter>
+                        <excludes combine.children="append">
+                            <exclude>net.sourceforge.pmd.cli.internal</exclude>
+                            <exclude>net.sourceforge.pmd.cli.commands.internal</exclude>
+                            <exclude>net.sourceforge.pmd.cli.commands.mixins.internal</exclude>
+                            <exclude>net.sourceforge.pmd.cli.commands.typesupport.internal</exclude>
+                        </excludes>
+                    </parameter>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/pmd-core/pom.xml
+++ b/pmd-core/pom.xml
@@ -76,6 +76,26 @@
                     <offlineLinks combine.self="override"></offlineLinks>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+                <configuration>
+                    <parameter>
+                        <excludes combine.children="append">
+                            <exclude>net.sourceforge.pmd.internal</exclude>
+                            <exclude>net.sourceforge.pmd.cache.internal</exclude>
+                            <exclude>net.sourceforge.pmd.cpd.internal</exclude>
+                            <exclude>net.sourceforge.pmd.lang.ast.internal</exclude>
+                            <exclude>net.sourceforge.pmd.lang.rule.internal</exclude>
+                            <exclude>net.sourceforge.pmd.lang.rule.xpath.internal</exclude>
+                            <exclude>net.sourceforge.pmd.properties.internal</exclude>
+                            <exclude>net.sourceforge.pmd.renderers.internal</exclude>
+                            <exclude>net.sourceforge.pmd.util.internal</exclude>
+                        </excludes>
+                    </parameter>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/pmd-doc/pom.xml
+++ b/pmd-doc/pom.xml
@@ -16,6 +16,22 @@
         <java.version>8</java.version>
     </properties>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+                <configuration>
+                    <parameter>
+                        <excludes combine.children="append">
+                            <exclude>net.sourceforge.pmd.doc.internal</exclude>
+                        </excludes>
+                    </parameter>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
     <profiles>
         <profile>
             <id>generate-rule-docs</id>

--- a/pmd-java/pom.xml
+++ b/pmd-java/pom.xml
@@ -122,6 +122,26 @@
                     <suppressionsLocation>pmd-java-checkstyle-suppressions.xml</suppressionsLocation>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+                <configuration>
+                    <parameter>
+                        <excludes combine.children="append">
+                            <exclude>net.sourceforge.pmd.lang.java.internal</exclude>
+                            <exclude>net.sourceforge.pmd.lang.java.ast.internal</exclude>
+                            <exclude>net.sourceforge.pmd.lang.java.metrics.internal</exclude>
+                            <exclude>net.sourceforge.pmd.lang.java.rule.internal</exclude>
+                            <exclude>net.sourceforge.pmd.lang.java.rule.xpath.internal</exclude>
+                            <exclude>net.sourceforge.pmd.lang.java.symbols.internal</exclude>
+                            <exclude>net.sourceforge.pmd.lang.java.symbols.table.internal</exclude>
+                            <exclude>net.sourceforge.pmd.lang.java.types.internal</exclude>
+                            <exclude>net.sourceforge.pmd.lang.java.types.ast.internal</exclude>
+                        </excludes>
+                    </parameter>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SingularFieldRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SingularFieldRule.java
@@ -79,7 +79,7 @@ public class SingularFieldRule extends AbstractJavaRulechainRule {
 
         DataflowResult dataflow = null;
         for (ASTFieldDeclaration fieldDecl : enclosingType.getDeclarations(ASTFieldDeclaration.class)) {
-            if (!mayBeSingular(fieldDecl)
+            if (!isPrivateNotFinal(fieldDecl)
                 || JavaAstUtils.hasAnyAnnotation(fieldDecl, getProperty(IGNORED_FIELD_ANNOTATIONS))) {
                 continue;
             }
@@ -95,13 +95,23 @@ public class SingularFieldRule extends AbstractJavaRulechainRule {
         return null;
     }
 
-    private static boolean mayBeSingular(ModifierOwner varId) {
+    /**
+     * This method is only relevant for this rule. It will be removed in the future.
+     *
+     * @deprecated This method will be removed. Don't use it.
+     */
+    @Deprecated //(since = "7.1.0", forRemoval = true)
+    public static boolean mayBeSingular(ModifierOwner varId) {
+        return isPrivateNotFinal(varId);
+    }
+
+    private static boolean isPrivateNotFinal(ModifierOwner varId) {
         return varId.getEffectiveVisibility().isAtMost(Visibility.V_PRIVATE)
-            // We ignore final variables for a reason:
-            // - if they're static they are there to share a value and that is not a mistake
-            // - if they're not static then if this rule matches, then so does FinalFieldCouldBeStatic,
-            // and that rule has the better fix.
-            && !varId.hasModifiers(JModifier.FINAL);
+                // We ignore final variables for a reason:
+                // - if they're static they are there to share a value and that is not a mistake
+                // - if they're not static then if this rule matches, then so does FinalFieldCouldBeStatic,
+                // and that rule has the better fix.
+                && !varId.hasModifiers(JModifier.FINAL);
     }
 
     private boolean isSingularField(ASTTypeDeclaration fieldOwner, ASTVariableId varId, DataflowResult dataflow) {

--- a/pmd-kotlin/pom.xml
+++ b/pmd-kotlin/pom.xml
@@ -63,6 +63,18 @@
                     </delimiters>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+                <configuration>
+                    <parameter>
+                        <excludes combine.children="append">
+                            <exclude>net.sourceforge.pmd.lang.kotlin.rule.xpath.internal</exclude>
+                        </excludes>
+                    </parameter>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/pmd-modelica/pom.xml
+++ b/pmd-modelica/pom.xml
@@ -76,6 +76,18 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+                <configuration>
+                    <parameter>
+                        <excludes combine.children="append">
+                            <exclude>net.sourceforge.pmd.lang.modelica.resolver.internal</exclude>
+                        </excludes>
+                    </parameter>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/pmd-plsql/pom.xml
+++ b/pmd-plsql/pom.xml
@@ -79,6 +79,18 @@
                     <suppressionsLocation>pmd-plsql-checkstyle-suppressions.xml</suppressionsLocation>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+                <configuration>
+                    <parameter>
+                        <excludes combine.children="append">
+                            <exclude>net.sourceforge.pmd.lang.plsql.ast.internal</exclude>
+                        </excludes>
+                    </parameter>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/pmd-scala-modules/pmd-scala-common/pom.xml
+++ b/pmd-scala-modules/pmd-scala-common/pom.xml
@@ -123,6 +123,18 @@
                         </offlineLinks>
                     </configuration>
                 </plugin>
+
+                <plugin>
+                    <groupId>com.github.siom79.japicmp</groupId>
+                    <artifactId>japicmp-maven-plugin</artifactId>
+                    <configuration>
+                        <parameter>
+                            <excludes combine.children="append">
+                                <exclude>net.sourceforge.pmd.lang.scala.internal</exclude>
+                            </excludes>
+                        </parameter>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/pmd-visualforce/pom.xml
+++ b/pmd-visualforce/pom.xml
@@ -74,6 +74,18 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+                <configuration>
+                    <parameter>
+                        <excludes combine.children="append">
+                            <exclude>net.sourceforge.pmd.lang.visualforce.rule.security.internal</exclude>
+                        </excludes>
+                    </parameter>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/pmd-xml/pom.xml
+++ b/pmd-xml/pom.xml
@@ -33,6 +33,18 @@
                     <escapeString>\</escapeString>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
+                <configuration>
+                    <parameter>
+                        <excludes combine.children="append">
+                            <exclude>net.sourceforge.pmd.lang.xml.ast.internal</exclude>
+                        </excludes>
+                    </parameter>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -634,6 +634,7 @@
                             <breakBuildBasedOnSemanticVersioning>true</breakBuildBasedOnSemanticVersioning>
                             <onlyModified>true</onlyModified>
                             <excludes>
+                                <exclude>@net.sourceforge.pmd.annotation.Experimental</exclude>
                                 <exclude>@net.sourceforge.pmd.annotation.InternalApi</exclude>
                             </excludes>
                         </parameter>

--- a/pom.xml
+++ b/pom.xml
@@ -624,6 +624,30 @@
                         </lifecycleMappingMetadata>
                     </configuration>
                 </plugin>
+
+                <plugin>
+                    <groupId>com.github.siom79.japicmp</groupId>
+                    <artifactId>japicmp-maven-plugin</artifactId>
+                    <version>0.20.0</version>
+                    <configuration>
+                        <parameter>
+                            <breakBuildBasedOnSemanticVersioning>true</breakBuildBasedOnSemanticVersioning>
+                            <onlyModified>true</onlyModified>
+                            <excludes>
+                                <exclude>@net.sourceforge.pmd.annotation.InternalApi</exclude>
+                            </excludes>
+                        </parameter>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>japicmp</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>cmp</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -727,6 +751,11 @@
                         </goals>
                     </execution>
                 </executions>
+            </plugin>
+            <!-- Enable japicmp for all modules by default -->
+            <plugin>
+                <groupId>com.github.siom79.japicmp</groupId>
+                <artifactId>japicmp-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>
@@ -1183,6 +1212,7 @@
                 <cpd.skip>true</cpd.skip>
                 <cyclonedx.skip>true</cyclonedx.skip>
                 <dokka.skip>true</dokka.skip>
+                <japicmp.skip>true</japicmp.skip>
             </properties>
         </profile>
 


### PR DESCRIPTION
## Describe the PR

This add [japicmp](https://siom79.github.io/japicmp/MavenPlugin.html) to the build and breaks the build, if we accidentally change a class/interface in an incompatible way.

I've excluded the internal packages by listing them explicitly in the excludes. If we add new packages, we need to update this. Theoretically, we could also add a wildcard (https://github.com/siom79/japicmp/blob/59467d292560d4583884ea42c691bf90992594d1/japicmp/src/main/java/japicmp/filter/JavadocLikePackageFilter.java#L11-L17), but I like for now, that we list the packages explicitly.

For now, I only listed the internal packages. Changes in impl packages would be picked up by the plugin. In case we change something there, we need to decide then: Change it or not. Currently, we don't provide guarantees for impl packages (https://docs.pmd-code.org/latest/pmd_projectdocs_decisions_adr_3.html#criteria-for-public-api) as we consider both `internal` and `impl` as private. But with this tool in place, we can maybe keep even impl stable?

I've tested some simple changes: Renaming methods is detected. Changes in InternalApiBridge are ignored (because of the annotation `@InternalApi`) and changes in internal packages are also ignored.

There was already some incompatibility introduced in SingularFieldRule in pmd-java. 

The plugin generates a nice report in `target/japicmp/japicmp.html`, e.g. for pmd-core:

![image](https://github.com/pmd/pmd/assets/1573684/64d9072a-e401-4686-9188-d03ca042c0e6)

and for pmd-java:

![image](https://github.com/pmd/pmd/assets/1573684/bc8cebb9-8dfd-42cc-a3c6-eacfb1128d77)

It would be nice, to leverage this in some way to have an overview of changed API (e.g. release notes).
I didn't do anything in this direction, just a thought. This comparison can always be created later again, even online :) https://www.japicmp.de

## Related issues

- Fixes #494 

## Ready?


- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

