### PR TITLE
[java] Fix #5073 - UnnecessaryCast FP with lambdas

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JExecutableSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JExecutableSymbol.java
@@ -12,6 +12,7 @@ import java.util.List;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+import net.sourceforge.pmd.lang.java.types.JMethodSig;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.Substitution;
 
@@ -110,4 +111,12 @@ public interface JExecutableSymbol extends JTypeParameterOwnerSymbol {
      */
     List<JTypeMirror> getThrownExceptionTypes(Substitution subst);
 
+    /**
+     * Return a method sig corresponding to this symbol.
+     * The returned signature may contain type parameters
+     * of this method and of the enclosing classes.
+     */
+    default JMethodSig getGenericSignature() {
+        return getTypeSystem().sigOf(this);
+    }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JMethodSig.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JMethodSig.java
@@ -162,6 +162,34 @@ public interface JMethodSig extends JTypeVisitable {
     }
 
 
+    /**
+     * Returns the type of the i-th formal parameter of the method.
+     * This is relevant when the call is varargs: {@code i} can in
+     * that case be greater that the number of formal parameters.
+     *
+     * @param i Index for a formal
+     * @param varargs Whether this is a varags call
+     *
+     * @throws AssertionError If the parameter is negative, or
+     *                        greater than the number of argument
+     *                        expressions to the method
+     */
+    default JTypeMirror ithFormalParam(int i, boolean varargs) {
+        assert !varargs || isVarargs() : "Method is not varargs " + this;
+        List<JTypeMirror> formals = getFormalParameters();
+        if (varargs) {
+            assert i >= 0 : "Argument index out of range: " + i;
+            if (i >= formals.size() - 1) {
+                JTypeMirror lastFormal = formals.get(formals.size() - 1);
+                return ((JArrayType) lastFormal).getComponentType();
+            }
+        } else {
+            assert i >= 0 && i < formals.size() : "Argument index out of range: " + i;
+        }
+        return formals.get(i);
+    }
+
+
     @Override
     JMethodSig subst(Function<? super SubstVar, ? extends @NonNull JTypeMirror> subst);
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/OverloadSelectionResult.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/OverloadSelectionResult.java
@@ -68,7 +68,9 @@ public interface OverloadSelectionResult {
      *                        greater than the number of argument
      *                        expressions to the method
      */
-    JTypeMirror ithFormalParam(int i);
+    default JTypeMirror ithFormalParam(int i) {
+        return getMethodType().ithFormalParam(i, isVarargsCall());
+    }
 
     /**
      * Returns true if the invocation of this method failed. This

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
@@ -2165,8 +2165,18 @@ public final class TypeOps {
      * context during type inference. Generic constructors
      * are always context dependent.
      */
+    @Deprecated
     public static boolean isContextDependent(JMethodSig sig) {
-        JExecutableSymbol symbol = sig.getSymbol();
+        return isContextDependent(sig.getSymbol());
+    }
+
+    /**
+     * Return true if the method is context dependent. That
+     * means its return type is influenced by the surrounding
+     * context during type inference. Generic constructors
+     * are always context dependent.
+     */
+    public static boolean isContextDependent(JExecutableSymbol symbol) {
         if (symbol.isGeneric() || symbol.getEnclosingClass().isGeneric()) {
             if (symbol instanceof JMethodSymbol) {
                 JTypeMirror returnType = ((JMethodSymbol) symbol).getReturnType(EMPTY);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/UnresolvedMethodSig.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/UnresolvedMethodSig.java
@@ -195,5 +195,10 @@ final class UnresolvedMethodSig implements JMethodSig, InternalMethodTypeItf {
         public String toString() {
             return getSimpleName();
         }
+
+        @Override
+        public JMethodSig getGenericSignature() {
+            return getTypeSystem().UNRESOLVED_METHOD;
+        }
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ast/internal/PolyResolution.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ast/internal/PolyResolution.java
@@ -535,7 +535,7 @@ public final class PolyResolution {
 
 
             JMethodSig fun = ((ASTLambdaExpression) papa).getFunctionalMethod();
-            if (fun == null || TypeOps.isContextDependent(fun)) {
+            if (fun == null || TypeOps.isContextDependent(fun.getSymbol())) {
                 // Missing context, because the expression type itself
                 // is used to infer the context type.
                 return ExprContext.getMissingInstance();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ExprMirror.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ExprMirror.java
@@ -509,11 +509,6 @@ public interface ExprMirror {
             }
 
             @Override
-            public JTypeMirror ithFormalParam(int i) {
-                return resolvePhase.ithFormal(getMethodType().getFormalParameters(), i);
-            }
-
-            @Override
             public boolean isFailed() {
                 return failed;
             }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryCast.xml
@@ -909,4 +909,121 @@ class Tester {
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Cast in return position of lambda</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            import java.util.*;
+            import static java.util.Comparator.nullsFirst;
+
+            public class Foo {
+                public int compare(List<String> someList) {
+                    final Set<String> set = Optional.ofNullable(someList)
+                                                .map(list -> (Set<String>) new HashSet<>(list)) // Code Style | UnnecessaryCast reported here
+                                                .orElseGet(Collections::emptySet);
+                }
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Cast in return position of lambda, true positives</description>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>13,14,15</expected-linenumbers>
+        <code><![CDATA[
+            import java.util.*;
+
+            interface L1<X> { Object foo(X x); }
+            interface L2<X, Q> { Q foo(X x); }
+
+
+            public class Foo {
+                <X> void bar(L1<X> l) {}
+                <X> void bar2(L2<X, ? extends Comparable<?>> l) {}
+                <X> void bar4(L2<X, Comparable<?>> l) {}
+                <X, Q> void bar3(L2<X, Q> l) {}
+                void foor(List<String> someList) {
+                    bar(x -> (Comparable<?>) "something"); // redundant
+                    bar2(x -> (Comparable<?>) "something"); // redundant: lambda not context dependent
+                    bar4(x -> (Comparable<?>) "something"); // redundant: lambda not context dependent
+                    bar3(x -> (Comparable<?>) "something"); // not redundant: method uses lambda ret ty
+                }
+            }
+            ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Cast in return position of lambda, types are unresolved</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            package org.example;
+
+            import io.vavr.collection.Array;
+            import io.vavr.collection.Seq;
+            import io.vavr.control.Either;
+
+            public class Main {
+
+                public Either<Seq<String>, String> loadAll() {
+                    return load()
+                            .mapLeft(it -> (Seq<String>) Array.of(it))
+                            .map(foo -> "bar");
+                }
+
+                private Either<String, String> load() {
+                    return Either.left("hello");
+                }
+
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Cast in return position of lambda, declare types here</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            interface Function<P,R> { R apply(P p); }
+            interface Seq<T> {}
+            interface Array<T> extends Seq<T> {
+                static <U> Array<U> of(U u) {}
+            }
+            interface Either<L, R> {
+                <T> Either<T, R> mapLeft(Function<? super L, ? extends T> f) {}
+                <T> Either<L, T> map(Function<? super R, ? extends T> f) {}
+            }
+
+            public class Main {
+
+                public Either<Seq<String>, String> loadAll() {
+                    return load()
+                            .mapLeft(it -> (Seq<String>) Array.of(it))
+                            .map(foo -> "bar");
+                }
+
+                private Either<String, String> load() {
+                    //                    return Either.left("hello");
+                }
+
+            }
+            ]]></code>
+    </test-code>
+
+
+    <test-code>
+        <description>Other example of cast in lambda return (#5440)</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            class Scratch {
+                public static void main(String[] args) {
+                    Object object = Optional
+                            .of(new Object())
+                            .map(o -> (Object) o.toString()) // <-- Unnecessary cast (Object)
+                            .orElse(Boolean.FALSE);
+                }
+            }
+            ]]></code>
+    </test-code>
+
 </test-data>


### PR DESCRIPTION
This doesn't entirely whitelist casts that are in return position of a lambda. Instead I analyze whether the type of the enclosing call chain depends on the return type of the lambda. If it does, then the cast is necessary. 

## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #5073
- Fix #5440 (a duplicate really)

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

