### PR TITLE
Bump gems and bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
     git (1.19.1)
       addressable (~> 2.8)
       rchardet (~> 1.8)
-    json (2.7.2)
+    json (2.7.5)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -74,10 +74,10 @@ GEM
     raabro (1.4.0)
     racc (1.8.1)
     rchardet (1.8.0)
-    rexml (3.3.8)
+    rexml (3.3.9)
     rouge (4.4.0)
-    rufus-scheduler (3.9.1)
-      fugit (~> 1.1, >= 1.1.6)
+    rufus-scheduler (3.9.2)
+      fugit (~> 1.1, >= 1.11.1)
     safe_yaml (1.0.5)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
@@ -102,4 +102,4 @@ DEPENDENCIES
   safe_yaml
 
 BUNDLED WITH
-   2.5.3
+   2.5.22

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,8 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.2.1)
+    activesupport (7.2.2)
       base64
+      benchmark (>= 0.3)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
@@ -15,6 +16,7 @@ GEM
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
     base64 (0.2.0)
+    benchmark (0.3.0)
     bigdecimal (3.1.8)
     coffee-script (2.4.1)
       coffee-script-source
@@ -34,9 +36,10 @@ GEM
     ethon (0.16.0)
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
-    execjs (2.9.1)
-    faraday (2.11.0)
+    execjs (2.10.0)
+    faraday (2.12.0)
       faraday-net_http (>= 2.0, < 3.4)
+      json
       logger
     faraday-net_http (3.3.0)
       net-http
@@ -99,7 +102,7 @@ GEM
       activesupport (>= 2)
       nokogiri (>= 1.4)
     http_parser.rb (0.8.0)
-    i18n (1.14.5)
+    i18n (1.14.6)
       concurrent-ruby (~> 1.0)
     jekyll (3.10.0)
       addressable (~> 2.4)
@@ -211,6 +214,7 @@ GEM
       gemoji (>= 3, < 5)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
+    json (2.7.5)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -219,7 +223,7 @@ GEM
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    logger (1.6.0)
+    logger (1.6.1)
     mercenary (0.3.6)
     minima (2.5.1)
       jekyll (>= 3.5, < 5.0)
@@ -240,8 +244,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.3.6)
-      strscan
+    rexml (3.3.9)
     rouge (3.30.0)
     rubyzip (2.3.2)
     safe_yaml (1.0.5)
@@ -255,7 +258,6 @@ GEM
       faraday (>= 0.17.3, < 3)
     securerandom (0.3.1)
     simpleidn (0.2.3)
-    strscan (3.1.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     typhoeus (1.4.1)
@@ -276,4 +278,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.5.3
+   2.5.22


### PR DESCRIPTION
## Describe the PR

- Bump bundler from 2.5.3 to 2.5.22
- Bump activesupport from 7.2.1 to 7.2.2
- Bump execjs from 2.9.1 to 2.10.0
- Bump faraday from 2.11.0 to 2.12.0
- Bump i18n from 1.14.5 to 1.14.6
- Bump json from 2.7.2 to 2.7.5
- Bump logger from 1.6.0 to 1.6.1
- Bump rexml from 3.3.6/3.3.8 to 3.3.9
- Bump rufus-scheduler from 3.9.2 to 3.9.2

- Fixes https://github.com/pmd/pmd/security/dependabot/69
- Fixes https://github.com/pmd/pmd/security/dependabot/70
