### PR TITLE
[java] Support annotated constructor return type in symbol API

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -66,6 +66,7 @@ Releases of PMD are available on [Maven Central](https://central.sonatype.com/) 
 * [#5700](https://github.com/pmd/pmd/pull/5700): \[core] Don't accidentally catch unexpected runtime exceptions in CpdAnalysis - [Elliotte Rusty Harold](https://github.com/elharo) (@elharo)
 * [#5716](https://github.com/pmd/pmd/pull/5716): Fix #5634: \[java] CommentDefaultAccessModifier: Comment between annotation and constructor not recognized - [Lukas Gräf](https://github.com/lukasgraef) (@lukasgraef)
 * [#5736](https://github.com/pmd/pmd/pull/5736): Fix #5061: \[java] UnusedLocalVariable FP when using compound assignment - [Lukas Gräf](https://github.com/lukasgraef) (@lukasgraef)
+* [#5763](https://github.com/pmd/pmd/pull/5763): \[java] Support annotated constructor return type in symbol API - [Clément Fournier](https://github.com/oowekyala) (@oowekyala)
 
 ### 📦 Dependency updates
 <!-- content will be automatically generated, see /do-release.sh -->

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JConstructorSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JConstructorSymbol.java
@@ -6,6 +6,9 @@
 package net.sourceforge.pmd.lang.java.symbols;
 
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
+import net.sourceforge.pmd.lang.java.types.JTypeMirror;
+import net.sourceforge.pmd.lang.java.types.Substitution;
+import net.sourceforge.pmd.lang.java.types.TypeSystem;
 
 
 /**
@@ -25,6 +28,11 @@ public interface JConstructorSymbol extends JExecutableSymbol, BoundToNode<ASTCo
         return CTOR_NAME;
     }
 
+    @Override
+    default JTypeMirror getReturnType(Substitution subst) {
+        TypeSystem ts = getTypeSystem();
+        return ts.declaration(getEnclosingClass()).subst(subst);
+    }
 
     @Override
     default <R, P> R acceptVisitor(SymbolVisitor<R, P> visitor, P param) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JExecutableSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JExecutableSymbol.java
@@ -15,6 +15,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import net.sourceforge.pmd.lang.java.types.JMethodSig;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.Substitution;
+import net.sourceforge.pmd.lang.java.types.TypeSystem;
 
 /**
  * Common supertype for {@linkplain JMethodSymbol method}
@@ -30,6 +31,21 @@ public interface JExecutableSymbol extends JTypeParameterOwnerSymbol {
      * instance.
      */
     List<JFormalParamSymbol> getFormalParameters();
+
+    /**
+     * Return the return type under the given substitution.
+     * For a constructor, return the type of the owner. This type
+     * may be annotated.
+     */
+    default JTypeMirror getReturnType(Substitution subst) {
+        if (this instanceof JConstructorSymbol) {
+            TypeSystem ts = getTypeSystem();
+            return ts.declaration(getEnclosingClass()).subst(subst);
+        }
+        // JMethodSymbol has always had this method abstract so this branch
+        // should never be taken.
+        throw new UnsupportedOperationException("Default method was added for compatibility, will be removed");
+    }
 
 
     default boolean isDefaultMethod() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JExecutableSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JExecutableSymbol.java
@@ -15,7 +15,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 import net.sourceforge.pmd.lang.java.types.JMethodSig;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.Substitution;
-import net.sourceforge.pmd.lang.java.types.TypeSystem;
 
 /**
  * Common supertype for {@linkplain JMethodSymbol method}

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JExecutableSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JExecutableSymbol.java
@@ -36,12 +36,9 @@ public interface JExecutableSymbol extends JTypeParameterOwnerSymbol {
      * Return the return type under the given substitution.
      * For a constructor, return the type of the owner. This type
      * may be annotated.
+     * @see JConstructorSymbol
      */
     default JTypeMirror getReturnType(Substitution subst) {
-        if (this instanceof JConstructorSymbol) {
-            TypeSystem ts = getTypeSystem();
-            return ts.declaration(getEnclosingClass()).subst(subst);
-        }
         // JMethodSymbol has always had this method abstract so this branch
         // should never be taken.
         throw new UnsupportedOperationException("Default method was added for compatibility, will be removed");

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JMethodSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JMethodSymbol.java
@@ -10,8 +10,6 @@ import java.lang.reflect.Modifier;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.sourceforge.pmd.lang.java.ast.ASTMethodDeclaration;
-import net.sourceforge.pmd.lang.java.types.JTypeMirror;
-import net.sourceforge.pmd.lang.java.types.Substitution;
 
 
 /**
@@ -30,10 +28,6 @@ public interface JMethodSymbol extends JExecutableSymbol, BoundToNode<ASTMethodD
     default boolean isStatic() {
         return Modifier.isStatic(getModifiers());
     }
-
-
-    /** Returns the return type under the given substitution. */
-    JTypeMirror getReturnType(Substitution subst);
 
     /**
      * Returns the default value, if this is a constant method. See

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ImplicitMemberSymbols.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ImplicitMemberSymbols.java
@@ -289,6 +289,7 @@ public final class ImplicitMemberSymbols {
             super(owner, JConstructorSymbol.CTOR_NAME, modifiers, formals);
         }
 
+
         @Override
         public boolean equals(Object o) {
             return SymbolEquality.CONSTRUCTOR.equals(this, o);

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ExecutableStub.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ExecutableStub.java
@@ -74,6 +74,11 @@ abstract class ExecutableStub extends MemberStubBase implements JExecutableSymbo
     }
 
     @Override
+    public JTypeMirror getReturnType(Substitution subst) {
+        return type.getReturnType().subst(subst);
+    }
+
+    @Override
     public boolean isVarargs() {
         return (getModifiers() & Opcodes.ACC_VARARGS) != 0;
     }
@@ -193,12 +198,6 @@ abstract class ExecutableStub extends MemberStubBase implements JExecutableSymbo
         public boolean isBridge() {
             return (getModifiers() & Opcodes.ACC_BRIDGE) != 0;
         }
-
-        @Override
-        public JTypeMirror getReturnType(Substitution subst) {
-            return type.getReturnType().subst(subst);
-        }
-
 
         @Override
         public String toString() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/GenericSigBase.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/GenericSigBase.java
@@ -21,6 +21,7 @@ import org.objectweb.asm.TypeReference;
 import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JTypeParameterOwnerSymbol;
 import net.sourceforge.pmd.lang.java.symbols.SymbolicValue.SymAnnot;
+import net.sourceforge.pmd.lang.java.symbols.internal.asm.ExecutableStub.CtorStub;
 import net.sourceforge.pmd.lang.java.symbols.internal.asm.TypeAnnotationHelper.TypeAnnotationSet;
 import net.sourceforge.pmd.lang.java.symbols.internal.asm.TypeAnnotationHelper.TypeAnnotationSetWithReferences;
 import net.sourceforge.pmd.lang.java.types.JClassType;
@@ -269,6 +270,13 @@ abstract class GenericSigBase<T extends JTypeParameterOwnerSymbol & AsmStub> {
                                             .map(ctx.getResolver()::resolveFromInternalNameCannotFail)
                                             .map(ctx.getTypeSystem()::rawType)
                                             .collect(CollectionUtil.toUnmodifiableList());
+            }
+            if (ctx instanceof CtorStub) {
+                // Is a constructor, return type of the descriptor is void.
+                // We replace the return type with the owner type. This must
+                // be done before type annotations are applied.
+                assert this.returnType.isVoid();
+                this.returnType = ctx.getTypeSystem().declaration(ctx.getEnclosingClass());
             }
             if (typeAnnots != null) {
                 // apply type annotations here

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AbstractAstAnnotableSym.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AbstractAstAnnotableSym.java
@@ -27,6 +27,7 @@ abstract class AbstractAstAnnotableSym<T extends SymbolDeclaratorNode & Annotata
     @Override
     public PSet<SymAnnot> getDeclaredAnnotations() {
         if (annots == null) {
+            // todo filter out type annotations
             annots = SymbolResolutionPass.buildSymbolicAnnotations(node.getDeclaredAnnotations());
         }
         return annots;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AbstractAstExecSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AbstractAstExecSymbol.java
@@ -4,10 +4,12 @@
 
 package net.sourceforge.pmd.lang.java.symbols.internal.ast;
 
+import java.lang.annotation.ElementType;
 import java.util.List;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.pcollections.PSet;
 
 import net.sourceforge.pmd.lang.java.ast.ASTExecutableDeclaration;
 import net.sourceforge.pmd.lang.java.ast.ASTList;
@@ -15,6 +17,7 @@ import net.sourceforge.pmd.lang.java.ast.ASTReceiverParameter;
 import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JExecutableSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JFormalParamSymbol;
+import net.sourceforge.pmd.lang.java.symbols.SymbolicValue.SymAnnot;
 import net.sourceforge.pmd.lang.java.types.JTypeMirror;
 import net.sourceforge.pmd.lang.java.types.Substitution;
 import net.sourceforge.pmd.util.CollectionUtil;
@@ -28,6 +31,8 @@ abstract class AbstractAstExecSymbol<T extends ASTExecutableDeclaration>
 
     private final JClassSymbol owner;
     private final List<JFormalParamSymbol> formals;
+    // these are ambiguous as they can apply to both the return type or the declaration
+    private PSet<SymAnnot> returnTypeAnnots;
 
     protected AbstractAstExecSymbol(T node, AstSymFactory factory, JClassSymbol owner) {
         super(node, factory);
@@ -69,6 +74,24 @@ abstract class AbstractAstExecSymbol<T extends ASTExecutableDeclaration>
         }
         return receiver.getReceiverType().getTypeMirror().subst(subst);
     }
+
+    @Override
+    public final JTypeMirror getReturnType(Substitution subst) {
+        JTypeMirror mirror = makeReturnType(subst);
+        if (returnTypeAnnots == null) {
+            returnTypeAnnots =
+                SymbolResolutionPass.buildSymbolicAnnotations(node.getDeclaredAnnotations())
+                                    .stream()
+                                    .filter(it -> it.getAnnotationSymbol().annotationAppliesTo(ElementType.TYPE_USE))
+                                    .collect(CollectionUtil.toPersistentSet());
+        }
+        if (returnTypeAnnots.isEmpty()) {
+            return mirror;
+        }
+        return mirror.withAnnotations(mirror.getTypeAnnotations().plusAll(returnTypeAnnots));
+    }
+
+    protected abstract JTypeMirror makeReturnType(Substitution subst);
 
     @Override
     public @NonNull JClassSymbol getEnclosingClass() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstCtorSym.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstCtorSym.java
@@ -7,14 +7,23 @@ package net.sourceforge.pmd.lang.java.symbols.internal.ast;
 import net.sourceforge.pmd.lang.java.ast.ASTConstructorDeclaration;
 import net.sourceforge.pmd.lang.java.symbols.JClassSymbol;
 import net.sourceforge.pmd.lang.java.symbols.JConstructorSymbol;
+import net.sourceforge.pmd.lang.java.types.JTypeMirror;
+import net.sourceforge.pmd.lang.java.types.Substitution;
+import net.sourceforge.pmd.lang.java.types.TypeSystem;
 
 /**
  * @author Clément Fournier
  */
 final class AstCtorSym extends AbstractAstExecSymbol<ASTConstructorDeclaration> implements JConstructorSymbol {
 
+
     AstCtorSym(ASTConstructorDeclaration node, AstSymFactory factory, JClassSymbol owner) {
         super(node, factory, owner);
     }
 
+    @Override
+    protected JTypeMirror makeReturnType(Substitution subst) {
+        TypeSystem ts = getTypeSystem();
+        return ts.declaration(getEnclosingClass()).subst(subst);
+    }
 }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstMethodSym.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstMethodSym.java
@@ -32,7 +32,7 @@ final class AstMethodSym
     }
 
     @Override
-    public JTypeMirror getReturnType(Substitution subst) {
+    protected JTypeMirror makeReturnType(Substitution subst) {
         ASTType rt = node.getResultTypeNode();
         return TypeOps.subst(rt.getTypeMirror(), subst);
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ClassMethodSigImpl.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ClassMethodSigImpl.java
@@ -17,7 +17,6 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 import net.sourceforge.pmd.lang.java.symbols.JExecutableSymbol;
-import net.sourceforge.pmd.lang.java.symbols.JMethodSymbol;
 import net.sourceforge.pmd.lang.java.types.internal.InternalMethodTypeItf;
 
 class ClassMethodSigImpl implements JMethodSig, InternalMethodTypeItf {
@@ -92,15 +91,10 @@ class ClassMethodSigImpl implements JMethodSig, InternalMethodTypeItf {
     @Override
     public JTypeMirror getReturnType() {
         if (resultType == null) {
-            if (symbol instanceof JMethodSymbol) {
-                if (owner.isRaw()) {
-                    resultType = ClassTypeImpl.eraseToRaw(((JMethodSymbol) symbol).getReturnType(EMPTY), getTypeParamSubst());
-                } else {
-                    resultType = ((JMethodSymbol) symbol).getReturnType(getTypeParamSubst());
-                }
+            if (owner.isRaw()) {
+                resultType = ClassTypeImpl.eraseToRaw(symbol.getReturnType(EMPTY), getTypeParamSubst());
             } else {
-                // constructor
-                resultType = owner;
+                resultType = symbol.getReturnType(getTypeParamSubst());
             }
         }
         return resultType;

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/internal/TypeAnnotReflectionOnMethodsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/internal/TypeAnnotReflectionOnMethodsTest.java
@@ -9,6 +9,7 @@ import static net.sourceforge.pmd.lang.java.symbols.internal.TypeAnnotTestUtil.A
 import static net.sourceforge.pmd.lang.java.symbols.internal.TypeAnnotTestUtil.ANNOT_B;
 import static net.sourceforge.pmd.lang.java.symbols.internal.TypeAnnotTestUtil.assertHasAnnots;
 import static net.sourceforge.pmd.lang.java.symbols.internal.TypeAnnotTestUtil.assertHasTypeAnnots;
+import static net.sourceforge.pmd.lang.java.symbols.internal.TypeAnnotTestUtil.getCtorType;
 import static net.sourceforge.pmd.lang.java.symbols.internal.TypeAnnotTestUtil.getMethodType;
 import static net.sourceforge.pmd.util.CollectionUtil.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -168,6 +169,36 @@ class TypeAnnotReflectionOnMethodsTest {
             JMethodSig t = getMethodType(sym, "abOnReceiver");
             assertThat(t.getFormalParameters(), Matchers.empty());
             assertHasTypeAnnots(t.getAnnotatedReceiverType(), ANNOTS_A_B);
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource
+    void testTypeAnnotOnCtor(SymImplementation impl) {
+        JClassType sym = impl.getDeclaration(ClassWithTypeAnnotationsOnMethods.CtorOwner.class);
+
+        /*
+            CtorOwner(@A @B int i) { }
+
+            @A CtorOwner() { }
+
+            CtorOwner(String i, int x) throws @A Exception {}
+         */
+
+        {
+            JMethodSig t = getCtorType(sym, 1);
+            assertHasTypeAnnots(t.getFormalParameters().get(0), ANNOTS_A_B);
+            assertHasTypeAnnots(t.getReturnType(), emptyList());
+        }
+        {
+            JMethodSig t = getCtorType(sym, 0);
+            assertHasTypeAnnots(t.getReturnType(), ANNOT_A);
+        }
+        {
+            JMethodSig t = getCtorType(sym, 2);
+            assertHasTypeAnnots(t.getFormalParameters().get(0), emptyList());
+            assertHasTypeAnnots(t.getFormalParameters().get(0), emptyList());
+            assertHasTypeAnnots(t.getThrownExceptions().get(0), ANNOT_A);
         }
     }
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/internal/TypeAnnotTestUtil.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/internal/TypeAnnotTestUtil.java
@@ -54,6 +54,9 @@ public class TypeAnnotTestUtil {
         return sym.streamMethods(it -> it.nameEquals(fieldName)).findFirst().get();
     }
 
+    public static JMethodSig getCtorType(JClassType sym, int arity) {
+        return sym.getConstructors().stream().filter(it -> it.getArity() == arity).findFirst().get();
+    }
 
     public static JMethodSymbol getMethodSym(JClassSymbol sym, String fieldName) {
         return sym.getDeclaredMethods().stream().filter(it -> it.nameEquals(fieldName)).findFirst().get();

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/testdata/ClassWithTypeAnnotationsOnMethods.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/testdata/ClassWithTypeAnnotationsOnMethods.java
@@ -11,7 +11,7 @@ import net.sourceforge.pmd.lang.java.symbols.testdata.ClassWithTypeAnnotationsIn
 import net.sourceforge.pmd.lang.java.symbols.testdata.ClassWithTypeAnnotationsInside.B;
 
 /**
- * See {@link TypeAnnotReflectionOnMethodsTest}.
+ * See {TypeAnnotReflectionOnMethodsTest}.
  *
  * @author Clément Fournier
  */
@@ -40,13 +40,13 @@ public abstract class ClassWithTypeAnnotationsOnMethods {
 
     abstract void abOnReceiver(@A @B ClassWithTypeAnnotationsOnMethods this);
 
-    static class CtorOwner {
+    public static class CtorOwner {
 
         CtorOwner(@A @B int i) { }
 
         @A CtorOwner() { }
 
-        CtorOwner(String i) throws @A Exception {}
+        CtorOwner(String i, int x) throws @A Exception {}
     }
 
 }


### PR DESCRIPTION

## Describe the PR
Just an incremental improvement.
<!-- A clear and concise description of the bug the PR fixes or the feature the PR introduces. -->

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Ref #4334


## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

