### PR TITLE
Fix #5442: [java] Fix stackoverflow with recursive generic types

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
@@ -401,6 +401,11 @@ public final class TypeOps {
         return SubtypeVisitor.INFERENCE.isConvertible(t, s, true);
     }
 
+    // test only
+    static Convertibility isConvertibleInferenceNoCapture(@NonNull JTypeMirror t, @NonNull JTypeMirror s) {
+        return SubtypeVisitor.INFERENCE.isConvertible(t, s, false);
+    }
+
     @Deprecated // unused
     public static Convertibility isConvertible(@NonNull JTypeMirror t, @NonNull JTypeMirror s, boolean capture) {
         return SubtypeVisitor.PURE.isConvertible(t, s, capture);
@@ -801,7 +806,10 @@ public final class TypeOps {
         public Convertibility visitTypeVar(JTypeVar t, JTypeMirror s) {
             if (s instanceof JTypeVar && t.getSymbol() != null && Objects.equals(t.getSymbol(), s.getSymbol())) {
                 return Convertibility.SUBTYPING;
+            } else if (s instanceof SentinelType) {
+                return Convertibility.SUBTYPING;
             }
+
             if (isTypeRange(s)) {
                 return isConvertible(t, lowerBoundRec(s));
             }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
@@ -401,11 +401,6 @@ public final class TypeOps {
         return SubtypeVisitor.INFERENCE.isConvertible(t, s, true);
     }
 
-    // test only
-    static Convertibility isConvertibleInferenceNoCapture(@NonNull JTypeMirror t, @NonNull JTypeMirror s) {
-        return SubtypeVisitor.INFERENCE.isConvertible(t, s, false);
-    }
-
     @Deprecated // unused
     public static Convertibility isConvertible(@NonNull JTypeMirror t, @NonNull JTypeMirror s, boolean capture) {
         return SubtypeVisitor.PURE.isConvertible(t, s, capture);

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/SubtypingTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/SubtypingTest.kt
@@ -17,17 +17,17 @@ import net.sourceforge.pmd.lang.java.ast.ParserTestCtx
 import net.sourceforge.pmd.lang.java.symbols.internal.UnresolvedClassStore
 import net.sourceforge.pmd.lang.java.symbols.internal.asm.createUnresolvedAsmSymbol
 import net.sourceforge.pmd.lang.java.types.TypeConversion.capture
-import net.sourceforge.pmd.lang.java.types.TypeOps.Convertibility
 import net.sourceforge.pmd.lang.java.types.TypeOps.Convertibility.UNCHECKED_NO_WARNING
 import net.sourceforge.pmd.lang.java.types.testdata.ComparableList
 import net.sourceforge.pmd.lang.java.types.testdata.SomeEnum
+import net.sourceforge.pmd.lang.test.ast.IntelliMarker
 import net.sourceforge.pmd.lang.test.ast.shouldBeA
 import kotlin.test.assertTrue
 
 /**
  * @author Clément Fournier
  */
-class SubtypingTest : FunSpec({
+class SubtypingTest : IntelliMarker, FunSpec({
 
     val ts = testTypeSystem
     with(TypeDslOf(ts)) {
@@ -331,18 +331,27 @@ class SubtypingTest : FunSpec({
     }
 
     test("Capture of recursive types #5442 stackoverflow") {
-        val acu = javaParser.parse(
+        javaParser.parse(
             """
-                abstract class AbstractResourceAssembler<R extends Resource<? extends R>, UID, V> implements EntityResourceAssembler<T, R, UID, V> {
-                }
-                abstract class Resource<T extends Resource<? extends T>> extends org.springframework.hateoas.RepresentationModel<T> {
+                package org.example;
+
+                import java.util.Collection;
+                import java.util.Collections;
+                import java.util.Optional;
+
+                public class Main {
+
+                    public static <T extends Comparable<? super T>> Optional<T> getMaxElementCausesStackoverflow(Collection<? extends T> collection) {
+                        return collection == null || collection.isEmpty() ? Optional.empty() : Optional.of(Collections.max(collection));
+                    }
+
+                    public static <T extends Comparable<? super T>> Optional<T> getMaxElementIsFine(Collection<? extends T> collection) {
+                        return Optional.ofNullable(collection).filter(c -> !c.isEmpty()).map(Collections::max);
+                    }
                 }
             """.trimIndent()
         )
 
-        val tvar = acu.typeVar("R")
-
-        TypeOps.isConvertibleInferenceNoCapture(tvar, tvar.typeSystem.UNKNOWN) shouldBe Convertibility.SUBTYPING
     }
 
 

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/SubtypingTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/SubtypingTest.kt
@@ -330,7 +330,7 @@ class SubtypingTest : IntelliMarker, FunSpec({
         }
     }
 
-    test("Capture of recursive types #5442 stackoverflow") {
+    test("Capture of recursive types #5505 stackoverflow") {
         javaParser.parse(
             """
                 package org.example;


### PR DESCRIPTION
~I unfortunately wasn't able to create source that triggers the bug. I identified the infinite loop from the stack trace, and had to add a new entry point to the convertibility visitor to fall into it.~ #5505 provided a test case.

## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #5442
- Fix #5505

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

