### PR TITLE
[java] Detect mismatch between Java language version used and version of classes on auxclasspath.

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/internal/JavaLanguageProcessor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/internal/JavaLanguageProcessor.java
@@ -4,13 +4,20 @@
 
 package net.sourceforge.pmd.lang.java.internal;
 
+import java.io.IOException;
+import java.io.InputStream;
 import java.util.List;
 import java.util.Objects;
+import java.util.OptionalInt;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Opcodes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import net.sourceforge.pmd.lang.LanguageVersion;
 import net.sourceforge.pmd.lang.LanguageVersionHandler;
 import net.sourceforge.pmd.lang.ast.Parser;
 import net.sourceforge.pmd.lang.impl.BatchLanguageProcessor;
@@ -38,7 +45,7 @@ import net.sourceforge.pmd.util.designerbindings.DesignerBindings;
 public class JavaLanguageProcessor extends BatchLanguageProcessor<JavaLanguageProperties>
     implements LanguageVersionHandler {
 
-    private static final Logger LOG = LoggerFactory.getLogger(JavaLanguageProcessor.class);
+    private static final Logger LOG = LoggerFactory.getLogger("net.sourceforge.pmd.lang.java");
 
     private final LanguageMetricsProvider myMetricsProvider = new JavaMetricsProvider();
     private final JavaParser parser;
@@ -59,6 +66,7 @@ public class JavaLanguageProcessor extends BatchLanguageProcessor<JavaLanguagePr
     public JavaLanguageProcessor(JavaLanguageProperties properties) {
         this(properties, TypeSystem.usingClassLoaderClasspath(properties.getAnalysisClassLoader()));
         LOG.debug("Using analysis classloader: {}", properties.getAnalysisClassLoader());
+        checkClasspathVersionMatchesAnalyzedVersion(properties.getAnalysisClassLoader(), properties.getLanguageVersion());
     }
 
     @Override
@@ -141,4 +149,78 @@ public class JavaLanguageProcessor extends BatchLanguageProcessor<JavaLanguagePr
         this.typeSystem.logStats();
         super.close();
     }
+
+    static void checkClasspathVersionMatchesAnalyzedVersion(ClassLoader loader, LanguageVersion currentJavaVersion) {
+        OptionalInt jdkVer = getVersionOfObject(loader);
+        if (!jdkVer.isPresent()) {
+            // there is a problem, we couldn't load java.lang.Object from the classpath...
+            return;
+        }
+
+        int version = jdkVer.getAsInt();
+        version = Math.max(version, 3); // our versions start at 3
+
+        int analysisVersion = JavaLanguageProperties.getInternalJdkVersion(currentJavaVersion);
+
+
+        String message =
+            "JDK classes on the auxclasspath are detected to be for Java {}, but you are analyzing Java {} sources. "
+                + "Please add the JDK classes of Java {} on your auxclasspath (see https://docs.pmd-code.org/latest/pmd_languages_java.html#providing-the-auxiliary-classpath).";
+        Object[] params = {version, analysisVersion, analysisVersion};
+        if (analysisVersion > version) {
+            // This is a warning because it's much more likely that this causes problems.
+            LOG.warn(message, params);
+        } else {
+            LOG.debug(message, params);
+        }
+    }
+
+
+    static OptionalInt getVersionOfObject(ClassLoader classLoader) {
+        OptionalInt internalVersion = findClassVersion(classLoader, "java/lang/Object.class");
+        if (!internalVersion.isPresent()) {
+            return OptionalInt.empty();
+        }
+        int version = internalVersion.getAsInt();
+        int major = version & 0xffff;
+        // https://javaalmanac.io/bytecode/versions/
+        // Our java versions start at 1.3, which is version 47.0.
+        // Minor version is only non-zero in 1.1 so we don't care about it
+        // Then it increments by 1 for each version.
+        assert major >= 45 : "major version is less than 45 (Java 1.0)";
+        int jdkVersion = major - 44;
+        return OptionalInt.of(jdkVersion); // this ranges from 1,2,3...25 for JDK 25 for instance.
+    }
+
+    private static OptionalInt findClassVersion(ClassLoader classLoader, String classFilePath) {
+
+        class FoundVersionException extends RuntimeException {
+            private final int internalVersion;
+
+            private FoundVersionException(int internalVersion) {
+                this.internalVersion = internalVersion;
+            }
+        }
+
+        try (InputStream stream = classLoader.getResourceAsStream(classFilePath)) {
+            if (stream == null) {
+                return OptionalInt.empty();
+            }
+
+            ClassReader classReader = new ClassReader(stream);
+            try {
+                classReader.accept(new ClassVisitor(Opcodes.ASM9) {
+                    @Override
+                    public void visit(int version, int access, String name, String signature, String superName, String[] interfaces) {
+                        throw new FoundVersionException(version);
+                    }
+                }, ClassReader.SKIP_CODE | ClassReader.SKIP_DEBUG | ClassReader.SKIP_FRAMES);
+            } catch (FoundVersionException found) {
+                return OptionalInt.of(found.internalVersion);
+            }
+        } catch (IOException ignored) {
+        }
+        return OptionalInt.empty();
+    }
+
 }


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
This is just an idea. With ASM, we can detect the version classes on the auxclasspath were compiled with. Here I just get the class version of java.lang.Object. Assuming every JDK version ships with compiled class files that have the corresponding internal version (meaning for instance, Java 21 jrtfs ships a java.lang.Object class that was compiled with Javac 21), we can use this information to detect that the user hasn't put the correct JDK classes on their auxclasspath. We can use this to log a warning. Wdyt?

The only problem I see is that if you use PMD's default Java version, you will most likely see this warning because it is always the newest Java version. Maybe the default java version should be the latest LTS? Would this change something?

For context, I had suggested this in https://github.com/pmd/pmd/issues/4291#issuecomment-1386967072. Putting JDK classes on the auxclasspath is recommended [on our website](https://docs.pmd-code.org/latest/pmd_languages_java.html#providing-the-auxiliary-classpath) but realistically this information is buried very deep and most people won't do it unless they see a warning.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Related to #5064 
-

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

