### PR TITLE
Fix #5711: [java] UseArrayAsList - only consider List.add

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -25,6 +25,8 @@ This is a {{ site.pmd.release_type }} release.
 ### 🚀 New and noteworthy
 
 ### 🐛 Fixed Issues
+* java-performance
+  * [#5711](https://github.com/pmd/pmd/issues/5711): [java] UseArraysAsList false positive with Sets
 
 ### 🚨 API Changes
 

--- a/pmd-java/src/main/resources/category/java/performance.xml
+++ b/pmd-java/src/main/resources/category/java/performance.xml
@@ -720,7 +720,7 @@ You must use `new ArrayList<>(Arrays.asList(...))` if that is inconvenient for y
   [*[2]//FieldAccess[@Name = 'length']/VariableAccess[pmd-java:typeIs("java.lang.Object[]")]]
   /*[last()]/ExpressionStatement/
     MethodCall
-      [pmd-java:matchesSig('java.util.Collection#add(_)')]
+      [pmd-java:matchesSig('java.util.List#add(_)')]
       [ArgumentList/ArrayAccess
         [VariableAccess[@Name = ancestor::ForStatement/ForInit/LocalVariableDeclaration/VariableDeclarator/VariableId/@Name]]
       ]
@@ -728,7 +728,7 @@ You must use `new ArrayList<>(Arrays.asList(...))` if that is inconvenient for y
 //ForeachStatement
   [VariableAccess[pmd-java:typeIs("java.lang.Object[]")]]
   /*[last()]/ExpressionStatement/MethodCall
-      [pmd-java:matchesSig('java.util.Collection#add(_)')]
+      [pmd-java:matchesSig('java.util.List#add(_)')]
       [ArgumentList
         [VariableAccess[@Name = ancestor::ForeachStatement/LocalVariableDeclaration/VariableDeclarator/VariableId/@Name]]
       ]

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/UseArraysAsList.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/performance/xml/UseArraysAsList.xml
@@ -254,4 +254,26 @@ class Test {
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>[java] UseArraysAsList false positive with Sets #5711</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.HashSet;
+import java.util.Set;
+
+public class Foo {
+    private final Set<String> hashSet = new HashSet<>();
+
+    public void parseData(final String dataString) {
+        final String[] myArray = dataString.split(",");
+
+        for (final String element : myArray) {
+            this.hashSet.add(element); // line 11 - false positive
+        }
+        // e.g. this.hashSet = Arrays.asList(myArray); won't compile
+    }
+}
+]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Collection.add was too broad and included Set.add as well. But this rule should only report, if values are added to a List.

## Related issues

- Fix #5711 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

