### PR TITLE
[java] Fix #5068: Class incorrectly identified as non-instantiatable

### DIFF
--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -2118,8 +2118,6 @@ $topLevelClass[
         (: … no nested classes, that are non-private and static … :)
         not(ClassBody/ClassDeclaration
             [pmd-java:modifiers() = "static" and @Visibility != "private"]
-            (: … with a default or non-private constructor … :)
-            [not(ClassBody/ConstructorDeclaration) or ClassBody/ConstructorDeclaration[@Visibility != "private"]]
             (: … and a non-private method returning the outer class type … :)
             [(ClassBody/MethodDeclaration
                 [@Visibility != "private"]

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/MissingStaticMethodInNonInstantiatableClass.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/MissingStaticMethodInNonInstantiatableClass.xml
@@ -617,4 +617,29 @@ public class Foo {
 ]]></code>
     </test-code>
 
+    <test-code>
+        <description>#5068:[java] fp when using builder with private constructor</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class MyClass {
+
+    private MyClass() {
+    }
+
+    public static class Builder {
+
+        private Builder() {}
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public MyClass build() {
+            return new MyClass();
+        }
+    }
+}
+]]></code>
+    </test-code>
+
 </test-data>


### PR DESCRIPTION
## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #5068 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

