### PR TITLE
[java] Revamp GuardLogStatementRule to allow var, field and array accesses

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -19,6 +19,7 @@ This is a {{ site.pmd.release_type }} release.
   * [#5139](https://github.com/pmd/pmd/issues/5139): \[apex] OperationWithHighCostInLoop not firing in triggers
 * java-bestpractices
   * [#5151](https://github.com/pmd/pmd/issues/5151): \[java] GuardLogStatement: Should not need to guard parameterized log messages where the replacement arg is a constant from another class
+  * [#5152](https://github.com/pmd/pmd/issues/5152): \[java] GuardLogStatement: Should not need to guard parameterized log messages where the replacement arg is "this"
 * plsql-bestpractices
   * [#5132](https://github.com/pmd/pmd/issues/5132): \[plsql] TomKytesDespair - exception for more complex exception handler
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -17,6 +17,8 @@ This is a {{ site.pmd.release_type }} release.
 ### 🐛 Fixed Issues
 * apex-performance
   * [#5139](https://github.com/pmd/pmd/issues/5139): \[apex] OperationWithHighCostInLoop not firing in triggers
+* java-bestpractices
+  * [#5151](https://github.com/pmd/pmd/issues/5151): \[java] GuardLogStatement: Should not need to guard parameterized log messages where the replacement arg is a constant from another class
 * plsql-bestpractices
   * [#5132](https://github.com/pmd/pmd/issues/5132): \[plsql] TomKytesDespair - exception for more complex exception handler
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -21,6 +21,7 @@ This is a {{ site.pmd.release_type }} release.
   * [#5167](https://github.com/pmd/pmd/pull/5167): \[java] java.lang.IllegalArgumentException: \<\?\> cannot be a wildcard bound
 * java-bestpractices
   * [#3602](https://github.com/pmd/pmd/issues/3602): \[java] GuardLogStatement: False positive when compile-time constant is created from external constants
+  * [#4731](https://github.com/pmd/pmd/issues/4731): \[java] GuardLogStatement documentation is unclear why getters are flagged
   * [#5145](https://github.com/pmd/pmd/issues/5145): \[java] False positive UnusedPrivateMethod
   * [#5151](https://github.com/pmd/pmd/issues/5151): \[java] GuardLogStatement: Should not need to guard parameterized log messages where the replacement arg is a constant from another class
   * [#5152](https://github.com/pmd/pmd/issues/5152): \[java] GuardLogStatement: Should not need to guard parameterized log messages where the replacement arg is "this"

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -20,6 +20,7 @@ This is a {{ site.pmd.release_type }} release.
 * java-bestpractices
   * [#5151](https://github.com/pmd/pmd/issues/5151): \[java] GuardLogStatement: Should not need to guard parameterized log messages where the replacement arg is a constant from another class
   * [#5152](https://github.com/pmd/pmd/issues/5152): \[java] GuardLogStatement: Should not need to guard parameterized log messages where the replacement arg is "this"
+  * [#5153](https://github.com/pmd/pmd/issues/5153): \[java] GuardLogStatement: Should not need to guard parameterized log messages where the replacement arg is an array element
 * plsql-bestpractices
   * [#5132](https://github.com/pmd/pmd/issues/5132): \[plsql] TomKytesDespair - exception for more complex exception handler
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -18,6 +18,7 @@ This is a {{ site.pmd.release_type }} release.
 * apex-performance
   * [#5139](https://github.com/pmd/pmd/issues/5139): \[apex] OperationWithHighCostInLoop not firing in triggers
 * java-bestpractices
+  * [#3602](https://github.com/pmd/pmd/issues/3602): \[java] GuardLogStatement: False positive when compile-time constant is created from external constants
   * [#5145](https://github.com/pmd/pmd/issues/5145): \[java] False positive UnusedPrivateMethod
   * [#5151](https://github.com/pmd/pmd/issues/5151): \[java] GuardLogStatement: Should not need to guard parameterized log messages where the replacement arg is a constant from another class
   * [#5152](https://github.com/pmd/pmd/issues/5152): \[java] GuardLogStatement: Should not need to guard parameterized log messages where the replacement arg is "this"

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
@@ -15,6 +15,7 @@ import java.util.Map;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
+import net.sourceforge.pmd.lang.java.ast.ASTArrayAccess;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignableExpr.ASTNamedReferenceExpr;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTExpressionStatement;
@@ -239,9 +240,14 @@ public class GuardLogStatementRule extends AbstractJavaRulechainRule {
         // so that we can ignore it
         return call.getArguments().toStream()
                    .drop(messageArgIndex) // remove the level argument if needed
-                   .all(it -> it instanceof ASTStringLiteral || it instanceof ASTLambdaExpression
-                           || it instanceof ASTVariableAccess || it instanceof ASTMethodReference
-                           || it instanceof ASTFieldAccess || it instanceof ASTThisExpression);
+                   .all(GuardLogStatementRule::isDirectAccess);
+    }
+
+    private static boolean isDirectAccess(ASTExpression it) {
+        return it instanceof ASTStringLiteral || it instanceof ASTLambdaExpression
+                || it instanceof ASTVariableAccess || it instanceof ASTMethodReference
+                || it instanceof ASTFieldAccess || it instanceof ASTThisExpression
+                || (it instanceof ASTArrayAccess && isDirectAccess(((ASTArrayAccess) it).getQualifier()) );
     }
 
     private void extractProperties() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
@@ -25,6 +25,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTLambdaExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodReference;
 import net.sourceforge.pmd.lang.java.ast.ASTStringLiteral;
+import net.sourceforge.pmd.lang.java.ast.ASTThisExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableAccess;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
 import net.sourceforge.pmd.lang.java.ast.BinaryOp;
@@ -240,7 +241,7 @@ public class GuardLogStatementRule extends AbstractJavaRulechainRule {
                    .drop(messageArgIndex) // remove the level argument if needed
                    .all(it -> it instanceof ASTStringLiteral || it instanceof ASTLambdaExpression
                            || it instanceof ASTVariableAccess || it instanceof ASTMethodReference
-                           || it instanceof ASTFieldAccess);
+                           || it instanceof ASTFieldAccess || it instanceof ASTThisExpression);
     }
 
     private void extractProperties() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
@@ -18,6 +18,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTAssignableExpr.ASTNamedReferenceExpr;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTExpressionStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTFieldAccess;
 import net.sourceforge.pmd.lang.java.ast.ASTIfStatement;
 import net.sourceforge.pmd.lang.java.ast.ASTInfixExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTLambdaExpression;
@@ -237,7 +238,9 @@ public class GuardLogStatementRule extends AbstractJavaRulechainRule {
         // so that we can ignore it
         return call.getArguments().toStream()
                    .drop(messageArgIndex) // remove the level argument if needed
-                   .all(it -> it instanceof ASTStringLiteral || it instanceof ASTLambdaExpression || it instanceof ASTVariableAccess || it instanceof ASTMethodReference);
+                   .all(it -> it instanceof ASTStringLiteral || it instanceof ASTLambdaExpression
+                           || it instanceof ASTVariableAccess || it instanceof ASTMethodReference
+                           || it instanceof ASTFieldAccess);
     }
 
     private void extractProperties() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
@@ -247,7 +247,7 @@ public class GuardLogStatementRule extends AbstractJavaRulechainRule {
         return it instanceof ASTStringLiteral || it instanceof ASTLambdaExpression
                 || it instanceof ASTVariableAccess || it instanceof ASTMethodReference
                 || it instanceof ASTFieldAccess || it instanceof ASTThisExpression
-                || (it instanceof ASTArrayAccess && isDirectAccess(((ASTArrayAccess) it).getQualifier()) );
+                || (it instanceof ASTArrayAccess && isDirectAccess(((ASTArrayAccess) it).getQualifier()));
     }
 
     private void extractProperties() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
@@ -113,6 +113,7 @@ public class GuardLogStatementRule extends AbstractJavaRulechainRule {
         return null;
     }
 
+    @SuppressWarnings("PMD.SimplifyBooleanReturns")
     private boolean needsGuard(ASTMethodCall node) {
         if (node.getArguments().isEmpty()) {
             return false;

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -603,7 +603,7 @@ for (int i = 0, j = 0; i < 10; i++, j += 2) {
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_bestpractices.html#guardlogstatement">
         <description>
 Whenever using a log level, one should check if the loglevel is actually enabled, or
-otherwise skip the associate String creation and manipulation.
+otherwise skip the associate String creation and manipulation, as well as any expensive method calls.
 
 An alternative to checking the log level are substituting parameters, formatters or lazy logging
 with lambdas. The available alternatives depend on the actual logging framework.
@@ -611,7 +611,7 @@ with lambdas. The available alternatives depend on the actual logging framework.
         <priority>2</priority>
         <example>
 <![CDATA[
-// Add this for performance
+// Add this for performance - avoid manipulating strings if the logger may drop it
 if (log.isDebugEnabled()) {
     log.debug("log something" + param1 + " and " + param2 + "concat strings");
 }
@@ -621,6 +621,9 @@ log.debug("log something {} and {}", param1, param2);
 
 // Avoid the guarding if statement with formatters
 log.debug("log something %s and %s", param1, param2);
+
+// This is still an issue, method invocations may be expensive / have side-effects
+log.debug("log something expensive: {}", calculateExpensiveLoggingText());
 
 // Avoid the guarding if statement with lazy logging and lambdas
 log.debug("log something expensive: {}", () -> calculateExpensiveLoggingText());

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -602,8 +602,8 @@ for (int i = 0, j = 0; i < 10; i++, j += 2) {
           class="net.sourceforge.pmd.lang.java.rule.bestpractices.GuardLogStatementRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_bestpractices.html#guardlogstatement">
         <description>
-Whenever using a log level, one should check if the loglevel is actually enabled, or
-otherwise skip the associate String creation and manipulation, as well as any expensive method calls.
+Whenever using a log level, one should check if it is actually enabled, or
+otherwise skip the associate String creation and manipulation, as well as any method calls.
 
 An alternative to checking the log level are substituting parameters, formatters or lazy logging
 with lambdas. The available alternatives depend on the actual logging framework.
@@ -627,6 +627,9 @@ log.debug("log something expensive: {}", calculateExpensiveLoggingText());
 
 // Avoid the guarding if statement with lazy logging and lambdas
 log.debug("log something expensive: {}", () -> calculateExpensiveLoggingText());
+
+// … alternatively use method references
+log.debug("log something expensive: {}", this::calculateExpensiveLoggingText);
 ]]>
         </example>
     </rule>

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementTest.java
@@ -8,4 +8,6 @@ import net.sourceforge.pmd.test.PmdRuleTst;
 
 class GuardLogStatementTest extends PmdRuleTst {
     // no additional unit tests
+
+    public static final String TERM_MSG = "A terminating log message.";
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
@@ -581,4 +581,25 @@ public class GuardLogStatementTest {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#5151 Field accesses do not require guards</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
+public class GuardLogStatementTest {
+    private static final Logger LOG = LogManager.getLogger(GuardLogStatementTest.class);
+    private static final String MY_CONSTANT = "";
+
+    public void test() {
+        LOG.info(
+                "Some message here : foo={}",
+                GuardLogStatementTest.MY_CONSTANT
+        );
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
@@ -706,6 +706,31 @@ public class GuardLogStatementTest {
     </test-code>
 
     <test-code>
+        <description>array access with computed keys require guards</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
+public class GuardLogStatementTest {
+    private static final Logger LOG = LogManager.getLogger(GuardLogStatementTest.class);
+    private final String[] foo = { "foo" };
+
+    public void test() {
+        LOG.info(
+            "Some message here : foo={}",
+            foo[getFooIndex()]
+        );
+    }
+
+    public int getFooIndex() {
+        return 0;
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>#5153 array access to method returned values require guards</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
@@ -583,6 +583,31 @@ public class GuardLogStatementTest {
     </test-code>
 
     <test-code>
+        <description>GuardLogStatement should flag method reference from method / constructor calls</description>
+        <expected-problems>2</expected-problems>
+        <code><![CDATA[
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
+public class GuardLogStatementTest {
+    String foo() {
+        return "foo";
+    }
+
+    private GuardLogStatementTest factory() {
+        return new GuardLogStatementTest();
+    }
+
+    public void test() {
+        final Logger logger = LogManager.getLogger(GuardLogStatementTest.class);
+        logger.info("Some info: {}", new GuardLogStatementTest()::foo);
+        logger.info("Some info: {}", factory()::foo);
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>#5151 Field accesses do not require guards</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
@@ -592,12 +617,48 @@ import org.apache.logging.log4j.LogManager;
 public class GuardLogStatementTest {
     private static final Logger LOG = LogManager.getLogger(GuardLogStatementTest.class);
     private static final String MY_CONSTANT = "";
+    private String my_field = "";
 
     public void test() {
         LOG.info(
             "Some message here : foo={}",
             GuardLogStatementTest.MY_CONSTANT
         );
+
+        LOG.info(
+            "Some message here : foo={}",
+            this.my_field
+        );
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#5151 Field accesses on method call returned values require guards</description>
+        <expected-problems>2</expected-problems>
+        <code><![CDATA[
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
+public class GuardLogStatementTest {
+    private static final Logger LOG = LogManager.getLogger(GuardLogStatementTest.class);
+    private String my_field = "";
+
+    public void test() {
+        LOG.info(
+            "Some message here : foo={}",
+            new GuardLogStatementTest().my_field
+        );
+
+        LOG.info(
+            "Some message here : foo={}",
+            factory().my_field
+        );
+    }
+
+    private GuardLogStatementTest factory() {
+        return new GuardLogStatementTest();
     }
 }
         ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
@@ -622,4 +622,49 @@ public class GuardLogStatementTest {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#5153 array access to constants do not require guards</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
+public class GuardLogStatementTest {
+    private static final Logger LOG = LogManager.getLogger(GuardLogStatementTest.class);
+    private final String[] foo = { "foo" };
+
+    public void test() {
+        LOG.info(
+            "Some message here : foo={}",
+            foo[0]
+        );
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#5153 array access to method returned values require guards</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
+public class GuardLogStatementTest {
+    private static final Logger LOG = LogManager.getLogger(GuardLogStatementTest.class);
+
+    public void test() {
+        LOG.info(
+            "Some message here : foo={}",
+            foo()[0]
+        );
+    }
+
+    private String[] foo() {
+        return new String[] { "foo" };
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
@@ -595,8 +595,28 @@ public class GuardLogStatementTest {
 
     public void test() {
         LOG.info(
-                "Some message here : foo={}",
-                GuardLogStatementTest.MY_CONSTANT
+            "Some message here : foo={}",
+            GuardLogStatementTest.MY_CONSTANT
+        );
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#5152 "this" do not require guards</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+
+public class GuardLogStatementTest {
+    private static final Logger LOG = LogManager.getLogger(GuardLogStatementTest.class);
+
+    public void test() {
+        LOG.info(
+            "Some message here : foo={}",
+            this
         );
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/GuardLogStatement.xml
@@ -753,4 +753,22 @@ public class GuardLogStatementTest {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#3602 False positive when compile-time constant is created from external constants</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import net.sourceforge.pmd.lang.java.rule.bestpractices.GuardLogStatementTest;
+
+public class MyClass {
+  private static final Logger logger = LogManager.getLogger();
+  public void doSomething() {
+     final Object arg = new Object();
+     logger.info("Problem message: {}. " + GuardLogStatementTest.TERM_MSG, arg);
+  }
+}
+        ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/InefficientStringBuffering.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/InefficientStringBuffering.xml
@@ -393,8 +393,7 @@ public class Foo {
 
     <test-code>
         <description>No violation: Avoid concat in append method invocations</description>
-        <expected-problems>3</expected-problems>
-        <expected-linenumbers>26,39,45</expected-linenumbers>
+        <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class Foo {
 
@@ -421,16 +420,12 @@ public class Foo {
     }
 
     private String testFinalFieldGood() {
-        return new StringBuilder().append("fld:" + FINAL_F).toString(); //not ok, it's not a compile time constant
+        return new StringBuilder().append("fld:" + FINAL_F).toString(); // good, it's a compile time constant
     }
 
     private String testStaticFinalFieldGood() {
         return new StringBuilder().append("fld:" + STATIC_FINAL_F).toString(); // good
     }
-
-    // the following are not compile-time constants, but
-    // the JVM will very probably constant fold them anyway...
-    // for now, report it
 
     private String testFinalLocalGood() {
         final String local = "local"; // final assumed a constant expression
@@ -441,7 +436,7 @@ public class Foo {
         final String local = "local"; // final assumed a constant expression
         StringBuilder sb = new StringBuilder();
         sb.append("local:" + local); // good
-        return sb.toString;
+        return sb.toString();
     }
 }
         ]]></code>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

- Fixes #3602 
- Fixes #4731
- Fixes #5151
- Fixes #5152
- Fixes #5153

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

