### PR TITLE
`LiteralsFirstInComparisonsRule#isConstantString` move redundant if statement

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
@@ -33,13 +33,16 @@ public class LiteralsFirstInComparisonsRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTMethodCall call, Object data) {
-        if (shouldCheckArgs(call)) {
-            checkArgs((RuleContext) data, call);
+        if (shouldVisit(call)
+                && call.getQualifier() != null
+                && !isConstantString(call.getQualifier())
+                && isConstantString(call.getArguments().get(0))) {
+            ((RuleContext) data).addViolation(call);
         }
         return data;
     }
 
-    private boolean shouldCheckArgs(ASTMethodCall call) {
+    private boolean shouldVisit(ASTMethodCall call) {
         return call.getArguments().size() == 1
                 && EQUALS.equals(call.getMethodName())
                 && isEqualsObjectAndNotAnOverload(call)
@@ -52,14 +55,7 @@ public class LiteralsFirstInComparisonsRule extends AbstractJavaRulechainRule {
                 || call.getMethodType().getFormalParameters().equals(listOf(call.getTypeSystem().OBJECT));
     }
 
-    private void checkArgs(RuleContext ctx, ASTMethodCall call) {
-        if (!isConstantString(call.getQualifier()) && isConstantString(call.getArguments().get(0))) {
-            ctx.addViolation(call);
-        }
-    }
-
-    private boolean isConstantString(@Nullable ASTExpression node) {
-        return node != null &&
-                (node instanceof ASTStringLiteral || node.getConstValue() instanceof String);
+    private boolean isConstantString(ASTExpression node) {
+        return node instanceof ASTStringLiteral || node.getConstValue() instanceof String;
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
@@ -53,14 +53,13 @@ public class LiteralsFirstInComparisonsRule extends AbstractJavaRulechainRule {
     }
 
     private void checkArgs(RuleContext ctx, ASTMethodCall call) {
-        @Nullable ASTExpression qualifier = call.getQualifier();
-        if (qualifier != null && !isConstantString(qualifier) && isConstantString(call.getArguments().get(0))) {
+        if (!isConstantString(call.getQualifier()) && isConstantString(call.getArguments().get(0))) {
             ctx.addViolation(call);
         }
     }
 
     private boolean isConstantString(@Nullable ASTExpression node) {
-        return node instanceof ASTStringLiteral
-                || node != null && node.getConstValue() instanceof String;
+        return node != null &&
+                (node instanceof ASTStringLiteral || node.getConstValue() instanceof String);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
@@ -9,8 +9,6 @@ import static net.sourceforge.pmd.util.CollectionUtil.setOf;
 
 import java.util.Set;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
-
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
 import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTStringLiteral;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
@@ -40,9 +40,11 @@ public class LiteralsFirstInComparisonsRule extends AbstractJavaRulechainRule {
     }
 
     private boolean shouldCheckArgs(ASTMethodCall call) {
-        return (EQUALS.equals(call.getMethodName()) && call.getArguments().size() == 1 && isEqualsObjectAndNotAnOverload(call))
-                || (STRING_COMPARISONS.contains(call.getMethodName()) && call.getArguments().size() == 1
-                && TypeTestUtil.isDeclaredInClass(String.class, call.getMethodType()));
+        return call.getArguments().size() == 1
+                && EQUALS.equals(call.getMethodName())
+                && isEqualsObjectAndNotAnOverload(call)
+                || STRING_COMPARISONS.contains(call.getMethodName())
+                && TypeTestUtil.isDeclaredInClass(String.class, call.getMethodType());
     }
 
     private boolean isEqualsObjectAndNotAnOverload(ASTMethodCall call) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
@@ -49,16 +49,14 @@ public class LiteralsFirstInComparisonsRule extends AbstractJavaRulechainRule {
                 || call.getMethodType().getFormalParameters().equals(listOf(call.getTypeSystem().OBJECT));
     }
 
-    private boolean isConstantString(@Nullable ASTExpression node) {
-        return node instanceof ASTStringLiteral
-            || node != null && node.getConstValue() instanceof String;
-    }
-
     private void checkArgs(RuleContext ctx, ASTMethodCall call) {
-        ASTExpression arg = call.getArguments().get(0);
-        @Nullable ASTExpression qualifier = call.getQualifier();
-        if (qualifier != null && !isConstantString(qualifier) && isConstantString(arg)) {
+        if (!isConstantString(call.getQualifier()) && isConstantString(call.getArguments().get(0))) {
             ctx.addViolation(call);
         }
+    }
+
+    private boolean isConstantString(@Nullable ASTExpression node) {
+        return node != null
+                && (node instanceof ASTStringLiteral || node.getConstValue() instanceof String);
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
@@ -25,6 +25,7 @@ public class LiteralsFirstInComparisonsRule extends AbstractJavaRulechainRule {
               "compareTo",
               "compareToIgnoreCase",
               "contentEquals");
+    private static final String EQUALS = "equals";
 
     public LiteralsFirstInComparisonsRule() {
         super(ASTMethodCall.class);
@@ -32,17 +33,18 @@ public class LiteralsFirstInComparisonsRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTMethodCall call, Object data) {
-        if ("equals".equals(call.getMethodName())
-            && call.getArguments().size() == 1
-            && isEqualsObjectAndNotAnOverload(call)) {
-            checkArgs((RuleContext) data, call);
-        } else if (STRING_COMPARISONS.contains(call.getMethodName())
-            && call.getArguments().size() == 1
-            && TypeTestUtil.isDeclaredInClass(String.class, call.getMethodType())) {
+        if (shouldCheckArgs(call)) {
             checkArgs((RuleContext) data, call);
         }
         return data;
     }
+
+    private boolean shouldCheckArgs(ASTMethodCall call) {
+        return (EQUALS.equals(call.getMethodName()) && call.getArguments().size() == 1 && isEqualsObjectAndNotAnOverload(call))
+                || (STRING_COMPARISONS.contains(call.getMethodName()) && call.getArguments().size() == 1
+                && TypeTestUtil.isDeclaredInClass(String.class, call.getMethodType()));
+    }
+
 
     private boolean isEqualsObjectAndNotAnOverload(ASTMethodCall call) {
         return call.getOverloadSelectionInfo().isFailed() // failed selection is considered probably equals(Object)

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
@@ -52,16 +52,15 @@ public class LiteralsFirstInComparisonsRule extends AbstractJavaRulechainRule {
                 || call.getMethodType().getFormalParameters().equals(listOf(call.getTypeSystem().OBJECT));
     }
 
+    private void checkArgs(RuleContext ctx, ASTMethodCall call) {
+        @Nullable ASTExpression qualifier = call.getQualifier();
+        if (qualifier != null && !isConstantString(qualifier) && isConstantString(call.getArguments().get(0))) {
+            ctx.addViolation(call);
+        }
+    }
+
     private boolean isConstantString(@Nullable ASTExpression node) {
         return node instanceof ASTStringLiteral
                 || node != null && node.getConstValue() instanceof String;
-    }
-
-    private void checkArgs(RuleContext ctx, ASTMethodCall call) {
-        ASTExpression arg = call.getArguments().get(0);
-        @Nullable ASTExpression qualifier = call.getQualifier();
-        if (qualifier != null && !isConstantString(qualifier) && isConstantString(arg)) {
-            ctx.addViolation(call);
-        }
     }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
@@ -45,20 +45,21 @@ public class LiteralsFirstInComparisonsRule extends AbstractJavaRulechainRule {
                 && TypeTestUtil.isDeclaredInClass(String.class, call.getMethodType()));
     }
 
-
     private boolean isEqualsObjectAndNotAnOverload(ASTMethodCall call) {
         return call.getOverloadSelectionInfo().isFailed() // failed selection is considered probably equals(Object)
                 || call.getMethodType().getFormalParameters().equals(listOf(call.getTypeSystem().OBJECT));
     }
 
-    private void checkArgs(RuleContext ctx, ASTMethodCall call) {
-        if (!isConstantString(call.getQualifier()) && isConstantString(call.getArguments().get(0))) {
-            ctx.addViolation(call);
-        }
+    private boolean isConstantString(@Nullable ASTExpression node) {
+        return node instanceof ASTStringLiteral
+                || node != null && node.getConstValue() instanceof String;
     }
 
-    private boolean isConstantString(@Nullable ASTExpression node) {
-        return node != null
-                && (node instanceof ASTStringLiteral || node.getConstValue() instanceof String);
+    private void checkArgs(RuleContext ctx, ASTMethodCall call) {
+        ASTExpression arg = call.getArguments().get(0);
+        @Nullable ASTExpression qualifier = call.getQualifier();
+        if (qualifier != null && !isConstantString(qualifier) && isConstantString(arg)) {
+            ctx.addViolation(call);
+        }
     }
 }


### PR DESCRIPTION
## `LiteralsFirstInComparisonsRule#isConstantString` move redundant if statement

move redundant if statement and applied already pretty good functional (clean code) pattern.

## Related issues

https://github.com/pmd/pmd/issues/5590

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

