### PR TITLE
[java] Properly handle @MethodSource in UnusedPrivateMethod

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -17,6 +17,7 @@ This is a {{ site.pmd.release_type }} release.
 ### 🐛 Fixed Issues
 
 * java-bestpractices
+  * [#4278](https://github.com/pmd/pmd/issues/4278): \[java] UnusedPrivateMethod FP with Junit 5 @MethodSource and default factory method name
   * [#4975](https://github.com/pmd/pmd/issues/4975): \[java] UnusedPrivateMethod false positive when using @MethodSource on a @Nested test
 
 ### 🚨 API Changes

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -16,6 +16,9 @@ This is a {{ site.pmd.release_type }} release.
 
 ### 🐛 Fixed Issues
 
+* java-bestpractices
+  * [#4975](https://github.com/pmd/pmd/issues/4975): \[java] UnusedPrivateMethod false positive when using @MethodSource on a @Nested test
+
 ### 🚨 API Changes
 
 ### ✨ External Contributions

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
@@ -54,6 +54,7 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
         //   first set, ie, not every call in the file.
 
         Set<String> methodsUsedByAnnotations = file.descendants(ASTMethodDeclaration.class)
+            .crossFindBoundaries()
             .children(ASTModifierList.class)
             .children(ASTAnnotation.class)
             .filter(t -> TypeTestUtil.isA("org.junit.jupiter.params.provider.MethodSource", t))

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import net.sourceforge.pmd.lang.ast.NodeStream;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
@@ -20,7 +21,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodReference;
 import net.sourceforge.pmd.lang.java.ast.ASTModifierList;
-import net.sourceforge.pmd.lang.java.ast.ASTStringLiteral;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.ast.MethodUsage;
 import net.sourceforge.pmd.lang.java.ast.ModifierOwner.Visibility;
@@ -58,9 +58,11 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
             .children(ASTModifierList.class)
             .children(ASTAnnotation.class)
             .filter(t -> TypeTestUtil.isA("org.junit.jupiter.params.provider.MethodSource", t))
-            .descendants(ASTStringLiteral.class)
             .toStream()
-            .map(ASTStringLiteral::getConstValue)
+            // Get the referenced method names… if none, use the test method name instead
+            .flatMap(a -> a.getFlatValue("value").isEmpty()
+                    ? Stream.of(a.ancestors(ASTMethodDeclaration.class).first().getName())
+                    : a.getFlatValue("value").toStream().map(mv -> (String) mv.getConstValue()))
             .collect(Collectors.toSet());
 
         Map<String, Set<ASTMethodDeclaration>> consideredNames =

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
@@ -1937,4 +1937,31 @@ class FooTest{
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[java] UnusedPrivateMethod FP with Junit 5 @MethodSource and default factory method name #4278</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.ParameterizedTest;
+
+class FooTest{
+    private static Stream<Arguments> testGetUsername_noMethodSourceValue() {
+        return Stream.of(
+                Arguments.of("foo"),
+                Arguments.of("bar"),
+                Arguments.of("baz")
+        );
+    }
+
+    @MethodSource
+    @ParameterizedTest
+    void testGetUsername_noMethodSourceValue(String username) {
+        User sut = new User(username);
+
+        Assertions.assertEquals(username, sut.getUsername());
+    }
+}
+]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
@@ -1903,4 +1903,38 @@ public class NotUsedPrivateMethodFalsePositive {
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[java] UnusedPrivateMethod false positive when using @MethodSource on a @Nested test #4975</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.ParameterizedTest;
+
+class FooTest{
+    @Nested
+    class ExampleTest {
+
+        @ParameterizedTest
+        @MethodSource("getStrings")
+        void exampleTestUsingPrivateMethod(
+                List<String> strings) {
+            // insert code
+        }
+
+        private static Stream<Arguments> getStrings() {
+            Stream<Arguments> tests = Stream.of(
+                    Arguments.of(List.of("TEST", "TEST_1")),
+                    Arguments.of(List.of("TEST_2", "TEST_3"))
+            );
+
+            return Stream.of(tests)
+                    .reduce(Stream::concat)
+                    .orElseGet(Stream::empty);
+        }
+    }
+}
+]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Fix a couple scenarios where we were not properly handling the `@MethodSource` annotation for rule `UnusedPrivateMethod`

## Related issues

- Fixes #4278 
- Fixes #4975 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

