### PR TITLE
Fix #1639 #5832: Use filtered comment text for UnnecessaryImport

### DIFF
--- a/docs/pages/release_notes.md
+++ b/docs/pages/release_notes.md
@@ -25,6 +25,9 @@ This is a {{ site.pmd.release_type }} release.
 ### 🚀 New and noteworthy
 
 ### 🐛 Fixed Issues
+* java-codestyle
+  * [#1639](https://github.com/pmd/pmd/issues/1639): \[java] UnnecessaryImport false positive for multiline @<!-- -->link Javadoc
+  * [#5832](https://github.com/pmd/pmd/issues/5832): \[java] UnnecessaryImport false positive for multiline @<!-- -->see Javadoc
 
 ### 🚨 API Changes
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryImportRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryImportRule.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -45,6 +46,7 @@ import net.sourceforge.pmd.lang.java.types.OverloadSelectionResult;
 import net.sourceforge.pmd.lang.java.types.TypeSystem;
 import net.sourceforge.pmd.lang.java.types.TypeTestUtil;
 import net.sourceforge.pmd.util.CollectionUtil;
+import net.sourceforge.pmd.util.IteratorUtil;
 
 /**
  * Detects unnecessary imports.
@@ -201,8 +203,12 @@ public class UnnecessaryImportRule extends AbstractJavaRule {
             if (!(comment instanceof JavadocComment)) {
                 continue;
             }
+
+            String filteredCommentText = IteratorUtil.toStream(comment.getFilteredLines(true))
+                    .collect(Collectors.joining("\n"));
+
             for (Pattern p : PATTERNS) {
-                Matcher m = p.matcher(comment.getText());
+                Matcher m = p.matcher(filteredCommentText);
                 while (m.find()) {
                     String fullname = m.group(1);
 

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryImport.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryImport.xml
@@ -1357,4 +1357,33 @@ public class C {
             ]]></code>
     </test-code>
 
+    <test-code>
+        <description>[java] UnnecessaryImport false positive for multiline @see Javadoc #5832</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * @see ArrayList#addAll(int,
+ *      Collection)
+ */
+public class Main { }
+]]></code>
+    </test-code>
+
+    <test-code>
+        <description>[java] UnusedImports false positive for multiline @link Javadoc #1639</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.io.File;
+import java.io.FileOutputStream;
+
+public class Demo {
+    /** {@link
+     * FileOutputStream#FileOutputStream(File)} */
+    void main() {}
+}
+]]></code>
+    </test-code>
 </test-data>


### PR DESCRIPTION
## Describe the PR

Filtered comment text has the prefixes "/**" and "*" removed, so that only the plain javadoc text is used. This allows for correct multiline detection of references in javadoc.

## Related issues

- Fix #1639 
- Fix #5832 

## Ready?

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

