### PR TITLE
[apex] New Rule: Annotations should be pascal case

### DIFF
--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/AnnotationsShouldBePascalCaseRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/AnnotationsShouldBePascalCaseRule.java
@@ -1,0 +1,67 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.rule.design;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+import net.sourceforge.pmd.lang.apex.ast.ASTAnnotation;
+import net.sourceforge.pmd.lang.apex.ast.ASTField;
+import net.sourceforge.pmd.lang.apex.ast.ASTMethod;
+import net.sourceforge.pmd.lang.apex.ast.ASTModifierNode;
+import net.sourceforge.pmd.lang.apex.ast.ASTUserClass;
+import net.sourceforge.pmd.lang.apex.ast.ASTUserInterface;
+import net.sourceforge.pmd.lang.apex.ast.ApexNode;
+import net.sourceforge.pmd.lang.apex.rule.AbstractApexRule;
+import net.sourceforge.pmd.lang.rule.RuleTargetSelector;
+
+/**
+ * Rule that checks if Apex annotations are written in PascalCase. This rule
+ * ensures that all annotations follow the standard naming convention where each
+ * word in the annotation name starts with a capital letter.
+ */
+public class AnnotationsShouldBePascalCaseRule extends AbstractApexRule {
+
+    private static final Set<Class<? extends ApexNode<?>>> VALID_PARENT_TYPES = Collections.unmodifiableSet(
+            new HashSet<>(Arrays.asList(ASTUserClass.class, ASTUserInterface.class, ASTMethod.class, ASTField.class)));
+
+    @Override
+    public Object visit(ASTAnnotation annotation, Object data) {
+        if (annotation.isResolved() && isValidAnnotationContext(annotation) && !isPascalCase(annotation)) {
+            asCtx(data).addViolation(annotation);
+        }
+        return data;
+    }
+
+    @Override
+    protected @NonNull RuleTargetSelector buildTargetSelector() {
+        return RuleTargetSelector.forTypes(ASTAnnotation.class);
+    }
+
+    /**
+     * Checks if the annotation is in a valid context (direct child of a
+     * modifier node that is a direct child of a valid parent type).
+     */
+    private boolean isValidAnnotationContext(ASTAnnotation annotation) {
+        if (!(annotation.getParent() instanceof ASTModifierNode)) {
+            return false;
+        }
+        ASTModifierNode modifierNode = (ASTModifierNode) annotation.getParent();
+        return VALID_PARENT_TYPES.stream().anyMatch(type -> type.isInstance(modifierNode.getParent()));
+    }
+
+    /**
+     * Checks if the annotation name matches its raw name (indicating
+     * PascalCase).
+     */
+    private boolean isPascalCase(ASTAnnotation annotation) {
+        return annotation.getName().equals(annotation.getRawName());
+    }
+
+}

--- a/pmd-apex/src/main/resources/category/apex/design.xml
+++ b/pmd-apex/src/main/resources/category/apex/design.xml
@@ -488,4 +488,41 @@ public class Person {
         </example>
     </rule>
 
+    <rule name="AnnotationsShouldBePascalCase"
+          language="apex"
+          since="7.15.0"
+          message="Annotations should be PascalCase"
+          class="net.sourceforge.pmd.lang.apex.rule.design.AnnotationsShouldBePascalCaseRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_apex_design.html#annotationsshouldbepascalcase">
+        <description>
+Apex, while case-insensitive, benefits from a consistent code style to improve readability and maintainability.
+Enforcing PascalCase for annotations aligns with the established conventions and reduces ambiguity - promoting a unified coding standard.
+        </description>
+        <priority>3</priority>
+        <example>
+<![CDATA[
+// Incorrect:
+@istest
+private static void fooShouldBar() {
+  //...
+}
+
+// Correct:
+@IsTest
+private static void fooShouldBar() {
+  //...
+}
+
+//Incorrect:
+@testvisible
+private boolean doSomething = false;
+
+
+//Correct:
+@TestVisible
+private boolean doSomething = false;
+]]>
+        </example>
+    </rule>
+
 </ruleset>

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/AnnotationsShouldBePascalCaseTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/AnnotationsShouldBePascalCaseTest.java
@@ -1,0 +1,11 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.apex.rule.design;
+
+import net.sourceforge.pmd.test.PmdRuleTst;
+
+class AnnotationsShouldBePascalCaseTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/xml/AnnotationsShouldBePascalCase.xml
+++ b/pmd-apex/src/test/resources/net/sourceforge/pmd/lang/apex/rule/design/xml/AnnotationsShouldBePascalCase.xml
@@ -1,0 +1,533 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+    xmlns="http://pmd.sourceforge.net/rule-tests"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+
+    <test-code>
+        <description>AuraEnabled PascalCase is correct</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @AuraEnabled
+    public static void bar(Boolean b) {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>AuraEnabled lowercase is incorrect</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @auraenabled
+    public static void bar(Boolean b) {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Deprecated PascalCase is correct</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @Deprecated
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Deprecated lowercase is incorrect</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @deprecated
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Future PascalCase is correct</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @Future
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Future lowercase is incorrect</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @future
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>InvocableMethod PascalCase is correct</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @InvocableMethod
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>InvocableMethod lowercase is incorrect</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @invocablemethod
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>InvocableVariable PascalCase is correct</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @InvocableVariable
+    public String myVar;
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>InvocableVariable lowercase is incorrect</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @invocablevariable
+    public String myVar;
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>IsTest PascalCase is correct</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+@IsTest
+public class Foo {
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>IsTest lowercase is incorrect</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+@istest
+public class Foo {
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>JsonAccess PascalCase is correct</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+@JsonAccess
+public class Foo {
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>JsonAccess lowercase is incorrect</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+@jsonaccess
+public class Foo {
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>NamespaceAccessible PascalCase is correct</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+@NamespaceAccessible
+public class Foo {
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>NamespaceAccessible lowercase is incorrect</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+@namespaceaccessible
+public class Foo {
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>ReadOnly PascalCase is correct</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+@ReadOnly
+public class Foo {
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>ReadOnly lowercase is incorrect</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+@readonly
+public class Foo {
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>RemoteAction PascalCase is correct</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @RemoteAction
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>RemoteAction lowercase is incorrect</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @remoteaction
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>SuppressWarnings PascalCase is correct</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+@SuppressWarnings
+public class Foo {
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>SuppressWarnings lowercase is incorrect</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+@suppresswarnings
+public class Foo {
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>TestSetup PascalCase is correct</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @TestSetup
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>TestSetup lowercase is incorrect</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @testsetup
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>TestVisible PascalCase is correct</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @TestVisible
+    private static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>TestVisible lowercase is incorrect</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @testvisible
+    private static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>RestResource PascalCase is correct</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+@RestResource(urlMapping='/yourUrl')
+public class Foo {
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>RestResource lowercase is incorrect</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+@restresource(urlMapping='/yourUrl')
+public class Foo {
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>HttpDelete PascalCase is correct</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+@RestResource(urlMapping='/yourUrl')
+public class Foo {
+    @HttpDelete
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>HttpDelete lowercase is incorrect</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+@RestResource(urlMapping='/yourUrl')
+public class Foo {
+    @httpdelete
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>HttpGet PascalCase is correct</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+@RestResource(urlMapping='/yourUrl')
+public class Foo {
+    @HttpGet
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>HttpGet lowercase is incorrect</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+@RestResource(urlMapping='/yourUrl')
+public class Foo {
+    @httpget
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>HttpPatch PascalCase is correct</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+@RestResource(urlMapping='/yourUrl')
+public class Foo {
+    @HttpPatch
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>HttpPatch lowercase is incorrect</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+@RestResource(urlMapping='/yourUrl')
+public class Foo {
+    @httppatch
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>HttpPost PascalCase is correct</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+@RestResource(urlMapping='/yourUrl')
+public class Foo {
+    @HttpPost
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>HttpPost lowercase is incorrect</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+@RestResource(urlMapping='/yourUrl')
+public class Foo {
+    @httppost
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>HttpPut PascalCase is correct</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+@RestResource(urlMapping='/yourUrl')
+public class Foo {
+    @HttpPut
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>HttpPut lowercase is incorrect</description>
+        <expected-problems>1</expected-problems>
+        <code><![CDATA[
+@RestResource(urlMapping='/yourUrl')
+public class Foo {
+    @httpput
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Invalid annotation on class is ignored</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+@nonexistent
+public class Foo {
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Invalid annotation on method is ignored</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Foo {
+    @nonexistent
+    public static void bar() {
+        // do something
+    }
+}
+        ]]></code>
+    </test-code>
+
+</test-data>


### PR DESCRIPTION
## Describe the PR

This PR introduces a new rule `AnnotationsShouldBePascalCase` for Apex that enforces PascalCase naming convention for annotations. The rule checks if Apex annotations are written in PascalCase format, where each word in the annotation name starts with a capital letter.

The rule validates annotations in the following contexts:
- Class-level annotations
- Interface-level annotations
- Method-level annotations
- Field-level annotations

The rule ensures that annotations like `@AuraEnabled`, `@Deprecated`, `@Future`, etc. are written in PascalCase format and reports violations when they are written in any other case (e.g., `@auraenabled`, `@deprecated`, `@FUTURE`).

## Related issues

- Fix #5650

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

