### PR TITLE
Fix reproducible build issues with 7.0.0

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -58,6 +58,8 @@ This is a {{ site.pmd.release_type }} release.
   * [#4886](https://github.com/pmd/pmd/issues/4886): \[java] BigIntegerInstantiation: False Positive with Java 17 and BigDecimal.TWO
 * pom-errorprone
   * [#4388](https://github.com/pmd/pmd/issues/4388): \[pom] InvalidDependencyTypes doesn't consider dependencies at all
+* misc
+  * [#4967](https://github.com/pmd/pmd/pull/4967): Fix reproducible build issues with 7.0.0
 
 ### 🚨 API Changes
 

--- a/pom.xml
+++ b/pom.xml
@@ -361,7 +361,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>3.3.0</version>
+                    <version>3.3.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -756,6 +756,18 @@
                         <goals>
                             <goal>makeAggregateBom</goal>
                         </goals>
+                        <configuration>
+                            <!-- PMD is released in two phases: first everything without pmd-cli/pmd-dist
+                                 (profile cli-dist-modules disabled), and then only pmd-cli/pmd-dist.
+                                 The BOM for the main artifact net.sourceforge.pmd:pmd is created and published
+                                 in the first phase and doesn't contain pmd-cli/pmd-dist. In order to be able
+                                 to reproduce the BOM, we exclude this two modules always.
+                            -->
+                            <excludeArtifactId>
+                                <artifactId>pmd-cli</artifactId>
+                                <artifactId>pmd-dist</artifactId>
+                            </excludeArtifactId>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,12 @@
                             <artifactId>javacc</artifactId>
                             <version>${javacc.version}</version>
                         </dependency>
+                        <!-- Use the latest ant version to preserve file permissions when doing replaceregexp -->
+                        <dependency>
+                            <groupId>org.apache.ant</groupId>
+                            <artifactId>ant</artifactId>
+                            <version>${ant.version}</version>
+                        </dependency>
                     </dependencies>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
## Describe the PR

For the latest release 7.0.0, not all artifacts are reproducible:
* https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/net/sourceforge/pmd/README.md
* https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/net/sourceforge/pmd/pmd-7.0.0.buildcompare

15 files are not reproducible. This PR fixes these.

1. The BOM for the parent POM created by cyclonedx contains all modules. However, due to the cyclic dependency between pmd and pmd-designer (see #4446) we do the release in two phases: first without pmd-cli/pmd-dist and in the 2nd phase only pmd-cli/pmd-dist. In the first phase, the parent POM is published and the BOM doesn't contain pmd-cli/pmd-dist. This PR now always excludes these two modules from the BOM, so that the whole project can be reproduced without doing the reproducible build in two phases as well.
2. When generating the tokenizers/parsers with javacc, we use maven-antrun-plugin to run some ant script that does some replaceregexp on files. When ant does this, it first performs the replaceregex on a temporary file with limited file permissions (like having umask 077). These files are then packed into the source jar by maven-source-plugin. In the older version of that plugin (3.2.1 used by PMD 7.0.0-rc4), these limited file permissions have obviously been ignored and all the files in the archive had the correct permission. The upgrade of maven-source-plugin to 3.3.0 changed to preserve the file permission (as opposed to reapply the umask for the files in the archive). Ant has a fix for the tasks, that create a temporary file, to preserve the permissions of the original file, so that the permissions in the archive are now correct. This PR now updates the ant version used by maven-antrun-plugin to use this fix.

## Related issues

- None

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

