### PR TITLE
[java] Fix #5083 - UnusedPrivateMethod false positive with mref without target type but with exact method

### DIFF
--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/UnresolvedTypesRecoveryTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/UnresolvedTypesRecoveryTest.kt
@@ -530,6 +530,7 @@ class C {
         val (mref) = acu.descendants(ASTMethodReference::class.java).toList()
 
         val (lambdaCall, mrefCall) = acu.descendants(ASTMethodCall::class.java).toList()
+        val (fooDecl) = acu.declaredMethodSignatures().toList()
 
         spy.shouldHaveNoApplicableMethods(lambdaCall)
         spy.shouldHaveNoApplicableMethods(mrefCall)
@@ -540,7 +541,7 @@ class C {
 
             mref shouldHaveType ts.UNKNOWN
             mref.functionalMethod shouldBe ts.UNRESOLVED_METHOD
-            mref.referencedMethod shouldBe ts.UNRESOLVED_METHOD
+            mref.referencedMethod shouldBe fooDecl // still populated because unambiguous
         }
     }
 
@@ -562,6 +563,7 @@ class C {
 
         val (lambda) = acu.descendants(ASTLambdaExpression::class.java).toList()
         val (mref) = acu.descendants(ASTMethodReference::class.java).toList()
+        val (fooDecl) = acu.declaredMethodSignatures().toList()
 
         spy.shouldHaveNoLambdaCtx(lambda)
         spy.shouldHaveNoLambdaCtx(mref)
@@ -572,7 +574,7 @@ class C {
 
             mref shouldHaveType ts.UNKNOWN
             mref.functionalMethod shouldBe ts.UNRESOLVED_METHOD
-            mref.referencedMethod shouldBe ts.UNRESOLVED_METHOD
+            mref.referencedMethod shouldBe fooDecl // still populated because unambiguous
         }
     }
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
@@ -2237,5 +2237,64 @@ public class ObtainViaTest {
             }
             ]]></code>
     </test-code>
+    <test-code>
+        <description>UnusedPrivateMethod #5083 - method reference without target type</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            @Getter
+            @RequiredArgsConstructor
+            enum GenerationType {
+                APPLE_DESKTOP("https://apps.apple.com/app/id", GenerationType::isAppleType),
+                APPLE_ITUNES("https://itunes.apple.com/app/id", GenerationType::isAppleType),
+                SAMSUNG("https://www.samsung.com/us/appstore/app/", GenerationType::isSamsungType),
+                ROKU("https://channelstore.roku.com/details/", GenerationType::isRokuType),
+                AMAZON("https://www.amazon.com/dp/", GenerationType::isAmazonType),
+                ANDROID("https://play.google.com/store/apps/details?id=", GenerationType::isAndroidType);
+
+                private final String baseUrl;
+                private final Predicate<String> predicate;
+
+                private static boolean isAppleType(String data) {
+                    return "apple".equals(data);
+                }
+
+                private static boolean isRokuType(String data) {
+                    return "roku".equals(data);
+                }
+
+                private static boolean isSamsungType(String data) {
+                    return "samsung".equals(data);
+                }
+
+                private static boolean isAmazonType(String data) {
+                    return "amazon".equals(data);
+                }
+
+                private static boolean isAndroidType(String data) {
+                    return "android".equals(data);
+                }
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>UnusedPrivateMethod #5083 - method reference without target type (2)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            class GenerationType {
+                static {
+                    foo(GenerationType::isAndroidType);
+                }
+                {
+                    foo(this::instance);
+                }
+
+                private  boolean instance(String data) {}
+                private static boolean isAndroidType(String data) {
+                    return "android".equals(data);
+                }
+            }
+            ]]></code>
+    </test-code>
 
 </test-data>


### PR DESCRIPTION
has compile time decl

## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #5083

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

