### PR TITLE
UnusedPrivateMethodRule: exclude serialization method readObjectNoData()

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
@@ -37,7 +37,7 @@ import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 public class UnusedPrivateMethodRule extends AbstractIgnoredAnnotationRule {
 
     private static final Set<String> SERIALIZATION_METHODS =
-        setOf("readObject", "writeObject", "readResolve", "writeReplace");
+        setOf("readObject", "readObjectNoData", "writeObject", "readResolve", "writeReplace");
 
     @Override
     protected Collection<String> defaultSuppressionAnnotations() {


### PR DESCRIPTION
UnusedPrivateMethodRule should exclude readObjectNoData() which is defined at https://docs.oracle.com/en/java/javase/11/docs/specs/serialization/input.html#the-readobjectnodata-method

## Describe the PR

UnusedPrivateMethodRule's list of serialization methods is missing readObjectNoData() which should be excluded as well.

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)