### PR TITLE
[ci] Improvements for "Publish Pull Requests"

### DIFF
--- a/.github/workflows/publish-pull-requests.yml
+++ b/.github/workflows/publish-pull-requests.yml
@@ -174,7 +174,7 @@ jobs:
           
           echo "### Result" >> "${GITHUB_STEP_SUMMARY}"
           echo "${comment}" >> "${GITHUB_STEP_SUMMARY}"
-      - uses: marocchino/sticky-pull-request-comment@v2
+      - uses: marocchino/sticky-pull-request-comment@67d0dec7b07ed060a405f9b2a64b8ab319fdd7db #v2.9.2
         with:
           header: pmd-publish-pull-requests
           number: ${{ env.PR_NUMBER }}

--- a/.github/workflows/publish-pull-requests.yml
+++ b/.github/workflows/publish-pull-requests.yml
@@ -39,7 +39,18 @@ jobs:
           echo "PR_NUMBER=${PR_NUMBER}" >> "${GITHUB_ENV}"
           echo "PR_BRANCH=${PR_BRANCH}" >> "${GITHUB_ENV}"
           echo "PR_SHA=${PR_SHA}" >> "${GITHUB_ENV}"
+      - name: Add Job Summary
+        env:
+          WORKFLOW_RUN_DISPLAY_TITLE: ${{ github.event.workflow_run.display_title }}
+          WORKFLOW_RUN_NAME: ${{ github.event.workflow_run.name }}
+          WORKFLOW_RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
+          WORKFLOW_RUN_HTML_URL: ${{ github.event.workflow_run.html_url }}
+        run: |
+          echo "### Run Info" >> "${GITHUB_STEP_SUMMARY}"
           echo "Triggered for PR [#${PR_NUMBER}](https://github.com/pmd/pmd/pull/${PR_NUMBER})" >> "${GITHUB_STEP_SUMMARY}"
+          echo "" >> "${GITHUB_STEP_SUMMARY}"
+          echo "Called by [${WORKFLOW_RUN_DISPLAY_TITLE} (${WORKFLOW_RUN_NAME} #${WORKFLOW_RUN_NUMBER})](${WORKFLOW_RUN_HTML_URL})" >> "${GITHUB_STEP_SUMMARY}"
+          echo "" >> "${GITHUB_STEP_SUMMARY}"
       - name: Download docs-artifact
         env:
           # Token required for GH CLI:
@@ -160,6 +171,9 @@ jobs:
           (comment created at $(date -u --rfc-3339=seconds) for ${PR_SHA})
           "
           echo "${comment}" > comment.txt
+          
+          echo "### Result" >> "${GITHUB_STEP_SUMMARY}"
+          echo "${comment}" >> "${GITHUB_STEP_SUMMARY}"
       - uses: marocchino/sticky-pull-request-comment@v2
         with:
           header: pmd-publish-pull-requests

--- a/.github/workflows/publish-pull-requests.yml
+++ b/.github/workflows/publish-pull-requests.yml
@@ -156,9 +156,12 @@ jobs:
           comment="[Documentation Preview](https://pull-requests.pmd-code.org/pr-${PR_NUMBER}/${PR_SHA}/docs)
           
           ${summary}
+          
+          (comment created at $(date -u --rfc-3339=seconds) for ${PR_SHA})
           "
           echo "${comment}" > comment.txt
       - uses: marocchino/sticky-pull-request-comment@v2
         with:
+          header: pmd-publish-pull-requests
           number: ${{ env.PR_NUMBER }}
           path: comment.txt

--- a/docs/pages/pmd/devdocs/github_actions_workflows.md
+++ b/docs/pages/pmd/devdocs/github_actions_workflows.md
@@ -101,3 +101,19 @@ to create or update a comment on the pull request which shows the regression tes
 This workflow is in that sense optional, as the docs-artifact and pmd-regression-tester artifacts can
 be manually downloaded from the "Pull Request Build" workflow run. It merely adds convenience by
 giving easy access to a preview of the documentation and to the regression tester results.
+
+In the end, this workflow adds additional links to a pull request page. For the comment, GitHub seems
+to automatically add "rel=nofollow" to the links in the text. This is also applied for the check status
+pages. However, the links in the commit status are plain links. This might lead to unnecessary
+crawling by search engines. To avoid this, the following robots.txt is used
+at <https://pull-requests.pmd-code.org/robots.txt> to disallow any (search engine) bot:
+
+```
+User-agent: *
+Disallow: /
+```
+
+The reasons, why we don't want to have the pages there indexed: They are short-lived and only
+temporary. These temporary created documentation pages should not end up in any search result.
+This also helps to avoid unnecessary traffic and load for both the hosting side and the
+crawling side.


### PR DESCRIPTION
## Describe the PR

This PR contains small improvements for the "Publish Pull Requests" workflow. These are cherry-picked from #5584:

* Add a timestamp to the PR comment, so that is is better visible, when it was last updated.
* Document robots.txt and follow links impact with search engines. The regression tester reports and the temporary documentation sites should not be indexed by search engines.
* Add a job summary where we can see, which pull request and which workflow run this new run of "Publish Pull Requests" has been triggered
* Use SHA1 for the sticky-pull-request-comment instead of `@v2`

## Related issues

- Refs #5584 
- Refs #4328 

## Ready?

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

