### PR TITLE
Fix #5476: [visualforce] Resolve data types of standard object fields

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -25,6 +25,8 @@ This is a {{ site.pmd.release_type }} release.
 ### 🚀 New and noteworthy
 
 ### 🐛 Fixed Issues
+* visualforce
+  * [#5476](https://github.com/pmd/pmd/issues/5476): \[visualforce] NPE when analyzing standard field references in visualforce page
 
 ### 🚨 API Changes
 

--- a/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/ast/VfExpressionTypeVisitorTest.java
+++ b/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/ast/VfExpressionTypeVisitorTest.java
@@ -158,6 +158,19 @@ class VfExpressionTypeVisitorTest {
                            .filterMatching(ASTIdentifier::getImage, "NotFoundProp"));
     }
 
+    /**
+     * @see <a href="https://github.com/pmd/pmd/issues/5476">[visualforce] NPE when analyzing standard field references in visualforce page #5476</a>
+     */
+    @Test
+    void standardFieldsOnlyHaveFullName() {
+        Node rootNode = compile("CasePrintPage.page");
+
+        ASTIdentifier description = rootNode.descendants(ASTIdentifier.class)
+                .filterMatching(ASTIdentifier::getImage, "Description")
+                .firstOrThrow();
+        assertEquals(DataType.Text, description.getDataType());
+    }
+
     private Node compile(String pageName) {
         return compile(pageName, false);
     }

--- a/pmd-visualforce/src/test/resources/net/sourceforge/pmd/lang/visualforce/ast/VfExpressionTypeVisitor/metadata/sfdx/objects/Case/fields/Description.field-meta.xml
+++ b/pmd-visualforce/src/test/resources/net/sourceforge/pmd/lang/visualforce/ast/VfExpressionTypeVisitor/metadata/sfdx/objects/Case/fields/Description.field-meta.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
+    <fullName>Description</fullName>
+</CustomField>

--- a/pmd-visualforce/src/test/resources/net/sourceforge/pmd/lang/visualforce/ast/VfExpressionTypeVisitor/metadata/sfdx/pages/CasePrintPage.page
+++ b/pmd-visualforce/src/test/resources/net/sourceforge/pmd/lang/visualforce/ast/VfExpressionTypeVisitor/metadata/sfdx/pages/CasePrintPage.page
@@ -1,0 +1,4 @@
+<!-- Test case for https://github.com/pmd/pmd/issues/5476 -->
+<apex:page standardController="Case" Extensions="CasePrintController" renderAs="pdf" standardStylesheets="false" showheader="false" sidebar="false" language="{!$CurrentPage.parameters.lang}">
+  <apex:OutputField value="{!Case.Description}"/>
+</apex:page>

--- a/pmd-visualforce/src/test/resources/net/sourceforge/pmd/lang/visualforce/ast/VfExpressionTypeVisitor/metadata/sfdx/pages/CasePrintPage.page-meta.xml
+++ b/pmd-visualforce/src/test/resources/net/sourceforge/pmd/lang/visualforce/ast/VfExpressionTypeVisitor/metadata/sfdx/pages/CasePrintPage.page-meta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ApexPage xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>32.0</apiVersion>
+    <availableInTouch>false</availableInTouch>
+    <confirmationTokenRequired>false</confirmationTokenRequired>
+    <description>A generic case print page in pdf format</description>
+    <label>CasePrintPage</label>
+</ApexPage>


### PR DESCRIPTION
## Describe the PR

- Add a test case with e.g. a apex page that references Case.Description
- Use apex-dev-tools:sobject-types dependency to lookup standard objects/fields

## Related issues

- Fix #5476

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

