### PR TITLE
[coco,gherkin,dart,go,julia,lua] Generate only lexers for cpd only languages using antlr

### DIFF
--- a/pmd-coco/src/main/antlr4/net/sourceforge/pmd/lang/coco/ast/Coco.g4
+++ b/pmd-coco/src/main/antlr4/net/sourceforge/pmd/lang/coco/ast/Coco.g4
@@ -3,7 +3,7 @@
 //// Reversed engineered by Dimitri van Heesch
 ///////////////////////////////////////////////////////////////////////////////
 
-grammar Coco;
+lexer grammar Coco;
 
 module  : (declaration)* EOF
 	;

--- a/pmd-dart/src/main/antlr4/net/sourceforge/pmd/lang/dart/ast/Dart.g4
+++ b/pmd-dart/src/main/antlr4/net/sourceforge/pmd/lang/dart/ast/Dart.g4
@@ -26,7 +26,7 @@
  THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 
-grammar Dart;
+lexer grammar Dart;
 
 compilationUnit: libraryDefinition | partDeclaration;
 

--- a/pmd-gherkin/src/main/antlr4/net/sourceforge/pmd/lang/gherkin/ast/Gherkin.g4
+++ b/pmd-gherkin/src/main/antlr4/net/sourceforge/pmd/lang/gherkin/ast/Gherkin.g4
@@ -1,4 +1,4 @@
-grammar Gherkin;
+lexer grammar Gherkin;
 
 // PARSER
 

--- a/pmd-go/src/main/antlr4/net/sourceforge/pmd/lang/go/ast/Golang.g4
+++ b/pmd-go/src/main/antlr4/net/sourceforge/pmd/lang/go/ast/Golang.g4
@@ -30,7 +30,7 @@
  * https://golang.org/ref/spec
  *
  */
-grammar Golang;
+lexer grammar Golang;
 
 @parser::members {
 

--- a/pmd-julia/src/main/antlr4/net/sourceforge/pmd/lang/julia/ast/Julia.g4
+++ b/pmd-julia/src/main/antlr4/net/sourceforge/pmd/lang/julia/ast/Julia.g4
@@ -1,4 +1,4 @@
-grammar Julia;
+lexer grammar Julia;
 
 // Parser
 

--- a/pmd-lua/src/main/antlr4/net/sourceforge/pmd/lang/lua/ast/Lua.g4
+++ b/pmd-lua/src/main/antlr4/net/sourceforge/pmd/lang/lua/ast/Lua.g4
@@ -65,7 +65,7 @@ Tested by Matt Hargett with:
     - Entire Lua codebase for nmap 7.92 : https://github.com/nmap/nmap
 */
 
-grammar Lua;
+lexer grammar Lua;
 
 chunk
     : block EOF


### PR DESCRIPTION
## Describe the PR

 - By flagging the grammars as "lexer" grammars, we don't generate parses and visitors, only the lexer, reducing build time.
 - If generated, the ant cleanup script still deletes them just in case, so no breaking changes by doing this now after #5345, #5346, #5347, etc.

Also, coverage has now went from 48% to 78% after flagging generated code as such! not bad!

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

