### PR TITLE
[core] Fix PMD's XMLRenderer to escape CDATA

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -20,6 +20,8 @@ This is a {{ site.pmd.release_type }} release.
     (ApexCRUDViolation, CognitiveComplexity, OperationWithLimitsInLoop)
   * [#5163](https://github.com/pmd/pmd/issues/5163): \[apex] Parser error when using toLabel in SOSL query
   * [#5182](https://github.com/pmd/pmd/issues/5182): \[apex] Parser error when using GROUPING in a SOQL query
+* core
+  * [#5059](https://github.com/pmd/pmd/issues/5059): \[core] xml output doesn't escape CDATA inside its own CDATA
 * java
   * [#5190](https://github.com/pmd/pmd/issues/5190): \[java] NPE in type inference
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XMLRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/XMLRenderer.java
@@ -196,7 +196,14 @@ public class XMLRenderer extends AbstractIncrementingRenderer {
                 xmlWriter.writeAttribute("filename", determineFileName(pe.getFileId()));
                 xmlWriter.writeAttribute("msg", pe.getMsg());
                 writeNewLine();
-                xmlWriter.writeCData(pe.getDetail());
+
+                // in case the message contains itself some CDATA sections, they need to be handled
+                // in order to not produce invalid XML...
+                String detail = pe.getDetail();
+                // split "]]>" into "]]" and ">" into two cdata sections
+                detail = detail.replace("]]>", "]]]]><![CDATA[>");
+
+                xmlWriter.writeCData(detail);
                 writeNewLine();
                 xmlWriter.writeEndElement();
             }


### PR DESCRIPTION
## Describe the PR

Processing errors might contain inside their details message a CDATA section. This is output itself as
a CDATA section, but XMLStreamWriter#writeCData doesn't escape it automatically - it just outputs the string as is. This results in invalid XML.

## Related issues

- Fixes #5059

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

