### PR TITLE
[apex] Updated the docs for UnusedMethod as per discussion #5200

### DIFF
--- a/pmd-apex/src/main/resources/category/apex/design.xml
+++ b/pmd-apex/src/main/resources/category/apex/design.xml
@@ -45,7 +45,8 @@ public class Foo {
         <description><![CDATA[
 Avoid having unused methods since they make understanding and maintaining code harder.
 
-This rule finds not only unused private methods, but public methods as well.
+This rule finds not only unused private methods, but public methods as well, as long as the class itself contains at least 
+one other method/variable declaration, as shown [here](https://github.com/pmd/pmd/blob/469b2a67ae375bde52bb33ccd4fb69e3c2993948/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/UnusedMethod/project1/src/Foo.cls#L6-L8)
 
 [ApexLink](https://github.com/nawforce/ApexLink) is used to make this possible and this needs
 additional configuration. The environment variable `PMD_APEX_ROOT_DIRECTORY` needs to be set prior to executing


### PR DESCRIPTION
## Describe the PR

Updated the documentation for the Apex > Design > UnusedMethod rule in conjunction with [this](https://github.com/pmd/pmd/discussions/5200#discussioncomment-11037719) discussion around a nuance with apex-link and not finding methods in 'empty' classes unless there's a variable declaration or other method present/called.
 
## Related issues

As above, relates to findings from discussion #5200 which was causing some unknown behaviour with the rule not firing as expected. Doesn't _fix_ #5200 but makes it clearer in the documentation.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [X] Added (in-code) documentation (if needed)

