### PR TITLE
[core] Don't accidentally catch unexpected runtime exceptions in CpdAnalysis

### DIFF
--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CpdAnalysis.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CpdAnalysis.java
@@ -183,8 +183,8 @@ public final class CpdAnalysis implements AutoCloseable {
                 }
             }
             if (!processingErrors.isEmpty() && !configuration.isSkipLexicalErrors()) {
-                // will be caught by CPD command
-                throw new IllegalStateException("Errors were detected while lexing source, exiting because --skip-lexical-errors is unset.");
+                reporter.error("Errors were detected while lexing source, exiting because --skip-lexical-errors is unset.");
+                return;
             }
 
             LOGGER.debug("Running match algorithm on {} files...", sourceManager.size());
@@ -202,7 +202,7 @@ public final class CpdAnalysis implements AutoCloseable {
             }
 
             consumer.accept(cpdReport);
-        } catch (Exception e) {
+        } catch (IOException e) {
             reporter.errorEx("Exception while running CPD", e);
         }
         // source manager is closed and closes all text files now.

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/SourceManager.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/SourceManager.java
@@ -68,10 +68,10 @@ class SourceManager implements AutoCloseable {
 
 
     @Override
-    public void close() throws Exception {
+    public void close() throws IOException {
         Exception exception = IOUtil.closeAll(textFiles);
         if (exception != null) {
-            throw exception;
+            throw new IOException(exception);
         }
     }
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CpdAnalysisTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CpdAnalysisTest.java
@@ -213,7 +213,7 @@ class CpdAnalysisTest {
         }
         verify(reporter).errorEx(eq("Error while tokenizing"), any(LexException.class));
         verify(reporter).errorEx(eq("Error while tokenizing"), any(MalformedSourceException.class));
-        verify(reporter).errorEx(eq("Exception while running CPD"), any(IllegalStateException.class));
+        verify(reporter).error(eq("Errors were detected while lexing source, exiting because --skip-lexical-errors is unset."));
         verifyNoMoreInteractions(reporter);
     }
 


### PR DESCRIPTION
## Describe the PR

In keeping with AutoCloseable Javadocs, Effective Java, and https://pmd.github.io/pmd/pmd_rules_java_design.html#avoidthrowingrawexceptiontypes

## Related issues

#5698

## Ready?


- [X] Added unit tests for fixed bug/feature
- [X] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

