### PR TITLE
[ci] Make build a reuseable workflow

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -1,0 +1,11 @@
+name: Build Pull Request
+
+on:
+  pull_request:
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  build:
+    name: Build Pull Request
+    uses: ./.github/workflows/build.yml

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -1,0 +1,17 @@
+name: Build Snapshot
+
+on:
+  push:
+    branches:
+      - '**'
+      # don't run on dependabot branches. Dependabot will create pull requests, which will then be run instead
+      - '!dependabot/**'
+  workflow_dispatch:
+  schedule:
+    # build it monthly: At 04:00 on day-of-month 1.
+    - cron:  '0 4 1 * *'
+
+jobs:
+  build:
+    name: Build Snapshot
+    uses: ./.github/workflows/build.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,17 +1,7 @@
 name: Build
 
 on:
-  pull_request:
-  merge_group:
-  push:
-    branches:
-      - '**'
-      # don't run on dependabot branches. Dependabot will create pull requests, which will then be run instead
-      - '!dependabot/**'
-  workflow_dispatch:
-  schedule:
-    # build it monthly: At 04:00 on day-of-month 1.
-    - cron:  '0 4 1 * *'
+  workflow_call:
 
 # if another commit is added to the same branch or PR (same github.ref),
 # then cancel already running jobs and start a new build.

--- a/.github/workflows/publish-pull-requests.yml
+++ b/.github/workflows/publish-pull-requests.yml
@@ -2,7 +2,7 @@ name: Publish Results from Pull Requests
 run-name: Publish Results for "${{ github.event.workflow_run.display_title }}"
 on:
   workflow_run:
-    workflows: [Build]
+    workflows: [Build Pull Request]
     types:
       - completed
 

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -2,7 +2,7 @@ name: Publish Snapshot
 
 on:
   workflow_run:
-    workflows: [Build]
+    workflows: [Build Snapshot]
     types:
       - completed
     branches:

--- a/docs/pages/pmd/devdocs/github_actions_workflows.md
+++ b/docs/pages/pmd/devdocs/github_actions_workflows.md
@@ -10,15 +10,27 @@ last_updated: May 2025 (7.14.0)
 
 {%include note.html content="This page is work in progress and does not yet describe all workflows."%}
 
-## Build
+## Build, Build Pull Request, Build Snapshot
 
-* Builds: <https://github.com/pmd/pmd/actions/workflows/build.yml>
-* Workflow file: <https://github.com/pmd/pmd/blob/main/.github/workflows/build.yml>
+"Build" itself is a [reuseable workflow](https://docs.github.com/en/actions/sharing-automations/reusing-workflows),
+that is called by "Build Pull Request" and "Build Snapshot".
 
-This workflow is triggered whenever new commits are pushed to a branch (including the default branch and
-including forks) or whenever a pull request is created or synchronized.
+* Workflow files:
+  * <https://github.com/pmd/pmd/blob/main/.github/workflows/build.yml>
+  * <https://github.com/pmd/pmd/blob/main/.github/workflows/build-pr.yml>
+  * <https://github.com/pmd/pmd/blob/main/.github/workflows/build-snapshot.yml>
+* Builds:
+  * Build Pull Request: <https://github.com/pmd/pmd/actions/workflows/build-pr.yml>
+  * Build Snapshot: <https://github.com/pmd/pmd/actions/workflows/build-snapshot.yml>
+
+All these workflows execute exactly the same steps. But only the triggering event is different.
 It is designed to run on the main repository in PMD's GitHub organization as well as for forks, as it does
 not require any secrets.
+
+"Build Pull Request" is triggered, whenever a pull request is created or synchronized.
+
+"Build Snapshot" is triggered, whenever new commits are pushed to a branch (including the default branch and
+including forks).
 
 In order to avoid unnecessary builds, we use concurrency control to make sure, we cancel any in-progress jobs for
 the current branch or pull request when a new commit has been pushed. This means, only the latest commit is built,
@@ -71,7 +83,7 @@ The jobs are:
 * Builds: <https://github.com/pmd/pmd/actions/workflows/publish-pull-requests.yml>
 * Workflow file: <https://github.com/pmd/pmd/blob/main/.github/workflows/publish-pull-requests.yml>
 
-This workflow runs after "Build" on a pull request is completed. It runs in the context of our own
+This workflow runs after "Build Pull Request", when it is completed. It runs in the context of our own
 repository and has write permissions and complete access to the configured secrets.
 For security reasons, this workflow won't check out the pull request code and won't build anything.
 
@@ -108,7 +120,6 @@ This workflow is in that sense optional, as the docs-artifact and pmd-regression
 be manually downloaded from the "Pull Request Build" workflow run. It merely adds convenience by
 giving easy access to a preview of the documentation and to the regression tester results.
 
-<<<<<<< HEAD
 In the end, this workflow adds additional links to a pull request page. For the comment, GitHub seems
 to automatically add "rel=nofollow" to the links in the text. This is also applied for the check status
 pages. However, the links in the commit status are plain links. This might lead to unnecessary
@@ -130,7 +141,7 @@ crawling side.
 * Builds: <https://github.com/pmd/pmd/actions/workflows/publish-snapshot.yml>
 * Workflow file: <https://github.com/pmd/pmd/blob/main/.github/workflows/publish-snapshot.yml>
 
-This runs after "Build" of a push on the `main` branch is finished.
+This runs after "Build Snapshot" of a push on the `main` branch is finished.
 It runs in the context of our own repository and has access to all secrets. In order
 to have a nicer display in GitHub actions, we leverage "environments", which also
 contain secrets.


### PR DESCRIPTION
## Describe the PR

This should avoid triggering unnecessary publish-* workflows, as we can now filter on the events beforehand.
The additional filter is still kept for additional safety.

## Related issues

Refs pmd/pmd#4328

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

