### PR TITLE
Fix #5452: [java] PackageCase reported on wrong line

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -17,6 +17,8 @@ This is a {{ site.pmd.release_type }} release.
 ### 🐛 Fixed Issues
 * java-bestpractices
   * [#5369](https://github.com/pmd/pmd/issues/5369): \[java] UnusedPrivateMethod false positives with lombok.val
+* java-codestyle
+  * [#5452](https://github.com/pmd/pmd/issues/5452): \[java] Suppression comment has no effect due to finding at wrong position in case of JavaDoc comment
 
 ### 🚨 API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPackageDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPackageDeclaration.java
@@ -4,6 +4,10 @@
 
 package net.sourceforge.pmd.lang.java.ast;
 
+import net.sourceforge.pmd.lang.ast.impl.javacc.JavaccToken;
+import net.sourceforge.pmd.lang.document.FileLocation;
+import net.sourceforge.pmd.lang.document.TextRegion;
+
 /**
  * Package declaration at the top of a {@linkplain ASTCompilationUnit source file}.
  * Since 7.0, there is no Name node anymore. Use {@link #getName()} instead.
@@ -18,6 +22,8 @@ package net.sourceforge.pmd.lang.java.ast;
  */
 public final class ASTPackageDeclaration extends AbstractJavaNode implements Annotatable, ASTTopLevelDeclaration, JavadocCommentOwner {
 
+    private TextRegion reportRegion;
+
     ASTPackageDeclaration(int id) {
         super(id);
     }
@@ -28,6 +34,15 @@ public final class ASTPackageDeclaration extends AbstractJavaNode implements Ann
         return visitor.visit(this, data);
     }
 
+    void setNameRegion(JavaccToken startTok, JavaccToken endTok) {
+        reportRegion = TextRegion.union(startTok.getRegion(), endTok.getRegion());
+    }
+
+    @Override
+    public FileLocation getReportLocation() {
+        // the report location is the name of the package
+        return getAstInfo().getTextDocument().toLocation(reportRegion);
+    }
 
     /**
      * Returns the name of the package.

--- a/pmd-java/src/main/javacc/Java.jjt
+++ b/pmd-java/src/main/javacc/Java.jjt
@@ -1096,9 +1096,15 @@ private void ModuleDeclLahead() #void:
 
 
 void PackageDeclaration() :
-{String image;}
+{String image; JavaccToken startTok, endTok;}
 {
-  ModAnnotationList() "package" image=VoidName() { jjtThis.setImage(image); } ";"
+  ModAnnotationList() startTok="package"
+  image=VoidName() {
+    endTok = getToken(0);
+    jjtThis.setNameRegion(startTok.getNext(), endTok);
+    jjtThis.setImage(image);
+  }
+  ";"
 }
 
 void ImportDeclaration() :

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTPackageDeclarationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTPackageDeclarationTest.java
@@ -8,6 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
+import net.sourceforge.pmd.lang.document.FileLocation;
+import net.sourceforge.pmd.lang.document.TextPos2d;
 import net.sourceforge.pmd.lang.java.BaseParserTest;
 
 class ASTPackageDeclarationTest extends BaseParserTest {
@@ -23,5 +25,32 @@ class ASTPackageDeclarationTest extends BaseParserTest {
 
         assertEquals("net.sourceforge.pmd.foobar", nodes.getPackageDeclaration().getName());
         assertEquals("net.sourceforge.pmd.foobar", nodes.getPackageName());
+    }
+
+    /**
+     * Regression test for bug 3524607.
+     */
+    @Test
+    void testReportLocation() {
+        ASTCompilationUnit nodes = java.parse(
+            "/** a javadoc comment */\n"
+                + "package \n"
+                + "     foo.\n"
+                + "     bar\n"
+                + ";"
+        );
+        ASTPackageDeclaration packageDecl = nodes.getPackageDeclaration();
+        // this is the range of the Name.
+        FileLocation loc = packageDecl.getReportLocation();
+        assertEquals(
+            TextPos2d.pos2d(3, 6),
+            loc.getStartPos()
+        );
+        assertEquals(
+            TextPos2d.pos2d(4, 9),
+            loc.getEndPos()
+        );
+        assertEquals(packageDecl.getTextRegion(),
+                     nodes.getTextDocument().getEntireRegion());
     }
 }

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/PackageCase.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/PackageCase.xml
@@ -15,6 +15,18 @@ public class Foo {
     </test-code>
 
     <test-code>
+        <description>javadoc comment</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <code><![CDATA[
+/**
+ *  comment
+ */
+package foo.BarBuz;
+        ]]></code>
+    </test-code>
+
+    <test-code>
         <description>good</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #5452

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

