### PR TITLE
[java] AvoidSynchronizedAtMethodLevel: Fixed error in code example

### DIFF
--- a/pmd-java/src/main/resources/category/java/multithreading.xml
+++ b/pmd-java/src/main/resources/category/java/multithreading.xml
@@ -69,10 +69,10 @@ public class Foo {
         // code, that doesn't need synchronization
         // ...
         try {
-            CLS_LOCK.lock();
+            CLASS_LOCK.lock();
             // code, that requires synchronization
         } finally {
-            CLS_LOCK.unlock();
+            CLASS_LOCK.unlock();
         }
         // more code, that doesn't need synchronization
         // ...


### PR DESCRIPTION
## Describe the PR

In https://docs.pmd-code.org/latest/pmd_rules_java_multithreading.html#avoidsynchronizedatmethodlevel the preferred example uses variable `CLS_LOCK` instead of `CLASS_LOCK`.

Renamed variable inside the example code for better consistency.

## Related issues

N/A

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

