### PR TITLE
[java] Fix IdenticalCatchBranch reporting branches that call different overloads

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/IdenticalCatchBranchesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/IdenticalCatchBranchesRule.java
@@ -47,8 +47,9 @@ public class IdenticalCatchBranchesRule extends AbstractJavaRulechainRule {
                                              if (n1 instanceof InvocationNode) {
                                                  JExecutableSymbol sym1 = ((InvocationNode) n1).getMethodType().getSymbol();
                                                  JExecutableSymbol sym2 = ((InvocationNode) n2).getMethodType().getSymbol();
-                                                 if (!Objects.equals(sym1, sym2))
+                                                 if (!Objects.equals(sym1, sym2)) {
                                                      return OptionalBool.NO;
+                                                 }
                                              }
                                              return OptionalBool.UNKNOWN;
                                          });

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/IdenticalCatchBranchesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/IdenticalCatchBranchesRule.java
@@ -7,13 +7,18 @@ package net.sourceforge.pmd.lang.java.rule.codestyle;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import net.sourceforge.pmd.lang.java.ast.ASTCatchClause;
 import net.sourceforge.pmd.lang.java.ast.ASTTryStatement;
+import net.sourceforge.pmd.lang.java.ast.InvocationNode;
+import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.ast.internal.JavaAstUtils;
 import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.lang.java.symbols.JExecutableSymbol;
+import net.sourceforge.pmd.util.OptionalBool;
 
 
 /**
@@ -28,12 +33,45 @@ public class IdenticalCatchBranchesRule extends AbstractJavaRulechainRule {
         super(ASTTryStatement.class);
     }
 
+    interface PartialEquivalenceRel<T> {
+        OptionalBool test(T t1, T t2);
+    }
 
     private boolean areEquivalent(ASTCatchClause st1, ASTCatchClause st2) {
         String e1Name = st1.getParameter().getName();
         String e2Name = st2.getParameter().getName();
 
-        return JavaAstUtils.tokenEquals(st1.getBody(), st2.getBody(), name -> name.equals(e1Name) ? e2Name : name);
+        return JavaAstUtils.tokenEquals(st1.getBody(), st2.getBody(), name -> name.equals(e1Name) ? e2Name : name)
+            && areStructurallyEquivalent(st1.getBody(), st2.getBody(),
+                                         (n1, n2) -> {
+                                             if (n1 instanceof InvocationNode) {
+                                                 JExecutableSymbol sym1 = ((InvocationNode) n1).getMethodType().getSymbol();
+                                                 JExecutableSymbol sym2 = ((InvocationNode) n2).getMethodType().getSymbol();
+                                                 if (!Objects.equals(sym1, sym2))
+                                                     return OptionalBool.NO;
+                                             }
+                                             return OptionalBool.UNKNOWN;
+                                         });
+    }
+
+    /**
+     * Check that both nodes have the same structure and that some semantic properties
+     * of the trees match (eg, methods that are being called). This is not a full
+     * equality routine, for instance we do not
+     */
+    private static boolean areStructurallyEquivalent(JavaNode n1, JavaNode n2, PartialEquivalenceRel<JavaNode> areEquivalent) {
+        if (n1.getNumChildren() != n2.getNumChildren()
+            || !n1.getClass().equals(n2.getClass())
+            || areEquivalent.test(n1, n2) == OptionalBool.NO) {
+            return false;
+        }
+
+        for (int i = 0; i < n1.getNumChildren(); i++) {
+            if (!areStructurallyEquivalent(n1.getChild(i), n2.getChild(i), areEquivalent)) {
+                return false;
+            }
+        }
+        return true;
     }
 
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/IdenticalCatchBranches.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/IdenticalCatchBranches.xml
@@ -145,4 +145,68 @@ class Foo {
             }
             ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[java] IdenticalCatchBranches false positive with overloads (control test)</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+            class Foo {
+                static <E extends Error> E report(E e, String parm, String other) {
+                    return e;
+                }
+
+                // this is not overloaded so the report is correct
+                static <E extends Error> E wrap(E e) {
+                    return e;
+                }
+
+                public boolean classNameExists(String fullyQualifiedClassName) {
+                    try {
+                        Foo.class.getClassLoader().loadClass(fullyQualifiedClassName);
+                        return true; // Class found
+                    } catch (AssertionError e) {
+                        return report(wrap(e), fullyQualifiedClassName, fullyQualifiedClassName);
+                    } catch (LinkageError e2) {
+                        return report(wrap(e2), fullyQualifiedClassName, fullyQualifiedClassName);
+                    }
+                }
+
+
+            }
+            ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] IdenticalCatchBranches false positive with overloads</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            class Foo {
+                static <E extends Error> E report(E e, String parm, String other) {
+                    return e;
+                }
+
+                // these are overloaded so it would not work
+                static AssertionError wrap(AssertionError e) {
+                    return e;
+                }
+
+                static LinkageError wrap(LinkageError e) {
+                    return e;
+                }
+
+                public boolean classNameExists(String fullyQualifiedClassName) {
+                    try {
+                        Foo.class.getClassLoader().loadClass(fullyQualifiedClassName);
+                        return true; // Class found
+                    } catch (AssertionError e) {
+                        return report(wrap(e), fullyQualifiedClassName, fullyQualifiedClassName);
+                    } catch (LinkageError e2) {
+                        return report(wrap(e2), fullyQualifiedClassName, fullyQualifiedClassName);
+                    }
+                }
+
+
+            }
+            ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
**Rule:** [IdenticalCatchBranches](https://docs.pmd-code.org/latest/pmd_rules_java_codestyle.html#identicalcatchbranches)

## Describe the PR

While executing PMD locally on our sources I found that IdenticalCatchBranches reports this place:
https://github.com/pmd/pmd/blob/6ac7fc8a9979f1e42b73a2f661e8561939c91d51/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/internal/RuleApplicator.java#L80-L83

While they look identical, the `AssertionUtils.contexted` is overloaded and each branch calls a different overload. So this is a false positive. I fix it here by comparing that the structure of the subtrees is identical, including the methods that they call.

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- The build of #5529 may be failing because of this? The maven log doesn't say, but that's what I found locally.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

