### PR TITLE
automate  `checkstyle` burden imposed on `trimTrailingWhitespace` and `removeUnusedImports` with `Maven Spotless Plugin`

### DIFF
--- a/.spotless/eclipse.importorder
+++ b/.spotless/eclipse.importorder
@@ -1,0 +1,7 @@
+#Organize Import Order
+#Sun Nov 20 10:59:37 CET 2016
+4=
+3=net.sourceforge.pmd
+2=org
+1=java
+0=\#

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/JavaccToken.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/JavaccToken.java
@@ -263,4 +263,3 @@ public class JavaccToken implements GenericToken<JavaccToken> {
         return new JavaccToken(IMPLICIT_TOKEN, "", offset, offset, document);
     }
 }
-

--- a/pmd-core/src/test/java/net/sourceforge/pmd/PmdCoreTestUtils.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/PmdCoreTestUtils.java
@@ -34,4 +34,3 @@ public final class PmdCoreTestUtils {
         return dummyLanguage().getDefaultVersion();
     }
 }
-

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractTypeDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractTypeDeclaration.java
@@ -81,4 +81,3 @@ abstract class AbstractTypeDeclaration extends AbstractTypedSymbolDeclarator<JCl
         return isNested();
     }
 }
-

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractTypedSymbolDeclarator.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractTypedSymbolDeclarator.java
@@ -43,4 +43,3 @@ abstract class AbstractTypedSymbolDeclarator<T extends JElementSymbol>
     }
 
 }
-

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/package-info.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/package-info.java
@@ -27,4 +27,3 @@
  *
  */
 package net.sourceforge.pmd.lang.java.ast;
-

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NPathComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NPathComplexityRule.java
@@ -58,4 +58,3 @@ public class NPathComplexityRule extends AbstractJavaRulechainRule {
         return data;
     }
 }
-

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/GetCommentOnFunction.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/GetCommentOnFunction.java
@@ -57,6 +57,3 @@ public class GetCommentOnFunction extends BaseJavaXPathFunction {
         };
     }
 }
-
-
-

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/JavaQualifiedNameTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/JavaQualifiedNameTest.java
@@ -234,4 +234,3 @@ class JavaQualifiedNameTest {
     }
 
 }
-

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AnonClassExample.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AnonClassExample.java
@@ -14,4 +14,3 @@ public class AnonClassExample {
         }).start();
     }
 }
-

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/typescript/ast/TypeScriptLexerBase.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/typescript/ast/TypeScriptLexerBase.java
@@ -7,10 +7,10 @@
 
 package net.sourceforge.pmd.lang.typescript.ast;
 
-import org.antlr.v4.runtime.*;
-
 import java.util.ArrayDeque;
 import java.util.Deque;
+
+import org.antlr.v4.runtime.*;
 
 /**
  * All lexer methods that used in grammar (IsStrictMode)

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/PlsqlParsingHelper.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/PlsqlParsingHelper.java
@@ -22,4 +22,3 @@ public class PlsqlParsingHelper extends BaseParsingHelper<PlsqlParsingHelper, AS
     }
 
 }
-

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/SalesforceFieldTypes.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/SalesforceFieldTypes.java
@@ -100,4 +100,3 @@ abstract class SalesforceFieldTypes {
      */
     protected abstract void findDataType(String expression, List<Path> metadataDirectories);
 }
-

--- a/pom.xml
+++ b/pom.xml
@@ -696,6 +696,53 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>com.diffplug.spotless</groupId>
+                    <artifactId>spotless-maven-plugin</artifactId>
+                    <version>2.44.5</version>
+                    <configuration>
+                        <formats>
+                            <format>
+                                <excludes>
+                                    <exclude>**/testdata/**</exclude>
+                                    <exclude>**gradlew**</exclude>
+                                    <exclude>**mvnw**</exclude>
+                                </excludes>
+                                <trimTrailingWhitespace/>
+                                <includes>
+                                    <include>.gitignore</include>
+                                </includes>
+                            </format>
+                        </formats>
+                        <java>
+                            <excludes>
+                                <exclude>**/src/main/java/net/sourceforge/pmd/lang/java/types/package-info.java</exclude>
+                                <exclude>**/testdata/**</exclude>
+                                <exclude>**/unnecessaryimport/package1/U.java</exclude>
+                            </excludes>
+                            <removeUnusedImports/>
+                            <importOrder>
+                                <file>${maven.multiModuleProjectDirectory}/.spotless/eclipse.importorder</file>
+                            </importOrder>
+                        </java>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>spotless-apply</id>
+                            <phase>process-sources</phase>
+                            <goals>
+                                <goal>apply</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>spotless-check</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -754,6 +801,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!-- configuration is in plugin management section -->
+            </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -701,6 +701,7 @@
                     <artifactId>spotless-maven-plugin</artifactId>
                     <version>2.44.5</version>
                     <configuration>
+                        <skip>${spot.skip}</skip>
                         <formats>
                             <format>
                                 <excludes>
@@ -708,10 +709,10 @@
                                     <exclude>**gradlew**</exclude>
                                     <exclude>**mvnw**</exclude>
                                 </excludes>
-                                <trimTrailingWhitespace/>
                                 <includes>
                                     <include>.gitignore</include>
                                 </includes>
+                                <trimTrailingWhitespace/>
                             </format>
                         </formats>
                         <java>
@@ -1242,6 +1243,7 @@
                 <maven.source.skip>true</maven.source.skip>
                 <checkstyle.skip>true</checkstyle.skip>
                 <pmd.skip>true</pmd.skip>
+                <spot.skip>true</spot.skip>
                 <cpd.skip>true</cpd.skip>
                 <cyclonedx.skip>true</cyclonedx.skip>
                 <dokka.skip>true</dokka.skip>


### PR DESCRIPTION
- https://github.com/pmd/pmd/issues/5848
- https://github.com/pmd/pmd/issues/5777

just like quarkus having eclipse config in place make is the perfect candidate for auto fix static analysis with spotless.

- https://github.com/projectnessie/nessie/pull/624
- https://github.com/quarkusio/quarkus/pull/48041
- https://github.com/spring-projects/spring-framework/pull/34978
- https://github.com/palantir/palantir-java-format
- https://github.com/diffplug/spotless/tree/main/plugin-maven#palantir-java-format

maven has check and spot so of course its possible to have both but actually spot covers what check does in ideal making it redundant. 

as seen in quarkus they have aligned config having seen here changed 7 years ago its clear thats its out of date:

- https://github.com/pmd/build-tools/blob/main/eclipse/pmd-eclipse-code-formatter.xml