### PR TITLE
Ignore generated-sources in coverage reports

### DIFF
--- a/antlr4-wrapper.xml
+++ b/antlr4-wrapper.xml
@@ -9,15 +9,29 @@
         - lang-id: the language id, used in the conventional package name (eg "swift")
         - node-prefix: prefix for generated AST nodes (eg "Sw")
         - root-node-name: name of the root node without prefix (eg "TopLevel"), will be made to implement RootNode
+        - ast-pkg: shouldn't be used, but needed for compatibility with Xml module. Used when the package is not "ast"
 
         See AntlrGeneratedParserBase
 
+        It also uses the following maven properties:
+
+         - ant.contrib.jar:  Location of the ant-contrib jar
 -->
 
-    <property name="target-package-dir" value="${antlr4.outputDirectory}/net/sourceforge/pmd/lang/${lang-id}/ast"/>
+    <taskdef resource="net/sf/antcontrib/antcontrib.properties">
+        <classpath>
+            <pathelement location="${ant.contrib.jar}"/>
+        </classpath>
+    </taskdef>
 
+    <!-- default to "ast" -->
+    <condition property="ast-pkg" value="${ast-pkg}" else="ast">
+        <isset property="ast-pkg" />
+    </condition>
 
-    <property name="lang-ast-package" value="net.sourceforge.pmd.lang.${lang-id}.ast" />
+    <property name="target-package-dir" value="${antlr4.outputDirectory}/net/sourceforge/pmd/lang/${lang-id}/${ast-pkg}"/>
+
+    <property name="lang-ast-package" value="net.sourceforge.pmd.lang.${lang-id}.${ast-pkg}" />
     <property name="ast-api-package" value="net.sourceforge.pmd.lang.ast" />
     <property name="ast-impl-package" value="${ast-api-package}.impl.antlr4" />
 
@@ -32,10 +46,13 @@
     <property name="base-visitor-file" value="${target-package-dir}/${base-visitor-name}.java"/>
 
     <property name="listener-name" value="${lang-name}Listener"/>
-    <property name="listener-file" value="${target-package-dir}/${visitor-name}.java"/>
+    <property name="listener-file" value="${target-package-dir}/${listener-name}.java"/>
 
     <property name="base-listener-name" value="${lang-name}BaseListener"/>
-    <property name="base-listener-file" value="${target-package-dir}/${base-visitor-name}.java"/>
+    <property name="base-listener-file" value="${target-package-dir}/${base-listener-name}.java"/>
+
+    <property name="lexer-name" value="${lang-name}Lexer"/>
+    <property name="lexer-file" value="${target-package-dir}/${lexer-name}.java"/>
 
     <property name="node-itf-name" value="${lang-name}Node"/>
     <property name="base-class-name" value="Abstract${lang-name}Node"/>
@@ -72,9 +89,76 @@
               tofile="${parser-file}"/>
     </target>
 
-    <target name="cpd-language" description="Adapt Antlr sources for CPD-only languages">
+    <target name="annotate-classes" description="Adds the @Generated annotation to all classes">
+        <if>
+            <available file="${parser-file}"/>
+            <then>
+                <replace file="${parser-file}"
+                         token="public class ${parser-name}"
+                         value='@net.sourceforge.pmd.annotation.Generated("org.antlr.v4.Tool")${line.separator}
+public class ${parser-name}'/>
+
+                <!-- Parse tree classes for each element -->
+                <replace file="${parser-file}"
+                         token="public static class "
+                         value='@net.sourceforge.pmd.annotation.Generated("org.antlr.v4.Tool")${line.separator}
+public static class '/>
+            </then>
+        </if>
+
+        <if>
+            <available file="${visitor-file}"/>
+            <then>
+                <replace file="${visitor-file}"
+                         token="public interface ${visitor-name}"
+                         value='@net.sourceforge.pmd.annotation.Generated("org.antlr.v4.Tool")${line.separator}
+public interface ${visitor-name}'/>
+            </then>
+        </if>
+
+        <if>
+            <available file="${base-visitor-file}"/>
+            <then>
+                <replace file="${base-visitor-file}"
+                         token="public class ${base-visitor-name}"
+                         value='@net.sourceforge.pmd.annotation.Generated("org.antlr.v4.Tool")${line.separator}
+public class ${base-visitor-name}'/>
+            </then>
+        </if>
+
+        <if>
+            <available file="${listener-file}"/>
+            <then>
+                <replace file="${listener-file}"
+                         token="public interface ${listener-name}"
+                         value='@net.sourceforge.pmd.annotation.Generated("org.antlr.v4.Tool")${line.separator}
+public interface ${listener-name}'/>
+            </then>
+        </if>
+
+        <if>
+            <available file="${base-listener-file}"/>
+            <then>
+                <replace file="${base-listener-file}"
+                         token="public class ${base-listener-name}"
+                         value='@net.sourceforge.pmd.annotation.Generated("org.antlr.v4.Tool")${line.separator}
+public class ${base-listener-name}'/>
+            </then>
+        </if>
+
+        <if>
+            <available file="${lexer-file}"/>
+            <then>
+            <replace file="${lexer-file}"
+                     token="public class ${lexer-name}"
+                     value='@net.sourceforge.pmd.annotation.Generated("org.antlr.v4.Tool")${line.separator}
+public class ${lexer-name}'/>
+            </then>
+        </if>
+    </target>
+
+    <target name="cpd-language" description="Adapt Antlr sources for CPD-only languages" depends="annotate-classes">
         <!-- We only need the Lexer file. -->
-        <delete file="${parser-file}"/>
         <delete>
             <fileset dir="${target-package-dir}">
                 <include name="*"/>
@@ -83,7 +167,7 @@
         </delete>
     </target>
 
-    <target name="pmd-language" description="Adapt Antlr sources for PMD languages" depends="rename-parser">
+    <target name="pmd-language" description="Adapt Antlr sources for PMD languages" depends="annotate-classes,rename-parser">
 
         <!-- Adapt parser. -->
         <replace file="${parser-file}">

--- a/javacc-wrapper.xml
+++ b/javacc-wrapper.xml
@@ -224,9 +224,7 @@
 
     <target name="cleanup-parser" unless="jjtreeBuildNotRequired">
 
-        <replace token="class ${parser-name}">
-            <replacevalue expandProperties="true"><![CDATA[@net.sourceforge.pmd.annotation.Generated("org.javacc.javacc")
-class ]]>${parser-name}</replacevalue>
+        <replace token="class ${parser-name}" value='@net.sourceforge.pmd.annotation.Generated("org.javacc.javacc")${line.separator}class ${parser-name}'>
             <file name="${parser-file}" />
         </replace>
 

--- a/javacc-wrapper.xml
+++ b/javacc-wrapper.xml
@@ -224,6 +224,11 @@
 
     <target name="cleanup-parser" unless="jjtreeBuildNotRequired">
 
+        <replace token="class ${parser-name}">
+            <replacevalue expandProperties="true"><![CDATA[@net.sourceforge.pmd.annotation.Generated("org.javacc.javacc")
+class ]]>${parser-name}</replacevalue>
+            <file name="${parser-file}" />
+        </replace>
 
         <replace token="new Token()" value="token_source.input_stream.getTokenDocument().open()">
             <file name="${parser-file}" />
@@ -262,7 +267,8 @@
 
         <replaceregexp>
             <regexp pattern="public interface"/>
-            <substitution expression="interface"/>
+            <substitution expression='@net.sourceforge.pmd.annotation.Generated("org.javacc.javacc")${line.separator}
+interface'/>
             <file name="${target-package-dir}/${parser-name}TreeConstants.java" />
         </replaceregexp>
 
@@ -272,7 +278,8 @@
 
         <replaceregexp>
             <regexp pattern='(public )?class ${tokenmgr-name}' />
-            <substitution expression='class ${tokenmgr-name} extends ${base-tokenmgr}' />
+            <substitution expression='@net.sourceforge.pmd.annotation.Generated("org.javacc.javacc")${line.separator}
+class ${tokenmgr-name} extends ${base-tokenmgr}' />
             <file name="${tokenmgr-file}" />
         </replaceregexp>
 
@@ -385,11 +392,12 @@
 
         <replaceregexp>
             <regexp pattern="(public )?interface ${constants-itf-name} \{" />
-            <substitution expression="/** Token kinds ({@link ${ast-impl-package}.JavaccToken#kind}) for this language. */${line.separator}
+            <substitution expression='/** Token kinds ({@link ${ast-impl-package}.JavaccToken#kind}) for this language. */${line.separator}
 @net.sourceforge.pmd.annotation.InternalApi${line.separator}
+@net.sourceforge.pmd.annotation.Generated("org.javacc.javacc")${line.separator}
 public final class ${token-constants-name} \{${line.separator}
     private ${token-constants-name}() { /* Utility class */ }${line.separator}
-"/>
+'/>
             <file name="${token-constants-file}" />
         </replaceregexp>
 
@@ -534,8 +542,9 @@ public final class ${token-constants-name} \{${line.separator}
     <target name="default-visitor" depends="jjtree" unless="jjtreeBuildNotRequired">
         <move file="${target-package-dir}/${gen-visitor-name}.java" tofile="${generic-visitor-interface-file}" />
         <replace file="${generic-visitor-interface-file}">
-            <replacefilter token="${gen-visitor-name}"
-                           value="${generic-visitor-interface-name}&lt;P, R> extends ${ast-api-package}.AstVisitor&lt;P, R>" />
+            <replacefilter token="public interface ${gen-visitor-name}"
+                           value='@net.sourceforge.pmd.annotation.Generated("org.javacc.javacc")${line.separator}
+public interface ${generic-visitor-interface-name}&lt;P, R> extends ${ast-api-package}.AstVisitor&lt;P, R>' />
 
             <replacefilter token="SimpleNode" value="${node-name}" />
             <!-- Root method, eg visitJavaNode -->

--- a/pmd-coco/pom.xml
+++ b/pmd-coco/pom.xml
@@ -27,6 +27,29 @@
                     </delimiters>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>antlr-cleanup</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <ant antfile="${antlr4.ant.wrapper}" target="cpd-language">
+                                    <property name="ant.contrib.jar" value="${ant.contrib.jar}" />
+                                    <property name="lang-name" value="Coco" />
+                                    <property name="lang-id" value="coco" />
+                                </ant>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/annotation/Generated.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/annotation/Generated.java
@@ -1,0 +1,23 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Marks a class as generated code, and therefore to be ignored for code coverage purposes.
+ *
+ * @since 7.6.0
+ */
+@Retention(RetentionPolicy.CLASS)
+@Documented
+public @interface Generated {
+
+    /** The generator that produced this code */
+    String value() default "";
+
+}

--- a/pmd-cs/pom.xml
+++ b/pmd-cs/pom.xml
@@ -30,6 +30,7 @@
                         <configuration>
                             <target>
                                 <ant antfile="${antlr4.ant.wrapper}" target="cpd-language">
+                                    <property name="ant.contrib.jar" value="${ant.contrib.jar}" />
                                     <property name="lang-name" value="CSharp" />
                                     <property name="lang-id" value="cs" />
                                 </ant>

--- a/pmd-dart/pom.xml
+++ b/pmd-dart/pom.xml
@@ -30,6 +30,7 @@
                         <configuration>
                             <target>
                                 <ant antfile="${antlr4.ant.wrapper}" target="cpd-language">
+                                    <property name="ant.contrib.jar" value="${ant.contrib.jar}" />
                                     <property name="lang-name" value="Dart" />
                                     <property name="lang-id" value="dart" />
                                 </ant>

--- a/pmd-gherkin/pom.xml
+++ b/pmd-gherkin/pom.xml
@@ -27,6 +27,29 @@
                     </delimiters>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>antlr-cleanup</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <ant antfile="${antlr4.ant.wrapper}" target="cpd-language">
+                                    <property name="ant.contrib.jar" value="${ant.contrib.jar}" />
+                                    <property name="lang-name" value="Gherkin" />
+                                    <property name="lang-id" value="gherkin" />
+                                </ant>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pmd-go/pom.xml
+++ b/pmd-go/pom.xml
@@ -30,6 +30,7 @@
                         <configuration>
                             <target>
                                 <ant antfile="${antlr4.ant.wrapper}" target="cpd-language">
+                                    <property name="ant.contrib.jar" value="${ant.contrib.jar}" />
                                     <property name="lang-name" value="Golang" />
                                     <property name="lang-id" value="go" />
                                 </ant>

--- a/pmd-javascript/pom.xml
+++ b/pmd-javascript/pom.xml
@@ -42,7 +42,7 @@
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>generate-sources</id>
+                        <id>generate-javacc-sources</id>
                         <phase>generate-sources</phase>
                         <configuration>
                             <target>
@@ -51,6 +51,22 @@
                                     <property name="lang-name" value="Ecmascript5" />
                                     <property name="lang-id" value="ecmascript5" />
                                     <property name="javacc.jar" value="${javacc.jar}" />
+                                </ant>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>generate-antlr-sources</id>
+                        <phase>generate-sources</phase>
+                        <configuration>
+                            <target>
+                                <ant antfile="${antlr4.ant.wrapper}" target="cpd-language">
+                                    <property name="ant.contrib.jar" value="${ant.contrib.jar}" />
+                                    <property name="lang-name" value="TypeScript" />
+                                    <property name="lang-id" value="typescript" />
                                 </ant>
                             </target>
                         </configuration>

--- a/pmd-julia/pom.xml
+++ b/pmd-julia/pom.xml
@@ -27,6 +27,29 @@
                     </delimiters>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>antlr-cleanup</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <ant antfile="${antlr4.ant.wrapper}" target="cpd-language">
+                                    <property name="ant.contrib.jar" value="${ant.contrib.jar}" />
+                                    <property name="lang-name" value="Julia" />
+                                    <property name="lang-id" value="julia" />
+                                </ant>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pmd-kotlin/pom.xml
+++ b/pmd-kotlin/pom.xml
@@ -43,6 +43,7 @@
                         <configuration>
                             <target>
                                 <ant antfile="${antlr4.ant.wrapper}" target="pmd-language">
+                                    <property name="ant.contrib.jar" value="${ant.contrib.jar}" />
                                     <property name="lang-name" value="Kotlin" />
                                     <property name="lang-id" value="kotlin" />
                                     <property name="root-node-name" value="KotlinFile" />

--- a/pmd-lua/pom.xml
+++ b/pmd-lua/pom.xml
@@ -30,6 +30,7 @@
                         <configuration>
                             <target>
                                 <ant antfile="${antlr4.ant.wrapper}" target="cpd-language">
+                                    <property name="ant.contrib.jar" value="${ant.contrib.jar}" />
                                     <property name="lang-name" value="Lua" />
                                     <property name="lang-id" value="lua" />
                                 </ant>

--- a/pmd-swift/pom.xml
+++ b/pmd-swift/pom.xml
@@ -42,6 +42,7 @@
                         <configuration>
                             <target>
                                 <ant antfile="${antlr4.ant.wrapper}" target="pmd-language">
+                                    <property name="ant.contrib.jar" value="${ant.contrib.jar}" />
                                     <property name="lang-name" value="Swift" />
                                     <property name="lang-id" value="swift" />
                                     <property name="root-node-name" value="TopLevel" />

--- a/pmd-tsql/pom.xml
+++ b/pmd-tsql/pom.xml
@@ -26,6 +26,28 @@
                     </delimiters>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>antlr-cleanup</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <ant antfile="${antlr4.ant.wrapper}" target="cpd-language">
+                                    <property name="ant.contrib.jar" value="${ant.contrib.jar}" />
+                                    <property name="lang-name" value="TSql" />
+                                    <property name="lang-id" value="tsql" />
+                                </ant>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/pmd-xml/pom.xml
+++ b/pmd-xml/pom.xml
@@ -35,6 +35,31 @@
             </plugin>
 
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>antlr-cleanup</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <ant antfile="${antlr4.ant.wrapper}" target="cpd-language">
+                                    <property name="ant.contrib.jar" value="${ant.contrib.jar}" />
+                                    <property name="lang-name" value="Xml" />
+                                    <property name="lang-id" value="xml" />
+                                    <!-- TODO : The XML namespacing of Antlr is different to all others… we need to change it in PMD 8 -->
+                                    <property name="ast-pkg" value="antlr4" />
+                                </ant>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
                 <groupId>com.github.siom79.japicmp</groupId>
                 <artifactId>japicmp-maven-plugin</artifactId>
                 <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -612,6 +612,11 @@
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>0.8.11</version>
+                    <configuration>
+                        <excludes>
+                            <exclude>**/target/generated-sources/**</exclude>
+                        </excludes>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.cyclonedx</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -611,12 +611,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.8.11</version>
-                    <configuration>
-                        <excludes>
-                            <exclude>**/target/generated-sources/**</exclude>
-                        </excludes>
-                    </configuration>
+                    <version>0.8.12</version>
                 </plugin>
                 <plugin>
                     <groupId>org.cyclonedx</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,9 @@
         <javacc.outputDirectory>${project.build.directory}/generated-sources/javacc</javacc.outputDirectory>
         <javacc.ant.wrapper>${project.basedir}/../javacc-wrapper.xml</javacc.ant.wrapper>
 
+        <ant-contrib.version>1.0b3</ant-contrib.version>
+        <ant.contrib.jar>${settings.localRepository}/ant-contrib/ant-contrib/${ant-contrib.version}/ant-contrib-${ant-contrib.version}.jar</ant.contrib.jar>
+
         <antlr4.outputDirectory>${project.build.directory}/generated-sources/antlr4</antlr4.outputDirectory>
         <antlr4.ant.wrapper>${project.basedir}/../antlr4-wrapper.xml</antlr4.ant.wrapper>
 
@@ -166,6 +169,11 @@
                             <groupId>org.apache.ant</groupId>
                             <artifactId>ant</artifactId>
                             <version>${ant.version}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>ant-contrib</groupId>
+                            <artifactId>ant-contrib</artifactId>
+                            <version>${ant-contrib.version}</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
## Describe the PR

Our current report shows a misleadingly low code coverage (48%). Even heavily tested modules like Java stand at 80%, but the actual number is closer to 90% when we look at actual code we wrote.

Since the generated code is not written by us, we don't test it directly, nor is it our job. We do test the AST (which are included in the report) however.

A bad grammar won't be processed at all (failing the build), or fail in subtle ways only detectable in specific tests on the AST / rules (which is included).
