### PR TITLE
[apex] Use case-insensitive input stream to avoid choking on Unicode escape sequences

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexCommentBuilder.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexCommentBuilder.java
@@ -22,6 +22,7 @@ import net.sourceforge.pmd.lang.document.TextDocument;
 import net.sourceforge.pmd.lang.document.TextRegion;
 
 import io.github.apexdevtools.apexparser.ApexLexer;
+import io.github.apexdevtools.apexparser.CaseInsensitiveInputStream;
 
 @InternalApi
 final class ApexCommentBuilder {
@@ -103,7 +104,8 @@ final class ApexCommentBuilder {
     }
 
     private static CommentInformation extractInformationFromComments(TextDocument sourceCode, String suppressMarker) {
-        ApexLexer lexer = new ApexLexer(CharStreams.fromString(sourceCode.getText().toString()));
+        String source = sourceCode.getText().toString();
+        ApexLexer lexer = new ApexLexer(new CaseInsensitiveInputStream(CharStreams.fromString(source)));
 
         List<Token> allCommentTokens = new ArrayList<>();
         Map<Integer, String> suppressMap = new HashMap<>();


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
The Apex lexer fails to correctly parse Unicode escape sequences when it does not operate on a `CaseInsensitiveInputStream`.
For example:
~~~java
ApexLexer lexer = new ApexLexer(CharStreams.fromString("'Fran\\u00E7ois'"));
CommonTokenStream tokens  = new CommonTokenStream(lexer);
tokens.fill();
~~~

This causes a runtime error during `tokens.fill()`:
~~~
line 1:0 token recognition error at: ''Fran\u00E'
line 1:14 token recognition error at: '''
~~~

The character stream must be wrapped in a `CaseInsensitiveInputStream`:

~~~java
ApexLexer lexer = new ApexLexer(new CaseInsensitiveInputStream(CharStreams.fromString("'Fran\\u00E7ois'")));
...
~~~

Performing a `pmd check` on Apex classes eventually leads to `ApexCommentBuilder.extractInformationFromComments()`, which does not include the wrapped `CaseInsensitiveInputStream` yet, causing analysis failures. This PR adds the wrapper and a unit test demonstrating the issue.

## Related issues

- Fixes #5333 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

