### PR TITLE
[doc] Fix search index

### DIFF
--- a/docs/_plugins/custom_filters.rb
+++ b/docs/_plugins/custom_filters.rb
@@ -106,6 +106,18 @@ module CustomFilters
     ('a'..'z').to_a.shuffle[0, length].join
   end
 
+  def escape_json(text)
+    if text
+      res = text
+      res = res.gsub(/\\/, '\\\\')
+      res = res.gsub(/"/, '\\"')
+      res = res.gsub(/\n/, '\\n')
+      res = res.gsub(/\r/, '\\r')
+      res = res.gsub(/\f/, '\\f')
+      res = res.gsub(/\t/, '\\t')
+      res = res.gsub(/\b/, '\\b')
+    end
+  end
 
   private
 

--- a/docs/search.json
+++ b/docs/search.json
@@ -16,7 +16,7 @@ search: exclude
 "tags": "{{ page.tags }}",
 "keywords": "{{rule}}",
 "url": "{{ page.url | remove: "/"}}#{{ rule | downcase }}",
-"summary": "{{page.summary | strip }}"
+"summary": "{{page.summary | strip | escape_json }}"
 }
 {% unless forloop.last %},{% endunless %}
 {% endfor %}
@@ -26,7 +26,7 @@ search: exclude
 "tags": "{{ page.tags }}",
 "keywords": "{{page.keywords}}",
 "url": "{{ page.url | remove: "/"}}",
-"summary": "{{page.summary | strip }}"
+"summary": "{{page.summary | strip | escape_json }}"
 }
 {% endif %}
 
@@ -42,7 +42,7 @@ search: exclude
 "tags": "{{ post.tags }}",
 "keywords": "{{post.keywords}}",
 "url": "{{ post.url | remove: "/" }}",
-"summary": "{{post.summary | strip }}"
+"summary": "{{post.summary | strip | escape_json }}"
 }
 {% unless forloop.last %},{% endunless %}
 {% endfor %}


### PR DESCRIPTION
Affected PMD Version: 7.11.0 (was working with 7.10.0)

Due to missing json escaping, the search.json file couldn't be loaded and no search was possible.

## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

