### PR TITLE
chore: Remove unnecessary suppress warnings

### DIFF
--- a/pmd-ant/src/main/java/net/sourceforge/pmd/ant/internal/Slf4jSimpleConfigurationForAnt.java
+++ b/pmd-ant/src/main/java/net/sourceforge/pmd/ant/internal/Slf4jSimpleConfigurationForAnt.java
@@ -107,7 +107,6 @@ public final class Slf4jSimpleConfigurationForAnt {
         }
     }
 
-    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
     private static Level getAntLogLevel(Project project) {
         for (final BuildListener l : project.getBuildListeners()) {
             Field declaredField = null;
@@ -148,7 +147,6 @@ public final class Slf4jSimpleConfigurationForAnt {
         return DEFAULT_LEVEL;
     }
 
-    @SuppressWarnings("PMD.AvoidAccessibilityAlteration")
     private static Level determineGradleLogLevel(Project project, BuildListener l) {
         try {
             project.log("Detected gradle AntLoggingAdapter", Project.MSG_DEBUG);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/PMDVersion.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/PMDVersion.java
@@ -80,7 +80,6 @@ public final class PMDVersion {
      * Checks if the current version is unknown.
      * @return True if an unknown version, false otherwise
      */
-    @SuppressWarnings("PMD.LiteralsFirstInComparisons")
     public static boolean isUnknown() {
         return UNKNOWN.equals(VERSION);
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/AbstractAnalysisCache.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cache/internal/AbstractAnalysisCache.java
@@ -126,8 +126,8 @@ abstract class AbstractAnalysisCache implements AnalysisCache {
 
             final long currentAuxClassPathChecksum;
             if (auxclassPathClassLoader instanceof URLClassLoader) {
-                // we don't want to close our aux classpath loader - we still need it...
-                @SuppressWarnings("PMD.CloseResource") final URLClassLoader urlClassLoader = (URLClassLoader) auxclassPathClassLoader;
+                // not using try-with-resources as we don't want to close our aux classpath loader - we still need it...
+                final URLClassLoader urlClassLoader = (URLClassLoader) auxclassPathClassLoader;
                 currentAuxClassPathChecksum = FINGERPRINTER.fingerprint(urlClassLoader.getURLs());
 
                 if (cacheIsValid && currentAuxClassPathChecksum != auxClassPathChecksum) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CpdAnalysis.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CpdAnalysis.java
@@ -196,7 +196,7 @@ public final class CpdAnalysis implements AutoCloseable {
             LOGGER.debug("Running match algorithm on {} files...", sourceManager.size());
             MatchAlgorithm matchAlgorithm = new MatchAlgorithm(tokens, configuration.getMinimumTileSize());
             List<Match> matches = matchAlgorithm.findMatches(listener, sourceManager);
-            tokens = null; // NOPMD null it out before rendering
+            tokens = null; // null it out before rendering, might help gc
             LOGGER.debug("Finished: {} duplicates found", matches.size());
 
             CPDReport cpdReport = new CPDReport(sourceManager, matches, numberOfTokensPerFile, processingErrors);

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CpdAnalysis.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CpdAnalysis.java
@@ -9,6 +9,7 @@ import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -75,6 +76,8 @@ public final class CpdAnalysis implements AutoCloseable {
     private final CPDConfiguration configuration;
     private final FileCollector files;
     private final PmdReporter reporter;
+    private final Map<FileId, Integer> numberOfTokensPerFile = new HashMap<>();
+    private final List<Report.ProcessingError> processingErrors = new ArrayList<>();
     private final @Nullable CPDReportRenderer renderer;
     private @NonNull CPDListener listener = new CPDNullListener();
 
@@ -152,52 +155,17 @@ public final class CpdAnalysis implements AutoCloseable {
         performAnalysis(r -> { });
     }
 
-    @SuppressWarnings("PMD.CloseResource")
     public void performAnalysis(Consumer<CPDReport> consumer) {
-
         try (SourceManager sourceManager = new SourceManager(files.getCollectedFiles())) {
             if (sourceManager.isEmpty()) {
                 reporter.warn("No files to analyze. Check input paths and exclude parameters, use --debug to see file collection traces.");
             }
 
-            Map<Language, CpdLexer> tokenizers =
-                sourceManager.getTextFiles().stream()
-                             .map(it -> it.getLanguageVersion().getLanguage())
-                             .distinct()
-                             .filter(it -> it instanceof CpdCapableLanguage)
-                             .collect(Collectors.toMap(lang -> lang, lang -> ((CpdCapableLanguage) lang).createCpdLexer(configuration.getLanguageProperties(lang))));
-
-            Map<FileId, Integer> numberOfTokensPerFile = new HashMap<>();
-
-            List<Report.ProcessingError> processingErrors = new ArrayList<>();
-            Tokens tokens = new Tokens();
-            for (TextFile textFile : sourceManager.getTextFiles()) {
-                TextDocument textDocument = sourceManager.get(textFile);
-                Tokens.State savedState = tokens.savePoint();
-                try {
-                    int newTokens = doTokenize(textDocument, tokenizers.get(textFile.getLanguageVersion().getLanguage()), tokens);
-                    numberOfTokensPerFile.put(textDocument.getFileId(), newTokens);
-                    listener.addedFile(1);
-                } catch (IOException | FileAnalysisException e) {
-                    if (e instanceof FileAnalysisException) { // NOPMD
-                        ((FileAnalysisException) e).setFileId(textFile.getFileId());
-                    }
-                    String message = configuration.isSkipLexicalErrors() ? "Skipping file" : "Error while tokenizing";
-                    reporter.errorEx(message, e);
-                    processingErrors.add(new Report.ProcessingError(e, textFile.getFileId()));
-                    savedState.restore(tokens);
-                }
-            }
-            if (!processingErrors.isEmpty() && !configuration.isSkipLexicalErrors()) {
+            List<Match> matches = findMatches(sourceManager);
+            if (shouldAbortEarlyBecauseOfProcessingErrors()) {
                 reporter.error("Errors were detected while lexing source, exiting because --skip-lexical-errors is unset.");
                 return;
             }
-
-            LOGGER.debug("Running match algorithm on {} files...", sourceManager.size());
-            MatchAlgorithm matchAlgorithm = new MatchAlgorithm(tokens, configuration.getMinimumTileSize());
-            List<Match> matches = matchAlgorithm.findMatches(listener, sourceManager);
-            tokens = null; // null it out before rendering, might help gc
-            LOGGER.debug("Finished: {} duplicates found", matches.size());
 
             CPDReport cpdReport = new CPDReport(sourceManager, matches, numberOfTokensPerFile, processingErrors);
 
@@ -216,6 +184,59 @@ public final class CpdAnalysis implements AutoCloseable {
         // source manager is closed and closes all text files now.
     }
 
+    private boolean shouldAbortEarlyBecauseOfProcessingErrors() {
+        return !processingErrors.isEmpty() && !configuration.isSkipLexicalErrors();
+    }
+
+    private List<Match> findMatches(SourceManager sourceManager) {
+        // Note: tokens contains all tokens of all analyzed files which is a huge data structure.
+        // The tokens are only needed for finding the matches and can be garbage collected afterwards.
+        // The report only needs the matches. Especially, the tokens are only referenced here and in
+        // matchAlgorithm. When this method finishes, tokens should be eligible for garbage collection
+        // making it possible to free up memory for render the report if needed.
+
+        Tokens tokens = tokenizeFiles(sourceManager);
+        if (shouldAbortEarlyBecauseOfProcessingErrors()) {
+            return Collections.emptyList();
+        }
+
+        LOGGER.debug("Running match algorithm on {} files...", sourceManager.size());
+        MatchAlgorithm matchAlgorithm = new MatchAlgorithm(tokens, configuration.getMinimumTileSize());
+        List<Match> matches = matchAlgorithm.findMatches(listener, sourceManager);
+        LOGGER.debug("Finished: {} duplicates found", matches.size());
+        return matches;
+    }
+
+    @SuppressWarnings("PMD.CloseResource")
+    // TextFiles and TextDocuments are managed by sourceManager, which closes all text files in the end.
+    private Tokens tokenizeFiles(SourceManager sourceManager) {
+        Map<Language, CpdLexer> tokenizers =
+                sourceManager.getTextFiles().stream()
+                        .map(it -> it.getLanguageVersion().getLanguage())
+                        .distinct()
+                        .filter(it -> it instanceof CpdCapableLanguage)
+                        .collect(Collectors.toMap(lang -> lang, lang -> ((CpdCapableLanguage) lang).createCpdLexer(configuration.getLanguageProperties(lang))));
+
+        Tokens tokens = new Tokens();
+        for (TextFile textFile : sourceManager.getTextFiles()) {
+            TextDocument textDocument = sourceManager.get(textFile);
+            Tokens.State savedState = tokens.savePoint();
+            try {
+                int newTokens = doTokenize(textDocument, tokenizers.get(textFile.getLanguageVersion().getLanguage()), tokens);
+                numberOfTokensPerFile.put(textDocument.getFileId(), newTokens);
+                listener.addedFile(1);
+            } catch (IOException | FileAnalysisException e) {
+                if (e instanceof FileAnalysisException) { // NOPMD
+                    ((FileAnalysisException) e).setFileId(textFile.getFileId());
+                }
+                String message = configuration.isSkipLexicalErrors() ? "Skipping file" : "Error while tokenizing";
+                reporter.errorEx(message, e);
+                processingErrors.add(new Report.ProcessingError(e, textFile.getFileId()));
+                savedState.restore(tokens);
+            }
+        }
+        return tokens;
+    }
 
     @Override
     public void close() throws IOException {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/TokenEntry.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/TokenEntry.java
@@ -93,7 +93,6 @@ public class TokenEntry implements Comparable<TokenEntry> {
         this.hashCode = hashCode;
     }
 
-    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/impl/BaseTokenFilter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/impl/BaseTokenFilter.java
@@ -144,7 +144,7 @@ public class BaseTokenFilter<T extends GenericToken<T>> implements TokenManager<
             @Override
             protected void computeNext() {
                 assert index >= 0;
-                if (startToken != currentToken) { // NOPMD - intentional check for reference equality
+                if (startToken != currentToken) {
                     throw new ConcurrentModificationException("Using iterator after next token has been requested.");
                 }
                 if (index < unprocessedTokens.size()) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/EscapeTranslator.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/EscapeTranslator.java
@@ -19,7 +19,6 @@ import net.sourceforge.pmd.util.AssertionUtil;
  * <p>This is an abstract class because the default implementation does not
  * perform any escape processing. Subclasses refine this behavior.
  */
-@SuppressWarnings("PMD.AssignmentInOperand")
 public abstract class EscapeTranslator {
     // Note that this can easily be turned into a java.io.Reader with
     // efficient block IO, optimized for the common case where there are

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/JavaEscapeTranslator.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/JavaEscapeTranslator.java
@@ -11,7 +11,6 @@ import net.sourceforge.pmd.lang.document.TextDocument;
  * An implementation of {@link EscapeTranslator} that translates Java
  * unicode escapes.
  */
-@SuppressWarnings("PMD.AssignmentInOperand")
 public final class JavaEscapeTranslator extends BackslashEscapeTranslator {
 
     public JavaEscapeTranslator(TextDocument input) {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/JjtreeBuilder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/JjtreeBuilder.java
@@ -182,7 +182,7 @@ public final class JjtreeBuilder<N extends AbstractJjtreeNode<N, ?>> {
 
 
     private void closeImpl(N n, JavaccToken lastToken) {
-        if (lastToken.getNext() == n.getFirstToken()) { // NOPMD CompareObjectsWithEquals
+        if (lastToken.getNext() == n.getFirstToken()) {
             // this means, that the node has zero length.
             // create an implicit token to represent this case.
             JavaccToken implicit = JavaccToken.implicitBefore(lastToken.getNext());

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/StreamImpl.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/StreamImpl.java
@@ -154,7 +154,7 @@ public final class StreamImpl {
 
         if (length == 0) {
             return empty();
-        } else if (filtermap == Filtermap.NODE_IDENTITY) { // NOPMD CompareObjectsWithEquals
+        } else if (filtermap == Filtermap.NODE_IDENTITY) {
             @SuppressWarnings("unchecked")
             NodeStream<T> res = length == 1 ? (NodeStream<T>) singleton(parent.getChild(from))
                                            : (NodeStream<T>) new ChildrenStream(parent, from, length);
@@ -179,7 +179,7 @@ public final class StreamImpl {
             return empty();
         }
 
-        if (target == Filtermap.NODE_IDENTITY) { // NOPMD CompareObjectsWithEquals
+        if (target == Filtermap.NODE_IDENTITY) {
             return (NodeStream<T>) new AncestorOrSelfStream(node);
         }
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/NioTextFile.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/NioTextFile.java
@@ -103,7 +103,6 @@ class NioTextFile extends BaseCloseable implements TextFile {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        @SuppressWarnings("PMD.CloseResource")
         NioTextFile that = (NioTextFile) o;
         return path.equals(that.path);
     }

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/TextDocument.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/TextDocument.java
@@ -274,7 +274,6 @@ public interface TextDocument extends Closeable {
      *
      * @see TextFile#forCharSeq(CharSequence, FileId, LanguageVersion)
      */
-    @SuppressWarnings("PMD.CloseResource")
     static TextDocument readOnlyString(@NonNull CharSequence source, @NonNull FileId filename, @NonNull LanguageVersion lv) {
         TextFile textFile = TextFile.forCharSeq(source, filename, lv);
         try {

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/TextFileBuilder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/TextFileBuilder.java
@@ -17,7 +17,6 @@ import net.sourceforge.pmd.util.AssertionUtil;
  * A builder for a new text file.
  * See static methods on {@link TextFile}.
  */
-@SuppressWarnings("PMD.MissingStaticMethodInNonInstantiatableClass")
 public abstract class TextFileBuilder {
 
     protected final LanguageVersion languageVersion;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/PmdDocumentSorter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/PmdDocumentSorter.java
@@ -22,7 +22,6 @@ final class PmdDocumentSorter implements Comparator<Node> {
     }
 
     @Override
-    @SuppressWarnings("PMD.CompareObjectsWithEquals")
     public int compare(Node node1, Node node2) {
         if (node1 == node2) {
             return 0;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonXPathRuleQuery.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonXPathRuleQuery.java
@@ -63,7 +63,6 @@ public class SaxonXPathRuleQuery {
     private static final SimpleDataKey<AstTreeInfo> SAXON_TREE_CACHE_KEY = DataMap.simpleDataKey("saxon.tree");
 
     private final String xpathExpr;
-    @SuppressWarnings("PMD") // may be useful later, idk
     private final XPathVersion version;
     private final Map<PropertyDescriptor<?>, Object> properties;
     private final XPathHandler xPathHandler;

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/CollectionUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/CollectionUtil.java
@@ -351,7 +351,7 @@ public final class CollectionUtil {
         AssertionUtil.requireParamNotNull("values", to);
         Validate.isTrue(from.size() == to.size(), "Mismatched list sizes %s to %s", from, to);
 
-        if (from.isEmpty()) { //NOPMD: we really want to compare references here
+        if (from.isEmpty()) {
             return emptyMap();
         }
 

--- a/pmd-cpp/src/main/java/net/sourceforge/pmd/lang/cpp/cpd/CppCpdLexer.java
+++ b/pmd-cpp/src/main/java/net/sourceforge/pmd/lang/cpp/cpd/CppCpdLexer.java
@@ -118,7 +118,7 @@ public class CppCpdLexer extends JavaccCpdLexer {
             if (ignoreLiteralSequences || ignoreIdentifierAndLiteralSeqences) {
                 final int kind = currentToken.getKind();
                 if (isDiscardingToken()) {
-                    if (currentToken == discardingTokensUntil) { // NOPMD - intentional check for reference equality
+                    if (currentToken == discardingTokensUntil) {
                         discardingTokensUntil = null;
                         discardCurrent = true;
                     }

--- a/pmd-cs/src/main/java/net/sourceforge/pmd/lang/cs/cpd/CsCpdLexer.java
+++ b/pmd-cs/src/main/java/net/sourceforge/pmd/lang/cs/cpd/CsCpdLexer.java
@@ -183,7 +183,7 @@ public class CsCpdLexer extends AntlrCpdLexer {
             if (ignoreLiteralSequences) {
                 final int type = currentToken.getKind();
                 if (isDiscardingLiterals()) {
-                    if (currentToken == discardingLiteralsUntil) { // NOPMD - intentional check for reference equality
+                    if (currentToken == discardingLiteralsUntil) {
                         discardingLiteralsUntil = null;
                         discardCurrent = true;
                     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableId.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTVariableId.java
@@ -365,7 +365,6 @@ public final class ASTVariableId extends AbstractTypedSymbolDeclarator<JVariable
      */
     // @formatter:on
     @Override
-    @SuppressWarnings("PMD.UselessOverridingMethod")
     public @NonNull JTypeMirror getTypeMirror() {
         return super.getTypeMirror();
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractLiteral.java
@@ -29,7 +29,7 @@ abstract class AbstractLiteral extends AbstractJavaExpr {
         // its parentheses have not yet been set yet so the text is
         // just the literal.
         assert getParenthesisDepth() == 0;
-        assert getFirstToken() == getLastToken(); // NOPMD
+        assert getFirstToken() == getLastToken();
         literalToken = getFirstToken();
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AstDisambiguationPass.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AstDisambiguationPass.java
@@ -139,7 +139,7 @@ final class AstDisambiguationPass {
                 checkParentIsMember(processor, resolvedType, parent);
             }
 
-            if (resolved != name) { // NOPMD - intentional check for reference equality
+            if (resolved != name) {
                 ((AbstractJavaNode) name.getParent()).setChild((AbstractJavaNode) resolved, name.getIndexInParent());
             }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/InternalInterfaces.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/InternalInterfaces.java
@@ -17,7 +17,6 @@ import net.sourceforge.pmd.lang.ast.NodeStream;
  * uniform names on related concepts. Maybe it makes sense to publish some of
  * them at some point.
  */
-@SuppressWarnings("PMD.MissingStaticMethodInNonInstantiatableClass")
 final class InternalInterfaces {
 
     private InternalInterfaces() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaComment.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaComment.java
@@ -94,7 +94,6 @@ public class JavaComment implements Reportable {
      * True if this is a comment delimiter or an asterisk. This
      * tests the whole parameter and not a prefix/suffix.
      */
-    @SuppressWarnings("PMD.LiteralsFirstInComparisons") // a fp
     public static boolean isMarkupWord(Chars word) {
         return word.length() <= 3
             && (word.contentEquals("*")

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningLoopVariablesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidReassigningLoopVariablesRule.java
@@ -166,7 +166,7 @@ public class AvoidReassigningLoopVariablesRule extends AbstractJavaRulechainRule
 
                     ASTStatement body = ((ASTLoopStatement) stmt).getBody();
                     for (JavaNode child : stmt.children()) {
-                        if (child != body) { // NOPMD
+                        if (child != body) {
                             checkVorViolations(child);
                         }
                     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryFullyQualifiedNameRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryFullyQualifiedNameRule.java
@@ -127,7 +127,7 @@ public class UnnecessaryFullyQualifiedNameRule extends AbstractJavaRulechainRule
             sb.append(startIncluded.getTypeMirror().getSymbol().getPackageName());
         }
         ASTClassType nextSimpleName = startIncluded;
-        while (nextSimpleName != stopExcluded) { // NOPMD we want identity comparison
+        while (nextSimpleName != stopExcluded) {
             sb.append('.').append(nextSimpleName.getSimpleName());
             nextSimpleName = (ASTClassType) nextSimpleName.getParent();
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LawOfDemeterRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/LawOfDemeterRule.java
@@ -159,7 +159,7 @@ public class LawOfDemeterRule extends AbstractJavaRule {
         }
         int degree = foreignDegree(expr);
         if (isReportedDegree(degree) && isUsedAsGetter(expr)) {
-            if (expr.getParent() instanceof ASTVariableDeclarator) { // NOPMD #3786
+            if (expr.getParent() instanceof ASTVariableDeclarator) {
                 // Stored in local var, don't report if some usages escape.
                 // In that case, usage sites with non-escaping usage will be reported.
                 return isAllowedStore(((ASTVariableDeclarator) expr.getParent()).getVarId());
@@ -263,7 +263,7 @@ public class LawOfDemeterRule extends AbstractJavaRule {
 
     private boolean isPureDataContainer(JTypeMirror type) {
         JTypeDeclSymbol symbol = type.getSymbol();
-        if (symbol instanceof JClassSymbol) { // NOPMD
+        if (symbol instanceof JClassSymbol) {
             return "java.util".equals(symbol.getPackageName()) // collection, map, iterator, properties, etc
                 || TypeTestUtil.isA(Stream.class, type)
                 || TypeTestUtil.isA(Class.class, type)
@@ -336,7 +336,7 @@ public class LawOfDemeterRule extends AbstractJavaRule {
 
     private boolean isFactoryMethod(ASTMethodCall expr) {
         ASTExpression qualifier = expr.getQualifier();
-        if (qualifier != null) { // NOPMD SimplifyBooleanReturns https://github.com/pmd/pmd/issues/3786
+        if (qualifier != null) {
             return typeEndsWith(qualifier, "Factory")
                 || nameEndsWith(qualifier, "Factory")
                 || nameIs(qualifier, "factory");

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/DataflowPass.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/DataflowPass.java
@@ -1032,7 +1032,7 @@ public final class DataflowPass {
                 && enclosingClassScope.equals(((JFieldSymbol) var).getEnclosingClass());
         }
 
-        private static JVariableSymbol getVarIfUnaryAssignment(ASTUnaryExpression node) { // NOPMD UnusedPrivateMethod
+        private static JVariableSymbol getVarIfUnaryAssignment(ASTUnaryExpression node) {
             ASTExpression operand = node.getOperand();
             if (!node.getOperator().isPure() && operand instanceof ASTNamedReferenceExpr) {
                 return ((ASTNamedReferenceExpr) operand).getReferencedSym();

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveAppendsShouldReuseRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/ConsecutiveAppendsShouldReuseRule.java
@@ -77,7 +77,7 @@ public class ConsecutiveAppendsShouldReuseRule extends AbstractJavaRule {
         while (expr instanceof ASTMethodCall && isStringBuilderAppend(expr)) {
             expr = ((ASTMethodCall) expr).getQualifier();
         }
-        return base == expr ? null : expr; // NOPMD
+        return base == expr ? null : expr;
     }
 
     private @Nullable JVariableSymbol getAssignmentLhsAsVar(@Nullable ASTExpression expr) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/SymbolEquality.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/SymbolEquality.java
@@ -29,7 +29,6 @@ import net.sourceforge.pmd.lang.java.types.Substitution;
  * synthetic stuff (eg implicit formal parameters, bridge methods),
  * which we must either filter-out or replicate in AST symbols. This is TODO
  */
-@SuppressWarnings("PMD.CompareObjectsWithEquals")
 public final class SymbolEquality {
 
     private SymbolEquality() {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ClassTypeImpl.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ClassTypeImpl.java
@@ -382,7 +382,7 @@ class ClassTypeImpl implements JClassType {
 
     @Override
     public final boolean isTop() {
-        return this.getSymbol().equals(ts.OBJECT.getSymbol()); // NOPMD CompareObjectsWithEquals
+        return this.getSymbol().equals(ts.OBJECT.getSymbol());
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/InvocationMatcher.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/InvocationMatcher.java
@@ -103,7 +103,7 @@ public final class InvocationMatcher {
     }
 
     private boolean matchQualifier(InvocationNode node) {
-        if (qualifierMatcher == TypeMatcher.ANY) { // NOPMD CompareObjectsWithEquals
+        if (qualifierMatcher == TypeMatcher.ANY) {
             return true;
         }
         if (node instanceof ASTConstructorCall) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JIntersectionType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JIntersectionType.java
@@ -147,7 +147,7 @@ public final class JIntersectionType implements JTypeMirror {
         JTypeMirror newPrimary = primaryBound.subst(subst);
         List<JClassType> myItfs = getInterfaces();
         List<JClassType> newBounds = TypeOps.substClasses(myItfs, subst);
-        return newPrimary == getPrimaryBound() && newBounds == myItfs // NOPMD UseEqualsToCompareObjectReferences
+        return newPrimary == getPrimaryBound() && newBounds == myItfs
                ? this
                : new JIntersectionType(ts, newPrimary, newBounds);
     }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JTypeMirror.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JTypeMirror.java
@@ -325,7 +325,7 @@ public interface JTypeMirror extends JTypeVisitable {
      * Returns true if this is {@link TypeSystem#NO_TYPE}, ie {@code void}.
      */
     default boolean isVoid() {
-        return this == getTypeSystem().NO_TYPE; // NOPMD CompareObjectsWithEquals
+        return this == getTypeSystem().NO_TYPE;
     }
 
     /** Returns true if this is an {@linkplain JArrayType array type}. */

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/LexicalScope.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/LexicalScope.java
@@ -40,7 +40,7 @@ public final class LexicalScope extends MapFunction<String, @Nullable JTypeVar> 
      * tvars that were in this scope.
      */
     public LexicalScope andThen(List<? extends JTypeVar> vars) {
-        if (this == EMPTY && vars.isEmpty()) { // NOPMD CompareObjectsWithEquals
+        if (this == EMPTY && vars.isEmpty()) {
             return EMPTY;
         }
         return new LexicalScope(associateByTo(new HashMap<>(getMap()), vars, JTypeVar::getName));

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ast/internal/LazyTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ast/internal/LazyTypeResolver.java
@@ -439,7 +439,7 @@ public final class LazyTypeResolver extends JavaVisitorBase<TypingContext, @NonN
 
                 JTypeMirror resolved = isUnresolved(lhs) ? rhs : lhs;
                 return resolved.isNumeric() ? unaryNumericPromotion(resolved)
-                                            : resolved == ts.BOOLEAN ? resolved  // NOPMD #3205
+                                            : resolved == ts.BOOLEAN ? resolved
                                                                      : ts.ERROR;
             } else {
                 // anything else, including error types & such: ERROR
@@ -474,11 +474,11 @@ public final class LazyTypeResolver extends JavaVisitorBase<TypingContext, @NonN
     }
 
     private boolean isUnresolved(JTypeMirror t) {
-        return t == ts.UNKNOWN;  // NOPMD CompareObjectsWithEquals
+        return t == ts.UNKNOWN;
     }
 
     private boolean isUnresolved(JMethodSig m) {
-        return m == null || m == ts.UNRESOLVED_METHOD;  // NOPMD CompareObjectsWithEquals
+        return m == null || m == ts.UNRESOLVED_METHOD;
     }
 
     @Override

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ast/internal/PolyResolution.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ast/internal/PolyResolution.java
@@ -576,7 +576,7 @@ public final class PolyResolution {
             case OR:
             case XOR:
             case AND:
-                return ctxType == ts.BOOLEAN ? booleanCtx : getNumericContext(ctxType); // NOPMD CompareObjectsWithEquals
+                return ctxType == ts.BOOLEAN ? booleanCtx : getNumericContext(ctxType);
             case LEFT_SHIFT:
             case RIGHT_SHIFT:
             case UNSIGNED_RIGHT_SHIFT:

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ExprOps.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ExprOps.java
@@ -38,7 +38,6 @@ import net.sourceforge.pmd.lang.java.types.internal.infer.ExprMirror.LambdaExprM
 import net.sourceforge.pmd.lang.java.types.internal.infer.ExprMirror.MethodRefMirror;
 import net.sourceforge.pmd.util.CollectionUtil;
 
-@SuppressWarnings("PMD.CompareObjectsWithEquals")
 public final class ExprOps {
 
     private final Infer infer;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/Infer.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/Infer.java
@@ -44,7 +44,7 @@ import net.sourceforge.pmd.util.OptionalBool;
 /**
  * Main entry point for type inference.
  */
-@SuppressWarnings({"PMD.FieldNamingConventions", "PMD.CompareObjectsWithEquals"})
+@SuppressWarnings("PMD.CompareObjectsWithEquals")
 public final class Infer {
 
     final ExprOps exprOps;
@@ -206,7 +206,7 @@ public final class Infer {
 
     private MethodCtDecl goToInvocationWithFallback(MethodCallSite site) {
         MethodCtDecl ctdecl = getCompileTimeDecl(site);
-        if (ctdecl == NO_CTDECL) { // NOPMD CompareObjectsWithEquals
+        if (ctdecl == NO_CTDECL) {
             return NO_CTDECL;
         }
 
@@ -216,7 +216,7 @@ public final class Infer {
 
         { // reduce scope of invocType, outside of here it's failed
             final MethodCtDecl invocType = finishInstantiation(site, ctdecl);
-            if (invocType != FAILED_INVOCATION) { // NOPMD CompareObjectsWithEquals
+            if (invocType != FAILED_INVOCATION) {
                 return invocType;
             }
         }
@@ -262,7 +262,7 @@ public final class Infer {
      */
     @NonNull MethodCtDecl determineInvocationTypeOrFail(MethodCallSite site) {
         MethodCtDecl ctdecl = getCompileTimeDecl(site);
-        if (ctdecl == NO_CTDECL) { // NOPMD CompareObjectsWithEquals
+        if (ctdecl == NO_CTDECL) {
             return ctdecl;
         }
 
@@ -786,7 +786,7 @@ public final class Infer {
 
             for (JTypeMirror aLowerBound : alpha.getBounds(BoundKind.LOWER)) {
                 for (JTypeMirror anotherLowerBound : alpha.getBounds(BoundKind.LOWER)) {
-                    if (aLowerBound != anotherLowerBound // NOPMD CompareObjectsWithEquals
+                    if (aLowerBound != anotherLowerBound
                         && infCtx.isGround(aLowerBound)
                         && infCtx.isGround(anotherLowerBound)
                         && commonSuperWithDiffParameterization(aLowerBound, anotherLowerBound)) {
@@ -985,7 +985,7 @@ public final class Infer {
      * https://docs.oracle.com/javase/specs/jls/se8/html/jls-5.html#jls-5.3
      */
     static Convertibility isConvertible(JTypeMirror exprType, JTypeMirror formalType, boolean canBox) {
-        if (exprType == formalType) { // NOPMD CompareObjectsWithEquals
+        if (exprType == formalType) {
             // fast path
             return Convertibility.SUBTYPING;
         }

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/InferenceContext.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/InferenceContext.java
@@ -439,7 +439,7 @@ final class InferenceContext {
     void onBoundAdded(InferenceVar ivar, BoundKind kind, JTypeMirror bound, boolean isPrimary) {
         // guard against α <: Object
         // all variables have it, it's useless to propagate it
-        if (kind != BoundKind.UPPER || bound != ts.OBJECT) { // NOPMD CompareObjectsWithEquals
+        if (kind != BoundKind.UPPER || bound != ts.OBJECT) {
             if (parent != null) {
                 parent.onBoundAdded(ivar, kind, bound, isPrimary);
                 return;

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/InferenceVar.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/InferenceVar.java
@@ -174,7 +174,7 @@ public final class InferenceVar implements SubstVar {
             for (JTypeMirror prev : prevBounds) {
                 // add substituted bound
                 JTypeMirror newBound = prev.subst(substitution);
-                if (newBound == prev || prevBounds.contains(newBound)) { // NOPMD CompareObjectsWithEquals
+                if (newBound == prev || prevBounds.contains(newBound)) {
                     // not actually new, don't call listeners, etc
                     newBounds.add(newBound);
                 } else {
@@ -199,7 +199,7 @@ public final class InferenceVar implements SubstVar {
 
     public boolean isEquivalentTo(JTypeMirror t) {
         return this == t || t instanceof InferenceVar
-            && ((InferenceVar) t).boundSet == this.boundSet; // NOPMD CompareObjectsWithEquals
+            && ((InferenceVar) t).boundSet == this.boundSet;
     }
 
     public boolean isSubtypeNoSideEffect(@NonNull JTypeMirror other) {

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/PhaseOverloadSet.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/PhaseOverloadSet.java
@@ -74,8 +74,7 @@ final class PhaseOverloadSet extends OverloadSet<MethodCtDecl> {
      * <p>https://docs.oracle.com/javase/specs/jls/se8/html/jls-15.html#jls-15.12.2.5
      */
     @Override
-    @SuppressWarnings("PMD.UselessOverridingMethod")
-    void add(MethodCtDecl sig) {
+    void add(MethodCtDecl sig) { // NOPMD UselessOverridingMethod
         super.add(sig);
     }
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ReductionStep.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ReductionStep.java
@@ -132,7 +132,7 @@ enum ReductionStep {
     }
 
     protected boolean acceptsBound(JTypeMirror bound, InferenceContext infCtx) {
-        return infCtx.isGround(bound) && bound != infCtx.ts.NULL_TYPE; // NOPMD CompareObjectsWithEquals
+        return infCtx.isGround(bound) && bound != infCtx.ts.NULL_TYPE;
     }
 
     /**

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/TypeInferenceLogger.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/TypeInferenceLogger.java
@@ -234,7 +234,7 @@ public interface TypeInferenceLogger {
 
         @Override
         public void logResolutionFail(ResolutionFailure exception) {
-            if (exception.getCallSite() instanceof MethodCallSite && exception != ResolutionFailure.UNKNOWN) { // NOPMD CompareObjectsWithEquals
+            if (exception.getCallSite() instanceof MethodCallSite && exception != ResolutionFailure.UNKNOWN) {
                 ((MethodCallSite) exception.getCallSite()).acceptFailure(exception);
             }
         }

--- a/pmd-lua/src/main/java/net/sourceforge/pmd/lang/lua/cpd/LuaCpdLexer.java
+++ b/pmd-lua/src/main/java/net/sourceforge/pmd/lang/lua/cpd/LuaCpdLexer.java
@@ -90,7 +90,7 @@ public class LuaCpdLexer extends AntlrCpdLexer {
             if (ignoreLiteralSequences) {
                 final int type = currentToken.getKind();
                 if (isDiscardingLiterals()) {
-                    if (currentToken == discardingLiteralsUntil) { // NOPMD - intentional check for reference equality
+                    if (currentToken == discardingLiteralsUntil) {
                         discardingLiteralsUntil = null;
                         discardCurrent = true;
                     }

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/TypeSet.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/TypeSet.java
@@ -91,7 +91,6 @@ public class TypeSet {
     public static class PrimitiveTypeResolver implements Resolver {
         private Map<String, Class<?>> primitiveTypes = new HashMap<>();
 
-        @SuppressWarnings("PMD.AvoidUsingShortType")
         public PrimitiveTypeResolver() {
             primitiveTypes.put("int", int.class);
             primitiveTypes.put("float", float.class);


### PR DESCRIPTION
## Describe the PR

I've applied the new rule [UnnecessaryWarningSuppression](https://docs.pmd-code.org/latest/pmd_rules_java_bestpractices.html#unnecessarywarningsuppression) against our own code base.

There is one strange behavior of this rule with [UselessOverridingMethod](https://docs.pmd-code.org/latest/pmd_rules_java_design.html#uselessoverridingmethod) in PhaseOverloadSet. That's why I changed the annotation to "NOPMD" comment.

## Related issues


## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

