### PR TITLE
[java] Avoid NPE in CloseResourceRule

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -51,6 +51,7 @@ This is a {{ site.pmd.release_type }} release.
   * [#4873](https://github.com/pmd/pmd/issues/4873): \[java] AvoidCatchingGenericException: Can no longer suppress on the exception itself
 * java-errorprone
   * [#2056](https://github.com/pmd/pmd/issues/2056): \[java] CloseResource false-positive with URLClassLoader in cast expression
+  * [#4751](https://github.com/pmd/pmd/issues/4751): \[java] PMD crashes when analyzing CloseResource Rule
   * [#4928](https://github.com/pmd/pmd/issues/4928): \[java] EmptyCatchBlock false negative when allowCommentedBlocks=true
 * java-performance
   * [#3845](https://github.com/pmd/pmd/issues/3845): \[java] InsufficientStringBufferDeclaration should consider literal expression

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
@@ -51,6 +51,7 @@ import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRule;
 import net.sourceforge.pmd.lang.java.rule.internal.JavaRuleUtil;
 import net.sourceforge.pmd.lang.java.symbols.JTypeDeclSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
 import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
@@ -287,12 +288,15 @@ public class CloseResourceRule extends AbstractJavaRule {
     private boolean isWrappingResourceSpecifiedInTry(ASTVariableId var) {
         ASTVariableAccess wrappedVarName = getWrappedVariableName(var);
         if (wrappedVarName != null) {
-            ASTVariableId referencedVar = wrappedVarName.getReferencedSym().tryGetNode();
-            if (referencedVar != null) {
-                List<ASTTryStatement> tryContainers = referencedVar.ancestors(ASTTryStatement.class).toList();
-                for (ASTTryStatement tryContainer : tryContainers) {
-                    if (isTryWithResourceSpecifyingVariable(tryContainer, referencedVar)) {
-                        return true;
+            JVariableSymbol referencedSym = wrappedVarName.getReferencedSym();
+            if (referencedSym != null) {
+                ASTVariableId referencedVar = referencedSym.tryGetNode();
+                if (referencedVar != null) {
+                    List<ASTTryStatement> tryContainers = referencedVar.ancestors(ASTTryStatement.class).toList();
+                    for (ASTTryStatement tryContainer : tryContainers) {
+                        if (isTryWithResourceSpecifyingVariable(tryContainer, referencedVar)) {
+                            return true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Describe the PR

Upon an incomplete auxclasspath, the symbol may be null. We need to handle that properly.

## Related issues

- Fixes #4751

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

