### PR TITLE
Fix #5061: [java] UnusedLocalVariable FP when using compound assignment

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/JavaAstUtils.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/JavaAstUtils.java
@@ -244,8 +244,14 @@ public final class JavaAstUtils {
     private static boolean isReadUsage(ASTNamedReferenceExpr expr) {
         return expr.getAccessType() == AccessType.READ
             // x++ as a method argument or used in other expression
-            || expr.getParent() instanceof ASTUnaryExpression
-            && !(expr.getParent().getParent() instanceof ASTExpressionStatement);
+            || ((expr.getParent() instanceof ASTUnaryExpression
+            // compound assignments like '+=' have AccessType.WRITE, but can also be used in another expression
+            || isCompoundAssignment(expr))
+            && !(expr.getParent().getParent() instanceof ASTExpressionStatement));
+    }
+
+    private static boolean isCompoundAssignment(ASTNamedReferenceExpr expr) {
+        return expr.getParent() instanceof ASTAssignmentExpression && ((ASTAssignmentExpression) expr.getParent()).isCompound();
     }
 
     /**

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedLocalVariable.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/bestpractices/xml/UnusedLocalVariable.xml
@@ -540,4 +540,22 @@ public class UnusedLocalVarsMultiple {
 }
 ]]></code>
     </test-code>
+
+    <test-code>
+        <description>Issues 5061/5081: Compound assignment used in another expression</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    void foo() {
+        int read = 0;
+        consume(read += 1);
+    }
+
+    void consume(int val) {
+        System.out.println(val);
+    }
+}
+        ]]></code>
+    </test-code>
+
 </test-data>


### PR DESCRIPTION
## Describe the PR

<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #5061
- Refs #5081 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

