### PR TITLE
Fix #5493 - illegal wildcard

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeVarImpl.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeVarImpl.java
@@ -76,7 +76,7 @@ abstract class TypeVarImpl implements JTypeVar {
      */
     static JTypeVar tvarCapture(@NonNull JTypeVar tv) {
         if (tv.isCaptured()) {
-            return tv;
+            return tv.withUpperBound(capture(tv.getUpperBound()));
         }
         // Need to capture the bounds because those bounds contributes the methods of the tvar.
         // Eg in `<C extends Collection<? super X>>` the methods available in C may mention the type
@@ -331,7 +331,7 @@ abstract class TypeVarImpl implements JTypeVar {
 
         @Override
         public JTypeVar withUpperBound(@NonNull JTypeMirror newUB) {
-            throw new UnsupportedOperationException("This only needs to be implemented on regular type variables");
+            return cloneWithBounds(upperBound, newUB);
         }
 
         @Override
@@ -353,6 +353,7 @@ abstract class TypeVarImpl implements JTypeVar {
         public @NonNull String getName() {
             Object captureOrigin = wildcard == null ? tvar : wildcard;
             return "capture#" + hashCode() % PRIME + " of " + captureOrigin;
+            // + "[" + lowerBound + ".." + upperBound + "]";
         }
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ast/internal/LazyTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ast/internal/LazyTypeResolver.java
@@ -271,7 +271,9 @@ public final class LazyTypeResolver extends JavaVisitorBase<TypingContext, @NonN
             if (isUnresolved(mirror)) {
                 return ts.UNKNOWN;
             }
-            return mirror.getFormalParameters().get(param.getIndexInParent());
+            JTypeMirror parmty = mirror.getFormalParameters().get(param.getIndexInParent());
+            // project upwards to remove captures
+            return TypeOps.projectUpwards(parmty);
 
         } else if (node.isEnumConstant()) {
 

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/AstTestUtil.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/AstTestUtil.kt
@@ -28,5 +28,5 @@ fun JavaNode.firstCtorCall() = ctorCalls().crossFindBoundaries().firstOrThrow()
 
 fun JavaNode.typeVariables(): MutableList<JTypeVar> = descendants(ASTTypeParameter::class.java).crossFindBoundaries().toList { it.typeMirror }
 fun JavaNode.varAccesses(name: String): NodeStream<ASTVariableAccess> = descendants(ASTVariableAccess::class.java).crossFindBoundaries().filter { it.name == name }
-fun JavaNode.varId(name: String) = descendants(ASTVariableId::class.java).filter { it.name == name }.firstOrThrow()
+fun JavaNode.varId(name: String) = descendants(ASTVariableId::class.java).crossFindBoundaries().filter { it.name == name }.firstOrThrow()
 fun JavaNode.typeVar(name: String) = descendants(ASTTypeParameter::class.java).crossFindBoundaries().filter { it.name == name }.firstOrThrow().typeMirror

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/CaptureTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/CaptureTest.kt
@@ -122,6 +122,73 @@ class CaptureTest : IntelliMarker, FunSpec({
                 }
             }
 
+            test("Capture of variable with capturable bound #5493") {
+                val acu = javaParser.parse(
+                    """
+                    
+                    interface ObservableList<T> {
+                    }
+                    
+                    interface EventStream<T> {
+                        Subscription subscribe(Consumer<? super T> observer);
+                    }
+                    
+                    interface BiFunction<A, B, C> {
+                        C apply(A a, B b);
+                    }
+                    
+                    interface Subscription {
+                    }
+                    
+                    interface Function<A, B> {
+                        B apply(A a);
+                    }
+                    
+                    interface Supplier<A> {
+                        A get();
+                    }
+                    
+                    interface Consumer<A> {
+                        void accept(A a);
+                    }
+                    
+                    class Ext {
+                    
+                        static <T> ObservableList<T> emptyList() {
+                        }
+                    
+                        public static <T> Subscription dynamic(
+                            ObservableList<? extends T> elems,
+                            BiFunction<? super T, Integer, ? extends Subscription> f) {
+
+                        }
+                    }
+                    
+                    public class Something<E> {
+                    
+                        ObservableList<E> base;
+                        Function<? super E, ? extends EventStream<?>> ticks;
+                    
+                        void notifyObservers(Supplier<? extends ObservableList<E>> f) {
+                        }
+                    
+                        protected Subscription observeInputs() {
+                            // ticks: Function<capt#1 of ? super E, capt#2 of ? extends EventStream<?>>
+                            // ticks.apply(e): capt#2 of ? extends EventStream<?>
+                            // capture(capt#2 of ...) should not return capt#2 unchanged,
+                            // but should return a capture var with its upper bound captured: EventStream<capt#3 of ?>
+                            return Ext.dynamic(base, (e, i) -> ticks.apply(e).subscribe(k -> this.notifyObservers(Ext::emptyList)));
+                        }
+                    }
+                """.trimIndent()
+                )
+
+                val subscribe = acu.firstMethodCall("subscribe")
+                subscribe.overloadSelectionInfo.isFailed shouldBe false
+                acu.varId("k") shouldHaveType ts.OBJECT // captureMatcher(`?`) // todo this should probably be projected upwards (and be Object)
+            }
+
+
 
 
         }


### PR DESCRIPTION
This is a leftover from #5387. Additionally, lambda parameter types are now projected upwards. That means they are "clean", like inferred local variable types, they don't mention capture variables. Since their uses are captured
anyway where it matters, this shouldn't change anything to the precision of inferred types.

## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #5493

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

