### PR TITLE
[java] Update AvoidSynchronizedAtMethodLevel message to mention ReentrantLock, new rule AvoidSynchronizedStatement

### DIFF
--- a/pmd-java/src/main/resources/category/java/multithreading.xml
+++ b/pmd-java/src/main/resources/category/java/multithreading.xml
@@ -30,7 +30,7 @@ needs mutual exclusion will be locked.
 <![CDATA[
 public class Foo {
     // Try to avoid this:
-    synchronized void bar() {
+    synchronized void foo() {
         // code, that doesn't need synchronization
         // ...
         // code, that requires synchronization
@@ -63,7 +63,7 @@ public class Foo {
     }
 
     // Prefer this:
-    private static Lock CLS_LOCK = new ReentrantLock();
+    private static Lock CLASS_LOCK = new ReentrantLock();
 
     static void barStatic() {
         // code, that doesn't need synchronization

--- a/pmd-java/src/main/resources/category/java/multithreading.xml
+++ b/pmd-java/src/main/resources/category/java/multithreading.xml
@@ -12,13 +12,13 @@ Rules that flag issues when dealing with multiple threads of execution.
     <rule name="AvoidSynchronizedAtMethodLevel"
           language="java"
           since="3.0"
-          message="Use block level rather than method level synchronization"
+          message="Use block level locking rather than method level synchronization"
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_multithreading.html#avoidsynchronizedatmethodlevel">
         <description>
-Method-level synchronization can cause problems when new code is added to the method.
-Block-level synchronization helps to ensure that only the code that needs synchronization
-gets it.
+Method-level synchronization will pin virtual threads and can cause performance problems. Additionally, it can cause
+problems when new code is added to the method.  Block-level ReentrantLock helps to ensure that only the code that
+needs mutual exclusion will be locked.
         </description>
         <priority>3</priority>
         <properties>
@@ -30,7 +30,7 @@ gets it.
 <![CDATA[
 public class Foo {
     // Try to avoid this:
-    synchronized void foo() {
+    synchronized void bar() {
         // code, that doesn't need synchronization
         // ...
         // code, that requires synchronization
@@ -41,13 +41,18 @@ public class Foo {
         // ...
     }
     // Prefer this:
+    Lock instanceLock = new ReentrantLock();
+
     void bar() {
         // code, that doesn't need synchronization
         // ...
-        synchronized(this) {
+        try {
+            instanceLock.lock();  // or instanceLock.tryLock(long time, TimeUnit unit)
             if (!sharedData.has("bar")) {
                 sharedData.add("bar");
             }
+        } finally {
+            instanceLock.unlock();
         }
         // more code, that doesn't need synchronization
         // ...
@@ -58,11 +63,16 @@ public class Foo {
     }
 
     // Prefer this:
+    private static Lock CLS_LOCK = new ReentrantLock();
+
     static void barStatic() {
         // code, that doesn't need synchronization
         // ...
-        synchronized(Foo.class) {
+        try {
+            CLS_LOCK.lock();
             // code, that requires synchronization
+        } finally {
+            CLS_LOCK.unlock();
         }
         // more code, that doesn't need synchronization
         // ...
@@ -71,6 +81,50 @@ public class Foo {
 ]]>
         </example>
     </rule>
+
+  <rule name="AvoidSynchronizedStatement"
+        language="java"
+        since="7.5.0"
+        message="Use ReentrantLock rather than synchronization"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+        externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_multithreading.html#avoidsynchronizedstatement">
+    <description>
+      Synchronization will pin virtual threads and can cause performance problems.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>//SynchronizedStatement</value>
+      </property>
+    </properties>
+    <example>
+      <![CDATA[
+public class Foo {
+    // Try to avoid this:
+    void foo() {
+        // code that doesn't need mutual exclusion
+        synchronized(this) {
+            // code that requires mutual exclusion
+        }
+        // more code that doesn't need mutual exclusion
+    }
+    // Prefer this:
+    Lock instanceLock = new ReentrantLock();
+
+    void foo() {
+        // code that doesn't need mutual exclusion
+        try {
+            instanceLock.lock();  // or instanceLock.tryLock(long time, TimeUnit unit)
+            // code that requires mutual exclusion
+        } finally {
+            instanceLock.unlock();
+        }
+        // more code that doesn't need mutual exclusion
+    }
+}
+]]>
+    </example>
+  </rule>
 
     <rule name="AvoidThreadGroup"
           language="java"

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/AvoidSynchronizedStatementTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/multithreading/AvoidSynchronizedStatementTest.java
@@ -1,0 +1,11 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.multithreading;
+
+import net.sourceforge.pmd.test.PmdRuleTst;
+
+class AvoidSynchronizedStatementTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/AvoidSynchronizedStatement.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/AvoidSynchronizedStatement.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
 
     <test-code>
-        <description>TEST1</description>
+        <description>Synchronized block in instance method</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Foo {
@@ -17,7 +17,7 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>#991 AvoidSynchronizedStatement for static methods</description>
+        <description>Synchronized block in static methods</description>
         <expected-problems>1</expected-problems>
         <code><![CDATA[
 public class Test {
@@ -26,6 +26,17 @@ public class Test {
             // only a block is synchronized on Test.class
         }
     }
+}
+        ]]></code>
+    </test-code>
+    
+    <test-code>
+        <description>synchronized methods are not flagged - we have a separate rule AvoidSynchronizedAtMethodLevel for that</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Test {
+    public synchronized void foo() {}
+    public static synchronized void fooStatic() {}
 }
         ]]></code>
     </test-code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/AvoidSynchronizedStatement.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/multithreading/xml/AvoidSynchronizedStatement.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+    <test-code>
+        <description>TEST1</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void foo () {
+        synchronized(mutex) {}
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#991 AvoidSynchronizedStatement for static methods</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Test {
+    public static void foo() {
+        synchronized(Test.class) {
+            // only a block is synchronized on Test.class
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+</test-data>


### PR DESCRIPTION
see https://openjdk.org/jeps/8337395

## Describe the PR

Modify advice for AvoidSynchronizedAtMethodLevel and add AvoidSynchronizedStatement.
See https://openjdk.org/jeps/8337395 for detailed information about virtual thread pinning concerns.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

