### PR TITLE
[java] Fix #4763 - wrong message for SimplifyBooleanReturns

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SimplifyBooleanReturnsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SimplifyBooleanReturnsRule.java
@@ -139,9 +139,9 @@ public class SimplifyBooleanReturnsRule extends AbstractJavaRulechainRule {
             if (thenTrue) {
                 return "return {condition} || {elseBranch};";
             } else if (thenFalse) {
-                return "return !{condition} || {elseBranch};";
+                return "return !{condition} && {elseBranch};";
             } else if (elseTrue) {
-                return "return !{condition} && {thenBranch};";
+                return "return !{condition} || {thenBranch};";
             } else {
                 return "return {condition} && {thenBranch};";
             }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/SimplifyBooleanReturns.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/SimplifyBooleanReturns.xml
@@ -185,8 +185,8 @@ public class SimplifyBooleanReturns {
         <expected-problems>2</expected-problems>
         <expected-linenumbers>3,8</expected-linenumbers>
         <expected-messages>
-            <message>This if statement can be replaced by `return !{condition} &amp;&amp; {thenBranch};`</message>
-            <message>This if statement can be replaced by `return !{condition} &amp;&amp; {thenBranch};`</message>
+            <message>This if statement can be replaced by `return !{condition} || {thenBranch};`</message>
+            <message>This if statement can be replaced by `return !{condition} || {thenBranch};`</message>
         </expected-messages>
         <code><![CDATA[
             public class Foo {
@@ -248,7 +248,7 @@ public class SimplifyBooleanReturns {
         <expected-problems>1</expected-problems>
         <expected-linenumbers>6</expected-linenumbers>
         <expected-messages>
-            <message>This if statement can be replaced by `return !{condition} &amp;&amp; {thenBranch};`</message>
+            <message>This if statement can be replaced by `return !{condition} || {thenBranch};`</message>
         </expected-messages>
         <code><![CDATA[
             public class Foo {
@@ -261,6 +261,32 @@ public class SimplifyBooleanReturns {
                     } else {
                         return true;
                     }
+                }
+            }
+            ]]></code>
+    </test-code>
+    <test-code>
+        <description> [java] SimplifyBooleanReturns - wrong suggested solution #4763 </description>
+        <expected-problems>2</expected-problems>
+        <expected-messages>
+            <message>This if statement can be replaced by `return !{condition} &amp;&amp; {elseBranch};`</message>
+            <message>This if statement can be replaced by `return !{condition} &amp;&amp; {elseBranch};`</message>
+        </expected-messages>
+        <code><![CDATA[
+            public class Foo {
+
+                public boolean foo(Object a) {
+                    if (a == null) {
+                        return false;
+                    }
+                    return "FOO".equals(a.toString());
+                }
+
+                public boolean bar(String stringA, String stringB) {
+                    if (StringUtils.isAnyBlank(stringA, stringB)) {
+                        return false;
+                    }
+                    return Objects.equals(stringA, stringB);
                 }
             }
             ]]></code>


### PR DESCRIPTION
Curiously existing tests had correct comments but wrong test assertions...

## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #4763

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

