### PR TITLE
[apex] Use case-insensitive lexer for CPD

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -15,6 +15,8 @@ This is a {{ site.pmd.release_type }} release.
 ### 🚀 New and noteworthy
 
 ### 🐛 Fixed Issues
+* apex
+  * [#5053](https://github.com/pmd/pmd/issues/5053): \[apex] CPD fails to parse string literals with escaped characters
 
 ### 🚨 API Changes
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/cpd/ApexCpdLexer.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/cpd/ApexCpdLexer.java
@@ -9,37 +9,35 @@ import java.util.Locale;
 
 import org.antlr.v4.runtime.CharStream;
 import org.antlr.v4.runtime.CharStreams;
-import org.antlr.v4.runtime.Token;
 
 import net.sourceforge.pmd.cpd.CpdLexer;
 import net.sourceforge.pmd.cpd.TokenFactory;
+import net.sourceforge.pmd.lang.ast.impl.antlr4.AntlrToken;
+import net.sourceforge.pmd.lang.ast.impl.antlr4.AntlrTokenManager;
 import net.sourceforge.pmd.lang.document.TextDocument;
 
 import com.nawforce.apexparser.ApexLexer;
+import com.nawforce.apexparser.CaseInsensitiveInputStream;
 
 public class ApexCpdLexer implements CpdLexer {
     @Override
     public void tokenize(TextDocument document, TokenFactory tokenEntries) throws IOException {
 
         CharStream charStream = CharStreams.fromReader(document.newReader());
-        ApexLexer lexer = new ApexLexer(charStream);
+        CaseInsensitiveInputStream caseInsensitiveInputStream = new CaseInsensitiveInputStream(charStream);
+        ApexLexer lexer = new ApexLexer(caseInsensitiveInputStream);
+        AntlrTokenManager tokenManager = new AntlrTokenManager(lexer, document);
 
-        Token token = lexer.nextToken();
+        AntlrToken token = tokenManager.getNextToken();
 
-        while (token.getType() != Token.EOF) {
-            if (token.getChannel() == ApexLexer.DEFAULT_TOKEN_CHANNEL) { // exclude WHITESPACE_CHANNEL and COMMENT_CHANNEL
-                String tokenText = token.getText();
+        while (!token.isEof()) {
+            if (token.isDefault()) { // excludes WHITESPACE_CHANNEL and COMMENT_CHANNEL
+                String tokenText = token.getImage();
                 // be case-insensitive
                 tokenText = tokenText.toLowerCase(Locale.ROOT);
-                tokenEntries.recordToken(
-                    tokenText,
-                    token.getLine(),
-                    token.getCharPositionInLine() + 1,
-                    token.getLine(),
-                    token.getCharPositionInLine() + tokenText.length() + 1
-                );
+                tokenEntries.recordToken(tokenText, token.getReportLocation());
             }
-            token = lexer.nextToken();
+            token = tokenManager.getNextToken();
         }
     }
 }

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/cpd/ApexCpdLexerTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/cpd/ApexCpdLexerTest.java
@@ -32,4 +32,14 @@ class ApexCpdLexerTest extends CpdTextComparisonTest {
     void testTabWidth() {
         doTest("tabWidth");
     }
+
+    @Test
+    void lexExceptionExpected() {
+        expectLexException("class Foo { String s = \"not a string literal\"; }");
+    }
+
+    @Test
+    void caseInsensitiveStringLiterals() {
+        doTest("StringLiterals5053");
+    }
 }

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/cpd/testdata/StringLiterals5053.cls
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/cpd/testdata/StringLiterals5053.cls
@@ -1,0 +1,12 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+// See https://github.com/pmd/pmd/issues/5053
+
+public with sharing class PMD7CPD {
+    public static void example(){
+      String str = 'alice';
+      str = str.replace('alice', '<bob></charlie>dan<!--JohannHeinrichvonThünen-->' + '\u00A0' + '"100%"');
+    }
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/cpd/testdata/StringLiterals5053.txt
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/cpd/testdata/StringLiterals5053.txt
@@ -1,0 +1,43 @@
+    [Image] or [Truncated image[            Bcol      Ecol
+L7
+    [public]                                1         7
+    [with]                                  8         12
+    [sharing]                               13        20
+    [class]                                 21        26
+    [pmd7cpd]                               27        34
+    [{]                                     35        36
+L8
+    [public]                                5         11
+    [static]                                12        18
+    [void]                                  19        23
+    [example]                               24        31
+    [(]                                     31        32
+    [)]                                     32        33
+    [{]                                     33        34
+L9
+    [string]                                7         13
+    [str]                                   14        17
+    [=]                                     18        19
+    ['alice']                               20        27
+    [;]                                     27        28
+L10
+    [str]                                   7         10
+    [=]                                     11        12
+    [str]                                   13        16
+    [.]                                     16        17
+    [replace]                               17        24
+    [(]                                     24        25
+    ['alice']                               25        32
+    [,]                                     32        33
+    ['<bob></charlie>dan<!--johannheinr[    34        84
+    [+]                                     85        86
+    ['\\u00a0']                             87        95
+    [+]                                     96        97
+    ['"100%"']                              98        106
+    [)]                                     106       107
+    [;]                                     107       108
+L11
+    [}]                                     5         6
+L12
+    [}]                                     1         2
+EOF


### PR DESCRIPTION
## Describe the PR

This makes it consistent with how the ApexParser
reads the files. And the case-sensitive ANTLR
rules (e.g. for string literals) work that
way.

Also, by using the AntlrTokenManager, we now fail with a LexException if we can't parse (and don't silently ignore such problems).

## Related issues

- Fixes #5053

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

