### PR TITLE
(PoC) [java] Verify JDK API Version

### DIFF
--- a/pmd-core/src/test/java/net/sourceforge/pmd/internal/util/ClasspathClassLoaderTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/internal/util/ClasspathClassLoaderTest.java
@@ -197,6 +197,7 @@ class ClasspathClassLoaderTest {
 
         try (ClasspathClassLoader loader = new ClasspathClassLoader(classPath, null)) {
             assertEquals(javaHome.toString(), loader.javaHome);
+            assertEquals(javaVersion, loader.jdkVersion);
             try (InputStream stream = loader.getResourceAsStream("java/lang/Object.class")) {
                 assertClassFile(stream, javaVersion);
             }
@@ -208,6 +209,27 @@ class ClasspathClassLoaderTest {
             try (InputStream stream = loader.getResourceAsStream("java.base/module-info.class")) {
                 assertClassFile(stream, javaVersion);
             }
+        }
+    }
+
+    @Test
+    void loadFromJava8() throws IOException {
+        Path javaHome = Paths.get(System.getProperty("user.home"), "openjdk8");
+        assumeTrue(Files.isDirectory(javaHome), "Couldn't find java8 installation at " + javaHome);
+
+        Path rtJarPath = javaHome.resolve("jre/lib/rt.jar");
+        assertTrue(Files.isRegularFile(rtJarPath), "java8 installation is incomplete. " + rtJarPath + " not found!");
+        String classPath = rtJarPath.toString();
+
+        try (ClasspathClassLoader loader = new ClasspathClassLoader(classPath, null)) {
+            assertNull(loader.javaHome);
+            assertEquals(8, loader.jdkVersion);
+            try (InputStream stream = loader.getResourceAsStream("java/lang/Object.class")) {
+                assertClassFile(stream, 8);
+            }
+
+            // should not fail for resources without a package
+            assertNull(loader.getResourceAsStream("ClassInDefaultPackage.class"));
         }
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaParser.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaParser.java
@@ -65,6 +65,11 @@ public class JavaParser extends JjtreeParserAdapter<ASTCompilationUnit> {
 
         levelChecker.check(root);
 
+        int jdkVersionAuxclasspath = javaProcessor.getJdkVersionAuxclasspath();
+        if (jdkVersionAuxclasspath > 0 && jdkVersion != jdkVersionAuxclasspath) {
+            task.getReporter().warning(root, "Auxclasspath contains Java API {0} but parser requested {1}", jdkVersionAuxclasspath, jdkVersion);
+        }
+
         if (postProcess) {
             JavaAstProcessor.process(javaProcessor, task.getReporter(), root);
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/internal/JavaLanguageProcessor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/internal/JavaLanguageProcessor.java
@@ -11,6 +11,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.sourceforge.pmd.internal.util.ClasspathClassLoader;
 import net.sourceforge.pmd.lang.LanguageVersionHandler;
 import net.sourceforge.pmd.lang.ast.Parser;
 import net.sourceforge.pmd.lang.impl.BatchLanguageProcessor;
@@ -44,19 +45,25 @@ public class JavaLanguageProcessor extends BatchLanguageProcessor<JavaLanguagePr
     private final JavaParser parser;
     private final JavaParser parserWithoutProcessing;
     private TypeSystem typeSystem;
+    private final int jdkVersionAuxclasspath;
 
-    public JavaLanguageProcessor(JavaLanguageProperties properties, TypeSystem typeSystem) {
+    public JavaLanguageProcessor(JavaLanguageProperties properties) {
         super(properties);
-        this.typeSystem = typeSystem;
-
+        this.typeSystem = TypeSystem.usingClassLoaderClasspath(properties.getAnalysisClassLoader());
         String suppressMarker = properties.getSuppressMarker();
         this.parser = new JavaParser(suppressMarker, this, true);
         this.parserWithoutProcessing = new JavaParser(suppressMarker, this, false);
+
+        LOG.debug("Using analysis classloader: {}", properties.getAnalysisClassLoader());
+        if (properties.getAnalysisClassLoader() instanceof ClasspathClassLoader) {
+            jdkVersionAuxclasspath = ((ClasspathClassLoader) properties.getAnalysisClassLoader()).getJdkVersion();
+        } else {
+            jdkVersionAuxclasspath = -1;
+        }
     }
 
-    public JavaLanguageProcessor(JavaLanguageProperties properties) {
-        this(properties, TypeSystem.usingClassLoaderClasspath(properties.getAnalysisClassLoader()));
-        LOG.debug("Using analysis classloader: {}", properties.getAnalysisClassLoader());
+    public int getJdkVersionAuxclasspath() {
+        return jdkVersionAuxclasspath;
     }
 
     @Override


### PR DESCRIPTION
## Describe the PR

This is just a PoC to get the idea out. We should implement something like this to warn users, if they execute PMD with incorrect java versions. Using the wrong java version on the auxclasspath leads to issues like #4620 - the Java API changed between and typeresolution works as designed. But with the wrong Java Runtime on the auxclasspath, false positives are detected.

You can specify the java runtime on the auxclasspath via CLI as described on https://docs.pmd-code.org/latest/pmd_languages_java.html#providing-the-auxiliary-classpath . But if no java runtime is provided, we fall back to the runtime java version, which might or might not be correct.

Note: For maven, there is currently no official way to configure the java runtime onto the auxclasspath. You can workaround by adding a system scoped dependency to your project, e.g.

```xml
        <dependency>
            <groupId>java8</groupId>
            <artifactId>java8-rt</artifactId>
            <version>8</version>
            <scope>system</scope>
            <systemPath>/path/to/jdk-8/jre/lib/rt.jar</systemPath>
        </dependency>
```

Since maven adds all project dependencies to the auxclasspath when executing PMD, this adds the java 8 runtime and false positives such as #4620 disappear.

In theory, you could also use maven toolchains to execute PMD with the correct java version.

At the beginning I think, we should issue a warning, if we detect a mismatch between the java language version and the java version, that we resolve from the auxclasspath. Note - the warning I added in this PR only appears in DEBUG mode. And I assume (needs to be verified) that we could do this check once at the beginning and don't need to issue a warning for every file...

Once the warning is out there and we provided enough documentation around how to resolve this warning, we could make this into a fatal error, aborting the PMD analysis. We might even think about not falling back to the runtime classpath for type resolution, forcing users to always configure the intended java version explicitly.

## Related issues

- Refs #4620 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

