### PR TITLE
Fix #5616: [apex] ExcessiveParameterList: Report only method signature

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -43,7 +43,7 @@ GEM
       logger
     faraday-net_http (3.3.0)
       net-http
-    ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.1-x86_64-linux-gnu)
     forwardable-extended (2.6.0)
     gemoji (4.1.0)
     github-pages (232)

--- a/docs/pages/pmd/userdocs/extending/testing.md
+++ b/docs/pages/pmd/userdocs/extending/testing.md
@@ -3,7 +3,7 @@ title: Testing your rules
 tags: [extending, userdocs]
 summary: "Learn how to use PMD's simple test framework for unit testing rules."
 permalink: pmd_userdocs_extending_testing.html
-last_updated: December 2023 (7.0.0)
+last_updated: March 2025 (7.12.0)
 author: Andreas Dangel <andreas.dangel@adangel.org>
 ---
 
@@ -157,7 +157,10 @@ The `<test-code>` elements understands the following optional attributes:
 *   **`<expected-linenumbers>`**: Optional element. It's a comma separated list of line numbers.
     If there are rule violations reported, then this allows you to
     assert the line numbers. Useful if multiple violations should be detected and to be sure that
-    false positives and negatives don't erase each other.
+    false positives and negatives don't erase each other.\
+    Since 7.12.0, you can also specify ranges in order to verify begin line and end line of the reported
+    violation's location. E.g. `1-3,4-5` asserts, that there are two violations, the first one from line 1 to 3,
+    and the second one from lines 4 to 5.
 
 *   **`<expected-messages>`**: Optional element, with `<message>` elements as children.
     Can be used to validate the correct error message, e.g. if the error message references a variable name.

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -15,6 +15,8 @@ This is a {{ site.pmd.release_type }} release.
 ### 🚀 New and noteworthy
 
 ### 🐛 Fixed Issues
+* apex-design
+  * [#5616](https://github.com/pmd/pmd/issues/5616): \[apex] ExcessiveParameterList reports entire method instead of signature only
 * java
   * [#5587](https://github.com/pmd/pmd/issues/5587): \[java] Thread deadlock during PMD analysis in ParseLock.getFinalStatus
 * java-bestpractices

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessiveParameterListRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/ExcessiveParameterListRule.java
@@ -5,12 +5,14 @@
 package net.sourceforge.pmd.lang.apex.rule.design;
 
 import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
+import net.sourceforge.pmd.lang.apex.ast.ASTParameter;
+import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.internal.AbstractCounterCheckRule;
+import net.sourceforge.pmd.lang.document.FileLocation;
+import net.sourceforge.pmd.lang.document.TextRange2d;
 
 /**
- * This rule detects an abnormally long parameter list. Note: This counts Nodes,
- * and not necessarily parameters, so the numbers may not match up. (But
- * topcount and sigma should work.)
+ * This rule detects an abnormally long parameter list.
  */
 public class ExcessiveParameterListRule extends AbstractCounterCheckRule<ASTMethod> {
 
@@ -22,6 +24,18 @@ public class ExcessiveParameterListRule extends AbstractCounterCheckRule<ASTMeth
     @Override
     protected int defaultReportLevel() {
         return 4;
+    }
+
+    @Override
+    protected FileLocation getReportLocation(ASTMethod node) {
+        ApexNode<?> lastParameter = node.children(ASTParameter.class).last();
+        if (lastParameter == null) {
+            lastParameter = node;
+        }
+        TextRange2d textRange = TextRange2d.range2d(node.getBeginLine(), node.getBeginColumn(),
+                lastParameter.getEndLine(), lastParameter.getEndColumn());
+
+        return FileLocation.range(node.getAstInfo().getTextDocument().getFileId(), textRange);
     }
 
     @Override

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/internal/AbstractCounterCheckRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/internal/AbstractCounterCheckRule.java
@@ -13,9 +13,11 @@ import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
 import net.sourceforge.pmd.lang.apex.ast.ApexNode;
 import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
 import net.sourceforge.pmd.lang.ast.Node;
+import net.sourceforge.pmd.lang.document.FileLocation;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
 import net.sourceforge.pmd.lang.rule.internal.CommonPropertyDescriptors;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
+import net.sourceforge.pmd.reporting.Reportable;
 
 
 /**
@@ -60,6 +62,9 @@ public abstract class AbstractCounterCheckRule<T extends ApexNode<?>> extends Ab
         return false;
     }
 
+    protected FileLocation getReportLocation(T node) {
+        return node.getReportLocation();
+    }
 
     @Override
     public Object visitApexNode(ApexNode<?> node, Object data) {
@@ -71,7 +76,7 @@ public abstract class AbstractCounterCheckRule<T extends ApexNode<?>> extends Ab
             int metric = getMetric(t);
             int limit = getProperty(reportLevel);
             if (metric >= limit) {
-                asCtx(data).addViolation(node, getViolationParameters(t, metric, limit));
+                asCtx(data).addViolationWithPosition(t, t.getAstInfo(), getReportLocation(t), getMessage(), getViolationParameters(t, metric, limit));
             }
         }
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/internal/AbstractCounterCheckRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/internal/AbstractCounterCheckRule.java
@@ -17,7 +17,6 @@ import net.sourceforge.pmd.lang.document.FileLocation;
 import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
 import net.sourceforge.pmd.lang.rule.internal.CommonPropertyDescriptors;
 import net.sourceforge.pmd.properties.PropertyDescriptor;
-import net.sourceforge.pmd.reporting.Reportable;
 
 
 /**

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/xml/ExcessiveParameterList.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/xml/ExcessiveParameterList.xml
@@ -19,6 +19,7 @@ public class Foo {
         <description>long</description>
         <rule-property name="minimum">9</rule-property>
         <expected-problems>1</expected-problems>
+        <expected-linenumbers>2</expected-linenumbers>
         <code><![CDATA[
 public class Foo {
     public void foo(Integer p01, Integer p02, Integer p03, Integer p04, Integer p05, Integer p06, Integer p07, Integer p08, Integer p09, Integer p10 ) { }
@@ -47,5 +48,27 @@ public class SomeClass {
     private String field;
 }
        ]]></code>
+    </test-code>
+    
+    <test-code>
+        <description>#5616 [apex] ExcessiveParameterList reports entire method instead of signature only</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>2-3,9-11</expected-linenumbers>
+        <code><![CDATA[
+class Excessive {
+    void method1(
+        int i1, int i2, int i3, int i4) {
+        // some more lines
+        someMethodCall(i1);
+        someMethodCall(i2);
+    }
+
+    void method2(
+        int i1, int i2,
+        int i3, int i4) {
+        // some more lines
+    }
+}
+]]></code>
     </test-code>
 </test-data>

--- a/pmd-test-schema/src/main/java/net/sourceforge/pmd/test/schema/BaseTestParserImpl.java
+++ b/pmd-test-schema/src/main/java/net/sourceforge/pmd/test/schema/BaseTestParserImpl.java
@@ -162,17 +162,25 @@ class BaseTestParserImpl {
         }
 
         List<Integer> expectedLineNumbers = Collections.emptyList();
+        List<Integer> expectedEndLineNumbers = Collections.emptyList();
         {
             Element lineNumbers = getSingleChild(testCode, "expected-linenumbers", false, err);
             if (lineNumbers != null) {
                 expectedLineNumbers = new ArrayList<>();
+                expectedEndLineNumbers = new ArrayList<>();
                 String[] linenos = parseTextNode(lineNumbers).split(",");
                 if (linenos.length != expectedProblems) {
                     err.at(expectedProblemsNode).error("Number of ''expected-linenumbers'' ({0}) does not match", linenos.length);
                     return;
                 }
                 for (String num : linenos) {
-                    expectedLineNumbers.add(Integer.valueOf(num.trim()));
+                    if (num.contains("-")) {
+                        String[] beginAndEnd = num.split("-", 2);
+                        expectedLineNumbers.add(Integer.valueOf(beginAndEnd[0].trim()));
+                        expectedEndLineNumbers.add(Integer.valueOf(beginAndEnd[1].trim()));
+                    } else {
+                        expectedLineNumbers.add(Integer.valueOf(num.trim()));
+                    }
                 }
             }
         }
@@ -180,6 +188,7 @@ class BaseTestParserImpl {
         descriptor.recordExpectedViolations(
             expectedProblems,
             expectedLineNumbers,
+            expectedEndLineNumbers,
             expectedMessages
         );
 

--- a/pmd-test-schema/src/main/java/net/sourceforge/pmd/test/schema/RuleTestDescriptor.java
+++ b/pmd-test-schema/src/main/java/net/sourceforge/pmd/test/schema/RuleTestDescriptor.java
@@ -25,6 +25,7 @@ public class RuleTestDescriptor {
     private String code;
     private int expectedProblems;
     private List<Integer> expectedLineNumbers;
+    private List<Integer> expectedEndLineNumbers;
     private List<String> expectedMessages;
     private int lineNumber;
 
@@ -86,6 +87,12 @@ public class RuleTestDescriptor {
         this.expectedMessages = expectedMessages;
     }
 
+    public void recordExpectedViolations(int expectedProblems, List<Integer> expectedLineNumbers, List<Integer> expectedEndLineNumbers, List<String> expectedMessages) {
+        checkListSize(expectedProblems, expectedEndLineNumbers);
+        this.expectedEndLineNumbers = expectedEndLineNumbers;
+        recordExpectedViolations(expectedProblems, expectedLineNumbers, expectedMessages);
+    }
+
     private void checkListSize(int expectedProblems, List<?> expectedMessages) {
         if (!expectedMessages.isEmpty() && expectedProblems != expectedMessages.size()) {
             throw new IllegalArgumentException(
@@ -103,6 +110,10 @@ public class RuleTestDescriptor {
 
     public List<Integer> getExpectedLineNumbers() {
         return expectedLineNumbers;
+    }
+
+    public List<Integer> getExpectedEndLineNumbers() {
+        return expectedEndLineNumbers;
     }
 
     public List<String> getExpectedMessages() {

--- a/pmd-test/src/test/java/net/sourceforge/pmd/test/RuleTstTest.java
+++ b/pmd-test/src/test/java/net/sourceforge/pmd/test/RuleTstTest.java
@@ -75,7 +75,7 @@ class RuleTstTest {
         testDescriptor.setLanguageVersion(dummyLanguage);
         testDescriptor.setCode(code);
         testDescriptor.setDescription("sample test");
-        testDescriptor.recordExpectedViolations(2, Arrays.asList(1, 2), Collections.emptyList());
+        testDescriptor.recordExpectedViolations(2, Arrays.asList(1, 2), Arrays.asList(1, 2), Collections.emptyList());
 
         ruleTester.runTest(testDescriptor);
     }


### PR DESCRIPTION
## Describe the PR

* This improves the test framework, so that we can assert line number ranges (begin line - end line)

## Related issues

- Fix #5616

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

