### PR TITLE
[ci] New optimized workflow for pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,6 @@ on:
       - main
     tags:
       - '**'
-  pull_request:
   merge_group:
   schedule:
     # build it monthly: At 04:00 on day-of-month 1.

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,0 +1,350 @@
+name: Pull Request Build
+
+on: pull_request
+
+# if another commit is added to the PR (same github.head_ref), then cancel already running jobs
+# and start a new build
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+env:
+  LANG: 'en_US.UTF-8'
+
+jobs:
+  compile:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - uses: actions/cache@v4
+        with:
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-
+          path: ~/.m2/repository
+          enableCrossOsArchive: true
+      - name: Fast Build with Maven
+        run: |
+          ./mvnw --show-version --errors --batch-mode \
+            verify -PfastSkip -DskipTests \
+            deploy:deploy -DdogfoodStagingRepo="$(pwd)/target/staging"
+      - name: Cleanup local repository
+        run: |
+          # Cleanup local repository to not poison the shared cache with our SNAPSHOTS of the current build.
+          # Some information is stored in maven-metadata-*.xml files which tells maven which
+          # version exactly is available in the staging repo. But if we rerun the build using the
+          # older cache, it points to the old staging versions, which are not available anymore.
+          find ~/.m2/repository/net/sourceforge/pmd -type d -name "*-SNAPSHOT" -and -not -wholename "*/pmd-designer/*" | xargs rm -vrf
+      - uses: actions/upload-artifact@v4
+        with:
+          name: compile-artifact
+          if-no-files-found: error
+          path: |
+            */target
+            */*/target
+            !pmd-dist/target/pmd-dist-*-bin.zip
+            !pmd-dist/target/pmd-dist-*-src.zip
+      - uses: actions/upload-artifact@v4
+        with:
+          name: staging-repository
+          if-no-files-found: error
+          path: target/staging
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-artifact
+          if-no-files-found: error
+          path: |
+            pmd-dist/target/pmd-dist-*-bin.zip
+            pmd-dist/target/pmd-dist-*-src.zip
+
+  verify:
+    needs: compile
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - uses: actions/cache@v4
+        with:
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-
+          path: ~/.m2/repository
+          enableCrossOsArchive: true
+      - uses: actions/download-artifact@v4
+        with:
+          name: compile-artifact
+      - name: Full Build with Maven
+        run: |
+          ./mvnw --show-version --errors --batch-mode \
+              verify \
+              -DskipTests -Dmaven.test.skip=true
+
+  verify-unittests:
+    needs: compile
+    timeout-minutes: 30
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+    strategy:
+      # don't fail fast - we want to know the results of all runs
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-java@v4
+        # under linux we execute more extensive integration tests with various java versions
+        if: ${{ runner.os == 'Linux' }}
+        with:
+          distribution: 'temurin'
+          java-version: |
+            8
+            17
+            21
+      - uses: actions/setup-java@v4
+        # default java version for all os is 11
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      # only restore the cache, don't create a new cache
+      # under Windows, hashFiles('**/pom.xml') gives a different result due to line endings
+      - uses: actions/cache/restore@v4
+        with:
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-
+          path: ~/.m2/repository
+          enableCrossOsArchive: true
+      - uses: actions/download-artifact@v4
+        # we can only reuse compile-artifacts under linux due to file timestamp issues and
+        # platform specific line endings in test files.
+        if: ${{ runner.os == 'Linux' }}
+        with:
+          name: compile-artifact
+      - name: Build with Maven and run unit tests
+        run: |
+          ./mvnw --show-version --errors --batch-mode \
+              verify \
+              -PfastSkip -Dcyclonedx.skip=false \
+              -Djava8.home="${JAVA_HOME_8_X64}" \
+              -Djava17.home="${JAVA_HOME_17_X64}" \
+              -Djava21.home="${JAVA_HOME_21_X64}"
+
+  dogfood:
+    needs: compile
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - uses: actions/cache@v4
+        with:
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-
+          path: ~/.m2/repository
+          enableCrossOsArchive: true
+      - uses: actions/download-artifact@v4
+        with:
+          name: compile-artifact
+      - uses: actions/download-artifact@v4
+        with:
+          name: staging-repository
+          path: target/staging
+      - name: Run PMD on PMD
+        run: |
+          # this only works if the triggering event of this workflow is "pull_request"
+          pr_number="$(jq -r ".number" "${GITHUB_EVENT_PATH}")"
+          echo "Determined PR number: ${pr_number}"
+
+          current_pmd_version=$(./mvnw --batch-mode --no-transfer-progress \
+              help:evaluate -Dexpression=project.version -q -DforceStdout || echo "failed_to_determine_current_pmd_version")
+          echo "Determined current pmd version: ${current_pmd_version}"
+
+          new_version="${current_pmd_version}-pr-${pr_number}-dogfood-SNAPSHOT"
+          echo "::group::Set version to ${new_version}"
+          ./mvnw versions:set --quiet -DnewVersion="${new_version}" -DgenerateBackupPoms=false
+          sed -i 's/<version>[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}.*<\/version>\( *<!-- pmd.dogfood.version -->\)/<version>'"${current_pmd_version}"'<\/version>\1/' pom.xml
+          echo "::endgroup::"
+
+          echo "::group::Run ./mvnw verify"
+          ./mvnw --show-version --errors --batch-mode \
+            verify \
+            -PfastSkip \
+            -DdogfoodStagingRepo="$(pwd)/target/staging" \
+            -DskipTests \
+            -Dpmd.skip=false \
+            -Dcpd.skip=false
+          echo "::endgroup::"
+
+          echo "::group::Restore version to ${current_pmd_version}"
+          ./mvnw versions:set --quiet -DnewVersion="${current_pmd_version}" -DgenerateBackupPoms=false
+          git checkout -- pom.xml
+          echo "::endgroup::"
+
+  documentation:
+    needs: compile
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - uses: actions/cache@v4
+        with:
+          key: maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: maven-
+          path: ~/.m2/repository
+          enableCrossOsArchive: true
+      - uses: actions/download-artifact@v4
+        with:
+          name: compile-artifact
+      - name: Generate rule docs
+        run: |
+          ./mvnw --show-version --errors --batch-mode \
+            verify \
+            -Pgenerate-rule-docs,fastSkip \
+            -DskipTests -Dmaven.test.skip=true -Dassembly.skipAssembly=true
+      - name: Set up Ruby 3.3
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3
+      - name: Setup bundler
+        run: |
+          cd docs
+          bundle config set --local path vendor/bundle
+          bundle install
+      - name: Build documentation
+        run: |
+          cd docs
+          bundle exec jekyll build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: docs-artifact
+          if-no-files-found: error
+          path: docs/_site
+
+  regressiontester:
+    needs: compile
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+      - name: Set up Ruby 3.3
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.gradle/caches
+            ~/work/pmd/target/repositories
+            vendor/bundle
+          key: regressiontester-${{ hashFiles('.ci/files/project-list.xml', 'Gemfile.lock') }}
+          restore-keys: regressiontester-
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist-artifact
+          path: pmd-dist/target
+      - name: Setup bundler
+        run: |
+          bundle config set --local path vendor/bundle
+          bundle install
+      - name: Prepare HOME/openjdk11
+        run: |
+          ln -sfn "${JAVA_HOME_11_X64}" "${HOME}/openjdk11"
+      - name: Run pmdtester
+        run: |
+          gpg --batch --yes --decrypt --passphrase="GnxdjywUEPveyCD1RLiTd7t8CImnefYr" \
+              --output .ci/files/public-env .ci/files/public-env.gpg
+          # shellcheck disable=SC1091
+          source .ci/files/public-env >/dev/null 2>&1
+          rm .ci/files/public-env
+
+          # this only works if the triggering event of this workflow is "pull_request"
+          PMD_CI_PULL_REQUEST_NUMBER="$(jq -r ".number" "${GITHUB_EVENT_PATH}")"
+          export PMD_CI_PULL_REQUEST_NUMBER
+          echo "Determined PR number: ${PMD_CI_PULL_REQUEST_NUMBER}"
+
+          export PMD_CI_BRANCH="${GITHUB_BASE_REF}"
+          echo "Determined Branch: ${PMD_CI_BRANCH}"
+
+          export PMD_CI_JOB_URL="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          echo "Determined Job Url: ${PMD_CI_JOB_URL}"
+
+          echo "::group::Fetching additional commits"
+          # git clone initially only fetched with depth 2. Danger and regression tester
+          # need more history, so we'll fetch more here
+          # and create local branches as well (${PMD_CI_BRANCH} and pr-fetch)
+      
+          echo "Fetching 25 commits for ${PMD_CI_BRANCH} and pull/${PMD_CI_PULL_REQUEST_NUMBER}/head"
+          git fetch --no-tags --depth=25 origin "${PMD_CI_BRANCH}:${PMD_CI_BRANCH}" "pull/${PMD_CI_PULL_REQUEST_NUMBER}/head:pr-fetch"
+      
+          # if the PR is older, base might have advanced more than 25 commits... fetch more, up to 150
+          for i in $(seq 1 3); do
+            if [ -z "$( git merge-base "${PMD_CI_BRANCH}" "pr-fetch" )" ]; then
+              echo "No merge-base yet - fetching more commits... (try $i)"
+              git fetch --no-tags --deepen=50 origin "${PMD_CI_BRANCH}:" "pull/${PMD_CI_PULL_REQUEST_NUMBER}/head:pr-fetch"
+            fi
+          done
+          echo "Merge base is: $( git merge-base "${PMD_CI_BRANCH}" "pr-fetch" )"
+          echo "::endgroup::"
+      
+          echo "::group::Running danger on branch ${PMD_CI_BRANCH}"
+          bundle exec danger --verbose
+          echo "::endgroup::"
+      - name: Workaround actions/upload-artifact#176
+        run: |
+          echo "artifacts_path=$(realpath ..)" >> $GITHUB_ENV
+      - name: Upload regression tester report
+        uses: actions/upload-artifact@v4
+        with:
+          name: pmd-regression-tester
+          path: ${{ env.artifacts_path }}/target/pr-*-diff-report-*.tar.gz
+          if-no-files-found: ignore

--- a/docs/_data/sidebars/pmd_sidebar.yml
+++ b/docs/_data/sidebars/pmd_sidebar.yml
@@ -568,6 +568,9 @@ entries:
     - title: Roadmap
       url: /pmd_devdocs_roadmap.html
       output: web, pdf
+    - title: GitHub Actions Workflows
+      url: /pmd_devdocs_github_actions_workflows.html
+      output: web, pdf
     - title: How PMD works
       url: /pmd_devdocs_how_pmd_works.html
       output: web, pdf

--- a/docs/pages/pmd/devdocs/github_actions_workflows.md
+++ b/docs/pages/pmd/devdocs/github_actions_workflows.md
@@ -1,0 +1,61 @@
+---
+title: GitHub Actions Workflows
+permalink: pmd_devdocs_github_actions_workflows.html
+summary: |
+  PMD uses GitHub Actions as the CI/CD infrastructure to build and release new versions.
+  This page gives an overview of how these workflows work and how to use them.
+author: Andreas Dangel <andreas.dangel@pmd-code.org>
+last_updated: February 2025 (7.11.0)
+---
+
+{%include note.html content="This page is work in progress and does not yet describe all workflows."%}
+
+## Pull Request Build
+
+* Builds: <https://github.com/pmd/pmd/actions/workflows/pull-requests.yml>
+* Workflow file: <https://github.com/pmd/pmd/blob/main/.github/workflows/pull-requests.yml>
+
+This workflow is triggered whenever a pull request is created or synchronized.
+
+In order to avoid unnecessary builds, we use concurrency control to make sure, we cancel any in-progress jobs for
+the current pull request when a new commit has been pushed. This means, only the latest commit is built, which
+is enough, since only this will be merged in the end. Only the latest build matters.
+
+The workflow is self-contained, e.g. it doesn't depend on the shell scripts from PMD's build-tools.
+It also uses only read permissions and doesn't need access to any secrets. It is safe to run also on
+forks.
+
+During the build we create a couple of artifacts, that can be downloaded:
+
+* compile-artifact: contains all the built classes (everything in the `target/` directories). It is built under Linux,
+  so unfortunately it can only be used to speed up other Linux based builds, but not Windows or MacOS.
+* staging-repository: contains all the artifacts of groupId `net.sourceforge.pmd`. Could be used as a local
+  repository to test against this built PMD version without the need to deploy the SNAPSHOTs anywhere. It is
+  actually used by the dogfood job.
+* dist-artifact: contains the binary distribution files, ready to be downloaded. This can be used to test
+  PMD with the changes from the pull request without the need to build it locally. It is actually used by the
+  regression tester job to avoid building PMD another time.
+* docs-artifact: contains the generated rule documentation.
+* pmd-regression-tester: contains the generation regression report, if there were any changes to rules.
+
+In order to have fast feedback of the build results, we run a couple of jobs in parallel and not sequentially.
+The jobs are:
+
+* "compile": First a fast compile job to sort out any basic problems at the beginning. If this job fails, nothing
+  else is executed. It also populates the build cache (maven dependencies) that is reused for the following jobs.
+  The created artifacts are: "compile-artifact", "staging-repository", "dist-artifact".
+* After this first job, a bunch of other jobs are run in parallel:
+    - "verify": runs a complete `./mvnw verify` with all code checks like checkstyle, japicmp, javadoc, etc.
+      but excluding unit tests (these are run in a separate job).
+      This job is only run on linux. It reuses the already compiled artifacts from the first "compile" job.
+    - "verify-unittests": just runs the unit tests on Linux, Windows and MacOS. Only linux reuses the
+      "compile-artifact" from the first job. For Windows/MacOS we can't reuse this due to platform specific line
+      endings and timestamp issues.
+    - "dogfood": runs maven-pmd-plugin on PMD with the latest changes from this very pull request. It uses the
+      "staging-repository" artifact.
+    - "documentation": generates the rule documentations and builds PMD's documentation page using jekyll.
+      It also executes the verification for wrong rule tags and dead links. It creates the artifact "docs-artifact".
+    - "regressiontester": runs the [pmdtester](pmd_devdocs_pmdtester.html) to produce the regression report.
+      It reuses the artifact "dist-artifact" so that we don't need to build PMD again. It uses a different build
+      cache as the other jobs, as this cache now contains the test projects (like Spring Framework) and their
+      dependencies. It produces the artifact "pmd-regression-tester" with the regression report.

--- a/docs/pages/pmd/projectdocs/committers/infrastructure.md
+++ b/docs/pages/pmd/projectdocs/committers/infrastructure.md
@@ -2,12 +2,12 @@
 title: Infrastructure
 permalink: pmd_projectdocs_committers_infrastructure.html
 author: Andreas Dangel <andreas.dangel@pmd-code.org>
-last_updated: April 2021
+last_updated: February 2025 (7.11.0)
 ---
 
 This page describes, which infrastructure and services is used by the pmd project.
 
-## github
+## GitHub
 
 The main repository is hosted on <https://github.com/pmd>. We own the organization "pmd".
 
@@ -16,19 +16,19 @@ The main repository is hosted on <https://github.com/pmd>. We own the organizati
 *   issue tracker
 *   discussions
 *   pull requests
-*   github actions for CI
+*   [GitHub Actions for CI](pmd_devdocs_github_actions_workflows.html)
 
 Also the [main landing page](pmd_projectdocs_committers_main_landing_page.html) (<https://pmd.github.io>)
-is hosted using github pages.
+is hosted using GitHub pages.
 
-## sourceforge
+## SourceForge
 
-Before moving to github, sourceforge was the main place. It is still there: <https://sourceforge.net/projects/pmd/>.
+Before moving to GitHub, SourceForge was the main place. It is still there: <https://sourceforge.net/projects/pmd/>.
 
-Nowadays it is used for:
+Nowadays, it is used for:
 
-*   hosting archive of binaries: https://sourceforge.net/projects/pmd/files/
-*   hosting an archive of documentation: https://pmd.sourceforge.io/archive.html
+*   hosting an archive of binaries: <https://sourceforge.net/projects/pmd/files/>
+*   hosting an archive of documentation: <https://pmd.sourceforge.io/archive.html>
 *   mailing lists:
     *   <pmd-commits@lists.sourceforge.net>
     *   <pmd-devel@lists.sourceforge.net>
@@ -36,7 +36,7 @@ Nowadays it is used for:
 
 It also contains the old issue tracker.
 
-## domain, email and homepage
+## Domain, mail and homepage
 
 We are using a webhosting package by [Netcup](https://www.netcup.de/).
 
@@ -56,27 +56,21 @@ The homepage <https://pmd-code.org> redirects to <https://pmd.github.io>.
 Some docs are hosted at <https://docs.pmd-code.org/>.
 
 
-## other services
+## Other services
 
-*   Deployment to maven central via <https://oss.sonatype.org/> and <https://issues.sonatype.org/browse/OSSRH-2295>
+*   Deployment to Maven Central via <https://oss.sonatype.org/> and <https://central.sonatype.org/register/central-portal/>
     Uploading requires credentials (CI_DEPLOY_USERNAME, CI_DEPLOY_PASSWORD) and permissions.
-*   Hosting eclipse plugin update site via <https://bintray.com/>
-    Uploading requires credentials (BINTRAY_USER, BINTRAY_APIKEY)
-    Note: This service is retired and the update site is now hosted via Github Pages (<https://github.com/pmd/pmd-eclipse-plugin-p2-site/>).
-*   Hosting result reports from pmd-regression-tester via <https://chunk.io/>
-    Uploading requires credentials (PMD_CI_CHUNK_TOKEN)
 *   Twitter: <https://twitter.com/pmd_analyzer>
 *   Rubygems for pmd-regression-tester: <https://rubygems.org/gems/pmdtester>
     Uploading requires credentials (GEM_HOST_API_KEY)
-*   sonarcloud: <https://sonarcloud.io/dashboard?id=net.sourceforge.pmd%3Apmd>
+*   SonarCloud: <https://sonarcloud.io/dashboard?id=net.sourceforge.pmd%3Apmd>
     We use the "CI-based Analysis method" with GitHub Actions.
     Documentation: <https://sonarcloud.io/documentation>
     Uploading new analysis results requires credentials (SONAR_TOKEN).
-    Login is via github.
-*   coveralls: <https://coveralls.io/github/pmd/pmd>
-    We don't use the [Coveralls Github Actions](https://github.com/marketplace/actions/coveralls-github-action) but the [coveralls-maven-plugin](https://github.com/trautonen/coveralls-maven-plugin).
+    Login is via GitHub.
+*   Coveralls: <https://coveralls.io/github/pmd/pmd>
+    We don't use the [Coveralls GitHub Actions](https://github.com/marketplace/actions/coveralls-github-action) but the [coveralls-maven-plugin](https://github.com/trautonen/coveralls-maven-plugin).
     Documentation: <https://docs.coveralls.io/>
     Uploading new results requires credentials (COVERALLS_REPO_TOKEN).
-    Login is via github.
-*   travis ci was used before github actions: <https://travis-ci.org/github/pmd>
+    Login is via GitHub.
 

--- a/pom.xml
+++ b/pom.xml
@@ -188,6 +188,11 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-help-plugin</artifactId>
+                    <version>3.5.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-release-plugin</artifactId>
                     <version>3.1.1</version>
                     <configuration>
@@ -1322,6 +1327,50 @@
                 <module>pmd-cli</module>
                 <module>pmd-dist</module>
             </modules>
+        </profile>
+
+        <profile>
+            <id>dogfood</id>
+            <activation>
+                <property>
+                    <name>dogfoodStagingRepo</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-deploy-plugin</artifactId>
+                        <configuration>
+                            <altDeploymentRepository>dogfood::file://${dogfoodStagingRepo}</altDeploymentRepository>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+            <pluginRepositories>
+                <pluginRepository>
+                    <id>dogfood</id>
+                    <url>file://${dogfoodStagingRepo}</url>
+                    <releases><enabled>false</enabled></releases>
+                    <snapshots><enabled>true</enabled></snapshots>
+                </pluginRepository>
+                <!-- disable sonatype-nexus-plugin-snapshots, so that only dogfood is used -->
+                <pluginRepository>
+                    <id>sonatype-nexus-plugin-snapshots</id>
+                    <name>Sonatype Nexus Snapshots</name>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+                    <releases><enabled>false</enabled></releases>
+                    <snapshots><enabled>false</enabled></snapshots>
+                </pluginRepository>
+                <!-- disable apache.snapshots, so that only dogfood is used -->
+                <pluginRepository>
+                    <id>apache.snapshots</id>
+                    <name>Apache Snapshot Repository</name>
+                    <url>https://repository.apache.org/snapshots</url>
+                    <releases><enabled>false</enabled></releases>
+                    <snapshots><enabled>false</enabled></snapshots>
+                </pluginRepository>
+            </pluginRepositories>
         </profile>
     </profiles>
 


### PR DESCRIPTION
## Describe the PR

The goal is
- to have faster feedback for PRs
- better visibility which part of the workflow failed
- have build artifacts available to verify/test locally

The jobs are:

- "compile": First a fast compile job. The result of this job are three artifacts:
  - the compilation results (everything in the target/ directories) is available in "compile-artifact"
  - a "staging-repository" with the currently built pmd artifacts. This is used by the dogfood job later.
  - a "dist-artifact" which contains the binary distribution files, ready to be downloaded from the workflow page, so that one can try out the built PMD from the PR branch without the need to built itself.
  - additional, the local maven repo is cached for the other jobs.
- Then in parallel a bunch of other jobs:
  - "verify": runs a complete `./mvnw verify` with all code checks, etc. This is only run on linux. It reuses the already compiled artifacts from the first "compile" job.
    - This runs very long (>10min). In future, this could be split up further e.g. to run  checkstyle, japicmp, javadoc in parallel jobs.
  - "verify-unittests": just runs the unit tests on linux, windows and macos
    - unfortunately these jobs can't reuse the already compiled artifacts from the first "compile" job due to file timestamp issues and platform specific line endings. So PMD needs to be compiled again for windows/macos. For linux, we can reuse the "compile-artifact"
  - "dogfood": runs maven-pmd-plugin on PMD with the latest changes from the pull request
    - it uses the "staging-repository" artifact
  - "documentation": generates the rule documentations and builds PMD's documentation page using jekyll. Also executes the verification for wrong rule tags and dead links.
    - creates the artifact "docs-artifact"
  - "regressiontester": runs the pmdtester to produce the regression report
    - uses the artifact "dist-artifact" so that we don't need to build PMD again
    - doesn't use the same maven cache as the other jobs, but creates a new one. The cache contains the test projects (like spring framework) and their dependencies.
    - uses danger to run pmdtester
    - produces the artifact "pmd-regression-tester" which the regression report, if there were any changes.

Since most jobs can be run in parallel and not sequentially, the results of the PR build should be available faster.

The concurrency control makes sure, that we cancel any in-progress jobs for the current pull request to avoid unnecessary builds. Only the latest build matters.

This new workflow "pull-requests.yml" now doesn't depend on the shell script in build-tools, so it is hopefully easier to maintain. The workflow only uses read permissions and doesn't require any extra secrets.

Right now, I reused Danger for running pmdtester. Midterm however, I'd like to migrate away from that, since it can't be used in a secure way: To upload the report to some hosting facility, we need a secret, but in the PR run, we don't have access to the secrets. Or in order to set the status of the pull request, we would need write access to the repo. That's why Danger says in the logs "Danger does not have write access to the PR to set a PR status."... Midterm, "pull-requests.yml" should only run pmdtester and create the report and maybe a status file with the messages and upload these as artifacts. Then it should trigger another workflow run that runs in the context of our repository and this one has write access and can then properly update the PR status. See https://stackoverflow.com/questions/69499645/how-to-securely-allow-github-actions-to-check-pr-and-post-results-in-comment/71366152#71366152 for more info on that topic.
These changes are out of scope for this PR however and can follow some time later.

If this pull-requests.yml workflow works, I'd like to rewrite the main build workflow in a similar way, so that we have the same benefits: faster feedback and better visibility which part of the build broke. The release workflow should also be separate.

## Related issues

- Refs #4328
- Supersedes #5513

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

