### PR TITLE
[java] Cleanup `UnusedPrivateMethodRule` implementation

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
@@ -95,6 +95,7 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
     }
 
     /**
+     * @implNote
      * Find the method in the compilation unit. Note that this is a patch to fix some
      * incorrect behavior of the rule in two cases:
      *

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
@@ -94,12 +94,22 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
         throw new IllegalStateException("unknown type: " + ref);
     }
 
-
     /**
-     * Collect potential unused private methods and index them by their symbol.
-     * We don't use {@link JExecutableSymbol#tryGetNode()} because it may return
-     * null for types that are treated specially by the type inference system. For
-     * instance for java.lang.String, the ASM symbol is preferred over the AST symbol.
+     * Find the method in the compilation unit. Note that this is a patch to fix some
+     * incorrect behavior of the rule in two cases:
+     *
+     * <p>1. While parsing and type resolving a referenced class, that itself
+     * references the current class. In that case, we end up with the ASM symbols
+     * and symbol.tryGetNode() returns null.
+     *
+     * <p>2. When dealing with classes in the java.lang package.
+     * This is due to the fact that some
+     * java.lang types (like Object, or primitive boxes) are
+     * treated specially by the type resolution framework, and
+     * for those the preexisting ASM symbol is preferred over
+     * the AST symbol - symbol.tryGetNode() returns null in that
+     * case. This is only relevant, when PMD is used to analyze OpenJDK
+     * sources, like with the regression tester.
      */
     private Map<JExecutableSymbol, ASTMethodDeclaration> findCandidates(ASTCompilationUnit file, Set<String> methodsUsedByAnnotations) {
         return file.descendants(ASTMethodDeclaration.class)

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
@@ -15,7 +15,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.sourceforge.pmd.lang.ast.NodeStream;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
@@ -24,7 +23,6 @@ import net.sourceforge.pmd.lang.java.ast.ASTMemberValue;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodReference;
-import net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.ast.MethodUsage;
 import net.sourceforge.pmd.lang.java.ast.ModifierOwner.Visibility;
@@ -53,120 +51,133 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
         );
     }
 
+    /**
+     * Visits the compilation unit to detect unused private methods.
+     *
+     * @param file  the compilation unit to visit
+     * @param param the context parameter
+     * @return null
+     */
     @Override
     public Object visit(ASTCompilationUnit file, Object param) {
-        // We do three traversals:
-        // - one to find methods:
-        // --- referenced by any attribute of any annotation
-        // --- with name same as a method annotated with Junit5 MethodSource if the annotation value is empty
-        // - one to find the "interesting methods", ie those that may be violations
-        // - another to find the possible usages. We only try to resolve
-        //   method calls/method refs that may refer to a method in the
-        //   first set, ie, not every call in the file.
-        Set<String> methodsUsedByAnnotations =
-                file.descendants(ASTAnnotation.class)
-                        .crossFindBoundaries()
-                        .toStream()
-                        .flatMap(a -> Stream.concat(
-                                        a.getFlatValues().toStream()
-                                                .map(ASTMemberValue::getConstValue)
-                                                .filter(String.class::isInstance)
-                                                .map(String.class::cast)
-                                                .filter(StringUtils::isNotEmpty),
-                                        NodeStream.of(a)
-                                                .filter(it -> TypeTestUtil.isA("org.junit.jupiter.params.provider.MethodSource", it)
-                                                        && it.getFlatValue("value").isEmpty())
-                                                .ancestors(ASTMethodDeclaration.class)
-                                                .take(1)
-                                                .toStream()
-                                                .map(ASTMethodDeclaration::getName)
-                                )
-                        )
-                        .collect(Collectors.toSet());
+        visit(
+            file,
+            findPrivateMethods(file, methodsUsedByAnnotations(file)),
+            param);
+        return null;
+    }
 
-        Map<String, Set<ASTMethodDeclaration>> consideredNames =
-            file.descendants(ASTMethodDeclaration.class)
-                .crossFindBoundaries()
-                // get methods whose usages are all in this file
-                // TODO we could use getEffectiveVisibility here, but we need to consider overrides then.
-                .filter(it -> it.getVisibility() == Visibility.V_PRIVATE)
-                .filter(it -> !hasIgnoredAnnotation(it)
-                        && !hasExcludedName(it) 
-                        && !(it.getArity() == 0 && methodsUsedByAnnotations.contains(it.getName())))
-                .toStream()
-                .collect(Collectors.groupingBy(ASTMethodDeclaration::getName, HashMap::new, CollectionUtil.toMutableSet()));
+    private void visit(ASTCompilationUnit file,
+                       Map<String, Set<ASTMethodDeclaration>> privateMethods,
+                       Object param) {
+        findUnusedMethods(
+            file,
+            privateMethods,
+            methodDeclarationsCache(file)
+        ).forEach((name, unused) -> addViolation(param, unused));
+    }
 
+    private void addViolation(Object param, Set<ASTMethodDeclaration> unused) {
+        for (ASTMethodDeclaration m : unused) {
+            asCtx(param).addViolation(m, PrettyPrintingUtil.displaySignature(m));
+        }
+    }
+
+    private static Map<String, Set<ASTMethodDeclaration>> findUnusedMethods(ASTCompilationUnit file,
+                                                                            Map<String,
+                                                                                Set<ASTMethodDeclaration>> methods,
+                                                                            Map<JExecutableSymbol,
+                                                                                ASTMethodDeclaration>
+                                                                                cache) {
         file.descendants()
             .crossFindBoundaries()
             .map(NodeStream.<MethodUsage>asInstanceOf(ASTMethodCall.class, ASTMethodReference.class))
             .forEach(ref -> {
-                String methodName = ref.getMethodName();
-                // the considered names might be mutated during the traversal
-                if (!consideredNames.containsKey(methodName)) {
-                    return;
-                }
-                JExecutableSymbol sym;
-                if (ref instanceof ASTMethodCall) {
-                    sym = ((ASTMethodCall) ref).getMethodType().getSymbol();
-                } else if (ref instanceof ASTMethodReference) {
-                    sym = ((ASTMethodReference) ref).getReferencedMethod().getSymbol();
-                } else {
-                    return;
-                }
-
-                JavaNode reffed = sym.tryGetNode();
-                if (reffed == null) {
-                    reffed = findDeclarationInCompilationUnit(file, sym);
-                }
-                if (reffed instanceof ASTMethodDeclaration
-                    && ref.ancestors(ASTMethodDeclaration.class).first() != reffed) {
-                    // remove from set, but only if it is called outside of itself
-                    Set<ASTMethodDeclaration> remainingUnused = consideredNames.get(methodName);
-                    if (remainingUnused != null
-                        && remainingUnused.remove(reffed) // note: side-effect
-                        && remainingUnused.isEmpty()) {
-                        consideredNames.remove(methodName); // clear this name
-                    }
-                }
+                final JExecutableSymbol sym = getJExecutableSymbol(ref);
+                filterUsedMethods(methods,
+                    ref,
+                    ref.getMethodName(),
+                    sym.tryGetNode() != null
+                        ? sym.tryGetNode()
+                        : cache.get(sym));
             });
+        return methods;
+    }
 
-        // those that remain are unused
-        consideredNames.forEach((name, unused) -> {
-            for (ASTMethodDeclaration m : unused) {
-                asCtx(param).addViolation(m, PrettyPrintingUtil.displaySignature(m));
+    private static void filterUsedMethods(Map<String, Set<ASTMethodDeclaration>> privateMethods,
+                                          MethodUsage ref,
+                                          String methodName,
+                                          JavaNode reffed) {
+        if (privateMethods.containsKey(methodName)
+            && reffed instanceof ASTMethodDeclaration
+            && ref.ancestors(ASTMethodDeclaration.class).first() != reffed) {
+            final Set<ASTMethodDeclaration> remainingUnused = privateMethods.get(methodName);
+            if (remainingUnused != null
+                && remainingUnused.remove(reffed)
+                && remainingUnused.isEmpty()) {
+                privateMethods.remove(methodName);
             }
-        });
+        }
+    }
 
-        return null;
+    private static Map<JExecutableSymbol, ASTMethodDeclaration> methodDeclarationsCache(ASTCompilationUnit file) {
+        return file.descendants(ASTMethodDeclaration.class)
+            .crossFindBoundaries()
+            .toStream()
+            .collect(Collectors.toMap(ASTMethodDeclaration::getSymbol, m -> m));
+    }
+
+    private static JExecutableSymbol getJExecutableSymbol(MethodUsage ref) {
+        if (ref instanceof ASTMethodCall) {
+            return ((ASTMethodCall) ref).getMethodType().getSymbol();
+        } else if (ref instanceof ASTMethodReference) {
+            return ((ASTMethodReference) ref).getReferencedMethod().getSymbol();
+        }
+        throw new IllegalStateException("unknown type: " + ref);
+    }
+
+    private Map<String, Set<ASTMethodDeclaration>> findPrivateMethods(ASTCompilationUnit file,
+                                                                      Set<String> methodsUsedByAnnotations) {
+        return file.descendants(ASTMethodDeclaration.class)
+            .crossFindBoundaries()
+            .filter(it -> it.getVisibility() == Visibility.V_PRIVATE)
+            .filter(it -> !hasIgnoredAnnotation(it)
+                && !hasExcludedName(it)
+                && !(it.getArity() == 0 && methodsUsedByAnnotations.contains(it.getName())))
+            .toStream()
+            .collect(Collectors.groupingBy(
+                ASTMethodDeclaration::getName,
+                HashMap::new,
+                CollectionUtil.toMutableSet()
+            ));
+    }
+
+    private static Set<String> methodsUsedByAnnotations(ASTCompilationUnit file) {
+        return file.descendants(ASTAnnotation.class)
+            .crossFindBoundaries()
+            .toStream()
+            .flatMap(UnusedPrivateMethodRule::extractMethodsFromAnnotation)
+            .collect(Collectors.toSet());
+    }
+
+    private static Stream<String> extractMethodsFromAnnotation(ASTAnnotation a) {
+        return Stream.concat(
+            a.getFlatValues().toStream()
+                .map(ASTMemberValue::getConstValue)
+                .filter(String.class::isInstance)
+                .map(String.class::cast)
+                .filter(StringUtils::isNotEmpty),
+            NodeStream.of(a)
+                .filter(it -> TypeTestUtil.isA("org.junit.jupiter.params.provider.MethodSource", it)
+                    && it.getFlatValue("value").isEmpty())
+                .ancestors(ASTMethodDeclaration.class)
+                .take(1)
+                .toStream()
+                .map(ASTMethodDeclaration::getName)
+        );
     }
 
     private boolean hasExcludedName(ASTMethodDeclaration node) {
         return SERIALIZATION_METHODS.contains(node.getName());
-    }
-
-    /**
-     * Find the method in the compilation unit. Note that this is a patch to fix some
-     * incorrect behavior of the rule in two cases:
-     *
-     * <p>1. While parsing and type resolving a referenced class, that itself
-     * references the current class. In that case, we end up with the ASM symbols
-     * and symbol.tryGetNode() returns null.
-     *
-     * <p>2. When dealing with classes in the java.lang package.
-     * This is due to the fact that some
-     * java.lang types (like Object, or primitive boxes) are
-     * treated specially by the type resolution framework, and
-     * for those the preexisting ASM symbol is preferred over
-     * the AST symbol - symbol.tryGetNode() returns null in that
-     * case. This is only relevant, when PMD is used to analyze OpenJDK
-     * sources, like with the regression tester.
-     */
-    private static @Nullable ASTMethodDeclaration findDeclarationInCompilationUnit(ASTCompilationUnit acu, JExecutableSymbol symbol) {
-        return acu.descendants(ASTTypeDeclaration.class)
-                  .crossFindBoundaries()
-                  .filter(it -> it.getSymbol().equals(symbol.getEnclosingClass()))
-                  .take(1)
-                  .flatMap(it -> it.getDeclarations(ASTMethodDeclaration.class))
-                  .first(m -> m.getSymbol().equals(symbol));
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
@@ -16,7 +16,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang3.StringUtils;
-import org.checkerframework.checker.nullness.qual.NonNull;
 
 import net.sourceforge.pmd.lang.ast.NodeStream;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
@@ -71,8 +70,8 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
         return candidates;
     }
 
-    private static Consumer<@NonNull MethodUsage> removeUsedMethods(Map<JExecutableSymbol, ASTMethodDeclaration> candidates) {
-        return ref -> candidates.compute(getMethodSymbol(ref), (sym2, reffed) -> {
+    private static Consumer<MethodUsage> removeUsedMethods(Map<JExecutableSymbol, ASTMethodDeclaration> candidates) {
+        return ref -> candidates.compute(getMethodSymbol(ref), (sym, reffed) -> {
             if (reffed != null && ref.ancestors(ASTMethodDeclaration.class).first() != reffed) {
                 return null; // remove mapping, but only if it is called from outside itself
             }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
@@ -57,6 +57,14 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
         return null;
     }
 
+    /**
+     * @implNote does following traversals:
+     * <ul>
+     * <li>one to find annotations that potentially reference a method</li>
+     * <li>one to collect candidates, that is, potentially unused methods</li>
+     * <li>one to walk through all possible usages of methods, and delete used methods from the set</li>
+     * </ul>
+     */
     private static Map<JExecutableSymbol, ASTMethodDeclaration> findViolations(ASTCompilationUnit file,
                                                                         Map<JExecutableSymbol, ASTMethodDeclaration> candidates) {
         // this does a couple of traversals:

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
@@ -57,7 +57,7 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
         return null;
     }
 
-    private Map<JExecutableSymbol, ASTMethodDeclaration> findViolations(ASTCompilationUnit file,
+    private static Map<JExecutableSymbol, ASTMethodDeclaration> findViolations(ASTCompilationUnit file,
                                                                         Map<JExecutableSymbol, ASTMethodDeclaration> candidates) {
         // this does a couple of traversals:
         // - one to find annotations that potentially reference a method
@@ -79,7 +79,7 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
         });
     }
 
-    private void addViolations(Map<JExecutableSymbol, ASTMethodDeclaration> violations, RuleContext ctx) {
+    private static void addViolations(Map<JExecutableSymbol, ASTMethodDeclaration> violations, RuleContext ctx) {
         for (ASTMethodDeclaration violation : violations.values()) {
             ctx.addViolation(violation, PrettyPrintingUtil.displaySignature(violation));
         }
@@ -139,7 +139,7 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
         );
     }
 
-    private boolean hasExcludedName(ASTMethodDeclaration node) {
+    private static boolean hasExcludedName(ASTMethodDeclaration node) {
         return SERIALIZATION_METHODS.contains(node.getName());
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
@@ -73,6 +73,10 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
                     return reffed;
                 });
             });
+        addViolations(param, candidates);
+    }
+
+    private void addViolations(Object param, Map<JExecutableSymbol, ASTMethodDeclaration> candidates) {
         for (ASTMethodDeclaration unusedMethod : candidates.values()) {
             asCtx(param).addViolation(unusedMethod, PrettyPrintingUtil.displaySignature(unusedMethod));
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
@@ -52,12 +52,12 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
 
     @Override
     public Object visit(ASTCompilationUnit file, Object param) {
-        visit(file, findCandidates(file, methodsUsedByAnnotations(file)), asCtx(param));
+        addViolations(findViolations(file, findCandidates(file, methodsUsedByAnnotations(file))), asCtx(param));
         return null;
     }
 
-    private void visit(ASTCompilationUnit file, Map<JExecutableSymbol, ASTMethodDeclaration> candidates,
-                       RuleContext ctx) {
+    private Map<JExecutableSymbol, ASTMethodDeclaration> findViolations(ASTCompilationUnit file,
+                                                                        Map<JExecutableSymbol, ASTMethodDeclaration> candidates) {
         // this does a couple of traversals:
         // - one to find annotations that potentially reference a method
         // - one to collect candidates, that is, potentially unused methods
@@ -75,7 +75,7 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
                     return reffed;
                 });
             });
-        addViolations(candidates, ctx);
+        return candidates;
     }
 
     private void addViolations(Map<JExecutableSymbol, ASTMethodDeclaration> candidates, RuleContext ctx) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
@@ -29,6 +29,7 @@ import net.sourceforge.pmd.lang.java.ast.internal.PrettyPrintingUtil;
 import net.sourceforge.pmd.lang.java.rule.internal.AbstractIgnoredAnnotationRule;
 import net.sourceforge.pmd.lang.java.symbols.JExecutableSymbol;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
+import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
  * This rule detects private methods, that are not used and can therefore be
@@ -51,11 +52,12 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
 
     @Override
     public Object visit(ASTCompilationUnit file, Object param) {
-        visit(file, param, findCandidates(file, methodsUsedByAnnotations(file)));
+        visit(file, findCandidates(file, methodsUsedByAnnotations(file)), asCtx(param));
         return null;
     }
 
-    private void visit(ASTCompilationUnit file, Object param, Map<JExecutableSymbol, ASTMethodDeclaration> candidates) {
+    private void visit(ASTCompilationUnit file, Map<JExecutableSymbol, ASTMethodDeclaration> candidates,
+                       RuleContext ctx) {
         // this does a couple of traversals:
         // - one to find annotations that potentially reference a method
         // - one to collect candidates, that is, potentially unused methods
@@ -73,12 +75,12 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
                     return reffed;
                 });
             });
-        addViolations(param, candidates);
+        addViolations(candidates, ctx);
     }
 
-    private void addViolations(Object param, Map<JExecutableSymbol, ASTMethodDeclaration> candidates) {
+    private void addViolations(Map<JExecutableSymbol, ASTMethodDeclaration> candidates, RuleContext ctx) {
         for (ASTMethodDeclaration unusedMethod : candidates.values()) {
-            asCtx(param).addViolation(unusedMethod, PrettyPrintingUtil.displaySignature(unusedMethod));
+            ctx.addViolation(unusedMethod, PrettyPrintingUtil.displaySignature(unusedMethod));
         }
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
@@ -65,15 +65,13 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
         file.descendants()
             .crossFindBoundaries()
             .<MethodUsage>map(asInstanceOf(ASTMethodCall.class, ASTMethodReference.class))
-            .forEach(ref -> {
-                candidates.compute(getMethodSymbol(ref), (sym2, reffed) -> {
-                    if (reffed != null && ref.ancestors(ASTMethodDeclaration.class).first() != reffed) {
-                        // remove mapping, but only if it is called from outside itself
-                        return null;
-                    }
-                    return reffed;
-                });
-            });
+            .forEach(ref -> candidates.compute(getMethodSymbol(ref), (sym2, reffed) -> {
+                if (reffed != null && ref.ancestors(ASTMethodDeclaration.class).first() != reffed) {
+                    // remove mapping, but only if it is called from outside itself
+                    return null;
+                }
+                return reffed;
+            }));
         return candidates;
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
@@ -66,8 +66,7 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
             .crossFindBoundaries()
             .<MethodUsage>map(asInstanceOf(ASTMethodCall.class, ASTMethodReference.class))
             .forEach(ref -> {
-                JExecutableSymbol calledMethod = getMethodSymbol(ref);
-                candidates.compute(calledMethod, (sym2, reffed) -> {
+                candidates.compute(getMethodSymbol(ref), (sym2, reffed) -> {
                     if (reffed != null && ref.ancestors(ASTMethodDeclaration.class).first() != reffed) {
                         // remove mapping, but only if it is called from outside itself
                         return null;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
@@ -77,9 +77,9 @@ public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
         return candidates;
     }
 
-    private void addViolations(Map<JExecutableSymbol, ASTMethodDeclaration> candidates, RuleContext ctx) {
-        for (ASTMethodDeclaration unusedMethod : candidates.values()) {
-            ctx.addViolation(unusedMethod, PrettyPrintingUtil.displaySignature(unusedMethod));
+    private void addViolations(Map<JExecutableSymbol, ASTMethodDeclaration> violations, RuleContext ctx) {
+        for (ASTMethodDeclaration violation : violations.values()) {
+            ctx.addViolation(violation, PrettyPrintingUtil.displaySignature(violation));
         }
     }
 


### PR DESCRIPTION
### Rewise `UnusedPrivateMethodRule` to Improve Separation of Concerns

Refactoring the `UnusedPrivateMethodRule` to better separate concerns can enhance maintainability and readability while keeping the code aligned with the single-responsibility principle.

## Revise `UnusedPrivateMethodRule`

#### References:
- [Single Responsibility Principle (Wikipedia)](https://en.wikipedia.org/wiki/Single-responsibility_principle)
- [Functions Should Do One Thing (Francisco Moretti)](https://www.franciscomoretti.com/blog/functions-should-do-one-thing)
- [Clean Code Method Length (Google Search)](https://www.google.com/search?q=clean+code+method+length&sca_esv=f7eed69fd92caa42&rlz=1C5CHFA_enDE753DE753&ei=NOjfZ9iSG_aA9u8P9pLpuQc&ved=0ahUKEwjY_KjnhKCMAxV2gP0HHXZJOncQ4dUDCBA&uact=5&oq=clean+code+method+length&gs_lp=Egxnd3Mtd2l6LXNlcnAiGGNsZWFuIGNvZGUgbWV0aG9kIGxlbmd0aDIHEAAYsAMYHjIIEAAYsAMY7wUyCBAAGLADGO8FMggQABiwAxjvBTIIEAAYsAMY7wVIngJQW1hbcAF4AJABAJgBAKABAKoBALgBA8gBAPgBAZgCAaACA5gDAOIDBRIBMSBAiAYBkAYFkgcBMaAHALIHALgHAA&sclient=gws-wiz-serp)


## Related Issues

<!-- PR relates to issues in the `pmd` repo: -->

- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by GitHub Actions)
- [x] Added (in-code) documentation (if needed)