### PR TITLE
Fix #5399: [cli] pmd.bat: Quote all variables when using SET

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -15,6 +15,8 @@ This is a {{ site.pmd.release_type }} release.
 ### 🚀 New and noteworthy
 
 ### 🐛 Fixed Issues
+* cli
+  * [#5399](https://github.com/pmd/pmd/issues/5399): \[cli] Windows: PMD fails to start with special characters in path names
 
 ### 🚨 API Changes
 

--- a/pmd-dist/src/main/resources/scripts/pmd.bat
+++ b/pmd-dist/src/main/resources/scripts/pmd.bat
@@ -1,10 +1,10 @@
 @echo off
 rem make all variables local to not add new global environment variables to the current cmd session
 setlocal
-set TOPDIR=%~dp0..
-set OPTS=
-set COMMAND=%1
-set MAIN_CLASS=net.sourceforge.pmd.cli.PmdCli
+set "TOPDIR=%~dp0.."
+set "OPTS="
+set "COMMAND=%1"
+set "MAIN_CLASS=net.sourceforge.pmd.cli.PmdCli"
 
 rem check whether java is available at all
 java -version > nul 2>&1 || (
@@ -68,14 +68,14 @@ if %_needjfxlib% EQU 1 (
     rem The wildcard will include only jar files, but we need to access also
     rem property files such as javafx.properties that lay bare in the dir
     rem note: no trailing backslash, as this would escape a following quote when %pmd_classpath% is used later
-    set pmd_classpath=%TOPDIR%\conf;%TOPDIR%\lib\*;%JAVAFX_HOME%\lib\*;%JAVAFX_HOME%\lib
+    set "pmd_classpath=%TOPDIR%\conf;%TOPDIR%\lib\*;%JAVAFX_HOME%\lib\*;%JAVAFX_HOME%\lib"
 ) else (
     rem note: no trailing backslash, as this would escape a following quote when %pmd_classpath% is used later
-    set pmd_classpath=%TOPDIR%\conf;%TOPDIR%\lib\*
+    set "pmd_classpath=%TOPDIR%\conf;%TOPDIR%\lib\*"
 )
 
 if defined CLASSPATH (
-    set pmd_classpath=%CLASSPATH%;%pmd_classpath%
+    set "pmd_classpath=%CLASSPATH%;%pmd_classpath%"
 )
 
 java %PMD_JAVA_OPTS% %jreopts% -classpath "%pmd_classpath%" %OPTS% %MAIN_CLASS% %*


### PR DESCRIPTION
## Describe the PR

If no quotes are used, then redirection characters such as `&` are interpreted and the resulting variables might contain only part of the desired values.

Performed manual testing. Test cases 6, 8, 9 were failing before and are fixed with this PR.

1) Happy case
```
SET "JAVA_HOME=C:\Users\adangel\openjdk\jdk-21.0.5+11"
SET "PMD_HOME=C:\Users\adangel\binaries\pmd-bin-7.8.0"
SET "PATHEXT=.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS ;.WSF;.WSH;.MSC"
SET "PATH=%PMD_HOME%\bin;%JAVA_HOME%\bin;C:\Windows\system32;C:\Windows"
SET "JAVAFX_HOME=C:\Users\adangel\openjdk\javafx-sdk-21.0.5"
SET "CLASSPATH="

pmd --version
```

2) JAVAFX_HOME with space
```
SET "JAVAFX_HOME=C:\Users\adangel\openjdk\javafx sdk 21.0.5"
```

3) JAVA_HOME with space
```
SET "JAVA_HOME=C:\Users\adangel\openjdk\jdk 21.0.5+11"
SET "PATH=%PMD_HOME%\bin;%JAVA_HOME%\bin;C:\Windows\system32;C:\Windows"
```

4) PMD_HOME with spaces
```
SET "PMD_HOME=C:\Users\adangel\binaries\pmd bin 7.8.0"
SET "PATH=%PMD_HOME%\bin;%JAVA_HOME%\bin;C:\Windows\system32;C:\Windows"
```

5) CLASSPATH with spaces
```
SET "CLASSPATH=C:\Users\adangel\sources\test project\classes"
```

6) JAVAFX_HOME with ampersand
```
SET "JAVAFX_HOME=C:\Users\adangel\openjdk\javafx & sdk 21.0.5"
```

7) JAVA_HOME with ampersand
```
SET "JAVA_HOME=C:\Users\adangel\openjdk\jdk & 21.0.5+11"
SET "PATH=%PMD_HOME%\bin;%JAVA_HOME%\bin;C:\Windows\system32;C:\Windows"
```

8) PMD_HOME with ampersand
```
SET "PMD_HOME=C:\Users\adangel\binaries\pmd bin & 7.8.0"
SET "PATH=%PMD_HOME%\bin;%JAVA_HOME%\bin;C:\Windows\system32;C:\Windows"
```

9) CLASSPATH with ampersand
```
SET "CLASSPATH=C:\Users\adangel\sources\test & project\classes"
```

## Related issues

- Fix #5399

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

