### PR TITLE
Fix #5401: [cli] pmd.bat: set codepage to 65001 (UTF-8)

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -15,6 +15,8 @@ This is a {{ site.pmd.release_type }} release.
 ### 🚀 New and noteworthy
 
 ### 🐛 Fixed Issues
+* cli
+  * [#5401](https://github.com/pmd/pmd/issues/5401): \[cli] Windows: Console output doesn't use unicode
 
 ### 🚨 API Changes
 

--- a/pmd-dist/src/main/resources/scripts/pmd.bat
+++ b/pmd-dist/src/main/resources/scripts/pmd.bat
@@ -1,4 +1,8 @@
 @echo off
+
+rem use unicode codepage to properly support UTF-8
+chcp 65001>nul
+
 rem make all variables local to not add new global environment variables to the current cmd session
 setlocal
 set TOPDIR=%~dp0..


### PR DESCRIPTION
## Related issues

- Fix #5401

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

