### PR TITLE
Fix #2462: [java] LinguisticNaming should ignore setters for Builders 

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LinguisticNamingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LinguisticNamingRule.java
@@ -140,10 +140,14 @@ public class LinguisticNamingRule extends AbstractJavaRulechainRule {
     }
 
     private void checkSetters(ASTMethodDeclaration node, Object data, String nameOfMethod) {
-        if (startsWithCamelCaseWord(nameOfMethod, "set") && !node.isVoid()) {
+        if (startsWithCamelCaseWord(nameOfMethod, "set") && !node.isVoid() && returnsEnclosingType(node)) {
             asCtx(data).addViolationWithMessage(node, "Linguistics Antipattern - The setter ''{0}'' should not return any type except void linguistically",
                                                 nameOfMethod);
         }
+    }
+
+    private static boolean returnsEnclosingType(ASTMethodDeclaration node) {
+        return !node.getResultTypeNode().getTypeMirror().equals(node.getEnclosingType().getTypeMirror());
     }
 
     private boolean isBooleanType(ASTType node) {

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LinguisticNaming.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LinguisticNaming.xml
@@ -618,7 +618,7 @@ public class SomeClass {
     </test-code>
 
     <test-code>
-        <description>#2462 LinguisticNaming must ignore setters that returns current type</description>
+        <description>#2462 LinguisticNaming must ignore setters that returns current type - Simple Builder</description>
         <expected-problems>0</expected-problems>
         <code><![CDATA[
 public class ObjectBuilder {
@@ -636,5 +636,26 @@ public class ObjectBuilder {
     }
 }
         ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>#2462 LinguisticNaming must ignore setters that returns current type - Builder as inner class</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class FooBar {
+    public static class FooBarBuilder {
+        public FooBarBuilder setFoo(String foo){
+            return this;
+        }
+
+        public FooBarBuilder setBar(int bar) {
+            return this;
+        }
+
+        public FooBar build() {
+            return null;
+        }
+    }
+}        ]]></code>
     </test-code>
 </test-data>

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LinguisticNaming.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/LinguisticNaming.xml
@@ -616,4 +616,25 @@ public class SomeClass {
 }
         ]]></code>
     </test-code>
+
+    <test-code>
+        <description>#2462 LinguisticNaming must ignore setters that returns current type</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class ObjectBuilder {
+
+   public ObjectBuilder setValue1(int value1) {
+        return this;
+    }
+
+    public ObjectBuilder setValue2(int value2) {
+        return this;
+    }
+
+    public Object build(){
+        return null;
+    }
+}
+        ]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #2462 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

