### PR TITLE
[java] New rule: ModifierOrder

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/reporting/RuleContext.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/reporting/RuleContext.java
@@ -146,6 +146,26 @@ public final class RuleContext {
     }
 
     /**
+     * Record a new violation of the contextual rule, at the given token location.
+     * The position is refined using the given begin and end line numbers.
+     * The given violation message ({@link Rule#getMessage()}) is treated
+     * as a format string for a {@link MessageFormat} and should hence use
+     * appropriate escapes. The given formatting arguments are used.
+     *
+     * @param node Location of the violation (node or token) - only used to determine suppression
+     * @param token   Report location of the violation
+     * @param message    Violation message
+     * @param formatArgs Format arguments for the message
+     * @experimental This will probably never be stabilized, will instead be
+     *      replaced by a fluent API or something to report violations. Do not use
+     *      this outside of the PMD codebase. See <a href="https://github.com/pmd/pmd/issues/5039">[core] Add fluent API to report violations #5039</a>.
+     */
+    @Experimental
+    public void addViolationWithPosition(Node node, JavaccToken token, String message, Object... formatArgs) {
+        addViolationWithPosition(node, node.getAstInfo(), token.getReportLocation(), message, formatArgs);
+    }
+
+    /**
      * Record a new violation of the contextual rule, at the given location (node or token).
      * The position is refined using the given begin and end line numbers.
      * The given violation message ({@link Rule#getMessage()}) is treated

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLambdaParameter.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLambdaParameter.java
@@ -21,8 +21,23 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public final class ASTLambdaParameter extends AbstractJavaTypeNode
     implements InternalInterfaces.VariableIdOwner, ModifierOwner {
 
+    private boolean usesVarKw;
+
     ASTLambdaParameter(int id) {
         super(id);
+    }
+
+
+    void setUsesVarKw(boolean usesVarKw) {
+        this.usesVarKw = usesVarKw;
+    }
+
+    /**
+     * If true, the type node is null and the type was written with the "var"
+     * keyword in the source.
+     */
+    public boolean hasVarKeyword() {
+        return usesVarKw;
     }
 
     /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTModifierList.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTModifierList.java
@@ -47,8 +47,18 @@ import java.util.Set;
  */
 public final class ASTModifierList extends AbstractJavaNode {
 
-    /** Might as well share it. */
-    static final Set<JModifier> JUST_FINAL = Collections.singleton(FINAL);
+    // We can share these sets.
+
+    static final Set<JModifier> JUST_FINAL =
+        Collections.unmodifiableSet(EnumSet.of(FINAL));
+
+    /**
+     * This one is not Collections.emptySet so that it has the same runtime
+     * type as other modifier sets. This makes optimizations like devirtualization
+     * possible in code that uses getExplicitModifiers.
+     */
+    static final Set<JModifier> EMPTY =
+        Collections.unmodifiableSet(EnumSet.noneOf(JModifier.class));
 
     private Set<JModifier> explicitModifiers;
     private Set<JModifier> effectiveModifiers;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/TypesFromAst.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/TypesFromAst.java
@@ -4,7 +4,6 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
-import java.lang.annotation.ElementType;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -280,7 +279,7 @@ final class TypesFromAst {
             PSet<SymAnnot> parentAnnots = getSymbolicAnnotations(parent);
             for (SymAnnot parentAnnot : parentAnnots) {
                 // filter annotations by whether they apply to the type use.
-                if (parentAnnot.getAnnotationSymbol().annotationAppliesTo(ElementType.TYPE_USE)) {
+                if (parentAnnot.getAnnotationSymbol().mayBeTypeAnnotation()) {
                     annotsOnType = annotsOnType.plus(parentAnnot);
                 }
             }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/PrettyPrintingUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/PrettyPrintingUtil.java
@@ -12,6 +12,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.sourceforge.pmd.lang.java.ast.ASTAmbiguousName;
+import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotationTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTArgumentList;
 import net.sourceforge.pmd.lang.java.ast.ASTArrayAccess;
@@ -231,6 +232,15 @@ public final class PrettyPrintingUtil {
             return name + ".*";
         }
         return name;
+    }
+
+
+    public static String prettyPrintAnnot(ASTAnnotation annot) {
+        String result = "@" + annot.getSimpleName();
+        if (annot.getMembers().isEmpty()) {
+            return result;
+        }
+        return result + "(...)";
     }
 
     /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ModifierOrderRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ModifierOrderRule.java
@@ -1,0 +1,329 @@
+package net.sourceforge.pmd.lang.java.rule.codestyle;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Target;
+import java.util.List;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+import net.sourceforge.pmd.lang.ast.impl.javacc.JavaccToken;
+import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
+import net.sourceforge.pmd.lang.java.ast.ASTArrayType;
+import net.sourceforge.pmd.lang.java.ast.ASTClassType;
+import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
+import net.sourceforge.pmd.lang.java.ast.ASTLambdaParameter;
+import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTModifierList;
+import net.sourceforge.pmd.lang.java.ast.ASTType;
+import net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration;
+import net.sourceforge.pmd.lang.java.ast.JModifier;
+import net.sourceforge.pmd.lang.java.ast.JavaNode;
+import net.sourceforge.pmd.lang.java.ast.JavaTokenKinds;
+import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JTypeDeclSymbol;
+import net.sourceforge.pmd.lang.java.symbols.SymbolicValue;
+import net.sourceforge.pmd.lang.java.symbols.SymbolicValue.SymAnnot;
+import net.sourceforge.pmd.lang.java.symbols.SymbolicValue.SymArray;
+import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.properties.PropertyFactory;
+import net.sourceforge.pmd.reporting.RuleContext;
+import net.sourceforge.pmd.util.AssertionUtil;
+
+public class ModifierOrderRule extends AbstractJavaRulechainRule {
+
+    private static final String MSG_TOKEN_ORDER =
+        "Modifier `{0}` should come after {1}.";
+
+    private static final String MSG_ANNOTATIONS_SHOULD_BE_BEFORE_MODS =
+        "Annotation {0} follows modifier `{1}`. Annotations should come before modifiers.";
+
+    private static final String MSG_TYPE_ANNOT_SHOULD_COME_BEFORE_TYPE =
+        "Type annotation {0} should be placed right before the type it applies to: `{1}`{2}.";
+
+    private static final PropertyDescriptor<Boolean> SORT_TYPE_ANNOTS
+        = PropertyFactory.booleanProperty("typeAnnotationsNextToType")
+                         .desc("Whether type annotations should be placed next to the type they qualify and not before modifiers.")
+                         .defaultValue(true)
+                         .build();
+
+    private boolean sortTypeAnnotations;
+
+    public ModifierOrderRule() {
+        super(
+            ASTTypeDeclaration.class,
+            ASTMethodDeclaration.class,
+            ASTFieldDeclaration.class
+        );
+        definePropertyDescriptor(SORT_TYPE_ANNOTS);
+    }
+
+    @Override
+    public void start(RuleContext ctx) {
+        this.sortTypeAnnotations = getProperty(SORT_TYPE_ANNOTS);
+    }
+
+
+    @Override
+    public Object visit(ASTModifierList modList, Object data) {
+        RuleContext ctx = asCtx(data);
+        ModifierOrderEvents eventHandler = new ModifierOrderEvents() {
+
+            private @Nullable JModifier lastModSeen;
+            private @Nullable ASTAnnotation typeAnnotationSeen;
+
+            private final TypeAnnotContext typeAnnotContext = new TypeAnnotContext(modList);
+
+            @Override
+            public boolean recordAnnotation(ASTAnnotation annot) {
+                if (sortTypeAnnotations && typeAnnotContext.acceptsTypeAnnots() && isTypeAnnotation(annot)) {
+                    typeAnnotationSeen = annot;
+                    return false;
+                }
+
+                if (checkTypeAnnotationProblem()) {
+                    return true;
+                }
+
+                if (lastModSeen != null) {
+                    // this annotation comes after some modifiers
+                    String annotString = PrettyPrintingUtil.prettyPrintAnnot(annot);
+                    ctx.addViolationWithMessage(annot, MSG_ANNOTATIONS_SHOULD_BE_BEFORE_MODS, annotString, lastModSeen);
+                    return true;
+                }
+                return false;
+            }
+
+            @Override
+            public boolean recordModifier(JModifier mod, JavaccToken token) {
+                if (checkTypeAnnotationProblem()) {
+                    return true;
+                }
+                if (lastModSeen != null && mod.compareTo(lastModSeen) < 0) {
+                    ctx.addViolationWithPosition(modList, token, MSG_TOKEN_ORDER, mod, lastModSeen);
+                    return true;
+                }
+                lastModSeen = mod;
+                return false;
+            }
+
+            private boolean checkTypeAnnotationProblem() {
+                if (sortTypeAnnotations && typeAnnotationSeen != null) {
+                    String annotString = PrettyPrintingUtil.prettyPrintAnnot(typeAnnotationSeen);
+                    String typeStr = typeAnnotContext.getTypeNodeDescription();
+                    String note = typeAnnotContext.getSyntaxNote();
+                    // this modifier comes after a type annotation. Report the annotation though
+                    ctx.addViolationWithMessage(typeAnnotationSeen, MSG_TYPE_ANNOT_SHOULD_COME_BEFORE_TYPE, annotString, typeStr, note);
+                    return true;
+                }
+                return false;
+            }
+        };
+
+        readModifierList(modList, eventHandler);
+        return null;
+    }
+
+
+    // https://docs.oracle.com/javase/specs/jls/se22/html/jls-9.html#jls-9.6.4.1
+    static class TypeAnnotContext {
+
+        private final boolean isTypeAnnotContext;
+        private final ASTModifierList modList;
+        private final @Nullable ASTType followingType;
+        private final boolean hasExtraDimensions;
+        private final boolean followedByVar;
+
+
+        TypeAnnotContext(ASTModifierList modList) {
+            this.modList = modList;
+            followingType = getFollowingType(modList);
+            followedByVar = isFollowedByVarKeyword(modList);
+            hasExtraDimensions = hasFollowingExtraBracketPairs(modList);
+            this.isTypeAnnotContext = followingType != null || followedByVar
+                || modList.getParent() instanceof ASTConstructorDeclaration;
+        }
+
+        private boolean acceptsTypeAnnots() {
+            return isTypeAnnotContext;
+        }
+
+        String getTypeNodeDescription() {
+            if (followedByVar) {
+                return "var";
+            } else if (followingType != null) {
+                return PrettyPrintingUtil.prettyPrintType(followingType);
+            } else if (modList.getParent() instanceof ASTConstructorDeclaration) {
+                return ((ASTConstructorDeclaration) modList.getParent()).getName();
+            }
+            throw AssertionUtil.shouldNotReachHere("not a type annot context");
+        }
+
+        String getSyntaxNote() {
+            if (hasExtraDimensions || followingType instanceof ASTArrayType) {
+                return "note: type annotations on arrays are placed right before the corresponding square bracket pair, eg `int @A []` or `int varname @A[]`. To annotate the element type, write `@A int[]`.";
+            } else if (followingType instanceof ASTClassType) {
+                ASTClassType classType = (ASTClassType) followingType;
+                if (classType.isFullyQualified() || classType.getQualifier() != null) {
+                    return "note: type annotations class types that have a qualifier must go before the type simple name, eg `java.util.@A List` or `Map.@Nullable Entry<...>`.";
+                }
+            }
+            return "";
+        }
+    }
+
+
+    private static boolean isTypeAnnotation(ASTAnnotation node) {
+        JTypeDeclSymbol sym = node.getTypeNode().getTypeMirror().getSymbol();
+        if (sym instanceof JClassSymbol && !sym.isUnresolved()) {
+            JClassSymbol classSym = (JClassSymbol) sym;
+            SymAnnot target = classSym.getDeclaredAnnotation(Target.class);
+            if (target == null) {
+                return false;
+            }
+            SymbolicValue value = target.getAttribute("value");
+            if (!(value instanceof SymArray)) {
+                return false;
+            }
+
+            // note that the annotation could apply to BOTH the type and the declaration,
+            // and in that case we would need to pick a side. Here I pick the side of the
+            // type annotation for simplicity.
+            return ((SymArray) value).containsValue(ElementType.TYPE_USE);
+        }
+        return false;
+    }
+
+    private static @Nullable ASTType getFollowingType(ASTModifierList node) {
+        JavaNode nextSibling = node.getNextSibling();
+        if (nextSibling instanceof ASTType) {
+            return (ASTType) nextSibling;
+        }
+        return null;
+    }
+
+    private static boolean isFollowedByVarKeyword(ASTModifierList node) {
+        JavaNode parent = node.getParent();
+        if (parent instanceof ASTLambdaParameter) {
+            return ((ASTLambdaParameter) parent).hasVarKeyword();
+        } else if (parent instanceof ASTLocalVariableDeclaration) {
+            return ((ASTLocalVariableDeclaration) parent).isTypeInferred();
+        }
+        return false;
+    }
+
+    private static boolean hasFollowingExtraBracketPairs(ASTModifierList node) {
+        JavaNode parent = node.getParent();
+        if (parent instanceof ASTLocalVariableDeclaration) {
+            return ((ASTLocalVariableDeclaration) parent).getVarIds().any(it -> it.getExtraDimensions() != null);
+        } else if (parent instanceof ASTFieldDeclaration) {
+            return ((ASTFieldDeclaration) parent).getVarIds().any(it -> it.getExtraDimensions() != null);
+        } else if (parent instanceof ASTLambdaParameter) {
+            return ((ASTLambdaParameter) parent).getVarId().getExtraDimensions() != null;
+        } else if (parent instanceof ASTFormalParameter) {
+            return ((ASTFormalParameter) parent).getVarId().getExtraDimensions() != null;
+        } else if (parent instanceof ASTMethodDeclaration) {
+            return ((ASTMethodDeclaration) parent).getExtraDimensions() != null;
+        }
+        return false;
+    }
+
+
+    /**
+     * Receives modifier events in order and checks their order. Methods return
+     * true if we found a violation and need to stop.
+     */
+    interface ModifierOrderEvents {
+
+        /** Record that the next modifier is the given annotation. */
+        boolean recordAnnotation(ASTAnnotation annot);
+
+        /** Record that the next modifier is the given one occurring at the given token. */
+        boolean recordModifier(JModifier mod, JavaccToken token);
+    }
+
+    /**
+     * Reads a modifier list in order, to recover the order of declared tokens.
+     * Records annotations and modifiers in source order on the given callback interface.
+     */
+    private static void readModifierList(ASTModifierList modList, ModifierOrderEvents events) {
+
+        JavaccToken tok = modList.getFirstToken();
+        final JavaccToken lastTok = modList.getLastToken();
+
+        int nextAnnotIndex = 0;
+        List<ASTAnnotation> children = modList.children(ASTAnnotation.class).toList();
+
+        while (tok != lastTok.getNext()) {
+            if (tok.kind == JavaTokenKinds.AT) {
+                // this is an annotation
+                assert nextAnnotIndex < children.size() : "annotation token was not parsed?";
+                ASTAnnotation annotation = children.get(nextAnnotIndex);
+                assert annotation.getFirstToken() == tok : "next annot index didn't match token";
+
+                if (events.recordAnnotation(annotation)) {
+                    return;
+                }
+                tok = annotation.getLastToken().getNext();
+            } else {
+                JModifier mod = getModFromToken(tok);
+                assert mod != null : "Token is not a modifier token? " + tok;
+                if (events.recordModifier(mod, tok)) {
+                    return;
+                }
+                if (mod == JModifier.NON_SEALED) {
+                    // advance until the sealed token
+                    tok = tok.getNext();
+                    assert tok.kind == JavaTokenKinds.MINUS;
+                    tok = tok.getNext();
+                    assert tok.kind == JavaTokenKinds.IDENTIFIER && tok.getImageCs().contentEquals("sealed");
+                }
+            }
+
+            tok = tok.getNext();
+        }
+
+
+    }
+
+    private static JModifier getModFromToken(JavaccToken tok) {
+        switch (tok.kind) {
+        case JavaTokenKinds.PUBLIC:
+            return JModifier.PUBLIC;
+        case JavaTokenKinds.PROTECTED:
+            return JModifier.PROTECTED;
+        case JavaTokenKinds.PRIVATE:
+            return JModifier.PRIVATE;
+        case JavaTokenKinds.STATIC:
+            return JModifier.STATIC;
+        case JavaTokenKinds.FINAL:
+            return JModifier.FINAL;
+        case JavaTokenKinds.ABSTRACT:
+            return JModifier.ABSTRACT;
+        case JavaTokenKinds.SYNCHRONIZED:
+            return JModifier.SYNCHRONIZED;
+        case JavaTokenKinds.NATIVE:
+            return JModifier.NATIVE;
+        case JavaTokenKinds.TRANSIENT:
+            return JModifier.TRANSIENT;
+        case JavaTokenKinds.VOLATILE:
+            return JModifier.VOLATILE;
+        case JavaTokenKinds.STRICTFP:
+            return JModifier.STRICTFP;
+        case JavaTokenKinds._DEFAULT:
+            return JModifier.DEFAULT;
+        case JavaTokenKinds.IDENTIFIER:
+            if (tok.getImageCs().contentEquals("non")) {
+                return JModifier.NON_SEALED;
+            } else if (tok.getImageCs().contentEquals("sealed")) {
+                return JModifier.SEALED;
+            }
+        }
+        return null;
+    }
+
+}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ModifierOrderRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/ModifierOrderRule.java
@@ -1,21 +1,18 @@
+/*
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Target;
 import java.util.List;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.sourceforge.pmd.lang.ast.impl.javacc.JavaccToken;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
-import net.sourceforge.pmd.lang.java.ast.ASTArrayType;
-import net.sourceforge.pmd.lang.java.ast.ASTClassType;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTFormalParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTLambdaParameter;
 import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
-import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTModifierList;
 import net.sourceforge.pmd.lang.java.ast.ASTType;
 import net.sourceforge.pmd.lang.java.ast.ASTVoidType;
@@ -26,9 +23,6 @@ import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
 import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JTypeDeclSymbol;
-import net.sourceforge.pmd.lang.java.symbols.SymbolicValue;
-import net.sourceforge.pmd.lang.java.symbols.SymbolicValue.SymAnnot;
-import net.sourceforge.pmd.lang.java.symbols.SymbolicValue.SymArray;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
 import net.sourceforge.pmd.properties.PropertyFactory;
 import net.sourceforge.pmd.reporting.RuleContext;
@@ -36,25 +30,25 @@ import net.sourceforge.pmd.util.AssertionUtil;
 
 public class ModifierOrderRule extends AbstractJavaRulechainRule {
 
-    private static final String MSG_TOKEN_ORDER =
+    private static final String MSG_KEYWORD_ORDER =
         "Missorted modifiers `{0} {1}`.";
 
     private static final String MSG_ANNOTATIONS_SHOULD_BE_BEFORE_MODS =
         "Missorted modifiers `{0} {1}`. Annotations should be placed before modifiers.";
 
-    private static final String MSG_TYPE_ANNOT_SHOULD_BE_AFTER_MODS =
+    private static final String MSG_TYPE_ANNOT_SHOULD_BE_BEFORE_TYPE =
         "Missorted modifiers `{0} {1}`. Type annotations should be placed before the type they qualify.";
 
-    private static final PropertyDescriptor<TypeAnnotationPolicy> TYPE_ANNOT_POLICY
-        = PropertyFactory.enumProperty("typeAnnotations", TypeAnnotationPolicy.class, TypeAnnotationPolicy::label)
+    private static final PropertyDescriptor<TypeAnnotationPosition> TYPE_ANNOT_POLICY
+        = PropertyFactory.enumProperty("typeAnnotations", TypeAnnotationPosition.class, TypeAnnotationPosition::label)
                          .desc("Whether type annotations should be placed next to the type they qualify and not before modifiers.")
-                         .defaultValue(TypeAnnotationPolicy.EITHER)
+                         .defaultValue(TypeAnnotationPosition.ANYWHERE)
                          .build();
 
-    public enum TypeAnnotationPolicy {
+    public enum TypeAnnotationPosition {
         ON_TYPE,
         ON_DECL,
-        EITHER;
+        ANYWHERE;
 
         String label() {
             switch (this) {
@@ -62,14 +56,15 @@ public class ModifierOrderRule extends AbstractJavaRulechainRule {
                 return "on type";
             case ON_DECL:
                 return "on decl";
-            case EITHER:
+            case ANYWHERE:
                 return "anywhere";
+            default:
+                throw AssertionUtil.shouldNotReachHere("exhaustive switch");
             }
-            throw AssertionUtil.shouldNotReachHere("exhaustive switch");
         }
     }
 
-    private TypeAnnotationPolicy sortTypeAnnotations;
+    private TypeAnnotationPosition typeAnnotPosition;
 
     public ModifierOrderRule() {
         super(ASTModifierList.class);
@@ -78,63 +73,130 @@ public class ModifierOrderRule extends AbstractJavaRulechainRule {
 
     @Override
     public void start(RuleContext ctx) {
-        this.sortTypeAnnotations = getProperty(TYPE_ANNOT_POLICY);
+        this.typeAnnotPosition = getProperty(TYPE_ANNOT_POLICY);
     }
 
+    /** Wrapper around a mod to do "double dispatch". */
+    abstract static class LastModSeen {
+        abstract boolean checkNextKeyword(KwMod next, RuleContext ctx);
+
+        abstract boolean checkNextAnnot(AnnotMod next, RuleContext ctx);
+
+        @Override
+        public abstract String toString();
+    }
+
+    class KwMod extends LastModSeen {
+        private final JModifier mod;
+        private final JavaccToken token;
+        private final JavaNode reportNode;
+
+        KwMod(JModifier mod, JavaccToken token, JavaNode reportNode) {
+            this.mod = mod;
+            this.token = token;
+            this.reportNode = reportNode;
+        }
+
+        @Override
+        boolean checkNextKeyword(KwMod next, RuleContext ctx) {
+            if (mod.compareTo(next.mod) > 0) {
+                ctx.addViolationWithPosition(reportNode, token, MSG_KEYWORD_ORDER, this, next);
+                return true;
+            }
+            return false;
+        }
+
+        @Override
+        boolean checkNextAnnot(AnnotMod next, RuleContext ctx) {
+            // keyword before annot
+            // check annot is
+            if (next.isTypeAnnot && typeAnnotPosition != TypeAnnotationPosition.ON_DECL) {
+                return false;
+            }
+            ctx.addViolationWithPosition(reportNode, token, MSG_ANNOTATIONS_SHOULD_BE_BEFORE_MODS, this, next);
+            return true;
+
+        }
+
+        @Override
+        public String toString() {
+            return mod.getToken();
+        }
+    }
+
+    class AnnotMod extends ModifierOrderRule.LastModSeen {
+        private final @Nullable LastModSeen previous;
+        private final ASTAnnotation annot;
+        private final boolean isTypeAnnot;
+
+        AnnotMod(@Nullable LastModSeen previous, ASTAnnotation annot, boolean contextsAcceptsTypeAnnot) {
+            this.previous = previous;
+            this.annot = annot;
+            this.isTypeAnnot = contextsAcceptsTypeAnnot && isTypeAnnotation(annot);
+        }
+
+
+        @Override
+        boolean checkNextKeyword(KwMod next, RuleContext ctx) {
+            if (isTypeAnnot && typeAnnotPosition == TypeAnnotationPosition.ON_TYPE) {
+                ctx.addViolationWithMessage(annot, MSG_TYPE_ANNOT_SHOULD_BE_BEFORE_TYPE, this, next);
+                return true;
+            }
+
+            if (previous instanceof KwMod) {
+                // annotation sandwiched between keywords
+                if (isTypeAnnot && typeAnnotPosition != TypeAnnotationPosition.ON_DECL) {
+                    ctx.addViolationWithMessage(annot, MSG_TYPE_ANNOT_SHOULD_BE_BEFORE_TYPE, this, next);
+                } else {
+                    ctx.addViolationWithMessage(annot, MSG_ANNOTATIONS_SHOULD_BE_BEFORE_MODS, previous, this);
+                }
+                return true;
+            }
+
+            return false;
+        }
+
+        @Override
+        boolean checkNextAnnot(AnnotMod next, RuleContext ctx) {
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return PrettyPrintingUtil.prettyPrintAnnot(annot);
+        }
+    }
 
     @Override
     public Object visit(ASTModifierList modList, Object data) {
         RuleContext ctx = asCtx(data);
+        boolean acceptsTypeAnnot = contextCanHaveTypeAnnots(modList);
         ModifierOrderEvents eventHandler = new ModifierOrderEvents() {
 
-            private @Nullable JModifier lastModSeen;
-            private @Nullable ASTAnnotation typeAnnotationSeen;
+            private @Nullable LastModSeen lastModSeen;
 
-            private final TypeAnnotContext typeAnnotContext = new TypeAnnotContext(modList);
 
             @Override
             public boolean recordAnnotation(ASTAnnotation annot) {
-                if (sortTypeAnnotations == TypeAnnotationPolicy.ON_TYPE
-                    && typeAnnotContext.acceptsTypeAnnots() && isTypeAnnotation(annot)) {
-                    typeAnnotationSeen = annot;
-                    return false;
-                }
-
-                if (checkTypeAnnotationProblem()) {
-                    return true;
-                }
-
+                AnnotMod annotMod = new AnnotMod(lastModSeen, annot, acceptsTypeAnnot);
                 if (lastModSeen != null) {
-                    // this annotation comes after some modifiers
-                    String annotString = PrettyPrintingUtil.prettyPrintAnnot(annot);
-                    ctx.addViolationWithMessage(annot, MSG_ANNOTATIONS_SHOULD_BE_BEFORE_MODS, annotString, lastModSeen);
-                    return true;
+                    if (lastModSeen.checkNextAnnot(annotMod, ctx)) {
+                        return true;
+                    }
                 }
+                lastModSeen = annotMod;
                 return false;
             }
 
             @Override
             public boolean recordModifier(JModifier mod, JavaccToken token) {
-                if (checkTypeAnnotationProblem()) {
-                    return true;
+                KwMod kwMod = new KwMod(mod, token, modList);
+                if (lastModSeen != null) {
+                    if (lastModSeen.checkNextKeyword(kwMod, ctx)) {
+                        return true;
+                    }
                 }
-                if (lastModSeen != null && mod.compareTo(lastModSeen) < 0) {
-                    ctx.addViolationWithPosition(modList, token, MSG_TOKEN_ORDER, lastModSeen, mod);
-                    return true;
-                }
-                lastModSeen = mod;
-                return false;
-            }
-
-            private boolean checkTypeAnnotationProblem() {
-                if (sortTypeAnnotations == TypeAnnotationPolicy.ON_TYPE && typeAnnotationSeen != null) {
-                    String annotString = PrettyPrintingUtil.prettyPrintAnnot(typeAnnotationSeen);
-                    String typeStr = typeAnnotContext.getTypeNodeDescription();
-                    String note = typeAnnotContext.getSyntaxNote();
-                    // this modifier comes after a type annotation. Report the annotation though
-                    ctx.addViolationWithMessage(typeAnnotationSeen, MSG_TYPE_ANNOT_SHOULD_BE_AFTER_MODS, annotString, typeStr, note);
-                    return true;
-                }
+                lastModSeen = kwMod;
                 return false;
             }
         };
@@ -143,76 +205,17 @@ public class ModifierOrderRule extends AbstractJavaRulechainRule {
         return null;
     }
 
-
-    // https://docs.oracle.com/javase/specs/jls/se22/html/jls-9.html#jls-9.6.4.1
-    static class TypeAnnotContext {
-
-        private final boolean isTypeAnnotContext;
-        private final ASTModifierList modList;
-        private final @Nullable ASTType followingType;
-        private final boolean hasExtraDimensions;
-        private final boolean followedByVar;
-
-
-        TypeAnnotContext(ASTModifierList modList) {
-            this.modList = modList;
-            followingType = getFollowingType(modList);
-            followedByVar = isFollowedByVarKeyword(modList);
-            hasExtraDimensions = hasFollowingExtraBracketPairs(modList);
-            this.isTypeAnnotContext =
-                followingType != null && !(followingType instanceof ASTVoidType)
-                    || followedByVar
-                    || modList.getParent() instanceof ASTConstructorDeclaration;
-        }
-
-        private boolean acceptsTypeAnnots() {
-            return isTypeAnnotContext;
-        }
-
-        String getTypeNodeDescription() {
-            assert acceptsTypeAnnots();
-            if (followedByVar) {
-                return "var";
-            } else if (followingType != null) {
-                return PrettyPrintingUtil.prettyPrintType(followingType);
-            } else if (modList.getParent() instanceof ASTConstructorDeclaration) {
-                return ((ASTConstructorDeclaration) modList.getParent()).getName();
-            }
-            throw AssertionUtil.shouldNotReachHere("not a type annot context");
-        }
-
-        String getSyntaxNote() {
-            assert acceptsTypeAnnots();
-            if (hasExtraDimensions || followingType instanceof ASTArrayType) {
-                return "note: type annotations on arrays are placed right before the corresponding square bracket pair, eg `int @A []` or `int varname @A[]`. To annotate the element type, write `@A int[]`.";
-            } else if (followingType instanceof ASTClassType) {
-                ASTClassType classType = (ASTClassType) followingType;
-                if (classType.isFullyQualified() || classType.getQualifier() != null) {
-                    return "note: type annotations class types that have a qualifier must go before the type simple name, eg `java.util.@A List` or `Map.@Nullable Entry<...>`.";
-                }
-            }
-            return "";
-        }
+    private static boolean contextCanHaveTypeAnnots(ASTModifierList modList) {
+        ASTType followingType = getFollowingType(modList);
+        return followingType != null && !(followingType instanceof ASTVoidType)
+            || isFollowedByVarKeyword(modList)
+            || modList.getParent() instanceof ASTConstructorDeclaration;
     }
-
 
     private static boolean isTypeAnnotation(ASTAnnotation node) {
         JTypeDeclSymbol sym = node.getTypeNode().getTypeMirror().getSymbol();
         if (sym instanceof JClassSymbol && !sym.isUnresolved()) {
-            JClassSymbol classSym = (JClassSymbol) sym;
-            SymAnnot target = classSym.getDeclaredAnnotation(Target.class);
-            if (target == null) {
-                return false;
-            }
-            SymbolicValue value = target.getAttribute("value");
-            if (!(value instanceof SymArray)) {
-                return false;
-            }
-
-            // note that the annotation could apply to BOTH the type and the declaration,
-            // and in that case we would need to pick a side. Here I pick the side of the
-            // type annotation for simplicity.
-            return ((SymArray) value).containsValue(ElementType.TYPE_USE);
+            return ((JClassSymbol) sym).mayBeTypeAnnotation();
         }
         return false;
     }
@@ -234,23 +237,6 @@ public class ModifierOrderRule extends AbstractJavaRulechainRule {
         }
         return false;
     }
-
-    private static boolean hasFollowingExtraBracketPairs(ASTModifierList node) {
-        JavaNode parent = node.getParent();
-        if (parent instanceof ASTLocalVariableDeclaration) {
-            return ((ASTLocalVariableDeclaration) parent).getVarIds().any(it -> it.getExtraDimensions() != null);
-        } else if (parent instanceof ASTFieldDeclaration) {
-            return ((ASTFieldDeclaration) parent).getVarIds().any(it -> it.getExtraDimensions() != null);
-        } else if (parent instanceof ASTLambdaParameter) {
-            return ((ASTLambdaParameter) parent).getVarId().getExtraDimensions() != null;
-        } else if (parent instanceof ASTFormalParameter) {
-            return ((ASTFormalParameter) parent).getVarId().getExtraDimensions() != null;
-        } else if (parent instanceof ASTMethodDeclaration) {
-            return ((ASTMethodDeclaration) parent).getExtraDimensions() != null;
-        }
-        return false;
-    }
-
 
     /**
      * Receives modifier events in order and checks their order. Methods return
@@ -347,8 +333,10 @@ public class ModifierOrderRule extends AbstractJavaRulechainRule {
             } else if (tok.getImageCs().contentEquals("sealed")) {
                 return JModifier.SEALED;
             }
+        // fallthrough
+        default:
+            return null;
         }
-        return null;
     }
 
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JClassSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JClassSymbol.java
@@ -343,9 +343,17 @@ public interface JClassSymbol extends JTypeDeclSymbol,
             // If an @Target meta-annotation is not present on an annotation type T,
             // then an annotation of type T may be written as a modifier
             // for any declaration except a type parameter declaration.
-            return elementType != ElementType.TYPE_PARAMETER;
+            return elementType != ElementType.TYPE_PARAMETER
+                && elementType != ElementType.TYPE_USE;
         }
         return target.attributeContains("value", elementType).isTrue();
+    }
+
+    /**
+     * Return whether this is an annotation type, and can apply to type use.
+     */
+    default boolean mayBeTypeAnnotation() {
+        return annotationAppliesTo(ElementType.TYPE_USE);
     }
 
     /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStub.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStub.java
@@ -40,6 +40,7 @@ import net.sourceforge.pmd.lang.java.types.LexicalScope;
 import net.sourceforge.pmd.lang.java.types.Substitution;
 import net.sourceforge.pmd.lang.java.types.TypeSystem;
 import net.sourceforge.pmd.util.CollectionUtil;
+import net.sourceforge.pmd.util.OptionalBool;
 
 
 final class ClassStub implements JClassSymbol, AsmStub, AnnotationOwner {
@@ -69,6 +70,7 @@ final class ClassStub implements JClassSymbol, AsmStub, AnnotationOwner {
     private PSet<SymAnnot> annotations = HashTreePSet.empty();
 
     private PSet<String> annotAttributes;
+    private OptionalBool mayBeTypeAnnotation;
 
     private final ParseLock parseLock;
 
@@ -379,6 +381,14 @@ final class ClassStub implements JClassSymbol, AsmStub, AnnotationOwner {
     public PSet<String> getAnnotationAttributeNames() {
         parseLock.ensureParsed();
         return annotAttributes;
+    }
+
+    @Override
+    public boolean mayBeTypeAnnotation() {
+        if (mayBeTypeAnnotation == null) {
+            mayBeTypeAnnotation = OptionalBool.definitely(JClassSymbol.super.mayBeTypeAnnotation());
+        }
+        return mayBeTypeAnnotation.isTrue();
     }
 
     @Override

--- a/pmd-java/src/main/javacc/Java.jjt
+++ b/pmd-java/src/main/javacc/Java.jjt
@@ -2215,11 +2215,11 @@ void SimpleLambdaParam() #LambdaParameter:
 }
 
 void LambdaParameter():
-{}
+{boolean hasVar = false;}
 {
     LocalVarModifierList() // this weakens the grammar a bit
     [
-       LambdaParameterType()
+       hasVar=LambdaParameterType() {jjtThis.setUsesVarKw(hasVar);}
     ]
     VariableIdWithDims()
 }

--- a/pmd-java/src/main/javacc/Java.jjt
+++ b/pmd-java/src/main/javacc/Java.jjt
@@ -550,7 +550,7 @@ class JavaParserImpl {
   private void pushEmptyModifierList() {
         ASTModifierList emptyMods = new ASTModifierList(JJTMODIFIERLIST);
 
-        emptyMods.setDeclaredModifiers(Collections.emptySet());
+        emptyMods.setDeclaredModifiers(ASTModifierList.EMPTY);
 
         JavaccToken tok = JavaccToken.implicitBefore(getToken(1));
         emptyMods.setFirstToken(tok);
@@ -562,7 +562,7 @@ class JavaParserImpl {
   private void insertEmptyModifierListWithAnnotations(AbstractJavaNode node, AbstractJavaNode nodeWithAnnotations) {
         ASTModifierList emptyMods = new ASTModifierList(JJTMODIFIERLIST);
 
-        emptyMods.setDeclaredModifiers(Collections.emptySet());
+        emptyMods.setDeclaredModifiers(ASTModifierList.EMPTY);
 
         JavaccToken tok = JavaccToken.implicitBefore(node.getFirstToken());
         emptyMods.setFirstToken(tok);
@@ -1505,7 +1505,7 @@ void AnnotationList() #void:
 }
 
 void ModAnnotationList() #ModifierList:
-{jjtThis.setDeclaredModifiers(Collections.emptySet());}
+{jjtThis.setDeclaredModifiers(ASTModifierList.EMPTY);}
 {
   (Annotation())*
 }
@@ -2473,7 +2473,7 @@ void LocalVariableDeclarationPendingModifiers() #LocalVariableDeclaration:
 }
 
 private void LocalVarModifierList() #ModifierList:
-{Set<JModifier> set = Collections.emptySet(); }
+{Set<JModifier> set = ASTModifierList.EMPTY; }
 {
     ( "final" { set = ASTModifierList.JUST_FINAL; } | Annotation() )*
     {jjtThis.setDeclaredModifiers(set);}

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1128,6 +1128,51 @@ public class Foo {
         </example>
     </rule>
 
+    <rule name="ModifierOrder"
+          language="java"
+          since="7.12.0"
+          message="Wrong modifier order (the actual message is written by the rule)"
+          class="net.sourceforge.pmd.lang.java.rule.codestyle.ModifierOrderRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#modifierorder">
+        <description>
+            Enforces the modifier order recommended by the JLS. Apart from sorting modifiers,
+            this rule also enforces that all annotations appear before all modifier keywords.
+            By setting the property `typeAnnotations`, you can also enforce that type
+            annotations appear right of the modifier keywords, next to the type they apply to.
+            This property can have three values:
+            - `on type`: Type annotations must be placed next to the type they apply to
+            - `on decl`: Type annotations must be placed with other annotations, before modifiers.
+            This is not enforced if the type annotations syntactically appears within the type, e.g.
+            in `public Map.@Nullable Entry&lt;K,V&gt; method()`.
+            - `anywhere` (default): Either position fits. They still cannot be interspersed within keyword
+            modifiers. Annotations that are not type annotations are still required to be before keyword
+            modifiers.
+        </description>
+        <priority>1</priority>
+        <example>
+<![CDATA[
+abstract public class Foo { // Warn: `public` should appear before `abstract`
+
+    // This order is not recommended, annotations should appear before keyword modifiers,
+    // and may appear after if they are type annotations.
+    public
+    @Override
+    static fooStuff() {
+    }
+
+    // This order is ok if property typeAnnotations is "anywhere", and enforced if it is "on decl":
+    @Nullable
+    public Object fooStuff() {}
+
+    // This order is ok if property typeAnnotations is "anywhere", and enforced if it is "on type":
+    public @Nullable Object fooStuff() {}
+
+
+}
+]]>
+        </example>
+    </rule>
+
     <rule name="NoPackage"
           language="java"
           since="3.3"

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/ModifierOrderTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/ModifierOrderTest.java
@@ -1,0 +1,11 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.codestyle;
+
+import net.sourceforge.pmd.test.PmdRuleTst;
+
+class ModifierOrderTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ModifierOrder.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ModifierOrder.xml
@@ -45,6 +45,10 @@ abstract public class Foo { // warn l1
                 @Decl @TypeA
                 public static int foo; // l20
 
+                public static @Decl @TypeA int foo; // l22
+
+                public @TypeA static int foo; // l24
+
                 public int @TypeA[] foo; // never reported
                 public  Foo.@TypeA Inner foo; // never reported
 
@@ -61,12 +65,14 @@ abstract public class Foo { // warn l1
     <test-code>
         <description>Annotation order (property=anywhere)</description>
         <rule-property name="typeAnnotations">anywhere</rule-property>
-        <expected-problems>3</expected-problems>
-        <expected-linenumbers>8,14,17</expected-linenumbers>
+        <expected-problems>5</expected-problems>
+        <expected-linenumbers>8,14,17,22,24</expected-linenumbers>
         <expected-messages>
             <message>Missorted modifiers `public @Decl`. Annotations should be placed before modifiers.</message>
             <message>Missorted modifiers `@TypeA static`. Type annotations should be placed before the type they qualify.</message>
             <message>Missorted modifiers `public @Decl`. Annotations should be placed before modifiers.</message>
+            <message>Missorted modifiers `static @Decl`. Annotations should be placed before modifiers.</message>
+            <message>Missorted modifiers `@TypeA static`. Type annotations should be placed before the type they qualify.</message>
         </expected-messages>
         <code-ref id="annotations"/>
     </test-code>
@@ -74,14 +80,16 @@ abstract public class Foo { // warn l1
     <test-code>
         <description>Annotation order (property=ontype)</description>
         <rule-property name="typeAnnotations">on type</rule-property>
-        <expected-problems>5</expected-problems>
-        <expected-linenumbers>8,11,14,17,20</expected-linenumbers>
+        <expected-problems>7</expected-problems>
+        <expected-linenumbers>7,10,14,16,19,22,24</expected-linenumbers>
         <expected-messages>
             <message>Missorted modifiers `@TypeA public`. Type annotations should be placed before the type they qualify.</message>
             <message>Missorted modifiers `@TypeA public`. Type annotations should be placed before the type they qualify.</message>
             <message>Missorted modifiers `@TypeA static`. Type annotations should be placed before the type they qualify.</message>
             <message>Missorted modifiers `@TypeA public`. Type annotations should be placed before the type they qualify.</message>
             <message>Missorted modifiers `@TypeA public`. Type annotations should be placed before the type they qualify.</message>
+            <message>Missorted modifiers `static @Decl`. Annotations should be placed before modifiers.</message>
+            <message>Missorted modifiers `@TypeA static`. Type annotations should be placed before the type they qualify.</message>
         </expected-messages>
         <code-ref id="annotations"/>
     </test-code>
@@ -89,13 +97,15 @@ abstract public class Foo { // warn l1
     <test-code>
         <description>Annotation order (property=ondecl)</description>
         <rule-property name="typeAnnotations">on decl</rule-property>
-        <expected-problems>4</expected-problems>
-        <expected-linenumbers>5,8,14,17</expected-linenumbers>
+        <expected-problems>6</expected-problems>
+        <expected-linenumbers>5,8,14,17,22,24</expected-linenumbers>
         <expected-messages>
             <message>Missorted modifiers `public @TypeA`. Annotations should be placed before modifiers.</message>
             <message>Missorted modifiers `public @Decl`. Annotations should be placed before modifiers.</message>
             <message>Missorted modifiers `public @TypeA`. Annotations should be placed before modifiers.</message>
             <message>Missorted modifiers `public @Decl`. Annotations should be placed before modifiers.</message>
+            <message>Missorted modifiers `static @Decl`. Annotations should be placed before modifiers.</message>
+            <message>Missorted modifiers `public @TypeA`. Annotations should be placed before modifiers.</message>
         </expected-messages>
         <code-ref id="annotations"/>
     </test-code>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ModifierOrder.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/ModifierOrder.xml
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+    <test-code>
+        <description>Keyword order</description>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>1,2,5</expected-linenumbers>
+        <expected-messages>
+            <message>Missorted modifiers `abstract public`.</message>
+            <message>Missorted modifiers `final static`.</message>
+            <message>Missorted modifiers `final public`.</message>
+        </expected-messages>
+        <code><![CDATA[
+abstract public class Foo { // warn l1
+    final static public enum Bar {} // warn l2
+    public static final enum Bar2 {} // ok
+
+    final public static int FOO = 2; // warn l5
+}
+        ]]></code>
+    </test-code>
+
+    <code-fragment id="annotations"><![CDATA[
+            class Foo {
+                class Inner{}
+
+                @Decl
+                public @TypeA int foo; // l5
+
+                @TypeA
+                public @Decl int foo; // l8
+
+                @Decl @TypeA
+                public int foo; // l11
+
+                @Decl
+                public @TypeA static int foo; // l14
+
+                @TypeA
+                public @Decl static int foo; // l17
+
+                @Decl @TypeA
+                public static int foo; // l20
+
+                public int @TypeA[] foo; // never reported
+                public  Foo.@TypeA Inner foo; // never reported
+
+            }
+
+            @java.lang.annotation.Target(java.lang.annotation.ElementType.TYPE_USE)
+            @interface TypeA {}
+
+            @interface Decl {}
+    ]]>
+    </code-fragment>
+
+
+    <test-code>
+        <description>Annotation order (property=anywhere)</description>
+        <rule-property name="typeAnnotations">anywhere</rule-property>
+        <expected-problems>3</expected-problems>
+        <expected-linenumbers>8,14,17</expected-linenumbers>
+        <expected-messages>
+            <message>Missorted modifiers `public @Decl`. Annotations should be placed before modifiers.</message>
+            <message>Missorted modifiers `@TypeA static`. Type annotations should be placed before the type they qualify.</message>
+            <message>Missorted modifiers `public @Decl`. Annotations should be placed before modifiers.</message>
+        </expected-messages>
+        <code-ref id="annotations"/>
+    </test-code>
+
+    <test-code>
+        <description>Annotation order (property=ontype)</description>
+        <rule-property name="typeAnnotations">on type</rule-property>
+        <expected-problems>5</expected-problems>
+        <expected-linenumbers>8,11,14,17,20</expected-linenumbers>
+        <expected-messages>
+            <message>Missorted modifiers `@TypeA public`. Type annotations should be placed before the type they qualify.</message>
+            <message>Missorted modifiers `@TypeA public`. Type annotations should be placed before the type they qualify.</message>
+            <message>Missorted modifiers `@TypeA static`. Type annotations should be placed before the type they qualify.</message>
+            <message>Missorted modifiers `@TypeA public`. Type annotations should be placed before the type they qualify.</message>
+            <message>Missorted modifiers `@TypeA public`. Type annotations should be placed before the type they qualify.</message>
+        </expected-messages>
+        <code-ref id="annotations"/>
+    </test-code>
+    
+    <test-code>
+        <description>Annotation order (property=ondecl)</description>
+        <rule-property name="typeAnnotations">on decl</rule-property>
+        <expected-problems>4</expected-problems>
+        <expected-linenumbers>5,8,14,17</expected-linenumbers>
+        <expected-messages>
+            <message>Missorted modifiers `public @TypeA`. Annotations should be placed before modifiers.</message>
+            <message>Missorted modifiers `public @Decl`. Annotations should be placed before modifiers.</message>
+            <message>Missorted modifiers `public @TypeA`. Annotations should be placed before modifiers.</message>
+            <message>Missorted modifiers `public @Decl`. Annotations should be placed before modifiers.</message>
+        </expected-messages>
+        <code-ref id="annotations"/>
+    </test-code>
+
+
+</test-data>


### PR DESCRIPTION
## Describe the PR

The rule enforces the conventional modifier order. It can also sort type annotations from regular annotations. This could allow us to enforce that eg `@Nullable` is always written next to the type it qualifies. I think this is a good fit for `quickstart.xml`, maybe not initially but after a couple releases.

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->


## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

