### PR TITLE
[java] Fix crash when parsing class for anonymous class

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JClassSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JClassSymbol.java
@@ -86,10 +86,14 @@ public interface JClassSymbol extends JTypeDeclSymbol,
 
     /**
      * Returns the method or constructor this symbol is declared in, if
-     * it represents a {@linkplain #isLocalClass() local class declaration}.
+     * it represents a {@linkplain #isLocalClass() local class declaration}
+     * or an anonymous class declaration.
      *
      * <p>Notice, that this returns null also if this class is local to
-     * a class or instance initializer.
+     * a class or instance initializer, a field initializer, and some other
+     * special circumstances.
+     *
+     * @see Class#getEnclosingMethod()
      */
     @Nullable JExecutableSymbol getEnclosingMethod();
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStub.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStub.java
@@ -510,7 +510,7 @@ final class ClassStub implements JClassSymbol, AsmStub, AnnotationOwner {
         String mySimpleName = names.simpleName;
         if (mySimpleName == null) {
             parseLock.ensureParsed();
-            return Objects.requireNonNull(names.simpleName, "Null simple name after parsing");
+            return Objects.requireNonNull(names.simpleName, "Null simple name after parsing " + getInternalName());
         }
         return mySimpleName;
     }
@@ -666,6 +666,8 @@ final class ClassStub implements JClassSymbol, AsmStub, AnnotationOwner {
         }
 
         boolean isLocal() {
+            // todo a class may be local in a static or instance initializer.
+            //  in that case the method name and descriptor are null.
             return methodName != null || methodDescriptor != null;
         }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStubBuilder.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStubBuilder.java
@@ -135,7 +135,7 @@ class ClassStubBuilder extends ClassVisitor {
             }
             myStub.setSimpleName(innerSimpleName == null ? "" : innerSimpleName); // may be null for anonymous
             myStub.setModifiers(access, false);
-            isInnerNonStaticClass &= (Opcodes.ACC_STATIC & access) == 0;
+            isInnerNonStaticClass = (Opcodes.ACC_STATIC & access) == 0;
         }
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStubBuilder.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStubBuilder.java
@@ -123,13 +123,15 @@ class ClassStubBuilder extends ClassVisitor {
             member.setSimpleName(innerSimpleName);
             member.setModifiers(access, false);
             myStub.addMemberClass(member);
-        } else if (myInternalName.equals(innerInternalName) && outerName != null) {
+        } else if (myInternalName.equals(innerInternalName)) {
             // then it's specifying the enclosing class
             // (myStub is the inner class)
-            ClassStub outer = resolver.resolveFromInternalNameCannotFail(outerName);
-            myStub.setSimpleName(innerSimpleName);
+            if (outerName != null) {
+                ClassStub outer = resolver.resolveFromInternalNameCannotFail(outerName);
+                myStub.setOuterClass(outer, null, null);
+            }
+            myStub.setSimpleName(innerSimpleName == null ? "" : innerSimpleName); // may be null for anonymous
             myStub.setModifiers(access, false);
-            myStub.setOuterClass(outer, null, null);
             isInnerNonStaticClass = (Opcodes.ACC_STATIC & access) == 0;
         }
     }

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStubTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStubTest.java
@@ -138,6 +138,18 @@ class ClassStubTest {
     }
 
 
+    @Test
+    void testLoadAnonClassFromEnum() {
+        TypeSystem ts = TypeSystem.usingClassLoaderClasspath(JavaParsingHelper.class.getClassLoader());
+        JClassSymbol enumClass = loadTestDataClass(ts, "EnumConstantWithBody");
+        assertThat(enumClass, hasProperty("simpleName", equalTo("EnumConstantWithBody")));
+
+        JClassSymbol anonClass = loadTestDataClass(ts, "EnumConstantWithBody$0");
+        assertThat(anonClass, hasProperty("simpleName", equalTo("")));
+
+    }
+
+
 
 
     private static void assertIsListWithTyAnnotation(JClassType withTyAnnotation) {
@@ -151,6 +163,10 @@ class ClassStubTest {
 
     private static @NonNull JClassSymbol loadScalaClass(TypeSystem typeSystem, String simpleName) {
         return loadClassInPackage("net.sourceforge.pmd.lang.java.symbols.scalaclasses", simpleName, typeSystem);
+    }
+
+    private static @NonNull JClassSymbol loadTestDataClass(TypeSystem typeSystem, String simpleName) {
+        return loadClassInPackage("net.sourceforge.pmd.lang.java.symbols.testdata", simpleName, typeSystem);
     }
 
     private static @NonNull JClassSymbol loadRecordClass(TypeSystem typeSystem, String simpleName) {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/testdata/EnumConstantWithBody.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/testdata/EnumConstantWithBody.java
@@ -1,0 +1,7 @@
+package net.sourceforge.pmd.lang.java.symbols.testdata;
+
+public enum EnumConstantWithBody {
+    A {
+        // this is anon class EnumConstantWithBody$1
+    }
+}

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/testdata/EnumConstantWithBody.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/testdata/EnumConstantWithBody.java
@@ -1,3 +1,7 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
 package net.sourceforge.pmd.lang.java.symbols.testdata;
 
 public enum EnumConstantWithBody {

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/testdata/LocalClasses.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/testdata/LocalClasses.java
@@ -1,0 +1,23 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.symbols.testdata;
+
+public class LocalClasses {
+    Object foo = new Object() {
+        // LocalClasses$1
+    };
+
+    static {
+        class Local1 {
+            // LocalClasses$Local1
+        }
+    }
+
+    void foo() {
+        class Local2 {
+            // LocalClasses$Local1
+        }
+    }
+}

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/asm/SigParserTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/symbols/internal/asm/SigParserTest.kt
@@ -11,14 +11,14 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import javasymbols.testdata.impls.SomeInnerClasses
-import net.sourceforge.pmd.lang.test.ast.IntelliMarker
-import net.sourceforge.pmd.lang.test.ast.shouldBe
 import net.sourceforge.pmd.lang.java.symbols.JTypeParameterSymbol
 import net.sourceforge.pmd.lang.java.symbols.internal.asm.GenericSigBase.LazyMethodType
 import net.sourceforge.pmd.lang.java.symbols.internal.asm.TypeParamsParser.BaseTypeParamsBuilder
 import net.sourceforge.pmd.lang.java.types.*
-import org.mockito.Mockito.`when`
+import net.sourceforge.pmd.lang.test.ast.IntelliMarker
+import net.sourceforge.pmd.lang.test.ast.shouldBe
 import org.mockito.Mockito.mock
+import org.mockito.Mockito.`when`
 
 
 fun TypeSystem.mockTypeVar(name: String): JTypeVar {

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeCreationDsl.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/TypeCreationDsl.kt
@@ -38,9 +38,13 @@ interface TypeDslMixin {
 
     /* extensions to turn a class (literal) into a type mirror */
 
-    val KClass<*>.raw: JClassType get() = ts.rawType(ts.getClassSymbol(this.java)!!) as JClassType
+    private fun getNonNullClassSymbol(klass: Class<*>): JClassSymbol =
+        ts.getClassSymbol(klass) ?: throw AssertionError("Symbol resolver couldn't resolve $klass")
+
+    val KClass<*>.raw: JClassType get() = java.raw
+    val Class<*>.raw: JClassType get() = ts.rawType(getNonNullClassSymbol(this)) as JClassType
     val KClass<*>.decl: JClassType get() = java.decl
-    val Class<*>.decl: JClassType get() = ts.declaration(ts.getClassSymbol(this)!!) as JClassType
+    val Class<*>.decl: JClassType get() = ts.declaration(getNonNullClassSymbol(this)) as JClassType
 
     /* aliases with regular java keywords */
 


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
Parsing the class file of an anonymous class was not populating the simple name, causing an NPE. I'm not sure why an anonymous class was parsed at all, but this crash occurred when analysing JDK sources.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

