### PR TITLE
chore: `AccessorClassGenerationRule` separation of concerns

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AccessorClassGenerationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AccessorClassGenerationRule.java
@@ -11,6 +11,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTConstructorCall;
 import net.sourceforge.pmd.lang.java.ast.ASTExplicitConstructorInvocation;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.lang.java.rule.bestpractices.util.AccessorUtil;
 import net.sourceforge.pmd.reporting.RuleContext;
 
 /**
@@ -45,7 +46,7 @@ public class AccessorClassGenerationRule extends AbstractJavaRulechainRule {
     @Override
     public Object visit(ASTConstructorCall node, Object data) {
         if (!node.isAnonymousClass()) {
-            AccessorMethodGenerationRule.checkMemberAccess((RuleContext) data, node, node.getMethodType().getSymbol(), this.reportedNodes);
+            AccessorUtil.checkMemberAccess((RuleContext) data, node, node.getMethodType().getSymbol(), this.reportedNodes);
         }
         return null;
     }
@@ -53,7 +54,7 @@ public class AccessorClassGenerationRule extends AbstractJavaRulechainRule {
     @Override
     public Object visit(ASTExplicitConstructorInvocation node, Object data) {
         if (node.isSuper()) {
-            AccessorMethodGenerationRule.checkMemberAccess((RuleContext) data, node, node.getMethodType().getSymbol(), this.reportedNodes);
+            AccessorUtil.checkMemberAccess((RuleContext) data, node, node.getMethodType().getSymbol(), this.reportedNodes);
         }
         return null;
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AccessorMethodGenerationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AccessorMethodGenerationRule.java
@@ -4,9 +4,7 @@
 
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 
-import java.lang.reflect.Modifier;
 import java.util.HashSet;
-import java.util.Objects;
 import java.util.Set;
 
 import net.sourceforge.pmd.lang.java.ast.ASTExpression;
@@ -15,11 +13,9 @@ import net.sourceforge.pmd.lang.java.ast.ASTMethodCall;
 import net.sourceforge.pmd.lang.java.ast.ASTVariableAccess;
 import net.sourceforge.pmd.lang.java.ast.JavaNode;
 import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+import net.sourceforge.pmd.lang.java.rule.bestpractices.util.AccessorUtil;
 import net.sourceforge.pmd.lang.java.symbols.JAccessibleElementSymbol;
-import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
-import net.sourceforge.pmd.lang.java.symbols.JConstructorSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JFieldSymbol;
-import net.sourceforge.pmd.lang.java.symbols.JMethodSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JVariableSymbol;
 import net.sourceforge.pmd.reporting.RuleContext;
 
@@ -48,57 +44,24 @@ public class AccessorMethodGenerationRule extends AbstractJavaRulechainRule {
 
     @Override
     public Object visit(ASTVariableAccess node, Object data) {
-        JVariableSymbol sym = node.getReferencedSym();
-        if (sym instanceof JFieldSymbol) {
-            JFieldSymbol fieldSym = (JFieldSymbol) sym;
-            if (((JFieldSymbol) sym).getConstValue() == null) {
-                checkMemberAccess((RuleContext) data, node, fieldSym);
-            }
-        }
+        visit(node, (RuleContext) data, node.getReferencedSym());
         return null;
+    }
+
+    private void visit(ASTVariableAccess node, RuleContext data, JVariableSymbol sym) {
+        if (sym instanceof JFieldSymbol && ((JFieldSymbol) sym).getConstValue() == null) {
+            checkMemberAccess(data, node, (JFieldSymbol) sym);
+        }
     }
 
     @Override
     public Object visit(ASTMethodCall node, Object data) {
-        JMethodSymbol symbol = (JMethodSymbol) node.getMethodType().getSymbol();
-        checkMemberAccess((RuleContext) data, node, symbol);
+        checkMemberAccess((RuleContext) data, node, node.getMethodType().getSymbol());
         return null;
     }
 
     private void checkMemberAccess(RuleContext data, ASTExpression node, JAccessibleElementSymbol symbol) {
-        checkMemberAccess(data, node, symbol, this.reportedNodes);
+        AccessorUtil.checkMemberAccess(data, node, symbol, reportedNodes);
     }
 
-    static void checkMemberAccess(RuleContext ruleContext, JavaNode refExpr, JAccessibleElementSymbol sym, Set<JavaNode> reportedNodes) {
-        if (Modifier.isPrivate(sym.getModifiers())
-            && !Objects.equals(sym.getEnclosingClass(),
-                               refExpr.getEnclosingType().getSymbol())) {
-
-            JavaNode node = sym.tryGetNode();
-            if (node == null && JConstructorSymbol.CTOR_NAME.equals(sym.getSimpleName())) {
-                // might be a default constructor, implicitly defined and not explicitly in the compilation unit
-                node = sym.getEnclosingClass().tryGetNode();
-            }
-            assert node != null : "Node should be in the same compilation unit";
-            if (reportedNodes.add(node)) {
-                ruleContext.addViolation(node, stripPackageName(refExpr.getEnclosingType().getSymbol()));
-            }
-        }
-    }
-
-    /**
-     * Returns the canonical name without the package name. Eg for a
-     * canonical name {@code com.github.Outer.Inner}, returns {@code Outer.Inner}.
-     */
-    private static String stripPackageName(JClassSymbol symbol) {
-        String p = symbol.getPackageName();
-        String canoName = symbol.getCanonicalName();
-        if (canoName == null) {
-            return symbol.getSimpleName();
-        }
-        if (p.isEmpty()) {
-            return canoName;
-        }
-        return canoName.substring(p.length() + 1); //+1 for the dot
-    }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/util/AccessorUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/util/AccessorUtil.java
@@ -1,0 +1,52 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.bestpractices.util;
+
+import java.lang.reflect.Modifier;
+import java.util.Objects;
+import java.util.Set;
+
+import net.sourceforge.pmd.lang.java.ast.JavaNode;
+import net.sourceforge.pmd.lang.java.symbols.JAccessibleElementSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
+import net.sourceforge.pmd.lang.java.symbols.JConstructorSymbol;
+import net.sourceforge.pmd.reporting.RuleContext;
+
+public interface AccessorUtil {
+
+    static void checkMemberAccess(RuleContext ruleContext, JavaNode refExpr, JAccessibleElementSymbol sym,
+                                  Set<JavaNode> reportedNodes) {
+        if (Modifier.isPrivate(sym.getModifiers())
+            && !Objects.equals(sym.getEnclosingClass(),
+            refExpr.getEnclosingType().getSymbol())) {
+
+            JavaNode node = sym.tryGetNode();
+            if (node == null && JConstructorSymbol.CTOR_NAME.equals(sym.getSimpleName())) {
+                // might be a default constructor, implicitly defined and not explicitly in the compilation unit
+                node = sym.getEnclosingClass().tryGetNode();
+            }
+            assert node != null : "Node should be in the same compilation unit";
+            if (reportedNodes.add(node)) {
+                ruleContext.addViolation(node, canonicalNameWithoutPackage(refExpr.getEnclosingType().getSymbol()));
+            }
+        }
+    }
+
+    /**
+     * Returns the canonical name without the package name.
+     * Eg for a canonical name {@code com.github.Outer.Inner}, returns {@code Outer.Inner}.
+     */
+    static String canonicalNameWithoutPackage(JClassSymbol symbol) {
+        return canonicalNameWithoutPackage(symbol, symbol.getCanonicalName());
+    }
+
+    static String canonicalNameWithoutPackage(JClassSymbol symbol, String canoName) {
+        return canoName == null
+            ? symbol.getSimpleName()
+            : symbol.getPackageName().isEmpty()
+            ? canoName
+            : canoName.substring(symbol.getPackageName().length() + 1); //+1 for the dot
+    }
+}


### PR DESCRIPTION
## [SOC: AccessorMethodGenerationRule](chore: `AccessorClassGenerationRule` separation of concerns)

chore: `AccessorClassGenerationRule` separation of concerns

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

