### PR TITLE
Bump checkstyle from 10.14.0 to 10.18.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <argLine>-Xmx512m -Dfile.encoding=${project.build.sourceEncoding} ${extraArgLine}</argLine>
         <extraArgLine /> <!-- empty by default, profiles set it as needed -->
 
-        <pmd.build-tools.version>26</pmd.build-tools.version>
+        <pmd.build-tools.version>27-SNAPSHOT</pmd.build-tools.version>
 
         <pmd-designer.version>7.2.0</pmd-designer.version>
         <javacc.jar>${settings.localRepository}/net/java/dev/javacc/javacc/${javacc.version}/javacc-${javacc.version}.jar</javacc.jar>

--- a/pom.xml
+++ b/pom.xml
@@ -99,8 +99,8 @@
 
         <javacc.version>5.0</javacc.version>
         <surefire.version>3.2.5</surefire.version>
-        <checkstyle.version>10.14.0</checkstyle.version>
-        <checkstyle.plugin.version>3.4.0</checkstyle.plugin.version>
+        <checkstyle.version>10.18.1</checkstyle.version>
+        <checkstyle.plugin.version>3.5.0</checkstyle.plugin.version>
         <pmd.plugin.version>3.24.0</pmd.plugin.version>
         <ant.version>1.10.14</ant.version>
         <javadoc.plugin.version>3.6.3</javadoc.plugin.version>


### PR DESCRIPTION
Also bump maven-checkstyle-plugin from 3.4.0 to 3.5.0

After that, we can update build-tools (see pmd/build-tools#33)

## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

