### PR TITLE
Fix #5590: [java] LiteralsFirstInComparisons with constant field

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTBooleanLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTBooleanLiteral.java
@@ -5,6 +5,7 @@
 package net.sourceforge.pmd.lang.java.ast;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.sourceforge.pmd.lang.document.Chars;
 
@@ -30,8 +31,13 @@ public final class ASTBooleanLiteral extends AbstractLiteral implements ASTLiter
     }
 
     @Override
-    public @NonNull Boolean getConstValue() {
-        return isTrue;
+    public @Nullable Boolean getConstValue() {
+        return (Boolean) super.getConstValue();
+    }
+
+    @Override
+    protected @NonNull ConstResult buildConstValue() {
+        return isTrue ? ConstResult.BOOL_TRUE : ConstResult.BOOL_FALSE;
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTBooleanLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTBooleanLiteral.java
@@ -4,7 +4,6 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.sourceforge.pmd.lang.document.Chars;
@@ -33,11 +32,6 @@ public final class ASTBooleanLiteral extends AbstractLiteral implements ASTLiter
     @Override
     public @Nullable Boolean getConstValue() {
         return (Boolean) super.getConstValue();
-    }
-
-    @Override
-    protected @NonNull ConstResult buildConstValue() {
-        return isTrue ? ConstResult.BOOL_TRUE : ConstResult.BOOL_FALSE;
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCharLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCharLiteral.java
@@ -34,9 +34,15 @@ public final class ASTCharLiteral extends AbstractLiteral implements ASTLiteral 
      */
     @Override
     public @NonNull Character getConstValue() {
+        return (Character) super.getConstValue();
+    }
+
+    @Override
+    protected @NonNull ConstResult buildConstValue() {
         Chars image = getLiteralText();
         Chars woDelims = image.subSequence(1, image.length() - 1);
-        return StringEscapeUtils.UNESCAPE_JAVA.translate(woDelims).charAt(0);
+        Character result = StringEscapeUtils.UNESCAPE_JAVA.translate(woDelims).charAt(0);
+        return ConstResult.ctConst(result);
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCharLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCharLiteral.java
@@ -4,7 +4,6 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
-import org.apache.commons.lang3.StringEscapeUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import net.sourceforge.pmd.lang.document.Chars;
@@ -35,14 +34,6 @@ public final class ASTCharLiteral extends AbstractLiteral implements ASTLiteral 
     @Override
     public @NonNull Character getConstValue() {
         return (Character) super.getConstValue();
-    }
-
-    @Override
-    protected @NonNull ConstResult buildConstValue() {
-        Chars image = getLiteralText();
-        Chars woDelims = image.subSequence(1, image.length() - 1);
-        Character result = StringEscapeUtils.UNESCAPE_JAVA.translate(woDelims).charAt(0);
-        return ConstResult.ctConst(result);
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExpression.java
@@ -152,7 +152,7 @@ public interface ASTExpression extends TypeNode, ASTMemberValue, ASTSwitchArrowR
      * Result of constant folding an expression. This can be in one of three states:
      * <ul>
      * <li>No constant value: constant folding failed, meaning, the value of the expression is not known at compile time.
-     * <li>Has ompile-time constant value: there is a constant value, and it is a compile-time constant in the sense of the JLS.
+     * <li>Has compile-time constant value: there is a constant value, and it is a compile-time constant in the sense of the JLS.
      * Such constants are inlined in class files. One restriction on them is that they only use literals or CT-constant
      * fields (which must be static final and have a CT-constant initializer), but not final variables or non-static fields
      * for instance.

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExpression.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import java.util.Objects;
+
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -79,15 +81,38 @@ public interface ASTExpression extends TypeNode, ASTMemberValue, ASTSwitchArrowR
         return getParenthesisDepth() > 0;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>Note that even if this is null, the constant value may be known anyway but
+     * technically not be a CT constant, because it uses non-static (final) fields
+     * for instance. See {@link #getConstFoldingResult()} and {@link ConstResult} to
+     * get a constant value in this case.
+     *
+     * @see #getConstFoldingResult() for more precise results.
+     */
     @Override
     default @Nullable Object getConstValue() {
-        return null;
+        ConstResult res = getConstFoldingResult();
+        return res.isCompileTimeConstant() ? res.getValue() : null;
     }
 
+    /**
+     * Returns the result of constant folding on this expression. This may find a
+     * constant value for more than strict compile-time constants. See {@link ConstResult}.
+     *
+     */
+    default @NonNull ConstResult getConstFoldingResult() {
+        return ConstResult.NO_CONST_VALUE;
+    }
 
-    /** Returns true if this expression is a compile-time constant, and is inlined. */
+    /**
+     * Returns true if this expression is a compile-time constant, and is inlined.
+     *
+     * @see #getConstFoldingResult()
+     */
     default boolean isCompileTimeConstant() {
-        return getConstValue() != null;
+        return getConstFoldingResult().isCompileTimeConstant();
     }
 
     /**
@@ -123,4 +148,62 @@ public interface ASTExpression extends TypeNode, ASTMemberValue, ASTSwitchArrowR
         return getRoot().getLazyTypeResolver().getConversionContextForExternalUse(this);
     }
 
+    /**
+     * Result of constant folding an expression. This can be in one of three states:
+     * <ul>
+     * <li>No constant value: constant folding failed, meaning, the value of the expression is not known at compile time.
+     * <li>Has ompile-time constant value: there is a constant value, and it is a compile-time constant in the sense of the JLS.
+     * Such constants are inlined in class files. One restriction on them is that they only use literals or CT-constant
+     * fields (which must be static final and have a CT-constant initializer), but not final variables or non-static fields
+     * for instance.
+     * <li>Has value, not compile-time constant: we could compute a constant value, but it is not CT-constant in the sense
+     * of the JLS. Maybe it uses the constant initializer of a final local variable for instance.
+     * </ul>
+     */
+    final class ConstResult {
+        private final boolean isCompileTimeConstant;
+        private final @Nullable Object value;
+
+        static final ConstResult NO_CONST_VALUE = new ConstResult(false, null);
+        static final ConstResult BOOL_TRUE = ctConst(true);
+        static final ConstResult BOOL_FALSE = ctConst(false);
+
+        ConstResult(boolean isCompileTimeConstant, @Nullable Object value) {
+            this.isCompileTimeConstant = isCompileTimeConstant && value != null;
+            this.value = value;
+        }
+
+        static @NonNull ConstResult ctConst(@NonNull Object result) {
+            return new ConstResult(true, Objects.requireNonNull(result));
+        }
+
+        static @NonNull ConstResult ctConstIfNotNull(@Nullable Object result) {
+            if (result == null) {
+                return NO_CONST_VALUE;
+            }
+            return new ConstResult(true, Objects.requireNonNull(result));
+        }
+
+        /**
+         * If true, this value is a compile-time constant in the sense of the JLS. See class description.
+         */
+        public boolean isCompileTimeConstant() {
+            return isCompileTimeConstant;
+        }
+
+        /**
+         * If true, a constant value could be computed. It is not necessarily a CT-constant. See class description.
+         */
+        public boolean hasValue() {
+            return value != null;
+        }
+
+        /**
+         * Get the value, or null if no value could be computed. The value has one of the primitive wrapper types,
+         * or String type.
+         */
+        public @Nullable Object getValue() {
+            return value;
+        }
+    }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTNullLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTNullLiteral.java
@@ -4,8 +4,6 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-
 import net.sourceforge.pmd.lang.document.Chars;
 
 /**
@@ -31,11 +29,6 @@ public final class ASTNullLiteral extends AbstractLiteral implements ASTLiteral 
     @Override
     public boolean isCompileTimeConstant() {
         return false;
-    }
-
-    @Override
-    protected @NonNull ConstResult buildConstValue() {
-        return ConstResult.NO_CONST_VALUE;
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTNullLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTNullLiteral.java
@@ -4,7 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 import net.sourceforge.pmd.lang.document.Chars;
 
@@ -34,8 +34,8 @@ public final class ASTNullLiteral extends AbstractLiteral implements ASTLiteral 
     }
 
     @Override
-    public @Nullable Object getConstValue() {
-        return null;
+    protected @NonNull ConstResult buildConstValue() {
+        return ConstResult.NO_CONST_VALUE;
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTNumericLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTNumericLiteral.java
@@ -47,19 +47,23 @@ public final class ASTNumericLiteral extends AbstractLiteral implements ASTLiter
     }
 
     @Override
-    protected @NonNull Number buildConstValue() {
+    protected @NonNull ConstResult buildConstValue() {
         // don't use ternaries, the compiler messes up autoboxing.
+        Object result;
         if (isIntegral()) {
             if (isIntLiteral()) {
-                return getValueAsInt();
+                result = getValueAsInt();
+            } else {
+                result = getValueAsLong();
             }
-            return getValueAsLong();
         } else {
             if (isFloatLiteral()) {
-                return getValueAsFloat();
+                result = getValueAsFloat();
+            } else {
+                result = getValueAsDouble();
             }
-            return getValueAsDouble();
         }
+        return ConstResult.ctConst(result);
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTNumericLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTNumericLiteral.java
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.java.ast;
 
 import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.sourceforge.pmd.lang.document.Chars;
 import net.sourceforge.pmd.lang.java.types.JPrimitiveType;
@@ -46,24 +47,13 @@ public final class ASTNumericLiteral extends AbstractLiteral implements ASTLiter
         return (Number) super.getConstValue();
     }
 
+    /**
+     * @deprecated See super method. This override is needed due to covariant return type change.
+     */
     @Override
-    protected @NonNull ConstResult buildConstValue() {
-        // don't use ternaries, the compiler messes up autoboxing.
-        Object result;
-        if (isIntegral()) {
-            if (isIntLiteral()) {
-                result = getValueAsInt();
-            } else {
-                result = getValueAsLong();
-            }
-        } else {
-            if (isFloatLiteral()) {
-                result = getValueAsFloat();
-            } else {
-                result = getValueAsDouble();
-            }
-        }
-        return ConstResult.ctConst(result);
+    @Deprecated
+    protected @Nullable Number buildConstValue() {
+        return (Number) super.buildConstValue();
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTStringLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTStringLiteral.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.sourceforge.pmd.lang.document.Chars;
 import net.sourceforge.pmd.lang.rule.xpath.NoAttribute;
@@ -87,15 +88,13 @@ public final class ASTStringLiteral extends AbstractLiteral implements ASTLitera
         return (String) super.getConstValue(); // value is cached
     }
 
+    /**
+     * @deprecated See super method. This override is needed due to covariant return type change.
+     */
     @Override
-    protected @NonNull ConstResult buildConstValue() {
-        String result;
-        if (isTextBlock()) {
-            result = determineTextBlockContent(getLiteralText());
-        } else {
-            result = determineStringContent(getLiteralText());
-        }
-        return ConstResult.ctConst(result);
+    @Deprecated
+    protected @Nullable String buildConstValue() {
+        return (String) super.buildConstValue();
     }
 
     static @NonNull String determineStringContent(Chars image) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTStringLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTStringLiteral.java
@@ -88,12 +88,14 @@ public final class ASTStringLiteral extends AbstractLiteral implements ASTLitera
     }
 
     @Override
-    protected @NonNull String buildConstValue() {
+    protected @NonNull ConstResult buildConstValue() {
+        String result;
         if (isTextBlock()) {
-            return determineTextBlockContent(getLiteralText());
+            result = determineTextBlockContent(getLiteralText());
         } else {
-            return determineStringContent(getLiteralText());
+            result = determineStringContent(getLiteralText());
         }
+        return ConstResult.ctConst(result);
     }
 
     static @NonNull String determineStringContent(Chars image) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractJavaExpr.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractJavaExpr.java
@@ -4,14 +4,15 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import java.util.Objects;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 abstract class AbstractJavaExpr extends AbstractJavaTypeNode implements ASTExpression {
 
-    private static final Object NOT_COMPUTED = new Object(); // null is sentinel value too
-
     private int parenDepth;
-    private Object constValue = NOT_COMPUTED;
+    private @Nullable ConstResult constValue;
 
     AbstractJavaExpr(int i) {
         super(i);
@@ -28,15 +29,16 @@ abstract class AbstractJavaExpr extends AbstractJavaTypeNode implements ASTExpre
     }
 
     @Override
-    public @Nullable Object getConstValue() {
-        if (constValue == NOT_COMPUTED) { // NOPMD we want identity semantics
-            constValue = null; // remove the sentinel, so that we don't reenter on cycle
+    public @NonNull ConstResult getConstFoldingResult() {
+        if (constValue == null) {
+            constValue = ConstResult.NO_CONST_VALUE; // make non-null, so that we don't reenter on cycle
             constValue = buildConstValue();
+            Objects.requireNonNull(constValue, "constValue must not be null");
         }
         return constValue;
     }
 
-    protected @Nullable Object buildConstValue() {
+    protected @NonNull ConstResult buildConstValue() {
         return acceptVisitor(ConstantFolder.INSTANCE, null);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractJavaExpr.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractJavaExpr.java
@@ -32,13 +32,21 @@ abstract class AbstractJavaExpr extends AbstractJavaTypeNode implements ASTExpre
     public @NonNull ConstResult getConstFoldingResult() {
         if (constValue == null) {
             constValue = ConstResult.NO_CONST_VALUE; // make non-null, so that we don't reenter on cycle
-            constValue = buildConstValue();
+            constValue = doBuildConstValue();
             Objects.requireNonNull(constValue, "constValue must not be null");
         }
         return constValue;
     }
 
-    protected @NonNull ConstResult buildConstValue() {
+    final @NonNull ConstResult doBuildConstValue() {
         return acceptVisitor(ConstantFolder.INSTANCE, null);
+    }
+
+    /**
+     * @deprecated Kept for binary compatibility. This method should have been package-private from the start.
+     */
+    @Deprecated
+    protected @Nullable Object buildConstValue() {
+        return doBuildConstValue().getValue();
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractLiteral.java
@@ -4,6 +4,8 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import org.checkerframework.checker.nullness.qual.NonNull;
+
 import net.sourceforge.pmd.lang.ast.impl.javacc.JavaccToken;
 import net.sourceforge.pmd.lang.document.Chars;
 import net.sourceforge.pmd.lang.rule.xpath.NoAttribute;
@@ -58,4 +60,7 @@ abstract class AbstractLiteral extends AbstractJavaExpr {
     public boolean isCompileTimeConstant() {
         return true; // note: NullLiteral overrides this to false
     }
+
+    @Override
+    protected abstract @NonNull ConstResult buildConstValue();
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractLiteral.java
@@ -4,8 +4,6 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
-import org.checkerframework.checker.nullness.qual.NonNull;
-
 import net.sourceforge.pmd.lang.ast.impl.javacc.JavaccToken;
 import net.sourceforge.pmd.lang.document.Chars;
 import net.sourceforge.pmd.lang.rule.xpath.NoAttribute;
@@ -60,7 +58,4 @@ abstract class AbstractLiteral extends AbstractJavaExpr {
     public boolean isCompileTimeConstant() {
         return true; // note: NullLiteral overrides this to false
     }
-
-    @Override
-    protected abstract @NonNull ConstResult buildConstValue();
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/GuardLogStatementRule.java
@@ -124,7 +124,7 @@ public class GuardLogStatementRule extends AbstractJavaRulechainRule {
         // or a compile-time constant string to not require a guard
         int messageArg = getMessageArgIndex(node);
         ASTExpression messageExpr = node.getArguments().get(messageArg);
-        if (!isDirectAccess(messageExpr) && !messageExpr.isCompileTimeConstant()) {
+        if (!isDirectAccess(messageExpr) && !messageExpr.getConstFoldingResult().hasValue()) {
             return true;
         }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
@@ -7,18 +7,12 @@ package net.sourceforge.pmd.lang.java.rule.bestpractices;
 import static net.sourceforge.pmd.util.CollectionUtil.listOf;
 import static net.sourceforge.pmd.util.CollectionUtil.setOf;
 
-import java.lang.reflect.Modifier;
 import java.util.Set;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
-
-import net.sourceforge.pmd.lang.java.ast.ASTAssignableExpr.ASTNamedReferenceExpr;
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTStringLiteral;
-import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
-import net.sourceforge.pmd.lang.java.symbols.JFieldSymbol;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.reporting.RuleContext;
 
@@ -53,29 +47,14 @@ public class LiteralsFirstInComparisonsRule extends AbstractJavaRulechainRule {
                 || call.getMethodType().getFormalParameters().equals(listOf(call.getTypeSystem().OBJECT));
     }
 
-    private boolean isConstantString(JavaNode node) {
-        if (node instanceof ASTNamedReferenceExpr) {
-            ASTNamedReferenceExpr reference = (ASTNamedReferenceExpr) node;
-            @Nullable
-            JFieldSymbol symbol = null;
-            if (reference.getReferencedSym() instanceof JFieldSymbol) {
-                symbol = (JFieldSymbol) reference.getReferencedSym();
-            }
-            if (symbol != null
-                && symbol.isFinal()
-                && Modifier.isStatic(symbol.getModifiers())) {
-                return reference.getTypeMirror().getSymbol()
-                    .equals(reference.getTypeSystem().getClassSymbol(String.class));
-            }
-        }
-
-        return node instanceof ASTStringLiteral;
+    private boolean isConstantString(ASTExpression node) {
+        return node instanceof ASTStringLiteral || node.getConstValue() instanceof String;
     }
 
     private void checkArgs(RuleContext ctx, ASTMethodCall call) {
         ASTExpression arg = call.getArguments().get(0);
         ASTExpression qualifier = call.getQualifier();
-        if (!isConstantString(qualifier) && (arg instanceof ASTStringLiteral || isConstantString(arg))) {
+        if (!isConstantString(qualifier) && isConstantString(arg)) {
             ctx.addViolation(call);
         }
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
@@ -9,6 +9,8 @@ import static net.sourceforge.pmd.util.CollectionUtil.setOf;
 
 import java.util.Set;
 
+import org.checkerframework.checker.nullness.qual.Nullable;
+
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTStringLiteral;
@@ -47,14 +49,15 @@ public class LiteralsFirstInComparisonsRule extends AbstractJavaRulechainRule {
                 || call.getMethodType().getFormalParameters().equals(listOf(call.getTypeSystem().OBJECT));
     }
 
-    private boolean isConstantString(ASTExpression node) {
-        return node instanceof ASTStringLiteral || node.getConstValue() instanceof String;
+    private boolean isConstantString(@Nullable ASTExpression node) {
+        return node instanceof ASTStringLiteral
+            || node != null && node.getConstValue() instanceof String;
     }
 
     private void checkArgs(RuleContext ctx, ASTMethodCall call) {
         ASTExpression arg = call.getArguments().get(0);
-        ASTExpression qualifier = call.getQualifier();
-        if (!isConstantString(qualifier) && isConstantString(arg)) {
+        @Nullable ASTExpression qualifier = call.getQualifier();
+        if (qualifier != null && !isConstantString(qualifier) && isConstantString(arg)) {
             ctx.addViolation(call);
         }
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientStringBufferingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/InefficientStringBufferingRule.java
@@ -49,7 +49,7 @@ public class InefficientStringBufferingRule extends AbstractJavaRulechainRule {
 
         if (JavaAstUtils.isStringConcatExpr(arg)
             // ignore concatenations that produce constants
-            && !arg.isCompileTimeConstant()) {
+            && !arg.getConstFoldingResult().hasValue()) {
             ctx.addViolation(arg);
         }
     }

--- a/pmd-java/src/main/resources/category/java/bestpractices.xml
+++ b/pmd-java/src/main/resources/category/java/bestpractices.xml
@@ -839,6 +839,9 @@ public class MyTest {
             Position literals first in all String comparisons, if the second argument is null then NullPointerExceptions
             can be avoided, they will just return false. Note that switching literal positions for compareTo and
             compareToIgnoreCase may change the result, see examples.
+
+            Note that compile-time constant strings are treated like literals. This is because they are inlined into
+            the class file, are necessarily non-null, and therefore cannot cause an NPE at runtime.
         </description>
         <priority>3</priority>
         <example>
@@ -858,6 +861,11 @@ class Foo {
     }
     boolean bar(String x) {
         return x.contentEquals("bar"); // should be "bar".contentEquals(x)
+    }
+
+    static final String CONSTANT = "const";
+    {
+        CONSTANT.equals("literal"); // not reported, this is effectively the same as writing "const".equals("foo")
     }
 }
 ]]>

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ConstValuesKotlinTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/ast/ConstValuesKotlinTest.kt
@@ -5,9 +5,8 @@
 package net.sourceforge.pmd.lang.java.ast
 
 import io.kotest.matchers.shouldBe
-import net.sourceforge.pmd.lang.test.ast.shouldBeA
 import net.sourceforge.pmd.lang.java.symbols.JFieldSymbol
-import net.sourceforge.pmd.lang.java.types.JPrimitiveType
+import net.sourceforge.pmd.lang.test.ast.shouldBeA
 
 /**
  *
@@ -33,5 +32,33 @@ class ConstValuesKotlinTest : ProcessorTestSpec({
         i3.symbol.shouldBeA<JFieldSymbol> {
             it.constValue shouldBe 0
         }
+    }
+
+
+    parserTest("Test non CT constants are still resolved") {
+        val acu = parser.parse(
+            """
+            class Foo {
+                final int i1 = 2;
+                static final int I1 = 2;
+                {
+                    final int i2 = 4;
+                    final int nonct = i2 * 4 + i1;
+                    final int ct = 4 + I1;
+                }
+            }
+            """.trimIndent()
+        )
+
+        val (i1, I1, i2, nonct, ct) = acu.descendants(ASTVariableId::class.java).toList()
+
+        i1.initializer!!.constValue shouldBe 2
+        I1.initializer!!.constValue shouldBe 2
+        i2.initializer!!.constValue shouldBe 4
+        nonct.initializer!!.constValue shouldBe null
+        ct.initializer!!.constValue shouldBe 6
+
+        nonct.initializer!!.constFoldingResult.isCompileTimeConstant shouldBe false
+        nonct.initializer!!.constFoldingResult.value shouldBe 18
     }
 })

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LiteralsFirstInComparisons.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LiteralsFirstInComparisons.xml
@@ -492,4 +492,21 @@ class Tester {
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>LiteralsFirstInComparisonsRule not applied on constant #5590</description>
+        <expected-problems>3</expected-problems>
+        <code><![CDATA[
+            static class Foo {
+                private static final String FOO = null;
+
+                public static void bar(String _null) {
+                    String _null2 = null;
+                    FOO.equals("RAW");
+                    _null.equals("RAW");
+                    _null2.equals("RAW");
+                }
+            }
+            ]]></code>
+    </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LiteralsFirstInComparisons.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/LiteralsFirstInComparisons.xml
@@ -432,10 +432,10 @@ public class Foo {
     </test-code>
 
     <test-code>
-        <description>[java] LiteralsFirstInComparisons with two constants #3315</description>
-        <expected-problems>0</expected-problems>
+        <description>[java] LiteralsFirstInComparisons with one constant and a constant field but not CT-const</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>8</expected-linenumbers>
         <code><![CDATA[
-import net.sourceforge.pmd.PMDVersion;
 public class LiteralsFirstInComparisonCase {
     private static final String S1 = "s1";
     private static final String S2 = "s2";
@@ -443,22 +443,37 @@ public class LiteralsFirstInComparisonCase {
         return S1.equals(S2);
     }
     public static boolean isUnkown() {
-        return PMDVersion.VERSION.equals(S2);
+        return Foo.VERSION.equals(S2);
+    }
+}
+class Foo {
+    // not a CT constant because initialized outline
+    public static final String VERSION;
+    static {
+        VERSION = "auhesouat";
     }
 }
         ]]></code>
     </test-code>
 
+
     <test-code>
-        <description>[java] LiteralsFirstInComparisons with two constants #3315 - with on demand import</description>
+        <description>[java] LiteralsFirstInComparisons with two constants #3315</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
-import net.sourceforge.pmd.*;
 public class LiteralsFirstInComparisonCase {
+    private static final String S1 = "s1";
     private static final String S2 = "s2";
-    public static boolean isUnkown() {
-        return PMDVersion.VERSION.equals(S2);
+    public static boolean compare() {
+        return S1.equals(S2);
     }
+    public static boolean isUnkown() {
+        return Foo.VERSION.equals(S2);
+    }
+}
+class Foo {
+    // is a CT constant because initialized inline
+    public static final String VERSION = "ctconstant";
 }
         ]]></code>
     </test-code>
@@ -505,6 +520,18 @@ class Tester {
                     FOO.equals("RAW");
                     _null.equals("RAW");
                     _null2.equals("RAW");
+                }
+            }
+            ]]></code>
+    </test-code>
+    <test-code>
+        <description>Equals with self</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+            static class Foo {
+
+                public static void bar(String _null) {
+                    equals("RAW");
                 }
             }
             ]]></code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/FinalFieldCouldBeStatic.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/design/xml/FinalFieldCouldBeStatic.xml
@@ -383,4 +383,16 @@ class MyConstants {
 }
 ]]></code>
     </test-code>
+    <test-code>
+        <description>Nonstatic</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>2,3</expected-linenumbers>
+        <code><![CDATA[
+class MyConstants {
+    private final byte BITARRAYMASK = (byte)0x1;
+    private final int  BYTEPOWER = 3;
+    private final int  BYTEMASK = (1 << BYTEPOWER) - 1; //this one cannot
+}
+]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

To fix this i had to refactor a bit the constant folding logic. It wasn't actually implementing the definition of the JLS for a "compile-time constant". The logic now makes `ASTExpression#isCompileTimeConstant()` and `#getConstValue()` respect the JLS definition, that is, the only variables referenced must be compile-time constant fields (ie static final with CT constant initializer, and cannot have blank initializer). However this is very restrictive, while some rules want to know if the value is known at compile time, even if it uses non-static final fields, or final local variables for instance. I extended the logic of the constant folder to track whether the resolved constant value is a CT constant according to the strict definition or to the loose definition.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #5590

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

