### PR TITLE
[java] Fix #5070 - confusing argument to varargs method FP when types are unknown

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseDiamondOperatorRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseDiamondOperatorRule.java
@@ -71,7 +71,7 @@ public class UseDiamondOperatorRule extends AbstractJavaRulechainRule {
         ASTTypeArguments targs = newTypeNode.getTypeArguments();
         if (targs != null && targs.isDiamond()
             // if unresolved we can't know whether the class is generic or not
-            || TypeOps.isUnresolved(newType)) {
+            || TypeOps.hasUnresolvedSymbol(newType)) {
             return null;
         }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConfusingArgumentToVarargsMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConfusingArgumentToVarargsMethodRule.java
@@ -47,7 +47,7 @@ public class ConfusingArgumentToVarargsMethodRule extends AbstractJavaRulechainR
         assert varargsArg != null;
         if (varargsArg.getTypeMirror().isSubtypeOf(expectedComponent)
             && !varargsArg.getTypeMirror().equals(lastFormal)
-            && !TypeOps.isSpecialUnresolved(varargsArg.getTypeMirror())) {
+            && !TypeOps.isSpecialUnresolvedOrArray(varargsArg.getTypeMirror())) {
             // confusing
 
             String message;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConfusingArgumentToVarargsMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConfusingArgumentToVarargsMethodRule.java
@@ -14,6 +14,7 @@ import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.types.JArrayType;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.OverloadSelectionResult;
+import net.sourceforge.pmd.lang.java.types.TypeOps;
 import net.sourceforge.pmd.lang.java.types.TypePrettyPrint;
 
 public class ConfusingArgumentToVarargsMethodRule extends AbstractJavaRulechainRule {
@@ -45,7 +46,8 @@ public class ConfusingArgumentToVarargsMethodRule extends AbstractJavaRulechainR
         ASTExpression varargsArg = argList.getLastChild();
         assert varargsArg != null;
         if (varargsArg.getTypeMirror().isSubtypeOf(expectedComponent)
-            && !varargsArg.getTypeMirror().equals(lastFormal)) {
+            && !varargsArg.getTypeMirror().equals(lastFormal)
+            && !TypeOps.isSpecialUnresolved(varargsArg.getTypeMirror())) {
             // confusing
 
             String message;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
@@ -2110,6 +2110,16 @@ public final class TypeOps {
         return t == null || isUnresolved(t);
     }
 
+    /**
+     * Return true if the type is null, (*unknown*), (*error*), or an array
+     * of unknown or error type.
+     */
+    public static boolean isSpecialUnresolvedOrArray(@Nullable JTypeMirror t) {
+        return t == null
+            || isSpecialUnresolved(t)
+            || t instanceof JArrayType && isSpecialUnresolved(((JArrayType) t).getElementType());
+    }
+
 
     public static @Nullable JTypeMirror getArrayComponent(@Nullable JTypeMirror t) {
         return t instanceof JArrayType ? ((JArrayType) t).getComponentType() : null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/PhaseOverloadSet.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/PhaseOverloadSet.java
@@ -210,7 +210,7 @@ final class PhaseOverloadSet extends OverloadSet<MethodCtDecl> {
 
     private @NonNull OptionalBool unresolvedTypeFallback(JTypeMirror si, JTypeMirror ti, ExprMirror argExpr) {
         JTypeMirror standalone = argExpr.getStandaloneType();
-        if (standalone != null && TypeOps.isUnresolved(standalone)) {
+        if (TypeOps.hasUnresolvedSymbolOrArray(standalone)) {
             if (standalone.equals(si)) {
                 return YES;
             } else if (standalone.equals(ti)) {

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeGenerationUtil.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeGenerationUtil.kt
@@ -38,7 +38,7 @@ val TypeSystem.allTypesGen: Arb<JTypeMirror>
 fun TypeSystem.subtypesArb() =
         Arb.pair(refTypeGen, refTypeGen)
                 .filter { (t, s) -> t.isConvertibleTo(s).bySubtyping() }
-                .filter { (t, s) -> !TypeOps.hasUnresolvedSymbol(t) && !TypeOps.hasUnresolvedSymbol(s) }
+                .filter { (t, s) -> !TypeOps.hasUnresolvedSymbolOrArray(t) && !TypeOps.hasUnresolvedSymbolOrArray(s) }
 
 infix fun Boolean.implies(v: () -> Boolean): Boolean = !this || v()
 

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeOpsTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeOpsTest.kt
@@ -7,6 +7,7 @@ package net.sourceforge.pmd.lang.java.types
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
 import io.kotest.property.Arb
 import io.kotest.property.arbitrary.shuffle
 import io.kotest.property.checkAll
@@ -129,6 +130,86 @@ class Foo {
 
                 spy.shouldBeOk {
                     methodId shouldHaveType barT[`?`]
+                }
+            }
+
+            test("isSpecialUnresolved") {
+                val unresolved = ts.declaration(ts.createUnresolvedAsmSymbol("Unknown"))
+                TypeOps.isSpecialUnresolved(unresolved) shouldBe false
+                TypeOps.isSpecialUnresolved(unresolved.toArray()) shouldBe false
+                TypeOps.isSpecialUnresolved(unresolved.toArray(3)) shouldBe false
+
+                for (ty in listOf(ts.UNKNOWN, ts.ERROR)) {
+                    TypeOps.isSpecialUnresolved(ty) shouldBe true
+                    TypeOps.isSpecialUnresolved(ty.toArray()) shouldBe false
+                    TypeOps.isSpecialUnresolved(ty.toArray(3)) shouldBe false
+                }
+            }
+
+            test("isSpecialUnresolvedOrArray") {
+                val unresolved = ts.declaration(ts.createUnresolvedAsmSymbol("Unknown"))
+                TypeOps.isSpecialUnresolvedOrArray(unresolved) shouldBe false
+                TypeOps.isSpecialUnresolvedOrArray(unresolved.toArray()) shouldBe false
+                TypeOps.isSpecialUnresolvedOrArray(unresolved.toArray(3)) shouldBe false
+
+                for (ty in listOf(ts.UNKNOWN, ts.ERROR)) {
+                    TypeOps.isSpecialUnresolvedOrArray(ty) shouldBe true
+                    TypeOps.isSpecialUnresolvedOrArray(ty.toArray()) shouldBe true
+                    TypeOps.isSpecialUnresolvedOrArray(ty.toArray(3)) shouldBe true
+                }
+            }
+
+            test("hasUnresolvedSymbol") {
+                val unresolved = ts.declaration(ts.createUnresolvedAsmSymbol("Unknown"))
+                TypeOps.hasUnresolvedSymbol(unresolved) shouldBe true
+                TypeOps.hasUnresolvedSymbol(unresolved.toArray()) shouldBe false
+                TypeOps.hasUnresolvedSymbol(unresolved.toArray(3)) shouldBe false
+
+                for (ty in listOf(ts.UNKNOWN, ts.ERROR)) {
+                    TypeOps.hasUnresolvedSymbol(ty) shouldBe false
+                    TypeOps.hasUnresolvedSymbol(ty.toArray()) shouldBe false
+                    TypeOps.hasUnresolvedSymbol(ty.toArray(3)) shouldBe false
+                }
+            }
+
+
+            test("hasUnresolvedSymbolOrArray") {
+                val unresolved = ts.declaration(ts.createUnresolvedAsmSymbol("Unknown"))
+                TypeOps.hasUnresolvedSymbolOrArray(unresolved) shouldBe true
+                TypeOps.hasUnresolvedSymbolOrArray(unresolved.toArray()) shouldBe true
+                TypeOps.hasUnresolvedSymbolOrArray(unresolved.toArray(3)) shouldBe true
+
+                for (ty in listOf(ts.UNKNOWN, ts.ERROR)) {
+                    TypeOps.hasUnresolvedSymbolOrArray(ty) shouldBe false
+                    TypeOps.hasUnresolvedSymbolOrArray(ty.toArray()) shouldBe false
+                    TypeOps.hasUnresolvedSymbolOrArray(ty.toArray(3)) shouldBe false
+                }
+            }
+
+
+            test("isUnresolved") {
+                val unresolved = ts.declaration(ts.createUnresolvedAsmSymbol("Unknown"))
+                TypeOps.isUnresolved(unresolved) shouldBe true
+                TypeOps.isUnresolved(unresolved.toArray()) shouldBe false
+                TypeOps.isUnresolved(unresolved.toArray(3)) shouldBe false
+
+                for (ty in listOf(ts.UNKNOWN, ts.ERROR)) {
+                    TypeOps.isUnresolved(ty) shouldBe true
+                    TypeOps.isUnresolved(ty.toArray()) shouldBe false
+                    TypeOps.isUnresolved(ty.toArray(3)) shouldBe false
+                }
+            }
+
+            test("isUnresolvedOrArray") {
+                val unresolved = ts.declaration(ts.createUnresolvedAsmSymbol("Unknown"))
+                TypeOps.isUnresolvedOrArray(unresolved) shouldBe true
+                TypeOps.isUnresolvedOrArray(unresolved.toArray()) shouldBe true
+                TypeOps.isUnresolvedOrArray(unresolved.toArray(3)) shouldBe true
+
+                for (ty in listOf(ts.UNKNOWN, ts.ERROR)) {
+                    TypeOps.isUnresolvedOrArray(ty) shouldBe true
+                    TypeOps.isUnresolvedOrArray(ty.toArray()) shouldBe true
+                    TypeOps.isUnresolvedOrArray(ty.toArray(3)) shouldBe true
                 }
             }
         }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ConfusingArgumentToVarargsMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ConfusingArgumentToVarargsMethod.xml
@@ -126,4 +126,20 @@
             ]]></code>
     </test-code>
 
+
+    <test-code>
+        <description>Types of args is array of unknown</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            public class Foo {
+                static {
+                    var x = arr(UNKNOWN); // x: (*unknown*)[]
+                    foo(x);
+                }
+                static <T> T[] arr(T[] x) { return x; }
+                static void foo(Object... args) {}
+            }
+            ]]></code>
+    </test-code>
+
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ConfusingArgumentToVarargsMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/errorprone/xml/ConfusingArgumentToVarargsMethod.xml
@@ -106,4 +106,24 @@
             ]]></code>
     </test-code>
 
+
+    <test-code>
+        <description>Types of args are unresolved</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+            public class Foo {
+                static {
+                    // if we don't know the type of ARRAY we should not report a violation
+                    foo(Somewhere.ARRAY);
+                    // here we know the type is Unknown[] even if Unknown is unresolved,
+                    // we know it's not Object[] so we report
+                    foo(UNKNOWN);
+                }
+                static Unknown[] UNKNOWN;
+                static void foo(Object... args) {}
+            }
+            ]]></code>
+    </test-code>
+
 </test-data>


### PR DESCRIPTION

## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #5070

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->
- [ ] needs test for when the type is `(*unknown*)[]`
- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

