### PR TITLE
[typescript] Add cleanup after generating ts lexer

### DIFF
--- a/antlr4-wrapper.xml
+++ b/antlr4-wrapper.xml
@@ -15,7 +15,7 @@
     <taskdef resource="net/sf/antcontrib/antcontrib.properties" />
 
     <property name="target-package-dir" value="${antlr4.outputDirectory}/net/sourceforge/pmd/lang/${lang-id}/ast"/>
-    <property name="stamp-file" value="${project.build.directory}/last-generated-timestamp" />
+    <property name="stamp-file" value="${project.build.directory}/last-generated-timestamp-antlr4" />
 
 
     <property name="lang-ast-package" value="net.sourceforge.pmd.lang.${lang-id}.ast" />

--- a/javacc-wrapper.xml
+++ b/javacc-wrapper.xml
@@ -38,7 +38,7 @@
     </condition>
 
     <property name="target-package-dir" value="${javacc.outputDirectory}/net/sourceforge/pmd/lang/${lang-id}/ast" />
-    <property name="stamp-file" value="${project.build.directory}/last-generated-timestamp" />
+    <property name="stamp-file" value="${project.build.directory}/last-generated-timestamp-javacc" />
 
     <property name="lang-ast-package" value="net.sourceforge.pmd.lang.${lang-id}.ast" />
     <property name="ast-api-package" value="net.sourceforge.pmd.lang.ast" />

--- a/pmd-javascript/pom.xml
+++ b/pmd-javascript/pom.xml
@@ -28,6 +28,27 @@
                 <artifactId>antlr4-maven-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>antlr-cleanup</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <target>
+                                <ant antfile="${antlr4.ant.wrapper}" target="cpd-language">
+                                    <property name="lang-name" value="TypeScript" />
+                                    <property name="lang-id" value="typescript" />
+                                </ant>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <configuration>
                     <useDefaultDelimiters>false</useDefaultDelimiters>


### PR DESCRIPTION
## Describe the PR

Ensures the lexer is annotated as generated code

## Related issues

- Follow up on #5258 

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

