### PR TITLE
Fix #5587: [java] Fix deadlock while loading ClassStub

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -20,6 +20,9 @@ This is a {{ site.pmd.release_type }} release.
 
 ### 🚨 API Changes
 
+- {% jdoc java::types.JTypeVar#withUpperbound(java::types.JTypeMirror) %} is deprecated. It was previously meant to be used
+  internally and not needed anymore.
+
 ### ✨ Merged pull requests
 <!-- content will be automatically generated, see /do-release.sh -->
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/AssertionUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/AssertionUtil.java
@@ -19,10 +19,25 @@ public final class AssertionUtil {
     private static final Pattern BINARY_NAME_PATTERN = Pattern.compile("[\\w$]+(?:\\.[\\w$]+)*(?:\\[])*");
     private static final Pattern BINARY_NAME_NO_ARRAY = Pattern.compile("[\\w$]++(?:\\.[\\w$]++)*");
 
+    private static final boolean ASSERT_ENABLED;
+
+    static {
+        boolean assertEnabled = false;
+        //noinspection AssertWithSideEffects
+        assert assertEnabled = true; // SUPPRESS CHECKSTYLE now
+        ASSERT_ENABLED = assertEnabled;
+    }
+
     private AssertionUtil() {
         // utility class
     }
 
+    /**
+     * Return true if the VM runs with assertions enabled.
+     */
+    public static boolean isAssertEnabled() {
+        return ASSERT_ENABLED;
+    }
 
     /** @throws NullPointerException if any item is null */
     public static void requireContainsNoNullValue(String name, Collection<?> c) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStub.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStub.java
@@ -34,6 +34,7 @@ import net.sourceforge.pmd.lang.java.symbols.internal.SymbolEquality;
 import net.sourceforge.pmd.lang.java.symbols.internal.asm.ExecutableStub.CtorStub;
 import net.sourceforge.pmd.lang.java.symbols.internal.asm.ExecutableStub.MethodStub;
 import net.sourceforge.pmd.lang.java.symbols.internal.asm.GenericSigBase.LazyClassSignature;
+import net.sourceforge.pmd.lang.java.symbols.internal.asm.ParseLock.CheckedParseLock;
 import net.sourceforge.pmd.lang.java.types.JClassType;
 import net.sourceforge.pmd.lang.java.types.JTypeVar;
 import net.sourceforge.pmd.lang.java.types.LexicalScope;
@@ -85,7 +86,7 @@ final class ClassStub implements JClassSymbol, AsmStub, AnnotationOwner {
         this.resolver = resolver;
         this.names = new Names(internalName);
 
-        this.parseLock = new ParseLock("ClassStub:" + internalName) {
+        this.parseLock = new CheckedParseLock("ClassStub:" + internalName) {
             @Override
             protected boolean doParse() throws IOException {
                 try (InputStream instream = loader.getInputStream()) {
@@ -110,7 +111,7 @@ final class ClassStub implements JClassSymbol, AsmStub, AnnotationOwner {
                     enclosingInfo = EnclosingInfo.NO_ENCLOSING;
                 }
                 if (signature == null) {
-                    assert failed : "No signature, but the parse hasn't failed? investigate";
+                    assert failed : "No signature, but the parse hasn't failed? investigate " +  names.internalName;
                     signature = LazyClassSignature.defaultWhenUnresolved(ClassStub.this, observedArity);
                 }
                 methods = Collections.unmodifiableList(methods);
@@ -119,7 +120,7 @@ final class ClassStub implements JClassSymbol, AsmStub, AnnotationOwner {
                 memberClasses = Collections.unmodifiableList(memberClasses);
                 enumConstants = CollectionUtil.makeUnmodifiableAndNonNull(enumConstants);
                 recordComponents = CollectionUtil.makeUnmodifiableAndNonNull(recordComponents);
-                if (isEnum()) {
+                if ((accessFlags & Opcodes.ACC_ENUM) != 0) {
                     permittedSubclasses = Collections.emptyList();
                 }
                 permittedSubclasses = CollectionUtil.makeUnmodifiableAndNonNull(permittedSubclasses);
@@ -130,32 +131,11 @@ final class ClassStub implements JClassSymbol, AsmStub, AnnotationOwner {
                     // whether they are top-level or not.
                     names.finishOuterClass();
                 }
-                assert names.simpleName != null : "At this point the simple name should be known";
-                if (!enclosingInfo.isLocalOrAnon && names.canonicalName == null) {
-                    // note that this may recursively parse the parent classes. This is
-                    // only necessary in specific cases where class simple names contain dollar signs.
-                    names.canonicalName = computeCanonicalName();
-                }
-
-                annotAttributes = (accessFlags & Opcodes.ACC_ANNOTATION) != 0
-                                  ? getDeclaredMethods().stream().filter(JMethodSymbol::isAnnotationAttribute)
-                                                        .map(JElementSymbol::getSimpleName)
-                                                        .collect(CollectionUtil.toPersistentSet())
-                                  : HashTreePSet.empty();
-            }
-
-            @Override
-            protected boolean canReenter() {
-                // We might call the parsing logic again in the same thread,
-                // e.g. in order to determine "annotAttributes", getDeclaredMethods() is called, which
-                // calls ensureParsed().
-                // Note: Other threads can't reenter, since our thread own the ParseLock monitor.
-                return true;
             }
 
             @Override
             protected boolean postCondition() {
-                return signature != null && enclosingInfo != null;
+                return signature != null && enclosingInfo != null && names.simpleName != null;
             }
         };
     }
@@ -377,14 +357,21 @@ final class ClassStub implements JClassSymbol, AsmStub, AnnotationOwner {
 
     @Override
     public PSet<String> getAnnotationAttributeNames() {
-        parseLock.ensureParsed();
+        if (annotAttributes == null) {
+            parseLock.ensureParsed();
+            annotAttributes = isAnnotation()
+                              ? getDeclaredMethods().stream().filter(JMethodSymbol::isAnnotationAttribute)
+                                                    .map(JElementSymbol::getSimpleName)
+                                                    .collect(CollectionUtil.toPersistentSet())
+                              : HashTreePSet.empty();
+        }
         return annotAttributes;
     }
 
     @Override
     public @Nullable SymbolicValue getDefaultAnnotationAttributeValue(String attrName) {
         parseLock.ensureParsed();
-        if (!annotAttributes.contains(attrName)) {
+        if (!getAnnotationAttributeNames().contains(attrName)) {
             // this is a shortcut, because the default impl checks each method
             return null;
         }
@@ -472,18 +459,22 @@ final class ClassStub implements JClassSymbol, AsmStub, AnnotationOwner {
     public @Nullable String getCanonicalName() {
         @Nullable String canoName = names.canonicalName;
         if (canoName == null) {
-            parseLock.ensureParsed();
-            canoName = names.canonicalName;
+            canoName = computeCanonicalName();
+            names.canonicalName = canoName;
+        }
+
+        if (Names.NO_CANONAME.equals(canoName)) {
+            return null;
         }
         return canoName;
     }
 
-    private @Nullable String computeCanonicalName() {
+    private @NonNull String computeCanonicalName() {
         parseLock.ensureParsed();
         if (names.canonicalName != null) {
             return names.canonicalName;
         } else if (enclosingInfo.isLocalOrAnon()) {
-            return null;
+            return Names.NO_CANONAME;
         }
         assert names.simpleName != null && !names.simpleName.isEmpty() : "Anon class should not take this branch";
 
@@ -493,7 +484,7 @@ final class ClassStub implements JClassSymbol, AsmStub, AnnotationOwner {
         }
         String outerName = enclosing.getCanonicalName();
         if (outerName == null) {
-            return null;
+            return Names.NO_CANONAME;
         }
         return outerName + '.' + names.simpleName;
     }
@@ -604,6 +595,12 @@ final class ClassStub implements JClassSymbol, AsmStub, AnnotationOwner {
 
 
     static class Names {
+        /**
+         * Placeholder to represent that the class has no canonical name.
+         * This is not a valid canonical names so cannot class with an
+         * actual canoname.
+         */
+        private static final String NO_CANONAME = "--NO-CANONICAL-NAME";
 
         final String binaryName;
         final String internalName;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStub.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStub.java
@@ -111,7 +111,7 @@ final class ClassStub implements JClassSymbol, AsmStub, AnnotationOwner {
                     enclosingInfo = EnclosingInfo.NO_ENCLOSING;
                 }
                 if (signature == null) {
-                    assert failed : "No signature, but the parse hasn't failed? investigate " +  names.internalName;
+                    assert failed : "No signature, but the parse hasn't failed? investigate " + names.internalName;
                     signature = LazyClassSignature.defaultWhenUnresolved(ClassStub.this, observedArity);
                 }
                 methods = Collections.unmodifiableList(methods);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/GenericSigBase.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/GenericSigBase.java
@@ -66,6 +66,7 @@ abstract class GenericSigBase<T extends JTypeParameterOwnerSymbol & AsmStub> {
                 }
             }
 
+
             @Override
             protected boolean postCondition() {
                 return GenericSigBase.this.postCondition();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ParseLock.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ParseLock.java
@@ -164,7 +164,7 @@ abstract class ParseLock {
         final void releaseLock() {
             if (isAssertEnabled()) {
                 ParseLock lock = CURRENT_LOCK.get();
-                assert lock == this : "Tried to release different parse lock " + lock + " from " + this;
+                assert lock == this : "Tried to release different parse lock " + lock + " from " + this; // NOPMD CompareObjectsWithEquals
                 CURRENT_LOCK.remove();
             }
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/TParamStub.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/TParamStub.java
@@ -4,7 +4,13 @@
 
 package net.sourceforge.pmd.lang.java.symbols.internal.asm;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.objectweb.asm.TypePath;
+import org.objectweb.asm.TypeReference;
 import org.pcollections.HashTreePSet;
 import org.pcollections.PSet;
 
@@ -13,6 +19,8 @@ import net.sourceforge.pmd.lang.java.symbols.JTypeParameterSymbol;
 import net.sourceforge.pmd.lang.java.symbols.SymbolicValue.SymAnnot;
 import net.sourceforge.pmd.lang.java.symbols.internal.SymbolEquality;
 import net.sourceforge.pmd.lang.java.symbols.internal.SymbolToStrings;
+import net.sourceforge.pmd.lang.java.symbols.internal.asm.TypeAnnotationHelper.TypeAnnotationSetWithReferences;
+import net.sourceforge.pmd.lang.java.types.JIntersectionType;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.JTypeVar;
 import net.sourceforge.pmd.lang.java.types.TypeSystem;
@@ -25,6 +33,8 @@ class TParamStub implements JTypeParameterSymbol {
     private final String boundSignature;
     private final SignatureParser sigParser;
     private PSet<SymAnnot> annotations = HashTreePSet.empty();
+    private TypeAnnotationSetWithReferences typeAnnotationsOnBound;
+    private boolean canComputeBound;
 
     TParamStub(String name, GenericSigBase<?> sig, String bound) {
         this.name = name;
@@ -44,10 +54,48 @@ class TParamStub implements JTypeParameterSymbol {
 
     @Override
     public JTypeMirror computeUpperBound() {
-        // Note: type annotations on the bound are added when applying
-        // type annots collected on the enclosing symbol. See usages of
-        // this method.
-        return sigParser.parseTypeVarBound(owner.getLexicalScope(), boundSignature);
+        if (!canComputeBound) {
+            throw new IllegalStateException(
+                "Can't compute upper bound of " + name + " in " + owner.getEnclosingTypeParameterOwner());
+        }
+        JTypeMirror bound = sigParser.parseTypeVarBound(owner.getLexicalScope(), boundSignature);
+        if (typeAnnotationsOnBound != null) {
+            // apply all type annotations.
+            return typeAnnotationsOnBound.reduce(
+                bound,
+                (tyRef, path, annot, acc) -> {
+                    int boundIdx = tyRef.getTypeParameterBoundIndex();
+
+                    return applyTypeAnnotationToBound(path, annot, boundIdx, acc);
+                });
+        }
+        return bound;
+    }
+
+    private static JTypeMirror applyTypeAnnotationToBound(@Nullable TypePath path, SymAnnot annot, int boundIdx, JTypeMirror ub) {
+        if (ub instanceof JIntersectionType) {
+            JIntersectionType intersection = (JIntersectionType) ub;
+
+            // Object is pruned from the component list
+            boundIdx = intersection.getPrimaryBound().isTop() ? boundIdx - 1 : boundIdx;
+
+            List<JTypeMirror> components = new ArrayList<>(intersection.getComponents());
+            JTypeMirror bound = components.get(boundIdx);
+            JTypeMirror newBound = TypeAnnotationHelper.applySinglePath(bound, path, annot);
+            components.set(boundIdx, newBound);
+            return intersection.getTypeSystem().glb(components);
+        } else {
+            return TypeAnnotationHelper.applySinglePath(ub, path, annot);
+        }
+    }
+
+    /**
+     * The bound cannot be computed before we have collected type annotations
+     * for the bound. These may come from the parsing of the type annotations
+     * for the enclosing declaration (method or class) so come relatively late.
+     */
+    void setCanComputeBound() {
+        this.canComputeBound = true;
     }
 
     @Override
@@ -89,4 +137,13 @@ class TParamStub implements JTypeParameterSymbol {
         return SymbolEquality.TYPE_PARAM.equals(this, obj);
     }
 
+    void addAnnotationOnBound(TypeReference tyRef, @Nullable TypePath path, SymAnnot annot) {
+        assert tyRef.getSort() == TypeReference.CLASS_TYPE_PARAMETER_BOUND
+            || tyRef.getSort() == TypeReference.METHOD_TYPE_PARAMETER_BOUND;
+
+        if (typeAnnotationsOnBound == null) {
+            typeAnnotationsOnBound = new TypeAnnotationSetWithReferences();
+        }
+        typeAnnotationsOnBound.add(tyRef, path, annot);
+    }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/TParamStub.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/TParamStub.java
@@ -59,17 +59,17 @@ class TParamStub implements JTypeParameterSymbol {
                 "Can't compute upper bound of " + name + " in " + owner.getEnclosingTypeParameterOwner());
         }
         JTypeMirror bound = sigParser.parseTypeVarBound(owner.getLexicalScope(), boundSignature);
-        if (typeAnnotationsOnBound != null) {
-            // apply all type annotations.
-            return typeAnnotationsOnBound.reduce(
-                bound,
-                (tyRef, path, annot, acc) -> {
-                    int boundIdx = tyRef.getTypeParameterBoundIndex();
-
-                    return applyTypeAnnotationToBound(path, annot, boundIdx, acc);
-                });
+        if (typeAnnotationsOnBound == null) {
+            return bound;
         }
-        return bound;
+        // apply all type annotations.
+        return typeAnnotationsOnBound.reduce(
+            bound,
+            (tyRef, path, annot, acc) -> {
+                int boundIdx = tyRef.getTypeParameterBoundIndex();
+
+                return applyTypeAnnotationToBound(path, annot, boundIdx, acc);
+            });
     }
 
     private static JTypeMirror applyTypeAnnotationToBound(@Nullable TypePath path, SymAnnot annot, int boundIdx, JTypeMirror ub) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/TypeAnnotationHelper.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/TypeAnnotationHelper.java
@@ -65,13 +65,20 @@ final class TypeAnnotationHelper {
             pathAndAnnot.add(Triple.of(reference, path, annot));
         }
 
-        /** Return true if the parameter returns true on any parameter. */
-        boolean forEach(TypeAnnotationConsumer consumer) {
-            boolean result = false;
+        /** Execute a callback on each annotations in this set. */
+        void forEach(TypeAnnotationConsumer consumer) {
             for (Triple<TypeReference, TypePath, SymAnnot> triple : pathAndAnnot) {
-                result |= consumer.acceptAnnotation(triple.getLeft(), triple.getMiddle(), triple.getRight());
+                consumer.acceptAnnotation(triple.getLeft(), triple.getMiddle(), triple.getRight());
             }
-            return result;
+        }
+
+        /** Accumulate a value while applying type annotations. */
+        <T> T reduce(final T init, TypeAnnotationReducer<T> consumer) {
+            T acc = init;
+            for (Triple<TypeReference, TypePath, SymAnnot> triple : pathAndAnnot) {
+                acc = consumer.acceptAnnotation(triple.getLeft(), triple.getMiddle(), triple.getRight(), acc);
+            }
+            return acc;
         }
 
         @Override
@@ -84,6 +91,13 @@ final class TypeAnnotationHelper {
 
             /** Add an annotation at the given path and type ref. */
             boolean acceptAnnotation(TypeReference tyRef, @Nullable TypePath path, SymAnnot annot);
+        }
+
+        @FunctionalInterface
+        interface TypeAnnotationReducer<T> {
+
+            /** Add an annotation at the given path and type ref. */
+            T acceptAnnotation(TypeReference tyRef, @Nullable TypePath path, SymAnnot annot, T acc);
         }
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JTypeMirror.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JTypeMirror.java
@@ -456,7 +456,8 @@ public interface JTypeMirror extends JTypeVisitable {
     /**
      * Returns a type mirror that is equal to this instance but has different
      * type annotations. Note that some types ignore this method and return
-     * themselves without changing. Eg the null type cannot be annotated.
+     * themselves without changing. Eg the null type or void type cannot be
+     * annotated.
      *
      * @param newTypeAnnots New type annotations (not null)
      *

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JTypeVar.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JTypeVar.java
@@ -129,7 +129,12 @@ public interface JTypeVar extends SubstVar {
      * @param newUB New upper bound
      *
      * @return a new tvar
+     *
+     * @deprecated There is no real use case for mutating the upper bound.
+     *  Also, the bound could have been changed to really anything, which means
+     *  it wasn't necessarily correct for two of those type vars to compare equals.
      */
+    @Deprecated
     JTypeVar withUpperBound(@NonNull JTypeMirror newUB);
 
     @Override // refine return type

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/DeadlockTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/DeadlockTest.java
@@ -12,7 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.RepeatedTest;
 import org.junit.jupiter.api.Timeout;
 
 import net.sourceforge.pmd.lang.java.JavaParsingHelper;
@@ -39,8 +39,8 @@ class DeadlockTest {
 
     abstract static class GenericClass<T> extends GenericBaseClass<Outer.Inner<T>> { }
 
-    @Test
     @Timeout(2)
+    @RepeatedTest(50)
     void parseWithoutDeadlock() throws InterruptedException {
         /*
          Deadlock:


### PR DESCRIPTION
ClassStubs now cannot request parsing of another ClassStub while they are themselves being parsed. This is enforced when assertions are enabled. ClassStubs can still be loaded in parallel but they never have to wait for another thread anymore which might be good for performance.

Maybe we should remove the logging statements in ParseLock, the ones about threads locking and such. There shouldn't be any threading problem happening


<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #5587
- Related to #5293 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

