### PR TITLE
[dist] Make pmd launch script compatible with /bin/sh

### DIFF
--- a/pmd-dist/src/main/resources/scripts/pmd
+++ b/pmd-dist/src/main/resources/scripts/pmd
@@ -205,5 +205,9 @@ cygwin_paths
 
 java_heapsize_settings
 
-java "$HEAPSIZE" $PMD_JAVA_OPTS $(jre_specific_vm_options) -cp "$classpath" net.sourceforge.pmd.cli.PmdCli "$@"
 # Note: we want word-splitting happening on PMD_JAVA_OPTS and jre_specific_vm_options
+exec java \
+  ${HEAPSIZE:+"$HEAPSIZE"} \
+  $PMD_JAVA_OPTS $(jre_specific_vm_options) \
+  -cp "$classpath" \
+  net.sourceforge.pmd.cli.PmdCli "$@"

--- a/pmd-dist/src/main/resources/scripts/pmd
+++ b/pmd-dist/src/main/resources/scripts/pmd
@@ -16,20 +16,20 @@ is_cygwin() {
 
 cygwin_paths() {
     # For Cygwin, switch paths to Windows format before running java
-    if ${cygwin} ; then
-        [ -n "${JAVA_HOME}" ] && JAVA_HOME=$(cygpath --windows "${JAVA_HOME}")
-        [ -n "${JAVAFX_HOME}" ] && JAVAFX_HOME=$(cygpath --windows "${JAVAFX_HOME}")
-        [ -n "${DIRECTORY}" ] && DIRECTORY=$(cygpath --windows "${DIRECTORY}")
-        classpath=$(cygpath --path --windows "${classpath}")
+    if [ "$cygwin" = true ] ; then
+        [ -n "$JAVA_HOME" ] && JAVA_HOME=$(cygpath --windows "$JAVA_HOME")
+        [ -n "$JAVAFX_HOME" ] && JAVAFX_HOME=$(cygpath --windows "$JAVAFX_HOME")
+        [ -n "$DIRECTORY" ] && DIRECTORY=$(cygpath --windows "$DIRECTORY")
+        classpath=$(cygpath --path --windows "$classpath")
     fi
 }
 
 convert_cygwin_vars() {
     # If cygwin, convert to Unix form before manipulating
-    if ${cygwin} ; then
-        [ -n "${JAVA_HOME}" ] && JAVA_HOME=$(cygpath --unix "${JAVA_HOME}")
-        [ -n "${JAVAFX_HOME}" ] && JAVAFX_HOME=$(cygpath --unix "${JAVAFX_HOME}")
-        [ -n "${CLASSPATH}" ] && CLASSPATH=$(cygpath --path --unix "${CLASSPATH}")
+    if [ "$cygwin" = true ] ; then
+        [ -n "$JAVA_HOME" ] && JAVA_HOME=$(cygpath --unix "$JAVA_HOME")
+        [ -n "$JAVAFX_HOME" ] && JAVAFX_HOME=$(cygpath --unix "$JAVAFX_HOME")
+        [ -n "$CLASSPATH" ] && CLASSPATH=$(cygpath --path --unix "$CLASSPATH")
     fi
 }
 
@@ -47,7 +47,7 @@ java_heapsize_settings() {
 }
 
 set_lib_dir() {
-  if [ -z "${LIB_DIR}" ]; then
+  if [ -z "$LIB_DIR" ]; then
     # Allow for symlinks to this script
     if [ -L "$0" ]; then
       script_real_loc=$(readlink "$0")
@@ -61,13 +61,13 @@ set_lib_dir() {
 }
 
 check_lib_dir() {
-  if [ ! -e "${LIB_DIR}" ]; then
-    echo "The jar directory [${LIB_DIR}] does not exist"
+  if [ ! -e "$LIB_DIR" ]; then
+    echo "The jar directory [$LIB_DIR] does not exist"
   fi
 }
 
 set_conf_dir() {
-  if [ -z ${CONF_DIR} ]; then
+  if [ -z "$CONF_DIR" ]; then
     # Allow for symlinks to this script
     if [ -L "$0" ]; then
       script_real_loc=$(readlink "$0")
@@ -81,8 +81,8 @@ set_conf_dir() {
 }
 
 check_conf_dir() {
-  if [ ! -e "${CONF_DIR}" ]; then
-    echo "The configuration directory [${CONF_DIR}] does not exist"
+  if [ ! -e "$CONF_DIR" ]; then
+    echo "The configuration directory [$CONF_DIR] does not exist"
   fi
 }
 
@@ -116,7 +116,7 @@ determine_java_version() {
 }
 
 jre_specific_vm_options() {
-  if [ "${APPNAME}" = "designer" ]
+  if [ "$APPNAME" = "designer" ]
   then
     options=""
 

--- a/pmd-dist/src/main/resources/scripts/pmd
+++ b/pmd-dist/src/main/resources/scripts/pmd
@@ -1,15 +1,17 @@
-#!/bin/bash
+#!/bin/sh
 
 is_cygwin() {
     case "$(uname)" in
         CYGWIN*|MINGW*)
-            readonly cygwin=true
+            cygwin=true
+            ;;
+        *)
+            # OS specific support.  $var _must_ be set to either true or false.
+            if [ -z "$cygwin" ] ; then
+              cygwin=false
+            fi
             ;;
     esac
-    # OS specific support.  $var _must_ be set to either true or false.
-    if [ -z ${cygwin} ] ; then
-        readonly cygwin=false
-    fi
 }
 
 cygwin_paths() {
@@ -32,33 +34,29 @@ convert_cygwin_vars() {
 }
 
 java_heapsize_settings() {
-    local heapsize=${HEAPSIZE}
-    case "${heapsize}" in
+    case "$HEAPSIZE" in
         [1-9]*[mgMG])
-            readonly HEAPSIZE="-Xmx${heapsize}"
+            HEAPSIZE="-Xmx$HEAPSIZE"
             ;;
         '')
             ;;
         *)
-            echo "HEAPSIZE '${HEAPSIZE}' unknown (try: 1024m)"
+            echo "HEAPSIZE '$HEAPSIZE' unknown (try: 1024m)"
             exit 1
     esac
 }
-
 
 set_lib_dir() {
   if [ -z "${LIB_DIR}" ]; then
     # Allow for symlinks to this script
     if [ -L "$0" ]; then
-      local script_real_loc=$(readlink "$0")
+      script_real_loc=$(readlink "$0")
     else
-      local script_real_loc=${BASH_SOURCE[0]:-${(%):-%x}}
+      script_real_loc="$0"
     fi
-    local script_dir=$(dirname "${script_real_loc}")
+    script_dir=$(dirname "$script_real_loc")
 
-    pushd "${script_dir}/../lib" >/dev/null
-    readonly LIB_DIR=$(pwd -P)
-    popd >/dev/null
+    LIB_DIR=$(realpath "$script_dir/../lib")
   fi
 }
 
@@ -71,16 +69,14 @@ check_lib_dir() {
 set_conf_dir() {
   if [ -z ${CONF_DIR} ]; then
     # Allow for symlinks to this script
-    if [ -L $0 ]; then
-      local script_real_loc=$(readlink "$0")
+    if [ -L "$0" ]; then
+      script_real_loc=$(readlink "$0")
     else
-      local script_real_loc=${BASH_SOURCE[0]:-${(%):-%x}}
+      script_real_loc="$0"
     fi
-    local script_dir=$(dirname "${script_real_loc}")
+    script_dir=$(dirname "$script_real_loc")
 
-    pushd "${script_dir}/../conf" >/dev/null
-    readonly CONF_DIR=$(pwd -P)
-    popd >/dev/null
+    CONF_DIR=$(realpath "$script_dir/../conf")
   fi
 }
 
@@ -90,12 +86,12 @@ check_conf_dir() {
   fi
 }
 
-function script_exit() {
+script_exit() {
     echo "$1" >&2
     exit 1
 }
 
-function check_java() {
+check_java() {
   java -version >/dev/null 2>&1
   if [ $? -ne 0 ]; then
     script_exit "No java executable found in PATH"
@@ -103,9 +99,9 @@ function check_java() {
 }
 
 determine_java_version() {
-    local full_ver=$(java -version 2>&1)
+    full_ver=$(java -version 2>&1)
     # java_ver is eg "80" for java 1.8, "90" for java 9.0, "100" for java 10.0.x
-    readonly java_ver=$(echo "$full_ver" | sed -n '{
+    java_ver=$(echo "$full_ver" | sed -n '{
         # replace early access versions, e.g. 11-ea with 11.0.0
         s/-ea/.0.0/
         # replace versions such as 10 with 10.0.0
@@ -116,7 +112,7 @@ determine_java_version() {
         s/^.* version "\([0-9]\{1,\}\)\.\([0-9]\{1,\}\).*".*$/\1\2/p
     }')
     # java_vendor is either java (oracle) or openjdk
-    readonly java_vendor=$(echo "$full_ver" | sed -n -e 's/^\(.*\) version .*$/\1/p')
+    java_vendor=$(echo "$full_ver" | sed -n -e 's/^\(.*\) version .*$/\1/p')
 }
 
 jre_specific_vm_options() {
@@ -134,59 +130,59 @@ jre_specific_vm_options() {
       # open internal module of javafx to reflection (for our TreeViewWrapper)
       options="--add-opens javafx.controls/javafx.scene.control.skin=ALL-UNNAMED"
       # The rest here is for RichtextFX
-      options+=" --add-opens javafx.graphics/javafx.scene.text=ALL-UNNAMED"
-      options+=" --add-opens javafx.graphics/com.sun.javafx.scene.text=ALL-UNNAMED"
-      options+=" --add-opens javafx.graphics/com.sun.javafx.text=ALL-UNNAMED"
-      options+=" --add-opens javafx.graphics/com.sun.javafx.geom=ALL-UNNAMED"
+      options="$options --add-opens javafx.graphics/javafx.scene.text=ALL-UNNAMED"
+      options="$options --add-opens javafx.graphics/com.sun.javafx.scene.text=ALL-UNNAMED"
+      options="$options --add-opens javafx.graphics/com.sun.javafx.text=ALL-UNNAMED"
+      options="$options --add-opens javafx.graphics/com.sun.javafx.geom=ALL-UNNAMED"
       # Warn of remaining illegal accesses
-      options+=" --illegal-access=warn"
-    elif [ "$java_vendor" = "openjdk" ] || ( [ "$java_vendor" = "java" ] && [ "$java_ver" -ge 110 ] )
+      options="$options --illegal-access=warn"
+    elif [ "$java_vendor" = "openjdk" ] || { [ "$java_vendor" = "java" ] && [ "$java_ver" -ge 110 ] ; }
     then
       # openjdk and java11 from oracle onwards do not contain javafx directly
       # there are no extra options either - javafx will be added to the classpath without modules
       options=""
     fi
 
-    echo $options
+    echo "$options"
   else
     echo ""
   fi
 }
 
-function add_pmd_classpath() {
+add_pmd_classpath() {
     if [ -n "$classpath" ]; then
-        classpath="$classpath:${CONF_DIR}:${LIB_DIR}/*"
+        classpath="$classpath:$CONF_DIR:$LIB_DIR/*"
     else
-        classpath="${CONF_DIR}:${LIB_DIR}/*"
+        classpath="$CONF_DIR:$LIB_DIR/*"
     fi
 }
 
-function add_openjfx_classpath() {
-  if [ "${APPNAME}" = "designer" ]
+add_openjfx_classpath() {
+  if [ "$APPNAME" = "designer" ]
   then
     if [ "$java_vendor" = "openjdk" ] && [ "$java_ver" -lt 100 ]
     then
       script_exit "For openjfx at least java 10 is required"
-    elif [ "$java_vendor" = "openjdk" ] || ( [ "$java_vendor" = "java" ] && [ "$java_ver" -ge 110 ] )
+    elif [ "$java_vendor" = "openjdk" ] || { [ "$java_vendor" = "java" ] && [ "$java_ver" -ge 110 ] ; }
     then
       # openjfx is required for openjdk builds and oracle java 11 or later
-      if [ -z "${JAVAFX_HOME}" ]
+      if [ -z "$JAVAFX_HOME" ]
       then
         script_exit "The environment variable JAVAFX_HOME is missing."
       else
         # The wildcard will include only jar files, but we need to access also
         # property files such as javafx.properties that lay bare in the dir
         if [ -n "$classpath" ]; then
-          classpath="$classpath:${JAVAFX_HOME}/lib/*:${JAVAFX_HOME}/lib/"
+          classpath="$classpath:$JAVAFX_HOME/lib/*:$JAVAFX_HOME/lib/"
         else
-          classpath="${JAVAFX_HOME}/lib/*:${JAVAFX_HOME}/lib/"
+          classpath="$JAVAFX_HOME/lib/*:$JAVAFX_HOME/lib/"
         fi
       fi
     fi
   fi
 }
 
-readonly APPNAME="${1}"
+APPNAME="$1"
 
 is_cygwin
 
@@ -209,4 +205,5 @@ cygwin_paths
 
 java_heapsize_settings
 
-java ${HEAPSIZE} ${PMD_JAVA_OPTS} $(jre_specific_vm_options) -cp "${classpath}" net.sourceforge.pmd.cli.PmdCli "$@"
+java "$HEAPSIZE" $PMD_JAVA_OPTS $(jre_specific_vm_options) -cp "$classpath" net.sourceforge.pmd.cli.PmdCli "$@"
+# Note: we want word-splitting happening on PMD_JAVA_OPTS and jre_specific_vm_options

--- a/pmd-dist/src/main/resources/scripts/pmd
+++ b/pmd-dist/src/main/resources/scripts/pmd
@@ -46,17 +46,37 @@ java_heapsize_settings() {
     esac
 }
 
+set_pmd_home_dir() {
+  if [ -z "$PMD_HOME" ]; then
+    script_real_loc="$0"
+
+    # see #4723 - allow calling as "bash pmd", when pmd is on the PATH
+    if [ ! -e "$script_real_loc" ]; then
+      script_real_loc=$(which "$script_real_loc")
+    fi
+  fi
+
+  if [ ! -e "$script_real_loc" ]; then
+    echo "Couldn't determine PMD_HOME path. Script location [$script_real_loc] does not exist"
+    exit 1
+  fi
+
+  # Allow for symlinks to this script
+  if [ -L "$script_real_loc" ]; then
+    script_real_loc=$(readlink "$script_real_loc")
+  fi
+
+  # use the directory of the script (which is ..../bin)
+  script_real_loc=$(dirname "$script_real_loc")
+  # use the parent directory
+  PMD_HOME="$script_real_loc/.."
+  # make it normalized and fully qualified
+  PMD_HOME=$(cd "$PMD_HOME" && pwd)
+}
+
 set_lib_dir() {
   if [ -z "$LIB_DIR" ]; then
-    # Allow for symlinks to this script
-    if [ -L "$0" ]; then
-      script_real_loc=$(readlink "$0")
-    else
-      script_real_loc="$0"
-    fi
-    script_dir=$(dirname "$script_real_loc")
-
-    LIB_DIR=$(realpath "$script_dir/../lib")
+    LIB_DIR="$PMD_HOME/lib"
   fi
 }
 
@@ -68,15 +88,7 @@ check_lib_dir() {
 
 set_conf_dir() {
   if [ -z "$CONF_DIR" ]; then
-    # Allow for symlinks to this script
-    if [ -L "$0" ]; then
-      script_real_loc=$(readlink "$0")
-    else
-      script_real_loc="$0"
-    fi
-    script_dir=$(dirname "$script_real_loc")
-
-    CONF_DIR=$(realpath "$script_dir/../conf")
+    CONF_DIR="$PMD_HOME/conf"
   fi
 }
 
@@ -92,8 +104,7 @@ script_exit() {
 }
 
 check_java() {
-  java -version >/dev/null 2>&1
-  if [ $? -ne 0 ]; then
+  if ! java -version >/dev/null 2>&1; then
     script_exit "No java executable found in PATH"
   fi
 }
@@ -188,6 +199,7 @@ is_cygwin
 
 check_java
 
+set_pmd_home_dir
 set_lib_dir
 check_lib_dir
 set_conf_dir


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->
Followup on https://github.com/pmd/pmd/pull/5594#issuecomment-2743410777. This makes the pmd launch script compatible with `/bin/sh` by removing bash-specific features. I did this with copilot and shellcheck.

I'm not sure about one change which is `${BASH_SOURCE[0]:-${(%):-%x}}` to `$0`. Shellcheck cannot even parse the expression on the left so I'm not sure what's going on here. And bash also errors with `bad substitution`.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

