### PR TITLE
[core] Actually duplicate the whole current config for RuleSetLoader

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -16,6 +16,8 @@ This is a {{ site.pmd.release_type }} release.
 
 ### 🐛 Fixed Issues
 
+* core
+  * [#4978](https://github.com/pmd/pmd/issues/4978): \[core] Referenced Rulesets do not emit details on validation errors
 * java-bestpractices
   * [#4278](https://github.com/pmd/pmd/issues/4278): \[java] UnusedPrivateMethod FP with Junit 5 @MethodSource and default factory method name
   * [#4975](https://github.com/pmd/pmd/issues/4975): \[java] UnusedPrivateMethod false positive when using @MethodSource on a @Nested test

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleSetFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleSetFactory.java
@@ -658,7 +658,9 @@ final class RuleSetFactory {
         return new RuleSetLoader().loadResourcesWith(resourceLoader)
                                   .filterAbovePriority(minimumPriority)
                                   .warnDeprecated(warnDeprecated)
-                                  .includeDeprecatedRuleReferences(includeDeprecatedRuleReferences);
+                                  .includeDeprecatedRuleReferences(includeDeprecatedRuleReferences)
+                                  .withReporter(reporter)
+                                  .withLanguages(languageRegistry);
     }
 
     private @NonNull XmlMessageHandler getXmlMessagePrinter() {


### PR DESCRIPTION
> Create a new {@link RuleSetLoader} with the same config as this factory.

In spite of the javadoc claiming the opposite, we didn't really copy over the current config to a the new `RuleSetLoader` when processing references. This caused the lack of appropriate error messages seen in #4978 

This PR fixes this, ensuring everything gets copied over.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

 - Fixes #4978

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

