### PR TITLE
Fix #2304: [java] UnnecessaryImport FP for on-demand imports in JavaDoc

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryImportRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryImportRule.java
@@ -453,7 +453,7 @@ public class UnnecessaryImportRule extends AbstractJavaRule {
             final ASTImportDeclaration importNode = it.node;
             if (importNode.isImportOnDemand()) {
                 final JClassSymbol symbol = TypesFromReflection.loadSymbol(importNode.getTypeSystem(), importNode.getImportedName());
-                return symbol != null && (symbol.getSimpleName().equals(referenceName) || symbol.getDeclaredField(referenceName) != null || symbol.getDeclaredClass(referenceName) != null);
+                return symbol != null && symbol.getDeclaredClass(referenceName) != null;
             }
 
             return false;

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryImport.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryImport.xml
@@ -1359,7 +1359,8 @@ public class C {
 
     <test-code>
         <description>#2304: [java] static on-demand field import in javadoc</description>
-        <expected-problems>0</expected-problems>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>1</expected-linenumbers>
         <code><![CDATA[
 import static java.nio.charset.StandardCharsets.*;
 public class Foo {
@@ -1373,7 +1374,8 @@ public class Foo {
 
     <test-code>
         <description>#2304: [java] static on-demand method import in javadoc</description>
-        <expected-problems>0</expected-problems>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>1</expected-linenumbers>
         <code><![CDATA[
 import static java.util.function.Predicate.*;
 public class Foo {


### PR DESCRIPTION
## Describe the PR

This should catch some FPs when referencing Classes/Methods/Fields from (static) on-demand imports in JavaDoc.
One case I explicitly didn't add support for was when referencing a static method in JavaDoc without its class, since IntelliJ also doesn't support such links.

Examples:

This is supported:
```java
import java.util.function.*;
/**
 * {@link Predicate#isEqual(Object)}}
 */
```

But this not: (this is also not supported by javadoc)
```java
import static java.util.function.Predicate.*;
/**
 * {@link isEqual(Object)}}
 */
```

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fixes #2304 

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

