### PR TITLE
[compat6] Make compat6 forward compatible with maven-pmd-plugin 3.22.0

### DIFF
--- a/pmd-compat6/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
+++ b/pmd-compat6/src/main/java/net/sourceforge/pmd/PMDConfiguration.java
@@ -346,6 +346,9 @@ public class PMDConfiguration extends AbstractConfiguration {
         this.minimumPriority = minimumPriority;
     }
 
+    public void setMinimumPriority(net.sourceforge.pmd.lang.rule.RulePriority mininumPriority) {
+        this.minimumPriority = RulePriority.valueOf(mininumPriority.name());
+    }
 
     /**
      * Create a Renderer instance based upon the configured reporting options.

--- a/pmd-compat6/src/main/java/net/sourceforge/pmd/Report.java
+++ b/pmd-compat6/src/main/java/net/sourceforge/pmd/Report.java
@@ -49,10 +49,10 @@ import net.sourceforge.pmd.util.BaseResultProducingCloseable;
 public class Report {
     // todo move to package reporting
 
-    private final List<RuleViolation> violations = synchronizedList(new ArrayList<>());
-    private final List<SuppressedViolation> suppressedRuleViolations = synchronizedList(new ArrayList<>());
-    private final List<ProcessingError> errors = synchronizedList(new ArrayList<>());
-    private final List<ConfigurationError> configErrors = synchronizedList(new ArrayList<>());
+    protected final List<RuleViolation> violations = synchronizedList(new ArrayList<>());
+    protected final List<SuppressedViolation> suppressedRuleViolations = synchronizedList(new ArrayList<>());
+    protected final List<ProcessingError> errors = synchronizedList(new ArrayList<>());
+    protected final List<ConfigurationError> configErrors = synchronizedList(new ArrayList<>());
 
     @DeprecatedUntil700
     @InternalApi

--- a/pmd-compat6/src/main/java/net/sourceforge/pmd/reporting/Report.java
+++ b/pmd-compat6/src/main/java/net/sourceforge/pmd/reporting/Report.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.reporting;
 
+import java.util.function.Predicate;
+
 import net.sourceforge.pmd.Rule;
 import net.sourceforge.pmd.lang.document.FileId;
 
@@ -44,5 +46,21 @@ public class Report extends net.sourceforge.pmd.Report {
     }
 
     public static final class ReportBuilderListener extends net.sourceforge.pmd.Report.ReportBuilderListener {
+    }
+
+    @Override
+    public Report filterViolations(Predicate<net.sourceforge.pmd.RuleViolation> filter) {
+        Report copy = new Report();
+
+        for (net.sourceforge.pmd.RuleViolation violation : violations) {
+            if (filter.test(violation)) {
+                copy.addRuleViolation(violation);
+            }
+        }
+
+        copy.suppressedRuleViolations.addAll(suppressedRuleViolations);
+        copy.errors.addAll(errors);
+        copy.configErrors.addAll(configErrors);
+        return copy;
     }
 }


### PR DESCRIPTION
## Describe the PR

This adds two missing methods, that will be needed if one uses the combination of PMD 7 + maven-pmd-plugin 3.22.0 + pmd-compat6.

Technically, pmd-compat6 won't be needed anymore with m-pmd-p 3.22.0. But if someone already uses m-pmd-p 3.21.2 + pmd 7.0.0 + pmd-compat6 7.0.0, then this probably will happen:

* dependabot suggests to upgrade m-pmd-p from 3.21.2 to 3.22.0
* the build is failing, as m-pmd-p 3.22.0 is now incompatible with pmd-compat6 7.0.0
* later dependabot suggests to upgrade pmd from 7.0.0 to 7.1.0
* this build will work (still with m-pmd-p 3.21.2)
* if projects now rebase/retry upgrade to m-pmd-p 3.22.0, this should work

So, one possible upgrade path would be:

1. pmd 7.0.0 + pmd-compat6 7.0.0 -> 7.1.0
2. m-pmd-p 3.21.2 -> 3.22.0
3. remove pmd-compat6

The correct fix for the projects, who want to upgrade m-pmd-p from 3.21.2 and 3.22.0 and using pmd 7.0.0 + pmd-compat6 7.0.0 would be to just remove pmd-compat6.

So, alternatively, we could remove pmd-compat6 directly with 7.1.0 - then the error message is different (dependency not found instead of MethodNotFoundError).
I guess, if we ship pmd-compat6 with 7.1.0, than it should be working with m-pmd-p 3.22.0.

## Related issues

- none

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

