### PR TITLE
[java] Fix #5006 - bad intersection in capture of recursive types

### DIFF
--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/CaptureTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/CaptureTest.kt
@@ -9,11 +9,12 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import net.sourceforge.pmd.lang.java.symbols.internal.asm.createUnresolvedAsmSymbol
 import net.sourceforge.pmd.lang.java.types.TypeConversion.*
+import net.sourceforge.pmd.lang.test.ast.IntelliMarker
 
 /**
  * @author Clément Fournier
  */
-class CaptureTest : FunSpec({
+class CaptureTest : IntelliMarker, FunSpec({
 
     with(TypeDslOf(testTypeSystem)) {
         with(gen) {
@@ -67,6 +68,24 @@ class CaptureTest : FunSpec({
                     it.isCaptured shouldBe true
                     it.isCaptureOf(`?` extends t_String) shouldBe true
                 }
+            }
+
+            test("Capture of recursive types #5006") {
+                val acu = javaParser.parse("""
+                    class Parent<T extends Parent<T>> {} // Recursive type T
+
+                    class Child extends Parent<Child> {}
+
+                    class Box<T extends Parent<T>> {
+                      public void foo(Box<? extends Child> box) {} // <-- The bug is triggered by this line
+                    }
+                """.trimIndent())
+
+                val (_, child, box) = acu.declaredTypeSignatures()
+
+                val type = acu.methodDeclarations().first()!!.formalParameters.get(0).typeMirror
+
+                 capture(type) shouldBe box[captureMatcher(`?` extends child)]
             }
 
         }


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #5006

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

