### PR TITLE
[cli] Fix pmd.bat for Windows when starting designer with JAVAFX_HOME

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -38,6 +38,8 @@ This is a {{ site.pmd.release_type }} release.
   * [#5086](https://github.com/pmd/pmd/pull/5086): \[plsql] Fixed issue with missing optional table alias in MERGE usage
   * [#5087](https://github.com/pmd/pmd/pull/5087): \[plsql] Add support for SQL_MACRO
   * [#5088](https://github.com/pmd/pmd/pull/5088): \[plsql] Add support for 'DEFAULT' clause on the arguments of some oracle functions
+* cli
+  * [#5120](https://github.com/pmd/pmd/issues/5120): \[cli] Can't start designer under Windows
 
 ### 🚨 API Changes
 

--- a/pmd-dist/src/main/resources/scripts/pmd.bat
+++ b/pmd-dist/src/main/resources/scripts/pmd.bat
@@ -67,8 +67,10 @@ if %_needjfxlib% EQU 1 (
     )
     rem The wildcard will include only jar files, but we need to access also
     rem property files such as javafx.properties that lay bare in the dir
-    set pmd_classpath=%TOPDIR%\conf;%TOPDIR%\lib\*;%JAVAFX_HOME%\lib\*;%JAVAFX_HOME%\lib\
+    rem note: no trailing backslash, as this would escape a following quote when %pmd_classpath% is used later
+    set pmd_classpath=%TOPDIR%\conf;%TOPDIR%\lib\*;%JAVAFX_HOME%\lib\*;%JAVAFX_HOME%\lib
 ) else (
+    rem note: no trailing backslash, as this would escape a following quote when %pmd_classpath% is used later
     set pmd_classpath=%TOPDIR%\conf;%TOPDIR%\lib\*
 )
 


### PR DESCRIPTION
## Describe the PR

The fix is to just remove the trailing backslash...

I did some more testing, and for me it looks good:

Test Matrix:

|Test|Result 🟢 🔴|
|----|------|
|cmd| |
|JAVA_HOME without spaces, JAVAFX_HOME without spaces, PMD_HOME without spaces| |
|`pmd check --help`|🟢|
|`pmd designer`|🟢|
|JAVA_HOME with spaces, JAVAFX_HOME without spaces, PMD_HOME without spaces| |
|`pmd check --help`|🟢|
|`pmd designer`|🟢|
|JAVA_HOME without spaces, JAVAFX_HOME with spaces, PMD_HOME without spaces| |
|`pmd check --help`|🟢|
|`pmd designer`|🟢|
|JAVA_HOME without spaces, JAVAFX_HOME without spaces, PMD_HOME with spaces| |
|`pmd check --help`|🟢|
|`pmd designer`|🟢|
|powershell| |
|JAVA_HOME without spaces, JAVAFX_HOME without spaces, PMD_HOME without spaces| |
|`.\pmd check --help`|🟢|
|`.\pmd designer`|🟢|
|JAVA_HOME with spaces, JAVAFX_HOME without spaces, PMD_HOME without spaces| |
|`.\pmd check --help`|🟢|
|`.\pmd designer`|🟢|
|JAVA_HOME without spaces, JAVAFX_HOME with spaces, PMD_HOME without spaces| |
|`.\pmd check --help`|🟢|
|`.\pmd designer`|🟢|
|JAVA_HOME without spaces, JAVAFX_HOME without spaces, PMD_HOME with spaces| |
|`.\pmd check --help`|🟢|
|`.\pmd designer`|🟢|
|git bash (is not using pmd.bat)| |
|JAVA_HOME without spaces, JAVAFX_HOME without spaces, PMD_HOME without spaces| |
|`./pmd check --help`|🟢|
|`./pmd designer`|🟢|
|JAVA_HOME with spaces, JAVAFX_HOME without spaces, PMD_HOME without spaces| |
|`./pmd check --help`|🟢|
|`./pmd designer`|🟢|
|JAVA_HOME without spaces, JAVAFX_HOME with spaces, PMD_HOME without spaces| |
|`./pmd check --help`|🟢|
|`./pmd designer`|🟢|
|JAVA_HOME without spaces, JAVAFX_HOME without spaces, PMD_HOME with spaces| |
|`./pmd check --help`|🟢|
|`./pmd designer`|🟢|



## Related issues

- Fixes #5120

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

