### PR TITLE
[ant] Formatter: avoid reflective access to determine console encoding

### DIFF
--- a/pmd-dist/src/test/java/net/sourceforge/pmd/dist/AntIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/dist/AntIT.java
@@ -5,6 +5,8 @@
 package net.sourceforge.pmd.dist;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.containsStringIgnoringCase;
+import static org.hamcrest.Matchers.not;
 
 import java.io.File;
 import java.io.IOException;
@@ -40,9 +42,9 @@ class AntIT extends AbstractBinaryDistributionTest {
 
         ExecutionResult result = runAnt(antBasepath, pmdHome, antTestProjectFolder);
         result.assertExitCode(0)
-              .assertStdOut(containsString("BUILD SUCCESSFUL"));
-        // the no package rule
-        result.assertExitCode(0)
+              .assertStdOut(containsString("BUILD SUCCESSFUL"))
+              .assertStdOut(not(containsStringIgnoringCase("Illegal reflective access"))) // #1860
+              // the no package rule
               .assertStdOut(containsString("NoPackage"));
     }
 


### PR DESCRIPTION
## Describe the PR

- for java 17+, there is public API to get the console encoding -> no problem
- for older java versions, try to use system property sun.jnu.encoding if it exists
- only then use the fall-backs with illegal reflective access to private fields/methods on java.io.Console
- Also avoid using reflection utils from apache commons, instead use reflection directly. The illegal access warnings are then properly reported against our class net.sourceforge.pmd.ant.Formatter.

## Related issues

- Fixes #1860

## Ready?

- [x] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

