### PR TITLE
Use plugin-classpath to simplify javacc-wrapper.xml

### DIFF
--- a/javacc-wrapper.xml
+++ b/javacc-wrapper.xml
@@ -25,9 +25,9 @@
          It also uses the following maven properties:
 
          - javacc.outputDirectory:  Directory in which to root the generated package tree
-         - javacc.jar:              JAR of JavaCC in the local maven repository
+         - plugin-classpath:        The classpath of maven-antrun-plugin with javacc.jar dependency
+                                    Provided by maven via "<property name="plugin-classpath" refid="maven.plugin.classpath"/>"
          - some properties of project.build
-
     -->
 
     <condition property="lang-name-camelcase" value="${lang-name}">
@@ -39,8 +39,6 @@
 
     <property name="target-package-dir" value="${javacc.outputDirectory}/net/sourceforge/pmd/lang/${lang-id}/ast" />
     <property name="stamp-file" value="${project.build.directory}/last-generated-timestamp" />
-
-    <property name="javacc-home.path" value="${project.build.directory}/lib/javacc" />
 
     <property name="lang-ast-package" value="net.sourceforge.pmd.lang.${lang-id}.ast" />
     <property name="ast-api-package" value="net.sourceforge.pmd.lang.ast" />
@@ -84,7 +82,7 @@
 
     <target name="alljavacc"
             description="Generates JavaCC sources and cleans them up"
-            depends="checkUpToDate,init,jjtree,jjtree-ersatz,javacc,adapt-generated,default-visitor,cleanup" />
+            depends="checkUpToDate,init,jjtree,jjtree-ersatz,javacc,adapt-generated,default-visitor" />
 
     <target name="checkUpToDate"
             description="Checks the input files are up to date">
@@ -104,9 +102,6 @@
 
 
     <target name="init" unless="javaccBuildNotRequired" description="Initialize build">
-        <mkdir dir="${javacc-home.path}" />
-        <copy file="${javacc.jar}" tofile="${javacc-home.path}/javacc.jar" />
-
         <mkdir dir="${javacc.outputDirectory}" />
         <touch file="${stamp-file}" />
         <delete dir="${target-package-dir}" />
@@ -117,11 +112,6 @@
         </condition>
     </target>
 
-    <target name="cleanup" unless="javaccBuildNotRequired">
-        <delete dir="${javacc-home.path}" />
-    </target>
-
-
     <target name="jjtree" unless="jjtreeBuildNotRequired" description="Runs JJTree">
 
         <!--
@@ -130,7 +120,7 @@
         -->
         <java fork="true"
               classname="jjtree"
-              classpath="${javacc-home.path}/javacc.jar">
+              classpath="${plugin-classpath}">
             <sysproperty key="file.encoding" value="UTF-8" />
             <arg value="-OUTPUT_DIRECTORY:${target-package-dir}" />
             <arg value="-NODE_USES_PARSER:false" />
@@ -148,7 +138,7 @@
     <target name="javacc" depends="jjtree" unless="javaccBuildNotRequired">
         <java fork="true"
               classname="javacc"
-              classpath="${javacc-home.path}/javacc.jar">
+              classpath="${plugin-classpath}">
             <sysproperty key="file.encoding" value="UTF-8" />
             <arg value="-STATIC:false" />
             <arg value="-USER_CHAR_STREAM:true" />

--- a/pmd-cpp/pom.xml
+++ b/pmd-cpp/pom.xml
@@ -34,10 +34,10 @@
                         <configuration>
                             <target>
                                 <ant antfile="${javacc.ant.wrapper}" target="alljavacc">
+                                    <property name="plugin-classpath" refid="maven.plugin.classpath"/>
                                     <property name="no-jjtree" value="true" /> <!-- This is a CPD module -->
                                     <property name="lang-name" value="Cpp" />
                                     <property name="lang-id" value="cpp" />
-                                    <property name="javacc.jar" value="${javacc.jar}" />
                                 </ant>
                             </target>
                         </configuration>

--- a/pmd-java/pom.xml
+++ b/pmd-java/pom.xml
@@ -105,7 +105,7 @@
                         <configuration>
                             <target>
                                 <ant antfile="${javacc.ant.wrapper}" target="alljavacc">
-                                    <property name="javacc.jar" value="${javacc.jar}" />
+                                    <property name="plugin-classpath" refid="maven.plugin.classpath"/>
                                     <property name="lang-name" value="Java" />
                                     <property name="lang-id" value="java" />
                                 </ant>

--- a/pmd-javascript/pom.xml
+++ b/pmd-javascript/pom.xml
@@ -47,10 +47,10 @@
                         <configuration>
                             <target>
                                 <ant antfile="${javacc.ant.wrapper}" target="alljavacc">
+                                    <property name="plugin-classpath" refid="maven.plugin.classpath"/>
                                     <property name="no-jjtree" value="true" /> <!-- This is a CPD module -->
                                     <property name="lang-name" value="Ecmascript5" />
                                     <property name="lang-id" value="ecmascript5" />
-                                    <property name="javacc.jar" value="${javacc.jar}" />
                                 </ant>
                             </target>
                         </configuration>

--- a/pmd-jsp/pom.xml
+++ b/pmd-jsp/pom.xml
@@ -40,7 +40,7 @@
                         <configuration>
                             <target>
                                 <ant antfile="${javacc.ant.wrapper}" target="alljavacc">
-                                    <property name="javacc.jar" value="${javacc.jar}" />
+                                    <property name="plugin-classpath" refid="maven.plugin.classpath"/>
                                     <property name="lang-name" value="Jsp" />
                                     <property name="lang-id" value="jsp" />
                                 </ant>

--- a/pmd-matlab/pom.xml
+++ b/pmd-matlab/pom.xml
@@ -34,10 +34,10 @@
                         <configuration>
                             <target>
                                 <ant antfile="${javacc.ant.wrapper}" target="alljavacc">
+                                    <property name="plugin-classpath" refid="maven.plugin.classpath"/>
                                     <property name="no-jjtree" value="true" /> <!-- This is a CPD module -->
                                     <property name="lang-name" value="Matlab" />
                                     <property name="lang-id" value="matlab" />
-                                    <property name="javacc.jar" value="${javacc.jar}" />
                                 </ant>
                             </target>
                         </configuration>

--- a/pmd-modelica/pom.xml
+++ b/pmd-modelica/pom.xml
@@ -64,7 +64,7 @@
                         <configuration>
                             <target>
                                 <ant antfile="${javacc.ant.wrapper}" target="alljavacc">
-                                    <property name="javacc.jar" value="${javacc.jar}" />
+                                    <property name="plugin-classpath" refid="maven.plugin.classpath"/>
                                     <property name="lang-name" value="Modelica" />
                                     <property name="lang-id" value="modelica" />
                                 </ant>

--- a/pmd-objectivec/pom.xml
+++ b/pmd-objectivec/pom.xml
@@ -34,10 +34,10 @@
                         <configuration>
                             <target>
                                 <ant antfile="${javacc.ant.wrapper}" target="alljavacc">
+                                    <property name="plugin-classpath" refid="maven.plugin.classpath"/>
                                     <property name="no-jjtree" value="true" /> <!-- This is a CPD module -->
                                     <property name="lang-name" value="ObjectiveC" />
                                     <property name="lang-id" value="objectivec" />
-                                    <property name="javacc.jar" value="${javacc.jar}" />
                                 </ant>
                             </target>
                         </configuration>

--- a/pmd-plsql/pom.xml
+++ b/pmd-plsql/pom.xml
@@ -40,7 +40,7 @@
                         <configuration>
                             <target>
                                 <ant antfile="${javacc.ant.wrapper}" target="alljavacc">
-                                    <property name="javacc.jar" value="${javacc.jar}" />
+                                    <property name="plugin-classpath" refid="maven.plugin.classpath"/>
                                     <property name="lang-name" value="PLSQL" />
                                     <property name="lang-name-camelcase" value="Plsql" />
                                     <property name="lang-id" value="plsql" />

--- a/pmd-python/pom.xml
+++ b/pmd-python/pom.xml
@@ -34,10 +34,10 @@
                         <configuration>
                             <target>
                                 <ant antfile="${javacc.ant.wrapper}" target="alljavacc">
+                                    <property name="plugin-classpath" refid="maven.plugin.classpath"/>
                                     <property name="no-jjtree" value="true" /> <!-- This is a CPD module -->
                                     <property name="lang-name" value="Python" />
                                     <property name="lang-id" value="python" />
-                                    <property name="javacc.jar" value="${javacc.jar}" />
                                 </ant>
                             </target>
                         </configuration>

--- a/pmd-velocity/pom.xml
+++ b/pmd-velocity/pom.xml
@@ -43,7 +43,7 @@
                         <configuration>
                             <target>
                                 <ant antfile="${javacc.ant.wrapper}" target="alljavacc">
-                                    <property name="javacc.jar" value="${javacc.jar}" />
+                                    <property name="plugin-classpath" refid="maven.plugin.classpath"/>
                                     <property name="lang-name" value="Vtl" />
                                     <property name="lang-id" value="velocity" />
                                 </ant>

--- a/pmd-visualforce/pom.xml
+++ b/pmd-visualforce/pom.xml
@@ -47,7 +47,7 @@
                         <configuration>
                             <target>
                                 <ant antfile="${javacc.ant.wrapper}" target="alljavacc">
-                                    <property name="javacc.jar" value="${javacc.jar}" />
+                                    <property name="plugin-classpath" refid="maven.plugin.classpath"/>
                                     <property name="lang-name" value="Vf" />
                                     <property name="lang-id" value="visualforce" />
                                 </ant>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         <pmd.build-tools.version>27</pmd.build-tools.version>
 
         <pmd-designer.version>7.2.0</pmd-designer.version>
-        <javacc.jar>${settings.localRepository}/net/java/dev/javacc/javacc/${javacc.version}/javacc-${javacc.version}.jar</javacc.jar>
+
         <javacc.outputDirectory>${project.build.directory}/generated-sources/javacc</javacc.outputDirectory>
         <javacc.ant.wrapper>${project.basedir}/../javacc-wrapper.xml</javacc.ant.wrapper>
 


### PR DESCRIPTION
## Describe the PR

javacc is on the antrun plugin's classpath. The javacc jar file doesn't need to be copied
explicitly, it can simply be used.

It uses the plugin classpath available from maven - see https://maven.apache.org/plugins/maven-antrun-plugin/examples/classpaths.html

Note: we need to use the java-task with "fork=true" to run javacc, as javacc stops the VM with System.exit(...) at the end - which would end ant/maven as well...

## Related issues

- none

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

