### PR TITLE
[java] Fix #3434 AssignmentInOperand FNs

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractRule.java
@@ -333,4 +333,14 @@ public abstract class AbstractRule extends AbstractPropertySource implements Rul
         }
         return rule;
     }
+
+    @Override
+    @SuppressWarnings("PMD.UselessOverridingMethod")
+    public String dysfunctionReason() {
+        // This method is overridden to let subclasses remove their implementation
+        // of dysfunctionReason in a binary compatible way. For this to
+        // work one implementation has to be in a superclass, however this
+        // method only has a default implementation in the interface.
+        return super.dysfunctionReason();
+    }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AssignmentInOperand.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AssignmentInOperand.xml
@@ -169,4 +169,31 @@ public class Foo {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>Assignments in other contexts</description>
+        <expected-problems>8</expected-problems>
+        <code><![CDATA[
+            class AssignmentInOperand{
+                void test(){
+                    keys.contains(k = random.nextLong()); // warn
+                    Character.isJavaIdentifierPart(text.charAt(--j)); // warn
+
+                    // case2
+                    addNextStaticMember = ((staticMember.getNextStaticMember() != null) ? true : false) ; // ok
+                    ((null == theClassMethods) ? (theClassMethods = theClass.getMethods()) : theClassMethods); // warn
+
+                    Character.isWhitespace(segment.array[offset++]); // warn
+                    subPropMatches[i++]; // warn
+
+                    (is = ia.getNext(null)).isPresent(); // warn
+                    (destFile = new File (dest, srcFO.getNameExt ())).exists(); // warn
+
+                    // case5
+                    new File(location,
+                             projectName = projectNamePrefix + "_" + num // warn
+                    ).exists();
+                }
+            }
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
The rule should now flag assignments in all operand contexts

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #3434

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

