### PR TITLE
Make <rule> element optional in ruleset_2_0_0.xsd

### DIFF
--- a/pmd-core/src/main/resources/ruleset_2_0_0.xsd
+++ b/pmd-core/src/main/resources/ruleset_2_0_0.xsd
@@ -11,7 +11,7 @@
         <xs:element name="description" type="xs:string" minOccurs="1" maxOccurs="1" />
         <xs:element name="exclude-pattern" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
         <xs:element name="include-pattern" type="xs:string" minOccurs="0" maxOccurs="unbounded" />
-        <xs:element name="rule" type="rule" minOccurs="1" maxOccurs="unbounded" />
+        <xs:element name="rule" type="rule" minOccurs="0" maxOccurs="unbounded" />
       </xs:sequence>
       <xs:attribute name="name" type="xs:string" use="required" />
     </xs:complexType>


### PR DESCRIPTION
This PR updates the `ruleset_2_0_0.xsd` schema to make the `<rule>` element optional. The current schema requires at least one `<rule>` element, but several existing ruleset files do not have this element. This change sets `minOccurs="0"` for the `<rule>` element to avoid validation errors on these files.

## Related issues

- Fixes #5265 

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)
