### PR TITLE
chore: `UnusedPrivateFieldRule` overturn negation `!isEmpty` to method `nonEmpty`

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateFieldRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateFieldRule.java
@@ -7,7 +7,6 @@ package net.sourceforge.pmd.lang.java.rule.bestpractices;
 import java.util.ArrayList;
 import java.util.List;
 
-import net.sourceforge.pmd.lang.ast.NodeStream;
 import net.sourceforge.pmd.lang.java.ast.ASTAnnotation;
 import net.sourceforge.pmd.lang.java.ast.ASTFieldDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTTypeDeclaration;
@@ -75,14 +74,13 @@ public class UnusedPrivateFieldRule extends AbstractJavaRulechainRule {
     }
 
     private boolean hasAnyAnnotation(Annotatable node) {
-        NodeStream<ASTAnnotation> declaredAnnotations = node.getDeclaredAnnotations();
         for (String reportAnnotation : getProperty(REPORT_FOR_ANNOTATIONS_DESCRIPTOR)) {
-            for (ASTAnnotation annotation: declaredAnnotations) {
+            for (ASTAnnotation annotation : node.getDeclaredAnnotations()) {
                 if (TypeTestUtil.isA(reportAnnotation, annotation)) {
                     return false;
                 }
             }
         }
-        return !declaredAnnotations.isEmpty();
+        return node.getDeclaredAnnotations().nonEmpty();
     }
 }


### PR DESCRIPTION
## chore: `UnusedPrivateFieldRule` overturn negation `!isEmpty` to method `nonEmpty`

chore: `UnusedPrivateFieldRule` overturn negation `!isEmpty` to method `nonEmpty`

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

