### PR TITLE
Fix #5845: [java] align  BSD-style license by automation

### DIFF
--- a/.spotless/copyright.txt
+++ b/.spotless/copyright.txt
@@ -1,0 +1,4 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+

--- a/.spotless/eclipse.importorder
+++ b/.spotless/eclipse.importorder
@@ -1,0 +1,7 @@
+#Organize Import Order
+#Sun Nov 20 10:59:37 CET 2016
+4=
+3=net.sourceforge.pmd
+2=org
+1=java
+0=\#

--- a/pmd-ant/src/main/java/net/sourceforge/pmd/ant/CPDTask.java
+++ b/pmd-ant/src/main/java/net/sourceforge/pmd/ant/CPDTask.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-ant/src/main/java/net/sourceforge/pmd/ant/InternalApiBridge.java
+++ b/pmd-ant/src/main/java/net/sourceforge/pmd/ant/InternalApiBridge.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-ant/src/main/java/net/sourceforge/pmd/ant/PMDTask.java
+++ b/pmd-ant/src/main/java/net/sourceforge/pmd/ant/PMDTask.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-ant/src/main/java/net/sourceforge/pmd/ant/ReportException.java
+++ b/pmd-ant/src/main/java/net/sourceforge/pmd/ant/ReportException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-ant/src/main/java/net/sourceforge/pmd/ant/internal/Slf4jSimpleConfigurationForAnt.java
+++ b/pmd-ant/src/main/java/net/sourceforge/pmd/ant/internal/Slf4jSimpleConfigurationForAnt.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-ant/src/test/java/net/sourceforge/pmd/ant/AbstractAntTest.java
+++ b/pmd-ant/src/test/java/net/sourceforge/pmd/ant/AbstractAntTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-ant/src/test/java/net/sourceforge/pmd/ant/CPDTaskTest.java
+++ b/pmd-ant/src/test/java/net/sourceforge/pmd/ant/CPDTaskTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-ant/src/test/java/net/sourceforge/pmd/ant/FormatterTest.java
+++ b/pmd-ant/src/test/java/net/sourceforge/pmd/ant/FormatterTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-ant/src/test/java/net/sourceforge/pmd/ant/PMDTaskTest.java
+++ b/pmd-ant/src/test/java/net/sourceforge/pmd/ant/PMDTaskTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ApexAnnotationSuppressor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ApexAnnotationSuppressor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ApexLanguageProperties.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ApexLanguageProperties.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotation.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotation.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotationParameter.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotationParameter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnonymousClass.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAnonymousClass.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTArrayLoadExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTArrayLoadExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTArrayStoreExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTArrayStoreExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAssignmentExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTAssignmentExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBinaryExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBinaryExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBindExpressions.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBindExpressions.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBlockStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBooleanExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBooleanExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBreakStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTBreakStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTCastExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTCastExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTCatchBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTCatchBlockStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTClassRefExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTClassRefExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTCommentContainer.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTCommentContainer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTConstructorPreamble.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTConstructorPreamble.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTConstructorPreambleStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTConstructorPreambleStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTContinueStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTContinueStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlDeleteStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlDeleteStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlInsertStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlInsertStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlMergeStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlMergeStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlUndeleteStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlUndeleteStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlUpdateStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlUpdateStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlUpsertStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDmlUpsertStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDoLoopStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTDoLoopStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTElseWhenBlock.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTElseWhenBlock.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTEmptyReferenceExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTEmptyReferenceExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTExpressionStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTExpressionStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTField.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTField.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclaration.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclaration.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclarationStatements.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclarationStatements.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTForEachStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTForEachStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTForLoopStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTForLoopStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFormalComment.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTFormalComment.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTIdentifierCase.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTIdentifierCase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTIfBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTIfBlockStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTIfElseBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTIfElseBlockStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTIllegalStoreExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTIllegalStoreExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTInstanceOfExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTInstanceOfExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTInvalidDependentCompilation.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTInvalidDependentCompilation.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTJavaMethodCallExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTJavaMethodCallExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTJavaVariableExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTJavaVariableExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralCase.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralCase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMapEntryNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMapEntryNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethod.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethod.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodBlockStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodCallExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodCallExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTModifier.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTModifier.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTModifierNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTModifierNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTModifierOrAnnotation.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTModifierOrAnnotation.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMultiStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTMultiStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNestedExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNestedExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNestedStoreExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNestedStoreExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewKeyValueObjectExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewKeyValueObjectExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewListInitExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewListInitExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewListLiteralExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewListLiteralExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewMapInitExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewMapInitExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewMapLiteralExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewMapLiteralExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewObjectExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewObjectExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewSetInitExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewSetInitExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewSetLiteralExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTNewSetLiteralExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPackageVersionExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPackageVersionExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTParameter.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTParameter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPostfixExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPostfixExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPrefixExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTPrefixExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTProperty.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTProperty.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTReferenceExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTReferenceExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTReturnStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTReturnStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTRunAsBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTRunAsBlockStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSoqlExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSoqlExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSoslExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSoslExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTStandardCondition.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTStandardCondition.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTStatementExecuted.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTStatementExecuted.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSuperMethodCallExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSuperMethodCallExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSuperVariableExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSuperVariableExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSwitchStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTSwitchStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTernaryExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTernaryExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThisMethodCallExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThisMethodCallExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThisVariableExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThisVariableExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThrowStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTThrowStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTriggerVariableExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTriggerVariableExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTryCatchFinallyBlockStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTryCatchFinallyBlockStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTypeWhenBlock.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTTypeWhenBlock.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClass.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClass.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClassMethods.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClassMethods.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClassOrInterface.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserClassOrInterface.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserEnum.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserEnum.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserExceptionMethods.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserExceptionMethods.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserInterface.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserInterface.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserTrigger.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTUserTrigger.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTValueWhenBlock.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTValueWhenBlock.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableDeclaration.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableDeclaration.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableDeclarationStatements.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableDeclarationStatements.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableExpression.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTVariableExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTWhileLoopStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ASTWhileLoopStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexCommentContainerNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexCommentContainerNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractApexNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractDmlStatement.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AbstractDmlStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AccessNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/AccessNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexCommentBuilder.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexCommentBuilder.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexParser.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexParser.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexQualifiableNode.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexQualifiableNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexQualifiedName.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexQualifiedName.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexVisitorBase.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ApexVisitorBase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/BaseApexClass.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/BaseApexClass.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ReferenceType.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/ReferenceType.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/TriggerUsage.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/ast/TriggerUsage.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/cpd/ApexCpdLexer.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/cpd/ApexCpdLexer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/internal/ApexDesignerBindings.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/internal/ApexDesignerBindings.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/ApexMetrics.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/ApexMetrics.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/internal/ApexMetricsHelper.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/internal/ApexMetricsHelper.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/internal/CognitiveComplexityVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/internal/CognitiveComplexityVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/internal/StandardCycloVisitor.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/metrics/internal/StandardCycloVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/multifile/InternalApiBridge.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/multifile/InternalApiBridge.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/AbstractApexUnitTestRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/AbstractApexUnitTestRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/QueueableWithoutFinalizerRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/QueueableWithoutFinalizerRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/AbstractNcssCountRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/design/AbstractNcssCountRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidStatefulDatabaseResultRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidStatefulDatabaseResultRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/OverrideBothEqualsAndHashcodeRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/OverrideBothEqualsAndHashcodeRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/TypeShadowsBuiltInNamespaceRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/errorprone/TypeShadowsBuiltInNamespaceRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/internal/AbstractCounterCheckRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/internal/AbstractCounterCheckRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/performance/AvoidNonRestrictiveQueriesRule.java
+++ b/pmd-apex/src/main/java/net/sourceforge/pmd/lang/apex/rule/performance/AvoidNonRestrictiveQueriesRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/AntlrVersionTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/AntlrVersionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotationTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTAnnotationTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTBlockStatementTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTBlockStatementTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclarationStatementsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTFieldDeclarationStatementsTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralExpressionTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTLiteralExpressionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTMethodTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTReferenceExpressionTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTReferenceExpressionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTSoqlExpressionTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTSoqlExpressionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTTryCatchFinallyBlockStatementTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ASTTryCatchFinallyBlockStatementTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexParserTestBase.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexParserTestBase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexTreeDumpTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/ast/ApexTreeDumpTest.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.apex.ast;
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/cpd/ApexCpdLexerTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/cpd/ApexCpdLexerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/cpd/ApexCpdTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/cpd/ApexCpdTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/multifile/ApexMultifileAnalysisTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/multifile/ApexMultifileAnalysisTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexRuleTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/AbstractApexRuleTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/ApexXPathRuleTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/ApexXPathRuleTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/DebugsShouldUseLoggingLevelTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/DebugsShouldUseLoggingLevelTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/QueueableWithoutFinalizerTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/QueueableWithoutFinalizerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/bestpractices/UnusedLocalVariableTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/CognitiveComplexityTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/CognitiveComplexityTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/UnusedMethodTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/design/UnusedMethodTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidStatefulDatabaseResultTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/errorprone/AvoidStatefulDatabaseResultTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/performance/AvoidDebugStatementsTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/performance/AvoidDebugStatementsTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/performance/AvoidNonRestrictiveQueriesTest.java
+++ b/pmd-apex/src/test/java/net/sourceforge/pmd/lang/apex/rule/performance/AvoidNonRestrictiveQueriesTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/PMDVersionProvider.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/internal/PMDVersionProvider.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/typesupport/internal/RulePriorityTypeSupport.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/commands/typesupport/internal/RulePriorityTypeSupport.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/internal/PmdBanner.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/internal/PmdBanner.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/internal/PmdRootLogger.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/internal/PmdRootLogger.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/main/java/net/sourceforge/pmd/cli/internal/ProgressBarListener.java
+++ b/pmd-cli/src/main/java/net/sourceforge/pmd/cli/internal/ProgressBarListener.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/test/java/net/sourceforge/pmd/cli/ForceLanguageCliTest.java
+++ b/pmd-cli/src/test/java/net/sourceforge/pmd/cli/ForceLanguageCliTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/test/java/net/sourceforge/pmd/cli/PmdCliTest.java
+++ b/pmd-cli/src/test/java/net/sourceforge/pmd/cli/PmdCliTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/test/java/net/sourceforge/pmd/cli/TreeExportCliTest.java
+++ b/pmd-cli/src/test/java/net/sourceforge/pmd/cli/TreeExportCliTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cli/src/test/java/net/sourceforge/pmd/cli/commands/typesupport/internal/NumThreadsConverterTest.java
+++ b/pmd-cli/src/test/java/net/sourceforge/pmd/cli/commands/typesupport/internal/NumThreadsConverterTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-coco/src/main/java/net/sourceforge/pmd/lang/coco/CocoLanguageModule.java
+++ b/pmd-coco/src/main/java/net/sourceforge/pmd/lang/coco/CocoLanguageModule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-coco/src/main/java/net/sourceforge/pmd/lang/coco/ast/CocoBaseListener.java
+++ b/pmd-coco/src/main/java/net/sourceforge/pmd/lang/coco/ast/CocoBaseListener.java
@@ -1,9 +1,7 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
-// CHECKSTYLE:OFF
-// Generated from net/sourceforge/pmd/lang/coco/ast/Coco.g4 by ANTLR 4.9.3
 package net.sourceforge.pmd.lang.coco.ast;
 
 import org.antlr.v4.runtime.ParserRuleContext;

--- a/pmd-coco/src/main/java/net/sourceforge/pmd/lang/coco/ast/CocoBaseVisitor.java
+++ b/pmd-coco/src/main/java/net/sourceforge/pmd/lang/coco/ast/CocoBaseVisitor.java
@@ -1,9 +1,7 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
-// CHECKSTYLE:OFF
-// Generated from net/sourceforge/pmd/lang/coco/ast/Coco.g4 by ANTLR 4.9.3
 package net.sourceforge.pmd.lang.coco.ast;
 import org.antlr.v4.runtime.tree.AbstractParseTreeVisitor;
 

--- a/pmd-coco/src/main/java/net/sourceforge/pmd/lang/coco/ast/CocoListener.java
+++ b/pmd-coco/src/main/java/net/sourceforge/pmd/lang/coco/ast/CocoListener.java
@@ -1,9 +1,7 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
-// CHECKSTYLE:OFF
-// Generated from net/sourceforge/pmd/lang/coco/ast/Coco.g4 by ANTLR 4.9.3
 package net.sourceforge.pmd.lang.coco.ast;
 import org.antlr.v4.runtime.tree.ParseTreeListener;
 

--- a/pmd-coco/src/main/java/net/sourceforge/pmd/lang/coco/ast/CocoParser.java
+++ b/pmd-coco/src/main/java/net/sourceforge/pmd/lang/coco/ast/CocoParser.java
@@ -1,10 +1,7 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
-// CPD-OFF
-// CHECKSTYLE:OFF
-// Generated from net/sourceforge/pmd/lang/coco/ast/Coco.g4 by ANTLR 4.9.3
 package net.sourceforge.pmd.lang.coco.ast;
 
 import java.util.List;

--- a/pmd-coco/src/main/java/net/sourceforge/pmd/lang/coco/ast/CocoVisitor.java
+++ b/pmd-coco/src/main/java/net/sourceforge/pmd/lang/coco/ast/CocoVisitor.java
@@ -1,9 +1,7 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
-// CHECKSTYLE:OFF
-// Generated from net/sourceforge/pmd/lang/coco/ast/Coco.g4 by ANTLR 4.9.3
 package net.sourceforge.pmd.lang.coco.ast;
 import org.antlr.v4.runtime.tree.ParseTreeVisitor;
 

--- a/pmd-coco/src/test/java/net/sourceforge/pmd/lang/coco/cpd/CocoCpdLexerTest.java
+++ b/pmd-coco/src/test/java/net/sourceforge/pmd/lang/coco/cpd/CocoCpdLexerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/annotation/Experimental.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/annotation/Experimental.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/annotation/Generated.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/annotation/Generated.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDReportRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CPDReportRenderer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CpdCapableLanguage.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CpdCapableLanguage.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CpdLanguageProperties.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/CpdLanguageProperties.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/GridBagHelper.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/GridBagHelper.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-// stolen from XPath Explorer (http://www.xpathexplorer.com)
 
 package net.sourceforge.pmd.cpd;
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/impl/AntlrCpdLexer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/impl/AntlrCpdLexer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/impl/AntlrTokenFilter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/impl/AntlrTokenFilter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/impl/BaseTokenFilter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/impl/BaseTokenFilter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/impl/JavaCCTokenFilter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/impl/JavaCCTokenFilter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/cpd/internal/CpdLanguagePropertiesDefaults.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/cpd/internal/CpdLanguagePropertiesDefaults.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/internal/LogMessages.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/internal/LogMessages.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/internal/Slf4jSimpleConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/internal/Slf4jSimpleConfiguration.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/internal/SystemProps.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/internal/SystemProps.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/internal/util/BaseCloseable.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/internal/util/BaseCloseable.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/internal/util/ClasspathClassLoader.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/internal/util/ClasspathClassLoader.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/internal/util/ExceptionContextDefaultImpl.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/internal/util/ExceptionContextDefaultImpl.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/internal/util/FileCollectionUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/internal/util/FileCollectionUtil.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/internal/util/FileExtensionFilter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/internal/util/FileExtensionFilter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/internal/util/FileFinder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/internal/util/FileFinder.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/internal/util/FileUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/internal/util/FileUtil.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/internal/util/IOUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/internal/util/IOUtil.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/internal/util/PredicateUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/internal/util/PredicateUtil.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/AbstractLanguageVersionHandler.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/AbstractLanguageVersionHandler.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/InternalApiBridge.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/InternalApiBridge.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/JvmLanguagePropertyBundle.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/JvmLanguagePropertyBundle.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageModuleBase.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageModuleBase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageProcessor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageProcessorRegistry.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageProcessorRegistry.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguagePropertyBundle.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguagePropertyBundle.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageRegistry.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/LanguageRegistry.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/PlainTextLanguage.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/PlainTextLanguage.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/PmdCapableLanguage.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/PmdCapableLanguage.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AstInfo.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AstInfo.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AstVisitor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AstVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AstVisitorBase.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/AstVisitorBase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/FileAnalysisException.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/FileAnalysisException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/GenericToken.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/GenericToken.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/InternalApiBridge.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/InternalApiBridge.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/LexException.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/LexException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/Node.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/Node.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/Parser.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/Parser.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/SemanticErrorReporter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/SemanticErrorReporter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/SemanticException.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/SemanticException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/TextAvailableNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/TextAvailableNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/AbstractNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/AbstractNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/GenericNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/GenericNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/TokenDocument.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/TokenDocument.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/AntlrBaseParser.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/AntlrBaseParser.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/AntlrGeneratedParserBase.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/AntlrGeneratedParserBase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/AntlrNameDictionary.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/AntlrNameDictionary.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/AntlrNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/AntlrNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/AntlrToken.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/AntlrToken.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/AntlrTokenManager.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/AntlrTokenManager.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/BaseAntlrErrorNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/BaseAntlrErrorNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/BaseAntlrInnerNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/BaseAntlrInnerNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/BaseAntlrNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/BaseAntlrNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/BaseAntlrTerminalNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/antlr4/BaseAntlrTerminalNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/AbstractJjtreeNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/AbstractJjtreeNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/AbstractTokenManager.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/AbstractTokenManager.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/BackslashEscapeTranslator.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/BackslashEscapeTranslator.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/CharStream.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/CharStream.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/EscapeTranslator.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/EscapeTranslator.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/JavaEscapeTranslator.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/JavaEscapeTranslator.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/JavaccToken.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/JavaccToken.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -263,4 +263,3 @@ public class JavaccToken implements GenericToken<JavaccToken> {
         return new JavaccToken(IMPLICIT_TOKEN, "", offset, offset, document);
     }
 }
-

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/JavaccTokenDocument.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/JavaccTokenDocument.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/JjtreeBuilder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/JjtreeBuilder.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/JjtreeNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/JjtreeNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/MalformedSourceException.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/impl/javacc/MalformedSourceException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/AncestorOrSelfIterator.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/AncestorOrSelfIterator.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/AxisStream.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/AxisStream.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/Filtermap.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/Filtermap.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/GreedyNStream.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/GreedyNStream.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/IteratorBasedNStream.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/IteratorBasedNStream.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/NodeFindingUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/NodeFindingUtil.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/SingletonNodeStream.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/SingletonNodeStream.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/StreamImpl.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/StreamImpl.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/TraversalUtils.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/TraversalUtils.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/TreeWalker.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/ast/internal/TreeWalker.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/BaseMappedDocument.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/BaseMappedDocument.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/Chars.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/Chars.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/FileCollector.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/FileCollector.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/FileId.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/FileId.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/FileLocation.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/FileLocation.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/FragmentedDocBuilder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/FragmentedDocBuilder.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/FragmentedTextDocument.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/FragmentedTextDocument.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/InternalApiBridge.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/InternalApiBridge.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/NioTextFile.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/NioTextFile.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/ReadOnlyFileException.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/ReadOnlyFileException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/ReaderTextFile.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/ReaderTextFile.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/RootTextDocument.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/RootTextDocument.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/SourceCodePositioner.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/SourceCodePositioner.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/StringTextFile.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/StringTextFile.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/TextDocument.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/TextDocument.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/TextFile.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/TextFile.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/TextFileBuilder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/TextFileBuilder.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/TextFileContent.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/TextFileContent.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/TextPos2d.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/TextPos2d.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/TextRange2d.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/TextRange2d.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/TextRegion.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/document/TextRegion.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/AbstractPMDProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/AbstractPMDProcessor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/BatchLanguageProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/BatchLanguageProcessor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/CpdOnlyLanguageModuleBase.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/CpdOnlyLanguageModuleBase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/MonoThreadProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/MonoThreadProcessor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/MultiThreadProcessor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/MultiThreadProcessor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/PmdRunnable.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/PmdRunnable.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/PmdThreadFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/PmdThreadFactory.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/SimpleDialectLanguageModuleBase.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/SimpleDialectLanguageModuleBase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/SimpleLanguageModuleBase.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/impl/SimpleLanguageModuleBase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/metrics/MetricsUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/metrics/MetricsUtil.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractVisitorRule.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/AbstractVisitorRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/InternalApiBridge.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/InternalApiBridge.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleFactory.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleSetFactory.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleSetFactory.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleSetLoadException.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleSetLoadException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleSetLoader.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleSetLoader.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleTargetSelector.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/RuleTargetSelector.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/internal/CommonPropertyDescriptors.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/internal/CommonPropertyDescriptors.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/internal/LatticeRelation.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/internal/LatticeRelation.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/internal/RuleApplicator.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/internal/RuleApplicator.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/internal/TargetSelectorInternal.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/internal/TargetSelectorInternal.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/internal/TopoOrder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/internal/TopoOrder.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/internal/TreeIndex.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/internal/TreeIndex.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/Attribute.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/Attribute.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/CommentNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/CommentNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/DeprecatedAttribute.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/DeprecatedAttribute.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/InternalApiBridge.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/InternalApiBridge.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/NoAttribute.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/NoAttribute.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/PmdXPathException.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/PmdXPathException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/TextNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/TextNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/XPathVersion.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/XPathVersion.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/impl/AttributeAxisIterator.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/impl/AttributeAxisIterator.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/impl/XPathFunctionDefinition.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/impl/XPathFunctionDefinition.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/impl/XPathFunctionException.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/impl/XPathFunctionException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/impl/XPathHandler.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/impl/XPathHandler.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/AstAttributeNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/AstAttributeNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/AstDocumentNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/AstDocumentNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/AstElementNode.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/AstElementNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/AstNodeOwner.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/AstNodeOwner.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/AstTreeInfo.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/AstTreeInfo.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/BaseNodeInfo.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/BaseNodeInfo.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/CoordinateXPathFunction.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/CoordinateXPathFunction.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/DefaultXPathFunctions.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/DefaultXPathFunctions.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.rule.xpath.internal;
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/DeprecatedAttrLogger.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/DeprecatedAttrLogger.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/DomainConversion.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/DomainConversion.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/ExpressionPrinter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/ExpressionPrinter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/FileNameXPathFunction.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/FileNameXPathFunction.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/PmdDocumentSorter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/PmdDocumentSorter.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.rule.xpath.internal;
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/RuleChainAnalyzer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/RuleChainAnalyzer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonExprTransformations.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonExprTransformations.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.rule.xpath.internal;
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonExprVisitor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonExprVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonExtensionFunctionDefinitionAdapter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonExtensionFunctionDefinitionAdapter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonXPathRuleQuery.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonXPathRuleQuery.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SplitUnions.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/SplitUnions.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.rule.xpath.internal;
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/XPathElementToNodeHelper.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/lang/rule/xpath/internal/XPathElementToNodeHelper.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/ConstraintDecorator.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/ConstraintDecorator.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/ConstraintViolatedException.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/ConstraintViolatedException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/InternalApiBridge.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/InternalApiBridge.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/NumericConstraints.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/NumericConstraints.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyConstraint.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertyConstraint.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertySerializer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/PropertySerializer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/internal/PropertyParsingUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/internal/PropertyParsingUtil.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/properties/internal/ValueSyntax.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/properties/internal/ValueSyntax.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/JsonRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/JsonRenderer.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.renderers;
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/SarifRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/SarifRenderer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/internal/sarif/SarifLog.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/internal/sarif/SarifLog.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/renderers/internal/sarif/SarifLogBuilder.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/renderers/internal/sarif/SarifLogBuilder.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/reporting/AbstractAnnotationSuppressor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/reporting/AbstractAnnotationSuppressor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/reporting/CloseHookFileListener.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/reporting/CloseHookFileListener.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/reporting/ConfigurableFileNameRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/reporting/ConfigurableFileNameRenderer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/reporting/DeterministicOutputListenerWrapper.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/reporting/DeterministicOutputListenerWrapper.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/reporting/FileAnalysisListener.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/reporting/FileAnalysisListener.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/reporting/FileNameRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/reporting/FileNameRenderer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/reporting/GlobalAnalysisListener.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/reporting/GlobalAnalysisListener.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/reporting/InternalApiBridge.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/reporting/InternalApiBridge.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/reporting/ListenerInitializer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/reporting/ListenerInitializer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/reporting/NoopAnalysisListener.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/reporting/NoopAnalysisListener.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/reporting/NoopFileListener.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/reporting/NoopFileListener.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/reporting/NoopListenerInitializer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/reporting/NoopListenerInitializer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/reporting/Report.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/reporting/Report.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/reporting/ReportStats.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/reporting/ReportStats.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/reporting/ReportStatsListener.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/reporting/ReportStatsListener.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/reporting/Reportable.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/reporting/Reportable.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/reporting/ViolationDecorator.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/reporting/ViolationDecorator.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/reporting/ViolationSuppressor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/reporting/ViolationSuppressor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/AssertionUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/AssertionUtil.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/BaseResultProducingCloseable.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/BaseResultProducingCloseable.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/ConsList.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/ConsList.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/ContextedAssertionError.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/ContextedAssertionError.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/ContextedStackOverflowError.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/ContextedStackOverflowError.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/DataMap.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/DataMap.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/GraphUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/GraphUtil.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.util;
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/IteratorUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/IteratorUtil.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/OptionalBool.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/OptionalBool.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/designerbindings/DesignerBindings.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/designerbindings/DesignerBindings.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/designerbindings/RelatedNodesSelector.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/designerbindings/RelatedNodesSelector.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/internal/xml/PmdXmlReporter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/internal/xml/PmdXmlReporter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/internal/xml/SchemaConstant.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/internal/xml/SchemaConstant.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/internal/xml/SchemaConstants.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/internal/xml/SchemaConstants.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/internal/xml/XmlErrorMessages.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/internal/xml/XmlErrorMessages.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/internal/xml/XmlUtil.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/internal/xml/XmlUtil.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/log/PmdReporter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/log/PmdReporter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/log/internal/ErrorsAsWarningsReporter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/log/internal/ErrorsAsWarningsReporter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/log/internal/MessageReporterBase.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/log/internal/MessageReporterBase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/log/internal/QuietReporter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/log/internal/QuietReporter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/log/internal/SimpleMessageReporter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/log/internal/SimpleMessageReporter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/Io.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/Io.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TextTreeRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TextTreeRenderer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeExportConfiguration.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeExportConfiguration.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeExporter.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeExporter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeRenderer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeRendererDescriptor.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeRendererDescriptor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeRendererDescriptorImpl.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeRendererDescriptorImpl.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeRenderers.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/TreeRenderers.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/XmlTreeRenderer.java
+++ b/pmd-core/src/main/java/net/sourceforge/pmd/util/treeexport/XmlTreeRenderer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/DummyParsingHelper.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/DummyParsingHelper.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/InternalApiBridgeForTestsOnly.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/InternalApiBridgeForTestsOnly.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/PmdAnalysisTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/PmdAnalysisTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/PmdCoreTestUtils.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/PmdCoreTestUtils.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -34,4 +34,3 @@ public final class PmdCoreTestUtils {
         return dummyLanguage().getDefaultVersion();
     }
 }
-

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CPDReportTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CPDReportTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CpdTestUtils.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CpdTestUtils.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CpdXsltTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/CpdXsltTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/MatchAlgorithmTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/MatchAlgorithmTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/XMLOldRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/XMLOldRendererTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/cpd/impl/BaseTokenFilterTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/cpd/impl/BaseTokenFilterTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/internal/util/ClasspathClassLoaderTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/internal/util/ClasspathClassLoaderTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/LanguageModuleBaseTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/LanguageModuleBaseTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/LanguageProcessorRegistryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/LanguageProcessorRegistryTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNodeWithListAndEnum.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/DummyNodeWithListAndEnum.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/LexExceptionTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/LexExceptionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/SemanticErrorReporterTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/SemanticErrorReporterTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/impl/AbstractNodeTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/impl/AbstractNodeTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/impl/DummyTreeUtil.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/impl/DummyTreeUtil.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/impl/javacc/CharStreamTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/impl/javacc/CharStreamTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/impl/javacc/JavaEscapeReaderTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/impl/javacc/JavaEscapeReaderTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/internal/NodeFindingUtilTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/internal/NodeFindingUtilTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/internal/NodeStreamBlanketTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/internal/NodeStreamBlanketTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/internal/NodeStreamTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/ast/internal/NodeStreamTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/CharsTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/CharsTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/FileCollectorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/FileCollectorTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/FileIdTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/FileIdTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/FileLocationTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/FileLocationTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/FragmentedTextDocumentTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/FragmentedTextDocumentTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/NioTextFileTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/NioTextFileTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/SimpleTestTextFile.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/SimpleTestTextFile.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/SourceCodePositionerTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/SourceCodePositionerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/TestMessageReporter.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/TestMessageReporter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/TextDocumentTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/TextDocumentTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/TextFileContentTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/TextFileContentTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/TextFilesTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/TextFilesTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/TextPos2dTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/TextPos2dTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/TextRange2dTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/TextRange2dTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/TextRegionTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/document/TextRegionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/impl/AbstractPMDProcessorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/impl/AbstractPMDProcessorTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/impl/MonoThreadProcessorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/impl/MonoThreadProcessorTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/impl/PmdRunnableTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/impl/PmdRunnableTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/metrics/ParameterizedMetricKeyTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/metrics/ParameterizedMetricKeyTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/MockRule.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/MockRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/MockRuleWithNoProperties.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/MockRuleWithNoProperties.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/RuleSetFactoryDuplicatedRuleLoggingTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/RuleSetFactoryDuplicatedRuleLoggingTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/RuleSetFactoryMessagesTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/RuleSetFactoryMessagesTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/RuleSetFactoryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/RuleSetFactoryTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/RulesetFactoryTestBase.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/RulesetFactoryTestBase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/XPathRuleTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/XPathRuleTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/internal/LatticeRelationTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/internal/LatticeRelationTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/NoAttributeTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/NoAttributeTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/impl/AttributeAxisIteratorTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/impl/AttributeAxisIteratorTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/impl/dummyast/AbstractNode.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/impl/dummyast/AbstractNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/impl/dummyast/ConcreteNode.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/impl/dummyast/ConcreteNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/impl/dummyast/ValueNode.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/impl/dummyast/ValueNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/internal/ElementNodeTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/internal/ElementNodeTest.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.rule.xpath.internal;
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonXPathRuleQueryTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/lang/rule/xpath/internal/SaxonXPathRuleQueryTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/properties/NumericConstraintsTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/properties/NumericConstraintsTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/properties/PropertySyntaxTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/properties/PropertySyntaxTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/JsonRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/JsonRendererTest.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.renderers;
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/renderers/SarifRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/renderers/SarifRendererTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/reporting/ConfigurableFileNameRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/reporting/ConfigurableFileNameRendererTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/reporting/DeterministicOutputListenerWrapperTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/reporting/DeterministicOutputListenerWrapperTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/reporting/GlobalAnalysisListenerTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/reporting/GlobalAnalysisListenerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/reporting/ReportTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/reporting/ReportTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/reporting/ReportTestUtil.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/reporting/ReportTestUtil.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/CollectionUtilTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/CollectionUtilTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/FooRuleWithLanguageSetInJava.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/FooRuleWithLanguageSetInJava.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/IOUtilTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/IOUtilTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/IteratorUtilTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/IteratorUtilTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/OptionalBoolTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/OptionalBoolTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/TreeRenderersTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/TreeRenderersTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/XmlTreeRendererTest.java
+++ b/pmd-core/src/test/java/net/sourceforge/pmd/util/treeexport/XmlTreeRendererTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cpp/src/main/java/net/sourceforge/pmd/lang/cpp/CppLanguageModule.java
+++ b/pmd-cpp/src/main/java/net/sourceforge/pmd/lang/cpp/CppLanguageModule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cpp/src/main/java/net/sourceforge/pmd/lang/cpp/cpd/CppBlockSkipper.java
+++ b/pmd-cpp/src/main/java/net/sourceforge/pmd/lang/cpp/cpd/CppBlockSkipper.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cpp/src/main/java/net/sourceforge/pmd/lang/cpp/cpd/CppCpdLexer.java
+++ b/pmd-cpp/src/main/java/net/sourceforge/pmd/lang/cpp/cpd/CppCpdLexer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cpp/src/main/java/net/sourceforge/pmd/lang/cpp/cpd/CppEscapeTranslator.java
+++ b/pmd-cpp/src/main/java/net/sourceforge/pmd/lang/cpp/cpd/CppEscapeTranslator.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cpp/src/test/java/net/sourceforge/pmd/lang/cpp/cpd/CppCharStreamTest.java
+++ b/pmd-cpp/src/test/java/net/sourceforge/pmd/lang/cpp/cpd/CppCharStreamTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cpp/src/test/java/net/sourceforge/pmd/lang/cpp/cpd/CppCpdLexerTest.java
+++ b/pmd-cpp/src/test/java/net/sourceforge/pmd/lang/cpp/cpd/CppCpdLexerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cpp/src/test/java/net/sourceforge/pmd/lang/cpp/cpd/CppCpdTest.java
+++ b/pmd-cpp/src/test/java/net/sourceforge/pmd/lang/cpp/cpd/CppCpdTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cs/src/main/java/net/sourceforge/pmd/lang/cs/CsLanguageModule.java
+++ b/pmd-cs/src/main/java/net/sourceforge/pmd/lang/cs/CsLanguageModule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cs/src/main/java/net/sourceforge/pmd/lang/cs/cpd/CsCpdLexer.java
+++ b/pmd-cs/src/main/java/net/sourceforge/pmd/lang/cs/cpd/CsCpdLexer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-cs/src/test/java/net/sourceforge/pmd/lang/cs/cpd/CsCpdLexerTest.java
+++ b/pmd-cs/src/test/java/net/sourceforge/pmd/lang/cs/cpd/CsCpdLexerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-dart/src/main/java/net/sourceforge/pmd/lang/dart/DartLanguageModule.java
+++ b/pmd-dart/src/main/java/net/sourceforge/pmd/lang/dart/DartLanguageModule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-dart/src/main/java/net/sourceforge/pmd/lang/dart/cpd/DartCpdLexer.java
+++ b/pmd-dart/src/main/java/net/sourceforge/pmd/lang/dart/cpd/DartCpdLexer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-dart/src/test/java/net/sourceforge/pmd/lang/dart/cpd/DartCpdLexerTest.java
+++ b/pmd-dart/src/test/java/net/sourceforge/pmd/lang/dart/cpd/DartCpdLexerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/dist/AbstractBinaryDistributionTest.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/dist/AbstractBinaryDistributionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/dist/AllRulesIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/dist/AllRulesIT.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/dist/AnalysisCacheIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/dist/AnalysisCacheIT.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/dist/AntIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/dist/AntIT.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-dist/src/test/java/net/sourceforge/pmd/dist/BinaryDistributionIT.java
+++ b/pmd-dist/src/test/java/net/sourceforge/pmd/dist/BinaryDistributionIT.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/doc/InternalApiBridge.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/doc/InternalApiBridge.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/RuleTagChecker.java
+++ b/pmd-doc/src/main/java/net/sourceforge/pmd/doc/internal/RuleTagChecker.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-doc/src/test/java/net/sourceforge/pmd/doc/internal/RuleTagCheckerTest.java
+++ b/pmd-doc/src/test/java/net/sourceforge/pmd/doc/internal/RuleTagCheckerTest.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.doc.internal;
 

--- a/pmd-fortran/src/main/java/net/sourceforge/pmd/lang/fortran/FortranLanguageModule.java
+++ b/pmd-fortran/src/main/java/net/sourceforge/pmd/lang/fortran/FortranLanguageModule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-fortran/src/test/java/net/sourceforge/pmd/lang/fortran/cpd/FortranCpdLexerTest.java
+++ b/pmd-fortran/src/test/java/net/sourceforge/pmd/lang/fortran/cpd/FortranCpdLexerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-gherkin/src/main/java/net/sourceforge/pmd/lang/gherkin/GherkinLanguageModule.java
+++ b/pmd-gherkin/src/main/java/net/sourceforge/pmd/lang/gherkin/GherkinLanguageModule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-gherkin/src/main/java/net/sourceforge/pmd/lang/gherkin/ast/GherkinBaseListener.java
+++ b/pmd-gherkin/src/main/java/net/sourceforge/pmd/lang/gherkin/ast/GherkinBaseListener.java
@@ -1,9 +1,7 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
-// CHECKSTYLE:OFF
-// Generated from net/sourceforge/pmd/lang/gherkin/ast/Gherkin.g4 by ANTLR 4.9.3
 package net.sourceforge.pmd.lang.gherkin.ast;
 
 import org.antlr.v4.runtime.ParserRuleContext;

--- a/pmd-gherkin/src/main/java/net/sourceforge/pmd/lang/gherkin/ast/GherkinBaseVisitor.java
+++ b/pmd-gherkin/src/main/java/net/sourceforge/pmd/lang/gherkin/ast/GherkinBaseVisitor.java
@@ -1,9 +1,7 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
-// CHECKSTYLE:OFF
-// Generated from net/sourceforge/pmd/lang/gherkin/ast/Gherkin.g4 by ANTLR 4.9.3
 package net.sourceforge.pmd.lang.gherkin.ast;
 import org.antlr.v4.runtime.tree.AbstractParseTreeVisitor;
 

--- a/pmd-gherkin/src/main/java/net/sourceforge/pmd/lang/gherkin/ast/GherkinListener.java
+++ b/pmd-gherkin/src/main/java/net/sourceforge/pmd/lang/gherkin/ast/GherkinListener.java
@@ -1,9 +1,7 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
-// CHECKSTYLE:OFF
-// Generated from net/sourceforge/pmd/lang/gherkin/ast/Gherkin.g4 by ANTLR 4.9.3
 package net.sourceforge.pmd.lang.gherkin.ast;
 import org.antlr.v4.runtime.tree.ParseTreeListener;
 

--- a/pmd-gherkin/src/main/java/net/sourceforge/pmd/lang/gherkin/ast/GherkinParser.java
+++ b/pmd-gherkin/src/main/java/net/sourceforge/pmd/lang/gherkin/ast/GherkinParser.java
@@ -1,9 +1,7 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
-// CHECKSTYLE:OFF
-// Generated from net/sourceforge/pmd/lang/gherkin/ast/Gherkin.g4 by ANTLR 4.9.3
 package net.sourceforge.pmd.lang.gherkin.ast;
 
 // CPD-OFF

--- a/pmd-gherkin/src/main/java/net/sourceforge/pmd/lang/gherkin/ast/GherkinVisitor.java
+++ b/pmd-gherkin/src/main/java/net/sourceforge/pmd/lang/gherkin/ast/GherkinVisitor.java
@@ -1,9 +1,7 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
-// CHECKSTYLE:OFF
-// Generated from net/sourceforge/pmd/lang/gherkin/ast/Gherkin.g4 by ANTLR 4.9.3
 package net.sourceforge.pmd.lang.gherkin.ast;
 import org.antlr.v4.runtime.tree.ParseTreeVisitor;
 

--- a/pmd-gherkin/src/test/java/net/sourceforge/pmd/lang/gherkin/cpd/GherkinCpdLexerTest.java
+++ b/pmd-gherkin/src/test/java/net/sourceforge/pmd/lang/gherkin/cpd/GherkinCpdLexerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-go/src/main/java/net/sourceforge/pmd/lang/go/GoLanguageModule.java
+++ b/pmd-go/src/main/java/net/sourceforge/pmd/lang/go/GoLanguageModule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-go/src/main/java/net/sourceforge/pmd/lang/go/cpd/GoCpdLexer.java
+++ b/pmd-go/src/main/java/net/sourceforge/pmd/lang/go/cpd/GoCpdLexer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-go/src/test/java/net/sourceforge/pmd/lang/go/cpd/GoCpdLexerTest.java
+++ b/pmd-go/src/test/java/net/sourceforge/pmd/lang/go/cpd/GoCpdLexerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-groovy/src/main/java/net/sourceforge/pmd/lang/groovy/GroovyLanguageModule.java
+++ b/pmd-groovy/src/main/java/net/sourceforge/pmd/lang/groovy/GroovyLanguageModule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-groovy/src/main/java/net/sourceforge/pmd/lang/groovy/ast/impl/antlr4/GroovyToken.java
+++ b/pmd-groovy/src/main/java/net/sourceforge/pmd/lang/groovy/ast/impl/antlr4/GroovyToken.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-groovy/src/main/java/net/sourceforge/pmd/lang/groovy/ast/impl/antlr4/GroovyTokenManager.java
+++ b/pmd-groovy/src/main/java/net/sourceforge/pmd/lang/groovy/ast/impl/antlr4/GroovyTokenManager.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-groovy/src/main/java/net/sourceforge/pmd/lang/groovy/cpd/GroovyCpdLexer.java
+++ b/pmd-groovy/src/main/java/net/sourceforge/pmd/lang/groovy/cpd/GroovyCpdLexer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-groovy/src/test/java/net/sourceforge/pmd/lang/groovy/cpd/GroovyCpdLexerTest.java
+++ b/pmd-groovy/src/test/java/net/sourceforge/pmd/lang/groovy/cpd/GroovyCpdLexerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/HtmlHandler.java
+++ b/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/HtmlHandler.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.html;
 

--- a/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/HtmlLanguageModule.java
+++ b/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/HtmlLanguageModule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/ASTHtmlCDataNode.java
+++ b/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/ASTHtmlCDataNode.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.html.ast;
 

--- a/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/ASTHtmlComment.java
+++ b/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/ASTHtmlComment.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.html.ast;
 

--- a/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/ASTHtmlDocument.java
+++ b/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/ASTHtmlDocument.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.html.ast;
 

--- a/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/ASTHtmlDocumentType.java
+++ b/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/ASTHtmlDocumentType.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.html.ast;
 

--- a/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/ASTHtmlElement.java
+++ b/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/ASTHtmlElement.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.html.ast;
 

--- a/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/ASTHtmlTextNode.java
+++ b/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/ASTHtmlTextNode.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.html.ast;
 

--- a/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/ASTHtmlXmlDeclaration.java
+++ b/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/ASTHtmlXmlDeclaration.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.html.ast;
 

--- a/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/AbstractHtmlNode.java
+++ b/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/AbstractHtmlNode.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.html.ast;
 

--- a/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/HtmlNode.java
+++ b/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/HtmlNode.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.html.ast;
 

--- a/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/HtmlParser.java
+++ b/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/HtmlParser.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.html.ast;
 

--- a/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/HtmlTreeBuilder.java
+++ b/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/HtmlTreeBuilder.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.html.ast;
 

--- a/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/HtmlVisitor.java
+++ b/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/ast/HtmlVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/cpd/HtmlCpdLexer.java
+++ b/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/cpd/HtmlCpdLexer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/rule/AbstractHtmlRule.java
+++ b/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/rule/AbstractHtmlRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/rule/bestpractices/UnnecessaryTypeAttributeRule.java
+++ b/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/rule/bestpractices/UnnecessaryTypeAttributeRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/rule/bestpractices/UseAltAttributeForImagesRule.java
+++ b/pmd-html/src/main/java/net/sourceforge/pmd/lang/html/rule/bestpractices/UseAltAttributeForImagesRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/HtmlJavaRuleTest.java
+++ b/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/HtmlJavaRuleTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/HtmlXPathRuleTest.java
+++ b/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/HtmlXPathRuleTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/LanguageVersionTest.java
+++ b/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/LanguageVersionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/ast/HtmlTreeDumpTest.java
+++ b/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/ast/HtmlTreeDumpTest.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.html.ast;
 

--- a/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/ast/PositionTest.java
+++ b/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/ast/PositionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/cpd/HtmlCpdLexerTest.java
+++ b/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/cpd/HtmlCpdLexerTest.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.html.cpd;
 

--- a/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/rule/bestpractices/UnnecessaryTypeAttributeTest.java
+++ b/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/rule/bestpractices/UnnecessaryTypeAttributeTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/rule/bestpractices/UseAltAttributeForImagesTest.java
+++ b/pmd-html/src/test/java/net/sourceforge/pmd/lang/html/rule/bestpractices/UseAltAttributeForImagesTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAssignableExpr.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTAssignableExpr.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCompactConstructorDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTCompactConstructorDeclaration.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.ast;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTEmptyDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTEmptyDeclaration.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExpressionStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTExpressionStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTGuard.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTGuard.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTImplicitClassDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTImplicitClassDeclaration.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTInfixExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTInfixExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTIntersectionType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTIntersectionType.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLambdaParameter.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLambdaParameter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLambdaParameterList.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLambdaParameterList.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLocalClassStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLocalClassStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLoopStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTLoopStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodReference.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTMethodReference.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTModifierList.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTModifierList.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPattern.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPattern.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPatternExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPatternExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPatternList.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTPatternList.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.ast;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTReceiverParameter.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTReceiverParameter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTRecordBody.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTRecordBody.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.ast;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTRecordComponent.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTRecordComponent.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.ast;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTRecordComponentList.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTRecordComponentList.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.ast;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTRecordDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTRecordDeclaration.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.ast;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTRecordPattern.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTRecordPattern.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTThrowsList.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTThrowsList.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeBody.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeBody.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypeExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypePattern.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTTypePattern.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTUnionType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTUnionType.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTUnnamedPattern.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ASTUnnamedPattern.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractInvocationExpr.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractInvocationExpr.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractJavaExpr.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractJavaExpr.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractJavaNode.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractJavaNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractLiteral.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractLiteral.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractStatement.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractTypeDeclaration.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractTypeDeclaration.java
@@ -81,4 +81,3 @@ abstract class AbstractTypeDeclaration extends AbstractTypedSymbolDeclarator<JCl
         return isNested();
     }
 }
-

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractTypedSymbolDeclarator.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AbstractTypedSymbolDeclarator.java
@@ -43,4 +43,3 @@ abstract class AbstractTypedSymbolDeclarator<T extends JElementSymbol>
     }
 
 }
-

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AstDisambiguationPass.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AstDisambiguationPass.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.ast;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AstImplUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/AstImplUtil.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/CommentAssignmentPass.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/CommentAssignmentPass.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ConstantFolder.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ConstantFolder.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/FunctionalExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/FunctionalExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/InternalApiBridge.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/InternalApiBridge.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/InternalInterfaces.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/InternalInterfaces.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/InvocationNode.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/InvocationNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JModifier.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JModifier.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaParser.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaParser.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaTokenDocumentBehavior.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavaTokenDocumentBehavior.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavadocCommentOwner.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/JavadocCommentOwner.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/LeftRecursiveNode.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/LeftRecursiveNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/MethodUsage.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/MethodUsage.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ModifierOwner.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/ModifierOwner.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/OverrideResolutionPass.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/OverrideResolutionPass.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/QualifiableExpression.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/QualifiableExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/SymbolDeclaratorNode.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/SymbolDeclaratorNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/SyntacticJavaTokenizerFactory.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/SyntacticJavaTokenizerFactory.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/TokenUtils.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/TokenUtils.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/TypeParamOwnerNode.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/TypeParamOwnerNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/TypesFromAst.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/TypesFromAst.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/UnaryOp.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/UnaryOp.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/JavaAstUtils.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/JavaAstUtils.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/LanguageLevelChecker.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/LanguageLevelChecker.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/PrettyPrintingUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/PrettyPrintingUtil.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/ReportingStrategy.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/internal/ReportingStrategy.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/package-info.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/ast/package-info.java
@@ -27,4 +27,3 @@
  *
  */
 package net.sourceforge.pmd.lang.java.ast;
-

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/cpd/JavaCpdLexer.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/cpd/JavaCpdLexer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/internal/JavaAnnotationSuppressor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/internal/JavaAnnotationSuppressor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/internal/JavaAstProcessor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/internal/JavaAstProcessor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/internal/JavaDesignerBindings.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/internal/JavaDesignerBindings.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/internal/JavaLanguageProcessor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/internal/JavaLanguageProcessor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/internal/JavaLanguageProperties.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/internal/JavaLanguageProperties.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/internal/JavaMetricsProvider.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/internal/JavaMetricsProvider.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/internal/JavaViolationDecorator.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/internal/JavaViolationDecorator.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/JavaMetrics.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/JavaMetrics.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/internal/AtfdBaseVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/internal/AtfdBaseVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/internal/ClassFanOutVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/internal/ClassFanOutVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/internal/CycloVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/internal/CycloVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/internal/NcssVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/internal/NcssVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/internal/NpathBaseVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/metrics/internal/NpathBaseVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJavaRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJavaRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJavaRulechainRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/AbstractJavaRulechainRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AbstractClassWithoutAbstractMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AbstractClassWithoutAbstractMethodRule.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.rule.bestpractices;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidUsingHardCodedIPRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/AvoidUsingHardCodedIPRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ForLoopCanBeForeachRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ForLoopCanBeForeachRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ImplicitFunctionalInterfaceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ImplicitFunctionalInterfaceRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/LiteralsFirstInComparisonsRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PrimitiveWrapperInstantiationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/PrimitiveWrapperInstantiationRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/SimplifiableTestAssertionRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/SimplifiableTestAssertionRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnnecessaryVarargsArrayCreationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnnecessaryVarargsArrayCreationRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedAssignmentRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedAssignmentRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedPrivateMethodRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseTryWithResourcesRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UseTryWithResourcesRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LinguisticNamingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/LinguisticNamingRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryBoxingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryBoxingRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryCastRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryCastRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryImportRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryImportRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryReturnRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryReturnRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseDiamondOperatorRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseDiamondOperatorRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ClassWithOnlyPrivateConstructorsShouldBeFinalRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ClassWithOnlyPrivateConstructorsShouldBeFinalRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CognitiveComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/CognitiveComplexityRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveImportsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveImportsRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveParameterListRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessiveParameterListRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessivePublicCountRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/ExcessivePublicCountRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/InvalidJavaBeanRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/InvalidJavaBeanRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NPathComplexityRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/NPathComplexityRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -58,4 +58,3 @@ public class NPathComplexityRule extends AbstractJavaRulechainRule {
         return data;
     }
 }
-

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SimplifyConditionalRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SimplifyConditionalRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SingularFieldRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/design/SingularFieldRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/CloseResourceRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConfusingArgumentToVarargsMethodRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ConfusingArgumentToVarargsMethodRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ImplicitSwitchFallThroughRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ImplicitSwitchFallThroughRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnitSpellingRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnitSpellingRule.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnitStaticSuiteRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/JUnitStaticSuiteRule.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ProperCloneImplementationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/errorprone/ProperCloneImplementationRule.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.rule.errorprone;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/AbstractIgnoredAnnotationRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/AbstractIgnoredAnnotationRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/AbstractJavaCounterCheckRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/AbstractJavaCounterCheckRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/DataflowPass.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/DataflowPass.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaPropertyUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaPropertyUtil.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtil.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/StablePathMatcher.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/StablePathMatcher.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtil.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TypeResTestRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/internal/TypeResTestRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/UseStringBufferForStringAppendsRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/performance/UseStringBufferForStringAppendsRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/AbstractHardCodedConstructorArgsVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/AbstractHardCodedConstructorArgsVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/HardCodedCryptoKeyRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/HardCodedCryptoKeyRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/InsecureCryptoIvRule.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/security/InsecureCryptoIvRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/BaseContextNodeTestFun.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/BaseContextNodeTestFun.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/BaseJavaXPathFunction.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/BaseJavaXPathFunction.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/BaseRewrittenFunction.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/BaseRewrittenFunction.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/GetCommentOnFunction.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/GetCommentOnFunction.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -57,6 +57,3 @@ public class GetCommentOnFunction extends BaseJavaXPathFunction {
         };
     }
 }
-
-
-

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/GetModifiersFun.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/GetModifiersFun.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/MatchesSignatureFunction.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/MatchesSignatureFunction.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/MetricFunction.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/MetricFunction.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/NodeIsFunction.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/NodeIsFunction.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/AnnotWrapper.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/AnnotWrapper.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/AnnotableSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/AnnotableSymbol.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/BoundToNode.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/BoundToNode.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.symbols;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JAccessibleElementSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JAccessibleElementSymbol.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.symbols;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JClassSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JClassSymbol.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.symbols;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JConstructorSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JConstructorSymbol.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.symbols;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JElementSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JElementSymbol.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.symbols;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JExecutableSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JExecutableSymbol.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JFieldSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JFieldSymbol.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.symbols;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JFormalParamSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JFormalParamSymbol.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.symbols;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JLocalVariableSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JLocalVariableSymbol.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.symbols;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JMethodSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JMethodSymbol.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.symbols;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JModuleSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JModuleSymbol.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JRecordComponentSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JRecordComponentSymbol.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.symbols;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JTypeDeclSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JTypeDeclSymbol.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.symbols;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JTypeParameterOwnerSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JTypeParameterOwnerSymbol.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.symbols;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JTypeParameterSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JTypeParameterSymbol.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.symbols;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JVariableSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/JVariableSymbol.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.symbols;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/SymbolResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/SymbolResolver.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/SymbolVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/SymbolVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/SymbolicValue.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/SymbolicValue.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/SymbolicValueHelper.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/SymbolicValueHelper.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/EmptyClassSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/EmptyClassSymbol.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/FakeSymAnnot.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/FakeSymAnnot.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/FlexibleUnresolvedClassImpl.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/FlexibleUnresolvedClassImpl.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ImplicitMemberSymbols.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ImplicitMemberSymbols.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/SymbolEquality.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/SymbolEquality.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/SymbolToStrings.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/SymbolToStrings.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/UnresolvedClassImpl.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/UnresolvedClassImpl.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/UnresolvedClassStore.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/UnresolvedClassStore.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/AnnotationBuilderVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/AnnotationBuilderVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/AnnotationOwner.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/AnnotationOwner.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/AsmStub.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/AsmStub.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/AsmSymbolResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/AsmSymbolResolver.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassNamesUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassNamesUtil.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStub.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStub.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStubBuilder.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStubBuilder.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/Classpath.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/Classpath.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ExecutableStub.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ExecutableStub.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/FieldStub.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/FieldStub.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/GenericSigBase.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/GenericSigBase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/GenericTypeParameterCounter.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/GenericTypeParameterCounter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/InvalidTypeSignatureException.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/InvalidTypeSignatureException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/LazyTypeSig.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/LazyTypeSig.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/Loader.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/Loader.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/MemberStubBase.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/MemberStubBase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/MethodInfoVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/MethodInfoVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ModuleStub.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ModuleStub.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ParseLock.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ParseLock.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/RecordComponentStub.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/RecordComponentStub.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/SignatureParser.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/SignatureParser.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/SignatureScanner.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/SignatureScanner.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/SymbolicAnnotationImpl.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/SymbolicAnnotationImpl.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/SymbolicValueBuilder.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/SymbolicValueBuilder.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/TParamStub.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/TParamStub.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/TypeAnnotationHelper.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/TypeAnnotationHelper.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/TypeAnnotationReceiver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/TypeAnnotationReceiver.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/TypeParamsParser.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/TypeParamsParser.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/TypeSigParser.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/TypeSigParser.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AbstractAstAnnotableSym.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AbstractAstAnnotableSym.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AbstractAstBackedSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AbstractAstBackedSymbol.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AbstractAstExecSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AbstractAstExecSymbol.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AbstractAstTParamOwner.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AbstractAstTParamOwner.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AbstractAstVariableSym.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AbstractAstVariableSym.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstClassSym.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstClassSym.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstCtorSym.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstCtorSym.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstFieldSym.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstFieldSym.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstFormalParamSym.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstFormalParamSym.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstLocalVarSym.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstLocalVarSym.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstMethodSym.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstMethodSym.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstRecordComponentSym.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstRecordComponentSym.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstSymFactory.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstSymFactory.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstSymbolMakerVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstSymbolMakerVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstSymbolicAnnot.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstSymbolicAnnot.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstTypeParamSym.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/AstTypeParamSym.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/MapSymResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/MapSymResolver.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/SymbolResolutionPass.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/internal/ast/SymbolResolutionPass.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/JSymbolTable.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/JSymbolTable.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/ScopeInfo.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/ScopeInfo.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/coreimpl/CachingShadowChainNode.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/coreimpl/CachingShadowChainNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/coreimpl/CoreResolvers.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/coreimpl/CoreResolvers.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/coreimpl/MostlySingularMultimap.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/coreimpl/MostlySingularMultimap.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/coreimpl/NameResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/coreimpl/NameResolver.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/coreimpl/ShadowChain.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/coreimpl/ShadowChain.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/coreimpl/ShadowChainBuilder.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/coreimpl/ShadowChainBuilder.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/coreimpl/ShadowChainIterator.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/coreimpl/ShadowChainIterator.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/coreimpl/ShadowChainIteratorImpl.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/coreimpl/ShadowChainIteratorImpl.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/coreimpl/ShadowChainNode.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/coreimpl/ShadowChainNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/coreimpl/ShadowChainNodeBase.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/coreimpl/ShadowChainNodeBase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/coreimpl/ShadowChainRoot.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/coreimpl/ShadowChainRoot.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/AbruptCompletionAnalysis.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/AbruptCompletionAnalysis.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/JavaResolvers.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/JavaResolvers.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/JavaSemanticErrors.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/JavaSemanticErrors.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/PatternBindingsUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/PatternBindingsUtil.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/ReferenceCtx.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/ReferenceCtx.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/SuperTypesEnumerator.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/SuperTypesEnumerator.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/SymTableFactory.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/SymTableFactory.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/SymbolChainBuilder.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/SymbolChainBuilder.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/SymbolTableImpl.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/SymbolTableImpl.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/SymbolTableResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/symbols/table/internal/SymbolTableResolver.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.symbols.table.internal;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ArrayMethodSigImpl.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ArrayMethodSigImpl.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ArraySymbolImpl.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ArraySymbolImpl.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/BasePrimitiveSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/BasePrimitiveSymbol.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/BoxedPrimitive.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/BoxedPrimitive.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/CaptureMatcher.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/CaptureMatcher.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ClassMethodSigImpl.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ClassMethodSigImpl.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ClassTypeImpl.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ClassTypeImpl.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ErasedClassType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ErasedClassType.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/FakeIntersectionSymbol.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/FakeIntersectionSymbol.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/InternalApiBridge.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/InternalApiBridge.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/InvocationMatcher.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/InvocationMatcher.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JArrayType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JArrayType.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.types;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JClassType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JClassType.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JIntersectionType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JIntersectionType.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.types;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JMethodSig.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JMethodSig.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JPrimitiveType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JPrimitiveType.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JTypeMirror.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JTypeMirror.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JTypeVar.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JTypeVar.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JTypeVisitable.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JTypeVisitable.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JTypeVisitor.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JTypeVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JVariableSig.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JVariableSig.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JWildcardType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/JWildcardType.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/LexicalScope.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/LexicalScope.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/Lub.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/Lub.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/MapFunction.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/MapFunction.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/OverloadSelectionResult.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/OverloadSelectionResult.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/SentinelType.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/SentinelType.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/SubstVar.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/SubstVar.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/Substitution.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/Substitution.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeConversion.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeConversion.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeOps.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypePrettyPrint.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypePrettyPrint.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeSystem.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeSystem.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeTestUtil.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeTestUtil.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeVarImpl.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypeVarImpl.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypesFromReflection.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypesFromReflection.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypingContext.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/TypingContext.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/UnresolvedMethodSig.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/UnresolvedMethodSig.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/WildcardTypeImpl.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/WildcardTypeImpl.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ast/ExprContext.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ast/ExprContext.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ast/InternalApiBridge.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ast/InternalApiBridge.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ast/internal/InvocCtx.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ast/internal/InvocCtx.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ast/internal/LazyTypeResolver.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ast/internal/LazyTypeResolver.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.types.ast.internal;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ast/internal/PolyResolution.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ast/internal/PolyResolution.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.types.ast.internal;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ast/internal/RegularCtx.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/ast/internal/RegularCtx.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/InternalMethodTypeItf.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/InternalMethodTypeItf.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ExprCheckHelper.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ExprCheckHelper.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ExprMirror.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ExprMirror.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ExprOps.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ExprOps.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/Graph.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/Graph.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/IncorporationAction.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/IncorporationAction.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/Infer.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/Infer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/InferenceContext.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/InferenceContext.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/InferenceVar.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/InferenceVar.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.types.internal.infer;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/InferenceVarSym.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/InferenceVarSym.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/MethodCallSite.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/MethodCallSite.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/MethodResolutionPhase.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/MethodResolutionPhase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/OverloadSet.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/OverloadSet.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/PhaseOverloadSet.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/PhaseOverloadSet.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/PolySite.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/PolySite.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ReductionStep.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ReductionStep.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ResolutionFailedException.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ResolutionFailedException.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ResolutionFailure.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ResolutionFailure.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/SupertypeCheckCache.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/SupertypeCheckCache.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/TypeInferenceLogger.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/TypeInferenceLogger.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.types.internal.infer;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/VarWalkStrategy.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/VarWalkStrategy.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/BaseExprMirror.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/BaseExprMirror.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/BaseFunctionalMirror.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/BaseFunctionalMirror.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/BaseInvocMirror.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/BaseInvocMirror.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.types.internal.infer.ast;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/BasePolyMirror.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/BasePolyMirror.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/ConditionalMirrorImpl.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/ConditionalMirrorImpl.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.types.internal.infer.ast;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/CtorInvocMirror.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/CtorInvocMirror.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.types.internal.infer.ast;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/JavaExprMirrors.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/JavaExprMirrors.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/LambdaMirrorImpl.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/LambdaMirrorImpl.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/MethodInvocMirror.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/MethodInvocMirror.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/MethodRefMirrorImpl.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/MethodRefMirrorImpl.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.types.internal.infer.ast;
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/StandaloneExprMirror.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/StandaloneExprMirror.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/SwitchMirror.java
+++ b/pmd-java/src/main/java/net/sourceforge/pmd/lang/java/types/internal/infer/ast/SwitchMirror.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/lombok/val.java
+++ b/pmd-java/src/test/java/lombok/val.java
@@ -1,8 +1,7 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
-// CHECKSTYLE:OFF
 package lombok;
 
 /**

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/BaseJavaTreeDumpTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/BaseJavaTreeDumpTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/BaseParserTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/BaseParserTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/JavaAttributesPrinter.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/JavaAttributesPrinter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/JavaLanguageModuleTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/JavaLanguageModuleTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTCompactConstructorDeclarationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTCompactConstructorDeclarationTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTNumericLiteralTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTNumericLiteralTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchLikeTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchLikeTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchStatementTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ASTSwitchStatementTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/CommentAssignmentTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/CommentAssignmentTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ConstantExpressionsTests.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/ConstantExpressionsTests.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java14TreeDumpTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java14TreeDumpTest.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.ast;
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java15TreeDumpTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java15TreeDumpTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java16TreeDumpTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java16TreeDumpTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java17TreeDumpTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java17TreeDumpTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java21TreeDumpTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java21TreeDumpTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java22TreeDumpTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java22TreeDumpTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java23PreviewTreeDumpTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java23PreviewTreeDumpTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java23TreeDumpTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java23TreeDumpTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java24PreviewTreeDumpTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java24PreviewTreeDumpTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java24TreeDumpTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/Java24TreeDumpTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/JavaCommentTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/JavaCommentTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/JavaQualifiedNameTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/JavaQualifiedNameTest.java
@@ -234,4 +234,3 @@ class JavaQualifiedNameTest {
     }
 
 }
-

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/internal/JavaAstUtilTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/internal/JavaAstUtilTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/internal/PrettyPrintingUtilTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/ast/internal/PrettyPrintingUtilTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/cpd/JavaCpdLexerTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/cpd/JavaCpdLexerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/JavaDoubleMetricTestRule.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/JavaDoubleMetricTestRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/JavaIntMetricTestRule.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/metrics/impl/JavaIntMetricTestRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/AllDataflowRuleTests.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/AllDataflowRuleTests.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/DummyJavaRule.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/DummyJavaRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/XPathRuleTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/XPathRuleTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/DoubleBraceInitializationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/DoubleBraceInitializationTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ExhaustiveSwitchHasDefaultTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/ExhaustiveSwitchHasDefaultTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnnecessaryVarargsArrayCreationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnnecessaryVarargsArrayCreationTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedAssignmentTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/UnusedAssignmentTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AbstractBuilderMixedTypeVarOverride.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AbstractBuilderMixedTypeVarOverride.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AnonClassExample.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/AnonClassExample.java
@@ -14,4 +14,3 @@ public class AnonClassExample {
         }).start();
     }
 }
-

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/EmptyEnum.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/EmptyEnum.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/EnumToString.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/EnumToString.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/InterfaceWithBound.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/InterfaceWithBound.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/a/PackagePrivateMethod.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/a/PackagePrivateMethod.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/a/PackagePrivateMethodRealExtend.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/a/PackagePrivateMethodRealExtend.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/b/PackagePrivateMethodExtend.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/missingoverride/b/PackagePrivateMethodExtend.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/switchstmtsshouldhavedefault/Animal.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/switchstmtsshouldhavedefault/Animal.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedprivatefield/Value.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedprivatefield/Value.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedprivatemethod/cache/CacheBuilder.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedprivatemethod/cache/CacheBuilder.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedprivatemethod/cache/CacheLoader.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedprivatemethod/cache/CacheLoader.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedprivatemethod/cache/LoadingCache.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedprivatemethod/cache/LoadingCache.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedprivatemethod/issue3899/Child.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedprivatemethod/issue3899/Child.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedprivatemethod/issue3899/Parent.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedprivatemethod/issue3899/Parent.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedprivatemethod/issue3899/PmdTestCase.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedprivatemethod/issue3899/PmdTestCase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedprivatemethod/issue5486/Class1.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedprivatemethod/issue5486/Class1.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedprivatemethod/issue5486/Class2.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/bestpractices/unusedprivatemethod/issue5486/Class2.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/FinalParameterInAbstractMethodTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/FinalParameterInAbstractMethodTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryBoxingTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryBoxingTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryCastTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryCastTest.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.rule.codestyle;
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryImportTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UnnecessaryImportTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseExplicitTypesTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/UseExplicitTypesTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryfullyqualifiedname/ClassA.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryfullyqualifiedname/ClassA.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryfullyqualifiedname/Container.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryfullyqualifiedname/Container.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryfullyqualifiedname/Deprecated.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryfullyqualifiedname/Deprecated.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryfullyqualifiedname/Foo.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryfullyqualifiedname/Foo.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryfullyqualifiedname/MyClass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryfullyqualifiedname/MyClass.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryfullyqualifiedname/TestClass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryfullyqualifiedname/TestClass.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryfullyqualifiedname/subpackage/MyAnnotation.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryfullyqualifiedname/subpackage/MyAnnotation.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryfullyqualifiedname/subpackage/MyClass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryfullyqualifiedname/subpackage/MyClass.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/ClassWithConstants.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/ClassWithConstants.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/ClassWithStringConstants.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/ClassWithStringConstants.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/ConcFlow.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/ConcFlow.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.rule.codestyle.unnecessaryimport;
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/Hello.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/Hello.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/HelloMore.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/HelloMore.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/Issue2001.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/Issue2001.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/Issue2016.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/Issue2016.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/NonStaticContainer.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/NonStaticContainer.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.rule.codestyle.unnecessaryimport;
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/PackagePrivateUtils.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/PackagePrivateUtils.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/PublicUtils.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/PublicUtils.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/item/Item.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/item/Item.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/item/ItemProducer.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/item/ItemProducer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/javalang/String.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/javalang/String.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/package2/C.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/codestyle/unnecessaryimport/package2/C.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/InvalidJavaBeanTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/InvalidJavaBeanTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/cognitivecomplexity/ReproducerFor5084.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/cognitivecomplexity/ReproducerFor5084.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/singularfield/Issue3303.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/singularfield/Issue3303.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/singularfield/NoThrowingCloseable.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/singularfield/NoThrowingCloseable.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/BaseClass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/BaseClass.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/DirectSubclass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/DirectSubclass.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/DirectSubclass2.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/DirectSubclass2.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/DirectSynchronizingSubclass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/DirectSynchronizingSubclass.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/ExposingSerializer.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/ExposingSerializer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/GeneratedValue.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/GeneratedValue.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/GenerationType.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/GenerationType.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/Id.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/Id.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/OtherSubclass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/OtherSubclass.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/Serializer.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/Serializer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/TransitiveSubclass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/TransitiveSubclass.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/UselessOverridingMethodHashCode.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/UselessOverridingMethodHashCode.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.java.rule.design.uselessoverridingmethod;
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/other/DirectSubclassInOtherPackage.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/other/DirectSubclassInOtherPackage.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/other/OtherClassInOtherPackage.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/design/uselessoverridingmethod/other/OtherClassInOtherPackage.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidAccessibilityAlterationTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/AvoidAccessibilityAlterationTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/DoNotTerminateVMTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/DoNotTerminateVMTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/closeresource/DAOTransaction.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/closeresource/DAOTransaction.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/closeresource/FakeContext.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/closeresource/FakeContext.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/closeresource/MyClass.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/closeresource/MyClass.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/closeresource/MyHelper.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/closeresource/MyHelper.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/closeresource/Pool.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/closeresource/Pool.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/closeresource/Statement.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/closeresource/Statement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/closeresource/TransactionManager.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/closeresource/TransactionManager.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/compareobjectswithequals/ClassWithFields.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/compareobjectswithequals/ClassWithFields.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/compareobjectswithequals/CompareObjectsWithEqualsSample.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/compareobjectswithequals/CompareObjectsWithEqualsSample.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/constructorcallsoverridablemethod/AbstractThing.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/constructorcallsoverridablemethod/AbstractThing.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/constructorcallsoverridablemethod/Thing.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/constructorcallsoverridablemethod/Thing.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/useequalstocomparestrings/ClassWithStringFields.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/useequalstocomparestrings/ClassWithStringFields.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/useequalstocomparestrings/UseEqualsToCompareStringsSample.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/errorprone/useequalstocomparestrings/UseEqualsToCompareStringsSample.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/DataflowPassTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/DataflowPassTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtilTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/JavaRuleUtilTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtilTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/internal/TestFrameworksUtilTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/UseIOStreamsWithApacheCommonsFileItemTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/UseIOStreamsWithApacheCommonsFileItemTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/UseStringBufferForStringAppendsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/UseStringBufferForStringAppendsTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/inefficientemptystringcheck/StringTrimIsEmpty.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/inefficientemptystringcheck/StringTrimIsEmpty.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/inefficientemptystringcheck/StringTrimLength.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/inefficientemptystringcheck/StringTrimLength.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/inefficientemptystringcheck/StringTrimMethodArgument.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/inefficientemptystringcheck/StringTrimMethodArgument.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/stringtostring/Car.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/stringtostring/Car.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/stringtostring/Issue2080.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/stringtostring/Issue2080.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/stringtostring/StringToStringFP.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/stringtostring/StringToStringFP.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/stringtostring/User.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/performance/stringtostring/User.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/security/HardCodedCryptoKeyTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/security/HardCodedCryptoKeyTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/security/InsecureCryptoIvTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/security/InsecureCryptoIvTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/BaseXPathFunctionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/BaseXPathFunctionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/GetModifiersFunctionsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/GetModifiersFunctionsTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/HasAnnotationXPathTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/HasAnnotationXPathTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/MatchesSignatureXPathTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/MatchesSignatureXPathTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/NodeIsFunctionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/NodeIsFunctionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/TypeIsFunctionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/TypeIsFunctionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/XPathMetricFunctionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/rule/xpath/internal/XPathMetricFunctionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/AnnotationReflectionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/AnnotationReflectionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/ClassLoadingChildFirstTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/ClassLoadingChildFirstTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/DeadlockTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/DeadlockTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/SymbolicValueTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/SymbolicValueTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/internal/SymImplementation.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/internal/SymImplementation.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/internal/TypeAnnotReflectionOnMethodsTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/internal/TypeAnnotReflectionOnMethodsTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/internal/TypeAnnotReflectionTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/internal/TypeAnnotReflectionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/internal/TypeAnnotTestUtil.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/internal/TypeAnnotTestUtil.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStubTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ClassStubTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ModuleStubTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/internal/asm/ModuleStubTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/table/internal/AbruptCompletionTests.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/table/internal/AbruptCompletionTests.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/table/internal/PatternBindingsTests.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/symbols/table/internal/PatternBindingsTests.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/GenericMethodReferenceTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/GenericMethodReferenceTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/InvocationMatcherTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/InvocationMatcherTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/TypeTestUtilTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/TypeTestUtilTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/TypesTreeDumpTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/TypesTreeDumpTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/internal/infer/BaseTypeInferenceUnitTest.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/internal/infer/BaseTypeInferenceUnitTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/internal/infer/InferenceCtxUnitTests.java
+++ b/pmd-java/src/test/java/net/sourceforge/pmd/lang/java/types/internal/infer/InferenceCtxUnitTests.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTArrayComprehension.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTArrayComprehension.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTArrayComprehensionLoop.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTArrayComprehensionLoop.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTArrayLiteral.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTArrayLiteral.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTAssignment.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTAssignment.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTAstRoot.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTAstRoot.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTBigIntLiteral.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTBigIntLiteral.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTBlock.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTBlock.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTBreakStatement.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTBreakStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTCatchClause.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTCatchClause.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTComment.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTComment.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTConditionalExpression.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTConditionalExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTContinueStatement.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTContinueStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTDoLoop.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTDoLoop.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTElementGet.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTElementGet.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTEmptyExpression.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTEmptyExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTEmptyStatement.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTEmptyStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTErrorNode.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTErrorNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTExpressionStatement.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTExpressionStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTForInLoop.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTForInLoop.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTForLoop.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTForLoop.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTFunctionCall.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTFunctionCall.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTFunctionNode.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTFunctionNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTGeneratorExpression.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTGeneratorExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTGeneratorExpressionLoop.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTGeneratorExpressionLoop.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTIfStatement.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTIfStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTInfixExpression.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTInfixExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTKeywordLiteral.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTKeywordLiteral.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTLabel.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTLabel.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTLabeledStatement.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTLabeledStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTLetNode.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTLetNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTName.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTName.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTNewExpression.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTNewExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTNumberLiteral.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTNumberLiteral.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTObjectLiteral.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTObjectLiteral.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTObjectProperty.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTObjectProperty.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTParenthesizedExpression.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTParenthesizedExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTPropertyGet.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTPropertyGet.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTRegExpLiteral.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTRegExpLiteral.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTReturnStatement.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTReturnStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTScope.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTScope.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTScriptNode.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTScriptNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTStringLiteral.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTStringLiteral.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTSwitchCase.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTSwitchCase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTSwitchStatement.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTSwitchStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTTaggedTemplateLiteral.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTTaggedTemplateLiteral.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTTemplateCharacters.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTTemplateCharacters.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTTemplateLiteral.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTTemplateLiteral.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTThrowStatement.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTThrowStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTTryStatement.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTTryStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTUnaryExpression.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTUnaryExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTUpdateExpression.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTUpdateExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTVariableDeclaration.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTVariableDeclaration.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTVariableInitializer.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTVariableInitializer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTWhileLoop.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTWhileLoop.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTWithStatement.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTWithStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTXmlDotQuery.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTXmlDotQuery.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTXmlElemRef.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTXmlElemRef.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTXmlExpression.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTXmlExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTXmlLiteral.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTXmlLiteral.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTXmlMemberGet.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTXmlMemberGet.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTXmlPropRef.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTXmlPropRef.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTXmlString.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTXmlString.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTYield.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTYield.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/AbstractEcmascriptNode.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/AbstractEcmascriptNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/AbstractFunctionCallNode.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/AbstractFunctionCallNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/AbstractInfixEcmascriptNode.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/AbstractInfixEcmascriptNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/DestructuringNode.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/DestructuringNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/EcmascriptNode.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/EcmascriptNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/EcmascriptParser.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/EcmascriptParser.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/EcmascriptTreeBuilder.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/EcmascriptTreeBuilder.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/EcmascriptVisitor.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/EcmascriptVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/EcmascriptVisitorBase.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/EcmascriptVisitorBase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/TrailingCommaNode.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/ast/TrailingCommaNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/cpd/EcmascriptCpdLexer.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/cpd/EcmascriptCpdLexer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/rule/AbstractEcmascriptRule.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/ecmascript/rule/AbstractEcmascriptRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/typescript/TsLanguageModule.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/typescript/TsLanguageModule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/typescript/ast/TypeScriptLexerBase.java
+++ b/pmd-javascript/src/main/java/net/sourceforge/pmd/lang/typescript/ast/TypeScriptLexerBase.java
@@ -1,16 +1,13 @@
 /**
- * Source: https://github.com/antlr/grammars-v4/tree/master/javascript/typescript
- * License: MIT
- *
- * Slightly modified to adapt to pmd's style.
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
 package net.sourceforge.pmd.lang.typescript.ast;
 
-import org.antlr.v4.runtime.*;
-
 import java.util.ArrayDeque;
 import java.util.Deque;
+
+import org.antlr.v4.runtime.*;
 
 /**
  * All lexer methods that used in grammar (IsStrictMode)

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/DummyJsRule.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/DummyJsRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTForInLoopTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTForInLoopTest.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.ecmascript.ast;
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTVariableDeclarationTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/ASTVariableDeclarationTest.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.ecmascript.ast;
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/JsTreeDumpTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/ast/JsTreeDumpTest.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.ecmascript.ast;
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/cpd/AnyCpdLexerForTypescriptTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/cpd/AnyCpdLexerForTypescriptTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/cpd/EcmascriptCpdLexerTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/cpd/EcmascriptCpdLexerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/performance/AvoidConsoleStatementsTest.java
+++ b/pmd-javascript/src/test/java/net/sourceforge/pmd/lang/ecmascript/rule/performance/AvoidConsoleStatementsTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/JspHandler.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/JspHandler.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/JspLanguageModule.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/JspLanguageModule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTAttribute.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTAttribute.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTAttributeValue.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTAttributeValue.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTCData.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTCData.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTCommentTag.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTCommentTag.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTCompilationUnit.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTCompilationUnit.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTContent.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTContent.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTDeclaration.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTDeclaration.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTDoctypeDeclaration.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTDoctypeDeclaration.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTDoctypeExternalId.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTDoctypeExternalId.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTElExpression.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTElExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTElement.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTElement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTHtmlScript.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTHtmlScript.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTJspComment.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTJspComment.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTJspDeclaration.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTJspDeclaration.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTJspDirective.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTJspDirective.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTJspDirectiveAttribute.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTJspDirectiveAttribute.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTJspExpression.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTJspExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTJspExpressionInAttribute.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTJspExpressionInAttribute.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTJspScriptlet.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTJspScriptlet.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTText.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTText.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTUnparsedText.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTUnparsedText.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTValueBinding.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/ASTValueBinding.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/AbstractContentNode.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/AbstractContentNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/AbstractExpression.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/AbstractExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/AbstractJspNode.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/AbstractJspNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/InternalApiBridge.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/InternalApiBridge.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/JspNode.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/JspNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/JspParser.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/JspParser.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/JspVisitorBase.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/JspVisitorBase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/OpenTagRegister.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/ast/OpenTagRegister.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/cpd/JspCpdLexer.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/cpd/JspCpdLexer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/AbstractJspRule.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/AbstractJspRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/codestyle/DuplicateJspImportsRule.java
+++ b/pmd-jsp/src/main/java/net/sourceforge/pmd/lang/jsp/rule/codestyle/DuplicateJspImportsRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/LanguageVersionDiscovererTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/LanguageVersionDiscovererTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/cpd/JspCpdLexerTest.java
+++ b/pmd-jsp/src/test/java/net/sourceforge/pmd/lang/jsp/cpd/JspCpdLexerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-julia/src/main/java/net/sourceforge/pmd/lang/julia/JuliaLanguageModule.java
+++ b/pmd-julia/src/main/java/net/sourceforge/pmd/lang/julia/JuliaLanguageModule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-julia/src/main/java/net/sourceforge/pmd/lang/julia/ast/JuliaBaseListener.java
+++ b/pmd-julia/src/main/java/net/sourceforge/pmd/lang/julia/ast/JuliaBaseListener.java
@@ -1,9 +1,7 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
-// CHECKSTYLE:OFF
-// Generated from net/sourceforge/pmd/lang/julia/ast/Julia.g4 by ANTLR 4.9.3
 package net.sourceforge.pmd.lang.julia.ast;
 
 import org.antlr.v4.runtime.ParserRuleContext;

--- a/pmd-julia/src/main/java/net/sourceforge/pmd/lang/julia/ast/JuliaBaseVisitor.java
+++ b/pmd-julia/src/main/java/net/sourceforge/pmd/lang/julia/ast/JuliaBaseVisitor.java
@@ -1,9 +1,7 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
-// CHECKSTYLE:OFF
-// Generated from net/sourceforge/pmd/lang/julia/ast/Julia.g4 by ANTLR 4.9.3
 package net.sourceforge.pmd.lang.julia.ast;
 import org.antlr.v4.runtime.tree.AbstractParseTreeVisitor;
 

--- a/pmd-julia/src/main/java/net/sourceforge/pmd/lang/julia/ast/JuliaListener.java
+++ b/pmd-julia/src/main/java/net/sourceforge/pmd/lang/julia/ast/JuliaListener.java
@@ -1,9 +1,7 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
-// CHECKSTYLE:OFF
-// Generated from net/sourceforge/pmd/lang/julia/ast/Julia.g4 by ANTLR 4.9.3
 package net.sourceforge.pmd.lang.julia.ast;
 import org.antlr.v4.runtime.tree.ParseTreeListener;
 

--- a/pmd-julia/src/main/java/net/sourceforge/pmd/lang/julia/ast/JuliaParser.java
+++ b/pmd-julia/src/main/java/net/sourceforge/pmd/lang/julia/ast/JuliaParser.java
@@ -1,9 +1,7 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
-// CHECKSTYLE:OFF
-// Generated from net/sourceforge/pmd/lang/julia/ast/Julia.g4 by ANTLR 4.9.3
 package net.sourceforge.pmd.lang.julia.ast;
 
 import java.util.List;

--- a/pmd-julia/src/main/java/net/sourceforge/pmd/lang/julia/ast/JuliaVisitor.java
+++ b/pmd-julia/src/main/java/net/sourceforge/pmd/lang/julia/ast/JuliaVisitor.java
@@ -1,9 +1,7 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
-// CHECKSTYLE:OFF
-// Generated from net/sourceforge/pmd/lang/julia/ast/Julia.g4 by ANTLR 4.9.3
 package net.sourceforge.pmd.lang.julia.ast;
 import org.antlr.v4.runtime.tree.ParseTreeVisitor;
 

--- a/pmd-julia/src/test/java/net/sourceforge/pmd/lang/julia/cpd/JuliaCpdLexerTest.java
+++ b/pmd-julia/src/test/java/net/sourceforge/pmd/lang/julia/cpd/JuliaCpdLexerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinErrorNode.java
+++ b/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinErrorNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinInnerNode.java
+++ b/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinInnerNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinNameDictionary.java
+++ b/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinNameDictionary.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinNode.java
+++ b/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinRootNode.java
+++ b/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinRootNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinTerminalNode.java
+++ b/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinTerminalNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinVisitorBase.java
+++ b/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinVisitorBase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/ast/PmdKotlinParser.java
+++ b/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/ast/PmdKotlinParser.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/ast/UnicodeClasses.java
+++ b/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/ast/UnicodeClasses.java
@@ -2,8 +2,6 @@
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
-// CHECKSTYLE:OFF
-// Generated from net/sourceforge/pmd/lang/kotlin/ast/UnicodeClasses.g4 by ANTLR 4.9.3
 package net.sourceforge.pmd.lang.kotlin.ast;
 
 import org.antlr.v4.runtime.CharStream;

--- a/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/cpd/KotlinCpdLexer.java
+++ b/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/cpd/KotlinCpdLexer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/rule/errorprone/OverrideBothEqualsAndHashcodeRule.java
+++ b/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/rule/errorprone/OverrideBothEqualsAndHashcodeRule.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.kotlin.rule.errorprone;
 

--- a/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/rule/xpath/internal/BaseKotlinXPathFunction.java
+++ b/pmd-kotlin/src/main/java/net/sourceforge/pmd/lang/kotlin/rule/xpath/internal/BaseKotlinXPathFunction.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/LanguageVersionTest.java
+++ b/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/LanguageVersionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/RuleSetFactoryTest.java
+++ b/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/RuleSetFactoryTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/ast/BaseKotlinTreeDumpTest.java
+++ b/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/ast/BaseKotlinTreeDumpTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinParserTests.java
+++ b/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinParserTests.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinParsingHelper.java
+++ b/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/ast/KotlinParsingHelper.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/cpd/KotlinCpdLexerTest.java
+++ b/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/cpd/KotlinCpdLexerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/rule/errorprone/OverrideBothEqualsAndHashcodeTest.java
+++ b/pmd-kotlin/src/test/java/net/sourceforge/pmd/lang/kotlin/rule/errorprone/OverrideBothEqualsAndHashcodeTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-lang-test/src/main/java/net/sourceforge/pmd/lang/test/AbstractMetricTestRule.java
+++ b/pmd-lang-test/src/main/java/net/sourceforge/pmd/lang/test/AbstractMetricTestRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-lua/src/main/java/net/sourceforge/pmd/lang/lua/LuaLanguageModule.java
+++ b/pmd-lua/src/main/java/net/sourceforge/pmd/lang/lua/LuaLanguageModule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-lua/src/main/java/net/sourceforge/pmd/lang/lua/cpd/LuaCpdLexer.java
+++ b/pmd-lua/src/main/java/net/sourceforge/pmd/lang/lua/cpd/LuaCpdLexer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-lua/src/test/java/net/sourceforge/pmd/lang/lua/cpd/LuaCpdLexerTest.java
+++ b/pmd-lua/src/test/java/net/sourceforge/pmd/lang/lua/cpd/LuaCpdLexerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-matlab/src/main/java/net/sourceforge/pmd/lang/matlab/MatlabLanguageModule.java
+++ b/pmd-matlab/src/main/java/net/sourceforge/pmd/lang/matlab/MatlabLanguageModule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-matlab/src/main/java/net/sourceforge/pmd/lang/matlab/cpd/MatlabCpdLexer.java
+++ b/pmd-matlab/src/main/java/net/sourceforge/pmd/lang/matlab/cpd/MatlabCpdLexer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-matlab/src/test/java/net/sourceforge/pmd/lang/matlab/cpd/MatlabCpdLexerTest.java
+++ b/pmd-matlab/src/test/java/net/sourceforge/pmd/lang/matlab/cpd/MatlabCpdLexerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTAddOp.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTAddOp.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTFactor.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTFactor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTLanguageSpecification.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTLanguageSpecification.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTMulOp.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTMulOp.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTNumberLiteral.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTNumberLiteral.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTRelOp.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTRelOp.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTSimpleName.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTSimpleName.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTStringComment.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTStringComment.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTStringLiteral.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ASTStringLiteral.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/AbstractOperator.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/AbstractOperator.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ModelicaParser.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ModelicaParser.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ModelicaVisitorBase.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/ast/ModelicaVisitorBase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/cpd/ModelicaCpdLexer.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/cpd/ModelicaCpdLexer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/AbstractModelicaRule.java
+++ b/pmd-modelica/src/main/java/net/sourceforge/pmd/lang/modelica/rule/AbstractModelicaRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-objectivec/src/main/java/net/sourceforge/pmd/lang/objectivec/ObjectiveCLanguageModule.java
+++ b/pmd-objectivec/src/main/java/net/sourceforge/pmd/lang/objectivec/ObjectiveCLanguageModule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-objectivec/src/main/java/net/sourceforge/pmd/lang/objectivec/cpd/ObjectiveCCpdLexer.java
+++ b/pmd-objectivec/src/main/java/net/sourceforge/pmd/lang/objectivec/cpd/ObjectiveCCpdLexer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-objectivec/src/test/java/net/sourceforge/pmd/lang/objectivec/cpd/ObjectiveCCpdLexerTest.java
+++ b/pmd-objectivec/src/test/java/net/sourceforge/pmd/lang/objectivec/cpd/ObjectiveCCpdLexerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-perl/src/main/java/net/sourceforge/pmd/lang/perl/PerlLanguageModule.java
+++ b/pmd-perl/src/main/java/net/sourceforge/pmd/lang/perl/PerlLanguageModule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-perl/src/test/java/net/sourceforge/pmd/lang/perl/cpd/PerlCpdLexerTest.java
+++ b/pmd-perl/src/test/java/net/sourceforge/pmd/lang/perl/cpd/PerlCpdLexerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-php/src/main/java/net/sourceforge/pmd/lang/php/PhpLanguageModule.java
+++ b/pmd-php/src/main/java/net/sourceforge/pmd/lang/php/PhpLanguageModule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTArguments.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTArguments.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTComparisonCondition.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTComparisonCondition.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTCompoundCondition.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTCompoundCondition.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTDatatype.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTDatatype.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTExtractExpression.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTExtractExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTFetchStatement.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTFetchStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTFormalParameter.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTFormalParameter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTIfStatement.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTIfStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTInlineConstraint.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTInlineConstraint.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTInnerCrossJoinClause.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTInnerCrossJoinClause.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTInput.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTInput.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTMethodDeclaration.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTMethodDeclaration.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTMethodDeclarator.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTMethodDeclarator.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTName.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTName.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTOutOfLineConstraint.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTOutOfLineConstraint.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTOuterJoinClause.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTOuterJoinClause.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTOuterJoinType.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTOuterJoinType.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTPackageBody.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTPackageBody.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTPackageSpecification.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTPackageSpecification.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTPrimaryPrefix.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTPrimaryPrefix.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTPrimarySuffix.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTPrimarySuffix.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTProgramUnit.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTProgramUnit.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTQueryBlock.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTQueryBlock.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTRegexpLikeCondition.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTRegexpLikeCondition.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTSelectIntoStatement.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTSelectIntoStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTSelectStatement.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTSelectStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTSqlMacroClause.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTSqlMacroClause.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTSqlStatement.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTSqlStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTStringLiteral.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTStringLiteral.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.plsql.ast;
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTSubqueryOperation.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTSubqueryOperation.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTTriggerTimingPointSection.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTTriggerTimingPointSection.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTTriggerUnit.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTTriggerUnit.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTTypeMethod.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTTypeMethod.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTTypeSpecification.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTTypeSpecification.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTVariableOrConstantDeclaratorId.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ASTVariableOrConstantDeclaratorId.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/AbstractPLSQLNode.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/AbstractPLSQLNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/AbstractSelectStatement.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/AbstractSelectStatement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ConstraintType.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ConstraintType.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ExecutableCode.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/ExecutableCode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/InternalApiBridge.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/InternalApiBridge.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.plsql.ast;
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/OracleObject.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/OracleObject.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLNode.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLParser.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLParser.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/PlsqlVisitorBase.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/PlsqlVisitorBase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/internal/ParsingExclusion.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/ast/internal/ParsingExclusion.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/cpd/PLSQLCpdLexer.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/cpd/PLSQLCpdLexer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractPLSQLRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/AbstractPLSQLRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/AbstractCounterCheckRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/AbstractCounterCheckRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/AbstractNcssCountRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/AbstractNcssCountRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/NPathComplexityVisitor.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/NPathComplexityVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/NcssMethodCountRule.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/rule/design/NcssMethodCountRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/ClassScope.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/ClassScope.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/LocalScope.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/LocalScope.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/MethodOrLocalScope.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/MethodOrLocalScope.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/MethodScope.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/MethodScope.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/ScopeAndDeclarationFinder.java
+++ b/pmd-plsql/src/main/java/net/sourceforge/pmd/lang/plsql/symboltable/ScopeAndDeclarationFinder.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/PlsqlParsingHelper.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/PlsqlParsingHelper.java
@@ -22,4 +22,3 @@ public class PlsqlParsingHelper extends BaseParsingHelper<PlsqlParsingHelper, AS
     }
 
 }
-

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ASTExtractExpressionTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ASTExtractExpressionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ASTFetchStatementTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ASTFetchStatementTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ASTSqlStatementTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/ASTSqlStatementTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/MultipleDDLStatementsTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/MultipleDDLStatementsTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLParserTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/PLSQLParserTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/PlsqlTreeDumpTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/PlsqlTreeDumpTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/TreatFunctionTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/TreatFunctionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/TriggerTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/TriggerTest.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.plsql.ast;
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/XmlDbTreeDumpTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/ast/XmlDbTreeDumpTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/cpd/PLSQLCpdLexerTest.java
+++ b/pmd-plsql/src/test/java/net/sourceforge/pmd/lang/plsql/cpd/PLSQLCpdLexerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-python/src/main/java/net/sourceforge/pmd/lang/python/PythonLanguageModule.java
+++ b/pmd-python/src/main/java/net/sourceforge/pmd/lang/python/PythonLanguageModule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-python/src/main/java/net/sourceforge/pmd/lang/python/cpd/PythonCpdLexer.java
+++ b/pmd-python/src/main/java/net/sourceforge/pmd/lang/python/cpd/PythonCpdLexer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-python/src/test/java/net/sourceforge/pmd/lang/python/cpd/PythonCpdLexerTest.java
+++ b/pmd-python/src/test/java/net/sourceforge/pmd/lang/python/cpd/PythonCpdLexerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-ruby/src/main/java/net/sourceforge/pmd/lang/ruby/RubyLanguageModule.java
+++ b/pmd-ruby/src/main/java/net/sourceforge/pmd/lang/ruby/RubyLanguageModule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-ruby/src/test/java/net/sourceforge/pmd/lang/ruby/cpd/RubyCpdLexerTest.java
+++ b/pmd-ruby/src/test/java/net/sourceforge/pmd/lang/ruby/cpd/RubyCpdLexerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-rust/src/main/java/net/sourceforge/pmd/lang/rust/RustLanguageModule.java
+++ b/pmd-rust/src/main/java/net/sourceforge/pmd/lang/rust/RustLanguageModule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-rust/src/main/java/net/sourceforge/pmd/lang/rust/cpd/RustCpdLexer.java
+++ b/pmd-rust/src/main/java/net/sourceforge/pmd/lang/rust/cpd/RustCpdLexer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-rust/src/test/java/net/sourceforge/pmd/lang/rust/cpd/RustCpdLexerTest.java
+++ b/pmd-rust/src/test/java/net/sourceforge/pmd/lang/rust/cpd/RustCpdLexerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ScalaLanguageHandler.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ScalaLanguageHandler.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ScalaLanguageModule.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ScalaLanguageModule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTCase.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTCase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTCtorPrimary.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTCtorPrimary.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTCtorSecondary.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTCtorSecondary.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTDeclDef.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTDeclDef.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTDeclType.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTDeclType.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTDeclVal.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTDeclVal.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTDeclVar.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTDeclVar.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTDefnClass.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTDefnClass.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTDefnDef.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTDefnDef.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTDefnMacro.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTDefnMacro.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTDefnObject.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTDefnObject.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTDefnTrait.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTDefnTrait.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTDefnType.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTDefnType.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTDefnVal.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTDefnVal.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTDefnVar.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTDefnVar.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTEnumeratorGenerator.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTEnumeratorGenerator.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTEnumeratorGuard.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTEnumeratorGuard.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTEnumeratorVal.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTEnumeratorVal.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTImport.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTImport.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTImporteeName.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTImporteeName.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTImporteeRename.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTImporteeRename.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTImporteeUnimport.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTImporteeUnimport.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTImporteeWildcard.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTImporteeWildcard.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTImporter.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTImporter.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTInit.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTInit.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTLitBoolean.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTLitBoolean.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTLitByte.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTLitByte.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTLitChar.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTLitChar.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTLitDouble.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTLitDouble.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTLitFloat.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTLitFloat.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTLitInt.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTLitInt.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTLitLong.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTLitLong.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTLitNull.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTLitNull.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTLitShort.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTLitShort.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTLitString.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTLitString.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTLitSymbol.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTLitSymbol.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTLitUnit.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTLitUnit.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTMemberParamClauseGroup.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTMemberParamClauseGroup.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModAbstract.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModAbstract.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModAnnot.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModAnnot.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModCase.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModCase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModContravariant.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModContravariant.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModCovariant.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModCovariant.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModFinal.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModFinal.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModImplicit.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModImplicit.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModInline.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModInline.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModLazy.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModLazy.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModOverride.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModOverride.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModPrivate.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModPrivate.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModProtected.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModProtected.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModSealed.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModSealed.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModValParam.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModValParam.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModVarParam.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTModVarParam.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTNameAnonymous.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTNameAnonymous.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTNameIndeterminate.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTNameIndeterminate.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPatAlternative.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPatAlternative.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPatArgClause.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPatArgClause.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPatBind.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPatBind.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPatExtract.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPatExtract.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPatExtractInfix.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPatExtractInfix.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPatInterpolate.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPatInterpolate.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPatSeqWildcard.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPatSeqWildcard.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPatTuple.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPatTuple.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPatTyped.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPatTyped.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPatVar.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPatVar.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPatWildcard.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPatWildcard.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPatXml.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPatXml.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPkg.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPkg.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPkgBody.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPkgBody.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPkgObject.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTPkgObject.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTQuasi.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTQuasi.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTSelf.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTSelf.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTSource.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTSource.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTemplate.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTemplate.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTemplateBody.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTemplateBody.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermAnnotate.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermAnnotate.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermApply.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermApply.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermApplyInfix.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermApplyInfix.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermApplyType.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermApplyType.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermApplyUnary.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermApplyUnary.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermArgClause.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermArgClause.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermAscribe.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermAscribe.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermAssign.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermAssign.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermBlock.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermBlock.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermCasesBlock.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermCasesBlock.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermDo.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermDo.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermEta.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermEta.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermFor.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermFor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermForYield.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermForYield.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermFunction.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermFunction.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermIf.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermIf.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermInterpolate.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermInterpolate.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermMatch.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermMatch.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermName.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermName.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermNew.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermNew.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermNewAnonymous.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermNewAnonymous.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermParam.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermParam.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermParamClause.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermParamClause.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermPartialFunction.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermPartialFunction.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermPlaceholder.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermPlaceholder.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermRepeated.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermRepeated.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermReturn.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermReturn.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermSelect.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermSelect.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermSuper.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermSuper.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermThis.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermThis.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermThrow.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermThrow.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermTry.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermTry.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermTryWithHandler.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermTryWithHandler.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermTuple.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermTuple.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermWhile.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermWhile.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermXml.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTermXml.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeAnd.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeAnd.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeAnnotate.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeAnnotate.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeApply.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeApply.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeApplyInfix.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeApplyInfix.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeArgClause.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeArgClause.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeBounds.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeBounds.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeByName.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeByName.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeExistential.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeExistential.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeFuncParamClause.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeFuncParamClause.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeFunction.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeFunction.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeImplicitFunction.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeImplicitFunction.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeLambda.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeLambda.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeMethod.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeMethod.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeName.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeName.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeOr.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeOr.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeParam.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeParam.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeParamClause.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeParamClause.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypePlaceholder.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypePlaceholder.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeProject.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeProject.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeRefine.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeRefine.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeRepeated.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeRepeated.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeSelect.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeSelect.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeSingleton.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeSingleton.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeTuple.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeTuple.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeVar.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeVar.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeWith.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ASTTypeWith.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/AbstractScalaNode.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/AbstractScalaNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ScalaNode.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ScalaNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ScalaParser.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ScalaParser.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ScalaTreeBuilder.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ScalaTreeBuilder.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ScalaVisitor.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ScalaVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ScalaVisitorBase.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/ast/ScalaVisitorBase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/internal/ScalaDialect.java
+++ b/pmd-scala-modules/pmd-scala-common/src/main/java/net/sourceforge/pmd/lang/scala/internal/ScalaDialect.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/test/java/net/sourceforge/pmd/lang/scala/ast/BaseScalaTest.java
+++ b/pmd-scala-modules/pmd-scala-common/src/test/java/net/sourceforge/pmd/lang/scala/ast/BaseScalaTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/test/java/net/sourceforge/pmd/lang/scala/ast/ScalaParsingHelper.java
+++ b/pmd-scala-modules/pmd-scala-common/src/test/java/net/sourceforge/pmd/lang/scala/ast/ScalaParsingHelper.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/test/java/net/sourceforge/pmd/lang/scala/rule/ScalaRuleTest.java
+++ b/pmd-scala-modules/pmd-scala-common/src/test/java/net/sourceforge/pmd/lang/scala/rule/ScalaRuleTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-scala-modules/pmd-scala-common/src/test/java/net/sourceforge/pmd/lang/scala/rule/XPathRuleTest.java
+++ b/pmd-scala-modules/pmd-scala-common/src/test/java/net/sourceforge/pmd/lang/scala/rule/XPathRuleTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/ast/PmdSwiftParser.java
+++ b/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/ast/PmdSwiftParser.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/ast/SwiftErrorNode.java
+++ b/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/ast/SwiftErrorNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/ast/SwiftInnerNode.java
+++ b/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/ast/SwiftInnerNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/ast/SwiftNameDictionary.java
+++ b/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/ast/SwiftNameDictionary.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/ast/SwiftNode.java
+++ b/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/ast/SwiftNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/ast/SwiftRootNode.java
+++ b/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/ast/SwiftRootNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/ast/SwiftTerminalNode.java
+++ b/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/ast/SwiftTerminalNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/ast/SwiftVisitorBase.java
+++ b/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/ast/SwiftVisitorBase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/cpd/SwiftCpdLexer.java
+++ b/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/cpd/SwiftCpdLexer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/rule/AbstractSwiftRule.java
+++ b/pmd-swift/src/main/java/net/sourceforge/pmd/lang/swift/rule/AbstractSwiftRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-swift/src/test/java/net/sourceforge/pmd/lang/swift/LanguageVersionTest.java
+++ b/pmd-swift/src/test/java/net/sourceforge/pmd/lang/swift/LanguageVersionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-swift/src/test/java/net/sourceforge/pmd/lang/swift/ast/BaseSwiftTreeDumpTest.java
+++ b/pmd-swift/src/test/java/net/sourceforge/pmd/lang/swift/ast/BaseSwiftTreeDumpTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-swift/src/test/java/net/sourceforge/pmd/lang/swift/ast/SwiftParserTests.java
+++ b/pmd-swift/src/test/java/net/sourceforge/pmd/lang/swift/ast/SwiftParserTests.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-swift/src/test/java/net/sourceforge/pmd/lang/swift/ast/SwiftParsingHelper.java
+++ b/pmd-swift/src/test/java/net/sourceforge/pmd/lang/swift/ast/SwiftParsingHelper.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-swift/src/test/java/net/sourceforge/pmd/lang/swift/cpd/SwiftCpdLexerTest.java
+++ b/pmd-swift/src/test/java/net/sourceforge/pmd/lang/swift/cpd/SwiftCpdLexerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-test-schema/src/main/java/net/sourceforge/pmd/test/schema/BaseTestParserImpl.java
+++ b/pmd-test-schema/src/main/java/net/sourceforge/pmd/test/schema/BaseTestParserImpl.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-test-schema/src/main/java/net/sourceforge/pmd/test/schema/RuleTestCollection.java
+++ b/pmd-test-schema/src/main/java/net/sourceforge/pmd/test/schema/RuleTestCollection.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-test-schema/src/main/java/net/sourceforge/pmd/test/schema/RuleTestDescriptor.java
+++ b/pmd-test-schema/src/main/java/net/sourceforge/pmd/test/schema/RuleTestDescriptor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-test-schema/src/main/java/net/sourceforge/pmd/test/schema/TestSchemaParser.java
+++ b/pmd-test-schema/src/main/java/net/sourceforge/pmd/test/schema/TestSchemaParser.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-test-schema/src/main/java/net/sourceforge/pmd/test/schema/TestSchemaVersion.java
+++ b/pmd-test-schema/src/main/java/net/sourceforge/pmd/test/schema/TestSchemaVersion.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-test-schema/src/test/java/net/sourceforge/pmd/test/schema/TestSchemaParserTest.java
+++ b/pmd-test-schema/src/test/java/net/sourceforge/pmd/test/schema/TestSchemaParserTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-tsql/src/main/java/net/sourceforge/pmd/lang/tsql/TSqlLanguageModule.java
+++ b/pmd-tsql/src/main/java/net/sourceforge/pmd/lang/tsql/TSqlLanguageModule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-tsql/src/main/java/net/sourceforge/pmd/lang/tsql/cpd/CaseChangingCharStream.java
+++ b/pmd-tsql/src/main/java/net/sourceforge/pmd/lang/tsql/cpd/CaseChangingCharStream.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/VtlHandler.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/VtlHandler.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/VtlLanguageModule.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/VtlLanguageModule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTAddNode.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTAddNode.java
@@ -1,3 +1,6 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
 
 package net.sourceforge.pmd.lang.velocity.ast;
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTBlock.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTBlock.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTDirective.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTDirective.java
@@ -1,3 +1,6 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
 
 package net.sourceforge.pmd.lang.velocity.ast;
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTDivNode.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTDivNode.java
@@ -1,3 +1,6 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
 
 package net.sourceforge.pmd.lang.velocity.ast;
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTEscape.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTEscape.java
@@ -1,3 +1,6 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
 
 package net.sourceforge.pmd.lang.velocity.ast;
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTMathNode.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTMathNode.java
@@ -1,3 +1,7 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
+
 package net.sourceforge.pmd.lang.velocity.ast;
 
 /*

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTMethod.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTMethod.java
@@ -1,3 +1,6 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
 
 package net.sourceforge.pmd.lang.velocity.ast;
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTModNode.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTModNode.java
@@ -1,3 +1,6 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
 
 package net.sourceforge.pmd.lang.velocity.ast;
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTMulNode.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTMulNode.java
@@ -1,3 +1,6 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
 
 package net.sourceforge.pmd.lang.velocity.ast;
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTReference.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTReference.java
@@ -1,3 +1,6 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
 
 package net.sourceforge.pmd.lang.velocity.ast;
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTStringLiteral.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTStringLiteral.java
@@ -1,3 +1,6 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
 
 package net.sourceforge.pmd.lang.velocity.ast;
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTSubtractNode.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTSubtractNode.java
@@ -1,3 +1,6 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
 
 package net.sourceforge.pmd.lang.velocity.ast;
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTTemplate.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/ASTTemplate.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/AbstractVtlNode.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/AbstractVtlNode.java
@@ -1,3 +1,6 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
 
 package net.sourceforge.pmd.lang.velocity.ast;
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/NodeUtils.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/NodeUtils.java
@@ -1,3 +1,6 @@
+/**
+ * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
+ */
 
 package net.sourceforge.pmd.lang.velocity.ast;
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/VtlNode.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/VtlNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/VtlParser.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/VtlParser.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/VtlVisitorBase.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/ast/VtlVisitorBase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/cpd/VtlCpdLexer.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/cpd/VtlCpdLexer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/AbstractVtlRule.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/AbstractVtlRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/bestpractices/AvoidReassigningParametersRule.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/bestpractices/AvoidReassigningParametersRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/bestpractices/UnusedMacroParameterRule.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/bestpractices/UnusedMacroParameterRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/design/AvoidDeeplyNestedIfStmtsRule.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/design/AvoidDeeplyNestedIfStmtsRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/design/CollapsibleIfStatementsRule.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/design/CollapsibleIfStatementsRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/design/ExcessiveTemplateLengthRule.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/design/ExcessiveTemplateLengthRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/design/NoInlineJavaScriptRule.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/design/NoInlineJavaScriptRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/errorprone/EmptyForeachStmtRule.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/errorprone/EmptyForeachStmtRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/errorprone/EmptyIfStmtRule.java
+++ b/pmd-velocity/src/main/java/net/sourceforge/pmd/lang/velocity/rule/errorprone/EmptyIfStmtRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/LanguageVersionTest.java
+++ b/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/LanguageVersionTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/RuleSetFactoryTest.java
+++ b/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/RuleSetFactoryTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/VtlParserTest.java
+++ b/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/VtlParserTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/VtlParsingHelper.java
+++ b/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/VtlParsingHelper.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/cpd/VtlCpdLexerTest.java
+++ b/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/cpd/VtlCpdLexerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/rule/bestpractices/AvoidReassigningParametersTest.java
+++ b/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/rule/bestpractices/AvoidReassigningParametersTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/rule/bestpractices/UnusedMacroParameterTest.java
+++ b/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/rule/bestpractices/UnusedMacroParameterTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/rule/design/AvoidDeeplyNestedIfStmtsTest.java
+++ b/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/rule/design/AvoidDeeplyNestedIfStmtsTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/rule/design/CollapsibleIfStatementsTest.java
+++ b/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/rule/design/CollapsibleIfStatementsTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/rule/design/ExcessiveTemplateLengthTest.java
+++ b/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/rule/design/ExcessiveTemplateLengthTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/rule/design/NoInlineJavaScriptTest.java
+++ b/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/rule/design/NoInlineJavaScriptTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/rule/design/NoInlineStylesTest.java
+++ b/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/rule/design/NoInlineStylesTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/rule/errorprone/EmptyForeachStmtTest.java
+++ b/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/rule/errorprone/EmptyForeachStmtTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/rule/errorprone/EmptyIfStmtTest.java
+++ b/pmd-velocity/src/test/java/net/sourceforge/pmd/lang/velocity/rule/errorprone/EmptyIfStmtTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/VfHandler.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/VfHandler.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/VfLanguageModule.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/VfLanguageModule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/VfLanguageProperties.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/VfLanguageProperties.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTArguments.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTArguments.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTAttribute.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTAttribute.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTAttributeValue.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTAttributeValue.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTCData.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTCData.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTCompilationUnit.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTCompilationUnit.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTContent.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTContent.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTDeclaration.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTDeclaration.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTDoctypeDeclaration.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTDoctypeDeclaration.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTDoctypeExternalId.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTDoctypeExternalId.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTDotExpression.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTDotExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTElExpression.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTElExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTElement.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTElement.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTExpression.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTHtmlScript.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTHtmlScript.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTIdentifier.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTIdentifier.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTLiteral.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTLiteral.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTNegationExpression.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTNegationExpression.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTText.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ASTText.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/AbstractVFDataNode.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/AbstractVFDataNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/AbstractVfNode.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/AbstractVfNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ApexClassPropertyTypes.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ApexClassPropertyTypes.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ApexClassPropertyTypesVisitor.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ApexClassPropertyTypesVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ObjectFieldTypes.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/ObjectFieldTypes.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/OpenTagRegister.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/OpenTagRegister.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/SalesforceFieldTypes.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/SalesforceFieldTypes.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 
@@ -100,4 +100,3 @@ abstract class SalesforceFieldTypes {
      */
     protected abstract void findDataType(String expression, List<Path> metadataDirectories);
 }
-

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/VfExpressionTypeVisitor.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/VfExpressionTypeVisitor.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/VfNode.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/VfNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/VfParser.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/VfParser.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/VfTypedNode.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/VfTypedNode.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/VfVisitorBase.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/ast/VfVisitorBase.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/cpd/VfCpdLexer.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/cpd/VfCpdLexer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/rule/AbstractVfRule.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/rule/AbstractVfRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/rule/security/VfHtmlStyleTagXssRule.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/rule/security/VfHtmlStyleTagXssRule.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/rule/security/internal/ElEscapeDetector.java
+++ b/pmd-visualforce/src/main/java/net/sourceforge/pmd/lang/visualforce/rule/security/internal/ElEscapeDetector.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/ast/ApexClassPropertyTypesTest.java
+++ b/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/ast/ApexClassPropertyTypesTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/ast/ApexClassPropertyTypesVisitorTest.java
+++ b/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/ast/ApexClassPropertyTypesVisitorTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/ast/ObjectFieldTypesTest.java
+++ b/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/ast/ObjectFieldTypesTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/ast/VfExpressionTypeVisitorTest.java
+++ b/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/ast/VfExpressionTypeVisitorTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/ast/VfParserTest.java
+++ b/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/ast/VfParserTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/cpd/VfCpdLexerTest.java
+++ b/pmd-visualforce/src/test/java/net/sourceforge/pmd/lang/visualforce/cpd/VfCpdLexerTest.java
@@ -1,7 +1,6 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
-
 
 package net.sourceforge.pmd.lang.visualforce.cpd;
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/internal/DOMLineNumbers.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/internal/DOMLineNumbers.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/internal/XmlNodeWrapper.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/internal/XmlNodeWrapper.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/internal/XmlParserImpl.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/ast/internal/XmlParserImpl.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/cpd/XmlCpdLexer.java
+++ b/pmd-xml/src/main/java/net/sourceforge/pmd/lang/xml/cpd/XmlCpdLexer.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/XmlParsingHelper.java
+++ b/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/XmlParsingHelper.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/ast/XmlCoordinatesTest.java
+++ b/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/ast/XmlCoordinatesTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/ast/XmlParserTest.java
+++ b/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/ast/XmlParserTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/cpd/XmlCPDCpdLexerTest.java
+++ b/pmd-xml/src/test/java/net/sourceforge/pmd/lang/xml/cpd/XmlCPDCpdLexerTest.java
@@ -1,4 +1,4 @@
-/*
+/**
  * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
  */
 

--- a/pom.xml
+++ b/pom.xml
@@ -696,6 +696,68 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>com.diffplug.spotless</groupId>
+                    <artifactId>spotless-maven-plugin</artifactId>
+                    <version>2.44.5</version>
+                    <configuration>
+                        <skip>${spot.skip}</skip>
+                        <formats>
+                            <format>
+                                <excludes>
+                                    <exclude>**/testdata/**</exclude>
+                                    <exclude>**gradlew**</exclude>
+                                    <exclude>**mvnw**</exclude>
+                                </excludes>
+                                <includes>
+                                    <include>.gitignore</include>
+                                </includes>
+                                <trimTrailingWhitespace/>
+                            </format>
+                        </formats>
+                        <java>
+                            <excludes>
+                                <exclude>**/src/main/java/net/sourceforge/pmd/lang/java/types/package-info.java</exclude>
+                                <exclude>**/testdata/**</exclude>
+                                <exclude>**/unnecessaryimport/package1/U.java</exclude>
+                            </excludes>
+                            <removeUnusedImports/>
+                            <importOrder>
+                                <file>${maven.multiModuleProjectDirectory}/.spotless/eclipse.importorder</file>
+                            </importOrder>
+                            <licenseHeader>
+                                <file>${maven.multiModuleProjectDirectory}/.spotless/copyright.txt</file>
+                            </licenseHeader>
+                        </java>
+                        <pom>
+<!--                            <sortPom/>-->
+<!--                                <expandEmptyElements>false</expandEmptyElements>-->
+<!--                                &lt;!&ndash; https://issues.apache.org/jira/browse/MRELEASE-1111 &ndash;&gt;-->
+<!--                                <spaceBeforeCloseEmptyElement>true</spaceBeforeCloseEmptyElement>-->
+<!--                                <quiet>true</quiet>-->
+<!--                            </sortPom>-->
+                        </pom>
+                        <upToDateChecking>
+                            <enabled>true</enabled>
+                        </upToDateChecking>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>spotless-apply</id>
+                            <phase>process-sources</phase>
+                            <goals>
+                                <goal>apply</goal>
+                            </goals>
+                        </execution>
+                        <execution>
+                            <id>spotless-check</id>
+                            <phase>verify</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -754,6 +816,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
                 <!-- configuration is in plugin management section -->
+            </plugin>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -1191,6 +1257,7 @@
                 <maven.source.skip>true</maven.source.skip>
                 <checkstyle.skip>true</checkstyle.skip>
                 <pmd.skip>true</pmd.skip>
+                <spot.skip>true</spot.skip>
                 <cpd.skip>true</cpd.skip>
                 <cyclonedx.skip>true</cyclonedx.skip>
                 <dokka.skip>true</dokka.skip>


### PR DESCRIPTION
## confusion licence header

having 2 variants for one and the same makes me wonder, which one is right? Actually no one seems to care, as expected, as its always some random impl. detail, no one considers, until broken. PMD deserves better.

Never the less SSOT/SPOT seem to finalize this discussion, **closing the broken window effect**.

spot is ready to take over the flaws missed by check:

- https://github.com/pmd/pmd/pull/5845


```
/**
 * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
 */
```

```
/*
 * BSD-style license; for more info see http://pmd.sourceforge.net/license.html
 */
```

<img width="1399" alt="image" src="https://github.com/user-attachments/assets/c0795b72-a639-44d4-adda-51cc74fa1848" />


<img width="1664" alt="image" src="https://github.com/user-attachments/assets/56aeb3b1-8124-4771-9fe4-fd96d32d6f4c" />


## Related issues

<!-- PR relates to issues in the `pmd` repo: -->

- Fix #

## Ready?

<!-- If you feel like you can help to check off the following tasks, that'd be great. If not, don't worry - we will take care of it. -->

- [ ] Added unit tests for fixed bug/feature
- [ ] Passing all unit tests
- [ ] Complete build `./mvnw clean verify` passes (checked automatically by github actions)
- [ ] Added (in-code) documentation (if needed)



