### PR TITLE
[java] Extend FinalCouldBeStatic to consider compile time constants

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -43,6 +43,7 @@ This is a {{ site.pmd.release_type }} release.
   * [#4779](https://github.com/pmd/pmd/issues/4779): \[java] Examples in documentation of MethodArgumentCanBeFinal do not trigger the rule
   * [#4881](https://github.com/pmd/pmd/issues/4881): \[java] ClassNamingConventions: interfaces are identified as abstract classes (regression in 7.0.0)
 * java-design
+  * [#2440](https://github.com/pmd/pmd/issues/2440): \[java] FinalFieldCouldBeStatic FN when the right side of the assignment is a constant expression
   * [#3694](https://github.com/pmd/pmd/issues/3694): \[java] SingularField ignores static variables
   * [#4873](https://github.com/pmd/pmd/issues/4873): \[java] AvoidCatchingGenericException: Can no longer suppress on the exception itself
 * java-errorprone

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -733,10 +733,10 @@ in each object at runtime.
     [not(pmd-java:modifiers() = 'static')]
     [not(./ancestor::ClassDeclaration[1][pmd-java:hasAnnotation('lombok.experimental.UtilityClass')])]
     [not(.//Annotation[pmd-java:typeIs('lombok.Builder.Default')])]
-    /VariableDeclarator[*[pmd-java:nodeIs('Literal')]
-         or VariableAccess[@Name = //FieldDeclaration[pmd-java:modifiers() = 'static']/VariableDeclarator/VariableId/@Name]
-         or FieldAccess
-         or ArrayAllocation/ArrayType/ArrayDimensions/ArrayDimExpr/NumericLiteral[@IntLiteral = true()][@Image = "0"]]
+    /VariableDeclarator[*[last()][@CompileTimeConstant = true()
+         or self::VariableAccess[@Name = //FieldDeclaration[pmd-java:modifiers() = 'static']/VariableDeclarator/VariableId/@Name]
+         or self::FieldAccess
+         or self::ArrayAllocation/ArrayType/ArrayDimensions/ArrayDimExpr/NumericLiteral[@IntLiteral = true()][@Image = "0"]]]
     /VariableId
         [not(@Name = //MethodDeclaration[not(pmd-java:modifiers() = 'static')]
             //SynchronizedStatement/(VariableAccess|FieldAccess[ThisExpression])/@Name)]

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/FinalFieldCouldBeStatic.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/FinalFieldCouldBeStatic.xml
@@ -278,4 +278,13 @@ public class Test {
 ]]></code>
     </test-code>
 
+    <test-code>
+        <description>FN when the right side of the assignment is a constant expression #2440</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Test {
+    private final double HALF_PI = Math.PI * 0.5; // false-negative
+}
+]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Instead of just seeing if the initializer is a single literal, look for a compile time constant expression.

## Related issues

- Fixes #2440

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

