### PR TITLE
[java] Improve a bit the recovery behavior for unknown types

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
@@ -440,7 +440,12 @@ public final class TypeOps {
             }
             // otherwise fallthrough
         } else if (isSpecialUnresolved(t)) {
-            // error type or unresolved type
+            // error type or unresolved type is subtype of everything
+            if (s instanceof JArrayType) {
+                // In case the array has an ivar 'a as element type, a bound will be added 'a >: (*unknown*)
+                // This helps inference recover in call chains and propagate the (*unknown*) types gracefully.
+                return isConvertible(t, ((JArrayType) s).getElementType());
+            }
             return Convertibility.SUBTYPING;
         } else if (hasUnresolvedSymbol(t) && t instanceof JClassType) {
             // This also considers types with an unresolved symbol

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/UnresolvedTypesRecoveryTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/UnresolvedTypesRecoveryTest.kt
@@ -7,11 +7,11 @@
 package net.sourceforge.pmd.lang.java.types.internal.infer
 
 import io.kotest.matchers.shouldBe
-import net.sourceforge.pmd.lang.test.ast.shouldBeA
-import net.sourceforge.pmd.lang.test.ast.shouldMatchN
 import net.sourceforge.pmd.lang.java.ast.*
 import net.sourceforge.pmd.lang.java.symbols.JClassSymbol
 import net.sourceforge.pmd.lang.java.types.*
+import net.sourceforge.pmd.lang.test.ast.shouldBeA
+import net.sourceforge.pmd.lang.test.ast.shouldMatchN
 
 /**
  */
@@ -648,6 +648,49 @@ class C {
             ok shouldHaveType t_Lambda
             wrong shouldHaveType t_Lambda
             wrong.parameters[0] shouldHaveType ts.UNKNOWN
+        }
+    }
+
+    parserTest("Method ref in unresolved call chain") {
+        /*
+            In this test we have Stream.of(/*some expr with unresolved type*/)
+
+            The difficult thing is that Stream.of has two overloads: of(U) and of(U...),
+            and the argument is unknown. This makes both methods match. Whichever method is matched,
+            we want the U to be inferred to (*unknown*) and not Object.
+         */
+
+        val (acu, _) = parser.parseWithTypeInferenceSpy("""
+                interface Function<T, R> {
+                    R call(T parm);
+                }
+                interface Stream<T> {
+                    <U> Stream<U> map(Function<? super T, ? extends U> fun);
+                    
+                    // the point of this test is there is an ambiguity between both of these overloads
+                    static <U> Stream<U> of(U u) {}
+                    static <U> Stream<U> of(U... u) {}
+                }
+                class Foo {
+                    {
+                        // var i = Stream.of("").map(Foo::toInt);
+                        var x = Stream.of(new Unresolved().getString())
+                                      .map(Foo::toInt);
+                    }
+                   private static Integer toInt(String s) {}
+                }
+        """)
+
+        val (fooToInt) = acu.descendants(ASTMethodReference::class.java).toList()
+        val (map, streamOf, getString) = acu.methodCalls().toList()
+        val (t_Function, t_Stream, t_Foo) = acu.declaredTypeSignatures()
+        val (_, _, _, _, toIntFun) = acu.methodDeclarations().toList { it.symbol }
+
+        acu.withTypeDsl {
+            streamOf shouldHaveType t_Stream[ts.UNKNOWN]
+            map shouldHaveType t_Stream[ts.INT.box()]
+            fooToInt shouldHaveType t_Function[ts.UNKNOWN, ts.INT.box()]
+            fooToInt.referencedMethod.symbol shouldBe toIntFun
         }
     }
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
@@ -1964,4 +1964,42 @@ class FooTest{
 }
 ]]></code>
     </test-code>
+    <test-code>
+        <description>[java] UnusedPrivateMethod false-positive / method reference in combination with custom object #4985</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            import java.util.List;
+
+            public class Main {
+
+                public static void main(String[] args) {
+                    System.out.println("list");
+
+                    // usage of method reference in combination with a custom object leads to a false positive of PMD.UnusedPrivateMethod
+                    List.of(new StringWrapper().getString())
+                        .stream()
+
+                        .map(Main::foo)
+                        .filter(Objects::nonNull)
+                        .toList();
+
+                    // no false positive .. :/
+                    List.of("s")
+                        .stream()
+                        .map(Main::foo2)
+                        .filter(Objects::nonNull)
+                        .toList();
+                }
+
+                private static int foo(String s) {
+                    return s.length();
+                }
+
+                private static int foo2(String s) {
+                    return s.length();
+                }
+
+            }
+            ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #4985, this will not occur anymore even with incomplete auxclasspath

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

