### PR TITLE
[core] Fix memory usage regression in CPD

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/MatchCollector.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/MatchCollector.java
@@ -68,7 +68,7 @@ class MatchCollector {
          *  - BC
          * It should be reduced to a single match with 3 marks
          */
-        if (tokenMatchSets.computeIfAbsent(mark1.getIndex(), HashSet::new).contains(mark2.getIndex())) {
+        if (tokenMatchSets.computeIfAbsent(mark1.getIndex(), (i) -> new HashSet<>()).contains(mark2.getIndex())) {
             return;
         }
 
@@ -76,7 +76,7 @@ class MatchCollector {
         // always rely on the lowest mark index, as that's the order in which process them
         final int lowestKey = tokenMatchSets.get(mark1.getIndex()).stream().reduce(mark1.getIndex(), Math::min);
 
-        List<Match> matches = matchTree.computeIfAbsent(lowestKey, ArrayList::new);
+        List<Match> matches = matchTree.computeIfAbsent(lowestKey, (i) -> new ArrayList<>());
         Iterator<Match> matchIterator = matches.iterator();
         while (matchIterator.hasNext()) {
             Match m = matchIterator.next();
@@ -116,8 +116,8 @@ class MatchCollector {
     }
 
     private void registerTokenMatch(TokenEntry mark1, TokenEntry mark2) {
-        tokenMatchSets.computeIfAbsent(mark1.getIndex(), HashSet::new).add(mark2.getIndex());
-        tokenMatchSets.computeIfAbsent(mark2.getIndex(), HashSet::new).add(mark1.getIndex());
+        tokenMatchSets.computeIfAbsent(mark1.getIndex(), (i) -> new HashSet<>()).add(mark2.getIndex());
+        tokenMatchSets.computeIfAbsent(mark2.getIndex(), (i) -> new HashSet<>()).add(mark1.getIndex());
     }
 
     List<Match> getMatches() {


### PR DESCRIPTION
 - inadvertently I was using the constructor that received an int as initial capacity, which instantiated massive collections leading to an increase in memory usage.

## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #5066 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

