### PR TITLE
[docs] Call render_release_notes.rb within docs

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -299,13 +299,13 @@ function pmd_ci_build_and_upload_doc() {
 
         # render release notes
         # updating github release text
-        rm -f .bundle/config
+        pushd docs || { echo "Directory 'docs' doesn't exist"; exit 1; }
         bundle config set --local path vendor/bundle
-        bundle config set --local with release_notes_preprocessing
         bundle install
         # renders, and skips the first 6 lines - the Jekyll front-matter
         local rendered_release_notes
-        rendered_release_notes=$(bundle exec docs/render_release_notes.rb docs/pages/release_notes.md | tail -n +6)
+        rendered_release_notes=$(bundle exec render_release_notes.rb pages/release_notes.md | tail -n +6)
+        popd || exit 1
         local release_name
         release_name="PMD ${PMD_CI_MAVEN_PROJECT_VERSION} ($(date -u +%d-%B-%Y))"
         # Upload to https://sourceforge.net/projects/pmd/files/pmd/${PMD_CI_MAVEN_PROJECT_VERSION}/ReadMe.md

--- a/Gemfile
+++ b/Gemfile
@@ -6,14 +6,4 @@ source 'https://rubygems.org/'
 gem 'pmdtester'
 gem 'danger'
 
-# This group is only needed for rendering release notes (docs/render_release_notes.rb)
-# this happens during release (.ci/build.sh and do-release.sh)
-# but also during regular builds (.ci/build.sh)
-group :release_notes_preprocessing do
-  gem 'liquid'
-  gem 'safe_yaml'
-  gem 'rouge'
-  gem 'bigdecimal'
-end
-
 # vim: syntax=ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,10 +77,8 @@ GEM
     racc (1.8.1)
     rchardet (1.8.0)
     rexml (3.3.9)
-    rouge (4.5.1)
     rufus-scheduler (3.9.2)
       fugit (~> 1.1, >= 1.11.1)
-    safe_yaml (1.0.5)
     sawyer (0.9.2)
       addressable (>= 2.3.5)
       faraday (>= 0.17.3, < 3)
@@ -97,12 +95,8 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  bigdecimal
   danger
-  liquid
   pmdtester
-  rouge
-  safe_yaml
 
 BUNDLED WITH
    2.5.22

--- a/do-release.sh
+++ b/do-release.sh
@@ -22,16 +22,14 @@ fi
 #
 set +e # don't stop for error "command not found" - it is handled
 ruby_version_full=$(ruby --version 2>&1)
-ruby_version=$(echo "${ruby_version_full}" | grep "ruby 3" | head -1 2>&1)
-if [ $? -eq 0 ] && [ -n "${ruby_version}" ]; then
+if ruby_version=$(echo "${ruby_version_full}" | grep "ruby 3" | head -1 2>&1) && [ -n "${ruby_version}" ]; then
   echo "Using ${ruby_version_full}"
 else
   echo "Wrong ruby version! Expected ruby 3"
   echo "${ruby_version_full}"
   exit 1
 fi
-bundler_version=$(bundler --version 2>&1)
-if [ $? -eq 0 ]; then
+if bundler_version=$(bundler --version 2>&1); then
   echo "Using ${bundler_version}"
 else
   echo "Missing bundler!"
@@ -151,15 +149,16 @@ echo
 echo "Press enter to continue..."
 read -r
 
-# install bundles needed for rendering release notes
+# install bundles needed for rendering release notes and execute rendering
+pushd docs || { echo "Directory 'docs' doesn't exist"; exit 1; }
 bundle config set --local path vendor/bundle
-bundle config set --local with release_notes_preprocessing
 bundle install
+NEW_RELEASE_NOTES=$(bundle exec render_release_notes.rb pages/release_notes.md | tail -n +6)
+popd || exit 1
 
 RELEASE_NOTES_POST="_posts/$(date -u +%Y-%m-%d)-PMD-${RELEASE_VERSION}.md"
 export RELEASE_NOTES_POST
 echo "Generating ../pmd.github.io/${RELEASE_NOTES_POST}..."
-NEW_RELEASE_NOTES=$(bundle exec docs/render_release_notes.rb docs/pages/release_notes.md | tail -n +6)
 cat > "../pmd.github.io/${RELEASE_NOTES_POST}" <<EOF
 ---
 layout: post

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -4,3 +4,7 @@ gem 'jekyll'
 gem 'github-pages'
 gem "webrick"
 gem "csv"
+gem 'liquid'
+gem 'safe_yaml'
+gem 'rouge'
+gem 'bigdecimal'

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -272,9 +272,13 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bigdecimal
   csv
   github-pages
   jekyll
+  liquid
+  rouge
+  safe_yaml
   webrick
 
 BUNDLED WITH

--- a/docs/pages/pmd/projectdocs/committers/releasing.md
+++ b/docs/pages/pmd/projectdocs/committers/releasing.md
@@ -152,15 +152,22 @@ Note: The release notes typically contain some Jekyll macros for linking to the 
 work in a plain markdown version. Therefore, you need to render the release notes first:
 
 ```shell
-# install bundles needed for rendering release notes
+# install bundles needed for rendering release notes and execute rendering
+cd docs
 bundle config set --local path vendor/bundle
-bundle config set --local with release_notes_preprocessing
 bundle install
+NEW_RELEASE_NOTES=$(bundle exec render_release_notes.rb pages/release_notes.md | tail -n +6)
+cd ..
 
 RELEASE_NOTES_POST="_posts/$(date -u +%Y-%m-%d)-PMD-${RELEASE_VERSION}.md"
 echo "Generating ../pmd.github.io/${RELEASE_NOTES_POST}..."
-NEW_RELEASE_NOTES=$(bundle exec docs/render_release_notes.rb docs/pages/release_notes.md | tail -n +6)
 cat > "../pmd.github.io/${RELEASE_NOTES_POST}" <<EOF
+---
+layout: post
+title: PMD ${RELEASE_VERSION} released
+---
+${NEW_RELEASE_NOTES}
+EOF
 ```
 
 Check in all (version, blog post) changes to branch main:

--- a/docs/render_release_notes.rb
+++ b/docs/render_release_notes.rb
@@ -12,7 +12,7 @@ require "liquid"
 require "safe_yaml"
 
 # include some custom liquid extensions
-require_relative "../docs/_plugins/all_extensions"
+require_relative "_plugins/all_extensions"
 
 # explicitly setting safe mode to get rid of the warning
 SafeYAML::OPTIONS[:default_mode] = :safe
@@ -27,11 +27,11 @@ end
 release_notes_file = ARGV[0]
 
 # Make the script execute wherever we are
-travis_dir = File.expand_path File.dirname(__FILE__)
+docs_dir = File.expand_path File.dirname(__FILE__)
 
 liquid_env = {
     # wrap the config under a "site." namespace because that's how jekyll does it
-    'site' => YAML.load_file(travis_dir + "/../docs/_config.yml"),
+    'site' => YAML.load_file(docs_dir + "/_config.yml"),
     'page' => YAML.load_file(release_notes_file),
     # This signals the links in {% rule %} tags that they should be rendered as absolute
     'is_release_notes_processor' => true


### PR DESCRIPTION
## Describe the PR

While release, I've seen the following warnings:

```
[DEPRECATION] Template.register_filter is deprecated. Use Environment#register_filter instead. Called from /home/andreas/PMD/source/pmd/docs/_plugins/custom_filters.rb:136:in `<top (required)>'
[DEPRECATION] Template.register_tag is deprecated. Use Environment#register_tag instead. Called from /home/andreas/PMD/source/pmd/docs/_plugins/details_block.rb:22:in `<top (required)>'
```

The reason is, that we use in our toplevel Gemfile already liquid 5.x, but in docs/Gemfile we still use liquid 4.x. We also can't just update to liquid 5 everywhere, as jekyll still uses liquid 4.
Furthermore, the pmdtester uses liquid 5 already.

I've cleaned up a bit, how we call render_release_notes.rb, so that we call it within the docs directory. Then we can reuse the Gemfile from docs rather than using a group.

The toplevel Gemfile is then only used for Danger and pmdtester.


## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

