### PR TITLE
Fix #5770: [java] UnnecessaryLocalBeforeBranchRule

### DIFF
--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryLocalBeforeThrowRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryLocalBeforeThrowRule.java
@@ -1,0 +1,36 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.codestyle;
+
+import static java.util.Objects.requireNonNull;
+
+import net.sourceforge.pmd.lang.java.ast.ASTExpression;
+import net.sourceforge.pmd.lang.java.ast.ASTLocalVariableDeclaration;
+import net.sourceforge.pmd.lang.java.ast.ASTThrowStatement;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableAccess;
+import net.sourceforge.pmd.lang.java.ast.ASTVariableId;
+import net.sourceforge.pmd.lang.java.rule.AbstractJavaRulechainRule;
+
+public class UnnecessaryLocalBeforeThrowRule extends AbstractJavaRulechainRule {
+
+    public UnnecessaryLocalBeforeThrowRule() {
+        super(ASTThrowStatement.class);
+    }
+
+    @Override
+    public Object visit(ASTThrowStatement throwStmt, Object data) {
+        ASTExpression expr = throwStmt.getExpr();
+        if (expr instanceof ASTVariableAccess) {
+            ASTVariableId varDecl = requireNonNull(((ASTVariableAccess) expr).getReferencedSym()).tryGetNode();
+            if (requireNonNull(varDecl).isLocalVariable()
+                    && !varDecl.getDeclaredAnnotations().nonEmpty()
+                    && varDecl.getLocalUsages().size() == 1
+                    && varDecl.ancestors(ASTLocalVariableDeclaration.class).firstOrThrow().getNextSibling() == throwStmt) {
+                asCtx(data).addViolation(throwStmt, varDecl.getName());
+            }
+        }
+        return null;
+    }
+}

--- a/pmd-java/src/main/resources/category/java/codestyle.xml
+++ b/pmd-java/src/main/resources/category/java/codestyle.xml
@@ -1783,6 +1783,28 @@ public class Foo {
         </example>
     </rule>
 
+    <rule name="UnnecessaryLocalBeforeThrow"
+          language="java"
+          since="7.15.0"
+          message="Consider simply throwing the value vs storing it in local variable ''{0}''."
+          class="net.sourceforge.pmd.lang.java.rule.codestyle.UnnecessaryLocalBeforeThrowRule"
+          externalInfoUrl="${pmd.website.baseurl}/pmd_rules_java_codestyle.html#unnecessarylocalbeforethrow">
+        <description>
+Avoid the creation of unnecessary local variables.
+        </description>
+        <priority>3</priority>
+        <example>
+<![CDATA[
+public class Foo {
+   public int foo(String bar) {
+     var ex = getIllegalArgumentException(bar);
+     throw ex; // instead, just 'throw getIllegalArgumentException(bar);'
+   }
+}
+]]>
+        </example>
+    </rule>
+
     <rule name="UnnecessaryModifier"
           language="java"
           since="1.02"

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryLocalBeforeThrowTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryLocalBeforeThrowTest.java
@@ -1,0 +1,11 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
+package net.sourceforge.pmd.lang.java.rule.codestyle;
+
+import net.sourceforge.pmd.test.PmdRuleTst;
+
+class UnnecessaryLocalBeforeThrowTest extends PmdRuleTst {
+    // no additional unit tests
+}

--- a/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryLocalBeforeThrow.xml
+++ b/pmd-java/src/test/resources/net/sourceforge/pmd/lang/java/rule/codestyle/xml/UnnecessaryLocalBeforeThrow.xml
@@ -1,0 +1,300 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test-data
+        xmlns="http://pmd.sourceforge.net/rule-tests"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://pmd.sourceforge.net/rule-tests http://pmd.sourceforge.net/rule-tests_1_0_0.xsd">
+    <test-code>
+        <description>#5770 Simple unnecessary local before throw</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>4</expected-linenumbers>
+        <code><![CDATA[
+public class Test {
+    void test() {
+        RuntimeException e = new RuntimeException();
+        throw e;
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Variable used elsewhere - no violation</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Test {
+    void test() {
+        RuntimeException e = new RuntimeException();
+        System.out.println(e.getMessage());
+        throw e;
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Annotated variable - no violation</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Test {
+    void test() {
+        @SuppressWarnings("serial")
+        RuntimeException e = new RuntimeException();
+        throw e;
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Statements not consecutive - no violation when order matters</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Test {
+    void test() {
+        RuntimeException e = new RuntimeException();
+        doSomething();
+        throw e;
+    }
+    void doSomething() {}
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Throw not using variable - no violation</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Test {
+    void test() {
+        RuntimeException e = new RuntimeException();
+        throw new IllegalStateException();
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Variable used in try-catch - no violation</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Test {
+    void test() {
+        Exception e;
+        try {
+            something();
+        } catch (Exception ex) {
+            e = ex;
+        }
+        throw e;
+    }
+    void something() throws Exception {}
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Multiple variables but only one used in throw</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Test {
+    void test() {
+        RuntimeException e1 = new RuntimeException();
+        RuntimeException e2 = new RuntimeException();
+        throw e1;
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Multiple variables but only one used in throw</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Test {
+    void test() {
+        RuntimeException e2 = new RuntimeException();
+        RuntimeException e1 = new RuntimeException();
+        throw e1;
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Throwing field - no violation</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Test {
+    private Exception e = new Exception();
+
+    void test() {
+        throw e;
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Throwing parameter - no violation</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Test {
+    void test(Exception e) {
+        throw e;
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Throw in switch statement</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>6</expected-linenumbers>
+        <code><![CDATA[
+public class Test {
+    void test(int value) {
+        switch (value) {
+            case 1:
+                RuntimeException e = new RuntimeException();
+                throw e;
+            default:
+                throw new IllegalArgumentException();
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Throw in if statement</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Test {
+    void test(boolean condition) {
+        if (condition) {
+            RuntimeException e = new RuntimeException();
+            throw e;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+    <test-code>
+        <description>Throw in try-with-resources</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Test {
+    void test() throws Exception {
+        try (AutoCloseable ac = something()) {
+            RuntimeException e = new RuntimeException();
+            throw e;
+        }
+    }
+    AutoCloseable something() { return null; }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Throw inside for loop block</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Test {
+    void test() {
+        for (int i = 0; i < 1; i++) {
+            RuntimeException e = new RuntimeException();
+            throw e;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Throw using lambda expression - no violation</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+import java.util.function.Supplier;
+
+public class Test {
+    void test() {
+        Supplier<RuntimeException> s = () -> new RuntimeException();
+        throw s.get();
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Throw in ternary - no violation</description>
+        <expected-problems>0</expected-problems>
+        <code><![CDATA[
+public class Test {
+    void test(boolean condition) {
+        throw condition ? new IllegalArgumentException() : new RuntimeException();
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Nested block with unnecessary throw variable</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Test {
+    void test() {
+        {
+            RuntimeException e = new RuntimeException();
+            throw e;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Inner class with throw - no violation</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Test {
+    class Inner {
+        void test() {
+            RuntimeException e = new RuntimeException();
+            throw e;
+        }
+    }
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Exception assigned and rethrown inside catch - no violation</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>7</expected-linenumbers>
+        <code><![CDATA[
+public class Test {
+    void test() {
+        try {
+            something();
+        } catch (Exception ex) {
+            Exception e = ex;
+            throw e;
+        }
+    }
+    void something() throws Exception {}
+}
+        ]]></code>
+    </test-code>
+
+    <test-code>
+        <description>Multiple throw variables but one is unnecessary</description>
+        <expected-problems>1</expected-problems>
+        <expected-linenumbers>5</expected-linenumbers>
+        <code><![CDATA[
+public class Test {
+    void test() {
+        RuntimeException e = new RuntimeException();
+        RuntimeException f = new RuntimeException();
+        throw f;
+    }
+}
+        ]]></code>
+    </test-code>
+
+
+</test-data>


### PR DESCRIPTION
## Fix #5770: [java] UnnecessaryLocalBeforeBranchRule

Add derivate of `UnnecessaryLocalBeforeReturnRule` to cover `throw` statement as well, considering `UnnecessaryLocalBeforeThrowRule`.

## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- https://github.com/pmd/pmd/issues/5770

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [x] Added unit tests for fixed bug/feature
- [x] Passing all unit tests
- [x] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [x] Added (in-code) documentation (if needed)

