### PR TITLE
[java] Fix EmptyCatchBlock with allowCommentedBlock

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -35,6 +35,8 @@ This is a {{ site.pmd.release_type }} release.
 * java-design
   * [#3694](https://github.com/pmd/pmd/issues/3694): \[java] SingularField ignores static variables
   * [#4873](https://github.com/pmd/pmd/issues/4873): \[java] AvoidCatchingGenericException: Can no longer suppress on the exception itself
+* java-errorprone
+  * [#4928](https://github.com/pmd/pmd/issues/4928): \[java] EmptyCatchBlock false negative when allowCommentedBlocks=true
 * java-performance
   * [#3845](https://github.com/pmd/pmd/issues/3845): \[java] InsufficientStringBufferDeclaration should consider literal expression
   * [#4874](https://github.com/pmd/pmd/issues/4874): \[java] StringInstantiation: False-positive when using `new String(charArray)`

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -1453,7 +1453,7 @@ or reported.
 //CatchClause[
   Block[
       count(*) = 0
-      and ($allowCommentedBlocks = false() or Block/@containsComment = false())
+      and ($allowCommentedBlocks = false() or @containsComment = false())
   ]
   and CatchParameter/VariableId[not(matches(@Name, $allowExceptionNameRegex))]
 ]

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/EmptyCatchBlock.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/EmptyCatchBlock.xml
@@ -108,7 +108,19 @@ public class Foo {
         ]]></code>
     </test-code>
 
-    <!-- Commented blocks -->
+    <!-- Catch blocks - with/without allowCommentedBlocks -->
+    <test-code>
+        <description>empty block is not OK with allowCommentedBlocks</description>
+        <rule-property name="allowCommentedBlocks">true</rule-property>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void bar() {
+        try {} catch (Exception e) {}
+    }
+}
+]]></code>
+    </test-code>
     <code-fragment id="single-line-comment"><![CDATA[
 public class Foo {
     void bar() {
@@ -126,7 +138,7 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>single-line comment is OK</description>
+        <description>single-line comment is OK with allowCommentedBlocks</description>
         <rule-property name="allowCommentedBlocks">true</rule-property>
         <expected-problems>0</expected-problems>
         <code-ref id="single-line-comment"/>
@@ -149,7 +161,7 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>multiple-line comment is OK</description>
+        <description>multiple-line comment is OK with allowCommentedBlocks</description>
         <rule-property name="allowCommentedBlocks">true</rule-property>
         <expected-problems>0</expected-problems>
         <code-ref id="multiple-line-comment"/>
@@ -168,6 +180,13 @@ public class Foo {
     <test-code>
         <description>Javadoc comment is not OK</description>
         <expected-problems>1</expected-problems>
+        <code-ref id="javadoc-comment"/>
+    </test-code>
+
+    <test-code>
+        <description>Javadoc comment is OK with allowCommentedBlocks</description>
+        <rule-property name="allowCommentedBlocks">true</rule-property>
+        <expected-problems>0</expected-problems>
         <code-ref id="javadoc-comment"/>
     </test-code>
 


### PR DESCRIPTION
- Fixes #4928 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

