### PR TITLE
[ci] publish-snapshot/old build: migrate to central portal

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -110,7 +110,7 @@ function build() {
         pmd_ci_setup_secrets_private_env
         pmd_ci_setup_secrets_gpg_key
         pmd_ci_setup_secrets_ssh
-        pmd_ci_maven_setup_settings
+        pmd_ci_build_setup_maven_settings
     pmd_ci_log_group_end
 
     pmd_ci_log_group_start "Build and Deploy"
@@ -234,6 +234,36 @@ function build() {
 function pmd_ci_build_setup_bundler() {
     pmd_ci_log_info "Checking bundler version..."
     bundle --version
+}
+
+function pmd_ci_build_setup_maven_settings() {
+      pmd_ci_log_info "Setting up maven at ${HOME}/.m2/settings.xml..."
+      mkdir -p "${HOME}/.m2"
+      cat > "${HOME}/.m2/settings.xml" <<EOF
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <localRepository/>
+  <interactiveMode/>
+  <usePluginRegistry/>
+  <offline/>
+  <pluginGroups>
+    <pluginGroup>org.sonarsource.scanner.maven</pluginGroup>
+  </pluginGroups>
+  <servers>
+    <server>
+      <id>central</id>
+      <username>\${env.CI_DEPLOY_USERNAME}</username>
+      <password>\${env.CI_DEPLOY_PASSWORD}</password>
+    </server>
+  </servers>
+  <mirrors/>
+  <proxies/>
+  <profiles/>
+  <activeProfiles/>
+</settings>
+EOF
 }
 
 #

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,8 +109,7 @@ jobs:
         run: |
           ./mvnw --show-version --errors --batch-mode \
               -Dmaven.repo.local=.m2/repository \
-              verify \
-              -DskipTests -Dmaven.test.skip=true
+              verify -DskipTests
       - uses: actions/upload-artifact@v4
         with:
           name: javadocs-artifact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -262,7 +262,7 @@ jobs:
             -Dmaven.repo.local=.m2/repository \
             verify \
             -Pgenerate-rule-docs,fastSkip \
-            -DskipTests -Dmaven.test.skip=true -Dassembly.skipAssembly=true
+            -DskipTests -Dassembly.skipAssembly=true
       - name: Set up Ruby 3.3
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -66,10 +66,10 @@ jobs:
 
   deploy-to-maven-central:
     needs: check-version
-    # use environment maven-central, where secrets are configured for OSSRH_*
+    # use environment maven-central, where secrets are configured for MAVEN_CENTRAL_PORTAL_*
     environment:
       name: maven-central
-      url: https://oss.sonatype.org/content/repositories/snapshots/net/sourceforge/pmd/
+      url: https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/net/sourceforge/pmd/
     runs-on: ubuntu-latest
     timeout-minutes: 20
     defaults:
@@ -83,7 +83,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '11'
-          server-id: ossrh
+          server-id: central
           server-username: MAVEN_USERNAME
           server-password: MAVEN_PASSWORD
           gpg-passphrase: MAVEN_GPG_PASSPHRASE
@@ -101,8 +101,8 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
       - name: Build and publish
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_PORTAL_USERNAME }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PORTAL_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.PMD_CI_GPG_PASSPHRASE }}
         # note: we can't use artifact staging-repository, as the jars are unsigned and javadoc+sources are missing.
         run: |

--- a/docs/pages/pmd/devdocs/building/building_general.md
+++ b/docs/pages/pmd/devdocs/building/building_general.md
@@ -76,22 +76,28 @@ If you integrate PMD as a dependency in your own project, you can also reference
 version. However, you also need to configure an additional Maven Repository, as the SNAPSHOTS are not published
 in Maven Central.
 
-Use the OSSRH snapshot repository url: `https://oss.sonatype.org/content/repositories/snapshots`. For Maven
+Use the Central Portal Snapshot repository url: `https://central.sonatype.com/repository/maven-snapshots/`. For Maven
 projects, this can be configured like:
 ```xml
 <repositories>
- <repository>
-   <id>sonatype-nexus-snapshots</id>
-   <name>Sonatype Nexus Snapshots</name>
-   <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-   <releases><enabled>false</enabled></releases>
-   <snapshots><enabled>true</enabled></snapshots>
- </repository>
+    <repository>
+        <name>Central Portal Snapshots</name>
+        <id>central-portal-snapshots</id>
+        <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+        <releases>
+            <enabled>false</enabled>
+        </releases>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
+    </repository>
 </repositories>
 ```
 
-Have a look at <https://oss.sonatype.org/content/repositories/snapshots/net/sourceforge/pmd/pmd/> to see which
+Have a look at <https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/net/sourceforge/pmd/pmd/> to see which
 SNAPSHOT versions are available. Note that old SNAPSHOT versions might be removed without prior notice.
+
+See also <https://central.sonatype.org/publish/publish-portal-snapshots/>.
 
 ## General Development Tips
 

--- a/docs/pages/pmd/devdocs/github_actions_workflows.md
+++ b/docs/pages/pmd/devdocs/github_actions_workflows.md
@@ -139,11 +139,11 @@ There is a first job "check-version" that just determines the version of PMD we 
 we are actually building a SNAPSHOT version. Then a couple of other jobs are being executed in parallel:
 
 * deploy-to-maven-central: Rebuilds PMD from branch main and deploys the snapshot artifacts to
-  <https://oss.sonatype.org/content/repositories/snapshots/net/sourceforge/pmd/>. Rebuilding is necessary in
-  order to produce all necessary artifacts (sources, javadoc) and also gpg-sign the artifacts. This
-  is not available from the build artifacts of the "Build" workflow.
+  <https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/net/sourceforge/pmd/>.
+  Rebuilding is necessary in order to produce all necessary artifacts (sources, javadoc) and also gpg-sign the
+  artifacts. This is not available from the build artifacts of the "Build" workflow.
   * Environment: maven-central
-  * Secrets: OSSRH_TOKEN, OSSRH_USERNAME
+  * Secrets: MAVEN_CENTRAL_PORTAL_USERNAME, MAVEN_CENTRAL_PORTAL_PASSWORD
 * deploy-to-sourceforge-files: Downloads the "dist-artifact" and "docs-artifact" from the "Build" workflow,
   gpg-signs the files and uploads them to <https://sourceforge.net/projects/pmd/files/pmd/>.
   * Environment: sourceforge
@@ -273,11 +273,9 @@ See <https://github.com/pmd/pmd-regression-tester/settings/secrets/actions>
 
 ### Repository pmd/pmd - Environment "maven-central"
 
-* `OSSRH_USERNAME` and `OSSRH_TOKEN`: Used to deploy artifacts to maven central via OSSRH to our namespace
-  [net.sourceforge.pmd](https://repo.maven.apache.org/maven2/net/sourceforge/pmd).  
-  Login on <https://oss.sonatype.org>, go to your user profile, select "User Token" and "Access User Token".
-  You'll see the tokens to be used for username and password.  
-  Note: This will soon be migrated to use <https://central.sonatype.com>.
+* `MAVEN_CENTRAL_PORTAL_USERNAME` and `MAVEN_CENTRAL_PORTAL_PASSWORD`: Used to deploy artifacts to maven
+  central via <https://central.sonatype.com>. See <https://central.sonatype.org/> for the documentation.
+  The upload uses token-based authentication, you can generate a user token on <https://central.sonatype.com/account>.
 
 ### Repository pmd/pmd - Environment "coveralls"
 * `COVERALLS_REPO_TOKEN`: Used to upload coverage results to <https://coveralls.io/github/pmd/pmd>.

--- a/pom.xml
+++ b/pom.xml
@@ -800,6 +800,8 @@
                             <goal>makeAggregateBom</goal>
                         </goals>
                         <configuration>
+                            <!-- to be removed when https://github.com/CycloneDX/cyclonedx-maven-plugin/issues/597 is fixed-->
+                            <skipNotDeployed>false</skipNotDeployed>
                             <!-- PMD is released in two phases: first everything without pmd-cli/pmd-dist
                                  (profile cli-dist-modules disabled), and then only pmd-cli/pmd-dist.
                                  The BOM for the main artifact net.sourceforge.pmd:pmd is created and published

--- a/pom.xml
+++ b/pom.xml
@@ -64,16 +64,6 @@
         <url>https://github.com/pmd/pmd</url>
         <tag>HEAD</tag>
     </scm>
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
     <organization>
         <name>PMD</name>
         <url>https://pmd.github.io/</url>
@@ -625,9 +615,9 @@
                     <version>2.18.0</version>
                 </plugin>
                 <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.7.0</version>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.7.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jacoco</groupId>
@@ -790,12 +780,14 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
                 <extensions>true</extensions>
                 <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
+                    <waitUntil>published</waitUntil>
+                    <deploymentName>${project.artifactId}</deploymentName>
                 </configuration>
             </plugin>
             <plugin>
@@ -1126,68 +1118,6 @@
         </dependencies>
     </dependencyManagement>
 
-    <repositories>
-        <repository>
-            <id>central</id>
-            <name>Central Repository</name>
-            <url>https://repo.maven.apache.org/maven2</url>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>never</updatePolicy>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <id>central</id>
-            <name>Central Repository</name>
-            <url>https://repo.maven.apache.org/maven2</url>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>never</updatePolicy>
-            </releases>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-        </pluginRepository>
-        <pluginRepository>
-            <id>sonatype-nexus-plugin-snapshots</id>
-            <name>Sonatype Nexus Snapshots</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </pluginRepository>
-        <pluginRepository>
-            <id>apache.snapshots</id>
-            <name>Apache Snapshot Repository</name>
-            <url>https://repository.apache.org/snapshots</url>
-            <releases>
-                <enabled>false</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </pluginRepository>
-    </pluginRepositories>
-
     <profiles>
         <profile>
             <!-- Adds an SLF4J implementation, useful when developing within an IDE -->
@@ -1370,21 +1300,35 @@
                     <releases><enabled>false</enabled></releases>
                     <snapshots><enabled>true</enabled></snapshots>
                 </pluginRepository>
-                <!-- disable sonatype-nexus-plugin-snapshots, so that only dogfood is used -->
+            </pluginRepositories>
+        </profile>
+
+        <profile>
+            <id>central-portal-snapshots</id>
+            <repositories>
+                <repository>
+                    <name>Central Portal Snapshots</name>
+                    <id>central-portal-snapshots</id>
+                    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+                    <releases>
+                        <enabled>false</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+            <pluginRepositories>
                 <pluginRepository>
-                    <id>sonatype-nexus-plugin-snapshots</id>
-                    <name>Sonatype Nexus Snapshots</name>
-                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-                    <releases><enabled>false</enabled></releases>
-                    <snapshots><enabled>false</enabled></snapshots>
-                </pluginRepository>
-                <!-- disable apache.snapshots, so that only dogfood is used -->
-                <pluginRepository>
-                    <id>apache.snapshots</id>
-                    <name>Apache Snapshot Repository</name>
-                    <url>https://repository.apache.org/snapshots</url>
-                    <releases><enabled>false</enabled></releases>
-                    <snapshots><enabled>false</enabled></snapshots>
+                    <name>Central Portal Snapshots</name>
+                    <id>central-portal-snapshots</id>
+                    <url>https://central.sonatype.com/repository/maven-snapshots/</url>
+                    <releases>
+                        <enabled>false</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
                 </pluginRepository>
             </pluginRepositories>
         </profile>


### PR DESCRIPTION
## Describe the PR

OSSRH is being shut down, we now need to use central portal for publish artifacts to maven central.

See https://central.sonatype.org/publish/publish-portal-guide/  
See https://central.sonatype.org/news/20250326_ossrh_sunset/

Note: The whole namespace `net.sourceforge.pmd:*` will need to be migrated at once, so we need to migrate pmd-designer and pmd at the same time.

## Related issues

- pmd/build-tools#69
- pmd/pmd-designer#169

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

