### PR TITLE
[cpd] Fix CPD crashes about unicode escapes 

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CpdAnalysis.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CpdAnalysis.java
@@ -24,6 +24,7 @@ import net.sourceforge.pmd.lang.Language;
 import net.sourceforge.pmd.lang.LanguagePropertyBundle;
 import net.sourceforge.pmd.lang.ast.FileAnalysisException;
 import net.sourceforge.pmd.lang.ast.LexException;
+import net.sourceforge.pmd.lang.ast.impl.javacc.MalformedSourceException;
 import net.sourceforge.pmd.lang.document.FileCollector;
 import net.sourceforge.pmd.lang.document.FileId;
 import net.sourceforge.pmd.lang.document.InternalApiBridge;
@@ -171,7 +172,7 @@ public final class CpdAnalysis implements AutoCloseable {
                     int newTokens = doTokenize(textDocument, tokenizers.get(textFile.getLanguageVersion().getLanguage()), tokens);
                     numberOfTokensPerFile.put(textDocument.getFileId(), newTokens);
                     listener.addedFile(1);
-                } catch (LexException | IOException e) {
+                } catch (LexException | IOException | MalformedSourceException e) {
                     if (e instanceof FileAnalysisException) { // NOPMD
                         ((FileAnalysisException) e).setFileId(textFile.getFileId());
                     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CpdAnalysis.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CpdAnalysis.java
@@ -24,7 +24,6 @@ import net.sourceforge.pmd.lang.Language;
 import net.sourceforge.pmd.lang.LanguagePropertyBundle;
 import net.sourceforge.pmd.lang.ast.FileAnalysisException;
 import net.sourceforge.pmd.lang.ast.LexException;
-import net.sourceforge.pmd.lang.ast.impl.javacc.MalformedSourceException;
 import net.sourceforge.pmd.lang.document.FileCollector;
 import net.sourceforge.pmd.lang.document.FileId;
 import net.sourceforge.pmd.lang.document.InternalApiBridge;
@@ -172,7 +171,7 @@ public final class CpdAnalysis implements AutoCloseable {
                     int newTokens = doTokenize(textDocument, tokenizers.get(textFile.getLanguageVersion().getLanguage()), tokens);
                     numberOfTokensPerFile.put(textDocument.getFileId(), newTokens);
                     listener.addedFile(1);
-                } catch (LexException | IOException | MalformedSourceException e) {
+                } catch (IOException | FileAnalysisException e) {
                     if (e instanceof FileAnalysisException) { // NOPMD
                         ((FileAnalysisException) e).setFileId(textFile.getFileId());
                     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/FileAnalysisException.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/FileAnalysisException.java
@@ -10,12 +10,14 @@ import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import net.sourceforge.pmd.lang.ast.impl.javacc.MalformedSourceException;
 import net.sourceforge.pmd.lang.document.FileId;
 import net.sourceforge.pmd.lang.document.FileLocation;
 
 /**
  * An exception that occurs while processing a file. Subtypes include
  * <ul>
+ * <li>{@link MalformedSourceException}: error in source format, eg invalid character escapes (in case that happens before lexing)
  * <li>{@link LexException}: lexical syntax errors
  * <li>{@link ParseException}: syntax errors
  * <li>{@link SemanticException}: exceptions occurring after the parsing

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/BaseMappedDocument.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/BaseMappedDocument.java
@@ -69,7 +69,7 @@ abstract class BaseMappedDocument implements TextDocument {
      */
     protected @NonNull TextRegion inputRegion(TextRegion outputRegion) {
         if (outputRegion.isEmpty()) {
-            return TextRegion.caretAt(inputOffset(outputRegion.getStartOffset(), false));
+            return TextRegion.caretAt(inputOffset(outputRegion.getStartOffset(), true));
         }
         return TextRegion.fromBothOffsets(inputOffset(outputRegion.getStartOffset(), true),
                                           inputOffset(outputRegion.getEndOffset(), false));

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/BaseMappedDocument.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/BaseMappedDocument.java
@@ -68,6 +68,9 @@ abstract class BaseMappedDocument implements TextDocument {
      * @return Input region
      */
     protected @NonNull TextRegion inputRegion(TextRegion outputRegion) {
+        if (outputRegion.isEmpty()) {
+            return TextRegion.caretAt(inputOffset(outputRegion.getStartOffset(), false));
+        }
         return TextRegion.fromBothOffsets(inputOffset(outputRegion.getStartOffset(), true),
                                           inputOffset(outputRegion.getEndOffset(), false));
     }

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CpdAnalysisTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CpdAnalysisTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.io.TempDir;
-import org.mockito.Mockito;
 
 import net.sourceforge.pmd.lang.DummyLanguageModule;
 import net.sourceforge.pmd.lang.ast.LexException;
@@ -197,9 +196,7 @@ class CpdAnalysisTest {
     }
 
     @Test
-    void testSkipLexicalErrors() throws IOException {
-
-
+    void testNoSkipLexicalErrors() throws IOException {
         PmdReporter reporter = mock(PmdReporter.class);
         config.setReporter(reporter);
 
@@ -213,8 +210,13 @@ class CpdAnalysisTest {
         verify(reporter).errorEx(eq("Error while tokenizing"), any(MalformedSourceException.class));
         verify(reporter).errorEx(eq("Exception while running CPD"), any(IllegalStateException.class));
         verifyNoMoreInteractions(reporter);
+    }
 
-        Mockito.reset(reporter);
+    @Test
+    void testSkipLexicalErrors() throws IOException {
+        PmdReporter reporter = mock(PmdReporter.class);
+        config.setReporter(reporter);
+
         config.setSkipLexicalErrors(true);
         try (CpdAnalysis cpd = CpdAnalysis.create(config)) {
             assertTrue(cpd.files().addSourceFile(FileId.fromPathLikeString("foo.dummy"), DummyLanguageModule.CPD_THROW_LEX_EXCEPTION));

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/FragmentedTextDocumentTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/FragmentedTextDocumentTest.java
@@ -1,0 +1,77 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.document;
+
+import static net.sourceforge.pmd.lang.document.TextPos2d.pos2d;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Test;
+
+import net.sourceforge.pmd.lang.DummyLanguageModule;
+import net.sourceforge.pmd.lang.LanguageVersion;
+
+class FragmentedTextDocumentTest {
+
+    LanguageVersion dummyVersion = DummyLanguageModule.getInstance().getDefaultVersion();
+
+    @Test
+    void testSimple() throws IOException {
+
+        try (TextDocument base = TextDocument.readOnlyString("abc", dummyVersion)) {
+            FragmentedDocBuilder builder = new FragmentedDocBuilder(base);
+            builder.recordDelta(1, 2, Chars.wrap("abx"));
+            try (TextDocument doc = builder.build()) {
+                assertEquals("aabxc", doc.getText().toString());
+
+                assertEquals(pos2d(1, 1), doc.lineColumnAtOffset(0));
+                assertEquals(pos2d(1, 2), doc.lineColumnAtOffset(1, true));
+                assertEquals(pos2d(1, 3), doc.lineColumnAtOffset(2, true));
+                assertEquals(pos2d(1, 3), doc.lineColumnAtOffset(2, false));
+                assertEquals(pos2d(1, 4), doc.lineColumnAtOffset(3, true));
+                assertEquals(pos2d(1, 4), doc.lineColumnAtOffset(3, false));
+                assertEquals(pos2d(1, 4), doc.lineColumnAtOffset(5));
+            }
+
+        }
+
+
+    }
+
+    @Test
+    void testToLocationWithCaret() throws IOException {
+
+        try (TextDocument base = TextDocument.readOnlyString("abc", dummyVersion)) {
+            FragmentedDocBuilder builder = new FragmentedDocBuilder(base);
+            builder.recordDelta(1, 2, Chars.wrap("abx"));
+            try (TextDocument doc = builder.build()) {
+                assertEquals("aabxc", doc.getText().toString());
+
+                TextRegion region = TextRegion.caretAt(4);
+                assertEquals(pos2d(1, 3), doc.toLocation(region).getStartPos());
+            }
+
+        }
+    }
+
+    @Test
+    void testToLocationWithCaretBetweenEscapes() throws IOException {
+
+        try (TextDocument base = TextDocument.readOnlyString("aBBCCd", dummyVersion)) {
+            FragmentedDocBuilder builder = new FragmentedDocBuilder(base);
+            builder.recordDelta(1, 3, Chars.wrap("X"));
+            builder.recordDelta(3, 5, Chars.wrap("Y"));
+            try (TextDocument doc = builder.build()) {
+                assertEquals("aXYd", doc.getText().toString());
+
+                TextRegion region = TextRegion.caretAt(2);
+                assertEquals(pos2d(1, 4), doc.toLocation(region).getStartPos());
+            }
+
+        }
+    }
+
+}


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
CPD used to crash if an invalid unicode escape was in a file. This was not treated as a (skippable) lexical error even if it should.

Another crash occurred if there was a lexical error and the current position of the token manager is a unicode escape. Then the routine to get the current line/column failed.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

