### PR TITLE
[core] add IDE agnostic configuration with `editorconfig.org` - `editorconfig-maven-plugin`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+[*]
+charset = utf-8
+# end_of_line = lf
+indent_style = space
+insert_final_newline = true
+max_line_length = 120
+
+[*.java]
+ij_continuation_indent_size = 4
+ij_java_class_count_to_use_import_on_demand = 999
+ij_java_imports_layout = $*, |, java.**, |, javax.**, |, org.**, |, net.**, |, com.**, |, *
+ij_java_names_count_to_use_import_on_demand = 999
+indent_size = 4

--- a/pom.xml
+++ b/pom.xml
@@ -700,6 +700,20 @@
         </pluginManagement>
         <plugins>
             <plugin>
+                <groupId>org.ec4j.maven</groupId>
+                <artifactId>editorconfig-maven-plugin</artifactId>
+                <version>0.1.3</version>
+                <executions>
+                    <execution>
+                        <id>editorconfig</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-enforcer-plugin</artifactId>
                 <executions>


### PR DESCRIPTION
## implement IDE agnostic configuration with `editorconfig.org` - `editorconfig-maven-plugin`

Autofix:  There are .editorconfig violations. You may want to run: `mvn editorconfig:format`

one time fixable / or ignorable end_of_line issues:
```
[ERROR] docs/assets/fontawesome-free-5.15.4-web/webfonts/fa-regular-400.woff2@109,21: Replace 'cr' with 'lf' - violates end_of_line = lf, reported by org.ec4j.linters.TextLinter
[ERROR] docs/css/syntax.css@60,68: Insert lf - violates insert_final_newline = true, reported by org.ec4j.linters.TextLinter
```

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

