### PR TITLE
[core] Upgrade saxon to 12.4

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/AstAttributeNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/AstAttributeNode.java
@@ -6,15 +6,14 @@ package net.sourceforge.pmd.lang.rule.xpath.internal;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Predicate;
 
 import net.sourceforge.pmd.lang.rule.xpath.Attribute;
 
 import net.sf.saxon.om.AtomicSequence;
 import net.sf.saxon.om.NodeInfo;
+import net.sf.saxon.pattern.NodeTest;
 import net.sf.saxon.tree.iter.AxisIterator;
 import net.sf.saxon.tree.iter.EmptyIterator;
-import net.sf.saxon.tree.util.FastStringBuffer;
 import net.sf.saxon.tree.util.Navigator;
 import net.sf.saxon.tree.wrapper.SiblingCountingNode;
 import net.sf.saxon.type.SchemaType;
@@ -53,17 +52,17 @@ class AstAttributeNode extends BaseNodeInfo implements SiblingCountingNode {
 
 
     @Override
-    protected AxisIterator iterateAttributes(Predicate<? super NodeInfo> nodeTest) {
+    protected AxisIterator iterateAttributes(NodeTest nodeTest) {
         return EmptyIterator.ofNodes();
     }
 
     @Override
-    protected AxisIterator iterateChildren(Predicate<? super NodeInfo> nodeTest) {
+    protected AxisIterator iterateChildren(NodeTest nodeTest) {
         return EmptyIterator.ofNodes();
     }
 
     @Override
-    protected AxisIterator iterateSiblings(Predicate<? super NodeInfo> nodeTest, boolean forwards) {
+    protected AxisIterator iterateSiblings(NodeTest nodeTest, boolean forwards) {
         return EmptyIterator.ofNodes();
     }
 
@@ -102,13 +101,13 @@ class AstAttributeNode extends BaseNodeInfo implements SiblingCountingNode {
 
 
     @Override
-    public void generateId(FastStringBuffer buffer) {
-        buffer.append(Integer.toString(hashCode()));
+    public void generateId(StringBuilder buffer) {
+        buffer.append(hashCode());
     }
 
 
     @Override
-    public CharSequence getStringValueCS() {
+    public String getStringValue() {
         getTreeInfo().getLogger().recordUsageOf(attribute);
         return attribute.getStringValue();
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/AstDocumentNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/AstDocumentNode.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.lang.rule.xpath.internal;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Predicate;
 
 import org.apache.commons.lang3.mutable.MutableInt;
 
@@ -15,9 +14,9 @@ import net.sourceforge.pmd.lang.ast.RootNode;
 
 import net.sf.saxon.Configuration;
 import net.sf.saxon.om.NodeInfo;
+import net.sf.saxon.pattern.NodeTest;
 import net.sf.saxon.tree.iter.AxisIterator;
 import net.sf.saxon.tree.iter.EmptyIterator;
-import net.sf.saxon.tree.util.FastStringBuffer;
 import net.sf.saxon.type.Type;
 
 /**
@@ -47,17 +46,17 @@ class AstDocumentNode extends BaseNodeInfo implements AstNodeOwner {
     }
 
     @Override
-    protected AxisIterator iterateAttributes(Predicate<? super NodeInfo> nodeTest) {
+    protected AxisIterator iterateAttributes(NodeTest nodeTest) {
         return EmptyIterator.ofNodes();
     }
 
     @Override
-    protected AxisIterator iterateChildren(Predicate<? super NodeInfo> nodeTest) {
+    protected AxisIterator iterateChildren(NodeTest nodeTest) {
         return filter(nodeTest, iterateList(children));
     }
 
     @Override
-    protected AxisIterator iterateSiblings(Predicate<? super NodeInfo> nodeTest, boolean forwards) {
+    protected AxisIterator iterateSiblings(NodeTest nodeTest, boolean forwards) {
         return EmptyIterator.ofNodes();
     }
 
@@ -89,12 +88,12 @@ class AstDocumentNode extends BaseNodeInfo implements AstNodeOwner {
     }
 
     @Override
-    public void generateId(FastStringBuffer buffer) {
+    public void generateId(StringBuilder buffer) {
         buffer.append("0");
     }
 
     @Override
-    public CharSequence getStringValueCS() {
+    public String getStringValue() {
         return "";
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/AstElementNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/AstElementNode.java
@@ -5,12 +5,10 @@
 package net.sourceforge.pmd.lang.rule.xpath.internal;
 
 import java.util.ArrayList;
-import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.mutable.MutableInt;
@@ -28,7 +26,6 @@ import net.sf.saxon.om.NamespaceUri;
 import net.sf.saxon.om.NodeInfo;
 import net.sf.saxon.pattern.NameTest;
 import net.sf.saxon.pattern.NodeTest;
-import net.sf.saxon.str.UnicodeString;
 import net.sf.saxon.tree.iter.AxisIterator;
 import net.sf.saxon.tree.iter.EmptyIterator;
 import net.sf.saxon.tree.iter.LookaheadIterator;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/AstElementNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/AstElementNode.java
@@ -208,11 +208,6 @@ public final class AstElementNode extends BaseNodeInfo implements SiblingCountin
     }
 
     @Override
-    public UnicodeString getUnicodeStringValue() {
-        return null;
-    }
-
-    @Override
     public String getStringValue() {
         Node node = getUnderlyingNode();
         if (node instanceof TextNode) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/AstElementNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/AstElementNode.java
@@ -26,11 +26,12 @@ import net.sourceforge.pmd.util.CollectionUtil;
 import net.sf.saxon.Configuration;
 import net.sf.saxon.om.NodeInfo;
 import net.sf.saxon.pattern.NameTest;
+import net.sf.saxon.pattern.NodeTest;
+import net.sf.saxon.str.UnicodeString;
 import net.sf.saxon.tree.iter.AxisIterator;
 import net.sf.saxon.tree.iter.EmptyIterator;
 import net.sf.saxon.tree.iter.LookaheadIterator;
 import net.sf.saxon.tree.iter.SingleNodeIterator;
-import net.sf.saxon.tree.util.FastStringBuffer;
 import net.sf.saxon.tree.util.Navigator;
 import net.sf.saxon.tree.wrapper.SiblingCountingNode;
 import net.sf.saxon.type.Type;
@@ -146,7 +147,7 @@ public final class AstElementNode extends BaseNodeInfo implements SiblingCountin
     }
 
     @Override
-    protected AxisIterator iterateAttributes(Predicate<? super NodeInfo> predicate) {
+    protected AxisIterator iterateAttributes(NodeTest predicate) {
         if (predicate instanceof NameTest) {
             String local = ((NameTest) predicate).getLocalPart();
             return SingleNodeIterator.makeIterator(getAttributes().get(local));
@@ -156,12 +157,12 @@ public final class AstElementNode extends BaseNodeInfo implements SiblingCountin
     }
 
     @Override
-    protected AxisIterator iterateChildren(Predicate<? super NodeInfo> nodeTest) {
+    protected AxisIterator iterateChildren(NodeTest nodeTest) {
         return filter(nodeTest, iterateList(children));
     }
 
     @Override // this excludes self
-    protected AxisIterator iterateSiblings(Predicate<? super NodeInfo> nodeTest, boolean forwards) {
+    protected AxisIterator iterateSiblings(NodeTest nodeTest, boolean forwards) {
         if (parent == null) {
             return EmptyIterator.ofNodes();
         }
@@ -197,8 +198,8 @@ public final class AstElementNode extends BaseNodeInfo implements SiblingCountin
 
 
     @Override
-    public void generateId(FastStringBuffer buffer) {
-        buffer.append(Integer.toString(id));
+    public void generateId(StringBuilder buffer) {
+        buffer.append(id);
     }
 
     @Override
@@ -206,9 +207,13 @@ public final class AstElementNode extends BaseNodeInfo implements SiblingCountin
         return wrappedNode.getXPathNodeName();
     }
 
+    @Override
+    public UnicodeString getUnicodeStringValue() {
+        return null;
+    }
 
     @Override
-    public CharSequence getStringValueCS() {
+    public String getStringValue() {
         Node node = getUnderlyingNode();
         if (node instanceof TextNode) {
             return ((TextNode) node).getText();
@@ -240,8 +245,6 @@ public final class AstElementNode extends BaseNodeInfo implements SiblingCountin
 
     private static class IteratorAdapter implements AxisIterator, LookaheadIterator {
 
-        @SuppressWarnings("PMD.LooseCoupling") // getProperties() below has to return EnumSet
-        private static final EnumSet<Property> PROPERTIES = EnumSet.of(Property.LOOKAHEAD);
         private final Iterator<? extends NodeInfo> it;
 
         IteratorAdapter(Iterator<? extends NodeInfo> it) {
@@ -263,10 +266,9 @@ public final class AstElementNode extends BaseNodeInfo implements SiblingCountin
             // nothing to do
         }
 
-
         @Override
-        public EnumSet<Property> getProperties() {
-            return PROPERTIES;
+        public boolean supportsHasNext() {
+            return true;
         }
     }
 }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/AstElementNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/AstElementNode.java
@@ -24,6 +24,7 @@ import net.sourceforge.pmd.lang.rule.xpath.TextNode;
 import net.sourceforge.pmd.util.CollectionUtil;
 
 import net.sf.saxon.Configuration;
+import net.sf.saxon.om.NamespaceUri;
 import net.sf.saxon.om.NodeInfo;
 import net.sf.saxon.pattern.NameTest;
 import net.sf.saxon.pattern.NodeTest;
@@ -175,7 +176,7 @@ public final class AstElementNode extends BaseNodeInfo implements SiblingCountin
     }
 
     @Override
-    public String getAttributeValue(String uri, String local) {
+    public String getAttributeValue(NamespaceUri uri, String local) {
         Attribute attribute = getLightAttributes().get(local);
         if (attribute != null) {
             getTreeInfo().getLogger().recordUsageOf(attribute);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/BaseNodeInfo.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/BaseNodeInfo.java
@@ -116,7 +116,7 @@ abstract class BaseNodeInfo extends AbstractNodeWrapper implements SiblingCounti
 
         RevListAxisIterator(List<NodeInfo> list) {
             super(list);
-            iter = list.listIterator();
+            iter = list.listIterator(list.size());
         }
 
         public NodeInfo next() {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/BaseNodeInfo.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/BaseNodeInfo.java
@@ -8,9 +8,11 @@ package net.sourceforge.pmd.lang.rule.xpath.internal;
 import java.util.List;
 import java.util.ListIterator;
 
+import net.sf.saxon.expr.LastPositionFinder;
 import net.sf.saxon.om.NamePool;
 import net.sf.saxon.om.NamespaceUri;
 import net.sf.saxon.om.NodeInfo;
+import net.sf.saxon.om.SequenceIterator;
 import net.sf.saxon.pattern.AnyNodeTest;
 import net.sf.saxon.pattern.NodeTest;
 import net.sf.saxon.str.StringView;
@@ -111,11 +113,10 @@ abstract class BaseNodeInfo extends AbstractNodeWrapper implements SiblingCounti
                         : new RevListAxisIterator((List<NodeInfo>) nodes);
     }
 
-    private static class RevListAxisIterator extends NodeListIterator implements AxisIterator {
+    private static class RevListAxisIterator implements AxisIterator {
         private final ListIterator<NodeInfo> iter;
 
         RevListAxisIterator(List<NodeInfo> list) {
-            super(list);
             iter = list.listIterator(list.size());
         }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/BaseNodeInfo.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/BaseNodeInfo.java
@@ -120,6 +120,7 @@ abstract class BaseNodeInfo extends AbstractNodeWrapper implements SiblingCounti
             iter = list.listIterator(list.size());
         }
 
+        @Override
         public NodeInfo next() {
             return this.iter.hasPrevious() ? this.iter.previous() : null;
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/BaseNodeInfo.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/BaseNodeInfo.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.ListIterator;
 
 import net.sf.saxon.om.NamePool;
+import net.sf.saxon.om.NamespaceUri;
 import net.sf.saxon.om.NodeInfo;
 import net.sf.saxon.pattern.AnyNodeTest;
 import net.sf.saxon.pattern.NodeTest;
@@ -34,7 +35,7 @@ abstract class BaseNodeInfo extends AbstractNodeWrapper implements SiblingCounti
     BaseNodeInfo(int nodeKind, NamePool namePool, String localName, BaseNodeInfo parent) {
         this.nodeKind = nodeKind;
         this.namePool = namePool;
-        this.fingerprint = namePool.allocateFingerprint("", localName) & NamePool.FP_MASK;
+        this.fingerprint = namePool.allocateFingerprint(NamespaceUri.NULL, localName) & NamePool.FP_MASK;
         this.parent = parent;
     }
 
@@ -88,6 +89,11 @@ abstract class BaseNodeInfo extends AbstractNodeWrapper implements SiblingCounti
     @Override
     public UnicodeString getUnicodeStringValue() {
         return StringView.of(getStringValue());
+    }
+
+    @Override
+    public NamespaceUri getNamespaceUri() {
+        return NamespaceUri.NULL;
     }
 
     protected static AxisIterator filter(NodeTest nodeTest, AxisIterator iter) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/BaseNodeInfo.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/BaseNodeInfo.java
@@ -8,11 +8,9 @@ package net.sourceforge.pmd.lang.rule.xpath.internal;
 import java.util.List;
 import java.util.ListIterator;
 
-import net.sf.saxon.expr.LastPositionFinder;
 import net.sf.saxon.om.NamePool;
 import net.sf.saxon.om.NamespaceUri;
 import net.sf.saxon.om.NodeInfo;
-import net.sf.saxon.om.SequenceIterator;
 import net.sf.saxon.pattern.AnyNodeTest;
 import net.sf.saxon.pattern.NodeTest;
 import net.sf.saxon.str.StringView;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/DomainConversion.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/DomainConversion.java
@@ -24,7 +24,6 @@ import net.sf.saxon.value.FloatValue;
 import net.sf.saxon.value.Int64Value;
 import net.sf.saxon.value.SequenceType;
 import net.sf.saxon.value.StringValue;
-import net.sf.saxon.value.UntypedAtomicValue;
 
 
 /**
@@ -131,10 +130,10 @@ public final class DomainConversion {
         (see http://openjdk.java.net/jeps/305) so that it looks clearer.
         */
         if (value == null) {
-            return UntypedAtomicValue.ZERO_LENGTH_UNTYPED;
+            return StringValue.ZERO_LENGTH_UNTYPED;
 
-        } else if (value instanceof CharSequence) {
-            return new StringValue((CharSequence) value);
+        } else if (value instanceof String) {
+            return new StringValue((String) value);
         } else if (value instanceof Boolean) {
             return BooleanValue.get((Boolean) value);
         } else if (value instanceof Integer) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonExtensionFunctionDefinitionAdapter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonExtensionFunctionDefinitionAdapter.java
@@ -96,7 +96,7 @@ public class SaxonExtensionFunctionDefinitionAdapter extends ExtensionFunctionDe
                 Object[] convertedArguments = new Object[definition.getArgumentTypes().length];
                 for (int i = 0; i < convertedArguments.length; i++) {
                     if (arguments[i] instanceof StringLiteral) {
-                        convertedArguments[i] = ((StringLiteral) arguments[i]).getString();
+                        convertedArguments[i] = ((StringLiteral) arguments[i]).getString().toString();
                     }
                 }
                 try {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonExtensionFunctionDefinitionAdapter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonExtensionFunctionDefinitionAdapter.java
@@ -96,7 +96,7 @@ public class SaxonExtensionFunctionDefinitionAdapter extends ExtensionFunctionDe
                 Object[] convertedArguments = new Object[definition.getArgumentTypes().length];
                 for (int i = 0; i < convertedArguments.length; i++) {
                     if (arguments[i] instanceof StringLiteral) {
-                        convertedArguments[i] = ((StringLiteral) arguments[i]).getStringValue();
+                        convertedArguments[i] = ((StringLiteral) arguments[i]).getString();
                     }
                 }
                 try {
@@ -150,11 +150,11 @@ public class SaxonExtensionFunctionDefinitionAdapter extends ExtensionFunctionDe
                     case OPTIONAL_STRING:
                         convertedResult = result instanceof Optional && ((Optional<String>) result).isPresent()
                                 ? new StringValue(((Optional<String>) result).get())
-                                : EmptyAtomicSequence.INSTANCE;
+                                : EmptyAtomicSequence.getInstance();
                         break;
                     case STRING_SEQUENCE:
                         convertedResult = result instanceof List
-                                ? new SequenceExtent(((List<String>) result).stream().map(StringValue::new).collect(Collectors.toList()))
+                                ? new SequenceExtent.Of<>(((List<String>) result).stream().map(StringValue::new).collect(Collectors.toList()))
                                 : EmptySequence.getInstance();
                         break;
                     case OPTIONAL_DECIMAL:

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonXPathRuleQuery.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonXPathRuleQuery.java
@@ -30,10 +30,10 @@ import net.sf.saxon.Configuration;
 import net.sf.saxon.expr.Expression;
 import net.sf.saxon.expr.LocalVariableReference;
 import net.sf.saxon.lib.ExtensionFunctionDefinition;
-import net.sf.saxon.lib.NamespaceConstant;
 import net.sf.saxon.om.AtomicSequence;
 import net.sf.saxon.om.Item;
 import net.sf.saxon.om.NamePool;
+import net.sf.saxon.om.NamespaceUri;
 import net.sf.saxon.om.SequenceIterator;
 import net.sf.saxon.om.StructuredQName;
 import net.sf.saxon.sxpath.IndependentContext;
@@ -187,10 +187,11 @@ public class SaxonXPathRuleQuery {
 
         this.configuration = Configuration.newConfiguration();
         this.configuration.setNamePool(getNamePool());
+        //this.configuration.setConfigurationProperty(Feature.OPTIMIZATION_LEVEL, (Integer) 0);
 
         StaticContextWithProperties staticCtx = new StaticContextWithProperties(this.configuration);
         staticCtx.setXPathLanguageLevel(version == XPathVersion.XPATH_3_1 ? 31 : 20);
-        staticCtx.declareNamespace("fn", NamespaceConstant.FN);
+        staticCtx.declareNamespace("fn", NamespaceUri.FN);
 
         for (final PropertyDescriptor<?> propertyDescriptor : properties.keySet()) {
             final String name = propertyDescriptor.name();
@@ -202,7 +203,7 @@ public class SaxonXPathRuleQuery {
         for (XPathFunctionDefinition xpathFun : xPathHandler.getRegisteredExtensionFunctions()) {
             ExtensionFunctionDefinition fun = new SaxonExtensionFunctionDefinitionAdapter(xpathFun);
             StructuredQName qname = fun.getFunctionQName();
-            staticCtx.declareNamespace(qname.getPrefix(), qname.getURI());
+            staticCtx.declareNamespace(qname.getPrefix(), qname.getNamespaceUri());
             this.configuration.registerExtensionFunction(fun);
         }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonXPathRuleQuery.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonXPathRuleQuery.java
@@ -187,10 +187,8 @@ public class SaxonXPathRuleQuery {
     }
 
     private void initialize() throws XPathException {
-
         this.configuration = Configuration.newConfiguration();
         this.configuration.setNamePool(getNamePool());
-        //this.configuration.setConfigurationProperty(Feature.OPTIMIZATION_LEVEL, (Integer) 0);
 
         StaticContextWithProperties staticCtx = new StaticContextWithProperties(this.configuration);
         staticCtx.setXPathLanguageLevel(version == XPathVersion.XPATH_3_1 ? 31 : 20);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonXPathRuleQuery.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonXPathRuleQuery.java
@@ -41,6 +41,7 @@ import net.sf.saxon.sxpath.XPathDynamicContext;
 import net.sf.saxon.sxpath.XPathEvaluator;
 import net.sf.saxon.sxpath.XPathExpression;
 import net.sf.saxon.sxpath.XPathVariable;
+import net.sf.saxon.trans.UncheckedXPathException;
 import net.sf.saxon.trans.XPathException;
 
 
@@ -140,6 +141,8 @@ public class SaxonXPathRuleQuery {
             return sortedRes;
         } catch (final XPathException e) {
             throw wrapException(e, Phase.EVALUATION);
+        } catch (final UncheckedXPathException e) {
+            throw wrapException(e.getXPathException(), Phase.EVALUATION);
         } finally {
             documentNode.setAttrCtx(DeprecatedAttrLogger.noop());
         }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonXPathRuleQuery.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonXPathRuleQuery.java
@@ -29,11 +29,14 @@ import net.sourceforge.pmd.util.DataMap.SimpleDataKey;
 import net.sf.saxon.Configuration;
 import net.sf.saxon.expr.Expression;
 import net.sf.saxon.expr.LocalVariableReference;
+import net.sf.saxon.expr.parser.OptimizerOptions;
 import net.sf.saxon.lib.ExtensionFunctionDefinition;
+import net.sf.saxon.lib.Feature;
 import net.sf.saxon.lib.NamespaceConstant;
 import net.sf.saxon.om.AtomicSequence;
 import net.sf.saxon.om.Item;
 import net.sf.saxon.om.NamePool;
+import net.sf.saxon.om.NamespaceUri;
 import net.sf.saxon.om.SequenceIterator;
 import net.sf.saxon.om.StructuredQName;
 import net.sf.saxon.sxpath.IndependentContext;
@@ -187,10 +190,11 @@ public class SaxonXPathRuleQuery {
 
         this.configuration = Configuration.newConfiguration();
         this.configuration.setNamePool(getNamePool());
+        //this.configuration.setConfigurationProperty(Feature.OPTIMIZATION_LEVEL, (Integer) 0);
 
         StaticContextWithProperties staticCtx = new StaticContextWithProperties(this.configuration);
         staticCtx.setXPathLanguageLevel(version == XPathVersion.XPATH_3_1 ? 31 : 20);
-        staticCtx.declareNamespace("fn", NamespaceConstant.FN);
+        staticCtx.declareNamespace("fn", NamespaceUri.FN);
 
         for (final PropertyDescriptor<?> propertyDescriptor : properties.keySet()) {
             final String name = propertyDescriptor.name();

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonXPathRuleQuery.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonXPathRuleQuery.java
@@ -29,14 +29,11 @@ import net.sourceforge.pmd.util.DataMap.SimpleDataKey;
 import net.sf.saxon.Configuration;
 import net.sf.saxon.expr.Expression;
 import net.sf.saxon.expr.LocalVariableReference;
-import net.sf.saxon.expr.parser.OptimizerOptions;
 import net.sf.saxon.lib.ExtensionFunctionDefinition;
-import net.sf.saxon.lib.Feature;
 import net.sf.saxon.lib.NamespaceConstant;
 import net.sf.saxon.om.AtomicSequence;
 import net.sf.saxon.om.Item;
 import net.sf.saxon.om.NamePool;
-import net.sf.saxon.om.NamespaceUri;
 import net.sf.saxon.om.SequenceIterator;
 import net.sf.saxon.om.StructuredQName;
 import net.sf.saxon.sxpath.IndependentContext;
@@ -190,11 +187,10 @@ public class SaxonXPathRuleQuery {
 
         this.configuration = Configuration.newConfiguration();
         this.configuration.setNamePool(getNamePool());
-        //this.configuration.setConfigurationProperty(Feature.OPTIMIZATION_LEVEL, (Integer) 0);
 
         StaticContextWithProperties staticCtx = new StaticContextWithProperties(this.configuration);
         staticCtx.setXPathLanguageLevel(version == XPathVersion.XPATH_3_1 ? 31 : 20);
-        staticCtx.declareNamespace("fn", NamespaceUri.FN);
+        staticCtx.declareNamespace("fn", NamespaceConstant.FN);
 
         for (final PropertyDescriptor<?> propertyDescriptor : properties.keySet()) {
             final String name = propertyDescriptor.name();

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonXPathRuleQueryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonXPathRuleQueryTest.java
@@ -143,11 +143,11 @@ class SaxonXPathRuleQueryTest {
         assertTrue(ruleChainVisits.contains("bar"));
 
         assertEquals(3, query.nodeNameToXPaths.size());
-        assertExpression("(self::node()[(string(data(@Image))) eq \"baz\"])/child::element(foo)", query.getExpressionsForLocalNameOrDefault("dummyNode").get(0));
-        assertExpression("self::node()[(boolean(data(@Public))) eq false()]", query.getExpressionsForLocalNameOrDefault("dummyNode").get(1));
+        assertExpression("(self::node()[(string(data(@Image))) eq baz])/child::element(foo)", query.getExpressionsForLocalNameOrDefault("dummyNode").get(0));
+        assertExpression("self::node()[(boolean(data(@Public))) eq false]", query.getExpressionsForLocalNameOrDefault("dummyNode").get(1));
         assertExpression("self::node()", query.getExpressionsForLocalNameOrDefault("dummyNode").get(2));
-        assertExpression("self::node()[(string(data(@Public))) eq \"true\"]", query.getExpressionsForLocalNameOrDefault("bar").get(0));
-        assertExpression("(((docOrder((((/)/descendant::element(dummyNode))[(string(data(@Image))) eq \"baz\"])/child::element(foo))) | (((/)/descendant::element(bar))[(string(data(@Public))) eq \"true\"])) | (((/)/descendant::element(dummyNode))[(boolean(data(@Public))) eq false()])) | ((/)/descendant::element(dummyNode))", query.getFallbackExpr());
+        assertExpression("self::node()[(string(data(@Public))) eq true]", query.getExpressionsForLocalNameOrDefault("bar").get(0));
+        assertExpression("(((docOrder((((/)/descendant::element(dummyNode))[(string(data(@Image))) eq baz])/child::element(foo))) | (((/)/descendant::element(bar))[(string(data(@Public))) eq true])) | (((/)/descendant::element(dummyNode))[(boolean(data(@Public))) eq false])) | ((/)/descendant::element(dummyNode))", query.getFallbackExpr());
     }
 
     @Test
@@ -157,8 +157,8 @@ class SaxonXPathRuleQueryTest {
         assertEquals(1, ruleChainVisits.size());
         assertTrue(ruleChainVisits.contains("dummyNode"));
         assertEquals(2, query.nodeNameToXPaths.size());
-        assertExpression("(self::node()[(boolean(data(@Test1))) eq false()])[(boolean(data(@Test2))) eq true()]", query.getExpressionsForLocalNameOrDefault("dummyNode").get(0));
-        assertExpression("(((/)/descendant::element(dummyNode))[(boolean(data(@Test1))) eq false()])[(boolean(data(@Test2))) eq true()]", query.getFallbackExpr());
+        assertExpression("(self::node()[(boolean(data(@Test1))) eq false])[(boolean(data(@Test2))) eq true]", query.getExpressionsForLocalNameOrDefault("dummyNode").get(0));
+        assertExpression("(((/)/descendant::element(dummyNode))[(boolean(data(@Test1))) eq false])[(boolean(data(@Test2))) eq true]", query.getFallbackExpr());
     }
 
     @Test
@@ -168,8 +168,8 @@ class SaxonXPathRuleQueryTest {
         assertEquals(1, ruleChainVisits.size());
         assertTrue(ruleChainVisits.contains("dummyNode"));
         assertEquals(2, query.nodeNameToXPaths.size());
-        assertExpression("self::node()[Q{http://pmd.sourceforge.net/pmd-dummy}imageIs(exactly-one(convertUntyped(data(@Image))))]", query.getExpressionsForLocalNameOrDefault("dummyNode").get(0));
-        assertExpression("((/)/descendant::element(Q{}dummyNode))[Q{http://pmd.sourceforge.net/pmd-dummy}imageIs(exactly-one(convertUntyped(data(@Image))))]", query.getFallbackExpr());
+        assertExpression("self::node()[Q{http://pmd.sourceforge.net/pmd-dummy}imageIs(exactly-one(convertTo_xs:string(data(@Image))))]", query.getExpressionsForLocalNameOrDefault("dummyNode").get(0));
+        assertExpression("((/)/descendant::element(Q{}dummyNode))[Q{http://pmd.sourceforge.net/pmd-dummy}imageIs(exactly-one(convertTo_xs:string(data(@Image))))]", query.getFallbackExpr());
     }
 
     /**
@@ -182,14 +182,14 @@ class SaxonXPathRuleQueryTest {
         List<String> ruleChainVisits = query.getRuleChainVisits();
         assertEquals(0, ruleChainVisits.size());
         assertEquals(1, query.nodeNameToXPaths.size());
-        assertExpression("let $Q{http://saxon.sf.net/generated-variable}v0 := (/)/descendant::element(Q{}ClassOrInterfaceType) return (((/)/descendant::element(Q{}dummyNode))[exists($Q{http://saxon.sf.net/generated-variable}v0)])", query.getFallbackExpr());
+        assertExpression("let $Q{http://saxon.sf.net/generated-variable}v0 := exists((/)/descendant::element(Q{}ClassOrInterfaceType)) return (((/)/descendant::element(Q{}dummyNode))[$Q{http://saxon.sf.net/generated-variable}v0])", query.getFallbackExpr());
 
         // second sample, more complex
         query = createQuery("//dummyNode[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType]]");
         ruleChainVisits = query.getRuleChainVisits();
         assertEquals(0, ruleChainVisits.size());
         assertEquals(1, query.nodeNameToXPaths.size());
-        assertExpression("let $Q{http://saxon.sf.net/generated-variable}v0 := (/)/descendant::element(Q{}ClassOrInterfaceType) return (((/)/descendant::element(Q{}dummyNode))[exists(ancestor::element(Q{}ClassOrInterfaceDeclaration)[exists($Q{http://saxon.sf.net/generated-variable}v0)])])", query.getFallbackExpr());
+        assertExpression("let $Q{http://saxon.sf.net/generated-variable}v0 := exists((/)/descendant::element(Q{}ClassOrInterfaceType)) return (((/)/descendant::element(Q{}dummyNode))[exists(ancestor::element(Q{}ClassOrInterfaceDeclaration)[$Q{http://saxon.sf.net/generated-variable}v0])])", query.getFallbackExpr());
 
         // third example, with boolean expr
         query = createQuery("//dummyNode[//ClassOrInterfaceType or //OtherNode]");
@@ -206,8 +206,8 @@ class SaxonXPathRuleQueryTest {
         assertEquals(1, ruleChainVisits.size());
         assertTrue(ruleChainVisits.contains("dummyNode"));
         assertEquals(2, query.nodeNameToXPaths.size());
-        assertExpression("(((self::node()/child::element(foo))/child::element())/child::element(bar))[(string(data(@Test))) eq \"false\"]", query.getExpressionsForLocalNameOrDefault("dummyNode").get(0));
-        assertExpression("docOrder(((docOrder((((/)/descendant::element(dummyNode))/child::element(foo))/child::element()))/child::element(bar))[(string(data(@Test))) eq \"false\"])", query.getFallbackExpr());
+        assertExpression("(((self::node()/child::element(foo))/child::element())/child::element(bar))[(string(data(@Test))) eq false]", query.getExpressionsForLocalNameOrDefault("dummyNode").get(0));
+        assertExpression("docOrder(((docOrder((((/)/descendant::element(dummyNode))/child::element(foo))/child::element()))/child::element(bar))[(string(data(@Test))) eq false])", query.getFallbackExpr());
     }
 
     @Test
@@ -217,8 +217,8 @@ class SaxonXPathRuleQueryTest {
         assertEquals(1, ruleChainVisits.size());
         assertTrue(ruleChainVisits.contains("dummyNode"));
         assertEquals(2, query.nodeNameToXPaths.size());
-        assertExpression("((((self::node()/child::element(foo))[(string(data(@Baz))) eq \"a\"])/child::element())/child::element(bar))[(string(data(@Test))) eq \"false\"]", query.getExpressionsForLocalNameOrDefault("dummyNode").get(0));
-        assertExpression("docOrder(((docOrder(((((/)/descendant::element(dummyNode))/child::element(foo))[(string(data(@Baz))) eq \"a\"])/child::element()))/child::element(bar))[(string(data(@Test))) eq \"false\"])", query.getFallbackExpr());
+        assertExpression("((((self::node()/child::element(foo))[(string(data(@Baz))) eq a])/child::element())/child::element(bar))[(string(data(@Test))) eq false]", query.getExpressionsForLocalNameOrDefault("dummyNode").get(0));
+        assertExpression("docOrder(((docOrder(((((/)/descendant::element(dummyNode))/child::element(foo))[(string(data(@Baz))) eq a])/child::element()))/child::element(bar))[(string(data(@Test))) eq false])", query.getFallbackExpr());
     }
 
     @Test
@@ -240,7 +240,7 @@ class SaxonXPathRuleQueryTest {
             assertEquals(followPath(tree, "10"), results.get(0));
         });
 
-        assertExpression("docOrder((((/)/descendant::(element(dummyNode) | element(dummyNodeB)))/child::element(dummyNode))[(string(data(@Image))) eq \"10\"])", query.getExpressionsForLocalNameOrDefault("dummyNode").get(0));
+        assertExpression("docOrder((((/)/descendant::(element(dummyNode) | element(dummyNodeB)))/child::element(dummyNode))[(string(data(@Image))) eq 10])", query.getExpressionsForLocalNameOrDefault("dummyNode").get(0));
     }
 
     @Test
@@ -257,7 +257,7 @@ class SaxonXPathRuleQueryTest {
         ));
 
         assertEquals(0, query.getRuleChainVisits().size());
-        assertExpression("docOrder((((((/)/descendant::element(dummyNode))[(string(data(@Image))) eq \"0\"]) | (((/)/descendant::element(dummyNodeB))[(string(data(@Image))) eq \"1\"]))/child::element(dummyNode))[(string(data(@Image))) eq \"10\"])", query.getFallbackExpr());
+        assertExpression("docOrder((((((/)/descendant::element(dummyNode))[(string(data(@Image))) eq 0]) | (((/)/descendant::element(dummyNodeB))[(string(data(@Image))) eq 1]))/child::element(dummyNode))[(string(data(@Image))) eq 10])", query.getFallbackExpr());
 
         tree.descendantsOrSelf().forEach(n -> {
             List<Node> results = query.evaluate(n);
@@ -299,8 +299,8 @@ class SaxonXPathRuleQueryTest {
         assertEquals(1, ruleChainVisits.size());
         assertTrue(ruleChainVisits.contains("dummyNode"));
         assertEquals(2, query.nodeNameToXPaths.size());
-        assertExpression("self::node()[matches(convertUntyped(data(@SimpleName)), \"a\", \"\")]", query.getExpressionsForLocalNameOrDefault("dummyNode").get(0));
-        assertExpression("((/)/descendant::element(Q{}dummyNode))[matches(convertUntyped(data(@SimpleName)), \"a\", \"\")]", query.getFallbackExpr());
+        assertExpression("self::node()[matches(convertTo_xs:string(data(@SimpleName)), a, )]", query.getExpressionsForLocalNameOrDefault("dummyNode").get(0));
+        assertExpression("((/)/descendant::element(Q{}dummyNode))[matches(convertTo_xs:string(data(@SimpleName)), a, )]", query.getFallbackExpr());
     }
 
     @Test
@@ -311,8 +311,8 @@ class SaxonXPathRuleQueryTest {
         assertEquals(1, ruleChainVisits.size());
         assertTrue(ruleChainVisits.contains("dummyNode"));
         assertEquals(2, query.nodeNameToXPaths.size());
-        assertExpression("(self::node()[matches(convertUntyped(data(@SimpleName)), \"a\", \"\")])/child::element(Q{}foo)", query.getExpressionsForLocalNameOrDefault("dummyNode").get(0));
-        assertExpression("docOrder((((/)/descendant::element(Q{}dummyNode))[matches(convertUntyped(data(@SimpleName)), \"a\", \"\")])/child::element(Q{}foo))", query.getFallbackExpr());
+        assertExpression("(self::node()[matches(convertTo_xs:string(data(@SimpleName)), a, )])/child::element(Q{}foo)", query.getExpressionsForLocalNameOrDefault("dummyNode").get(0));
+        assertExpression("docOrder((((/)/descendant::element(Q{}dummyNode))[matches(convertTo_xs:string(data(@SimpleName)), a, )])/child::element(Q{}foo))", query.getFallbackExpr());
     }
 
     @Test
@@ -322,7 +322,7 @@ class SaxonXPathRuleQueryTest {
         assertEquals(1, ruleChainVisits.size());
         assertTrue(ruleChainVisits.contains("dummyNode"));
         assertEquals(2, query.nodeNameToXPaths.size());
-        assertExpression("let $v0 := imageIs(\"bar\") return ((self::node()[ends-with(convertUntyped(data(@Image)), \"foo\")])[$v0])", query.nodeNameToXPaths.get("dummyNode").get(0));
+        assertExpression("let $v0 := imageIs(bar) return ((self::node()[ends-with(convertTo_xs:string(data(@Image)), foo)])[$v0])", query.nodeNameToXPaths.get("dummyNode").get(0));
     }
 
     @Test
@@ -364,7 +364,7 @@ class SaxonXPathRuleQueryTest {
         assertTrue(ruleChainVisits.contains("WhileStatement"));
         assertTrue(ruleChainVisits.contains("DoStatement"));
 
-        final String expectedSubexpression = "(self::node()/descendant::element(dummyNode))[imageIs(exactly-one(convertUntyped(data(@Image))))]";
+        final String expectedSubexpression = "(self::node()/descendant::element(dummyNode))[imageIs(exactly-one(convertTo_xs:string(data(@Image))))]";
         assertExpression(expectedSubexpression, query.nodeNameToXPaths.get("ForStatement").get(0));
         assertExpression(expectedSubexpression, query.nodeNameToXPaths.get("WhileStatement").get(0));
         assertExpression(expectedSubexpression, query.nodeNameToXPaths.get("DoStatement").get(0));

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/SaxonDomXPathQuery.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/rule/SaxonDomXPathQuery.java
@@ -31,10 +31,10 @@ import net.sourceforge.pmd.util.DataMap.SimpleDataKey;
 import net.sf.saxon.Configuration;
 import net.sf.saxon.dom.DocumentWrapper;
 import net.sf.saxon.lib.ExtensionFunctionDefinition;
-import net.sf.saxon.lib.NamespaceConstant;
 import net.sf.saxon.om.AtomicSequence;
 import net.sf.saxon.om.Item;
 import net.sf.saxon.om.NamePool;
+import net.sf.saxon.om.NamespaceUri;
 import net.sf.saxon.om.StructuredQName;
 import net.sf.saxon.sxpath.IndependentContext;
 import net.sf.saxon.sxpath.XPathDynamicContext;
@@ -74,16 +74,13 @@ final class SaxonDomXPathQuery {
 
     private XPathExpressionWithProperties makeXPathExpression(String xpath, String defaultUri, List<PropertyDescriptor<?>> properties) {
         final IndependentContext xpathStaticContext = new IndependentContext(configuration);
-        xpathStaticContext.declareNamespace("fn", NamespaceConstant.FN);
-        xpathStaticContext.setDefaultElementNamespace(defaultUri);
-
-
-
+        xpathStaticContext.declareNamespace("fn", NamespaceUri.FN);
+        xpathStaticContext.setDefaultElementNamespace(NamespaceUri.of(defaultUri));
 
         for (XPathFunctionDefinition xpathFun : xpathHandler.getRegisteredExtensionFunctions()) {
             ExtensionFunctionDefinition fun = new SaxonExtensionFunctionDefinitionAdapter(xpathFun);
             StructuredQName qname = fun.getFunctionQName();
-            xpathStaticContext.declareNamespace(qname.getPrefix(), qname.getURI());
+            xpathStaticContext.declareNamespace(qname.getPrefix(), qname.getNamespaceUri());
             this.configuration.registerExtensionFunction(fun);
         }
 

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <javadoc.plugin.version>3.6.3</javadoc.plugin.version>
         <antlr.version>4.9.3</antlr.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <saxon.version>11.6</saxon.version>
+        <saxon.version>12.4</saxon.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <javadoc.plugin.version>3.6.3</javadoc.plugin.version>
         <antlr.version>4.9.3</antlr.version>
         <slf4j.version>1.7.36</slf4j.version>
-        <saxon.version>10.9</saxon.version>
+        <saxon.version>11.6</saxon.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
## Describe the PR

Saxon currently supports versions 10, 11 and 12. How long version 10 will remain to be supported is not clear, making the upgrade now gives us some future-proofing, while allowing us to benefit from further improvements in Saxon.

All changes are to internal classes, so this is backwards compatible.

Saxon 11+ and 12.1+ support Java 8+, so since PMD 7.0.0 there is no incompatibility on this front either.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

