### PR TITLE
[doc] Introducing PMD Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/ea550046a02344ec850553476c4aa2ca)](https://app.codacy.com/organizations/gh/pmd/dashboard)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](code_of_conduct.md) 
 [![Documentation (latest)](https://img.shields.io/badge/docs-latest-green)](https://docs.pmd-code.org/latest/)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20PMD%20Guru-006BFF)](https://gurubase.io/g/pmd)
 
 **PMD** is an extensible multilanguage static code analyzer. It finds common programming flaws like unused variables,
 empty catch blocks, unnecessary object creation, and so forth. It's mainly concerned with **Java and


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [PMD Guru](https://gurubase.io/g/pmd) to Gurubase. PMD Guru uses the data from this repo and data from the [docs](https://docs.pmd-code.org/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "PMD Guru", which highlights that PMD now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable PMD Guru in Gurubase, just let me know that's totally fine.
