### PR TITLE
[java] Fix #4861 - UnusedPrivateMethod FP in JDK classes

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
@@ -15,6 +15,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.sourceforge.pmd.lang.ast.NodeStream;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
@@ -23,6 +24,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTMemberValue;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodReference;
+import net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.ast.MethodUsage;
 import net.sourceforge.pmd.lang.java.ast.ModifierOwner.Visibility;
@@ -112,6 +114,9 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
                 }
 
                 JavaNode reffed = sym.tryGetNode();
+                if (reffed == null) {
+                    reffed = findDeclarationInCompilationUnit(file, sym);
+                }
                 if (reffed instanceof ASTMethodDeclaration
                     && ref.ancestors(ASTMethodDeclaration.class).first() != reffed) {
                     // remove from set, but only if it is called outside of itself
@@ -136,5 +141,29 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
 
     private boolean hasExcludedName(ASTMethodDeclaration node) {
         return SERIALIZATION_METHODS.contains(node.getName());
+    }
+
+    /**
+     * Find the method in the compilation unit. Note that this
+     * is a patch to fix some incorrect behavior of the rule in
+     * the java.lang package. This is due to the fact that some
+     * java.lang types (like Object, or primitive boxes) are
+     * treated specially by the type resolution framework, and
+     * for those the preexisting ASM symbol is preferred over
+     * the AST symbol. Since it only applies to these types we
+     * check that the package name is java.lang, to avoid doing
+     * that for other types.
+     */
+    private static @Nullable ASTMethodDeclaration findDeclarationInCompilationUnit(ASTCompilationUnit acu, JExecutableSymbol symbol) {
+        if (!"java.lang".equals(acu.getPackageName())
+            || !"java.lang".equals(symbol.getPackageName())) {
+            return null;
+        }
+        return acu.descendants(ASTTypeDeclaration.class)
+                  .crossFindBoundaries()
+                  .filter(it -> it.getSymbol().equals(symbol.getEnclosingClass()))
+                  .take(1)
+                  .flatMap(it -> it.getDeclarations(ASTMethodDeclaration.class))
+                  .first(m -> m.getSymbol().equals(symbol));
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/SymbolEquality.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/SymbolEquality.java
@@ -9,6 +9,7 @@ import java.util.Objects;
 import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JConstructorSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JElementSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JExecutableSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JFieldSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JFormalParamSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JLocalVariableSymbol;
@@ -17,6 +18,7 @@ import net.sourceforge.pmd.lang.java.symbols.JRecordComponentSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JTypeParameterSymbol;
 import net.sourceforge.pmd.lang.java.symbols.SymbolVisitor;
 import net.sourceforge.pmd.lang.java.symbols.SymbolicValue.SymAnnot;
+import net.sourceforge.pmd.lang.java.types.Substitution;
 
 /**
  * Routines to share logic for equality, respecting the contract of
@@ -71,13 +73,18 @@ public final class SymbolEquality {
             }
             JMethodSymbol m2 = (JMethodSymbol) o;
 
-            // FIXME arity check is not enough for overloads
-            return m1.getModifiers() == m2.getModifiers()
-                && m1.getArity() == m2.getArity()
-                && Objects.equals(m1.getSimpleName(), m2.getSimpleName())
-                && m1.getEnclosingClass().equals(m2.getEnclosingClass());
+            return executableSymsAreEqual(m1, m2);
         }
     };
+
+    private static boolean executableSymsAreEqual(JExecutableSymbol m1, JExecutableSymbol m2) {
+        return m1.getModifiers() == m2.getModifiers()
+            && m1.getArity() == m2.getArity()
+            && Objects.equals(m1.getSimpleName(), m2.getSimpleName())
+            && m1.getEnclosingClass().equals(m2.getEnclosingClass())
+            && m1.getFormalParameterTypes(Substitution.erasing(m1.getTypeParameters()))
+                 .equals(m2.getFormalParameterTypes(Substitution.erasing(m2.getTypeParameters())));
+    }
 
     public static final EqAndHash<JConstructorSymbol> CONSTRUCTOR = new EqAndHash<JConstructorSymbol>() {
         @Override
@@ -95,11 +102,7 @@ public final class SymbolEquality {
             }
             JConstructorSymbol m2 = (JConstructorSymbol) o;
 
-            // FIXME arity check is not enough for overloads
-            return m1.getModifiers() == m2.getModifiers()
-                && m1.getArity() == m2.getArity()
-                && Objects.equals(m1.getSimpleName(), m2.getSimpleName())
-                && m1.getEnclosingClass().equals(m2.getEnclosingClass());
+            return executableSymsAreEqual(m1, m2);
         }
     };
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedPrivateMethod.xml
@@ -2353,4 +2353,19 @@ public class ObtainViaTest {
             }
             ]]></code>
     </test-code>
+
+    <test-code>
+        <description>
+            [java] UnusedPrivateMethod - false positive with static methods in core JDK classes #4861 </description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            package java.lang;
+            class Integer {
+                static {
+                    toStringUTF16(1, 2);
+                }
+                private static String toStringUTF16(int i, int j) {}
+            }
+            ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #4861

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

