### PR TITLE
[java] Remove redundant interface declarations in pmd-java

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotation.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAnnotation.java
@@ -21,7 +21,7 @@ import net.sourceforge.pmd.lang.java.types.JClassType;
  *
  * </pre>
  */
-public final class ASTAnnotation extends AbstractJavaTypeNode implements TypeNode, ASTMemberValue, Iterable<ASTMemberValuePair> {
+public final class ASTAnnotation extends AbstractJavaTypeNode implements ASTMemberValue, Iterable<ASTMemberValuePair> {
 
     ASTAnnotation(int id) {
         super(id);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTArrayDimExpr.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTArrayDimExpr.java
@@ -17,7 +17,7 @@ package net.sourceforge.pmd.lang.java.ast;
  *
  * </pre>
  */
-public final class ASTArrayDimExpr extends ASTArrayTypeDim implements Annotatable {
+public final class ASTArrayDimExpr extends ASTArrayTypeDim {
 
     ASTArrayDimExpr(int id) {
         super(id);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTArrayInitializer.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTArrayInitializer.java
@@ -22,7 +22,7 @@ import java.util.Iterator;
  * </pre>
  *
  */
-public final class ASTArrayInitializer extends AbstractJavaExpr implements ASTExpression, Iterable<ASTExpression> {
+public final class ASTArrayInitializer extends AbstractJavaExpr implements Iterable<ASTExpression> {
 
     ASTArrayInitializer(int id) {
         super(id);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTBlock.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTBlock.java
@@ -6,7 +6,6 @@ package net.sourceforge.pmd.lang.java.ast;
 
 import net.sourceforge.pmd.lang.ast.impl.javacc.JavaccToken;
 import net.sourceforge.pmd.lang.java.ast.ASTList.ASTMaybeEmptyListOf;
-import net.sourceforge.pmd.lang.java.ast.InternalInterfaces.AllChildrenAreOfType;
 
 /**
  * A block of code. This is a {@linkplain ASTStatement statement} that
@@ -19,7 +18,7 @@ import net.sourceforge.pmd.lang.java.ast.InternalInterfaces.AllChildrenAreOfType
  * </pre>
  */
 public final class ASTBlock extends ASTMaybeEmptyListOf<ASTStatement>
-        implements ASTSwitchArrowRHS, ASTStatement, AllChildrenAreOfType<ASTStatement> {
+        implements ASTSwitchArrowRHS, ASTStatement {
 
     ASTBlock(int id) {
         super(id, ASTStatement.class);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTBooleanLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTBooleanLiteral.java
@@ -9,7 +9,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 /**
  * The boolean literal, either "true" or "false".
  */
-public final class ASTBooleanLiteral extends AbstractLiteral implements ASTLiteral {
+public final class ASTBooleanLiteral extends AbstractLiteral {
 
     private boolean isTrue;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCastExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCastExpression.java
@@ -14,7 +14,7 @@ package net.sourceforge.pmd.lang.java.ast;
  *
  * </pre>
  */
-public final class ASTCastExpression extends AbstractJavaExpr implements ASTExpression {
+public final class ASTCastExpression extends AbstractJavaExpr {
 
     ASTCastExpression(int id) {
         super(id);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCharLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCharLiteral.java
@@ -15,7 +15,7 @@ import net.sourceforge.pmd.lang.document.Chars;
  * retrieve the actual runtime value. Use {@link #getLiteralText()} to
  * retrieve the text.
  */
-public final class ASTCharLiteral extends AbstractLiteral implements ASTLiteral {
+public final class ASTCharLiteral extends AbstractLiteral {
 
 
     ASTCharLiteral(int id) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCompilationUnit.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCompilationUnit.java
@@ -13,7 +13,6 @@ import net.sourceforge.pmd.annotation.Experimental;
 import net.sourceforge.pmd.lang.ast.AstInfo;
 import net.sourceforge.pmd.lang.ast.NodeStream;
 import net.sourceforge.pmd.lang.ast.RootNode;
-import net.sourceforge.pmd.lang.ast.impl.GenericNode;
 import net.sourceforge.pmd.lang.java.symbols.table.JSymbolTable;
 import net.sourceforge.pmd.lang.java.types.TypeSystem;
 import net.sourceforge.pmd.lang.java.types.ast.internal.LazyTypeResolver;
@@ -49,7 +48,7 @@ import net.sourceforge.pmd.lang.rule.xpath.NoAttribute;
  * @see <a href="https://openjdk.org/jeps/445">JEP 445: Unnamed Classes and Instance Main Methods (Preview)</a> (Java 21)
  * @see #isUnnamedClass()
  */
-public final class ASTCompilationUnit extends AbstractJavaNode implements JavaNode, GenericNode<JavaNode>, RootNode {
+public final class ASTCompilationUnit extends AbstractJavaNode implements RootNode {
 
     private LazyTypeResolver lazyTypeResolver;
     private List<JavaComment> comments;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTConstructorCall.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTConstructorCall.java
@@ -22,11 +22,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *
  * </pre>
  */
-public final class ASTConstructorCall extends AbstractInvocationExpr
-    implements ASTPrimaryExpression,
-               QualifiableExpression,
-               LeftRecursiveNode,
-               InvocationNode {
+public final class ASTConstructorCall extends AbstractInvocationExpr implements QualifiableExpression, LeftRecursiveNode {
 
     ASTConstructorCall(int id) {
         super(id);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTEnumConstant.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTEnumConstant.java
@@ -19,9 +19,8 @@ import net.sourceforge.pmd.lang.java.types.OverloadSelectionResult;
  * </pre>
  */
 public final class ASTEnumConstant extends AbstractJavaTypeNode
-    implements Annotatable,
-               InvocationNode,
-        ModifierOwner,
+    implements InvocationNode,
+               ModifierOwner,
                ASTBodyDeclaration,
                InternalInterfaces.VariableIdOwner,
                JavadocCommentOwner {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExecutableDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExecutableDeclaration.java
@@ -7,7 +7,6 @@ package net.sourceforge.pmd.lang.java.ast;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import net.sourceforge.pmd.lang.ast.impl.GenericNode;
 import net.sourceforge.pmd.lang.java.symbols.JExecutableSymbol;
 import net.sourceforge.pmd.lang.java.types.JClassType;
 import net.sourceforge.pmd.lang.java.types.JMethodSig;
@@ -32,7 +31,6 @@ public interface ASTExecutableDeclaration
     extends ModifierOwner,
             ASTBodyDeclaration,
             TypeParamOwnerNode,
-            GenericNode<JavaNode>,
             JavadocCommentOwner {
 
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExpression.java
@@ -39,11 +39,7 @@ import net.sourceforge.pmd.lang.java.types.ast.ExprContext;
  *
  * </pre>
  */
-public interface ASTExpression
-    extends JavaNode,
-            TypeNode,
-            ASTMemberValue,
-            ASTSwitchArrowRHS {
+public interface ASTExpression extends TypeNode, ASTMemberValue, ASTSwitchArrowRHS {
 
     /**
      * Always returns true. This is to allow XPath queries

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFieldDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFieldDeclaration.java
@@ -22,9 +22,7 @@ import net.sourceforge.pmd.lang.rule.xpath.DeprecatedAttribute;
  * </pre>
  */
 public final class ASTFieldDeclaration extends AbstractJavaNode
-    implements Iterable<ASTVariableId>,
-               LeftRecursiveNode,
-        ModifierOwner,
+    implements LeftRecursiveNode,
                ASTBodyDeclaration,
                InternalInterfaces.MultiVariableIdOwner,
                JavadocCommentOwner {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFormalParameter.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTFormalParameter.java
@@ -25,10 +25,7 @@ import net.sourceforge.pmd.lang.java.types.TypingContext;
  * </pre>
  */
 public final class ASTFormalParameter extends AbstractJavaNode
-    implements ModifierOwner,
-               TypeNode,
-               Annotatable,
-               VariableIdOwner {
+    implements ModifierOwner, TypeNode, VariableIdOwner {
 
     ASTFormalParameter(int id) {
         super(id);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLocalVariableDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLocalVariableDeclaration.java
@@ -25,9 +25,7 @@ import net.sourceforge.pmd.lang.document.FileLocation;
  */
 // TODO extend AbstractStatement
 public final class ASTLocalVariableDeclaration extends AbstractJavaNode
-    implements Iterable<ASTVariableId>,
-               ASTStatement,
-        ModifierOwner,
+    implements ASTStatement,
                LeftRecursiveNode, // ModifierList is parsed separately in BlockStatement
                InternalInterfaces.MultiVariableIdOwner {
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodCall.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodCall.java
@@ -19,11 +19,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *
  * </pre>
  */
-public final class ASTMethodCall extends AbstractInvocationExpr
-    implements ASTPrimaryExpression,
-               QualifiableExpression,
-               InvocationNode,
-               MethodUsage {
+public final class ASTMethodCall extends AbstractInvocationExpr implements QualifiableExpression {
 
     ASTMethodCall(int id) {
         super(id);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodReference.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodReference.java
@@ -23,8 +23,7 @@ import net.sourceforge.pmd.lang.java.types.TypeSystem;
  * </pre>
  */
 public final class ASTMethodReference extends AbstractJavaExpr
-    implements ASTPrimaryExpression,
-               QualifiableExpression,
+    implements QualifiableExpression,
                LeftRecursiveNode,
                MethodUsage,
                FunctionalExpression {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTNullLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTNullLiteral.java
@@ -15,7 +15,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *
  * </pre>
  */
-public final class ASTNullLiteral extends AbstractLiteral implements ASTLiteral {
+public final class ASTNullLiteral extends AbstractLiteral {
     ASTNullLiteral(int id) {
         super(id);
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTNumericLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTNumericLiteral.java
@@ -14,7 +14,7 @@ import net.sourceforge.pmd.lang.java.types.JPrimitiveType;
 /**
  * A numeric literal of any type (double, int, long, float, etc).
  */
-public final class ASTNumericLiteral extends AbstractLiteral implements ASTLiteral {
+public final class ASTNumericLiteral extends AbstractLiteral {
 
     /**
      * True if this is an integral literal, ie int OR long,

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTRecordComponentList.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTRecordComponentList.java
@@ -6,7 +6,6 @@
 package net.sourceforge.pmd.lang.java.ast;
 
 import net.sourceforge.pmd.lang.java.ast.ASTList.ASTMaybeEmptyListOf;
-import net.sourceforge.pmd.lang.java.ast.InternalInterfaces.AllChildrenAreOfType;
 import net.sourceforge.pmd.lang.java.symbols.JConstructorSymbol;
 
 /**
@@ -18,8 +17,7 @@ import net.sourceforge.pmd.lang.java.symbols.JConstructorSymbol;
  *
  * </pre>
  */
-public final class ASTRecordComponentList extends ASTMaybeEmptyListOf<ASTRecordComponent>
-        implements SymbolDeclaratorNode, AllChildrenAreOfType<ASTRecordComponent> {
+public final class ASTRecordComponentList extends ASTMaybeEmptyListOf<ASTRecordComponent> implements SymbolDeclaratorNode {
 
     private JConstructorSymbol symbol;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTStringLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTStringLiteral.java
@@ -18,7 +18,7 @@ import net.sourceforge.pmd.util.StringUtil;
  * in the source ({@link #getLiteralText()}). {@link #getConstValue()} allows to recover
  * the actual runtime value, by processing escapes.
  */
-public final class ASTStringLiteral extends AbstractLiteral implements ASTLiteral {
+public final class ASTStringLiteral extends AbstractLiteral {
 
     private static final String TEXTBLOCK_DELIMITER = "\"\"\"";
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchExpression.java
@@ -18,9 +18,7 @@ import net.sourceforge.pmd.lang.ast.NodeStream;
  *
  * <p>Their syntax is identical though, and described on {@link ASTSwitchLike}.
  */
-public final class ASTSwitchExpression extends AbstractJavaExpr
-    implements ASTExpression,
-               ASTSwitchLike {
+public final class ASTSwitchExpression extends AbstractJavaExpr implements ASTSwitchLike {
 
     ASTSwitchExpression(int id) {
         super(id);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableId.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableId.java
@@ -43,7 +43,7 @@ import net.sourceforge.pmd.lang.java.types.JTypeMirror;
  * <p>Note: This node has been called ASTVariableDeclaratorId in PMD 6.
  */
 // @formatter:on
-public final class ASTVariableId extends AbstractTypedSymbolDeclarator<JVariableSymbol> implements ModifierOwner, SymbolDeclaratorNode {
+public final class ASTVariableId extends AbstractTypedSymbolDeclarator<JVariableSymbol> implements ModifierOwner {
 
     private String name;
     private List<ASTNamedReferenceExpr> usages = Collections.emptyList();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractTypeBodyDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractTypeBodyDeclaration.java
@@ -8,7 +8,7 @@ package net.sourceforge.pmd.lang.java.ast;
  * @author Clément Fournier
  * @since 6.2.0
  */
-abstract class AbstractTypeBodyDeclaration extends AbstractJavaNode implements JavaNode {
+abstract class AbstractTypeBodyDeclaration extends AbstractJavaNode {
 
     AbstractTypeBodyDeclaration(int id) {
         super(id);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/InternalInterfaces.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/InternalInterfaces.java
@@ -134,7 +134,7 @@ final class InternalInterfaces {
         ASTVariableId getVarId();
     }
 
-    interface MultiVariableIdOwner extends JavaNode, Iterable<ASTVariableId>, ModifierOwner {
+    interface MultiVariableIdOwner extends Iterable<ASTVariableId>, ModifierOwner {
 
         /**
          * Returns a stream of the variable ids declared

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JAccessibleElementSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JAccessibleElementSymbol.java
@@ -16,7 +16,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *
  * @since 7.0.0
  */
-public interface JAccessibleElementSymbol extends JElementSymbol, AnnotableSymbol {
+public interface JAccessibleElementSymbol extends AnnotableSymbol {
 
     /**
      * Conventional return value of {@link #getPackageName()} for

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JExecutableSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JExecutableSymbol.java
@@ -19,7 +19,7 @@ import net.sourceforge.pmd.lang.java.types.Substitution;
  * Common supertype for {@linkplain JMethodSymbol method}
  * and {@linkplain JConstructorSymbol constructor symbols}.
  */
-public interface JExecutableSymbol extends JAccessibleElementSymbol, JTypeParameterOwnerSymbol {
+public interface JExecutableSymbol extends JTypeParameterOwnerSymbol {
 
 
     /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JTypeDeclSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JTypeDeclSymbol.java
@@ -21,7 +21,7 @@ import net.sourceforge.pmd.lang.java.types.JTypeMirror;
  *
  * @since 7.0.0
  */
-public interface JTypeDeclSymbol extends JElementSymbol, JAccessibleElementSymbol {
+public interface JTypeDeclSymbol extends JAccessibleElementSymbol {
 
     /**
      * Returns true if this class is a symbolic reference to an unresolved

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstUnnamedClassSym.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstUnnamedClassSym.java
@@ -16,12 +16,11 @@ import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
 import net.sourceforge.pmd.lang.java.ast.JModifier;
-import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JFieldSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JMethodSymbol;
 import net.sourceforge.pmd.lang.java.symbols.internal.EmptyClassSymbol;
 
-class AstUnnamedClassSym extends EmptyClassSymbol implements JClassSymbol {
+class AstUnnamedClassSym extends EmptyClassSymbol {
     private final List<JMethodSymbol> declaredMethods;
     private final List<JFieldSymbol> declaredFields;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/BasePrimitiveSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/BasePrimitiveSymbol.java
@@ -10,13 +10,12 @@ import java.lang.reflect.Modifier;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
 import net.sourceforge.pmd.lang.java.symbols.internal.EmptyClassSymbol;
 import net.sourceforge.pmd.lang.java.symbols.internal.SymbolEquality;
 import net.sourceforge.pmd.lang.java.symbols.internal.SymbolToStrings;
 import net.sourceforge.pmd.lang.java.types.JPrimitiveType.PrimitiveTypeKind;
 
-abstract class BasePrimitiveSymbol extends EmptyClassSymbol implements JClassSymbol {
+abstract class BasePrimitiveSymbol extends EmptyClassSymbol {
 
     BasePrimitiveSymbol(TypeSystem ts) {
         super(() -> ts);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JTypeVar.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JTypeVar.java
@@ -36,7 +36,7 @@ import net.sourceforge.pmd.lang.java.symbols.SymbolicValue.SymAnnot;
  * <p>Type variables do not, in general, use reference identity. Use
  * equals to compare them.
  */
-public interface JTypeVar extends JTypeMirror, SubstVar {
+public interface JTypeVar extends SubstVar {
 
 
     /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/InferenceVar.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/InferenceVar.java
@@ -35,7 +35,7 @@ import net.sourceforge.pmd.lang.java.types.TypeSystem;
  * type is of no importance outside the implementation of this framework.
  */
 @SuppressWarnings("PMD.CompareObjectsWithEquals")
-public final class InferenceVar implements JTypeMirror, SubstVar {
+public final class InferenceVar implements SubstVar {
 
     // we used to use greek letters (for style), but they're hard to type
     private static final String NAMES = "abcdefghijklmnopqrstuvwxyz"; // + "αβγδεζηθκλμνξπρςυφχψω"

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/MethodInvocMirror.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/MethodInvocMirror.java
@@ -21,10 +21,9 @@ import net.sourceforge.pmd.lang.java.types.TypeConversion;
 import net.sourceforge.pmd.lang.java.types.TypeOps;
 import net.sourceforge.pmd.lang.java.types.internal.InternalMethodTypeItf;
 import net.sourceforge.pmd.lang.java.types.internal.infer.ExprMirror;
-import net.sourceforge.pmd.lang.java.types.internal.infer.ExprMirror.InvocationMirror;
 import net.sourceforge.pmd.lang.java.types.internal.infer.ast.JavaExprMirrors.MirrorMaker;
 
-class MethodInvocMirror extends BaseInvocMirror<ASTMethodCall> implements InvocationMirror {
+class MethodInvocMirror extends BaseInvocMirror<ASTMethodCall> {
 
 
     MethodInvocMirror(JavaExprMirrors mirrors, ASTMethodCall call, @Nullable ExprMirror parent, MirrorMaker subexprMaker) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/StandaloneExprMirror.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/StandaloneExprMirror.java
@@ -10,7 +10,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.internal.infer.ExprMirror;
 
-class StandaloneExprMirror extends BaseExprMirror<ASTExpression> implements ExprMirror {
+class StandaloneExprMirror extends BaseExprMirror<ASTExpression> {
 
     StandaloneExprMirror(JavaExprMirrors factory, ASTExpression myNode, @Nullable ExprMirror parent) {
         super(factory, myNode, parent);


### PR DESCRIPTION
Related to #4885

## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->


## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

