### PR TITLE
[javascript] Bump rhino from 1.7.14 to 1.7.15

### DIFF
--- a/pmd-javascript/pom.xml
+++ b/pmd-javascript/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>org.mozilla</groupId>
             <artifactId>rhino</artifactId>
-            <version>1.7.14</version>
+            <version>1.7.15</version>
         </dependency>
 
         <dependency>

--- a/pmd-javascript/src/test/resources/net/sourceforge/pmd/lang/ecmascript/ast/testdata/jquery-selector.txt
+++ b/pmd-javascript/src/test/resources/net/sourceforge/pmd/lang/ecmascript/ast/testdata/jquery-selector.txt
@@ -792,7 +792,7 @@
                   |     |                    |     +- Name
                   |     |                    +- CatchClause
                   |     |                    |  +- Name
-                  |     |                    |  +- Block
+                  |     |                    |  +- Scope
                   |     |                    |     +- ExpressionStatement
                   |     |                    |        +- FunctionCall
                   |     |                    |           +- Name
@@ -1265,7 +1265,7 @@
                   |           |        |        +- Name
                   |           |        +- CatchClause
                   |           |           +- Name
-                  |           |           +- Block
+                  |           |           +- Scope
                   |           |              +- ExpressionStatement
                   |           |                 +- FunctionCall
                   |           |                    +- Name


### PR DESCRIPTION
## Describe the PR

Just a small update to [Rhino 1.7.15](https://github.com/mozilla/rhino/releases/tag/Rhino1_7_15_Release).
I don't think, it is necessary to mention this in the release notes.

## Related issues

- None

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

