### PR TITLE
Fix #5634: [java] CommentDefaultAccessModifier: Comment between annotation and constructor not recognized

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaComment.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaComment.java
@@ -132,9 +132,9 @@ public class JavaComment implements Reportable {
     }
 
     public static Stream<JavaComment> getLeadingComments(JavaNode node) {
-        Stream<JavaccToken> specialTokens;
+        Stream<JavaccToken> specialTokens = getSpecialTokensIn(node);
         
-        if (node instanceof ModifierOwner) {
+        if (node instanceof ModifierOwner && !(node instanceof ASTConstructorDeclaration)) {
             node = ((ModifierOwner) node).getModifiers();
             specialTokens = getSpecialTokensIn(node);
             
@@ -142,8 +142,6 @@ public class JavaComment implements Reportable {
             if (!node.getFirstToken().isImplicit()) {
                 specialTokens = Stream.concat(specialTokens, getSpecialTokensIn(node.getNextSibling()));
             }
-        } else {
-            specialTokens = getSpecialTokensIn(node);
         }
         
         return specialTokens.filter(JavaComment::isComment)

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/JavaCommentTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/JavaCommentTest.java
@@ -14,6 +14,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import net.sourceforge.pmd.lang.document.Chars;
@@ -75,6 +76,26 @@ class JavaCommentTest extends BaseParserTest {
 
         checkCommentMatches(docCommentOwners.get(0), "/** a */");
         checkCommentMatches(docCommentOwners.get(1), "/** b */");
+    }
+
+    @Test
+    void getLeadingCommentsAnnotatedMethod() {
+        ASTCompilationUnit parsed = java.parse("/* a */ class Foo { /* b */ @SuppressWarnings(\"\") /* c */ void noOp() {}; }");
+
+        assertLeadingCommentsMatch(parsed, "/* a */", "/* b */", "/* c */");
+    }
+
+    @Test
+    void getLeadingCommentsAnnotatedConstructor() {
+        ASTCompilationUnit parsed = java.parse("/* a */ class Foo { /* b */ @SuppressWarnings(\"\") /* c */ Foo() /* d */ {}; }");
+
+        assertLeadingCommentsMatch(parsed, "/* a */", "/* b */", "/* c */", "/* d */");
+    }
+
+    private static void assertLeadingCommentsMatch(ASTCompilationUnit parsed, String... expectedComments) {
+        Assertions.assertThat(JavaComment.getLeadingComments(parsed))
+                .extracting(c -> c.getText().toString())
+                .containsExactly(expectedComments);
     }
 
     private static void checkCommentMatches(JavadocCommentOwner commentOwner, String expectedText) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/CommentDefaultAccessModifier.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/CommentDefaultAccessModifier.xml
@@ -583,4 +583,22 @@ public class Test {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#5634: Annotated constructors with comment</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @SuppressWarnings("")
+    /* package */ Foo() {}
+
+    /* package */ @SuppressWarnings("")
+    Foo() {}
+
+    @SuppressWarnings("")
+    Foo() /* package */ {}
+}
+        ]]></code>
+    </test-code>
+
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #5634

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

