### PR TITLE
[apex] Add ASTAnnotation#getRawName

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -26,6 +26,8 @@ This is a {{ site.pmd.release_type }} release.
 * cli
   * [#4791](https://github.com/pmd/pmd/issues/4791): \[cli] Could not find or load main class
   * [#4913](https://github.com/pmd/pmd/issues/4913): \[cli] cpd-gui closes immediately
+* apex
+  * [#4418](https://github.com/pmd/pmd/issues/4418): \[apex] ASTAnnotation.getImage() does not return value as written in the class
 * apex-errorprone
   * [#3953](https://github.com/pmd/pmd/issues/3953): \[apex] EmptyCatchBlock false positive with formal (doc) comments
 * java-bestpractices

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotation.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotation.java
@@ -13,8 +13,8 @@ public final class ASTAnnotation extends AbstractApexNode.Single<AnnotationModif
 
     /**
      * Valid annotations in the Apex language.
-     * <p>
-     * Includes all annotations from the <a href="https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_annotation.htm">official
+     *
+     * <p>Includes all annotations from the <a href="https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_annotation.htm">official
      * documentation</a>, plus
      * <ul>
      *     <li>{@code AllowCertifiedApex}</li>
@@ -71,21 +71,38 @@ public final class ASTAnnotation extends AbstractApexNode.Single<AnnotationModif
         return visitor.visit(this, data);
     }
 
+    /**
+     * Returns the normalized annotation name for known, valid annotations.
+     * The normalized name is in PascalCase. If an unknown annotation is used,
+     * the raw name (as in the source code) is returned.
+     *
+     * @see #getRawName()
+     */
     public String getName() {
         // If resolvable to a known name, return the case-normalized name.
-        String rawName = node.getName().getString();
+        String rawName = getRawName();
         if (NORMALIZED_ANNOTATION_NAMES.contains(rawName)) {
             return NORMALIZED_ANNOTATION_NAMES.floor(rawName);
         }
         return rawName;
     }
-    
+
+    /**
+     * Returns the annotation name as it appears in the source code.
+     * This allows to verify the casing.
+     *
+     * @since 7.1.0
+     */
+    public String getRawName() {
+        return node.getName().getString();
+    }
+
     @Override
     public String getImage() {
         return getName();
     }
 
     public boolean isResolved() {
-        return NORMALIZED_ANNOTATION_NAMES.contains(node.getName().getString());
+        return NORMALIZED_ANNOTATION_NAMES.contains(getRawName());
     }
 }

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotationTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotationTest.java
@@ -1,0 +1,30 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.ast;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+import net.sourceforge.pmd.lang.document.Chars;
+
+class ASTAnnotationTest extends ApexParserTestBase {
+    @Test
+    void caseSensitiveName() {
+        ASTUserClassOrInterface<?> parsed = parse("public with sharing class Example {\n"
+                + "\n"
+                + "  @istest\n"
+                + "  private static void fooShouldBar() {\n"
+                + "  }\n"
+                + "  \n"
+                + "}");
+        ASTAnnotation annotation = parsed.descendants(ASTAnnotation.class).first();
+
+        assertEquals("IsTest", annotation.getName());
+        assertEquals("istest", annotation.getRawName());
+        Chars text = annotation.getTextDocument().sliceOriginalText(annotation.getTextRegion());
+        assertEquals("@istest", text.toString());
+    }
+}


### PR DESCRIPTION
## Describe the PR

This adds a new getter `getRawName()` for annotations, which returns the original annotation name, that is not normalized.

For Java rules, the same is basically available via `annotationNode.getTextDocument().sliceOriginalText(annotationNode.getTextRegion())`, but for XPath rules this might be useful as an attribute `@RawName`.

## Related issues

- Fixes #4418

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

