### PR TITLE
Fix #5667: [apex] ApexUnitTestShouldNotUseSeeAllDataTrue false negative when seeAllDate parameter is a string

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestShouldNotUseSeeAllDataTrueRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestShouldNotUseSeeAllDataTrueRule.java
@@ -45,8 +45,8 @@ public class ApexUnitTestShouldNotUseSeeAllDataTrueRule extends AbstractApexUnit
 
         if (modifierNode != null) {
             for (ASTAnnotationParameter parameter : modifierNode.descendants(ASTAnnotationParameter.class)) {
-                if (parameter.hasName(ASTAnnotationParameter.SEE_ALL_DATA) &&
-                        (parameter.getBooleanValue() || "true".equalsIgnoreCase(parameter.getValue()))) {
+                if (parameter.hasName(ASTAnnotationParameter.SEE_ALL_DATA)
+                        && (parameter.getBooleanValue() || "true".equalsIgnoreCase(parameter.getValue()))) {
                     asCtx(data).addViolation(node);
                     return data;
                 }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestShouldNotUseSeeAllDataTrueRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestShouldNotUseSeeAllDataTrueRule.java
@@ -45,11 +45,10 @@ public class ApexUnitTestShouldNotUseSeeAllDataTrueRule extends AbstractApexUnit
 
         if (modifierNode != null) {
             for (ASTAnnotationParameter parameter : modifierNode.descendants(ASTAnnotationParameter.class)) {
-                if (parameter.hasName(ASTAnnotationParameter.SEE_ALL_DATA)) {
-                    if (parameter.getBooleanValue() || "true".equalsIgnoreCase(parameter.getValue())) {
-                        asCtx(data).addViolation(node);
-                        return data;
-                    }
+                if (parameter.hasName(ASTAnnotationParameter.SEE_ALL_DATA) &&
+                        (parameter.getBooleanValue() || "true".equalsIgnoreCase(parameter.getValue()))) {
+                    asCtx(data).addViolation(node);
+                    return data;
                 }
             }
         }

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestShouldNotUseSeeAllDataTrueRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/ApexUnitTestShouldNotUseSeeAllDataTrueRule.java
@@ -45,13 +45,16 @@ public class ApexUnitTestShouldNotUseSeeAllDataTrueRule extends AbstractApexUnit
 
         if (modifierNode != null) {
             for (ASTAnnotationParameter parameter : modifierNode.descendants(ASTAnnotationParameter.class)) {
-                if (parameter.hasName(ASTAnnotationParameter.SEE_ALL_DATA) && parameter.getBooleanValue()) {
-                    asCtx(data).addViolation(node);
-                    return data;
+                if (parameter.hasName(ASTAnnotationParameter.SEE_ALL_DATA)) {
+                    if (parameter.getBooleanValue() || "true".equalsIgnoreCase(parameter.getValue())) {
+                        asCtx(data).addViolation(node);
+                        return data;
+                    }
                 }
             }
         }
 
         return data;
     }
+
 }

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/ApexUnitTestShouldNotUseSeeAllDataTrue.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/bestpractices/xml/ApexUnitTestShouldNotUseSeeAllDataTrue.xml
@@ -34,7 +34,7 @@ public class Foo {
 }
         ]]></code>
     </test-code>
-    
+
     <test-code>
         <description>[apex] ApexUnitTestShouldNotUseSeeAllDataTrue false negative due to casing (regression in PMD 7) #5095</description>
         <expected-problems>9</expected-problems>
@@ -80,6 +80,22 @@ public class SomeTest {
 
     @isTest(seeAllData=True)
     public static void testMethod8() {
+        System.assertEquals(1 + 2, 3);
+    }
+}
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[apex] ApexUnitTestShouldNotUseSeeAllDataTrue seeAllData boolean enclosed in quote #5667</description>
+        <expected-problems>2</expected-problems>
+        <expected-linenumbers>2,5</expected-linenumbers>
+        <code><![CDATA[
+@isTest(SeeAllData = 'true')
+public class SomeTest {
+
+    @IsTest(SeeAllData=true)
+    public static void testMethod1() {
         System.assertEquals(1 + 2, 3);
     }
 }


### PR DESCRIPTION
## Describe the PR

- Updated ApexUnitTestShouldNotUseSeeAllDataTrueRule.java to check for SEE_ALL_DATA parameter value being true.
- Added a new test case in `ApexUnitTestShouldNotUseSeeAllDataTrue.xml` to validate the updated rule.

## Related issues

- Fix #5667

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

