### PR TITLE
[java]  Fix #4852 - TypeTestUtil.isA considers intersection type subtype of everything

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeTestUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeTestUtil.java
@@ -139,7 +139,7 @@ public final class TypeTestUtil {
      * @param t1 A supertype
      * @param t2 A type
      *
-     * @return Whether t1 is a subtype of t2
+     * @return Whether t2 is a subtype of t1
      */
     public static boolean isA(@Nullable JTypeMirror t1, @NonNull JTypeMirror t2) {
         if (t1 == null) {
@@ -153,6 +153,13 @@ public final class TypeTestUtil {
             return false; // conventionally
         } else if (t2 instanceof JTypeVar) {
             return t1.isTop() || isA(t1, ((JTypeVar) t2).getUpperBound());
+        } else if (t2 instanceof JIntersectionType) {
+            for (JTypeMirror subt : ((JIntersectionType) t2).getComponents()) {
+                if (isA(t1, subt)) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         return t2.isSubtypeOf(t1);

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -1312,12 +1312,13 @@ Consider replacing Vector usages with the newer java.util.ArrayList if expensive
         <properties>
             <property name="xpath">
                 <value><![CDATA[
-                //ClassType[pmd-java:typeIs('java.util.Vector')]
+                //ClassType[pmd-java:typeIsExactly('java.util.Vector')]
                 ]]></value>
             </property>
         </properties>
         <example>
 <![CDATA[
+import java.util.Vector;
 public class Foo {
     void bar() {
         Vector v = new Vector();

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/TypeTestUtilTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/TypeTestUtilTest.java
@@ -174,6 +174,24 @@ class TypeTestUtilTest extends BaseParserTest {
     }
 
     @Test
+    void testIsATypeVarWithUnresolvedIntersectionBound() {
+        // a type var with an unresolved bound should not be considered
+        // a subtype of everything
+        // #4852
+
+        ASTType field =
+            java.parse("class Foo<T extends Number & Unresolved> {\n"
+                           + "\tT field;\n"
+                           + "}")
+                .descendants(ASTFieldDeclaration.class)
+                .firstOrThrow().getTypeNode();
+
+        assertIsA(field, Object.class);
+        assertIsA(field, Number.class);
+        assertIsNot(field, String.class);
+    }
+
+    @Test
     void testIsAStringWithTypeArguments() {
 
         ASTTypeDeclaration klass =

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/ReplaceVectorWithList.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/ReplaceVectorWithList.xml
@@ -30,6 +30,20 @@ public class Foo {
         ]]></code>
     </test-code>
 
+
+    <test-code>
+        <description>Generic vector</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import java.util.Vector;
+
+public class Foo {
+    void bar(Vector<Integer> v) {
+    }
+}
+        ]]></code>
+    </test-code>
+
     <test-code>
         <description>ok, not java.util.Vector</description>
         <expected-problems>0</expected-problems>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/ReplaceVectorWithList.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/ReplaceVectorWithList.xml
@@ -42,4 +42,23 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>Not about vector</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            package pmd.false_positive;
+
+            import java.util.Map;
+            import java.util.function.Predicate;
+
+            public class AAntiFraudPolicy<C extends IAntiFraudCriterion> {
+
+                public static <E extends Enum<E> & IAntiFraudCriterion> AAntiFraudPolicy<E> of(Class<E> enumClass,
+                                                                                               Map<E, Predicate<AntiFraudCheckResult>> criterionChecks) {
+                    return new AAntiFraudPolicy<E>();
+                }
+
+            }
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #4852

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

