### PR TITLE
[java] Cleanup `AccessorClassGenerationRule` implementation

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AccessorMethodGenerationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AccessorMethodGenerationRule.java
@@ -48,9 +48,9 @@ public class AccessorMethodGenerationRule extends AbstractJavaRulechainRule {
         return null;
     }
 
-    private void checkMemberAccessIfConstValueIsNull(JavaNode node, RuleContext data, JVariableSymbol sym) {
+    private void checkMemberAccessIfConstValueIsNull(ASTExpression node, RuleContext data, JVariableSymbol sym) {
         if (sym instanceof JFieldSymbol && ((JFieldSymbol) sym).getConstValue() == null) {
-            checkMemberAccess(data, (ASTExpression) node, (JFieldSymbol) sym);
+            checkMemberAccess(data, node, (JFieldSymbol) sym);
         }
     }
 


### PR DESCRIPTION
## chore: Merge If Statement `instanceof JFieldSymbol` in `AccessorClassGenerationRule`

The current implementation performs 90% of the same logic, except for data transformation or type casting. However, instead of using a centralized approach, it follows a duplicated approach, which breaks the design by violating:

- **Feature Envy**  
- **Single Responsibility Principle (SRP)**  
- **Separation of Concerns (SoC)**  

### Suggested Fix  
- Refactor redundant `if` statements into a centralized method.  
- Apply the **Don't Repeat Yourself (DRY)** principle.  
- Ensure clear separation of concerns to enhance maintainability.  

`Since this is core business logic, it's important and should be centralized. Having the same logic in two places is one too many in this case, in my opinion.`

<img width="1690" alt="image" src="https://github.com/user-attachments/assets/776654c7-0ad3-4593-b166-6fbea52ab5f5" />

## Related issues

[<!-- PR relates to issues in the `pmd` repo: -->](https://github.com/pmd/pmd/pull/5620)

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

