### PR TITLE
[doc] Fix javadoc plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -400,11 +400,11 @@
                         <detectOfflineLinks>false</detectOfflineLinks>
                         <offlineLinks>
                             <offlineLink>
-                                <location>${project.basedir}/../pmd-core/target/apidocs</location>
+                                <location>${project.basedir}/../pmd-core/target/reports/apidocs</location>
                                 <url>../../pmd-core/${project.version}</url>
                             </offlineLink>
                             <offlineLink>
-                                <location>${project.basedir}/../pmd-test/target/apidocs</location>
+                                <location>${project.basedir}/../pmd-test/target/reports/apidocs</location>
                                 <url>../../pmd-test/${project.version}</url>
                             </offlineLink>
                             <offlineLink>


### PR DESCRIPTION
## Describe the PR

Since upgrade to version 3.10.0 the links to pmd-core from other modules didn't work anymore.
Compare https://docs.pmd-code.org/apidocs/pmd-java/7.0.0/net/sourceforge/pmd/lang/java/JavaLanguageModule.html with https://docs.pmd-code.org/apidocs/pmd-java/7.14.0/net/sourceforge/pmd/lang/java/JavaLanguageModule.html

Last working version: 7.8.0

This also fixes the error messages like

```
[INFO] --- javadoc:3.11.2:jar (attach-javadocs) @ pmd-lua ---
[ERROR] The given File link: /home/andreas/temp/pmd-release-7.14.0/pmd/pmd-lua/../pmd-core/target/apidocs is not a dir.
[ERROR] Error fetching link: /home/andreas/temp/pmd-release-7.14.0/pmd/pmd-lua/../pmd-core/target/apidocs. Ignored it.
[ERROR] The given File link: /home/andreas/temp/pmd-release-7.14.0/pmd/pmd-lua/../pmd-test/target/apidocs is not a dir.
[ERROR] Error fetching link: /home/andreas/temp/pmd-release-7.14.0/pmd/pmd-lua/../pmd-test/target/apidocs. Ignored it.
```



## Related issues

- Refs #5410

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)

