### PR TITLE
Fix #5448: [ci] Maintain public Docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,14 @@ jobs:
         ( [ -e .ci/$f ] || curl -sSL "${PMD_CI_SCRIPTS_URL}/$f" > ".ci/$f" ) && \
         chmod 755 .ci/$f && \
         .ci/$f
+    - uses: actions/create-github-app-token@v2
+      id: pmd-actions-helper-app-token
+      with:
+        app-id: ${{ secrets.PMD_ACTIONS_HELPER_ID }}
+        private-key: ${{ secrets.PMD_ACTIONS_HELPER_PRIVATE_KEY }}
+        owner: ${{ github.repository_owner }}
+        repositories: docker
+        permission-actions: write
     - name: Build
       run: .ci/build.sh
       shell: bash
@@ -76,6 +84,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         PMD_CI_GPG_PRIVATE_KEY: ${{ secrets.PMD_CI_GPG_PRIVATE_KEY }}
         MAVEN_GPG_PASSPHRASE: ${{ secrets.PMD_CI_GPG_PASSPHRASE }}
+        PMD_ACTIONS_HELPER_TOKEN: ${{ steps.pmd-actions-helper-app-token.outputs.token }}
     - name: Workaround actions/upload-artifact#176
       run: |
         echo "artifacts_path=$(realpath ..)" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](code_of_conduct.md) 
 [![Documentation (latest)](https://img.shields.io/badge/docs-latest-green)](https://docs.pmd-code.org/latest/)
 [![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20PMD%20Guru-006BFF)](https://gurubase.io/g/pmd)
+[![Docker Image Version](https://img.shields.io/docker/v/pmdcode/pmd?sort=semver&label=Docker)](https://hub.docker.com/r/pmdcode/pmd)
 
 **PMD** is an extensible multilanguage static code analyzer. It finds common programming flaws like unused variables,
 empty catch blocks, unnecessary object creation, and so forth. It's mainly concerned with **Java and

--- a/do-release.sh
+++ b/do-release.sh
@@ -337,6 +337,7 @@ echo "  * <https://repo.maven.apache.org/maven2/net/sourceforge/pmd/pmd-core/${R
 echo "  * <https://repo.maven.apache.org/maven2/net/sourceforge/pmd/pmd-java/${RELEASE_VERSION}/>"
 echo "  * <https://repo.maven.apache.org/maven2/net/sourceforge/pmd/pmd-designer/${RELEASE_VERSION}/>"
 echo "* Regression Tester baseline has been created: <https://pmd-code.org/pmd-regression-tester/>"
+echo "* Docker images have been created: <https://hub.docker.com/r/pmdcode/pmd> / <https://github.com/pmd/docker/pkgs/container/pmd>"
 echo
 echo "*   Send out an announcement mail to the mailing list:"
 echo

--- a/docs/pages/pmd/projectdocs/committers/releasing.md
+++ b/docs/pages/pmd/projectdocs/committers/releasing.md
@@ -2,7 +2,7 @@
 title: Release process
 permalink: pmd_projectdocs_committers_releasing.html
 author: Romain Pelisse <rpelisse@users.sourceforge.net>, Andreas Dangel <andreas.dangel@pmd-code.org>
-last_updated: July 2024 (7.5.0)
+last_updated: April 2025 (7.13.0)
 ---
 
 This page describes the current status of the release process.
@@ -267,6 +267,8 @@ perform the following steps:
     selected as the new default for PMD.
 *   As a last step, a new baseline for the [regression tester](https://github.com/pmd/pmd-regression-tester)
     is created and uploaded to <https://pmd-code.org/pmd-regression-tester>.
+*   After that, the workflow in <https://github.com/pmd/docker/actions/workflows/publish-docker-image.yaml>
+    is triggered to create and publish a new docker image for the new PMD version.
 
 Once this second GitHub Action run is done, you can spread additional news:
 
@@ -291,22 +293,23 @@ Tweet on <https://twitter.com/pmd_analyzer>, eg.:
 
 ### Checklist
 
-| Task              | Description                                                                          | URL                                                             | ☐ / ✔                   |
-|-------------------|--------------------------------------------------------------------------------------|-----------------------------------------------------------------|-------------------------|
-| maven central     | The new version of all artifacts are available in maven central                      | <https://repo.maven.apache.org/maven2/net/sourceforge/pmd/pmd/> | <input type="checkbox"> |
-| github releases   | A new release with 3 assets (bin, src, doc) is created                               | <https://github.com/pmd/pmd/releases>                           | <input type="checkbox"> |
-| sourceforge files | The 3 assets (bin, src, doc) are uploaded, the new version is pre-selected as latest | <https://sourceforge.net/projects/pmd/files/pmd/>               | <input type="checkbox"> |
-| homepage          | Main landing page points to new version, doc for new version is available            | <https://pmd.github.io>                                         | <input type="checkbox"> |
-| homepage2         | New blogpost for the new release is posted                                           | <https://pmd.github.io/#news>                                   | <input type="checkbox"> |
-| docs              | New docs are uploaded                                                                | <https://docs.pmd-code.org/latest/>                             | <input type="checkbox"> |
-| docs2             | New version in the docs is listed under "Version specific documentation"             | <https://docs.pmd-code.org/>                                    | <input type="checkbox"> |
-| docs-archive      | New docs are also on archive site                                                    | <https://pmd.sourceforge.io/archive.phtml>                      | <input type="checkbox"> |
-| javadoc           | New javadocs are uploaded                                                            | <https://docs.pmd-code.org/apidocs/>                            | <input type="checkbox"> |
-| news              | New blogpost on sourceforge is posted                                                | <https://sourceforge.net/p/pmd/news/>                           | <input type="checkbox"> |
-| regression-tester | New release baseline is uploaded                                                     | <https://pmd-code.org/pmd-regression-tester>                    | <input type="checkbox"> |
-| mailing list      | announcement on mailing list is sent                                                 | <https://sourceforge.net/p/pmd/mailman/pmd-devel/>              | <input type="checkbox"> |
-| twitter           | tweet about the new release                                                          | <https://twitter.com/pmd_analyzer>                              | <input type="checkbox"> |
-| gitter            | message about the new release                                                        | <https://matrix.to/#/#pmd_pmd:gitter.im>                        | <input type="checkbox"> |
+| Task              | Description                                                                          | URL                                                                                         | ☐ / ✔                   |
+|-------------------|--------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|-------------------------|
+| maven central     | The new version of all artifacts are available in maven central                      | <https://repo.maven.apache.org/maven2/net/sourceforge/pmd/pmd/>                             | <input type="checkbox"> |
+| github releases   | A new release with 3 assets (bin, src, doc) is created                               | <https://github.com/pmd/pmd/releases>                                                       | <input type="checkbox"> |
+| sourceforge files | The 3 assets (bin, src, doc) are uploaded, the new version is pre-selected as latest | <https://sourceforge.net/projects/pmd/files/pmd/>                                           | <input type="checkbox"> |
+| docker image      | New docker images are available                                                      | <https://hub.docker.com/r/pmdcode/pmd> / <https://github.com/pmd/docker/pkgs/container/pmd> | <input type="checkbox"> |
+| homepage          | Main landing page points to new version, doc for new version is available            | <https://pmd.github.io>                                                                     | <input type="checkbox"> |
+| homepage2         | New blogpost for the new release is posted                                           | <https://pmd.github.io/#news>                                                               | <input type="checkbox"> |
+| docs              | New docs are uploaded                                                                | <https://docs.pmd-code.org/latest/>                                                         | <input type="checkbox"> |
+| docs2             | New version in the docs is listed under "Version specific documentation"             | <https://docs.pmd-code.org/>                                                                | <input type="checkbox"> |
+| docs-archive      | New docs are also on archive site                                                    | <https://pmd.sourceforge.io/archive.phtml>                                                  | <input type="checkbox"> |
+| javadoc           | New javadocs are uploaded                                                            | <https://docs.pmd-code.org/apidocs/>                                                        | <input type="checkbox"> |
+| news              | New blogpost on sourceforge is posted                                                | <https://sourceforge.net/p/pmd/news/>                                                       | <input type="checkbox"> |
+| regression-tester | New release baseline is uploaded                                                     | <https://pmd-code.org/pmd-regression-tester>                                                | <input type="checkbox"> |
+| mailing list      | announcement on mailing list is sent                                                 | <https://sourceforge.net/p/pmd/mailman/pmd-devel/>                                          | <input type="checkbox"> |
+| twitter           | tweet about the new release                                                          | <https://twitter.com/pmd_analyzer>                                                          | <input type="checkbox"> |
+| gitter            | message about the new release                                                        | <https://matrix.to/#/#pmd_pmd:gitter.im>                                                    | <input type="checkbox"> |
 
 ## Prepare the next release
 

--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -14,8 +14,22 @@ This is a {{ site.pmd.release_type }} release.
 
 ### 🚀 New and noteworthy
 
+#### Docker images
+
+PMD is now providing official docker images at <https://hub.docker.com/r/pmdcode/pmd> and
+<https://github.com/pmd/docker/pkgs/container/pmd>.
+
+You can now analyze your code with PMD by using docker like so: 
+
+```
+docker run --rm --tty -v $PWD:/src pmdcode/pmd:latest check -d . -R rulesets/java/quickstart.xml`
+```
+
+More information is available at <https://github.com/pmd/docker>.
+
 ### 🐛 Fixed Issues
 * core
+  * [#5448](https://github.com/pmd/pmd/issues/5448): Maintain a public PMD docker image
   * [#5623](https://github.com/pmd/pmd/issues/5623): \[dist] Make pmd launch script compatible with /bin/sh
 * java
   * [#5645](https://github.com/pmd/pmd/issues/5645): \[java] Parse error on switch with yield


### PR DESCRIPTION
## Describe the PR

- This enhances the current release workflow to also trigger the workflow in https://github.com/pmd/docker to create a new image
- This is a workflow in a different repository, so GitHub Actions permissions are bit different. In order to make this (hopefully) work, I created a new custom GitHub App in our organization (https://github.com/pmd) and installed it. This GitHub App is named "PMD Actions Helper" and for now has the only permission to trigger workflows in any of our repositories (permission: actions=write).
- This app installation is used to request a new installation access token when the release workflow is run and this token is used to execute workflow dispatch API call (https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event )
- The app id and private key are configured as organization wide secrets


## Related issues

- Fix #5448 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

