### PR TITLE
Use new gpg key (A0B5CA1A4E086838)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
       run: |
         echo "LANG=en_US.UTF-8" >> $GITHUB_ENV
         echo "MAVEN_OPTS=-Daether.connector.http.connectionMaxTtl=180 -DautoReleaseAfterClose=true -DstagingProgressTimeoutMinutes=30" >> $GITHUB_ENV
-        echo "PMD_CI_SCRIPTS_URL=https://raw.githubusercontent.com/pmd/build-tools/28/scripts" >> $GITHUB_ENV
+        echo "PMD_CI_SCRIPTS_URL=https://raw.githubusercontent.com/pmd/build-tools/main/scripts" >> $GITHUB_ENV
     - name: Check Environment
       shell: bash
       run: |
@@ -75,6 +75,8 @@ jobs:
         BUILD_CLI_DIST_ONLY: ${{ inputs.build_cli_dist_only }}
         PMD_CI_SECRET_PASSPHRASE: ${{ secrets.PMD_CI_SECRET_PASSPHRASE }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        PMD_CI_GPG_PRIVATE_KEY: ${{ secrets.PMD_CI_GPG_PRIVATE_KEY }}
+        MAVEN_GPG_PASSPHRASE: ${{ secrets.PMD_CI_GPG_PASSPHRASE }}
     - name: Workaround actions/upload-artifact#176
       run: |
         echo "artifacts_path=$(realpath ..)" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
       run: |
         echo "LANG=en_US.UTF-8" >> $GITHUB_ENV
         echo "MAVEN_OPTS=-Daether.connector.http.connectionMaxTtl=180 -DautoReleaseAfterClose=true -DstagingProgressTimeoutMinutes=30" >> $GITHUB_ENV
-        echo "PMD_CI_SCRIPTS_URL=https://raw.githubusercontent.com/pmd/build-tools/main/scripts" >> $GITHUB_ENV
+        echo "PMD_CI_SCRIPTS_URL=https://raw.githubusercontent.com/pmd/build-tools/29/scripts" >> $GITHUB_ENV
     - name: Check Environment
       shell: bash
       run: |

--- a/.github/workflows/git-repo-sync.yml
+++ b/.github/workflows/git-repo-sync.yml
@@ -23,7 +23,7 @@ jobs:
       shell: bash
       run: |
         echo "LANG=en_US.UTF-8" >> $GITHUB_ENV
-        echo "PMD_CI_SCRIPTS_URL=https://raw.githubusercontent.com/pmd/build-tools/28/scripts" >> $GITHUB_ENV
+        echo "PMD_CI_SCRIPTS_URL=https://raw.githubusercontent.com/pmd/build-tools/29/scripts" >> $GITHUB_ENV
     - name: Sync
       run: .ci/git-repo-sync.sh
       shell: bash

--- a/.github/workflows/troubleshooting.yml
+++ b/.github/workflows/troubleshooting.yml
@@ -36,7 +36,7 @@ jobs:
         run: |
           echo "LANG=en_US.UTF-8" >> $GITHUB_ENV
           echo "MAVEN_OPTS=-Daether.connector.http.connectionMaxTtl=180 -DstagingProgressTimeoutMinutes=30" >> $GITHUB_ENV
-          echo "PMD_CI_SCRIPTS_URL=https://raw.githubusercontent.com/pmd/build-tools/28/scripts" >> $GITHUB_ENV
+          echo "PMD_CI_SCRIPTS_URL=https://raw.githubusercontent.com/pmd/build-tools/29/scripts" >> $GITHUB_ENV
       - name: Check Environment
         shell: bash
         run: |

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -25,6 +25,12 @@ safe to use anymore. While the key itself is not compromised as far as we know, 
 new key, just to be safe. As until now (January 2025) we are not aware, that the key actually has been misused.
 The previous releases of PMD in Maven Central can still be considered untampered, as Maven Central is read-only.
 
+This unexpected issue was discovered while checking [Reproducible Builds](https://reproducible-builds.org/) by a
+third party.
+
+The compromised passphrase is tracked as [GHSA-88m4-h43f-wx84](https://github.com/pmd/pmd/security/advisories/GHSA-88m4-h43f-wx84)
+and [CVE-2025-23215](https://www.cve.org/CVERecord?id=CVE-2025-23215).
+
 ### 🐛 Fixed Issues
 
 ### 🚨 API Changes

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -14,6 +14,17 @@ This is a {{ site.pmd.release_type }} release.
 
 ### 🚀 New and noteworthy
 
+### New GPG Release Signing Key
+
+Since January 2025, we switched the GPG Key we use for signing releases in Maven Central to be
+[A0B5CA1A4E086838](https://keyserver.ubuntu.com/pks/lookup?search=0x2EFA55D0785C31F956F2F87EA0B5CA1A4E086838&fingerprint=on&op=index).
+The full fingerprint is `2EFA 55D0 785C 31F9 56F2  F87E A0B5 CA1A 4E08 6838`.
+
+This step was necessary, as the passphrase of the old key has been compromised and therefore the key is not
+safe to use anymore. While the key itself is not compromised as far as we know, we still decided to generate a
+new key, just to be safe. As until now (January 2025) we are not aware, that the key actually has been misused.
+The previous releases of PMD in Maven Central can still be considered untampered, as Maven Central is read-only.
+
 ### 🐛 Fixed Issues
 
 ### 🚨 API Changes

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <argLine>-Xmx512m -Dfile.encoding=${project.build.sourceEncoding} ${extraArgLine}</argLine>
         <extraArgLine /> <!-- empty by default, profiles set it as needed -->
 
-        <pmd.build-tools.version>28</pmd.build-tools.version>
+        <pmd.build-tools.version>29-SNAPSHOT</pmd.build-tools.version>
 
         <pmd-designer.version>7.2.0</pmd-designer.version>
 
@@ -1206,7 +1206,10 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.1.0</version>
+                        <version>3.2.7</version>
+                        <configuration>
+                            <bestPractices>true</bestPractices>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
         <argLine>-Xmx512m -Dfile.encoding=${project.build.sourceEncoding} ${extraArgLine}</argLine>
         <extraArgLine /> <!-- empty by default, profiles set it as needed -->
 
-        <pmd.build-tools.version>29-SNAPSHOT</pmd.build-tools.version>
+        <pmd.build-tools.version>29</pmd.build-tools.version>
 
         <pmd-designer.version>7.2.0</pmd-designer.version>
 


### PR DESCRIPTION
## Describe the PR

After merging this PR, the new GPG key will be used for the SNAPSHOT deployments to Maven Central.
Before we release 7.10.0, we of course need to release build-tools 29-SNAPSHOT before.

Note: The new secrets (PMD_CI_GPG_PRIVATE_KEY and PMD_CI_GPG_PASSPHRASE) are setup already.

## Related issues

- See also https://github.com/pmd/pmd-designer/pull/98
- See also https://github.com/pmd/pmd-eclipse-plugin/pull/237

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

