### PR TITLE
Bump pmd from 7.7.0 to 7.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -569,34 +569,28 @@
                         <dependency>
                             <groupId>net.sourceforge.pmd</groupId>
                             <artifactId>pmd-core</artifactId>
-                            <version>7.7.0</version> <!-- pmd.dogfood.version -->
+                            <version>7.8.0</version> <!-- pmd.dogfood.version -->
                         </dependency>
                         <dependency>
                             <groupId>net.sourceforge.pmd</groupId>
                             <artifactId>pmd-java</artifactId>
-                            <version>7.7.0</version> <!-- pmd.dogfood.version -->
+                            <version>7.8.0</version> <!-- pmd.dogfood.version -->
                         </dependency>
                         <dependency>
                             <groupId>net.sourceforge.pmd</groupId>
                             <artifactId>pmd-jsp</artifactId>
-                            <version>7.7.0</version> <!-- pmd.dogfood.version -->
+                            <version>7.8.0</version> <!-- pmd.dogfood.version -->
                         </dependency>
                         <dependency>
                             <groupId>net.sourceforge.pmd</groupId>
                             <artifactId>pmd-javascript</artifactId>
-                            <version>7.7.0</version> <!-- pmd.dogfood.version -->
+                            <version>7.8.0</version> <!-- pmd.dogfood.version -->
                         </dependency>
                         <!-- This contains the dogfood ruleset -->
                         <dependency>
                             <groupId>net.sourceforge.pmd</groupId>
                             <artifactId>pmd-build-tools-config</artifactId>
                             <version>${pmd.build-tools.version}</version>
-                        </dependency>
-                        <!-- Allow to build PMD with Java 24 -->
-                        <dependency>
-                            <groupId>org.ow2.asm</groupId>
-                            <artifactId>asm</artifactId>
-                            <version>9.7.1</version>
                         </dependency>
                     </dependencies>
                 </plugin>


### PR DESCRIPTION
## Describe the PR

- dogfooding
- asm dependency override is not needed anymore, as pmd 7.8.0 uses asm 9.7.1 already
