### PR TITLE
[java] Fix race condition in ClassStub for inner classes

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStub.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStub.java
@@ -227,11 +227,17 @@ final class ClassStub implements JClassSymbol, AsmStub, AnnotationOwner {
         }
         this.accessFlags = myAccess | accessFlags;
 
-        if ((accessFlags & Opcodes.ACC_ENUM) != 0) {
-            this.enumConstants = new ArrayList<>();
-        }
-        if ((accessFlags & Opcodes.ACC_RECORD) != 0) {
-            this.recordComponents = new ArrayList<>();
+        // setModifiers is called multiple times: once from ClassFile structure (fromClassInfo==true)
+        // and additionally from InnerClasses attribute (fromClassInfo==false)
+        // The enum constants and record components should only be initialized once
+        // to avoid losing the constants.
+        if (fromClassInfo) {
+            if ((accessFlags & Opcodes.ACC_ENUM) != 0) {
+                this.enumConstants = new ArrayList<>();
+            }
+            if ((accessFlags & Opcodes.ACC_RECORD) != 0) {
+                this.recordComponents = new ArrayList<>();
+            }
         }
     }
 


### PR DESCRIPTION
## Describe the PR

This fixes a small race condition I noticed when fixing the integration test for regression tester (https://github.com/pmd/pmd-regression-tester/actions/workflows/manual-integration-tests.yml):

Sometimes (not reliably reproducible) there appears a false negative for ExhaustiveSwitchHasDefault: The following exhaustive switch is sometimes detected, sometimes not: https://github.com/checkstyle/checkstyle/blob/master/src/test/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModelTest.java#L62
It is definitely exhaustive, as the enum is declared here with only 3 constants: https://github.com/checkstyle/checkstyle/blob/master/src/main/java/com/puppycrawl/tools/checkstyle/gui/MainFrameModel.java#L42

It turned out, this appears only, when the enum is declared as a inner class. Then we sometimes parse the parent class and the inner class in different threads and both initialize the class stub for the inner class (as the parent class has the InnerClasses attribute) - thus overriding the enumConstants list.

## Related issues

- With https://github.com/pmd/pmd-regression-tester/pull/129 the manual integration test should be fixed, but still isn't... hopefully after this fix, it will turn green again, until #5550 is merged...

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

