### PR TITLE
[core] Don't log warning about skipLexicalErrors twice

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -15,6 +15,8 @@ This is a {{ site.pmd.release_type }} release.
 ### 🚀 New and noteworthy
 
 ### 🐛 Fixed Issues
+* core
+  * [#5091](https://github.com/pmd/pmd/issues/5091): \[core] PMD CPD v7.3.0 gives deprecation warning for skipLexicalErrors even when not used
 
 ### 🚨 API Changes
 

--- a/pmd-ant/src/main/java/net/sourceforge/pmd/ant/CPDTask.java
+++ b/pmd-ant/src/main/java/net/sourceforge/pmd/ant/CPDTask.java
@@ -111,9 +111,6 @@ public class CPDTask extends Task {
                         + "Use failOnError=\"false\" to not fail the build.", Project.MSG_WARN);
             }
 
-            // implicitly enable skipLexicalErrors, so that we can fail the build at the end. A report is created in any case.
-            config.setSkipLexicalErrors(true);
-
             config.setIgnoreAnnotations(ignoreAnnotations);
             config.setIgnoreLiterals(ignoreLiterals);
             config.setIgnoreIdentifiers(ignoreIdentifiers);

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/CpdCommand.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/CpdCommand.java
@@ -124,7 +124,6 @@ public class CpdCommand extends AbstractAnalysisPmdSubcommand<CPDConfiguration> 
         configuration.setRendererName(rendererName);
         configuration.setSkipBlocksPattern(skipBlocksPattern);
         configuration.setSkipDuplicates(skipDuplicates);
-        configuration.setSkipLexicalErrors(skipLexicalErrors);
         configuration.setSourceEncoding(encoding.getEncoding());
         configuration.setInputUri(uri);
 
@@ -132,9 +131,6 @@ public class CpdCommand extends AbstractAnalysisPmdSubcommand<CPDConfiguration> 
             configuration.getReporter().warn("--skip-lexical-errors is deprecated. Use --no-fail-on-error instead.");
             configuration.setFailOnError(false);
         }
-
-        // implicitly enable skipLexicalErrors, so that we can fail the build at the end. A report is created in any case.
-        configuration.setSkipLexicalErrors(true);
 
         return configuration;
     }

--- a/pmd-cli/src/test/java/net/sourceforge/pmd/cli/BaseCliTest.java
+++ b/pmd-cli/src/test/java/net/sourceforge/pmd/cli/BaseCliTest.java
@@ -5,7 +5,7 @@
 package net.sourceforge.pmd.cli;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.emptyString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.ByteArrayOutputStream;
@@ -146,7 +146,7 @@ abstract class BaseCliTest {
         }
 
         public void checkNoErrorOutput() {
-            checkStdErr(equalTo(""));
+            checkStdErr(emptyString());
         }
 
         public void checkStdOut(Matcher<? super String> matcher) {

--- a/pmd-cli/src/test/java/net/sourceforge/pmd/cli/CpdCliTest.java
+++ b/pmd-cli/src/test/java/net/sourceforge/pmd/cli/CpdCliTest.java
@@ -239,8 +239,22 @@ class CpdCliTest extends BaseCliTest {
                "--skip-lexical-errors")
             .verify(r -> {
                 r.checkStdErr(containsPattern("Skipping file: Lexical error in file .*?BadFile\\.java"));
+                r.checkStdErr(containsString("--skip-lexical-errors is deprecated. Use --no-fail-on-error instead."));
                 r.checkStdOut(containsString("Found a 5 line (13 tokens) duplication"));
             });
+    }
+
+    /**
+     * @see <a href="https://github.com/pmd/pmd/issues/5091">[core] PMD CPD v7.3.0 gives deprecation warning for skipLexicalErrors even when not used #5091</a>
+     * @throws Exception
+     */
+    @Test
+    void noWarningsWithoutSkipLexicalErrors() throws Exception {
+        runCliSuccessfully("--minimum-tokens", "340", "--language", "java", "--dir", SRC_DIR, "--format", "text")
+                .verify(r -> {
+                    r.checkNoErrorOutput();
+                    r.checkStdOut(emptyString());
+                });
     }
 
     @Test

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDConfiguration.java
@@ -67,7 +67,8 @@ public class CPDConfiguration extends AbstractConfiguration {
     private boolean ignoreIdentifierAndLiteralSequences = false;
 
     @Deprecated
-    private boolean skipLexicalErrors = false;
+    // Note: The default value was false until up to 7.3.0 and is true since 7.4.0
+    private boolean skipLexicalErrors = true;
 
     private boolean noSkipBlocks = false;
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CpdAnalysis.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CpdAnalysis.java
@@ -153,10 +153,6 @@ public final class CpdAnalysis implements AutoCloseable {
 
     @SuppressWarnings("PMD.CloseResource")
     public void performAnalysis(Consumer<CPDReport> consumer) {
-        if (configuration.isSkipLexicalErrors()) {
-            LOGGER.warn("The option skipLexicalErrors is deprecated. Use failOnError instead.");
-        }
-
         try (SourceManager sourceManager = new SourceManager(files.getCollectedFiles())) {
             Map<Language, CpdLexer> tokenizers =
                 sourceManager.getTextFiles().stream()

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CpdAnalysisTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CpdAnalysisTest.java
@@ -223,7 +223,6 @@ class CpdAnalysisTest {
         PmdReporter reporter = mock(PmdReporter.class);
         config.setReporter(reporter);
 
-        config.setSkipLexicalErrors(true); // must be true, otherwise CPD is aborted with first processing error
         try (CpdAnalysis cpd = CpdAnalysis.create(config)) {
             assertTrue(cpd.files().addSourceFile(FileId.fromPathLikeString("foo.dummy"), DummyLanguageModule.CPD_THROW_LEX_EXCEPTION));
             assertTrue(cpd.files().addSourceFile(FileId.fromPathLikeString("foo2.dummy"), DummyLanguageModule.CPD_THROW_MALFORMED_SOURCE_EXCEPTION));
@@ -252,7 +251,6 @@ class CpdAnalysisTest {
         PmdReporter reporter = mock(PmdReporter.class);
         config.setReporter(reporter);
 
-        config.setSkipLexicalErrors(true);
         try (CpdAnalysis cpd = CpdAnalysis.create(config)) {
             assertTrue(cpd.files().addSourceFile(FileId.fromPathLikeString("foo.dummy"), DummyLanguageModule.CPD_THROW_LEX_EXCEPTION));
             assertTrue(cpd.files().addSourceFile(FileId.fromPathLikeString("foo2.dummy"), DummyLanguageModule.CPD_THROW_MALFORMED_SOURCE_EXCEPTION));


### PR DESCRIPTION
## Related issues

- Fixes #5091

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

