### PR TITLE
[java] Fix Double Literal for Java19+ compatibility

### DIFF
--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/jdkversiontests/java14/YieldStatements.java
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/jdkversiontests/java14/YieldStatements.java
@@ -47,7 +47,7 @@ public class YieldStatements {
             yield 004;
             yield 2e74;
             yield 0b01;
-            yield 0x4P60;
+            yield 0x4P61;
             yield new Object();
             yield (new Object());
             yield switch(foo) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/jdkversiontests/java14/YieldStatements.txt
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/ast/jdkversiontests/java14/YieldStatements.txt
@@ -137,7 +137,7 @@
                               +- YieldStatement[]
                               |  +- NumericLiteral[@Base = 2, @CompileTimeConstant = true, @DoubleLiteral = false, @FloatLiteral = false, @Image = "0b01", @IntLiteral = true, @Integral = true, @LiteralText = "0b01", @LongLiteral = false, @ParenthesisDepth = 0, @Parenthesized = false, @ValueAsDouble = 1.0, @ValueAsFloat = 1.0, @ValueAsInt = 1, @ValueAsLong = 1]
                               +- YieldStatement[]
-                              |  +- NumericLiteral[@Base = 16, @CompileTimeConstant = true, @DoubleLiteral = true, @FloatLiteral = false, @Image = "0x4P60", @IntLiteral = false, @Integral = false, @LiteralText = "0x4P60", @LongLiteral = false, @ParenthesisDepth = 0, @Parenthesized = false, @ValueAsDouble = 4.6116860184273879E18, @ValueAsFloat = 4.611686E18, @ValueAsInt = 0, @ValueAsLong = 4611686018427387904]
+                              |  +- NumericLiteral[@Base = 16, @CompileTimeConstant = true, @DoubleLiteral = true, @FloatLiteral = false, @Image = "0x4P61", @IntLiteral = false, @Integral = false, @LiteralText = "0x4P61", @LongLiteral = false, @ParenthesisDepth = 0, @Parenthesized = false, @ValueAsDouble = 9.223372036854776E18, @ValueAsFloat = 9.223372E18, @ValueAsInt = -1, @ValueAsLong = 9223372036854775807]
                               +- YieldStatement[]
                               |  +- ConstructorCall[@AnonymousClass = false, @CompileTimeConstant = false, @DiamondTypeArgs = false, @MethodName = "new", @ParenthesisDepth = 0, @Parenthesized = false, @QualifiedInstanceCreation = false]
                               |     +- ClassType[@FullyQualified = false, @PackageQualifier = null, @SimpleName = "Object"]


### PR DESCRIPTION
## Describe the PR
Seems the value `0x4P60` also hits the bug, that was fixed in Java 19.

See #4401, https://bugs.openjdk.org/browse/JDK-4511638, https://bugs.openjdk.org/browse/JDK-8291475 and https://inside.java/2022/09/23/quality-heads-up/

We now use "0x4P61", which doesn't hit this bug...

## Related issues

- Refs #4401 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

