### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,23 @@
 version: 2
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "master"
-    open-pull-requests-limit: 0
+  - package-ecosystem: "bundler"
+    directories:
+      - "/"
+      - "/docs"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-gems:
+        patterns: [ "*" ]
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
-    target-branch: "master"
+    groups:
+      all-actions:
+        patterns: [ "*" ]

--- a/do-release.sh
+++ b/do-release.sh
@@ -126,21 +126,43 @@ echo "Press enter to continue..."
 read -r
 
 
-# calculating stats for release notes
+# determine current milestone
+MILESTONE_JSON=$(curl -s "https://api.github.com/repos/pmd/pmd/milestones?state=all&direction=desc&per_page=5"|jq ".[] | select(.title == \"$RELEASE_VERSION\")")
+MILESTONE=$(echo "$MILESTONE_JSON" | jq .number)
 
+# determine dependency updates
+DEPENDENCIES_JSON=$(curl -s "https://api.github.com/repos/pmd/pmd/issues?labels=dependencies&state=closed&direction=asc&per_page=50&page=1&milestone=${MILESTONE}")
+DEPENDENCIES_COUNT=$(echo "$DEPENDENCIES_JSON" | jq length)
+DEPENDENCIES=""
+if [ $DEPENDENCIES_COUNT -gt 0 ]; then
+  DEPENDENCIES=$(
+    echo "### 📦 Dependency updates"
+    echo "$DEPENDENCIES_JSON" | jq --raw-output '.[] | "* [#\(.number)](https://github.com/pmd/pmd/issues/\(.number)): \(.title)"'
+  )
+else
+  DEPENDENCIES=$(
+    echo "### 📦 Dependency updates"
+    echo "No dependency updates"
+  )
+fi
+
+# calculating stats for release notes (excluding dependency updates)
+STATS_CLOSED_ISSUES=$(echo "$MILESTONE_JSON" | jq .closed_issues)
 STATS=$(
 echo "### 📈 Stats"
 echo "* $(git log pmd_releases/"${LAST_VERSION}"..HEAD --oneline --no-merges |wc -l) commits"
-echo "* $(curl -s "https://api.github.com/repos/pmd/pmd/milestones?state=all&direction=desc&per_page=5"|jq ".[] | select(.title == \"$RELEASE_VERSION\") | .closed_issues") closed tickets & PRs"
+echo "* $(($STATS_CLOSED_ISSUES - $DEPENDENCIES_COUNT)) closed tickets & PRs"
 echo "* Days since last release: $(( ( $(date +%s) - $(git log --max-count=1 --format="%at" pmd_releases/"${LAST_VERSION}") ) / 86400))"
 )
 
+
 TEMP_RELEASE_NOTES=$(cat docs/pages/release_notes.md)
-TEMP_RELEASE_NOTES=${TEMP_RELEASE_NOTES/\{\% endtocmaker \%\}/${STATS//\&/\\\&}$'\n'$'\n'\{\% endtocmaker \%\}}
+TEMP_RELEASE_NOTES=${TEMP_RELEASE_NOTES/\{\% endtocmaker \%\}/${DEPENDENCIES//\&/\\\&}$'\n'$'\n'${STATS//\&/\\\&}$'\n'$'\n'\{\% endtocmaker \%\}}
 echo "${TEMP_RELEASE_NOTES}" > docs/pages/release_notes.md
 
 echo
-echo "Updated stats in release notes:"
+echo "Updated dependencies and stats in release notes:"
+echo "$DEPENDENCIES"
 echo "$STATS"
 echo
 echo "Please verify docs/pages/release_notes.md"


### PR DESCRIPTION
## Describe the PR

- dependabot runs weekly
- github-action and bundler are creating a single PR for updating
- also integrate automatic release notes generation

More info:
- https://github.blog/2024-05-02-dependabot-on-github-actions-and-self-hosted-runners-is-now-generally-available/
  I've enabled this option for us, so we should see the dependabot runs under https://github.com/pmd/pmd/actions
- reference doc: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
- for pmd-github-action, we already use it: https://github.com/pmd/pmd-github-actions/blob/main/.github/dependabot.yml
- by default, the created PRs are labeled with "dependencies". When merging them, we must assign them to the correct milestone, to keep track, what is in a release.

## Related issues

- none

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

