### PR TITLE
Add `AvoidBooleanMethodParameters` rule

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/AvoidBooleanMethodParametersRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/AvoidBooleanMethodParametersRule.java
@@ -1,0 +1,81 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.rule.design;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
+import net.sourceforge.pmd.lang.apex.ast.ASTModifierNode;
+import net.sourceforge.pmd.lang.apex.ast.ASTParameter;
+import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+
+/**
+ * Rule that detects boolean parameters in public and global Apex methods.
+ * 
+ * <p>
+ * Boolean parameters can make method calls difficult to understand and
+ * maintain. They often indicate that a method is doing more than one thing and
+ * could benefit from being split into separate methods with more descriptive
+ * names.
+ * </p>
+ * 
+ * <p>
+ * This rule flags any boolean parameters found in public or global methods,
+ * encouraging developers to use more expressive alternatives such as enums,
+ * separate methods, or configuration objects.
+ * </p>
+ * 
+ * @see https://github.com/pmd/pmd/issues/5427
+ */
+public class AvoidBooleanMethodParametersRule extends AbstractApexRule {
+
+    private static final String BOOLEAN_TYPE = "boolean";
+
+    /**
+     * Visits an Apex method node and checks for boolean global/public
+     * parameters.
+     * 
+     * @param theMethod
+     *            the method node being visited
+     * @param data
+     *            the rule context data
+     * @return the rule context data
+     */
+    @Override
+    public Object visit(ASTMethod theMethod, Object data) {
+        if (!isPublicOrGlobal(theMethod)) {
+            return data;
+        }
+        theMethod.descendants(ASTParameter.class).filter(parameter -> isBoolean(parameter))
+                .forEach(parameter -> asCtx(data).addViolation(parameter));
+        return data;
+    }
+
+    /**
+     * Builds the target selector for this rule.
+     * 
+     * <p>
+     * This rule targets Apex method nodes ({@link ASTMethod}) since it needs to
+     * analyze method parameters for boolean types.
+     * </p>
+     * 
+     * @return a rule target selector configured for ASTMethod nodes
+     */
+    @Override
+    protected @NonNull RuleTargetSelector buildTargetSelector() {
+        return RuleTargetSelector.forTypes(ASTMethod.class);
+    }
+
+
+    private boolean isPublicOrGlobal(ASTMethod method) {
+        ASTModifierNode modifier = method.getModifiers();
+        return modifier.isPublic() || modifier.isGlobal();
+    }
+
+    private boolean isBoolean(ASTParameter parameter) {
+        return BOOLEAN_TYPE.equalsIgnoreCase(parameter.getType());
+    }
+}

--- a/pmd-apex/src/main/resources/category/apex/design.xml
+++ b/pmd-apex/src/main/resources/category/apex/design.xml
@@ -488,4 +488,49 @@ public class Person {
         </example>
     </rule>
 
+
+    <rule name="AvoidBooleanMethodParameters"
+          language="apex"
+          since="7.15.0"
+          message="Avoid Boolean method parameters"
+          class="net.sourceforge.pmd.lang.apex.rule.design.AvoidBooleanMethodParametersRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_design.html#avoidbooleanmethodparameters">
+        <description>
+Boolean parameters in a system's API can make method calls difficult to understand and
+maintain. They often indicate that a method is doing more than one thing and
+could benefit from being split into separate methods with more descriptive
+names.
+
+This rule flags any boolean parameters found in public or global methods,
+encouraging developers to use more expressive alternatives such as enums,
+separate methods, or configuration objects.
+        </description>
+        <priority>2</priority>
+        <example>
+<![CDATA[
+// Violates the rule: Uses a Boolean parameter
+public class MyClass {
+  public static void doSomething(Boolean isSomething) {
+    if (isSomething == true) {
+      // Do something
+    } else { 
+      // Do something else, or maybe do nothing if isSomething is null? 
+    }
+  }
+}
+
+// Compliant code: Two separate methods
+public class MyClass {
+  public static void doSomething() {
+    // Do something
+  }
+
+  public static void doSomethingElse() {
+    // Do something else
+  }
+}
+]]>
+        </example>
+    </rule>
+
 </ruleset>

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/AvoidBooleanMethodParametersTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/AvoidBooleanMethodParametersTest.java
@@ -1,0 +1,11 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.rule.design;
+
+import net.sourceforge.pmd.test.PmdRuleTst;
+
+class AvoidBooleanMethodParametersTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/xml/AvoidBooleanMethodParameters.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/xml/AvoidBooleanMethodParameters.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+    <test-code>
+        <description>Global Boolean parameter should cause violation</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+global class Foo {
+    global static void bar(Boolean b) {
+        if (b) {
+            // do something
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Public Boolean parameter should cause violation</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public static void bar(Boolean b) {
+        if (b) {
+            // do something
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Case insensitive type declaration of Boolean parameter should cause violation</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    public static void bar(BoOlEaN b) {
+        if (b) {
+            // do something
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Protected Boolean parameter should not cause violation</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    protected void bar(Boolean b) {
+        if (b) {
+            // do something
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Private Boolean parameter should not cause violation</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    private void bar(Boolean b) {
+        if (b) {
+            // do something
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+</test-data>


### PR DESCRIPTION
## Describe the PR

This PR implements a new Apex rule `AvoidBooleanMethodParametersRule` that detects boolean parameters in public and global methods. The rule discourages the use of Boolean parameters in public APIs as they can lead to ambiguity (especially with null handling in Apex) and make method calls harder to understand. Instead, the rule encourages developers to use more expressive alternatives such as separate methods with descriptive names, enums, or configuration objects.

The rule specifically targets:
- Public and global methods only (private and protected methods are excluded)
- Parameters with boolean type
- Encourages splitting methods or using more descriptive parameter types

## Related issues

- Fix #5427

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)