### PR TITLE
[core] Typesafe saxon node iterators

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/BaseNodeInfo.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/BaseNodeInfo.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.rule.xpath.internal;
 
 
+import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
 
@@ -16,6 +17,7 @@ import net.sf.saxon.pattern.NodeTest;
 import net.sf.saxon.str.StringView;
 import net.sf.saxon.str.UnicodeString;
 import net.sf.saxon.tree.iter.AxisIterator;
+import net.sf.saxon.tree.iter.NodeListIterator;
 import net.sf.saxon.tree.util.Navigator.AxisFilter;
 import net.sf.saxon.tree.wrapper.AbstractNodeWrapper;
 import net.sf.saxon.tree.wrapper.SiblingCountingNode;
@@ -105,21 +107,8 @@ abstract class BaseNodeInfo extends AbstractNodeWrapper implements SiblingCounti
     }
 
     static <N extends NodeInfo> AxisIterator iterateList(List<N> nodes, boolean forwards) {
-        return forwards ? new NodeListIterator<>(nodes)
+        return forwards ? new NodeListIterator(Collections.unmodifiableList(nodes))
                         : new RevListAxisIterator<>(nodes);
-    }
-
-    private static class NodeListIterator<N extends NodeInfo> implements AxisIterator {
-        private final ListIterator<N> iter;
-
-        NodeListIterator(List<N> list) {
-            iter = list.listIterator();
-        }
-
-        @Override
-        public NodeInfo next() {
-            return this.iter.hasNext() ? this.iter.next() : null;
-        }
     }
 
     private static class RevListAxisIterator<N extends NodeInfo> implements AxisIterator {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/BaseNodeInfo.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/BaseNodeInfo.java
@@ -16,7 +16,6 @@ import net.sf.saxon.pattern.NodeTest;
 import net.sf.saxon.str.StringView;
 import net.sf.saxon.str.UnicodeString;
 import net.sf.saxon.tree.iter.AxisIterator;
-import net.sf.saxon.tree.iter.NodeListIterator;
 import net.sf.saxon.tree.util.Navigator.AxisFilter;
 import net.sf.saxon.tree.wrapper.AbstractNodeWrapper;
 import net.sf.saxon.tree.wrapper.SiblingCountingNode;
@@ -105,16 +104,28 @@ abstract class BaseNodeInfo extends AbstractNodeWrapper implements SiblingCounti
         return iterateList(nodes, true);
     }
 
-    @SuppressWarnings({"unchecked", "rawtypes"})
-    static AxisIterator iterateList(List<? extends NodeInfo> nodes, boolean forwards) {
-        return forwards ? new NodeListIterator((List<NodeInfo>) nodes)
-                        : new RevListAxisIterator((List<NodeInfo>) nodes);
+    static <N extends NodeInfo> AxisIterator iterateList(List<N> nodes, boolean forwards) {
+        return forwards ? new NodeListIterator<>(nodes)
+                        : new RevListAxisIterator<>(nodes);
     }
 
-    private static class RevListAxisIterator implements AxisIterator {
-        private final ListIterator<NodeInfo> iter;
+    private static class NodeListIterator<N extends NodeInfo> implements AxisIterator {
+        private final ListIterator<N> iter;
 
-        RevListAxisIterator(List<NodeInfo> list) {
+        NodeListIterator(List<N> list) {
+            iter = list.listIterator();
+        }
+
+        @Override
+        public NodeInfo next() {
+            return this.iter.hasNext() ? this.iter.next() : null;
+        }
+    }
+
+    private static class RevListAxisIterator<N extends NodeInfo> implements AxisIterator {
+        private final ListIterator<N> iter;
+
+        RevListAxisIterator(List<N> list) {
             iter = list.listIterator(list.size());
         }
 


### PR DESCRIPTION
## Describe the PR

This avoids the unchecked cast, but not sure, whether it's better readable at all.

The other point: Now I'm not extends saxon's [ListIterator](https://saxonica.plan.io/projects/saxonmirrorhe/repository/he/revisions/saxon12/entry/src/main/java/net/sf/saxon/tree/iter/ListIterator.java) anymore, which seems to have a lot of optimizations (LastPositionFinder, Lookahead, ...). Maybe that has some performance impact?

So, overall, I'm not sure, whether this change is worth it...

Let's see, whether at least all our XPath rules still work :)

## Related issues

- Relates to #4959 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

