### PR TITLE
[java] CouplingBetweenObjects: improve violation message

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CouplingBetweenObjectsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CouplingBetweenObjectsRule.java
@@ -52,9 +52,9 @@ public class CouplingBetweenObjectsRule extends AbstractJavaRule {
     public Object visit(ASTCompilationUnit cu, Object data) {
         super.visit(cu, data);
 
-        if (couplingCount > getProperty(THRESHOLD_DESCRIPTOR)) {
-            asCtx(data).addViolation(cu,
-                         "A value of " + couplingCount + " may denote a high amount of coupling within the class");
+        Integer threshold = getProperty(THRESHOLD_DESCRIPTOR);
+        if (couplingCount > threshold) {
+            asCtx(data).addViolation(cu, couplingCount, threshold);
         }
 
         couplingCount = 0;

--- a/pmd-java/src/main/resources/category/java/design.xml
+++ b/pmd-java/src/main/resources/category/java/design.xml
@@ -377,7 +377,7 @@ class Foo {
     <rule name="CouplingBetweenObjects"
           language="java"
           since="1.04"
-          message="High amount of different objects as members denotes a high coupling"
+          message="A value of {0} may denote a high amount of coupling within the class (threshold: {1})"
           class="net.sourceforge.pmd.lang.java.rule.design.CouplingBetweenObjectsRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_design.html#couplingbetweenobjects">
         <description>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/CouplingBetweenObjects.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/CouplingBetweenObjects.xml
@@ -9,6 +9,9 @@
         <rule-property name="threshold">2</rule-property>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>1</expected-linenumbers>
+        <expected-messages>
+            <message>A value of 3 may denote a high amount of coupling within the class (threshold: 2)</message>
+        </expected-messages>
         <code><![CDATA[
 import java.util.*;
 public class Foo {
@@ -51,6 +54,9 @@ public interface Foo {
         <rule-property name="threshold">2</rule-property>
         <expected-problems>1</expected-problems>
         <expected-linenumbers>1</expected-linenumbers>
+        <expected-messages>
+            <message>A value of 3 may denote a high amount of coupling within the class (threshold: 2)</message>
+        </expected-messages>
         <code><![CDATA[
 import java.util.*;
 public interface Foo {


### PR DESCRIPTION
## Describe the PR

That's a small bugfix - the rule [CouplingBetweenObject](https://docs.pmd-code.org/latest/pmd_rules_java_design.html#couplingbetweenobjects) intended to report the actual count to the message, but used the wrong addViolation method call always using the default message.

This refactors now that we use parameters in the message and adds additionally the threshold value to the message.

When we add the actual count to the message, we can more easily verify that the rule works
as expected.

Note: This should now result by the regression tester, that all messages have been changed. Otherwise there should be no other changes (number violations should stay the same).


## Related issues

- none

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

