### PR TITLE
[doc] Fix its/it's and doable/double typos

### DIFF
--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/AvoidGlobalModifier.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/AvoidGlobalModifier.xml
@@ -55,7 +55,7 @@ global class Foo {
     </test-code>
 
     <test-code>
-        <description>#1348 [apex] AvoidGlobalModifierRule gives warning even when its a REST webservice - false positive</description>
+        <description>#1348 [apex] AvoidGlobalModifierRule gives warning even when it's a REST webservice - false positive</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 @RestResource(urlMapping = '/partners/submit/*')
@@ -68,7 +68,7 @@ global class Generic_LoanCreation {
     </test-code>
 
     <test-code>
-        <description>#1348 [apex] AvoidGlobalModifierRule gives warning even when its a SOAP webservice - false positive</description>
+        <description>#1348 [apex] AvoidGlobalModifierRule gives warning even when it's a SOAP webservice - false positive</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 global class Generic_LoanCreation {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/AbstractConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/AbstractConfiguration.java
@@ -176,7 +176,7 @@ public abstract class AbstractConfiguration {
     }
 
     /**
-     * Set the given LanguageVersion as the current default for it's Language.
+     * Set the given LanguageVersion as the current default for its Language.
      *
      * @param languageVersion the LanguageVersion
      */
@@ -253,7 +253,7 @@ public abstract class AbstractConfiguration {
      */
     public void addRelativizeRoot(Path path) {
         // Note: the given path is not further modified or resolved. E.g. there is no special handling for symlinks.
-        // The goal is, that if the user inputs a path, PMD should output in terms of that path, not it's resolution.
+        // The goal is, that if the user inputs a path, PMD should output in terms of that path, not its resolution.
         this.relativizeRoots.add(Objects.requireNonNull(path));
 
         if (Files.isRegularFile(path)) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimeTracker.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/benchmark/TimeTracker.java
@@ -80,7 +80,7 @@ public final class TimeTracker {
     }
 
     /**
-     * Initialize a thread, starting to track it's own time.
+     * Initialize a thread, starting to track its own time.
      */
     public static void initThread() {
         if (!trackTime) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/RawFileFingerprinter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/RawFileFingerprinter.java
@@ -41,7 +41,7 @@ public class RawFileFingerprinter implements ClasspathEntryFingerprinter {
     @Override
     public void fingerprint(URL entry, Checksum checksum) throws IOException {
         try (CheckedInputStream inputStream = new CheckedInputStream(entry.openStream(), checksum)) {
-            // Just read it, the CheckedInputStream will update the checksum on it's own
+            // Just read it, the CheckedInputStream will update the checksum on its own
             while (IOUtil.skipFully(inputStream, Long.MAX_VALUE) == Long.MAX_VALUE) {
                 // just loop
             }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageVersionDiscoverer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageVersionDiscoverer.java
@@ -48,7 +48,7 @@ public class LanguageVersionDiscoverer {
     }
 
     /**
-     * Set the given LanguageVersion as the current default for it's Language.
+     * Set the given LanguageVersion as the current default for its Language.
      *
      * @param languageVersion
      *            The new default for the Language.

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleSetFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleSetFactory.java
@@ -491,7 +491,7 @@ final class RuleSetFactory {
 
     /**
      * Parse a rule node as a RuleReference. A RuleReference is a single Rule
-     * which comes from another RuleSet with some of it's attributes potentially
+     * which comes from another RuleSet with some of its attributes potentially
      * overridden.
      *
      * @param ruleSetReferenceId           The RuleSetReferenceId of the RuleSet being parsed.

--- a/pmd-doc/src/test/resources/expected/java.md
+++ b/pmd-doc/src/test/resources/expected/java.md
@@ -13,7 +13,7 @@ editmepath: false
 {% include callout.html content="Sample ruleset to test rule doc generation.  Here might be &lt;script&gt;alert('XSS');&lt;/script&gt; as well. And &quot;quotes&quot;.  Inside CDATA &lt;script&gt;alert('XSS');&lt;/script&gt;." %}
 
 *   [DeprecatedSample](pmd_rules_java_sample.html#deprecatedsample): <span style="border-radius: 0.25em; color: #fff; padding: 0.2em 0.6em 0.3em; display: inline; background-color: #d9534f; font-size: 75%;">Deprecated</span> Just some description of a deprecated rule. RuleTag with quotes: Use {% rule "RenamedRule" %} ins...
-*   [JumbledIncrementer](pmd_rules_java_sample.html#jumbledincrementer): Avoid jumbled loop incrementers - its usually a mistake, and is confusing even if intentional.
+*   [JumbledIncrementer](pmd_rules_java_sample.html#jumbledincrementer): Avoid jumbled loop incrementers - it's usually a mistake, and is confusing even if intentional.
 *   [MovedRule](pmd_rules_java_sample.html#movedrule): <span style="border-radius: 0.25em; color: #fff; padding: 0.2em 0.6em 0.3em; display: inline; background-color: #d9534f; font-size: 75%;">Deprecated</span> The rule has been moved to another ruleset. Use instead [JumbledIncrementer](pmd_rules_java_sample2.html#jumbledincrementer).
 *   [OverrideBothEqualsAndHashcode](pmd_rules_java_sample.html#overridebothequalsandhashcode): Override both 'public boolean Object.equals(Object other)', and 'public int Object.hashCode()', o...
 *   [RenamedRule1](pmd_rules_java_sample.html#renamedrule1): <span style="border-radius: 0.25em; color: #fff; padding: 0.2em 0.6em 0.3em; display: inline; background-color: #d9534f; font-size: 75%;">Deprecated</span> The rule has been renamed. Use instead [JumbledIncrementer](pmd_rules_java_sample.html#jumbledincrementer).

--- a/pmd-doc/src/test/resources/expected/sample.md
+++ b/pmd-doc/src/test/resources/expected/sample.md
@@ -43,7 +43,7 @@ RuleTag with full category and without quotes: Use {% rule java/sample/RenamedRu
 
 **Priority:** Medium (3)
 
-Avoid jumbled loop incrementers - its usually a mistake, and is confusing even if intentional.
+Avoid jumbled loop incrementers - it's usually a mistake, and is confusing even if intentional.
 
 **This rule is defined by the following XPath expression:**
 ``` xpath
@@ -116,7 +116,7 @@ The rule has been moved to another ruleset. Use instead: [JumbledIncrementer](pm
 
 **Priority:** Medium (3)
 
-Avoid jumbled loop incrementers - its usually a mistake, and is confusing even if intentional.
+Avoid jumbled loop incrementers - it's usually a mistake, and is confusing even if intentional.
 
 **This rule is defined by the following XPath expression:**
 ``` xpath
@@ -216,7 +216,7 @@ This rule has been renamed. Use instead: [JumbledIncrementer](#jumbledincremente
 
 **Priority:** Medium (3)
 
-Avoid jumbled loop incrementers - its usually a mistake, and is confusing even if intentional.
+Avoid jumbled loop incrementers - it's usually a mistake, and is confusing even if intentional.
 
 **This rule is defined by the following XPath expression:**
 ``` xpath
@@ -289,7 +289,7 @@ This rule has been renamed. Use instead: [JumbledIncrementer](#jumbledincremente
 
 **Priority:** Medium (3)
 
-Avoid jumbled loop incrementers - its usually a mistake, and is confusing even if intentional.
+Avoid jumbled loop incrementers - it's usually a mistake, and is confusing even if intentional.
 
 **This rule is defined by the following XPath expression:**
 ``` xpath
@@ -364,7 +364,7 @@ This rule has been renamed. Use instead: [JumbledIncrementer](#jumbledincremente
 
 **Priority:** Medium (3)
 
-Avoid jumbled loop incrementers - its usually a mistake, and is confusing even if intentional.
+Avoid jumbled loop incrementers - it's usually a mistake, and is confusing even if intentional.
 
 **This rule is defined by the following XPath expression:**
 ``` xpath
@@ -439,7 +439,7 @@ This rule has been renamed. Use instead: [JumbledIncrementer](#jumbledincremente
 
 **Priority:** Medium (3)
 
-Avoid jumbled loop incrementers - its usually a mistake, and is confusing even if intentional.
+Avoid jumbled loop incrementers - it's usually a mistake, and is confusing even if intentional.
 
 **This rule is defined by the following XPath expression:**
 ``` xpath

--- a/pmd-doc/src/test/resources/rulesets/ruledoctest/sample.xml
+++ b/pmd-doc/src/test/resources/rulesets/ruledoctest/sample.xml
@@ -142,7 +142,7 @@ public class Foo {
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_sample.html#jumbledincrementer">
      <description>
-Avoid jumbled loop incrementers - its usually a mistake, and is confusing even if intentional.
+Avoid jumbled loop incrementers - it's usually a mistake, and is confusing even if intentional.
      </description>
      <priority>3</priority>
      <properties>

--- a/pmd-doc/src/test/resources/rulesets/ruledoctest/sample2.xml
+++ b/pmd-doc/src/test/resources/rulesets/ruledoctest/sample2.xml
@@ -15,7 +15,7 @@ Sample ruleset to test rule doc generation.
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_sample.html#jumbledincrementer">
      <description>
-Avoid jumbled loop incrementers - its usually a mistake, and is confusing even if intentional.
+Avoid jumbled loop incrementers - it's usually a mistake, and is confusing even if intentional.
      </description>
      <priority>3</priority>
      <properties>

--- a/pmd-java/src/main/resources/category/java/multithreading.xml
+++ b/pmd-java/src/main/resources/category/java/multithreading.xml
@@ -432,7 +432,7 @@ public class ConcurrentApp {
           externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_multithreading.html#usenotifyallinsteadofnotify">
         <description>
 Thread.notify() awakens a thread monitoring the object. If more than one thread is monitoring, then only
-one is chosen.  The thread chosen is arbitrary; thus its usually safer to call notifyAll() instead.
+one is chosen.  The thread chosen is arbitrary; thus it's usually safer to call notifyAll() instead.
         </description>
         <priority>3</priority>
         <properties>

--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -549,7 +549,7 @@ public class C {
     long l      = 0;
 
     float f     = .0f;    // all possible float literals
-    doable d    = 0d;     // all possible double literals
+    double d    = 0d;     // all possible double literals
     Object o    = null;
 
     MyClass mca[] = null;

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ant/classpathtest/ruleset.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ant/classpathtest/ruleset.xml
@@ -15,7 +15,7 @@ The Basic ruleset contains a collection of good practices which should be follow
           class="net.sourceforge.pmd.lang.rule.xpath.XPathRule"
           externalInfoUrl="${pmd.website.baseurl}/rules/java/basic.html#JumbledIncrementer">
      <description>
-Avoid jumbled loop incrementers - its usually a mistake, and is confusing even if intentional.
+Avoid jumbled loop incrementers - it's usually a mistake, and is confusing even if intentional.
      </description>
      <priority>3</priority>
      <properties>

--- a/pmd-velocity/src/main/javacc/Vtl.jjt
+++ b/pmd-velocity/src/main/javacc/Vtl.jjt
@@ -18,7 +18,7 @@
  */
 
 /*
- *  NOTE : please see documentation at bottom of this file. (It was placed there its tiring
+ *  NOTE : please see documentation at bottom of this file. (It was placed there it's tiring
  *    to always have to page past it... :)
  */
 options
@@ -415,7 +415,7 @@ TOKEN:
 
 
 /*
- * needed because #set is so wacky in it's desired behavior.  We want set
+ * needed because #set is so wacky in its desired behavior.  We want set
  * to eat any preceding whitespace so it is invisible in formatting.
  * (As it should be.)  If this works well, I am going to chuck the whole MORE:
  * token abomination.

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/DataType.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/DataType.java
@@ -50,7 +50,7 @@ public enum DataType {
     Time(false, "Time"),
     Url(false),
     /**
-     * Indicates that Metatada was found, but it's type was not mappable. This could because it is a type which isn't
+     * Indicates that Metatada was found, but its type was not mappable. This could because it is a type which isn't
      * mapped, or it was an edge case where the type was ambiguously defined in the Metadata.
      */
     Unknown(true);


### PR DESCRIPTION
## Describe the PR

I noticed a mistaken "its" when it should be "it's" in a rule description, and also "doable" when it was supposed to be double.  Decided to poke around more broadly and fix all instances I could find

## Related issues

N/A

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)
