### PR TITLE
Bump build-tools to 28

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
       run: |
         echo "LANG=en_US.UTF-8" >> $GITHUB_ENV
         echo "MAVEN_OPTS=-Daether.connector.http.connectionMaxTtl=180 -DautoReleaseAfterClose=true -DstagingProgressTimeoutMinutes=30" >> $GITHUB_ENV
-        echo "PMD_CI_SCRIPTS_URL=https://raw.githubusercontent.com/pmd/build-tools/27/scripts" >> $GITHUB_ENV
+        echo "PMD_CI_SCRIPTS_URL=https://raw.githubusercontent.com/pmd/build-tools/28/scripts" >> $GITHUB_ENV
     - name: Check Environment
       shell: bash
       run: |

--- a/.github/workflows/git-repo-sync.yml
+++ b/.github/workflows/git-repo-sync.yml
@@ -23,7 +23,7 @@ jobs:
       shell: bash
       run: |
         echo "LANG=en_US.UTF-8" >> $GITHUB_ENV
-        echo "PMD_CI_SCRIPTS_URL=https://raw.githubusercontent.com/pmd/build-tools/27/scripts" >> $GITHUB_ENV
+        echo "PMD_CI_SCRIPTS_URL=https://raw.githubusercontent.com/pmd/build-tools/28/scripts" >> $GITHUB_ENV
     - name: Sync
       run: .ci/git-repo-sync.sh
       shell: bash

--- a/.github/workflows/troubleshooting.yml
+++ b/.github/workflows/troubleshooting.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           echo "LANG=en_US.UTF-8" >> $GITHUB_ENV
           echo "MAVEN_OPTS=-Daether.connector.http.connectionMaxTtl=180 -DstagingProgressTimeoutMinutes=30" >> $GITHUB_ENV
-          echo "PMD_CI_SCRIPTS_URL=https://raw.githubusercontent.com/pmd/build-tools/27/scripts" >> $GITHUB_ENV
+          echo "PMD_CI_SCRIPTS_URL=https://raw.githubusercontent.com/pmd/build-tools/28/scripts" >> $GITHUB_ENV
       - name: Check Environment
         shell: bash
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <argLine>-Xmx512m -Dfile.encoding=${project.build.sourceEncoding} ${extraArgLine}</argLine>
         <extraArgLine /> <!-- empty by default, profiles set it as needed -->
 
-        <pmd.build-tools.version>28-SNAPSHOT</pmd.build-tools.version>
+        <pmd.build-tools.version>28</pmd.build-tools.version>
 
         <pmd-designer.version>7.2.0</pmd-designer.version>
 


### PR DESCRIPTION
This contains the PMD Release Signing Key,
that is valid for another year.

