### PR TITLE
[java] Fix AvoidUsingOctalValues false-positive

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTNumericLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTNumericLiteral.java
@@ -120,10 +120,10 @@ public final class ASTNumericLiteral extends AbstractLiteral implements ASTLiter
      * for the literal {@code 0} (which can really be any base).
      */
     public int getBase() {
-        return getBase(getLiteralText());
+        return getBase(getLiteralText(), isIntegral());
     }
 
-    static int getBase(Chars image) {
+    static int getBase(Chars image, boolean isIntegral) {
         if (image.length() > 1 && image.charAt(0) == '0') {
             switch (image.charAt(1)) {
             case 'x':
@@ -132,10 +132,8 @@ public final class ASTNumericLiteral extends AbstractLiteral implements ASTLiter
             case 'b':
             case 'B':
                 return 2;
-            case '.':
-                return 10;
             default:
-                return 8;
+                return isIntegral ? 8 : 10;
             }
         }
         return 10;
@@ -172,7 +170,7 @@ public final class ASTNumericLiteral extends AbstractLiteral implements ASTLiter
      * <p>Invalid literals or overflows result in {@code 0L}.
      */
     static long parseIntegralValue(Chars image) {
-        final int base = getBase(image);
+        final int base = getBase(image, true);
         if (base == 8) {
             image = image.subSequence(1); // 0
         } else if (base != 10) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UseUnderscoresInNumericLiterals.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UseUnderscoresInNumericLiterals.xml
@@ -245,6 +245,16 @@ public class Foo {
     </test-code>
 
     <test-code>
+        <description>ok, float literal in hexadecimal and exponent</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    float f = 0x1.0000_ffff_eeeep+2f;
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>ok, Lengthy numeric literal with variable name as serialVersionUID</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidUsingOctalValues.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/AvoidUsingOctalValues.xml
@@ -55,6 +55,48 @@ public class Foo {
     </test-code>
 
     <test-code>
+        <description>OK, double value</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    double d = 012.0;
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>OK, double suffix</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    double d1 = 012d;
+    double d2 = 012D;
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>OK, float suffix</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    float f = 012f;
+    float f = 012F;
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>OK, double value with exponent</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    double d = 012e0;
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>bad, 012L</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[


### PR DESCRIPTION
## Describe the PR

ASTNumericLiteral did not correctly determine the base when a number ended with a non-number (L, F, D, .) This PR checks if the number ends with one of those characters, and correctly returns a base of 10.

## Related issues

- Fixes #5007

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

