### PR TITLE
Fix #5705: [cli] Always determine PMD_HOME based on script location

### DIFF
--- a/pmd-dist/src/main/resources/scripts/pmd
+++ b/pmd-dist/src/main/resources/scripts/pmd
@@ -47,13 +47,11 @@ java_heapsize_settings() {
 }
 
 set_pmd_home_dir() {
-  if [ -z "$PMD_HOME" ]; then
-    script_real_loc="$0"
+  script_real_loc="$0"
 
-    # see #4723 - allow calling as "bash pmd", when pmd is on the PATH
-    if [ ! -e "$script_real_loc" ]; then
-      script_real_loc=$(which "$script_real_loc")
-    fi
+  # see #4723 - allow calling as "bash pmd", when pmd is on the PATH
+  if [ ! -e "$script_real_loc" ]; then
+    script_real_loc=$(which "$script_real_loc")
   fi
 
   if [ ! -e "$script_real_loc" ]; then


### PR DESCRIPTION
## Describe the PR

Now we always determine PMD_HOME based on the script location. If PMD_HOME is already defined, it is ignored.

## Related issues

- Fix #5705 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

