### PR TITLE
Fix #5079: [java] LocalVariableCouldBeFinal false-positive with lombok.val

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLocalVariableDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLocalVariableDeclaration.java
@@ -74,7 +74,11 @@ public final class ASTLocalVariableDeclaration extends AbstractJavaNode
         return firstChild(ASTType.class);
     }
 
+    /**
+     * Return whether this declaration is final (including implicitly).
+     * If lombok support is enabled, then return true if the type is lombok.val.
+     */
     public boolean isFinal() {
-        return hasModifiers(JModifier.FINAL);
+        return hasModifiers(JModifier.FINAL) || ASTVariableId.isLombokVal(getTypeNode());
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableId.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableId.java
@@ -101,11 +101,7 @@ public final class ASTVariableId extends AbstractTypedSymbolDeclarator<JVariable
      * There may not be an explicit final modifier, e.g. for enum constants.
      */
     public boolean isFinal() {
-        if (hasModifiers(JModifier.FINAL)) {
-            return true;
-        }
-        // check if this is a lombok.val (and we have lombok support enabled)
-        return isLombokVal(getTypeNode());
+        return hasModifiers(JModifier.FINAL) || isLombokVal(getTypeNode());
     }
 
     /**
@@ -268,10 +264,7 @@ public final class ASTVariableId extends AbstractTypedSymbolDeclarator<JVariable
      */
     public boolean isTypeInferred() {
         ASTType typeNode = getTypeNode();
-        if (typeNode == null) {
-            return true;
-        }
-        return isLombokValOrVar(typeNode, false);
+        return typeNode == null || isLombokValOrVar(typeNode, false);
     }
 
     static boolean isLombokVal(@Nullable ASTType typeNode) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableCouldBeFinalRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LocalVariableCouldBeFinalRule.java
@@ -25,7 +25,7 @@ public class LocalVariableCouldBeFinalRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTLocalVariableDeclaration node, Object data) {
-        if (node.isFinal()) { // also for implicit finals, like resources
+        if (node.isFinal()) { // also for implicit finals, like resources, or lombok.val
             return data;
         }
         if (getProperty(IGNORE_FOR_EACH) && node.getParent() instanceof ASTForeachStatement) {

--- a/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/LombokTest.kt
+++ b/pmd-java/src/test/kotlin/net/sourceforge/pmd/lang/java/types/internal/infer/LombokTest.kt
@@ -6,6 +6,7 @@ package net.sourceforge.pmd.lang.java.types.internal.infer
 
 import io.kotest.matchers.shouldBe
 import net.sourceforge.pmd.lang.java.JavaParsingHelper
+import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration
 import net.sourceforge.pmd.lang.java.ast.JavaVersion
 import net.sourceforge.pmd.lang.java.ast.JavaVersion.J9
 import net.sourceforge.pmd.lang.java.ast.ProcessorTestSpec
@@ -42,8 +43,12 @@ class LombokTest : IntelliMarker, ProcessorTestSpec({
         val acu = parser.parse(lombokValCode)
 
         acu.withTypeDsl {
-            acu.varId("q") shouldHaveType float
-            acu.varId("q").isTypeInferred shouldBe true
+            acu.varId("q").let {
+                it shouldHaveType float
+                it.isTypeInferred shouldBe true
+                it.isFinal shouldBe true
+                it.ancestors(ASTLocalVariableDeclaration::class.java).firstOrThrow().isFinal shouldBe true
+            }
             acu.varId("n") shouldHaveType java.util.List::class.raw
         }
     }
@@ -56,13 +61,20 @@ class LombokTest : IntelliMarker, ProcessorTestSpec({
         val acu = parser.disableLombok().parse(lombokValCode)
 
         acu.withTypeDsl {
-            acu.varId("q").isTypeInferred shouldBe false
-            acu.varId("q").typeMirror.shouldBeA<JClassType> {
-                it.symbol.canonicalName shouldBe "lombok.val"
+            acu.varId("q").let {
+                it.isTypeInferred shouldBe false
+                it.isFinal shouldBe false
+                it.typeMirror.shouldBeA<JClassType> {
+                    it.symbol.canonicalName shouldBe "lombok.val"
+                }
+                it.ancestors(ASTLocalVariableDeclaration::class.java).firstOrThrow().isFinal shouldBe false
             }
-            acu.varId("n").isTypeInferred shouldBe false
-            acu.varId("n").typeMirror.shouldBeA<JClassType> {
-                it.symbol.canonicalName shouldBe "lombok.val"
+            acu.varId("n").let {
+                it.isTypeInferred shouldBe false
+                it.isFinal shouldBe false
+                it.typeMirror.shouldBeA<JClassType> {
+                    it.symbol.canonicalName shouldBe "lombok.val"
+                }
             }
         }
     }
@@ -83,8 +95,11 @@ class LombokTest : IntelliMarker, ProcessorTestSpec({
         val acu = parser.parse(lombokVarCode)
 
         acu.withTypeDsl {
-            acu.varId("i").isTypeInferred shouldBe true
-            acu.varId("i") shouldHaveType int
+            acu.varId("i").let {
+                it.isTypeInferred shouldBe true
+                it shouldHaveType int
+                it.isFinal shouldBe false
+            }
         }
     }
 
@@ -95,9 +110,12 @@ class LombokTest : IntelliMarker, ProcessorTestSpec({
         val acu = parser.disableLombok().parse(lombokVarCode)
 
         acu.withTypeDsl {
-            acu.varId("i").isTypeInferred shouldBe false
-            acu.varId("i").typeMirror.shouldBeA<JClassType> {
-                it.symbol.canonicalName shouldBe "lombok.var"
+            acu.varId("i").let {
+                it.isTypeInferred shouldBe false
+                it.isFinal shouldBe false
+                it.typeMirror.shouldBeA<JClassType> {
+                    it.symbol.canonicalName shouldBe "lombok.var"
+                }
             }
         }
     }
@@ -110,9 +128,12 @@ class LombokTest : IntelliMarker, ProcessorTestSpec({
         val acu = parser.disableLombok().parse(lombokVarCode)
 
         acu.withTypeDsl {
-            acu.varId("i").isTypeInferred shouldBe true
-            acu.varId("i") shouldHaveType int
-            acu.varId("i").typeNode shouldBe null
+            acu.varId("i").let {
+                it.isTypeInferred shouldBe true
+                it shouldHaveType int
+                it.typeNode shouldBe null
+                it.isFinal shouldBe false
+            }
         }
     }
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableCouldBeFinal.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LocalVariableCouldBeFinal.xml
@@ -409,4 +409,18 @@ public class ClassWithLambda {
 }
         ]]></code>
     </test-code>
+    <test-code>
+        <description>[java] LocalVariableCouldBeFinal false-positive with lombok.val #5079</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import lombok.val;
+public class Test {
+    private StringBuilder createFileWatcher() {
+        val tost = "uaoleudaou";
+        return new StringBuilder(tost);
+    }
+
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION

## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #5079
- Ref #3119


## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

