### PR TITLE
[ci] New optimized workflow for pull requests

### DIFF
--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,0 +1,202 @@
+name: Pull Request Build
+
+on: pull_request
+
+# if another commit is added to the PR (same github.head_ref), then cancel already running jobs
+# and start a new build
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'maven'
+      - name: Fast Build with Maven
+        run: ./mvnw -B package -DskipTests
+      - uses: actions/upload-artifact@v4
+        with:
+          name: compile-artifact
+          if-no-files-found: error
+          path: |
+            */target
+            */*/target
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-artifact
+          if-no-files-found: error
+          path: |
+            pmd-dist/target/pmd-dist-*-bin.zip
+            pmd-dist/target/pmd-dist-*-src.zip
+
+  verify-complete:
+    runs-on: ubuntu-latest
+    needs: compile
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: |
+            8
+            17
+            21
+            11
+          cache: 'maven'
+      - uses: actions/download-artifact@v4
+        with:
+          name: compile-artifact
+      - name: Full Build with Maven
+        run: ./mvnw verify -Pgenerate-rule-docs -Djava8.home=JAVA_HOME_8_X64 -Djava17.home=JAVA_HOME_17_X64 -Djava21.home=JAVA_HOME_21_X64
+
+  verify-unittests:
+    needs: compile
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ windows-latest, macos-latest ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: |
+            8
+            17
+            21
+            11
+          cache: 'maven'
+      - uses: actions/download-artifact@v4
+        with:
+          name: compile-artifact
+      - name: Build with Maven and run unit tests
+        run: ./mvnw -B verify -PfastSkip -Djava8.home=JAVA_HOME_8_X64 -Djava17.home=JAVA_HOME_17_X64 -Djava21.home=JAVA_HOME_21_X64
+
+  dogfood:
+    needs: compile
+    runs-on: ubuntu-linux
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'maven'
+      - uses: actions/download-artifact@v4
+        with:
+          name: compile-artifact
+      - name: Run PMD on PMD
+        run: |
+          # this only works if the triggering event of this workflow is "pull_request"
+          pr_number="$(jq -r ".number" "${GITHUB_EVENT_PATH}")"
+          echo "Determined PR number: ${pr_number}"
+
+          current_pmd_version=$(./mvnw --batch-mode --no-transfer-progress \
+              org.apache.maven.plugins:maven-help-plugin:3.5.1:evaluate \
+              -Dexpression=project.version -q -DforceStdout || echo "failed_to_determine_current_pmd_version")
+          echo "Determined current pmd version: ${current_pmd_version}"
+
+          new_version="${current_pmd_version}-pr-${pr_number}-dogfood-SNAPSHOT"
+          echo "::group::Set version to ${new_version}"
+          ./mvnw versions:set -DnewVersion="${new_version}" -DgenerateBackupPoms=false
+          sed -i 's/<version>[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}.*<\/version>\( *<!-- pmd.dogfood.version -->\)/<version>'"${current_pmd_version}"'<\/version>\1/' pom.xml
+          echo "::endgroup::"
+
+          echo "::group::Run ./mvnw verify"
+          ./mvnw verify --show-version --errors --batch-mode \
+            -PfastSkip \
+            -DskipTests \
+            -Dpmd.skip=false \
+            -Dcpd.skip=false
+          echo "::endgroup::"
+
+          echo "::group::Restore version to ${current_pmd_version}"
+          ./mvnw versions:set -DnewVersion="${current_pmd_version}" -DgenerateBackupPoms=false
+          git checkout -- pom.xml
+          echo "::endgroup::"
+
+  regressiontester:
+    needs: compile
+    runs-on: ubuntu-linux
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gradle/caches
+            ~/work/pmd/target/repositories
+            vendor/bundle
+          key: regressiontester-${{ hashFiles('.ci/files/project-list.xml') }}
+      - uses: actions/download-artifact@v4
+        with:
+          name: compile-artifact
+      - name: Setup bundler
+        run: |
+          bundle config set --local path vendor/bundle
+          bundle install
+      - name: Run pmdtester
+        run: |
+          # this only works if the triggering event of this workflow is "pull_request"
+          export PMD_CI_PULL_REQUEST_NUMBER="$(jq -r ".number" "${GITHUB_EVENT_PATH}")"
+          echo "Determined PR number: ${PMD_CI_PULL_REQUEST_NUMBER}"
+
+          export PMD_CI_BRANCH="${GITHUB_BASE_REF}"
+          echo "Determined Branch: ${PMD_CI_BRANCH}"
+
+          export PMD_CI_JOB_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          echo "Determined Job Url: ${PMD_CI_JOB_URL}
+
+          echo "::group::Fetching additional commits"
+          # git clone initially only fetched with depth 2. Danger and regression tester
+          # need more history, so we'll fetch more here
+          # and create local branches as well (${PMD_CI_BRANCH} and pr-fetch)
+      
+          echo "Fetching 25 commits for ${PMD_CI_BRANCH} and pull/${PMD_CI_PULL_REQUEST_NUMBER}/head"
+          git fetch --no-tags --depth=25 origin "${PMD_CI_BRANCH}:${PMD_CI_BRANCH}" "pull/${PMD_CI_PULL_REQUEST_NUMBER}/head:pr-fetch"
+      
+          # if the PR is older, base might have advanced more than 25 commits... fetch more, up to 150
+          for i in $(seq 1 3); do
+            if [ -z "$( git merge-base "${PMD_CI_BRANCH}" "pr-fetch" )" ]; then
+              echo "No merge-base yet - fetching more commits... (try $i)"
+              git fetch --no-tags --deepen=50 origin "${PMD_CI_BRANCH}:" "pull/${PMD_CI_PULL_REQUEST_NUMBER}/head:pr-fetch"
+            fi
+          done
+          echo "Merge base is: $( git merge-base "${PMD_CI_BRANCH}" "pr-fetch" )"
+          echo "::endgroup::"
+      
+          echo "::group::Running danger on branch ${PMD_CI_BRANCH}"
+          bundle exec danger --verbose
+          echo "::endgroup::"
+      - name: Workaround actions/upload-artifact#176
+        run: |
+          echo "artifacts_path=$(realpath ..)" >> $GITHUB_ENV
+      - name: Upload regression tester report
+        uses: actions/upload-artifact@v4
+        with:
+          name: pmd-regression-tester
+          path: ${{ env.artifacts_path }}/target/pr-*-diff-report-*.tar.gz
+          if-no-files-found: ignore


### PR DESCRIPTION
## Describe the PR

The goal is to have faster feedback for PRs
and better visibility which part of the workflow part failed.

- First a fast compile job. The result of this job is shared via compile-artifact with the following jobs.
- Then in parallel a bunch of other jobs
  - verify-complete: runs a complete `./mvnw verify` with all tests, code checks, etc. This is only run on linux.
  - verify-unittests: just runs the unit tests on windows and macos
  - dogfood: run PMD on PMD with the latest changes from the pull request
  - regressiontester: runs the pmdtester to produce the regression report

Since most jobs can be run in parallel and not sequentially, the results of the PR build should be available faster.

The concurrency control makes sure, that we cancel any in-progress jobs for the current pull request to avoid unnecessary builds. Only the latest build matters.

This new workflow "pull-requests.yml" now doesn't depend on the shell script in build-tools, so it is hopefully easier to maintain. The workflow only uses read permissions and doesn't require any extra secrets.

Right now, I reused Danger for running pmdtester. Midterm however, I'd like to migrate away from that, since it can't be used in a secure way: To upload the report to some hosting facility, we need a secret, but in the PR run, we don't have access to the secrets. Or in order to set the status of the pull request, we would need write access to the repo. That's why Danger says in the logs "Danger does not have write access to the PR to set a PR status."... Midterm, "pull-requests.yml" should only run pmdtester and create the report and maybe a status file with the messages and upload these as artifacts. Then it should trigger another workflow run that runs in the context of our repository and this one has write access and can then properly update the PR status. See https://stackoverflow.com/questions/69499645/how-to-securely-allow-github-actions-to-check-pr-and-post-results-in-comment/71366152#71366152 for more info on that topic.
These changes are out of scope for this PR however and can follow some time later.


If this pull-requests.yml workflow works, I'd like to rewrite the main build workflow in a similar way, so that we have the same benefits: faster feedback and better visibility which part of the build broke. The release workflow should also be separate.

## Related issues

- Refs #4328

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

