### PR TITLE
[java] Fix #5067: CloseResource: False positive for FileSystems.getDefault()

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
@@ -503,7 +503,7 @@ public class CloseResourceRule extends AbstractJavaRule {
     private boolean isDefaultFileSystem(ASTVariableId varId) {
         @Nullable
         ASTExpression initializer = varId.getInitializer();
-        return initializer != null && initializer.getText().contentEquals("FileSystems.getDefault()");
+        return initializer != null && InvocationMatcher.parse("java.nio.file.FileSystems#getDefault()").matchesCall(initializer);
     }
 
     private boolean isVariableSpecifiedInTryWithResource(ASTVariableId varId, ASTTryStatement tryWithResource) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
@@ -108,6 +108,7 @@ public class CloseResourceRule extends AbstractJavaRule {
                 .desc("Detect if 'close' (or other closeTargets) is called outside of a finally-block").defaultValue(false).build();
 
     private static final InvocationMatcher OBJECTS_NON_NULL = InvocationMatcher.parse("java.util.Objects#nonNull(_)");
+    private static final InvocationMatcher FILESYSTEMS_GET_DEFAULT = InvocationMatcher.parse("java.nio.file.FileSystems#getDefault()");
 
     private final Set<String> types = new HashSet<>();
     private final Set<String> simpleTypes = new HashSet<>();
@@ -503,7 +504,7 @@ public class CloseResourceRule extends AbstractJavaRule {
     private boolean isDefaultFileSystem(ASTVariableId varId) {
         @Nullable
         ASTExpression initializer = varId.getInitializer();
-        return initializer != null && InvocationMatcher.parse("java.nio.file.FileSystems#getDefault()").matchesCall(initializer);
+        return FILESYSTEMS_GET_DEFAULT.matchesCall(initializer);
     }
 
     private boolean isVariableSpecifiedInTryWithResource(ASTVariableId varId, ASTTryStatement tryWithResource) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
@@ -204,6 +204,7 @@ public class CloseResourceRule extends AbstractJavaRule {
             .filter(this::isVariableNotSpecifiedInTryWithResource)
             .filter(var -> isResourceTypeOrSubtype(var) || isNodeInstanceOfResourceType(getTypeOfVariable(var)))
             .filterNot(var -> var.isAnnotationPresent("lombok.Cleanup"))
+            .filterNot(this::isDefaultFileSystem)
             .toList();
 
         for (ASTVariableId var : vars) {
@@ -497,6 +498,12 @@ public class CloseResourceRule extends AbstractJavaRule {
             .filter(ASTTryStatement::isTryWithResources)
             .first();
         return tryStatement == null || !isVariableSpecifiedInTryWithResource(varId, tryStatement);
+    }
+
+    private boolean isDefaultFileSystem(ASTVariableId varId) {
+        @Nullable
+        ASTExpression initializer = varId.getInitializer();
+        return initializer != null && initializer.getText().contentEquals("FileSystems.getDefault()");
     }
 
     private boolean isVariableSpecifiedInTryWithResource(ASTVariableId varId, ASTTryStatement tryWithResource) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/CloseResource.xml
@@ -2047,4 +2047,18 @@ public class CastedParameter {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>#5067: FileSystems.getDefault() can't be closed </description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+
+public class DefaultFileSystemUsage {
+    public void useDefaultFS() {
+        FileSystem defaultFS = FileSystems.getDefault();
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
…fault()

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #5067 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

