### PR TITLE
[java] Fix problem with type inference with enums sharing a common interface

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/Lub.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/Lub.java
@@ -4,10 +4,11 @@
 
 package net.sourceforge.pmd.lang.java.types;
 
+import static net.sourceforge.pmd.util.CollectionUtil.setOf;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
@@ -69,7 +70,8 @@ final class Lub {
      *
      * @return null if G is not a generic type, otherwise Relevant(G)
      */
-    @SuppressWarnings("PMD.ReturnEmptyCollectionRatherThanNull") // null is explicit mentioned as a possible return value
+    @SuppressWarnings("PMD.ReturnEmptyCollectionRatherThanNull")
+    // null is explicit mentioned as a possible return value
     static @Nullable List<JClassType> relevant(JClassType g, Set<JTypeMirror> stunion) {
         if (!g.isRaw()) {
             return null;
@@ -259,7 +261,9 @@ final class Lub {
         }
     }
 
-    /** Simple record type for a pair of types. */
+    /**
+     * Simple record type for a pair of types.
+     */
     private static final class TypePair {
 
         public final JTypeMirror left;
@@ -319,33 +323,47 @@ final class Lub {
             return mostSpecific.iterator().next();
         }
 
-        List<JTypeMirror> bounds = new ArrayList<>(mostSpecific);
+        List<JTypeMirror> bounds = new ArrayList<>(mostSpecific.size());
+        bounds.add(null); // first element will be replaced with primary bound
 
         JTypeMirror primaryBound = null;
 
-        for (int i = 0; i < bounds.size(); i++) {
-            JTypeMirror ci = bounds.get(i);
-
+        for (JTypeMirror ci : mostSpecific) {
             if (isExclusiveIntersectionBound(ci)) {
                 // either Ci is an array, or Ci is a class, or Ci is a type var (possibly captured)
                 // Ci is not unresolved
                 if (primaryBound == null) {
                     primaryBound = ci;
-                    // move primary bound first
-                    Collections.swap(bounds, 0, i);
+                } else if (ci.isArray() && primaryBound.isArray()) {
+                    // A[] & B[] = (A & B)[]
+                    // Note that since we're after mostSpecific, we already know
+                    // that A is unrelated to B. Therefore if both B and A are classes,
+                    // then A & B cannot exist and so (A & B)[] similarly does not exist.
+
+                    JTypeMirror componentGlb = glb(ts, setOf(((JArrayType) ci).getComponentType(),
+                                                             ((JArrayType) primaryBound).getComponentType()));
+                    primaryBound = ts.arrayType(componentGlb);
                 } else {
                     throw new IllegalArgumentException(
                         "Bad intersection, unrelated class types " + ci + " and " + primaryBound + " in " + types
                     );
                 }
+            } else {
+                bounds.add(ci);
             }
         }
 
+
         if (primaryBound == null) {
-            if (bounds.size() == 1) {
-                return bounds.get(0);
-            }
             primaryBound = ts.OBJECT;
+        }
+        bounds.set(0, primaryBound); // set the primary bound
+        if (primaryBound == ts.OBJECT) {
+            // if primary bound is object, it does not appear in the bounds
+            bounds = bounds.subList(1, bounds.size());
+        }
+        if (bounds.size() == 1) {
+            return bounds.get(0); // not an intersection
         }
 
         return new JIntersectionType(ts, primaryBound, bounds);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/Lub.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/Lub.java
@@ -70,8 +70,7 @@ final class Lub {
      *
      * @return null if G is not a generic type, otherwise Relevant(G)
      */
-    @SuppressWarnings("PMD.ReturnEmptyCollectionRatherThanNull")
-    // null is explicit mentioned as a possible return value
+    @SuppressWarnings("PMD.ReturnEmptyCollectionRatherThanNull") // null is explicit mentioned as a possible return value
     static @Nullable List<JClassType> relevant(JClassType g, Set<JTypeMirror> stunion) {
         if (!g.isRaw()) {
             return null;
@@ -261,9 +260,7 @@ final class Lub {
         }
     }
 
-    /**
-     * Simple record type for a pair of types.
-     */
+    /** Simple record type for a pair of types. */
     private static final class TypePair {
 
         public final JTypeMirror left;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
@@ -1733,8 +1733,15 @@ public final class TypeOps {
         vLoop:
         for (JTypeMirror v : set) {
             for (JTypeMirror w : set) {
-                if (!w.equals(v) && !hasUnresolvedSymbol(w) && isSubtypePure(w, v).bySubtyping()) {
-                    continue vLoop;
+                if (!w.equals(v) && !hasUnresolvedSymbol(w)) {
+                    Convertibility isConvertible = isSubtypePure(w, v);
+                    if (isConvertible.bySubtyping()
+                        // This last case covers unchecked conversion. It is made antisymmetric by the
+                        // test for a symbol. eg |G| <~> G<?> so it would fail.
+                        // However, |G| ~> S if |G| <: |S|, so we should consider |G| more specific than S.
+                        || isConvertible.somehow() && !Objects.equals(w.getSymbol(), v.getSymbol())) {
+                        continue vLoop;
+                    }
                 }
             }
             result.add(v);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
@@ -580,6 +580,11 @@ public final class TypeOps {
             return this == UNCHECKED_WARNING;
         }
 
+        /** True if this is {@link #SUBTYPING} or {@link #UNCHECKED_NO_WARNING}. */
+        public boolean withoutWarnings() {
+            return this == SUBTYPING || this == UNCHECKED_NO_WARNING;
+        }
+
         // package:
 
 
@@ -1739,7 +1744,7 @@ public final class TypeOps {
                         // This last case covers unchecked conversion. It is made antisymmetric by the
                         // test for a symbol. eg |G| <~> G<?> so it would fail.
                         // However, |G| ~> S if |G| <: |S|, so we should consider |G| more specific than S.
-                        || isConvertible.somehow() && !Objects.equals(w.getSymbol(), v.getSymbol())) {
+                        || isConvertible.withoutWarnings() && !Objects.equals(w.getSymbol(), v.getSymbol())) {
                         continue vLoop;
                     }
                 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeSystem.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeSystem.java
@@ -697,12 +697,20 @@ public final class TypeSystem {
      * <li>The intersection has a single component that is a
      * class, array, or type variable. If all components are interfaces,
      * then that component is {@link #OBJECT}.
+     * <li>If several components are arrays, then their components
+     * are intersected: {@code A[] & B[] = (A & B)[]}
      * </ul>
      *
      * <p>If after these transformations, only a single component remains,
      * then that is the returned type. Otherwise a {@link JIntersectionType}
      * is created. Note that the intersection may be unsatisfiable (eg {@code A[] & Runnable}),
-     * but we don't attempt to minimize this to {@link #NULL_TYPE}.
+     * but we don't attempt to minimize this to {@link #NULL_TYPE}. Similarly,
+     * we do not attempt to minimize valid intersections. For instance {@code List<?> & Collection<Number>}
+     * can technically be minimized to {@code List<Number>}, but doing this
+     * requires inference of a fitting parameterization in general, which is
+     * complex, and not necessary in the internal tasks where intersection types are
+     * useful. In fact intersection types are precisely useful because they are
+     * simple to build.
      *
      * <p>See also JLS§4.9 (Intersection types).
      *

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/testdata/LubTestData.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/testdata/LubTestData.java
@@ -46,5 +46,8 @@ public class LubTestData {
     public static class GenericSub2<T> extends GenericSuper<T> implements I2<I3>, I4 {
     }
 
+    public interface EnumSuperItf {}
+    public enum Enum1 implements EnumSuperItf {}
+    public enum Enum2 implements EnumSuperItf {}
 
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/testdata/LubTestData.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/testdata/LubTestData.java
@@ -50,4 +50,7 @@ public class LubTestData {
     public enum Enum1 implements EnumSuperItf {}
     public enum Enum2 implements EnumSuperItf {}
 
+    // unrelated
+    public static class C1 {}
+    public static class C2 {}
 }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/testdata/LubTestData.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/testdata/LubTestData.java
@@ -46,11 +46,19 @@ public class LubTestData {
     public static class GenericSub2<T> extends GenericSuper<T> implements I2<I3>, I4 {
     }
 
-    public interface EnumSuperItf {}
-    public enum Enum1 implements EnumSuperItf {}
-    public enum Enum2 implements EnumSuperItf {}
+    public interface EnumSuperItf {
+    }
+
+    public enum Enum1 implements EnumSuperItf {
+    }
+
+    public enum Enum2 implements EnumSuperItf {
+    }
 
     // unrelated
-    public static class C1 {}
-    public static class C2 {}
+    public static class C1 {
+    }
+
+    public static class C2 {
+    }
 }

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/GlbTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/GlbTest.kt
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.java.types
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.property.checkAll
@@ -115,7 +116,22 @@ class GlbTest : FunSpec({
                 }
             }
 
+            test("test corner case") {
+
+                TypeOps.mostSpecific(
+                    setOf(
+                        t_Collection[`?` extends t_Number],
+                        `t_List{?}`,
+                        t_List
+                    )
+                ) shouldBe setOf(t_Collection[`?` extends t_Number], `t_List{?}`)
+            }
+
             test("Test GLB corner cases") {
+
+                // note: intersections are not minimized, or reduced to the null type if they are unsatisfiable.
+                // note also that in this test we test the components explicitly instead of using the DSL,
+                // because the DSL operator to create intersections actually calls GLB.
 
                 glb(t_Iterable[`?` extends t_Number], t_Iterable[t_String]).shouldBeA<JIntersectionType> {
                     it.components.shouldContainExactly(t_Iterable[`?` extends t_Number], t_Iterable[t_String])
@@ -138,13 +154,21 @@ class GlbTest : FunSpec({
                     it.components.shouldContainExactly(`t_Enum{JPrimitiveType}`, `t_List{? extends Number}`, `t_List{String}`)
                 }
 
-
-                glb(t_Collection[`?` extends t_Number],
+                glb(
+                    t_Collection[`?` extends t_Number],
                     `t_List{?}`,
-                    t_List) shouldBe `t_List{?}` // todo check that
+                    t_List
+                ).shouldBeA<JIntersectionType> {
+                    it.components.shouldContainExactlyInAnyOrder(t_Collection[`?` extends t_Number], `t_List{?}`)
+                }
 
                 glb(t_List, `t_List{?}`) shouldBe `t_List{?}`
-                glb(t_Collection[`?` extends t_Number], `t_List{?}`) shouldBe `t_List{?}`
+                glb(
+                    t_Collection[`?` extends t_Number],
+                    `t_List{?}`
+                ).shouldBeA<JIntersectionType> {
+                    it.components.shouldContainExactlyInAnyOrder(t_Collection[`?` extends t_Number], `t_List{?}`)
+                }
 
             }
 

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/GlbTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/GlbTest.kt
@@ -10,6 +10,7 @@ import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.property.checkAll
+import io.mockk.InternalPlatformDsl.toArray
 import net.sourceforge.pmd.lang.test.ast.shouldBeA
 import net.sourceforge.pmd.lang.java.symbols.internal.asm.createUnresolvedAsmSymbol
 
@@ -68,6 +69,14 @@ class GlbTest : FunSpec({
                 glb(ts.SERIALIZABLE, t_ArrayList) shouldBe t_ArrayList
                 glb(t_ArrayList, ts.SERIALIZABLE) shouldBe t_ArrayList
                 glb(t_List, `t_List{?}`) shouldBe `t_List{?}`
+
+            }
+
+            test("Test GLB of arrays") {
+
+                glb(ts.SERIALIZABLE.toArray(), t_ArrayList.toArray()) shouldBe t_ArrayList.toArray()
+                glb(t_ArrayList.toArray(), ts.SERIALIZABLE.toArray()) shouldBe t_ArrayList.toArray()
+                glb(t_List.toArray(), `t_List{?}`.toArray()) shouldBe `t_List{?}`.toArray()
 
             }
 

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/GlbTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/GlbTest.kt
@@ -96,6 +96,7 @@ class GlbTest : FunSpec({
 
                 // but C1[] & I1[] = (C1 & I1)[] exists because I1 is an interface.
                 glb(LubTestData.C1::class.decl.toArray(), LubTestData.I1::class.decl.toArray())
+                    .shouldBe((LubTestData.C1::class.decl * LubTestData.I1::class.decl).toArray())
             }
 
 
@@ -138,20 +139,20 @@ class GlbTest : FunSpec({
                 }
                 glb(`t_ArrayList{Integer}`, ts.NULL_TYPE) shouldBe ts.NULL_TYPE
                 glb(`t_ArrayList{Integer}`, t_Iterable[`?` extends t_Number], t_Iterable[t_String]).shouldBeA<JIntersectionType> {
-                    it.components.shouldContainExactly(`t_ArrayList{Integer}`, t_Iterable[t_String])
+                    it.components.shouldContainExactlyInAnyOrder(`t_ArrayList{Integer}`, t_Iterable[t_String])
                 }
 
                 glb(`t_List{? extends Number}`, `t_Collection{Integer}`).shouldBeA<JIntersectionType> {
-                    it.components.shouldContainExactly(`t_List{? extends Number}`, `t_Collection{Integer}`)
+                    it.components.shouldContainExactlyInAnyOrder(`t_List{? extends Number}`, `t_Collection{Integer}`)
                 }
 
                 glb(t_List.toArray(), t_Iterable).shouldBeA<JIntersectionType> {
-                    it.components.shouldContainExactly(t_List.toArray(), t_Iterable)
+                    it.components.shouldContainExactlyInAnyOrder(t_List.toArray(), t_Iterable)
                     it.inducedClassType.shouldBeNull()
                 }
                 glb(`t_List{? extends Number}`, `t_Collection{Integer}`, `t_ArrayList{Integer}`) shouldBe `t_ArrayList{Integer}`
                 glb(`t_List{? extends Number}`, `t_List{String}`, `t_Enum{JPrimitiveType}`).shouldBeA<JIntersectionType> {
-                    it.components.shouldContainExactly(`t_Enum{JPrimitiveType}`, `t_List{? extends Number}`, `t_List{String}`)
+                    it.components.shouldContainExactlyInAnyOrder(`t_Enum{JPrimitiveType}`, `t_List{String}`, `t_List{? extends Number}`)
                 }
 
                 glb(

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/LubTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/LubTest.kt
@@ -8,6 +8,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.property.checkAll
+import net.sourceforge.pmd.lang.java.types.testdata.LubTestData
 import net.sourceforge.pmd.lang.java.types.testdata.LubTestData.*
 
 /**
@@ -138,6 +139,22 @@ class LubTest : FunSpec({
                 val result = List::class[`?` extends (I1::class.decl * t_Comparable[`?`])]
 
                 lub(t_List[Sub1::class.decl], t_List[Sub2::class.decl]) shouldBe result
+
+            }
+
+            test("Test lub of related arrays") {
+
+                // the component type
+                lub(
+                    Enum1::class.decl,
+                    Enum2::class.decl,
+                ) shouldBe t_Enum[`?` extends t_Enum[`?`] * EnumSuperItf::class.decl] * EnumSuperItf::class.decl
+
+                // let's try arrays
+                lub(
+                    Enum1::class.decl.toArray(),
+                    Enum2::class.decl.toArray(),
+                ) shouldBe t_Enum[`?` extends t_Enum[`?`] * EnumSuperItf::class.decl] * EnumSuperItf::class.decl
 
             }
         }

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/LubTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/LubTest.kt
@@ -8,7 +8,6 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.property.checkAll
-import net.sourceforge.pmd.lang.java.types.testdata.LubTestData
 import net.sourceforge.pmd.lang.java.types.testdata.LubTestData.*
 
 /**
@@ -154,7 +153,7 @@ class LubTest : FunSpec({
                 lub(
                     Enum1::class.decl.toArray(),
                     Enum2::class.decl.toArray(),
-                ) shouldBe t_Enum[`?` extends t_Enum[`?`] * EnumSuperItf::class.decl] * EnumSuperItf::class.decl
+                ) shouldBe (t_Enum * EnumSuperItf::class.decl).toArray()
 
             }
         }


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #4902

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

