### PR TITLE
[doc] Fix outdated classname in example

### DIFF
--- a/docs/pages/pmd/userdocs/extending/your_first_rule.md
+++ b/docs/pages/pmd/userdocs/extending/your_first_rule.md
@@ -127,7 +127,7 @@ copy-paste into your ruleset XML. The resulting element looks like so:
 <rule name="DontCallBossShort"
       language="java"
       message="Boss wants to talk to you."
-      class="net.sourceforge.pmd.lang.rule.xpath.XPathRule">
+      class="net.sourceforge.pmd.lang.rule.XPathRule">
     <description>
         TODO
     </description>


### PR DESCRIPTION
The class is in a new place.

## Describe the PR

Updates outdated documentation.