### PR TITLE
[apex] New Rule: Avoid Stateful Database Results

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidStatefulDatabaseResultRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidStatefulDatabaseResultRule.java
@@ -1,0 +1,83 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.rule.errorprone;
+
+import com.google.common.base.Ascii;
+import com.google.common.collect.ImmutableSet;
+import net.sourceforge.pmd.lang.apex.ast.ASTField;
+import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
+import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+
+/**
+ * Using stateful `Database.[x]Result` instance variables can cause odd
+ * serialization errors between successive batch iterations.
+ *
+ * https://issues.salesforce.com/issue/a028c00000qPwlqAAC/stateful-batch-job-that-stores-databasesaveresult-failed-after-validation-errors-throws-error-during-deserialization
+ *
+ * This rule scans classes which implement the `Database.Stateful` interface. If
+ * there are instance variables of type `Database.[x]Result` (ex:
+ * `Database.SaveResult`), then a violation will be added to those variables.
+ */
+public final class AvoidStatefulDatabaseResultRule extends AbstractApexRule {
+
+    private static final ImmutableSet<String> DATABASE_RESULT_TYPES = ImmutableSet.of(
+            "database.convertleadresult",
+            "database.deleteresult",
+            "database.emptyrecyclebinresult",
+            "database.mergeresult",
+            "database.saveresult",
+            "database.undeleteresult",
+            "database.upsertresult");
+
+    @Override
+    public Object visit(ASTUserClass theClass, Object data) {
+        if (!implementsDatabaseStateful(theClass)) {
+            return data;
+        }
+        // Note that inner classes cannot implement `Database.Stateful`
+        // interface, so we only need to check the top level class
+        for (ASTField theField : theClass.descendants(ASTField.class)) {
+            if (isNonTransientInstanceDatabaseResultField(theField)) {
+                asCtx(data).addViolation(theField);
+            }
+        }
+        return data;
+    }
+
+    /** Determines if the class implements the `Database.Stateful` interface */
+    private boolean implementsDatabaseStateful(ASTUserClass theClass) {
+        for (String interfaceName : theClass.getInterfaceNames()) {
+            if (Ascii.equalsIgnoreCase(interfaceName, "database.stateful")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Determines if a variable's definition may cause issues within batch
+     * iteration by being: an instance variable, not transient, and a data type
+     * of `Database.[x]Result` (or collection of them).
+     */
+    private boolean isNonTransientInstanceDatabaseResultField(ASTField theField) {
+        return !theField.getModifiers().isStatic()
+                && !theField.getModifiers().isTransient()
+                && isDatabaseResultOrCollection(theField.getType());
+    }
+
+    /**
+     * Determines if any of the unsupported types contains the type. We check
+     * containment even as a substring to check if the type is a collection of
+     * the result types ex: `List<Database.SaveResult>`.
+     */
+    private boolean isDatabaseResultOrCollection(String type) {
+        for (String databaseResultType : DATABASE_RESULT_TYPES) {
+            if (Ascii.toLowerCase(type).contains(databaseResultType)) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidStatefulDatabaseResultRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidStatefulDatabaseResultRule.java
@@ -4,11 +4,13 @@
 
 package net.sourceforge.pmd.lang.apex.rule.errorprone;
 
-import com.google.common.base.Ascii;
-import com.google.common.collect.ImmutableSet;
+import java.util.Locale;
+import java.util.Set;
+
 import net.sourceforge.pmd.lang.apex.ast.ASTField;
 import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+import net.sourceforge.pmd.util.CollectionUtil;
 
 /**
  * Using stateful `Database.[x]Result` instance variables can cause odd
@@ -22,14 +24,9 @@ import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
  */
 public final class AvoidStatefulDatabaseResultRule extends AbstractApexRule {
 
-    private static final ImmutableSet<String> DATABASE_RESULT_TYPES = ImmutableSet.of(
-            "database.convertleadresult",
-            "database.deleteresult",
-            "database.emptyrecyclebinresult",
-            "database.mergeresult",
-            "database.saveresult",
-            "database.undeleteresult",
-            "database.upsertresult");
+    private static final Set<String> DATABASE_RESULT_TYPES = CollectionUtil.immutableSetOf("database.leadconvertresult",
+            "database.deleteresult", "database.emptyrecyclebinresult", "database.mergeresult", "database.saveresult",
+            "database.undeleteresult", "database.upsertresult");
 
     @Override
     public Object visit(ASTUserClass theClass, Object data) {
@@ -49,7 +46,7 @@ public final class AvoidStatefulDatabaseResultRule extends AbstractApexRule {
     /** Determines if the class implements the `Database.Stateful` interface */
     private boolean implementsDatabaseStateful(ASTUserClass theClass) {
         for (String interfaceName : theClass.getInterfaceNames()) {
-            if (Ascii.equalsIgnoreCase(interfaceName, "database.stateful")) {
+            if ("database.stateful".equalsIgnoreCase(interfaceName)) {
                 return true;
             }
         }
@@ -62,8 +59,7 @@ public final class AvoidStatefulDatabaseResultRule extends AbstractApexRule {
      * of `Database.[x]Result` (or collection of them).
      */
     private boolean isNonTransientInstanceDatabaseResultField(ASTField theField) {
-        return !theField.getModifiers().isStatic()
-                && !theField.getModifiers().isTransient()
+        return !theField.getModifiers().isStatic() && !theField.getModifiers().isTransient()
                 && isDatabaseResultOrCollection(theField.getType());
     }
 
@@ -74,7 +70,7 @@ public final class AvoidStatefulDatabaseResultRule extends AbstractApexRule {
      */
     private boolean isDatabaseResultOrCollection(String type) {
         for (String databaseResultType : DATABASE_RESULT_TYPES) {
-            if (Ascii.toLowerCase(type).contains(databaseResultType)) {
+            if (type.toLowerCase(Locale.ROOT).contains(databaseResultType)) {
                 return true;
             }
         }

--- a/pmd-apex/src/main/resources/category/apex/errorprone.xml
+++ b/pmd-apex/src/main/resources/category/apex/errorprone.xml
@@ -520,50 +520,56 @@ private class TestClass {
         class="net.sourceforge.pmd.lang.apex.rule.errorprone.AvoidStatefulDatabaseResultRule"
         externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#avoidstatefuldatabaseresult">
     <description>
-      Storing Database.insertResult, Database.updateResult, etc. in instance variables
-      of a stateful batch class can cause serialization errors between batch iterations.
-      When this occurs, it is often inconsistent and challenging to troubleshoot.
+      Using instance variables of the following types (or collections of these types) within a stateful batch class can cause serialization errors between batch iterations:
       
-      See https://issues.salesforce.com/issue/a028c00000qPwlqAAC/stateful-batch-job-that-stores-databasesaveresult-failed-after-validation-errors-throws-error-during-deserialization for more details.
+      - `Database.DeleteResult`
+      - `Database.EmptyRecycleBinResult`
+      - `Database.MergeResult`
+      - `Database.SaveResult`
+      - `Database.UndeleteResult`
+      - `Database.UpsertResult`
       
-      This issue can be avoided by marking the variable as transient, or using a different
+      This error occurs inconsistently and asynchronously with an obscure error message - making it particularly challenging to troubleshoot.
+      See [this issue](https://issues.salesforce.com/issue/a028c00000qPwlqAAC/stateful-batch-job-that-stores-databasesaveresult-failed-after-validation-errors-throws-error-during-deserialization) for more details.
+      
+      These errors can be avoided by marking the variable as static, transient, or using a different
       data type that is safe to serialize.
     </description>
-    <priority>3</priority>
+    <priority>2</priority>
     <example>
       <![CDATA[// Violating
-public class Example implements Database.Batchable, Database.Stateful {
-  List<Database.SaveResult> results = new List<Database.SaveResult>(); // this can cause failures
+public class Example implements Database.Batchable<SObject>, Database.Stateful {
+  List<Database.SaveResult> results = new List<Database.SaveResult>(); // This can cause failures
 
-  public Database.Querylocator start(Database.BatchableContext context){
+  public Database.Querylocator start(Database.BatchableContext context) {
     return Database.getQueryLocator('SELECT Id FROM Account');
   }
 
-  public void execute(Database.BatchableContext context, List<SObject> scope){
+  public void execute(Database.BatchableContext context, List<SObject> scope) {
     Database.SaveResult[] saveResults = Database.update(scope, false);
     results.addAll(saveResults);
   }
 
-  public void finish(database.BatchableContext context){
+  public void finish(database.BatchableContext context) {
   }
 }
 
 // Compliant
-public class Example implements Database.Batchable, Database.Stateful {
+public class Example implements Database.Batchable<SObject>, Database.Stateful {
   List<StatefulResult> results = new List<StatefulResult>(); // Use a different custom type to persist state
 
-  public Database.Querylocator start(Database.BatchableContext context){
+  public Database.Querylocator start(Database.BatchableContext context) {
     return Database.getQueryLocator('SELECT Id FROM Account');
   }
 
-  public void execute(Database.BatchableContext context, List<SObject> scope){
+  public void execute(Database.BatchableContext context, List<SObject> scope) {
     Database.SaveResult[] saveResults = Database.update(scope, false);
     for (Database.SaveResult result : saveResults) {
       results.add(new StatefulResult(result));
     }
   }
 
-  public void finish(database.BatchableContext context){
+  public void finish(database.BatchableContext context) {
   }
 
 }
@@ -573,21 +579,21 @@ public class StatefulResult {
   private Id id;
   private Database.Error[] errors;
 
-  public StatefulResult(Database.SaveResult result){
+  public StatefulResult(Database.SaveResult result) {
     isSuccess = result.isSuccess();
     id = result.getId();
     errors = result.getErrors();
   }
 
-  public Boolean isSuccess(){
+  public Boolean isSuccess() {
     return isSuccess;
   }
 
-  public Id getId(){
+  public Id getId() {
     return id;
   }
 
-  public Database.Error[] getErrors(){
+  public Database.Error[] getErrors() {
     return errors;
   }
 }

--- a/pmd-apex/src/main/resources/category/apex/errorprone.xml
+++ b/pmd-apex/src/main/resources/category/apex/errorprone.xml
@@ -4,32 +4,32 @@
          xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
-
+  
+  <description>
+    Rules to detect constructs that are either broken, extremely confusing or prone to runtime errors.
+  </description>
+  
+  <rule name="ApexCSRF"
+        language="apex"
+        since="5.5.3"
+        message="Avoid making DML operations in Apex class constructor or initializers"
+        class="net.sourceforge.pmd.lang.apex.rule.errorprone.ApexCSRFRule"
+        externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#apexcsrf">
     <description>
-Rules to detect constructs that are either broken, extremely confusing or prone to runtime errors.
+      Having DML operations in Apex class constructor or initializers can have unexpected side effects:
+      By just accessing a page, the DML statements would be executed and the database would be modified.
+      Just querying the database is permitted.
+      
+      In addition to constructors and initializers, any method called `init` is checked as well.
+      
+      Salesforce Apex already protects against this scenario and raises a runtime exception.
+      
+      Note: This rule has been moved from category "Security" to "Error Prone" with PMD 6.21.0, since
+      using DML in constructors is not a security problem, but crashes the application.
     </description>
-
-    <rule name="ApexCSRF"
-          language="apex"
-          since="5.5.3"
-          message="Avoid making DML operations in Apex class constructor or initializers"
-          class="net.sourceforge.pmd.lang.apex.rule.errorprone.ApexCSRFRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#apexcsrf">
-        <description>
-Having DML operations in Apex class constructor or initializers can have unexpected side effects:
-By just accessing a page, the DML statements would be executed and the database would be modified.
-Just querying the database is permitted.
-
-In addition to constructors and initializers, any method called `init` is checked as well.
-
-Salesforce Apex already protects against this scenario and raises a runtime exception.
-
-Note: This rule has been moved from category "Security" to "Error Prone" with PMD 6.21.0, since
-using DML in constructors is not a security problem, but crashes the application.
-        </description>
-        <priority>3</priority>
-        <example>
-<![CDATA[
+    <priority>3</priority>
+    <example>
+      <![CDATA[
 public class Foo {
     // initializer
     {
@@ -47,30 +47,30 @@ public class Foo {
     }
 }
 ]]>
-        </example>
-    </rule>
-
-    <rule name="AvoidDirectAccessTriggerMap"
-          language="apex"
-          since="6.0.0"
-          message="Avoid directly accessing Trigger.old and Trigger.new"
-          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#avoiddirectaccesstriggermap">
-        <description>
-Avoid directly accessing Trigger.old and Trigger.new as it can lead to a bug. Triggers should be bulkified and iterate through the map to handle the actions for each item separately.
-        </description>
-        <priority>3</priority>
-            <properties>
-            <property name="xpath">
-                <value>
-<![CDATA[
+    </example>
+  </rule>
+  
+  <rule name="AvoidDirectAccessTriggerMap"
+        language="apex"
+        since="6.0.0"
+        message="Avoid directly accessing Trigger.old and Trigger.new"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+        externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#avoiddirectaccesstriggermap">
+    <description>
+      Avoid directly accessing Trigger.old and Trigger.new as it can lead to a bug. Triggers should be bulkified and iterate through the map to handle the actions for each item separately.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>
+          <![CDATA[
 //ArrayLoadExpression[TriggerVariableExpression and LiteralExpression]
 ]]>
-                </value>
-            </property>
-        </properties>
-        <example>
-<![CDATA[
+        </value>
+      </property>
+    </properties>
+    <example>
+      <![CDATA[
 trigger AccountTrigger on Account (before insert, before update) {
    Account a = Trigger.new[0]; //Bad: Accessing the trigger array directly is not recommended.
 
@@ -79,23 +79,23 @@ trigger AccountTrigger on Account (before insert, before update) {
    }
 }
 ]]>
-        </example>
-    </rule>
-
-    <rule name="AvoidHardcodingId"
-          language="apex"
-          since="6.0.0"
-          message="Hardcoding Id's is bound to break when changing environments."
-          class="net.sourceforge.pmd.lang.apex.rule.errorprone.AvoidHardcodingIdRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#avoidhardcodingid">
-        <description>
-When deploying Apex code between sandbox and production environments, or installing Force.com AppExchange packages,
-it is essential to avoid hardcoding IDs in the Apex code. By doing so, if the record IDs change between environments,
-the logic can dynamically identify the proper data to operate against and not fail.
-        </description>
-        <priority>3</priority>
-        <example>
-<![CDATA[
+    </example>
+  </rule>
+  
+  <rule name="AvoidHardcodingId"
+        language="apex"
+        since="6.0.0"
+        message="Hardcoding Id's is bound to break when changing environments."
+        class="net.sourceforge.pmd.lang.apex.rule.errorprone.AvoidHardcodingIdRule"
+        externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#avoidhardcodingid">
+    <description>
+      When deploying Apex code between sandbox and production environments, or installing Force.com AppExchange packages,
+      it is essential to avoid hardcoding IDs in the Apex code. By doing so, if the record IDs change between environments,
+      the logic can dynamically identify the proper data to operate against and not fail.
+    </description>
+    <priority>3</priority>
+    <example>
+      <![CDATA[
 public without sharing class Foo {
     void foo() {
         //Error - hardcoded the record type id
@@ -107,60 +107,60 @@ public without sharing class Foo {
     }
 }
 ]]>
-        </example>
-    </rule>
-
-    <rule name="AvoidNonExistentAnnotations"
-          language="apex"
-          since="6.5.0"
-          message="Use of non existent annotations will lead to broken Apex code which will not compile in the future."
-          class="net.sourceforge.pmd.lang.apex.rule.errorprone.AvoidNonExistentAnnotationsRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#avoidnonexistentannotations">
-        <description>
-            Apex supported non existent annotations for legacy reasons.
-            In the future, use of such non-existent annotations could result in broken apex code that will not compile.
-            This will prevent users of garbage annotations from being able to use legitimate annotations added to Apex in the future.
-            A full list of supported annotations can be found at https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_annotation.htm
-        </description>
-        <priority>3</priority>
-        <example>
-<![CDATA[
+    </example>
+  </rule>
+  
+  <rule name="AvoidNonExistentAnnotations"
+        language="apex"
+        since="6.5.0"
+        message="Use of non existent annotations will lead to broken Apex code which will not compile in the future."
+        class="net.sourceforge.pmd.lang.apex.rule.errorprone.AvoidNonExistentAnnotationsRule"
+        externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#avoidnonexistentannotations">
+    <description>
+      Apex supported non existent annotations for legacy reasons.
+      In the future, use of such non-existent annotations could result in broken apex code that will not compile.
+      This will prevent users of garbage annotations from being able to use legitimate annotations added to Apex in the future.
+      A full list of supported annotations can be found at https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/apex_classes_annotation.htm
+    </description>
+    <priority>3</priority>
+    <example>
+      <![CDATA[
 @NonExistentAnnotation public class ClassWithNonexistentAnnotation {
     @NonExistentAnnotation public void methodWithNonExistentAnnotation() {
         // ...
     }
 }
 ]]>
-        </example>
-    </rule>
-
-    <rule name="EmptyCatchBlock"
-          language="apex"
-          since="6.0.0"
-          message="Avoid empty catch blocks"
-          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#emptycatchblock">
-        <description>
-Empty Catch Block finds instances where an exception is caught, but nothing is done.
-In most circumstances, this swallows an exception which should either be acted on
-or reported.
-        </description>
-        <priority>3</priority>
-        <properties>
-            <property name="allowCommentedBlocks" type="Boolean" description="Empty blocks containing comments will be skipped" value="false"/>
-            <property name="allowExceptionNameRegex" type="Regex" description="Empty blocks catching exceptions with names matching this regular expression will be skipped" value="^(ignored|expected)$"/>
-            <property name="xpath">
-                <value>
-<![CDATA[
+    </example>
+  </rule>
+  
+  <rule name="EmptyCatchBlock"
+        language="apex"
+        since="6.0.0"
+        message="Avoid empty catch blocks"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+        externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#emptycatchblock">
+    <description>
+      Empty Catch Block finds instances where an exception is caught, but nothing is done.
+      In most circumstances, this swallows an exception which should either be acted on
+      or reported.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="allowCommentedBlocks" type="Boolean" description="Empty blocks containing comments will be skipped" value="false"/>
+      <property name="allowExceptionNameRegex" type="Regex" description="Empty blocks catching exceptions with names matching this regular expression will be skipped" value="^(ignored|expected)$"/>
+      <property name="xpath">
+        <value>
+          <![CDATA[
 //CatchBlockStatement[./BlockStatement[count(*) = 0] and
     not(matches(@VariableName, $allowExceptionNameRegex)) and
     ($allowCommentedBlocks = false() or @ContainsComment = false())]
 ]]>
-                </value>
-            </property>
-        </properties>
-        <example>
-<![CDATA[
+        </value>
+      </property>
+    </properties>
+    <example>
+      <![CDATA[
 public void doSomething() {
     ...
     try {
@@ -170,31 +170,31 @@ public void doSomething() {
     }
 }
 ]]>
-        </example>
-    </rule>
-
-    <rule name="EmptyIfStmt"
-          language="apex"
-          since="6.0.0"
-          message="Avoid empty 'if' statements"
-          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#emptyifstmt">
-        <description>
-Empty If Statement finds instances where a condition is checked but nothing is done about it.
-        </description>
-        <priority>3</priority>
-        <properties>
-            <property name="xpath">
-                <value>
-<![CDATA[
-//IfBlockStatement
- [BlockStatement[count(*) = 0]]
-]]>
-                </value>
-            </property>
-        </properties>
-        <example>
-<![CDATA[
+    </example>
+  </rule>
+  
+  <rule name="EmptyIfStmt"
+        language="apex"
+        since="6.0.0"
+        message="Avoid empty 'if' statements"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+        externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#emptyifstmt">
+    <description>
+      Empty If Statement finds instances where a condition is checked but nothing is done about it.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>
+          <![CDATA[
+          //IfBlockStatement
+          [BlockStatement[count(*) = 0]]
+          ]]>
+        </value>
+      </property>
+    </properties>
+    <example>
+      <![CDATA[
 public class Foo {
     public void bar(Integer x) {
         if (x == 0) {
@@ -203,25 +203,25 @@ public class Foo {
     }
 }
 ]]>
-        </example>
-    </rule>
-
-    <rule name="EmptyStatementBlock"
-          language="apex"
-          since="6.0.0"
-          message="Avoid empty block statements."
-          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#emptystatementblock">
-        <description>
-Empty block statements serve no purpose and should be removed.
-        </description>
-        <priority>3</priority>
-        <properties>
-            <property name="reportEmptyPrivateNoArgConstructor" type="Boolean" value="true" description="If false, empty private no-arg constructors are not flagged. This supports a common idiom used by singleton pattern implementations, utility classes, etc."/>
-            <property name="reportEmptyVirtualMethod" type="Boolean" value="true" description="If false, empty virtual methods are not flagged. This supports abstract base classes with default no-op implementations."/>
-            <property name="xpath">
-                <value>
-<![CDATA[
+    </example>
+  </rule>
+  
+  <rule name="EmptyStatementBlock"
+        language="apex"
+        since="6.0.0"
+        message="Avoid empty block statements."
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+        externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#emptystatementblock">
+    <description>
+      Empty block statements serve no purpose and should be removed.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="reportEmptyPrivateNoArgConstructor" type="Boolean" value="true" description="If false, empty private no-arg constructors are not flagged. This supports a common idiom used by singleton pattern implementations, utility classes, etc."/>
+      <property name="reportEmptyVirtualMethod" type="Boolean" value="true" description="If false, empty virtual methods are not flagged. This supports abstract base classes with default no-op implementations."/>
+      <property name="xpath">
+        <value>
+          <![CDATA[
 //Method[$reportEmptyPrivateNoArgConstructor = true()
     or (@Constructor != true()
     or ./ModifierNode[@Private != true()]
@@ -234,11 +234,11 @@ Empty block statements serve no purpose and should be removed.
     [count(*) = 0]
     [@RealLoc = true()]
 ]]>
-                </value>
-            </property>
-        </properties>
-        <example>
-<![CDATA[
+        </value>
+      </property>
+    </properties>
+    <example>
+      <![CDATA[
 public class Foo {
 
    private Integer _bar;
@@ -249,30 +249,30 @@ public class Foo {
 
 }
 ]]>
-        </example>
-    </rule>
-
-    <rule name="EmptyTryOrFinallyBlock"
-          language="apex"
-          since="6.0.0"
-          message="Avoid empty try or finally blocks"
-          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#emptytryorfinallyblock">
-        <description>
-Avoid empty try or finally blocks - what's the point?
-        </description>
-        <priority>3</priority>
-        <properties>
-            <property name="xpath">
-                <value>
-<![CDATA[
-//TryCatchFinallyBlockStatement[./BlockStatement[count(*) = 0]]
-]]>
-                </value>
-            </property>
-        </properties>
-        <example>
-<![CDATA[
+    </example>
+  </rule>
+  
+  <rule name="EmptyTryOrFinallyBlock"
+        language="apex"
+        since="6.0.0"
+        message="Avoid empty try or finally blocks"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+        externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#emptytryorfinallyblock">
+    <description>
+      Avoid empty try or finally blocks - what's the point?
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>
+          <![CDATA[
+          //TryCatchFinallyBlockStatement[./BlockStatement[count(*) = 0]]
+          ]]>
+        </value>
+      </property>
+    </properties>
+    <example>
+      <![CDATA[
 public class Foo {
     public void bar() {
         try {
@@ -293,55 +293,55 @@ public class Foo {
     }
 }
 ]]>
-        </example>
-    </rule>
-
-    <rule name="EmptyWhileStmt"
-          language="apex"
-          since="6.0.0"
-          message="Avoid empty 'while' statements"
-          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#emptywhilestmt">
-        <description>
-Empty While Statement finds all instances where a while statement does nothing.
-If it is a timing loop, then you should use Thread.sleep() for it; if it is
-a while loop that does a lot in the exit expression, rewrite it to make it clearer.
-        </description>
-        <priority>3</priority>
-        <properties>
-            <property name="xpath">
-                <value>
-<![CDATA[
-//WhileLoopStatement[./BlockStatement[count(*) = 0]]
-]]>
-                </value>
-            </property>
-        </properties>
-        <example>
-<![CDATA[
+    </example>
+  </rule>
+  
+  <rule name="EmptyWhileStmt"
+        language="apex"
+        since="6.0.0"
+        message="Avoid empty 'while' statements"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+        externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#emptywhilestmt">
+    <description>
+      Empty While Statement finds all instances where a while statement does nothing.
+      If it is a timing loop, then you should use Thread.sleep() for it; if it is
+      a while loop that does a lot in the exit expression, rewrite it to make it clearer.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>
+          <![CDATA[
+          //WhileLoopStatement[./BlockStatement[count(*) = 0]]
+          ]]>
+        </value>
+      </property>
+    </properties>
+    <example>
+      <![CDATA[
 public void bar(Integer a, Integer b) {
   while (a == b) {
     // empty!
   }
 }
 ]]>
-        </example>
-    </rule>
-
-    <rule name="InaccessibleAuraEnabledGetter"
-          language="apex"
-          since="6.36.0"
-          message="AuraEnabled getter must be public or global if is referenced in Lightning components"
-          class="net.sourceforge.pmd.lang.apex.rule.errorprone.InaccessibleAuraEnabledGetterRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#inaccessibleauraenabledgetter">
-        <description>
-In the Summer '21 release, a mandatory security update enforces access modifiers on Apex properties in
-Lightning component markup. The update prevents access to private or protected Apex getters from Aura
-and Lightning Web Components.
-        </description>
-        <priority>3</priority>
-        <example>
-<![CDATA[
+    </example>
+  </rule>
+  
+  <rule name="InaccessibleAuraEnabledGetter"
+        language="apex"
+        since="6.36.0"
+        message="AuraEnabled getter must be public or global if is referenced in Lightning components"
+        class="net.sourceforge.pmd.lang.apex.rule.errorprone.InaccessibleAuraEnabledGetterRule"
+        externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#inaccessibleauraenabledgetter">
+    <description>
+      In the Summer '21 release, a mandatory security update enforces access modifiers on Apex properties in
+      Lightning component markup. The update prevents access to private or protected Apex getters from Aura
+      and Lightning Web Components.
+    </description>
+    <priority>3</priority>
+    <example>
+      <![CDATA[
 public class Foo {
     @AuraEnabled
     public Integer counter { private get; set; } // Violating - Private getter is inaccessible to Lightning components
@@ -355,9 +355,9 @@ public class Foo {
     }
 }
 ]]>
-        </example>
-        <example>
-<![CDATA[
+    </example>
+    <example>
+      <![CDATA[
 public class Foo {
     @AuraEnabled
     public Integer counter { protected get; set; } // Violating - Protected getter is inaccessible to Lightning components
@@ -371,9 +371,9 @@ public class Foo {
     }
 }
 ]]>
-        </example>
-        <example>
-<![CDATA[
+    </example>
+    <example>
+      <![CDATA[
 public class Foo {
     @AuraEnabled
     public Integer counter { get; set; } // Compliant - Public getter is accessible to Lightning components
@@ -387,21 +387,21 @@ public class Foo {
     }
 }
 ]]>
-        </example>
-    </rule>
-
-    <rule name="MethodWithSameNameAsEnclosingClass"
-          language="apex"
-          since="5.5.0"
-          message="Classes should not have non-constructor methods with the same name as the class"
-          class="net.sourceforge.pmd.lang.apex.rule.errorprone.MethodWithSameNameAsEnclosingClassRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#methodwithsamenameasenclosingclass">
-        <description>
-Non-constructor methods should not have the same name as the enclosing class.
-        </description>
-        <priority>3</priority>
-        <example>
-<![CDATA[
+    </example>
+  </rule>
+  
+  <rule name="MethodWithSameNameAsEnclosingClass"
+        language="apex"
+        since="5.5.0"
+        message="Classes should not have non-constructor methods with the same name as the class"
+        class="net.sourceforge.pmd.lang.apex.rule.errorprone.MethodWithSameNameAsEnclosingClassRule"
+        externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#methodwithsamenameasenclosingclass">
+    <description>
+      Non-constructor methods should not have the same name as the enclosing class.
+    </description>
+    <priority>3</priority>
+    <example>
+      <![CDATA[
 public class MyClass {
     // this is OK because it is a constructor
     public MyClass() {}
@@ -409,25 +409,25 @@ public class MyClass {
     public void MyClass() {}
 }
 ]]>
-        </example>
-    </rule>
-
-    <rule name="OverrideBothEqualsAndHashcode"
-          language="apex"
-          since="6.31.0"
-          message="Ensure you override both equals() and hashCode()"
-          class="net.sourceforge.pmd.lang.apex.rule.errorprone.OverrideBothEqualsAndHashcodeRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#overridebothequalsandhashcode">
-        <description>
-Override both `public Boolean equals(Object obj)`, and `public Integer hashCode()`, or override neither.
-Even if you are inheriting a hashCode() from a parent class, consider implementing hashCode and explicitly
-delegating to your superclass.
-
-This is especially important when [Using Custom Types in Map Keys and Sets](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/langCon_apex_collections_maps_keys_userdefined.htm).
-        </description>
-        <priority>3</priority>
-        <example>
-<![CDATA[
+    </example>
+  </rule>
+  
+  <rule name="OverrideBothEqualsAndHashcode"
+        language="apex"
+        since="6.31.0"
+        message="Ensure you override both equals() and hashCode()"
+        class="net.sourceforge.pmd.lang.apex.rule.errorprone.OverrideBothEqualsAndHashcodeRule"
+        externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#overridebothequalsandhashcode">
+    <description>
+      Override both `public Boolean equals(Object obj)`, and `public Integer hashCode()`, or override neither.
+      Even if you are inheriting a hashCode() from a parent class, consider implementing hashCode and explicitly
+      delegating to your superclass.
+      
+      This is especially important when [Using Custom Types in Map Keys and Sets](https://developer.salesforce.com/docs/atlas.en-us.apexcode.meta/apexcode/langCon_apex_collections_maps_keys_userdefined.htm).
+    </description>
+    <priority>3</priority>
+    <example>
+      <![CDATA[
 public class Bar {        // poor, missing a hashCode() method
     public Boolean equals(Object o) {
       // do some comparison
@@ -447,29 +447,29 @@ public class Foo {        // perfect, both methods provided
     }
 }
 ]]>
-        </example>
-    </rule>
-
-    <rule name="TestMethodsMustBeInTestClasses"
-          language="apex"
-          since="6.22.0"
-          message="Test methods must be in test classes"
-          class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#testmethodsmustbeintestclasses">
-       <description>
-          Test methods marked as a testMethod or annotated with @IsTest,
-          but not residing in a test class should be moved to a proper
-          class or have the @IsTest annotation added to the class.
-
-          Support for tests inside functional classes was removed in Spring-13 (API Version 27.0),
-          making classes that violate this rule fail compile-time. This rule is mostly usable when
-          dealing with legacy code.
-       </description>
-       <priority>3</priority>
-       <properties>
-          <property name="xpath">
-             <value>
-    <![CDATA[
+    </example>
+  </rule>
+  
+  <rule name="TestMethodsMustBeInTestClasses"
+        language="apex"
+        since="6.22.0"
+        message="Test methods must be in test classes"
+        class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
+        externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#testmethodsmustbeintestclasses">
+    <description>
+      Test methods marked as a testMethod or annotated with @IsTest,
+      but not residing in a test class should be moved to a proper
+      class or have the @IsTest annotation added to the class.
+      
+      Support for tests inside functional classes was removed in Spring-13 (API Version 27.0),
+      making classes that violate this rule fail compile-time. This rule is mostly usable when
+      dealing with legacy code.
+    </description>
+    <priority>3</priority>
+    <properties>
+      <property name="xpath">
+        <value>
+          <![CDATA[
     //UserClass[
       not(./ModifierNode/Annotation[lower-case(@Name) = 'istest']) and
       (
@@ -479,11 +479,11 @@ public class Foo {        // perfect, both methods provided
     ]
 
     ]]>
-             </value>
-          </property>
-       </properties>
-       <example>
-           <![CDATA[// Violating
+        </value>
+      </property>
+    </properties>
+    <example>
+      <![CDATA[// Violating
 private class TestClass {
   @IsTest static void myTest() {
     // Code here
@@ -511,27 +511,29 @@ private class TestClass {
   }
 }
 ]]>
-       </example>
-    </rule>
-    <rule name="AvoidStatefulDatabaseResult"
-          language="apex"
-          since="7.10.0"
-          message="Using stateful `Database.[x]Result` instance variables can cause serialization errors between successive batch iterations."
-          class="net.sourceforge.pmd.lang.apex.rule.errorprone.AvoidStatefulDatabaseResultRule"
-          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#avoidstatefuldatabaseresult">
-       <description>
-          Storing Database.insertResult, Database.updateResult, etc. in instance variables
-          of a stateful batch class can cause serialization errors between batch iterations.
-          When this occurs, it is often inconsistent and challenging to troubleshoot.
-
-          This issue can be avoided by marking the variable as transient, or using a different
-          data type that is safe to serialize.
-       </description>
-       <priority>3</priority>
-       <example>
-           <![CDATA[// Violating
+    </example>
+  </rule>
+  <rule name="AvoidStatefulDatabaseResult"
+        language="apex"
+        since="7.10.0"
+        message="Using stateful `Database.[x]Result` instance variables can cause serialization errors between successive batch iterations."
+        class="net.sourceforge.pmd.lang.apex.rule.errorprone.AvoidStatefulDatabaseResultRule"
+        externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#avoidstatefuldatabaseresult">
+    <description>
+      Storing Database.insertResult, Database.updateResult, etc. in instance variables
+      of a stateful batch class can cause serialization errors between batch iterations.
+      When this occurs, it is often inconsistent and challenging to troubleshoot.
+      
+      See https://issues.salesforce.com/issue/a028c00000qPwlqAAC/stateful-batch-job-that-stores-databasesaveresult-failed-after-validation-errors-throws-error-during-deserialization for more details.
+      
+      This issue can be avoided by marking the variable as transient, or using a different
+      data type that is safe to serialize.
+    </description>
+    <priority>3</priority>
+    <example>
+      <![CDATA[// Violating
 public class Example implements Database.Batchable, Database.Stateful {
-  Database.SaveResult[] results = new Database.SaveResult[]; // this can cause failures
+  List<Database.SaveResult> results = new List<Database.SaveResult>(); // this can cause failures
 
   public Database.Querylocator start(Database.BatchableContext context){
     return Database.getQueryLocator('SELECT Id FROM Account');
@@ -548,7 +550,7 @@ public class Example implements Database.Batchable, Database.Stateful {
 
 // Compliant
 public class Example implements Database.Batchable, Database.Stateful {
-  StatefulResult[] results = new StatefulResult[]; // Use a different custom type to persist state
+  List<StatefulResult> results = new List<StatefulResult>(); // Use a different custom type to persist state
 
   public Database.Querylocator start(Database.BatchableContext context){
     return Database.getQueryLocator('SELECT Id FROM Account');
@@ -590,6 +592,6 @@ public class StatefulResult {
   }
 }
 ]]>
-       </example>
-    </rule>
+    </example>
+  </rule>
 </ruleset>

--- a/pmd-apex/src/main/resources/category/apex/errorprone.xml
+++ b/pmd-apex/src/main/resources/category/apex/errorprone.xml
@@ -513,4 +513,83 @@ private class TestClass {
 ]]>
        </example>
     </rule>
+    <rule name="AvoidStatefulDatabaseResult"
+          language="apex"
+          since="7.10.0"
+          message="Using stateful `Database.[x]Result` instance variables can cause serialization errors between successive batch iterations."
+          class="net.sourceforge.pmd.lang.apex.rule.errorprone.AvoidStatefulDatabaseResultRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_errorprone.html#avoidstatefuldatabaseresult">
+       <description>
+          Storing Database.insertResult, Database.updateResult, etc. in instance variables
+          of a stateful batch class can cause serialization errors between batch iterations.
+          When this occurs, it is often inconsistent and challenging to troubleshoot.
+
+          This issue can be avoided by marking the variable as transient, or using a different
+          data type that is safe to serialize.
+       </description>
+       <priority>3</priority>
+       <example>
+           <![CDATA[// Violating
+public class Example implements Database.Batchable, Database.Stateful {
+  Database.SaveResult[] results = new Database.SaveResult[]; // this can cause failures
+
+  public Database.Querylocator start(Database.BatchableContext context){
+    return Database.getQueryLocator('SELECT Id FROM Account');
+  }
+
+  public void execute(Database.BatchableContext context, List<SObject> scope){
+    Database.SaveResult[] saveResults = Database.update(scope, false);
+    results.addAll(saveResults);
+  }
+
+  public void finish(database.BatchableContext context){
+  }
+}
+
+// Compliant
+public class Example implements Database.Batchable, Database.Stateful {
+  StatefulResult[] results = new StatefulResult[]; // Use a different custom type to persist state
+
+  public Database.Querylocator start(Database.BatchableContext context){
+    return Database.getQueryLocator('SELECT Id FROM Account');
+  }
+
+  public void execute(Database.BatchableContext context, List<SObject> scope){
+    Database.SaveResult[] saveResults = Database.update(scope, false);
+    for (Database.SaveResult result : saveResults) {
+      results.add(new StatefulResult(result));
+    }
+  }
+
+  public void finish(database.BatchableContext context){
+  }
+
+}
+
+public class StatefulResult {
+  private Boolean isSuccess;
+  private Id id;
+  private Database.Error[] errors;
+
+  public StatefulResult(Database.SaveResult result){
+    isSuccess = result.isSuccess();
+    id = result.getId();
+    errors = result.getErrors();
+  }
+
+  public Boolean isSuccess(){
+    return isSuccess;
+  }
+
+  public Id getId(){
+    return id;
+  }
+
+  public Database.Error[] getErrors(){
+    return errors;
+  }
+}
+]]>
+       </example>
+    </rule>
 </ruleset>

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidStatefulDatabaseResultTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidStatefulDatabaseResultTest.java
@@ -1,0 +1,11 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.rule.errorprone;
+
+import net.sourceforge.pmd.test.PmdRuleTst;
+
+class AvoidStatefulDatabaseResultTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/xml/AvoidStatefulDatabaseResult.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/xml/AvoidStatefulDatabaseResult.xml
@@ -17,14 +17,14 @@ public class Example implements Database.Batchable<SObject>, Database.Stateful {
   private Database.UndeleteResult undeleteResult;
   private Database.UpsertResult upsertResult;
 
-  public Database.Querylocator start(Database.BatchableContext context){
+  public Database.Querylocator start(Database.BatchableContext context) {
     return Database.getQueryLocator('SELECT Id FROM Account');
   }
 
-  public void execute(Database.BatchableContext context, List<SObject> scope){
+  public void execute(Database.BatchableContext context, List<SObject> scope) {
   }
 
-  public void finish(database.BatchableContext context){
+  public void finish(database.BatchableContext context) {
   }
 }
         ]]></code>
@@ -43,14 +43,14 @@ public class Example implements Database.Batchable<SObject>, Database.Stateful {
   private List<Database.UndeleteResult> undeleteResults = new List<Database.UndeleteResult>();
   private List<Database.UpsertResult> upsertResults = new List<Database.UpsertResult>();
 
-  public Database.Querylocator start(Database.BatchableContext context){
+  public Database.Querylocator start(Database.BatchableContext context) {
     return Database.getQueryLocator('SELECT Id FROM Account');
   }
 
-  public void execute(Database.BatchableContext context, List<SObject> scope){
+  public void execute(Database.BatchableContext context, List<SObject> scope) {
   }
 
-  public void finish(database.BatchableContext context){
+  public void finish(database.BatchableContext context) {
   }
 }
         ]]></code>
@@ -69,14 +69,14 @@ public class Example implements Database.Batchable<SObject>, Database.Stateful {
   private Set<Database.UndeleteResult> undeleteResults = new Set<Database.UndeleteResult>();
   private Set<Database.UpsertResult> upsertResults = new Set<Database.UpsertResult>();
 
-  public Database.Querylocator start(Database.BatchableContext context){
+  public Database.Querylocator start(Database.BatchableContext context) {
     return Database.getQueryLocator('SELECT Id FROM Account');
   }
 
-  public void execute(Database.BatchableContext context, List<SObject> scope){
+  public void execute(Database.BatchableContext context, List<SObject> scope) {
   }
 
-  public void finish(database.BatchableContext context){
+  public void finish(database.BatchableContext context) {
   }
 }
         ]]></code>
@@ -95,14 +95,14 @@ public class Example implements Database.Batchable<SObject>, Database.Stateful {
   private Map<Id, Database.UndeleteResult> undeleteResults = new Map<Id, Database.UndeleteResult>();
   private Map<Id, Database.UpsertResult> upsertResults = new Map<Id, Database.UpsertResult>();
 
-  public Database.Querylocator start(Database.BatchableContext context){
+  public Database.Querylocator start(Database.BatchableContext context) {
     return Database.getQueryLocator('SELECT Id FROM Account');
   }
 
-  public void execute(Database.BatchableContext context, List<SObject> scope){
+  public void execute(Database.BatchableContext context, List<SObject> scope) {
   }
 
-  public void finish(database.BatchableContext context){
+  public void finish(database.BatchableContext context) {
   }
 }
         ]]></code>
@@ -121,14 +121,14 @@ public class Example implements Database.Batchable<SObject>, Database.Stateful {
   private transient Database.UndeleteResult undeleteResult;
   private transient Database.UpsertResult upsertResult;
 
-  public Database.Querylocator start(Database.BatchableContext context){
+  public Database.Querylocator start(Database.BatchableContext context) {
     return Database.getQueryLocator('SELECT Id FROM Account');
   }
 
-  public void execute(Database.BatchableContext context, List<SObject> scope){
+  public void execute(Database.BatchableContext context, List<SObject> scope) {
   }
 
-  public void finish(database.BatchableContext context){
+  public void finish(database.BatchableContext context) {
   }
 }
         ]]></code>
@@ -147,14 +147,14 @@ public class Example implements Database.Batchable<SObject>, Database.Stateful {
   private static Database.UndeleteResult undeleteResult;
   private static Database.UpsertResult upsertResult;
 
-  public Database.Querylocator start(Database.BatchableContext context){
+  public Database.Querylocator start(Database.BatchableContext context) {
     return Database.getQueryLocator('SELECT Id FROM Account');
   }
 
-  public void execute(Database.BatchableContext context, List<SObject> scope){
+  public void execute(Database.BatchableContext context, List<SObject> scope) {
   }
 
-  public void finish(database.BatchableContext context){
+  public void finish(database.BatchableContext context) {
   }
 }
         ]]></code>
@@ -173,14 +173,14 @@ public class Example implements Database.Batchable<SObject> {
   private Database.UndeleteResult undeleteResult;
   private Database.UpsertResult upsertResult;
 
-  public Database.Querylocator start(Database.BatchableContext context){
+  public Database.Querylocator start(Database.BatchableContext context) {
     return Database.getQueryLocator('SELECT Id FROM Account');
   }
 
-  public void execute(Database.BatchableContext context, List<SObject> scope){
+  public void execute(Database.BatchableContext context, List<SObject> scope) {
   }
 
-  public void finish(database.BatchableContext context){
+  public void finish(database.BatchableContext context) {
   }
 }
         ]]></code>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/xml/AvoidStatefulDatabaseResult.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/xml/AvoidStatefulDatabaseResult.xml
@@ -1,29 +1,189 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <test-data
-    xmlns="http://pmd.sourceforge.net/rule-tests"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
-
-    <test-code>
-        <description>SaveResult array.</description>
-        <expected-problems>1</expected-problems>
-        <code><![CDATA[
-public class Example implements Database.Batchable, Database.Stateful {
-  Database.SaveResult[] results = new Database.SaveResult[]; // this can cause failures
+  xmlns="http://pmd.sourceforge.net/rule-tests"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+  
+  <test-code>
+    <description>Result instances in stateful class</description>
+    <expected-problems>7</expected-problems>
+    <code><![CDATA[
+public class Example implements Database.Batchable<SObject>, Database.Stateful {
+  private Database.DeleteResult deleteResult;
+  private Database.EmptyRecycleBinResult emptyRecycleBinResult;
+  private Database.LeadConvertResult leadConvertResult;
+  private Database.MergeResult mergeResult;
+  private Database.SaveResult saveResult;
+  private Database.UndeleteResult undeleteResult;
+  private Database.UpsertResult upsertResult;
 
   public Database.Querylocator start(Database.BatchableContext context){
     return Database.getQueryLocator('SELECT Id FROM Account');
   }
 
   public void execute(Database.BatchableContext context, List<SObject> scope){
-    Database.SaveResult[] saveResults = Database.update(scope, false);
-    results.addAll(saveResults);
   }
 
   public void finish(database.BatchableContext context){
   }
 }
         ]]></code>
-    </test-code>
+  </test-code>
+  
+  <test-code>
+    <description>Result lists in stateful class</description>
+    <expected-problems>7</expected-problems>
+    <code><![CDATA[
+public class Example implements Database.Batchable<SObject>, Database.Stateful {
+  private List<Database.DeleteResult> deleteResults = new List<Database.DeleteResult>();
+  private List<Database.EmptyRecycleBinResult> emptyRecycleBinResults = new List<Database.EmptyRecycleBinResult>();
+  private List<Database.LeadConvertResult> leadConvertResults = new List<Database.LeadConvertResult>();
+  private List<Database.MergeResult> mergeResults = new List<Database.MergeResult>();
+  private List<Database.SaveResult> saveResults = new List<Database.SaveResult>();
+  private List<Database.UndeleteResult> undeleteResults = new List<Database.UndeleteResult>();
+  private List<Database.UpsertResult> upsertResults = new List<Database.UpsertResult>();
 
+  public Database.Querylocator start(Database.BatchableContext context){
+    return Database.getQueryLocator('SELECT Id FROM Account');
+  }
+
+  public void execute(Database.BatchableContext context, List<SObject> scope){
+  }
+
+  public void finish(database.BatchableContext context){
+  }
+}
+        ]]></code>
+  </test-code>
+  
+  <test-code>
+    <description>Result sets in stateful class</description>
+    <expected-problems>7</expected-problems>
+    <code><![CDATA[
+public class Example implements Database.Batchable<SObject>, Database.Stateful {
+  private Set<Database.DeleteResult> deleteResults = new Set<Database.DeleteResult>();
+  private Set<Database.EmptyRecycleBinResult> emptyRecycleBinResults = new Set<Database.EmptyRecycleBinResult>();
+  private Set<Database.LeadConvertResult> leadConvertResults = new Set<Database.LeadConvertResult>();
+  private Set<Database.MergeResult> mergeResults = new Set<Database.MergeResult>();
+  private Set<Database.SaveResult> saveResults = new Set<Database.SaveResult>();
+  private Set<Database.UndeleteResult> undeleteResults = new Set<Database.UndeleteResult>();
+  private Set<Database.UpsertResult> upsertResults = new Set<Database.UpsertResult>();
+
+  public Database.Querylocator start(Database.BatchableContext context){
+    return Database.getQueryLocator('SELECT Id FROM Account');
+  }
+
+  public void execute(Database.BatchableContext context, List<SObject> scope){
+  }
+
+  public void finish(database.BatchableContext context){
+  }
+}
+        ]]></code>
+  </test-code>
+  
+  <test-code>
+    <description>Result maps in stateful class</description>
+    <expected-problems>7</expected-problems>
+    <code><![CDATA[
+public class Example implements Database.Batchable<SObject>, Database.Stateful {
+  private Map<Id, Database.DeleteResult> deleteResults = new Map<Id, Database.DeleteResult>();
+  private Map<Id, Database.EmptyRecycleBinResult> emptyRecycleBinResults = new Map<Id, Database.EmptyRecycleBinResult>();
+  private Map<Id, Database.LeadConvertResult> leadConvertResults = new Map<Id, Database.LeadConvertResult>();
+  private Map<Id, Database.MergeResult> mergeResults = new Map<Id, Database.MergeResult>();
+  private Map<Id, Database.SaveResult> saveResults = new Map<Id, Database.SaveResult>();
+  private Map<Id, Database.UndeleteResult> undeleteResults = new Map<Id, Database.UndeleteResult>();
+  private Map<Id, Database.UpsertResult> upsertResults = new Map<Id, Database.UpsertResult>();
+
+  public Database.Querylocator start(Database.BatchableContext context){
+    return Database.getQueryLocator('SELECT Id FROM Account');
+  }
+
+  public void execute(Database.BatchableContext context, List<SObject> scope){
+  }
+
+  public void finish(database.BatchableContext context){
+  }
+}
+        ]]></code>
+  </test-code>
+  
+  <test-code>
+    <description>Transient result in stateful class</description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+public class Example implements Database.Batchable<SObject>, Database.Stateful {
+  private transient Database.DeleteResult deleteResult;
+  private transient Database.EmptyRecycleBinResult emptyRecycleBinResult;
+  private transient Database.LeadConvertResult leadConvertResult;
+  private transient Database.MergeResult mergeResult;
+  private transient Database.SaveResult saveResult;
+  private transient Database.UndeleteResult undeleteResult;
+  private transient Database.UpsertResult upsertResult;
+
+  public Database.Querylocator start(Database.BatchableContext context){
+    return Database.getQueryLocator('SELECT Id FROM Account');
+  }
+
+  public void execute(Database.BatchableContext context, List<SObject> scope){
+  }
+
+  public void finish(database.BatchableContext context){
+  }
+}
+        ]]></code>
+  </test-code>
+  
+  <test-code>
+    <description>Static results in stateful class</description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+public class Example implements Database.Batchable<SObject>, Database.Stateful {
+  private static Database.DeleteResult deleteResult;
+  private static Database.EmptyRecycleBinResult emptyRecycleBinResult;
+  private static Database.LeadConvertResult leadConvertResult;
+  private static Database.MergeResult mergeResult;
+  private static Database.SaveResult saveResult;
+  private static Database.UndeleteResult undeleteResult;
+  private static Database.UpsertResult upsertResult;
+
+  public Database.Querylocator start(Database.BatchableContext context){
+    return Database.getQueryLocator('SELECT Id FROM Account');
+  }
+
+  public void execute(Database.BatchableContext context, List<SObject> scope){
+  }
+
+  public void finish(database.BatchableContext context){
+  }
+}
+        ]]></code>
+  </test-code>
+  
+  <test-code>
+    <description>Results in non-stateful class.</description>
+    <expected-problems>0</expected-problems>
+    <code><![CDATA[
+public class Example implements Database.Batchable<SObject> {
+  private Database.DeleteResult deleteResult;
+  private Database.EmptyRecycleBinResult emptyRecycleBinResult;
+  private Database.LeadConvertResult leadConvertResult;
+  private Database.MergeResult mergeResult;
+  private Database.SaveResult saveResult;
+  private Database.UndeleteResult undeleteResult;
+  private Database.UpsertResult upsertResult;
+
+  public Database.Querylocator start(Database.BatchableContext context){
+    return Database.getQueryLocator('SELECT Id FROM Account');
+  }
+
+  public void execute(Database.BatchableContext context, List<SObject> scope){
+  }
+
+  public void finish(database.BatchableContext context){
+  }
+}
+        ]]></code>
+  </test-code>
+  
 </test-data>

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/xml/AvoidStatefulDatabaseResult.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/errorprone/xml/AvoidStatefulDatabaseResult.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+    <test-code>
+        <description>SaveResult array.</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Example implements Database.Batchable, Database.Stateful {
+  Database.SaveResult[] results = new Database.SaveResult[]; // this can cause failures
+
+  public Database.Querylocator start(Database.BatchableContext context){
+    return Database.getQueryLocator('SELECT Id FROM Account');
+  }
+
+  public void execute(Database.BatchableContext context, List<SObject> scope){
+    Database.SaveResult[] saveResults = Database.update(scope, false);
+    results.addAll(saveResults);
+  }
+
+  public void finish(database.BatchableContext context){
+  }
+}
+        ]]></code>
+    </test-code>
+
+</test-data>


### PR DESCRIPTION
## Describe the PR

Warns the author when they write a class which implements `Database.Stateful` and define `Database.[x]Result` or a collection of `Database.[x]Result` (e.g. : `Database.SaveResult`) as a non-transient instance variable. This can cause serialization errors between batch iterations.

See [this issue](https://issues.salesforce.com/issue/a028c00000qPwlqAAC/stateful-batch-job-that-stores-databasesaveresult-failed-after-validation-errors-throws-error-during-deserialization) for more details.

## Related issues

- Fix #5305

## Ready?


- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

