### PR TITLE
[java] Fix #5214 - LambdaCanBeMethodReference issue with method of enclosing class

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
@@ -1681,7 +1681,7 @@ public final class TypeOps {
      * Return the base type of t or any of its outer types that starts
      * with the given type.  If none exists, return null.
      */
-    public static JClassType asOuterSuper(JTypeMirror t, JClassSymbol sym) {
+    public static @Nullable JClassType asOuterSuper(JTypeMirror t, JClassSymbol sym) {
         if (t instanceof JClassType) {
             JClassType ct = (JClassType) t;
             do {
@@ -1694,6 +1694,23 @@ public final class TypeOps {
         } else if (t instanceof JTypeVar || t instanceof JArrayType) {
             return (JClassType) t.getAsSuper(sym);
         }
+        return null;
+    }
+
+    /**
+     * Return the first enclosing type of the container type
+     * that has the given symbol in its supertypes. Return null
+     * if this is not found.
+     */
+    public static @Nullable JClassType getReceiverType(@NonNull JClassType containerType, JClassSymbol sym) {
+        JClassType ct = containerType;
+        do {
+            JClassType sup = ct.getAsSuper(sym);
+            if (sup != null) {
+                return ct;
+            }
+            ct = ct.getEnclosingType();
+        } while (ct != null);
         return null;
     }
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LambdaCanBeMethodReference.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LambdaCanBeMethodReference.xml
@@ -336,5 +336,43 @@
 
 
 
+    <test-code>
+        <description>#5214 message when method is in outer class</description>
+        <expected-problems>2</expected-problems>
+        <expected-messages>
+            <message>Lambda expression could be written as a method reference: `Outer.this::correct`</message>
+            <message>Lambda expression could be written as a method reference: `Inner.this::something`</message>
+        </expected-messages>
+        <code><![CDATA[
+            public final class Outer {
+
+                class Inner {
+
+                    {
+                        iTakeLambda(i -> correct(i));
+                    }
+
+                    boolean something(int x) { return true; }
+                    class Deeper {
+
+                        {
+                            iTakeLambda(i -> something(i));
+                        }
+                    }
+                }
+
+                static void iTakeLambda(ALambda2 l) {
+                }
+
+                public boolean correct(int a) {
+                    return false;
+                }
+            }
+            interface ALambda2 {
+                boolean doSomething(int a);
+            }
+            ]]></code>
+    </test-code>
+
 
 </test-data>


### PR DESCRIPTION


## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #5214

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

