### PR TITLE
Added Inner Classes to Class Naming Conventions Rule

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/ClassNamingConventionsRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/codestyle/ClassNamingConventionsRule.java
@@ -22,6 +22,9 @@ public class ClassNamingConventionsRule extends AbstractNamingConventionsRule {
     private static final PropertyDescriptor<Pattern> TEST_CLASS_REGEX = prop("testClassPattern", "test class",
             DESCRIPTOR_TO_DISPLAY_NAME).defaultValue(PASCAL_CASE_WITH_UNDERSCORES).build();
 
+    private static final PropertyDescriptor<Pattern> INNER_CLASS_REGEX = prop("innerClassPattern", "inner class",
+            DESCRIPTOR_TO_DISPLAY_NAME).defaultValue(PASCAL_CASE_WITH_UNDERSCORES).build();
+
     private static final PropertyDescriptor<Pattern> ABSTRACT_CLASS_REGEX = prop("abstractClassPattern", "abstract class",
             DESCRIPTOR_TO_DISPLAY_NAME).defaultValue(PASCAL_CASE_WITH_UNDERSCORES).build();
 
@@ -36,6 +39,7 @@ public class ClassNamingConventionsRule extends AbstractNamingConventionsRule {
 
     public ClassNamingConventionsRule() {
         definePropertyDescriptor(TEST_CLASS_REGEX);
+        definePropertyDescriptor(INNER_CLASS_REGEX);
         definePropertyDescriptor(ABSTRACT_CLASS_REGEX);
         definePropertyDescriptor(CLASS_REGEX);
         definePropertyDescriptor(INTERFACE_REGEX);
@@ -53,6 +57,8 @@ public class ClassNamingConventionsRule extends AbstractNamingConventionsRule {
             checkMatches(TEST_CLASS_REGEX, node, data);
         } else if (node.getModifiers().isAbstract()) {
             checkMatches(ABSTRACT_CLASS_REGEX, node, data);
+        } else if (node.getParent() instanceof ASTUserClass) {
+            checkMatches(INNER_CLASS_REGEX, node, data);
         } else {
             checkMatches(CLASS_REGEX, node, data);
         }


### PR DESCRIPTION


## Describe the PR

Added inner classes to ClassNamingConventionsRule, and added property to support name checking for inner classes.

## Related issues

None (this was uncovered while developing custom rules for Apex

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

