### PR TITLE
[java] Exclude constructor with lombok.Builder for MissingStaticMethodInNonInstantiatableClass

### DIFF
--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2086,7 +2086,7 @@ See the property `annotations`.
         </description>
         <priority>3</priority>
         <properties>
-            <property name="annotations" type="List[String]" value="org.springframework.beans.factory.annotation.Autowired,javax.inject.Inject,com.google.inject.Inject" description="If a constructor is annotated with one of these annotations, then the class is ignored."/>
+            <property name="annotations" type="List[String]" value="org.springframework.beans.factory.annotation.Autowired,javax.inject.Inject,com.google.inject.Inject,lombok.Builder" description="If a constructor is annotated with one of these annotations, then the class is ignored."/>
             <property name="xpath">
                 <value>
 <![CDATA[

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/MissingStaticMethodInNonInstantiatableClass.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/MissingStaticMethodInNonInstantiatableClass.xml
@@ -593,4 +593,16 @@ public class Bar extends Foo {
 ]]></code>
     </test-code>
 
+    <test-code>
+        <description>#1488:[java]false-positive about MissingStaticMethodInNonInstantiatableClass and @lombok.Builder</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import lombok.Builder;
+public class Foo {
+   @Builder
+   private Foo() {}
+}
+]]></code>
+    </test-code>
+
 </test-data>


### PR DESCRIPTION
## Describe the PR

Do not report MissingStaticMethodInNonInstantiatableClass for private constructor with `@lombok.Builder`

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #1488

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [*] Added unit tests for fixed bug/feature
- [*] Passing all unit tests
- [*] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [*] Added (in-code) documentation (if needed)

