### PR TITLE
[core] Introduce a new @DeprecatedUntil annotation

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/annotation/DeprecatedUntil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/annotation/DeprecatedUntil.java
@@ -1,0 +1,29 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.annotation;
+
+import java.lang.annotation.Documented;
+
+/**
+ * Tags a deprecated member that should not be removed before PMD {@link #major()}.
+ * Such members were made deprecated on the PMD {@link #major()} development branch but
+ * are to be kept for backwards compatibility on the day of the PMD {@link #major()} release.
+ */
+@Documented
+public @interface DeprecatedUntil {
+    /**
+     * @return The major version until which the deprecated API is to be kept and supported.
+     */
+    String major();
+
+    /**
+     * @return The future outcome for this API, weather it's to be removed completely or converted to an {@link InternalApi}
+     */
+    FutureOutcome future();
+
+    enum FutureOutcome {
+        REMOVAL, INTERNALIZATION;
+    }
+}


### PR DESCRIPTION
## Describe the PR

 - This should be a better and more stable solution to the old @DeprecatedUntil700 we used during PMD 7's development.
   - It is not tied to a specific major.
   - It allows us to give more than 1 major to remove something if we ever want to…
   - It allows us to explicitly document what we want to do in the next major.
   - It doesn't force us to immediately apply other annotations such as @InternalApi which lead to inconsistency (ie: is is already private or will be made private in the next major?)

## Related issues

- See https://github.com/pmd/pmd/pull/4926#issuecomment-2037644580

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

