### PR TITLE
Fix #5244: [java] UselessOperationOnImmutable: consider java.time.* types

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -36,6 +36,7 @@ The old rule names still work but are deprecated.
   * [#5253](https://github.com/pmd/pmd/issues/5253): \[java] BooleanGetMethodName: False-negatives with `Boolean` wrapper
 * java-errorprone
   * [#5067](https://github.com/pmd/pmd/issues/5067): \[java] CloseResource: False positive for FileSystems.getDefault()
+  * [#5244](https://github.com/pmd/pmd/issues/5244): \[java] UselessOperationOnImmutable should detect java.time types
 
 ### 🚨 API Changes
 * java-bestpractices

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -57,6 +57,7 @@ The old rule names still work but are deprecated.
 * [#5269](https://github.com/pmd/pmd/pull/5269): Fix #5253: \[java] Support Boolean wrapper class for BooleanGetMethodName rule - [Aryant Tripathi](https://github.com/Aryant-Tripathi) (@Aryant-Tripathi)
 * [#5275](https://github.com/pmd/pmd/pull/5275): Use plugin-classpath to simplify javacc-wrapper.xml - [Andreas Dangel](https://github.com/adangel) (@adangel)
 * [#5278](https://github.com/pmd/pmd/pull/5278): \[java] CouplingBetweenObjects: improve violation message - [Andreas Dangel](https://github.com/adangel) (@adangel)
+* [#5279](https://github.com/pmd/pmd/pull/5279): Fix #5244: \[java] UselessOperationOnImmutable: consider java.time.* types - [Andreas Dangel](https://github.com/adangel) (@adangel)
 
 {% endtocmaker %}
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UselessOperationOnImmutableRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UselessOperationOnImmutableRule.java
@@ -6,6 +6,9 @@ package net.sourceforge.pmd.lang.java.rule.errorprone;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.time.Duration;
+import java.time.Period;
+import java.time.temporal.Temporal;
 
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTExpressionStatement;
@@ -37,6 +40,10 @@ public class UselessOperationOnImmutableRule extends AbstractJavaRulechainRule {
                 }
             } else if (TypeTestUtil.isA(BigDecimal.class, qualifier)
                 || TypeTestUtil.isA(BigInteger.class, qualifier)) {
+                asCtx(data).addViolation(node);
+            } else if (TypeTestUtil.isA(Temporal.class, qualifier)
+                || TypeTestUtil.isA(Duration.class, qualifier)
+                || TypeTestUtil.isA(Period.class, qualifier)) {
                 asCtx(data).addViolation(node);
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UselessOperationOnImmutableRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/UselessOperationOnImmutableRule.java
@@ -30,7 +30,8 @@ public class UselessOperationOnImmutableRule extends AbstractJavaRulechainRule {
     @Override
     public Object visit(ASTMethodCall node, Object data) {
         ASTExpression qualifier = node.getQualifier();
-        if (node.getParent() instanceof ASTExpressionStatement && qualifier != null) {
+        boolean returnsVoid = node.getTypeMirror().isVoid();
+        if (node.getParent() instanceof ASTExpressionStatement && qualifier != null && !returnsVoid) {
 
             // these types are immutable, so any method of those whose
             // result is ignored is a violation

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -3127,13 +3127,14 @@ public boolean test(String s) {
     <rule name="UselessOperationOnImmutable"
           language="java"
           since="3.5"
-          message="An operation on an Immutable object (String, BigDecimal, BigInteger or java.time.*) won't change the object itself"
+          message="The result of an operation on an immutable object is ignored"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.UselessOperationOnImmutableRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#uselessoperationonimmutable">
         <description>
-An operation on an Immutable object (`String`, `BigDecimal`, `BigInteger` or any type from `java.time.*`)
-won't change the object itself since the result of the operation is a new object.
-Therefore, ignoring the operation result is an error.
+An operation on an immutable object will not change the object itself since the result of the operation is a new object.
+Therefore, ignoring the result of such an operation is likely a mistake. The operation can probably be removed.
+
+This rule recognizes the types `String`, `BigDecimal`, `BigInteger` or any type from `java.time.*` as immutable.
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/main/resources/category/java/errorprone.xml
+++ b/pmd-java/src/main/resources/category/java/errorprone.xml
@@ -3127,12 +3127,13 @@ public boolean test(String s) {
     <rule name="UselessOperationOnImmutable"
           language="java"
           since="3.5"
-          message="An operation on an Immutable object (String, BigDecimal or BigInteger) won't change the object itself"
+          message="An operation on an Immutable object (String, BigDecimal, BigInteger or java.time.*) won't change the object itself"
           class="net.sourceforge.pmd.lang.java.rule.errorprone.UselessOperationOnImmutableRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_errorprone.html#uselessoperationonimmutable">
         <description>
-An operation on an Immutable object (String, BigDecimal or BigInteger) won't change the object itself
-since the result of the operation is a new object. Therefore, ignoring the operation result is an error.
+An operation on an Immutable object (`String`, `BigDecimal`, `BigInteger` or any type from `java.time.*`)
+won't change the object itself since the result of the operation is a new object.
+Therefore, ignoring the operation result is an error.
         </description>
         <priority>3</priority>
         <example>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UselessOperationOnImmutable.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UselessOperationOnImmutable.xml
@@ -320,4 +320,18 @@ class Tester {
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>False positive for package private method calls in openjdk</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+package java.time;
+import java.io.ObjectOutput;
+class Tester {
+    static void writeExternal(ZonedDateTime zonedDateTime, ObjectOutput out) {
+        zonedDateTime.writeExternal(out); // false positive
+    }
+}
+]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UselessOperationOnImmutable.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/UselessOperationOnImmutable.xml
@@ -212,4 +212,112 @@ public class TestCase {
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[java] UselessOperationOnImmutable should detect java.time types #5244</description>
+        <expected-problems>44</expected-problems>
+        <expected-linenumbers>7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,61,66,71,76</expected-linenumbers>
+        <code><![CDATA[
+import java.time.*;
+import java.time.temporal.ChronoField;
+import java.time.temporal.ChronoUnit;
+class Tester {
+    void violationsWithInstant() {
+        Instant instant = Instant.now();
+        instant.atOffset(ZoneOffset.UTC); // violation
+        instant.atZone(ZoneId.systemDefault()); // violation
+        instant.minus(1, ChronoUnit.SECONDS); // violation
+        instant.minus(Duration.ofSeconds(1)); // violation
+        instant.minusMillis(1); // violation
+        instant.minusNanos(1); // violation
+        instant.minusSeconds(1); // violation
+        instant.plus(1, ChronoUnit.SECONDS); // violation
+        instant.plus(Duration.ofSeconds(1)); // violation
+        instant.plusMillis(1); // violation
+        instant.plusNanos(1); // violation
+        instant.plusSeconds(1); // violation
+        instant.truncatedTo(ChronoUnit.MINUTES); // violation
+        instant.with(LocalDateTime.now()); // violation
+        instant.with(ChronoField.INSTANT_SECONDS, 1); // violation
+    }
+    void correctInstantExample() {
+        Instant instant = Instant.now();
+        instant = instant.plusSeconds(1);
+    }
+    void violationsWithLocalDate() {
+        LocalDate localDate = LocalDate.now();
+        localDate.atStartOfDay(); // violation
+        localDate.atStartOfDay(ZoneId.systemDefault()); // violation
+        localDate.atTime(10, 11); // violation
+        localDate.atTime(10, 11, 12); // violation
+        localDate.atTime(10, 11, 12, 13); // violation
+        localDate.atTime(LocalTime.now()); // violation
+        localDate.atTime(OffsetTime.now()); // violation
+        localDate.minus(1, ChronoUnit.SECONDS); // violation
+        localDate.minus(Duration.ofSeconds(1)); // violation
+        localDate.minusDays(1); // violation
+        localDate.minusMonths(1); // violation
+        localDate.minusWeeks(1); // violation
+        localDate.minusYears(1); // violation
+        localDate.plus(1, ChronoUnit.SECONDS); // violation
+        localDate.plus(Duration.ofSeconds(1)); // violation
+        localDate.plusDays(1); // violation
+        localDate.plusMonths(1); // violation
+        localDate.plusWeeks(1); // violation
+        localDate.plusYears(1); // violation
+        localDate.with(LocalDateTime.now()); // violation
+        localDate.with(ChronoField.DAY_OF_MONTH, 1); // violation
+        localDate.withDayOfMonth(1); // violation
+        localDate.withDayOfYear(1); // violation
+        localDate.withMonth(1); // violation
+        localDate.withYear(1); // violation
+    }
+    void correctLocalDateExample() {
+        LocalDate localDate = LocalDate.now();
+        localDate = localDate.plusDays(1);
+    }
+    void localTimeExamples() {
+        LocalTime localTime = LocalTime.now();
+        localTime.minusHours(1); // violation
+        localTime = localTime.plusMinutes(1); // ok
+    }
+    void localDateTimeExamples() {
+        LocalDateTime localDateTime = LocalDateTime.now();
+        localDateTime.minusDays(1); // violation
+        localDateTime = localDateTime.plusHours(1); // ok
+    }
+    void zonedDateTimeExamples() {
+        ZonedDateTime zonedDateTime = new ZonedDateTime.now();
+        zonedDateTime.minusMonths(1); // violation
+        zonedDateTime = zonedDateTime.plusWeeks(1); // ok
+    }
+    void offsetDateTimeExamples() {
+        OffsetDateTime offsetDateTime = OffsetDateTime.now();
+        offsetDateTime.minusDays(1); // violation
+        offsetDateTime = offsetDateTime.plusYears(1); // ok
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] UselessOperationOnImmutable should detect java.time types #5244 - Duration, Period</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>5,10</expected-linenumbers>
+        <code><![CDATA[
+import java.time.*;
+class Tester {
+    void durationExamples() {
+        Duration duration = Duration.ofSeconds(1);
+        duration.minusMillis(1); // violation
+        duration = duration.plusDays(1); //ok
+    }
+    void periodExamples() {
+        Period period = Period.ofMonths(1);
+        period.minusDays(1); // violation
+        period = period.plusWeeks(1); // ok
+    }
+}
+]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

## Related issues

- Fixes #5244

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

