### PR TITLE
[java] Adjust signature matching in CheckSkipResultRule

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -24,6 +24,8 @@ This is a {{ site.pmd.release_type }} release.
   * [#5059](https://github.com/pmd/pmd/issues/5059): \[core] xml output doesn't escape CDATA inside its own CDATA
 * java
   * [#5190](https://github.com/pmd/pmd/issues/5190): \[java] NPE in type inference
+* java-errorprone
+  * [#5207](https://github.com/pmd/pmd/issues/5207): \[java] CheckSkipResult: false positve for a private method `void skip(int)` in a subclass of FilterInputStream
 
 ### 🚨 API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CheckSkipResultRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CheckSkipResultRule.java
@@ -11,7 +11,7 @@ import net.sourceforge.pmd.lang.java.types.InvocationMatcher;
 
 public class CheckSkipResultRule extends AbstractJavaRulechainRule {
 
-    private static final InvocationMatcher SKIP_METHOD = InvocationMatcher.parse("java.io.InputStream#skip(_*)");
+    private static final InvocationMatcher SKIP_METHOD = InvocationMatcher.parse("java.io.InputStream#skip(long)");
 
     public CheckSkipResultRule() {
         super(ASTMethodCall.class);

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CheckSkipResult.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CheckSkipResult.xml
@@ -116,4 +116,22 @@ public class Foo {
             }
             ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#5207 FP with skip overload on custom FileInputStream class</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.FileInputStream;
+import java.io.IOException;
+
+public class Foo extends FileInputStream {
+    public void bar() {
+        skip(1);
+    }
+
+    public void skip(int n) throws IOException {
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #5207 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

